### PR TITLE
Do not push trivial projections through union

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushProjectionThroughUnion.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushProjectionThroughUnion.java
@@ -44,6 +44,7 @@ public class PushProjectionThroughUnion
     private static final Capture<UnionNode> CHILD = newCapture();
 
     private static final Pattern<ProjectNode> PATTERN = project()
+            .matching(PushProjectionThroughUnion::nonTrivialProjection)
             .with(source().matching(union().capturedAs(CHILD)));
 
     @Override
@@ -86,5 +87,12 @@ public class PushProjectionThroughUnion
         }
 
         return Result.ofPlanNode(new UnionNode(parent.getId(), outputSources.build(), mappings.build(), ImmutableList.copyOf(mappings.build().keySet())));
+    }
+
+    private static boolean nonTrivialProjection(ProjectNode project)
+    {
+        return !project.getAssignments()
+                .getExpressions().stream()
+                .allMatch(SymbolReference.class::isInstance);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushProjectionThroughUnion.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushProjectionThroughUnion.java
@@ -43,6 +43,29 @@ public class TestPushProjectionThroughUnion
     }
 
     @Test
+    public void testTrivialProjection()
+    {
+        tester().assertThat(new PushProjectionThroughUnion())
+                .on(p -> {
+                    Symbol left = p.symbol("left");
+                    Symbol right = p.symbol("right");
+                    Symbol unioned = p.symbol("unioned");
+                    Symbol renamed = p.symbol("renamed");
+                    return p.project(
+                            Assignments.of(renamed, unioned.toSymbolReference()),
+                            p.union(
+                                    ImmutableListMultimap.<Symbol, Symbol>builder()
+                                            .put(unioned, left)
+                                            .put(unioned, right)
+                                            .build(),
+                                    ImmutableList.of(
+                                            p.values(left),
+                                            p.values(right))));
+                })
+                .doesNotFire();
+    }
+
+    @Test
     public void test()
     {
         tester().assertThat(new PushProjectionThroughUnion())


### PR DESCRIPTION
Pushing down simple identity or renaming projections gets in the
way of symbol unaliasing.