### PR TITLE
Add support for fractional weights in approx_percentile

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -182,29 +182,29 @@ Approximate Aggregate Functions
 .. function:: approx_percentile(x, w, percentage) -> [same as x]
 
     Returns the approximate weighed percentile for all input values of ``x``
-    using the per-item weight ``w`` at the percentage ``p``. The weight must be
-    an integer value of at least one. It is effectively a replication count for
-    the value ``x`` in the percentile set. The value of ``p`` must be between
-    zero and one and must be constant for all input rows.
+    using the per-item weight ``w`` at the percentage ``p``. Weights must be
+    strictly positive. Integer-value weights can be thought of as a replication
+    count for the value ``x`` in the percentile set. The value of ``p`` must be
+    between zero and one and must be constant for all input rows.
 
 .. function:: approx_percentile(x, w, percentage, accuracy) -> [same as x]
 
     Returns the approximate weighed percentile for all input values of ``x``
     using the per-item weight ``w`` at the percentage ``p``, with a maximum rank
-    error of ``accuracy``. The weight must be an integer value of at least one.
-    It is effectively a replication count for the value ``x`` in the percentile
-    set. The value of ``p`` must be between zero and one and must be constant
-    for all input rows. ``accuracy`` must be a value greater than zero and less
-    than one, and it must be constant for all input rows.
+    error of ``accuracy``. Weights must be strictly positive. Integer-value
+    weights can be thought of as a replication count for the value ``x`` in the
+    percentile set. The value of ``p`` must be between zero and one and must be
+    constant for all input rows. ``accuracy`` must be a value greater than zero
+    and less than one, and it must be constant for all input rows.
 
 .. function:: approx_percentile(x, w, percentages) -> array<[same as x]>
 
     Returns the approximate weighed percentile for all input values of ``x``
     using the per-item weight ``w`` at each of the given percentages specified
-    in the array. The weight must be an integer value of at least one. It is
-    effectively a replication count for the value ``x`` in the percentile set.
-    Each element of the array must be between zero and one, and the array must
-    be constant for all input rows.
+    in the array. Weights must be strictly positive. Integer-value weights can
+    be thought of as a replication count for the value ``x`` in the percentile
+    set. Each element of the array must be between zero and one, and the array
+    must be constant for all input rows.
 
 .. function:: approx_set(x) -> HyperLogLog
     :noindex:

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateDoublePercentileAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateDoublePercentileAggregations.java
@@ -43,13 +43,13 @@ public final class ApproximateDoublePercentileAggregations
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile)
+    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType(StandardTypes.DOUBLE) double percentile)
     {
         ApproximateLongPercentileAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentile);
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
+    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
     {
         ApproximateLongPercentileAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentile, accuracy);
     }

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateDoublePercentileArrayAggregations.java
@@ -43,7 +43,7 @@ public final class ApproximateDoublePercentileArrayAggregations
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType("array(double)") Block percentilesArrayBlock)
+    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType("array(double)") Block percentilesArrayBlock)
     {
         ApproximateLongPercentileArrayAggregations.weightedInput(state, doubleToSortableLong(value), weight, percentilesArrayBlock);
     }

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateLongPercentileAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateLongPercentileAggregations.java
@@ -54,7 +54,7 @@ public final class ApproximateLongPercentileAggregations
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile)
+    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType(StandardTypes.DOUBLE) double percentile)
     {
         checkWeight(weight);
 
@@ -75,7 +75,7 @@ public final class ApproximateLongPercentileAggregations
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
+    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
     {
         checkWeight(weight);
 
@@ -133,7 +133,7 @@ public final class ApproximateLongPercentileAggregations
         }
     }
 
-    private static void checkWeight(long weight)
+    private static void checkWeight(double weight)
     {
         checkCondition(weight > 0, INVALID_FUNCTION_ARGUMENT, "percentile weight must be > 0");
     }

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateLongPercentileArrayAggregations.java
@@ -51,7 +51,7 @@ public final class ApproximateLongPercentileArrayAggregations
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType("array(double)") Block percentilesArrayBlock)
+    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType("array(double)") Block percentilesArrayBlock)
     {
         initializePercentilesArray(state, percentilesArrayBlock);
         initializeDigest(state);

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateRealPercentileAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateRealPercentileAggregations.java
@@ -45,13 +45,13 @@ public class ApproximateRealPercentileAggregations
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile)
+    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType(StandardTypes.DOUBLE) double percentile)
     {
         ApproximateLongPercentileAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentile);
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
+    public static void weightedInput(@AggregationState DigestAndPercentileState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType(StandardTypes.DOUBLE) double percentile, @SqlType(StandardTypes.DOUBLE) double accuracy)
     {
         ApproximateLongPercentileAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentile, accuracy);
     }

--- a/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
+++ b/presto-main/src/main/java/io/prestosql/operator/aggregation/ApproximateRealPercentileArrayAggregations.java
@@ -45,7 +45,7 @@ public class ApproximateRealPercentileArrayAggregations
     }
 
     @InputFunction
-    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.BIGINT) long weight, @SqlType("array(double)") Block percentilesArrayBlock)
+    public static void weightedInput(@AggregationState DigestAndPercentileArrayState state, @SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.DOUBLE) double weight, @SqlType("array(double)") Block percentilesArrayBlock)
     {
         ApproximateLongPercentileArrayAggregations.weightedInput(state, floatToSortableInt(intBitsToFloat((int) value)), weight, percentilesArrayBlock);
     }

--- a/presto-main/src/test/java/io/prestosql/block/BlockAssertions.java
+++ b/presto-main/src/test/java/io/prestosql/block/BlockAssertions.java
@@ -405,6 +405,15 @@ public final class BlockAssertions
         return builder.build();
     }
 
+    public static Block createDoubleRepeatBlock(double value, int length)
+    {
+        BlockBuilder builder = DOUBLE.createFixedSizeBlockBuilder(length);
+        for (int i = 0; i < length; i++) {
+            DOUBLE.writeDouble(builder, value);
+        }
+        return builder.build();
+    }
+
     public static Block createTimestampsWithTimezoneBlock(Long... values)
     {
         BlockBuilder builder = TIMESTAMP_WITH_TIME_ZONE.createFixedSizeBlockBuilder(values.length);

--- a/presto-main/src/test/java/io/prestosql/operator/aggregation/TestApproximatePercentileAggregation.java
+++ b/presto-main/src/test/java/io/prestosql/operator/aggregation/TestApproximatePercentileAggregation.java
@@ -22,9 +22,9 @@ import io.prestosql.spi.type.ArrayType;
 import org.testng.annotations.Test;
 
 import static io.prestosql.block.BlockAssertions.createBlockOfReals;
+import static io.prestosql.block.BlockAssertions.createDoubleRepeatBlock;
 import static io.prestosql.block.BlockAssertions.createDoubleSequenceBlock;
 import static io.prestosql.block.BlockAssertions.createDoublesBlock;
-import static io.prestosql.block.BlockAssertions.createLongRepeatBlock;
 import static io.prestosql.block.BlockAssertions.createLongSequenceBlock;
 import static io.prestosql.block.BlockAssertions.createLongsBlock;
 import static io.prestosql.block.BlockAssertions.createSequenceBlockOfReal;
@@ -43,43 +43,43 @@ public class TestApproximatePercentileAggregation
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_AGGREGATION = metadata.getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = metadata.getAggregateFunctionImplementation(
-            new Signature("approx_percentile", AGGREGATE, DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature()));
+            new Signature("approx_percentile", AGGREGATE, DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY = metadata.getAggregateFunctionImplementation(
-            new Signature("approx_percentile", AGGREGATE, DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
+            new Signature("approx_percentile", AGGREGATE, DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
 
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_AGGREGATION = metadata.getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature()));
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = metadata.getAggregateFunctionImplementation(
-            new Signature("approx_percentile", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature()));
+            new Signature("approx_percentile", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY = metadata.getAggregateFunctionImplementation(
-            new Signature("approx_percentile", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
+            new Signature("approx_percentile", AGGREGATE, BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature()));
 
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = metadata.getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, parseTypeSignature("array(double)"), DOUBLE.getTypeSignature(), parseTypeSignature("array(double)")));
     private static final InternalAggregationFunction DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = metadata.getAggregateFunctionImplementation(
-            new Signature("approx_percentile", AGGREGATE, parseTypeSignature("array(double)"), DOUBLE.getTypeSignature(), BIGINT.getTypeSignature(), parseTypeSignature("array(double)")));
+            new Signature("approx_percentile", AGGREGATE, parseTypeSignature("array(double)"), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), parseTypeSignature("array(double)")));
 
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = metadata.getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, parseTypeSignature("array(bigint)"), BIGINT.getTypeSignature(), parseTypeSignature("array(double)")));
     private static final InternalAggregationFunction LONG_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = metadata.getAggregateFunctionImplementation(
-            new Signature("approx_percentile", AGGREGATE, parseTypeSignature("array(bigint)"), BIGINT.getTypeSignature(), BIGINT.getTypeSignature(), parseTypeSignature("array(double)")));
+            new Signature("approx_percentile", AGGREGATE, parseTypeSignature("array(bigint)"), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature(), parseTypeSignature("array(double)")));
 
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_AGGREGATION = metadata.getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, REAL.getTypeSignature(),
                     ImmutableList.of(REAL.getTypeSignature(), DOUBLE.getTypeSignature())));
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION = metadata.getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, REAL.getTypeSignature(),
-                    ImmutableList.of(REAL.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature())));
+                    ImmutableList.of(REAL.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature())));
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY = metadata.getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, REAL.getTypeSignature(),
-                    ImmutableList.of(REAL.getTypeSignature(), BIGINT.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature())));
+                    ImmutableList.of(REAL.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature(), DOUBLE.getTypeSignature())));
 
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_ARRAY_AGGREGATION = metadata.getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, new ArrayType(REAL).getTypeSignature(),
                     ImmutableList.of(REAL.getTypeSignature(), new ArrayType(DOUBLE).getTypeSignature())));
     private static final InternalAggregationFunction FLOAT_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION = metadata.getAggregateFunctionImplementation(
             new Signature("approx_percentile", AGGREGATE, new ArrayType(REAL).getTypeSignature(),
-                    ImmutableList.of(REAL.getTypeSignature(), BIGINT.getTypeSignature(), new ArrayType(DOUBLE).getTypeSignature())));
+                    ImmutableList.of(REAL.getTypeSignature(), DOUBLE.getTypeSignature(), new ArrayType(DOUBLE).getTypeSignature())));
 
     @Test
     public void testLongPartialStep()
@@ -162,35 +162,49 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1L,
                 createLongsBlock(null, 1L),
-                createLongsBlock(1L, 1L),
+                createDoublesBlock(1.0, 1.0),
                 createRLEBlock(0.5, 2));
 
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 2L,
                 createLongsBlock(null, 1L, 2L, 3L),
-                createLongsBlock(1L, 1L, 1L, 1L),
+                createDoublesBlock(1.0, 1.0, 1.0, 1.0),
                 createRLEBlock(0.5, 4));
 
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 2L,
                 createLongsBlock(1L, 2L, 3L),
-                createLongsBlock(1L, 1L, 1L),
+                createDoublesBlock(1.0, 1.0, 1.0),
+                createRLEBlock(0.5, 3));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
+                2L,
+                createLongsBlock(1L, 2L, 3L),
+                createDoublesBlock(0.1, 0.1, 0.1),
                 createRLEBlock(0.5, 3));
 
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 3L,
                 createLongsBlock(1L, null, 2L, null, 2L, null, 2L, null, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
-                createLongsBlock(1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L),
+                createDoublesBlock(1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+                createRLEBlock(0.5, 17));
+
+        assertAggregation(
+                LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
+                3L,
+                createLongsBlock(1L, null, 2L, null, 2L, null, 2L, null, 3L, null, 3L, null, 3L, 4L, 5L, 6L, 7L),
+                createDoublesBlock(0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1),
                 createRLEBlock(0.5, 17));
 
         assertAggregation(
                 LONG_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY,
                 9900L,
                 createLongSequenceBlock(0, 10000),
-                createLongRepeatBlock(1, 10000),
+                createDoubleRepeatBlock(1.0, 10000),
                 createRLEBlock(0.99, 10000),
                 createRLEBlock(0.001, 10000));
 
@@ -199,7 +213,7 @@ public class TestApproximatePercentileAggregation
                 LONG_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION,
                 ImmutableList.of(1L, 2L),
                 createLongsBlock(1L, 2L, 3L),
-                createLongsBlock(4L, 2L, 1L),
+                createDoublesBlock(4.0, 2.0, 1.0),
                 createRLEBlock(ImmutableList.of(0.5, 0.8), 3));
     }
 
@@ -298,35 +312,42 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0f,
                 createBlockOfReals(null, 1.0f),
-                createLongsBlock(1L, 1L),
+                createDoublesBlock(1.0, 1.0),
                 createRLEBlock(0.5, 2));
 
         assertAggregation(
                 FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 2.0f,
                 createBlockOfReals(null, 1.0f, 2.0f, 3.0f),
-                createLongsBlock(1L, 1L, 1L, 1L),
+                createDoublesBlock(1.0, 1.0, 1.0, 1.0),
                 createRLEBlock(0.5, 4));
 
         assertAggregation(
                 FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 2.0f,
                 createBlockOfReals(1.0f, 2.0f, 3.0f),
-                createLongsBlock(1L, 1L, 1L),
+                createDoublesBlock(1.0, 1.0, 1.0),
                 createRLEBlock(0.5, 3));
 
         assertAggregation(
                 FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 3.0f,
                 createBlockOfReals(1.0f, null, 2.0f, null, 2.0f, null, 2.0f, null, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
-                createLongsBlock(1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L),
+                createDoublesBlock(1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+                createRLEBlock(0.5, 17));
+
+        assertAggregation(
+                FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
+                3.0f,
+                createBlockOfReals(1.0f, null, 2.0f, null, 2.0f, null, 2.0f, null, 3.0f, null, 3.0f, null, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f),
+                createDoublesBlock(0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1),
                 createRLEBlock(0.5, 17));
 
         assertAggregation(
                 FLOAT_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY,
                 9900.0f,
                 createSequenceBlockOfReal(0, 10000),
-                createLongRepeatBlock(1, 10000),
+                createDoubleRepeatBlock(1, 10000),
                 createRLEBlock(0.99, 10000),
                 createRLEBlock(0.001, 10000));
 
@@ -335,7 +356,7 @@ public class TestApproximatePercentileAggregation
                 FLOAT_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION,
                 ImmutableList.of(1.0f, 2.0f),
                 createBlockOfReals(1.0f, 2.0f, 3.0f),
-                createLongsBlock(4L, 2L, 1L),
+                createDoublesBlock(4.0, 2.0, 1.0),
                 createRLEBlock(ImmutableList.of(0.5, 0.8), 3));
     }
 
@@ -422,35 +443,42 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 1.0,
                 createDoublesBlock(null, 1.0),
-                createLongsBlock(1L, 1L),
+                createDoublesBlock(1.0, 1.0),
                 createRLEBlock(0.5, 2));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 2.0,
                 createDoublesBlock(null, 1.0, 2.0, 3.0),
-                createLongsBlock(1L, 1L, 1L, 1L),
+                createDoublesBlock(1.0, 1.0, 1.0, 1.0),
                 createRLEBlock(0.5, 4));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 2.0,
                 createDoublesBlock(1.0, 2.0, 3.0),
-                createLongsBlock(1L, 1L, 1L),
+                createDoublesBlock(1.0, 1.0, 1.0),
                 createRLEBlock(0.5, 3));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
                 3.0,
                 createDoublesBlock(1.0, null, 2.0, null, 2.0, null, 2.0, null, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
-                createLongsBlock(1L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 2L, 1L, 1L, 1L, 1L, 1L, 1L, 1L, 1L),
+                createDoublesBlock(1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0),
+                createRLEBlock(0.5, 17));
+
+        assertAggregation(
+                DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION,
+                3.0,
+                createDoublesBlock(1.0, null, 2.0, null, 2.0, null, 2.0, null, 3.0, null, 3.0, null, 3.0, 4.0, 5.0, 6.0, 7.0),
+                createDoublesBlock(0.1, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1),
                 createRLEBlock(0.5, 17));
 
         assertAggregation(
                 DOUBLE_APPROXIMATE_PERCENTILE_WEIGHTED_AGGREGATION_WITH_ACCURACY,
                 9900.0,
                 createDoubleSequenceBlock(0, 10000),
-                createLongRepeatBlock(1, 10000),
+                createDoubleRepeatBlock(1.0, 10000),
                 createRLEBlock(0.99, 10000),
                 createRLEBlock(0.001, 10000));
 
@@ -459,7 +487,7 @@ public class TestApproximatePercentileAggregation
                 DOUBLE_APPROXIMATE_PERCENTILE_ARRAY_WEIGHTED_AGGREGATION,
                 ImmutableList.of(1.0, 2.0),
                 createDoublesBlock(1.0, 2.0, 3.0),
-                createLongsBlock(4L, 2L, 1L),
+                createDoublesBlock(4.0, 2.0, 1.0),
                 createRLEBlock(ImmutableList.of(0.5, 0.8), 3));
     }
 

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/math_functions/checkMathFunctionsRegistered.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/math_functions/checkMathFunctionsRegistered.result
@@ -4,9 +4,9 @@
  acos | double | double | scalar | true | arc cosine |
  approx_distinct | bigint | T | aggregate | true | |
  approx_distinct | bigint | T, double | aggregate | true | |
- approx_percentile | bigint | bigint, bigint, double | aggregate | true | |
+ approx_percentile | bigint | bigint, double, double | aggregate | true | |
  approx_percentile | bigint | bigint, double | aggregate | true | |
- approx_percentile | double | double, bigint, double | aggregate | true | |
+ approx_percentile | double | double, double, double | aggregate | true | |
  approx_percentile | double | double, double | aggregate | true | |
  approx_set | HyperLogLog | bigint | aggregate | true | |
  approx_set | HyperLogLog | double | aggregate | true | |

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
@@ -735,7 +735,9 @@ public abstract class AbstractTestQueries
                 "   approx_percentile(orderkey, 0.5), " +
                 "   approx_percentile(totalprice, 0.5)," +
                 "   approx_percentile(orderkey, 2, 0.5)," +
-                "   approx_percentile(totalprice, 2, 0.5)\n" +
+                "   approx_percentile(totalprice, 2, 0.5)," +
+                "   approx_percentile(orderkey, .2, 0.5)," +
+                "   approx_percentile(totalprice, .2, 0.5)\n" +
                 "FROM orders\n" +
                 "GROUP BY orderstatus");
 
@@ -745,6 +747,8 @@ public abstract class AbstractTestQueries
             Double totalPrice = (Double) row.getField(2);
             Long orderKeyWeighted = ((Number) row.getField(3)).longValue();
             Double totalPriceWeighted = (Double) row.getField(4);
+            Long orderKeyFractionalWeighted = ((Number) row.getField(5)).longValue();
+            Double totalPriceFractionalWeighted = (Double) row.getField(6);
 
             List<Long> orderKeys = Ordering.natural().sortedCopy(orderKeyByStatus.get(status));
             List<Double> totalPrices = Ordering.natural().sortedCopy(totalPriceByStatus.get(status));
@@ -756,11 +760,17 @@ public abstract class AbstractTestQueries
             assertTrue(orderKeyWeighted >= orderKeys.get((int) (0.49 * orderKeys.size())));
             assertTrue(orderKeyWeighted <= orderKeys.get((int) (0.51 * orderKeys.size())));
 
+            assertTrue(orderKeyFractionalWeighted >= orderKeys.get((int) (0.49 * orderKeys.size())));
+            assertTrue(orderKeyFractionalWeighted <= orderKeys.get((int) (0.51 * orderKeys.size())));
+
             assertTrue(totalPrice >= totalPrices.get((int) (0.49 * totalPrices.size())));
             assertTrue(totalPrice <= totalPrices.get((int) (0.51 * totalPrices.size())));
 
             assertTrue(totalPriceWeighted >= totalPrices.get((int) (0.49 * totalPrices.size())));
             assertTrue(totalPriceWeighted <= totalPrices.get((int) (0.51 * totalPrices.size())));
+
+            assertTrue(totalPriceFractionalWeighted >= totalPrices.get((int) (0.49 * totalPrices.size())));
+            assertTrue(totalPriceFractionalWeighted <= totalPrices.get((int) (0.51 * totalPrices.size())));
         }
     }
 


### PR DESCRIPTION
This is a re-post of #765 with comments applied.

Closes #758