### PR TITLE
Remove duplicate predicates

### DIFF
--- a/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoinPlanning.java
+++ b/presto-geospatial/src/test/java/io/prestosql/plugin/geospatial/TestSpatialJoinPlanning.java
@@ -295,14 +295,14 @@ public class TestSpatialJoinPlanning
 
         assertPlan("SELECT b.name, a.name " +
                         "FROM (VALUES (2.1, 2.1, 'x')) AS a (lng, lat, name), (VALUES (2.1, 2.1, 'x')) AS b (lng, lat, name) " +
-                        "WHERE ST_Distance(ST_Point(a.lng, a.lat), ST_Point(b.lng, b.lat)) <= 300 / (111321 * cos(radians(b.lat)))",
+                        "WHERE ST_Distance(ST_Point(a.lng, a.lat), ST_Point(b.lng, b.lat)) <= 300 / (cos(radians(b.lat)) * 111321)",
                 anyTree(
                         spatialJoin("st_distance(st_point_a, st_point_b) <= radius",
                                 project(ImmutableMap.of("st_point_a", expression("ST_Point(cast(a_lng as double), cast(a_lat as double))")),
                                         anyTree(
                                                 values(ImmutableMap.of("a_lng", 0, "a_lat", 1)))),
                                 anyTree(
-                                        project(ImmutableMap.of("st_point_b", expression("ST_Point(cast(b_lng as double), cast(b_lat as double))"), "radius", expression("3e2 / (111.321e3 * cos(radians(cast(b_lat as double))))")),
+                                        project(ImmutableMap.of("st_point_b", expression("ST_Point(cast(b_lng as double), cast(b_lat as double))"), "radius", expression("3e2 / (cos(radians(cast(b_lat as double))) * 111.321e3)")),
                                                 anyTree(
                                                         values(ImmutableMap.of("b_lng", 0, "b_lat", 1))))))));
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -97,6 +97,7 @@ import io.prestosql.sql.planner.iterative.rule.PushTopNThroughOuterJoin;
 import io.prestosql.sql.planner.iterative.rule.PushTopNThroughProject;
 import io.prestosql.sql.planner.iterative.rule.PushTopNThroughUnion;
 import io.prestosql.sql.planner.iterative.rule.RemoveAggregationInSemiJoin;
+import io.prestosql.sql.planner.iterative.rule.RemoveDuplicateConditions;
 import io.prestosql.sql.planner.iterative.rule.RemoveEmptyDelete;
 import io.prestosql.sql.planner.iterative.rule.RemoveFullSample;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantDistinctLimit;
@@ -263,7 +264,11 @@ public class PlanOptimizers
                 ruleStats,
                 statsCalculator,
                 estimatedExchangesCostCalculator,
-                new SimplifyExpressions(metadata, typeAnalyzer).rules());
+                ImmutableSet.<Rule<?>>builder()
+                    .addAll(new SimplifyExpressions(metadata, typeAnalyzer).rules())
+                    .addAll(new RemoveDuplicateConditions().rules())
+                    .addAll(new CanonicalizeExpressions().rules())
+                    .build());
 
         PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, typeAnalyzer));
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveDuplicateConditions.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveDuplicateConditions.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.ExpressionTreeRewriter;
+import io.prestosql.sql.tree.LogicalBinaryExpression;
+
+import static io.prestosql.sql.ExpressionUtils.combinePredicates;
+import static io.prestosql.sql.ExpressionUtils.extractPredicates;
+
+/**
+ * Flattens and removes duplicate conjuncts or disjuncts. E.g.,
+ *
+ * a = 1 AND a = 1
+ *
+ * rewrites to:
+ *
+ * a = 1
+ */
+public class RemoveDuplicateConditions
+        extends ExpressionRewriteRuleSet
+{
+    public RemoveDuplicateConditions()
+    {
+        super(createRewrite());
+    }
+
+    private static ExpressionRewriter createRewrite()
+    {
+        return (expression, context) -> ExpressionTreeRewriter.rewriteWith(new Visitor(), expression);
+    }
+
+    private static class Visitor
+            extends io.prestosql.sql.tree.ExpressionRewriter<Void>
+    {
+        @Override
+        public Expression rewriteLogicalBinaryExpression(LogicalBinaryExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            return combinePredicates(node.getOperator(), extractPredicates(node));
+        }
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
@@ -1132,8 +1132,8 @@ public class TestExpressionInterpreter
         assertOptimizedEquals("coalesce(2 * 3 * unbound_long, 1 - 1, null)", "coalesce(6 * unbound_long, 0)");
         assertOptimizedEquals("coalesce(2 * 3 * unbound_long, 1.0E0/2.0E0, null)", "coalesce(6 * unbound_long, 0.5E0)");
         assertOptimizedEquals("coalesce(unbound_long, 2, 1.0E0/2.0E0, 12.34E0, null)", "coalesce(unbound_long, 2.0E0, 0.5E0, 12.34E0)");
-        assertOptimizedEquals("coalesce(2 * 3 * unbound_integer, 1 - 1, null)", "coalesce(6 * unbound_integer, 0)");
-        assertOptimizedEquals("coalesce(2 * 3 * unbound_integer, 1.0E0/2.0E0, null)", "coalesce(6 * unbound_integer, 0.5E0)");
+        assertOptimizedEquals("coalesce(unbound_integer * (2 * 3), 1 - 1, null)", "coalesce(6 * unbound_integer, 0)");
+        assertOptimizedEquals("coalesce(unbound_integer * (2 * 3), 1.0E0/2.0E0, null)", "coalesce(6 * unbound_integer, 0.5E0)");
         assertOptimizedEquals("coalesce(unbound_integer, 2, 1.0E0/2.0E0, 12.34E0, null)", "coalesce(unbound_integer, 2.0E0, 0.5E0, 12.34E0)");
         assertOptimizedMatches("coalesce(0 / 0 > 1, unbound_boolean, 0 / 0 = 0)",
                 "coalesce(cast(fail() as boolean), unbound_boolean)");

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestPredicatePushdown.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestPredicatePushdown.java
@@ -451,7 +451,7 @@ public class TestPredicatePushdown
                         "FROM orders" +
                         ") WHERE custkey > 100*rand()",
                 anyTree(
-                        filter("CAST(\"CUST_KEY\" AS double) > (1E2 * \"rand\"())",
+                        filter("CAST(\"CUST_KEY\" AS double) > (\"rand\"() * 1E2)",
                                 anyTree(
                                         node(WindowNode.class,
                                                 anyTree(

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestRemoveDuplicatePredicates.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestRemoveDuplicatePredicates.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner;
+
+import io.prestosql.sql.planner.assertions.BasePlanTest;
+import org.testng.annotations.Test;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestRemoveDuplicatePredicates
+        extends BasePlanTest
+{
+    @Test
+    public void testAnd()
+    {
+        assertPlan(
+                "SELECT * FROM (VALUES 1) t(a) WHERE a = 1 AND 1 = a AND a = 1",
+                anyTree(
+                        filter("A = 1",
+                                values("A"))));
+    }
+
+    @Test
+    public void testOr()
+    {
+        assertPlan(
+                "SELECT * FROM (VALUES 1) t(a) WHERE a = 1 OR 1 = a OR a = 1",
+                anyTree(
+                        filter("A = 1",
+                                values("A"))));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestCanonicalizeExpressionRewriter.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestCanonicalizeExpressionRewriter.java
@@ -45,6 +45,41 @@ public class TestCanonicalizeExpressionRewriter
         assertRewritten("EXTRACT(YEAR FROM '2017-07-20')", "year('2017-07-20')");
     }
 
+    @Test
+    public void testCanonicalizeArithmetic()
+    {
+        assertRewritten("a + 1", "a + 1");
+        assertRewritten("1 + a", "a + 1");
+
+        assertRewritten("a * 1", "a * 1");
+        assertRewritten("1 * a", "a * 1");
+    }
+
+    @Test
+    public void testCanonicalizeComparison()
+    {
+        assertRewritten("a = 1", "a = 1");
+        assertRewritten("1 = a", "a = 1");
+
+        assertRewritten("a <> 1", "a <> 1");
+        assertRewritten("1 <> a", "a <> 1");
+
+        assertRewritten("a > 1", "a > 1");
+        assertRewritten("1 > a", "a < 1");
+
+        assertRewritten("a < 1", "a < 1");
+        assertRewritten("1 < a", "a > 1");
+
+        assertRewritten("a >= 1", "a >= 1");
+        assertRewritten("1 >= a", "a <= 1");
+
+        assertRewritten("a <= 1", "a <= 1");
+        assertRewritten("1 <= a", "a >= 1");
+
+        assertRewritten("a IS DISTINCT FROM 1", "a IS DISTINCT FROM 1");
+        assertRewritten("1 IS DISTINCT FROM a", "a IS DISTINCT FROM 1");
+    }
+
     private static void assertRewritten(String from, String to)
     {
         assertEquals(canonicalizeExpression(PlanBuilder.expression(from)), PlanBuilder.expression(to));

--- a/presto-main/src/test/java/io/prestosql/type/TestBigintOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestBigintOperators.java
@@ -235,7 +235,7 @@ public class TestBigintOperators
     @Test
     public void testOverflowAdd()
     {
-        assertNumericOverflow(format("%s + 1", Long.MAX_VALUE), "bigint addition overflow: 9223372036854775807 + 1");
+        assertNumericOverflow(format("%s + BIGINT '1'", Long.MAX_VALUE), "bigint addition overflow: 9223372036854775807 + 1");
     }
 
     @Test
@@ -248,7 +248,7 @@ public class TestBigintOperators
     @Test
     public void testOverflowMultiply()
     {
-        assertNumericOverflow(format("%s * 2", Long.MAX_VALUE), "bigint multiplication overflow: 9223372036854775807 * 2");
+        assertNumericOverflow(format("%s * BIGINT '2'", Long.MAX_VALUE), "bigint multiplication overflow: 9223372036854775807 * 2");
         // TODO: uncomment when https://github.com/prestodb/presto/issues/4571 is fixed
         //assertNumericOverflow(format("%s * -1", Long.MAX_VALUE), "bigint multiplication overflow: 9223372036854775807 * -1");
     }


### PR DESCRIPTION
Remove duplicate predicates in logical binary expressions (AND, OR).
Canonicalizes commutative arithmetic expressions and comparisons to
handle a larger number of variants.