### PR TITLE
 Add applyFilter equivalent to Constraint-based table layout selection

### DIFF
--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -2874,7 +2874,7 @@ public class TestHiveIntegrationSmokeTest
             if (actualRemoteExchangesCount != expectedRemoteExchangesCount) {
                 Session session = getSession();
                 Metadata metadata = ((DistributedQueryRunner) getQueryRunner()).getCoordinator().getMetadata();
-                String formattedPlan = textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionRegistry(), StatsAndCosts.empty(), session, 0);
+                String formattedPlan = textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionRegistry(), Optional.of(metadata), StatsAndCosts.empty(), session, 0);
                 throw new AssertionError(format(
                         "Expected [\n%s\n] remote exchanges but found [\n%s\n] remote exchanges. Actual plan is [\n\n%s\n]",
                         expectedRemoteExchangesCount,

--- a/presto-main/src/main/java/io/prestosql/cost/TableScanStatsRule.java
+++ b/presto-main/src/main/java/io/prestosql/cost/TableScanStatsRule.java
@@ -59,7 +59,7 @@ public class TableScanStatsRule
     protected Optional<PlanNodeStatsEstimate> doCalculate(TableScanNode node, StatsProvider sourceStats, Lookup lookup, Session session, TypeProvider types)
     {
         // TODO Construct predicate like AddExchanges's LayoutConstraintEvaluator
-        Constraint<ColumnHandle> constraint = new Constraint<>(node.getCurrentConstraint());
+        Constraint<ColumnHandle> constraint = new Constraint<>(metadata.getTableProperties(session, node.getTable()).getPredicate());
 
         TableStatistics tableStatistics = metadata.getTableStatistics(session, node.getTable(), constraint);
         verify(tableStatistics != null, "tableStatistics is null for %s", node);

--- a/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
+++ b/presto-main/src/main/java/io/prestosql/event/QueryMonitor.java
@@ -89,6 +89,7 @@ public class QueryMonitor
     private final String environment;
     private final SessionPropertyManager sessionPropertyManager;
     private final FunctionRegistry functionRegistry;
+    private final Metadata metadata;
     private final int maxJsonLimit;
 
     @Inject
@@ -113,7 +114,8 @@ public class QueryMonitor
         this.serverAddress = requireNonNull(nodeInfo, "nodeInfo is null").getExternalAddress();
         this.environment = requireNonNull(nodeInfo, "nodeInfo is null").getEnvironment();
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
-        this.functionRegistry = requireNonNull(metadata, "metadata is null").getFunctionRegistry();
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.functionRegistry = metadata.getFunctionRegistry();
         this.maxJsonLimit = toIntExact(requireNonNull(config, "config is null").getMaxOutputStageJsonSize().toBytes());
     }
 
@@ -306,6 +308,7 @@ public class QueryMonitor
                 return Optional.of(textDistributedPlan(
                         queryInfo.getOutputStage().get(),
                         functionRegistry,
+                        Optional.empty(), // transaction is no longer active, so metadata is useless
                         queryInfo.getSession().toSession(sessionPropertyManager),
                         false));
             }

--- a/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
@@ -25,6 +25,7 @@ import io.prestosql.spi.connector.ConnectorCapabilities;
 import io.prestosql.spi.connector.ConnectorOutputMetadata;
 import io.prestosql.spi.connector.ConnectorTableMetadata;
 import io.prestosql.spi.connector.Constraint;
+import io.prestosql.spi.connector.ConstraintApplicationResult;
 import io.prestosql.spi.connector.LimitApplicationResult;
 import io.prestosql.spi.connector.SystemTable;
 import io.prestosql.spi.predicate.TupleDomain;
@@ -390,4 +391,6 @@ public interface Metadata
     boolean usesLegacyTableLayouts(Session session, TableHandle table);
 
     Optional<LimitApplicationResult<TableHandle>> applyLimit(Session session, TableHandle table, long limit);
+
+    Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint<ColumnHandle> constraint);
 }

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/QueryExplainer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/QueryExplainer.java
@@ -117,10 +117,10 @@ public class QueryExplainer
         switch (planType) {
             case LOGICAL:
                 Plan plan = getLogicalPlan(session, statement, parameters, warningCollector);
-                return PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionRegistry(), plan.getStatsAndCosts(), session, 0, false);
+                return PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionRegistry(), Optional.of(metadata), plan.getStatsAndCosts(), session, 0, false);
             case DISTRIBUTED:
                 SubPlan subPlan = getDistributedPlan(session, statement, parameters, warningCollector);
-                return PlanPrinter.textDistributedPlan(subPlan, metadata.getFunctionRegistry(), session, false);
+                return PlanPrinter.textDistributedPlan(subPlan, metadata.getFunctionRegistry(), Optional.of(metadata), session, false);
             case IO:
                 return IoPlanPrinter.textIoPlan(getLogicalPlan(session, statement, parameters, warningCollector).getRoot(), metadata, session);
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/LocalExecutionPlanner.java
@@ -755,6 +755,7 @@ public class LocalExecutionPlanner
                     node.getId(),
                     analyzeContext.getQueryPerformanceFetcher(),
                     metadata.getFunctionRegistry(),
+                    metadata,
                     node.isVerbose());
             return new PhysicalOperation(operatorFactory, makeLayout(node), context, source);
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanFragmenter.java
@@ -246,7 +246,7 @@ public class PlanFragmenter
                     properties.getPartitioningScheme(),
                     ungroupedExecution(),
                     statsAndCosts.getForSubplan(root),
-                    Optional.of(jsonFragmentPlan(root, symbols, metadata.getFunctionRegistry(), session)));
+                    Optional.of(jsonFragmentPlan(root, symbols, metadata.getFunctionRegistry(), Optional.of(metadata), session)));
 
             return new SubPlan(fragment, properties.getChildren());
         }
@@ -775,7 +775,6 @@ public class PlanFragmenter
                     newTable,
                     node.getOutputSymbols(),
                     node.getAssignments(),
-                    node.getCurrentConstraint(),
                     node.getEnforcedConstraint());
         }
     }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneTableScanColumns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneTableScanColumns.java
@@ -42,7 +42,6 @@ public class PruneTableScanColumns
                         tableScanNode.getTable(),
                         filteredCopy(tableScanNode.getOutputSymbols(), referencedOutputs::contains),
                         filterKeys(tableScanNode.getAssignments(), referencedOutputs::contains),
-                        tableScanNode.getCurrentConstraint(),
                         tableScanNode.getEnforcedConstraint()));
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushLimitIntoTableScan.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushLimitIntoTableScan.java
@@ -59,7 +59,6 @@ public class PushLimitIntoTableScan
                             result.getHandle(),
                             tableScan.getOutputSymbols(),
                             tableScan.getAssignments(),
-                            tableScan.getCurrentConstraint(),
                             tableScan.getEnforcedConstraint());
 
                     if (!result.isLimitGuaranteed()) {

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -137,8 +137,7 @@ public class PushPredicateIntoTableScan
 
         TableScanNode rewrittenTableScan = (TableScanNode) rewrittenFilter.getSource();
 
-        return Objects.equals(tableScan.getCurrentConstraint(), rewrittenTableScan.getCurrentConstraint())
-                && Objects.equals(tableScan.getEnforcedConstraint(), rewrittenTableScan.getEnforcedConstraint());
+        return Objects.equals(tableScan.getEnforcedConstraint(), rewrittenTableScan.getEnforcedConstraint());
     }
 
     public static Optional<PlanNode> pushFilterIntoTableScan(
@@ -209,7 +208,6 @@ public class PushPredicateIntoTableScan
                 layout.get().getNewTableHandle(),
                 node.getOutputSymbols(),
                 node.getAssignments(),
-                layout.get().getTableProperties().getPredicate(),
                 computeEnforced(newDomain, layout.get().getUnenforcedConstraint()));
 
         // The order of the arguments to combineConjuncts matters:

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/BeginTableWrite.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/BeginTableWrite.java
@@ -192,7 +192,6 @@ public class BeginTableWrite
                         handle,
                         scan.getOutputSymbols(),
                         scan.getAssignments(),
-                        scan.getCurrentConstraint(),
                         scan.getEnforcedConstraint());
             }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PredicatePushDown.java
@@ -106,7 +106,7 @@ public class PredicatePushDown
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.literalEncoder = new LiteralEncoder(metadata.getBlockEncodingSerde());
-        this.effectivePredicateExtractor = new EffectivePredicateExtractor(new DomainTranslator(literalEncoder));
+        this.effectivePredicateExtractor = new EffectivePredicateExtractor(new DomainTranslator(literalEncoder), metadata);
         this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
     }
 
@@ -383,8 +383,8 @@ public class PredicatePushDown
             // See if we can rewrite outer joins in terms of a plain inner join
             node = tryNormalizeToOuterToInnerJoin(node, inheritedPredicate);
 
-            Expression leftEffectivePredicate = effectivePredicateExtractor.extract(node.getLeft());
-            Expression rightEffectivePredicate = effectivePredicateExtractor.extract(node.getRight());
+            Expression leftEffectivePredicate = effectivePredicateExtractor.extract(session, node.getLeft());
+            Expression rightEffectivePredicate = effectivePredicateExtractor.extract(session, node.getRight());
             Expression joinPredicate = extractJoinPredicate(node);
 
             Expression leftPredicate;
@@ -549,8 +549,8 @@ public class PredicatePushDown
                 node = new SpatialJoinNode(node.getId(), SpatialJoinNode.Type.INNER, node.getLeft(), node.getRight(), node.getOutputSymbols(), node.getFilter(), node.getLeftPartitionSymbol(), node.getRightPartitionSymbol(), node.getKdbTree());
             }
 
-            Expression leftEffectivePredicate = effectivePredicateExtractor.extract(node.getLeft());
-            Expression rightEffectivePredicate = effectivePredicateExtractor.extract(node.getRight());
+            Expression leftEffectivePredicate = effectivePredicateExtractor.extract(session, node.getLeft());
+            Expression rightEffectivePredicate = effectivePredicateExtractor.extract(session, node.getRight());
             Expression joinPredicate = node.getFilter();
 
             Expression leftPredicate;
@@ -1036,8 +1036,8 @@ public class PredicatePushDown
         {
             Expression inheritedPredicate = context.get();
             Expression deterministicInheritedPredicate = filterDeterministicConjuncts(inheritedPredicate);
-            Expression sourceEffectivePredicate = filterDeterministicConjuncts(effectivePredicateExtractor.extract(node.getSource()));
-            Expression filteringSourceEffectivePredicate = filterDeterministicConjuncts(effectivePredicateExtractor.extract(node.getFilteringSource()));
+            Expression sourceEffectivePredicate = filterDeterministicConjuncts(effectivePredicateExtractor.extract(session, node.getSource()));
+            Expression filteringSourceEffectivePredicate = filterDeterministicConjuncts(effectivePredicateExtractor.extract(session, node.getFilteringSource()));
             Expression joinExpression = new ComparisonExpression(
                     ComparisonExpression.Operator.EQUAL,
                     node.getSourceJoinSymbol().toSymbolReference(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PropertyDerivations.java
@@ -713,7 +713,9 @@ public class PropertyDerivations
 
             // Globally constant assignments
             Map<ColumnHandle, NullableValue> globalConstants = new HashMap<>();
-            extractFixedValues(node.getCurrentConstraint()).orElse(ImmutableMap.of())
+
+            extractFixedValues(metadata.getTableProperties(session, node.getTable()).getPredicate())
+                    .orElse(ImmutableMap.of())
                     .entrySet().stream()
                     .filter(entry -> !entry.getValue().isNull())
                     .forEach(entry -> globalConstants.put(entry.getKey(), entry.getValue()));

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -426,7 +426,6 @@ public class PruneUnreferencedOutputs
                     node.getTable(),
                     newOutputs,
                     newAssignments,
-                    node.getCurrentConstraint(),
                     node.getEnforcedConstraint());
         }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -259,7 +259,8 @@ public final class StreamPropertyDerivations
 
             // Globally constant assignments
             Set<ColumnHandle> constants = new HashSet<>();
-            extractFixedValues(node.getCurrentConstraint()).orElse(ImmutableMap.of())
+            extractFixedValues(metadata.getTableProperties(session, node.getTable()).getPredicate())
+                    .orElse(ImmutableMap.of())
                     .entrySet().stream()
                     .filter(entry -> !entry.getValue().isNull())  // TODO consider allowing nulls
                     .forEach(entry -> constants.add(entry.getKey()));

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/IoPlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/IoPlanPrinter.java
@@ -474,12 +474,13 @@ public class IoPlanPrinter
         public Void visitTableScan(TableScanNode node, IoPlanBuilder context)
         {
             TableMetadata tableMetadata = metadata.getTableMetadata(session, node.getTable());
+            TupleDomain<ColumnHandle> predicate = metadata.getTableProperties(session, node.getTable()).getPredicate();
             context.addInputTableColumnInfo(new IoPlan.TableColumnInfo(
                     new CatalogSchemaTableName(
                             tableMetadata.getCatalogName().getCatalogName(),
                             tableMetadata.getTable().getSchemaName(),
                             tableMetadata.getTable().getTableName()),
-                    parseConstraints(node.getTable(), node.getCurrentConstraint())));
+                    parseConstraints(node.getTable(), predicate)));
             return null;
         }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
@@ -31,6 +31,7 @@ import io.prestosql.cost.StatsAndCosts;
 import io.prestosql.execution.StageInfo;
 import io.prestosql.execution.StageStats;
 import io.prestosql.metadata.FunctionRegistry;
+import io.prestosql.metadata.Metadata;
 import io.prestosql.metadata.OperatorNotFoundException;
 import io.prestosql.metadata.Signature;
 import io.prestosql.metadata.TableHandle;
@@ -139,12 +140,14 @@ public class PlanPrinter
 {
     private final PlanRepresentation representation;
     private final FunctionRegistry functionRegistry;
+    private final Optional<Metadata> metadata;
 
     private PlanPrinter(
             PlanNode planRoot,
             TypeProvider types,
             Optional<StageExecutionDescriptor> stageExecutionStrategy,
             FunctionRegistry functionRegistry,
+            Optional<Metadata> metadata,
             StatsAndCosts estimatedStatsAndCosts,
             Session session,
             Optional<Map<PlanNodeId, PlanNodeStats>> stats)
@@ -152,10 +155,12 @@ public class PlanPrinter
         requireNonNull(planRoot, "planRoot is null");
         requireNonNull(types, "types is null");
         requireNonNull(functionRegistry, "functionRegistry is null");
+        requireNonNull(metadata, "metadata is null");
         requireNonNull(estimatedStatsAndCosts, "estimatedStatsAndCosts is null");
         requireNonNull(stats, "stats is null");
 
         this.functionRegistry = functionRegistry;
+        this.metadata = metadata;
 
         Optional<Duration> totalCpuTime = stats.map(s -> new Duration(s.values().stream()
                 .mapToLong(planNode -> planNode.getPlanNodeScheduledTime().toMillis())
@@ -181,30 +186,31 @@ public class PlanPrinter
         return new JsonRenderer().render(representation);
     }
 
-    public static String jsonFragmentPlan(PlanNode root, Map<Symbol, Type> symbols, FunctionRegistry functionRegistry, Session session)
+    public static String jsonFragmentPlan(PlanNode root, Map<Symbol, Type> symbols, FunctionRegistry functionRegistry, Optional<Metadata> metadata, Session session)
     {
         TypeProvider typeProvider = TypeProvider.copyOf(symbols.entrySet().stream()
                 .distinct()
                 .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
 
-        return new PlanPrinter(root, typeProvider, Optional.empty(), functionRegistry, StatsAndCosts.empty(), session, Optional.empty()).toJson();
+        return new PlanPrinter(root, typeProvider, Optional.empty(), functionRegistry, metadata, StatsAndCosts.empty(), session, Optional.empty()).toJson();
     }
 
-    public static String textLogicalPlan(PlanNode plan, TypeProvider types, FunctionRegistry functionRegistry, StatsAndCosts estimatedStatsAndCosts, Session session, int level)
+    public static String textLogicalPlan(PlanNode plan, TypeProvider types, FunctionRegistry functionRegistry, Optional<Metadata> metadata, StatsAndCosts estimatedStatsAndCosts, Session session, int level)
     {
-        return new PlanPrinter(plan, types, Optional.empty(), functionRegistry, estimatedStatsAndCosts, session, Optional.empty()).toText(false, level);
+        return new PlanPrinter(plan, types, Optional.empty(), functionRegistry, metadata, estimatedStatsAndCosts, session, Optional.empty()).toText(false, level);
     }
 
     public static String textLogicalPlan(
             PlanNode plan,
             TypeProvider types,
             FunctionRegistry functionRegistry,
+            Optional<Metadata> metadata,
             StatsAndCosts estimatedStatsAndCosts,
             Session session,
             int level,
             boolean verbose)
     {
-        return textLogicalPlan(plan, types, Optional.empty(), functionRegistry, estimatedStatsAndCosts, session, Optional.empty(), level, verbose);
+        return textLogicalPlan(plan, types, Optional.empty(), functionRegistry, metadata, estimatedStatsAndCosts, session, Optional.empty(), level, verbose);
     }
 
     public static String textLogicalPlan(
@@ -212,16 +218,17 @@ public class PlanPrinter
             TypeProvider types,
             Optional<StageExecutionDescriptor> stageExecutionStrategy,
             FunctionRegistry functionRegistry,
+            Optional<Metadata> metadata,
             StatsAndCosts estimatedStatsAndCosts,
             Session session,
             Optional<Map<PlanNodeId, PlanNodeStats>> stats,
             int level,
             boolean verbose)
     {
-        return new PlanPrinter(plan, types, stageExecutionStrategy, functionRegistry, estimatedStatsAndCosts, session, stats).toText(verbose, level);
+        return new PlanPrinter(plan, types, stageExecutionStrategy, functionRegistry, metadata, estimatedStatsAndCosts, session, stats).toText(verbose, level);
     }
 
-    public static String textDistributedPlan(StageInfo outputStageInfo, FunctionRegistry functionRegistry, Session session, boolean verbose)
+    public static String textDistributedPlan(StageInfo outputStageInfo, FunctionRegistry functionRegistry, Optional<Metadata> metadata, Session session, boolean verbose)
     {
         StringBuilder builder = new StringBuilder();
         List<StageInfo> allStages = getAllStages(Optional.of(outputStageInfo));
@@ -230,23 +237,23 @@ public class PlanPrinter
                 .collect(toImmutableList());
         Map<PlanNodeId, PlanNodeStats> aggregatedStats = aggregateStageStats(allStages);
         for (StageInfo stageInfo : allStages) {
-            builder.append(formatFragment(functionRegistry, session, stageInfo.getPlan(), Optional.of(stageInfo), Optional.of(aggregatedStats), verbose, allFragments));
+            builder.append(formatFragment(functionRegistry, metadata, session, stageInfo.getPlan(), Optional.of(stageInfo), Optional.of(aggregatedStats), verbose, allFragments));
         }
 
         return builder.toString();
     }
 
-    public static String textDistributedPlan(SubPlan plan, FunctionRegistry functionRegistry, Session session, boolean verbose)
+    public static String textDistributedPlan(SubPlan plan, FunctionRegistry functionRegistry, Optional<Metadata> metadata, Session session, boolean verbose)
     {
         StringBuilder builder = new StringBuilder();
         for (PlanFragment fragment : plan.getAllFragments()) {
-            builder.append(formatFragment(functionRegistry, session, fragment, Optional.empty(), Optional.empty(), verbose, plan.getAllFragments()));
+            builder.append(formatFragment(functionRegistry, metadata, session, fragment, Optional.empty(), Optional.empty(), verbose, plan.getAllFragments()));
         }
 
         return builder.toString();
     }
 
-    private static String formatFragment(FunctionRegistry functionRegistry, Session session, PlanFragment fragment, Optional<StageInfo> stageInfo, Optional<Map<PlanNodeId, PlanNodeStats>> planNodeStats, boolean verbose, List<PlanFragment> allFragments)
+    private static String formatFragment(FunctionRegistry functionRegistry, Optional<Metadata> metadata, Session session, PlanFragment fragment, Optional<StageInfo> stageInfo, Optional<Map<PlanNodeId, PlanNodeStats>> planNodeStats, boolean verbose, List<PlanFragment> allFragments)
     {
         StringBuilder builder = new StringBuilder();
         builder.append(format("Fragment %s [%s]\n",
@@ -307,7 +314,7 @@ public class PlanPrinter
                 .flatMap(f -> f.getSymbols().entrySet().stream())
                 .distinct()
                 .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
-        builder.append(textLogicalPlan(fragment.getRoot(), typeProvider, Optional.of(fragment.getStageExecutionDescriptor()), functionRegistry, fragment.getStatsAndCosts(), session, planNodeStats, 1, verbose))
+        builder.append(textLogicalPlan(fragment.getRoot(), typeProvider, Optional.of(fragment.getStageExecutionDescriptor()), functionRegistry, metadata, fragment.getStatsAndCosts(), session, planNodeStats, 1, verbose))
                 .append("\n");
 
         return builder.toString();
@@ -758,7 +765,10 @@ public class PlanPrinter
 
         private void printTableScanInfo(NodeRepresentation nodeOutput, TableScanNode node)
         {
-            TupleDomain<ColumnHandle> predicate = node.getCurrentConstraint();
+            TupleDomain<ColumnHandle> predicate = metadata
+                    .map(value -> value.getTableProperties(session, node.getTable()).getPredicate())
+                    .orElse(TupleDomain.all());
+
             if (predicate.isNone()) {
                 nodeOutput.appendDetailsLine(":: NONE");
             }

--- a/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowStatsRewrite.java
+++ b/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowStatsRewrite.java
@@ -201,7 +201,7 @@ public class ShowStatsRewrite
                 return Constraint.alwaysFalse();
             }
 
-            return new Constraint<>(scanNode.get().getCurrentConstraint());
+            return new Constraint<>(metadata.getTableProperties(session, scanNode.get().getTable()).getPredicate());
         }
 
         private TableHandle getTableHandle(ShowStats node, QualifiedName table)

--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -686,7 +686,7 @@ public class LocalQueryRunner
     private List<Driver> createDrivers(Session session, Plan plan, OutputFactory outputFactory, TaskContext taskContext)
     {
         if (printPlan) {
-            System.out.println(PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionRegistry(), plan.getStatsAndCosts(), session, 0, false));
+            System.out.println(PlanPrinter.textLogicalPlan(plan.getRoot(), plan.getTypes(), metadata.getFunctionRegistry(), Optional.of(metadata), plan.getStatsAndCosts(), session, 0, false));
         }
 
         SubPlan subplan = planFragmenter.createSubPlans(session, plan, true, WarningCollector.NOOP);

--- a/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/io/prestosql/cost/TestCostCalculator.java
@@ -750,7 +750,6 @@ public class TestCostCalculator
                 new TableHandle(new CatalogName("tpch"), tableHandle, INSTANCE, Optional.of(new TpchTableLayoutHandle(tableHandle, TupleDomain.all()))),
                 symbolsList,
                 assignments.build(),
-                TupleDomain.all(),
                 TupleDomain.all());
     }
 

--- a/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
@@ -24,6 +24,7 @@ import io.prestosql.spi.connector.ConnectorCapabilities;
 import io.prestosql.spi.connector.ConnectorOutputMetadata;
 import io.prestosql.spi.connector.ConnectorTableMetadata;
 import io.prestosql.spi.connector.Constraint;
+import io.prestosql.spi.connector.ConstraintApplicationResult;
 import io.prestosql.spi.connector.LimitApplicationResult;
 import io.prestosql.spi.connector.SystemTable;
 import io.prestosql.spi.predicate.TupleDomain;
@@ -525,6 +526,12 @@ public abstract class AbstractMockMetadata
 
     @Override
     public Optional<LimitApplicationResult<TableHandle>> applyLimit(Session session, TableHandle table, long limit)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ConstraintApplicationResult<TableHandle>> applyFilter(Session session, TableHandle table, Constraint<ColumnHandle> constraint)
     {
         return Optional.empty();
     }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestTypeValidator.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestTypeValidator.java
@@ -99,7 +99,6 @@ public class TestTypeValidator
                 TEST_TABLE_HANDLE,
                 ImmutableList.copyOf(assignments.keySet()),
                 assignments,
-                TupleDomain.all(),
                 TupleDomain.all());
     }
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanAssert.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanAssert.java
@@ -23,6 +23,8 @@ import io.prestosql.sql.planner.Plan;
 import io.prestosql.sql.planner.iterative.Lookup;
 import io.prestosql.sql.planner.plan.PlanNode;
 
+import java.util.Optional;
+
 import static io.prestosql.sql.planner.iterative.Lookup.noLookup;
 import static io.prestosql.sql.planner.iterative.Plans.resolveGroupReferences;
 import static io.prestosql.sql.planner.planprinter.PlanPrinter.textLogicalPlan;
@@ -47,9 +49,9 @@ public final class PlanAssert
     {
         MatchResult matches = actual.getRoot().accept(new PlanMatchingVisitor(session, metadata, statsProvider, lookup), pattern);
         if (!matches.isMatch()) {
-            String formattedPlan = textLogicalPlan(actual.getRoot(), actual.getTypes(), metadata.getFunctionRegistry(), StatsAndCosts.empty(), session, 0);
+            String formattedPlan = textLogicalPlan(actual.getRoot(), actual.getTypes(), metadata.getFunctionRegistry(), Optional.of(metadata), StatsAndCosts.empty(), session, 0);
             PlanNode resolvedPlan = resolveGroupReferences(actual.getRoot(), lookup);
-            String resolvedFormattedPlan = textLogicalPlan(resolvedPlan, actual.getTypes(), metadata.getFunctionRegistry(), StatsAndCosts.empty(), session, 0);
+            String resolvedFormattedPlan = textLogicalPlan(resolvedPlan, actual.getTypes(), metadata.getFunctionRegistry(), Optional.of(metadata), StatsAndCosts.empty(), session, 0);
             throw new AssertionError(format(
                     "Plan does not match, expected [\n\n%s\n] but found [\n\n%s\n] which resolves to [\n\n%s\n]",
                     pattern,

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/TableScanMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/TableScanMatcher.java
@@ -61,7 +61,7 @@ final class TableScanMatcher
         return new MatchResult(
                 expectedTableName.equalsIgnoreCase(actualTableName) &&
                         ((!expectedConstraint.isPresent()) ||
-                                domainsMatch(expectedConstraint, tableScanNode.getCurrentConstraint(), tableScanNode.getTable(), session, metadata)));
+                                domainsMatch(expectedConstraint, tableScanNode.getEnforcedConstraint(), tableScanNode.getTable(), session, metadata)));
     }
 
     @Override

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
@@ -103,7 +103,6 @@ public class TestPushPredicateIntoTableScan
                                 nationTableHandle,
                                 ImmutableList.of(p.symbol("nationkey", BIGINT)),
                                 ImmutableMap.of(p.symbol("nationkey", BIGINT), columnHandle),
-                                TupleDomain.none(),
                                 TupleDomain.none())))
                 .matches(values("A"));
     }
@@ -117,7 +116,6 @@ public class TestPushPredicateIntoTableScan
                                 nationTableHandle,
                                 ImmutableList.of(p.symbol("nationkey", BIGINT)),
                                 ImmutableMap.of(p.symbol("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)),
-                                TupleDomain.all(),
                                 TupleDomain.all())))
                 .doesNotFire();
     }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -380,14 +380,13 @@ public class PlanBuilder
             List<Symbol> symbols,
             Map<Symbol, ColumnHandle> assignments)
     {
-        return tableScan(tableHandle, symbols, assignments, TupleDomain.all(), TupleDomain.all());
+        return tableScan(tableHandle, symbols, assignments, TupleDomain.all());
     }
 
     public TableScanNode tableScan(
             TableHandle tableHandle,
             List<Symbol> symbols,
             Map<Symbol, ColumnHandle> assignments,
-            TupleDomain<ColumnHandle> currentConstraint,
             TupleDomain<ColumnHandle> enforcedConstraint)
     {
         return new TableScanNode(
@@ -395,7 +394,6 @@ public class PlanBuilder
                 tableHandle,
                 symbols,
                 assignments,
-                currentConstraint,
                 enforcedConstraint);
     }
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/RuleAssert.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/RuleAssert.java
@@ -120,7 +120,7 @@ public class RuleAssert
             fail(format(
                     "Expected %s to not fire for:\n%s",
                     rule.getClass().getName(),
-                    inTransaction(session -> textLogicalPlan(plan, ruleApplication.types, metadata.getFunctionRegistry(), StatsAndCosts.empty(), session, 2))));
+                    inTransaction(session -> textLogicalPlan(plan, ruleApplication.types, metadata.getFunctionRegistry(), Optional.of(metadata), StatsAndCosts.empty(), session, 2))));
         }
     }
 
@@ -194,7 +194,7 @@ public class RuleAssert
     {
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator, session, types);
         CostProvider costProvider = new CachingCostProvider(costCalculator, statsProvider, session, types);
-        return inTransaction(session -> textLogicalPlan(plan, types, metadata.getFunctionRegistry(), StatsAndCosts.create(plan, statsProvider, costProvider), session, 2, false));
+        return inTransaction(session -> textLogicalPlan(plan, types, metadata.getFunctionRegistry(), Optional.of(metadata), StatsAndCosts.create(plan, statsProvider, costProvider), session, 2, false));
     }
 
     private <T> T inTransaction(Function<Session, T> transactionSessionConsumer)

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
@@ -602,4 +602,23 @@ public interface ConnectorMetadata
     {
         return Optional.empty();
     }
+
+    /**
+     * Attempt to push down the provided constraint into the table. This method is provided as replacement to
+     * {@link ConnectorMetadata#getTableLayouts(ConnectorSession, ConnectorTableHandle, Constraint, Optional)} to ease
+     * migration for the legacy API.
+     * <p>
+     * Connectors can indicate whether they don't support predicate pushdown or that the action had no effect
+     * by returning {@link Optional#empty()}. Connectors should expect this method to be called multiple times
+     * during the optimization of a given query.
+     * <p>
+     * <b>Note</b>: it's critical for connectors to return Optional.empty() if calling this method has no effect for that
+     * invocation, even if the connector generally supports pushdown. Doing otherwise can cause the optimizer
+     * to loop indefinitely.
+     * </p>
+     */
+    default Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorTableHandle handle, Constraint constraint)
+    {
+        return Optional.empty();
+    }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConstraintApplicationResult.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConstraintApplicationResult.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi.connector;
+
+import io.prestosql.spi.predicate.TupleDomain;
+
+import static java.util.Objects.requireNonNull;
+
+public class ConstraintApplicationResult<T>
+{
+    private final T handle;
+    private final TupleDomain<ColumnHandle> remainingFilter;
+
+    public ConstraintApplicationResult(T handle, TupleDomain<ColumnHandle> remainingFilter)
+    {
+        this.handle = requireNonNull(handle, "handle is null");
+        this.remainingFilter = requireNonNull(remainingFilter, "remainingFilter is null");
+    }
+
+    public T getHandle()
+    {
+        return handle;
+    }
+
+    public TupleDomain<ColumnHandle> getRemainingFilter()
+    {
+        return remainingFilter;
+    }
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -33,6 +33,7 @@ import io.prestosql.spi.connector.ConnectorTableMetadata;
 import io.prestosql.spi.connector.ConnectorTableProperties;
 import io.prestosql.spi.connector.ConnectorViewDefinition;
 import io.prestosql.spi.connector.Constraint;
+import io.prestosql.spi.connector.ConstraintApplicationResult;
 import io.prestosql.spi.connector.LimitApplicationResult;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
@@ -564,6 +565,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.applyLimit(table, limit);
+        }
+    }
+
+    @Override
+    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorTableHandle table, Constraint constraint)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.applyFilter(table, constraint);
         }
     }
 }

--- a/presto-tests/src/main/java/io/prestosql/tests/PlanDeterminismChecker.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/PlanDeterminismChecker.java
@@ -20,6 +20,7 @@ import io.prestosql.sql.planner.Plan;
 import io.prestosql.sql.planner.planprinter.PlanPrinter;
 import io.prestosql.testing.LocalQueryRunner;
 
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
@@ -67,6 +68,7 @@ public class PlanDeterminismChecker
                     plan.getRoot(),
                     plan.getTypes(),
                     localQueryRunner.getMetadata().getFunctionRegistry(),
+                    Optional.of(localQueryRunner.getMetadata()),
                     plan.getStatsAndCosts(),
                     transactionSession,
                     0,

--- a/presto-tpch/src/main/java/io/prestosql/plugin/tpch/TpchMetadata.java
+++ b/presto-tpch/src/main/java/io/prestosql/plugin/tpch/TpchMetadata.java
@@ -265,7 +265,7 @@ public class TpchMetadata
         TpchTableLayoutHandle layout = (TpchTableLayoutHandle) handle;
 
         // tables in this connector have a single layout
-        return getTableLayouts(session, layout.getTable(), Constraint.alwaysTrue(), Optional.empty())
+        return getTableLayouts(session, layout.getTable(), new Constraint<>(layout.getPredicate()), Optional.empty())
                 .get(0)
                 .getTableLayout();
     }


### PR DESCRIPTION
The ability to push down a Constraint (TupleDomain + opaque predicate evaluator) is the last piece needed to fully deprecate Table Layouts. The new applyFilter function introduces a specialized API that connectors can implement to obtain the same behavior without having to deal with Table Layouts, TableLayoutHandle, etc. It is meant as a transitional API until the fully-feature applyFilter with generalized predicates is implemented.