### PR TITLE
Allow the connector to delegate filter statistics estimation to the engine

### DIFF
--- a/presto-main/src/main/java/io/prestosql/cost/StatsCalculatorModule.java
+++ b/presto-main/src/main/java/io/prestosql/cost/StatsCalculatorModule.java
@@ -40,7 +40,7 @@ public class StatsCalculatorModule
 
         ImmutableList.Builder<ComposableStatsCalculator.Rule<?>> rules = ImmutableList.builder();
         rules.add(new OutputStatsRule());
-        rules.add(new TableScanStatsRule(metadata, normalizer));
+        rules.add(new TableScanStatsRule(metadata, normalizer, filterStatsCalculator));
         rules.add(new SimpleFilterProjectSemiJoinStatsRule(metadata, normalizer, filterStatsCalculator)); // this must be before FilterStatsRule
         rules.add(new FilterStatsRule(normalizer, filterStatsCalculator));
         rules.add(new ValuesStatsRule(metadata));


### PR DESCRIPTION
If the connector don't support statistics estimation for pushed-down predicate, we use `FilterStatsCalculator` to heuristically update the `PlanNodeStatsEstimate` (similarly to how it's done by `FilterStatsRule`).

It would allow connectors that support generic predicate pushdown, but don't support efficient statistics estimation with a predicate - to return a better estimate of the filtered statistics.