### PR TITLE
Support mixed case fields in Elasticsearch

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchClient.java
@@ -250,6 +250,7 @@ public class ElasticsearchClient
         List<ColumnMetadata> result = new ArrayList<>();
         for (ElasticsearchColumn column : columns) {
             Map<String, Object> properties = new HashMap<>();
+            properties.put("originalColumnName", column.getName());
             properties.put("jsonPath", column.getJsonPath());
             properties.put("jsonType", column.getJsonType());
             properties.put("isList", column.isList());

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchMetadata.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchMetadata.java
@@ -113,7 +113,7 @@ public class ElasticsearchMetadata
             int position = ordinalPosition == -1 ? index : ordinalPosition;
             columnHandles.put(column.getName(),
                     new ElasticsearchColumnHandle(
-                        column.getName(),
+                        String.valueOf(properties.get("originalColumnName")),
                         column.getType(),
                         String.valueOf(properties.get("jsonPath")),
                         String.valueOf(properties.get("jsonType")),

--- a/presto-elasticsearch/src/test/resources/queryrunner/test.person.json
+++ b/presto-elasticsearch/src/test/resources/queryrunner/test.person.json
@@ -1,0 +1,25 @@
+{
+  "tableName": "person",
+  "schemaName": "test",
+  "host": "localhost",
+  "port": "9300",
+  "clusterName": "test",
+  "index": "person",
+  "type": "doc",
+  "columns": [
+    {
+      "name": "Name",
+      "type": "varchar",
+      "jsonPath": "Name",
+      "jsonType": "varchar",
+      "ordinalPosition": "0"
+    },
+    {
+      "name": "Age",
+      "type": "integer",
+      "jsonPath": "Age",
+      "jsonType": "integer",
+      "ordinalPosition": "1"
+    }
+  ]
+}


### PR DESCRIPTION
Preserve the original (mixed-case) column name for further requests
to Elasticsearch instead of relying on the name from ColumnMetadata,
which is lower-cased.

Fixes https://github.com/prestodb/presto/issues/12562