### PR TITLE
Tighten equality inference for expressions involving casts

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/NullabilityAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/NullabilityAnalyzer.java
@@ -55,8 +55,17 @@ public final class NullabilityAnalyzer
         @Override
         protected Void visitCast(Cast node, AtomicBoolean result)
         {
-            // try_cast and cast(JSON 'null' AS ...) can return null
-            result.set(true);
+            // Certain casts (e.g., cast(JSON 'null' AS ...)) can return null, but we know
+            // that any "type-only" coercion cannot produce null on non-null input, so
+            // take advantage of that fact to produce a more precise result.
+            //
+            // TODO: need a generic way to determine whether a CAST can produce null on non-null input.
+            // This should be part of the metadata associated with the CAST. (N.B. the rules in
+            // ISO/IEC 9075-2:2016, section 7.16.21 seems to imply that CAST cannot return NULL
+            // except for the CAST(NULL AS x) case -- we should fix this at some point)
+            //
+            // Also, try_cast (i.e., safe cast) can return null
+            result.set(node.isSafe() || !node.isTypeOnly());
             return null;
         }
 


### PR DESCRIPTION
Inferring equality based on join criteria requires being
able to prove that the values involved in the comparison
are not null. The current implementation (NullabilityAnalyzer)
produces an extremely conservative answer on whether
an expression might produce a null. In particular, it always
indicates that an expression containing a cast may produce null.

SQL expressions involving values of different types will always
have some intervening cast to a common type. This is particularly
common for expressions involving constants, whose derived type
is the most specific type that fits the value (e.g., varchar(n),
decimal(p, s)).

This change tightens the heuristic for determining if a cast can
produce null by taking advantage of the fact that type-only
casts (i.e., widening conversions for certain types) can never
produce null.