### PR TITLE
Render output layout in a separate line

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/TextRenderer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/TextRenderer.java
@@ -60,11 +60,13 @@ public class TextRenderer
                 .append("- ")
                 .append(node.getName())
                 .append(node.getIdentifier())
-                .append(" => [")
-                .append(node.getOutputs().stream()
-                        .map(s -> s.getSymbol() + ":" + s.getType())
-                        .collect(joining(", ")))
-                .append("]\n");
+                .append("\n");
+
+        String columns = node.getOutputs().stream()
+                .map(s -> s.getSymbol() + ":" + s.getType())
+                .collect(joining(", "));
+
+        output.append(indentMultilineString("Layout: [" + columns + "]\n", level + 2));
 
         String estimates = printEstimates(plan, node);
         if (!estimates.isEmpty()) {


### PR DESCRIPTION
It makes it easier to visually separate it from the main details of the given operation.

Example:

```
- ScanFilterProject[table = tpch:orders:sf0.01, filterPredicate = ("orderdate" > DATE '2019-01-01')]
         Layout: [orderdate:date, orderstatus:varchar(1), expr:double]
         Estimates: {rows: 15000 (278.32kB), cpu: 285003.00, memory: 0.00, network: 0.00}/{rows: 0 (0B), cpu: 570006.00, memory: 0.00, network
         expr := ("totalprice" / 1E3)
         orderstatus := tpch:orderstatus
             :: [[F], [O], [P]]
         totalprice := tpch:totalprice
         orderdate := tpch:orderdate
```