### PR TITLE
Do not process Apply assignments via expression rewrites

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DesugarAtTimeZone.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DesugarAtTimeZone.java
@@ -13,13 +13,9 @@
  */
 package io.prestosql.sql.planner.iterative.rule;
 
-import com.google.common.collect.ImmutableSet;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.sql.planner.DesugarAtTimeZoneRewriter;
 import io.prestosql.sql.planner.TypeAnalyzer;
-import io.prestosql.sql.planner.iterative.Rule;
-
-import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -29,17 +25,6 @@ public class DesugarAtTimeZone
     public DesugarAtTimeZone(Metadata metadata, TypeAnalyzer typeAnalyzer)
     {
         super(createRewrite(metadata, typeAnalyzer));
-    }
-
-    @Override
-    public Set<Rule<?>> rules()
-    {
-        return ImmutableSet.of(
-                projectExpressionRewrite(),
-                aggregationExpressionRewrite(),
-                filterExpressionRewrite(),
-                joinExpressionRewrite(),
-                valuesExpressionRewrite());
     }
 
     private static ExpressionRewriter createRewrite(Metadata metadata, TypeAnalyzer typeAnalyzer)

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DesugarLambdaExpression.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DesugarLambdaExpression.java
@@ -13,11 +13,8 @@
  */
 package io.prestosql.sql.planner.iterative.rule;
 
-import com.google.common.collect.ImmutableSet;
 import io.prestosql.sql.planner.iterative.Rule;
 import io.prestosql.sql.tree.Expression;
-
-import java.util.Set;
 
 public class DesugarLambdaExpression
         extends ExpressionRewriteRuleSet
@@ -25,17 +22,6 @@ public class DesugarLambdaExpression
     public DesugarLambdaExpression()
     {
         super(DesugarLambdaExpression::rewrite);
-    }
-
-    @Override
-    public Set<Rule<?>> rules()
-    {
-        return ImmutableSet.of(
-                projectExpressionRewrite(),
-                aggregationExpressionRewrite(),
-                filterExpressionRewrite(),
-                joinExpressionRewrite(),
-                valuesExpressionRewrite());
     }
 
     private static Expression rewrite(Expression expression, Rule.Context context)

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DesugarRowSubscript.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/DesugarRowSubscript.java
@@ -13,12 +13,8 @@
  */
 package io.prestosql.sql.planner.iterative.rule;
 
-import com.google.common.collect.ImmutableSet;
 import io.prestosql.sql.planner.DesugarRowSubscriptRewriter;
 import io.prestosql.sql.planner.TypeAnalyzer;
-import io.prestosql.sql.planner.iterative.Rule;
-
-import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -28,17 +24,6 @@ public class DesugarRowSubscript
     public DesugarRowSubscript(TypeAnalyzer typeAnalyzer)
     {
         super(createRewrite(typeAnalyzer));
-    }
-
-    @Override
-    public Set<Rule<?>> rules()
-    {
-        return ImmutableSet.of(
-                projectExpressionRewrite(),
-                aggregationExpressionRewrite(),
-                filterExpressionRewrite(),
-                joinExpressionRewrite(),
-                valuesExpressionRewrite());
     }
 
     private static ExpressionRewriter createRewrite(TypeAnalyzer typeAnalyzer)


### PR DESCRIPTION
The assignment in Apply has semantics that are different from regular
expressions, so it may be incorrect to rewrite them like every
other expression in the course of optimization. The assignments
can currently take one of these shapes:

```
x = EXISTS(true)
x = y <comparison> <quantifier> z
x = y IN z
```

`z` represents the set of all values for that column in the subquery, but it's being
expressed as a scalar expression in the IR. EXISTS(true) is non-sensical under the
semantics of EXISTS.