### PR TITLE
Change client to assume types are encoded as text

### DIFF
--- a/presto-client/src/main/java/io/prestosql/client/ClientStandardTypes.java
+++ b/presto-client/src/main/java/io/prestosql/client/ClientStandardTypes.java
@@ -26,6 +26,7 @@ public final class ClientStandardTypes
     public static final String DOUBLE = "double";
     public static final String HYPER_LOG_LOG = "HyperLogLog";
     public static final String QDIGEST = "qdigest";
+    public static final String SET_DIGEST = "SetDigest";
     public static final String P4_HYPER_LOG_LOG = "P4HyperLogLog";
     public static final String INTERVAL_DAY_TO_SECOND = "interval day to second";
     public static final String INTERVAL_YEAR_TO_MONTH = "interval year to month";
@@ -44,6 +45,9 @@ public final class ClientStandardTypes
     public static final String UUID = "uuid";
     public static final String GEOMETRY = "Geometry";
     public static final String BING_TILE = "BingTile";
+    public static final String OBJECT_ID = "ObjectId";
+    public static final String MODEL = "Model";
+    public static final String REGRESSOR = "Regressor";
 
     private ClientStandardTypes() {}
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/StandardTypes.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/StandardTypes.java
@@ -26,6 +26,7 @@ public final class StandardTypes
     public static final String DOUBLE = "double";
     public static final String HYPER_LOG_LOG = "HyperLogLog";
     public static final String QDIGEST = "qdigest";
+    public static final String SET_DIGEST = "SetDigest";
     public static final String P4_HYPER_LOG_LOG = "P4HyperLogLog";
     public static final String INTERVAL_DAY_TO_SECOND = "interval day to second";
     public static final String INTERVAL_YEAR_TO_MONTH = "interval year to month";


### PR DESCRIPTION
Assuming that unknown types are base64 encoded binary is bad because
the failure mode is an error. If we assume the value is text, then
users will receive a valid base64 string. Also, most new types have
ended up using a textual representation.