### PR TITLE
Do not substitute parameters during SQL/Expression formatting

### DIFF
--- a/presto-main/src/main/java/io/prestosql/execution/CreateViewTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/CreateViewTask.java
@@ -74,7 +74,7 @@ public class CreateViewTask
 
         accessControl.checkCanCreateView(session.getRequiredTransactionId(), session.getIdentity(), name);
 
-        String sql = getFormattedSql(statement.getQuery(), sqlParser, Optional.of(parameters));
+        String sql = getFormattedSql(statement.getQuery(), sqlParser);
 
         Analysis analysis = analyzeStatement(statement, session, metadata, accessControl, parameters, stateMachine.getWarningCollector());
 

--- a/presto-main/src/main/java/io/prestosql/execution/DataDefinitionTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/DataDefinitionTask.java
@@ -18,12 +18,10 @@ import io.prestosql.metadata.Metadata;
 import io.prestosql.security.AccessControl;
 import io.prestosql.sql.SqlFormatter;
 import io.prestosql.sql.tree.Expression;
-import io.prestosql.sql.tree.Prepare;
 import io.prestosql.sql.tree.Statement;
 import io.prestosql.transaction.TransactionManager;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface DataDefinitionTask<T extends Statement>
 {
@@ -33,11 +31,17 @@ public interface DataDefinitionTask<T extends Statement>
 
     default String explain(T statement, List<Expression> parameters)
     {
-        if (statement instanceof Prepare) {
-            return SqlFormatter.formatSql(statement, Optional.empty());
+        StringBuilder builder = new StringBuilder();
+
+        builder.append(SqlFormatter.formatSql(statement));
+
+        if (!parameters.isEmpty()) {
+            builder.append("\n")
+                    .append("Parameters: ")
+                    .append(parameters);
         }
 
-        return SqlFormatter.formatSql(statement, Optional.of(parameters));
+        return builder.toString();
     }
 
     default boolean isTransactionControl()

--- a/presto-main/src/main/java/io/prestosql/execution/PrepareTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/PrepareTask.java
@@ -28,7 +28,6 @@ import io.prestosql.transaction.TransactionManager;
 import javax.inject.Inject;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -68,7 +67,7 @@ public class PrepareTask
             throw new PrestoException(NOT_SUPPORTED, "Invalid statement type for prepared statement: " + type);
         }
 
-        String sql = getFormattedSql(statement, sqlParser, Optional.empty());
+        String sql = getFormattedSql(statement, sqlParser);
         stateMachine.addPreparedStatement(prepare.getName().getValue(), sql);
         return immediateFuture(null);
     }

--- a/presto-main/src/main/java/io/prestosql/sql/Serialization.java
+++ b/presto-main/src/main/java/io/prestosql/sql/Serialization.java
@@ -26,7 +26,6 @@ import io.prestosql.sql.tree.FunctionCall;
 import javax.inject.Inject;
 
 import java.io.IOException;
-import java.util.Optional;
 
 import static io.prestosql.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
 
@@ -41,7 +40,7 @@ public final class Serialization
         public void serialize(Expression expression, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
                 throws IOException
         {
-            jsonGenerator.writeString(ExpressionFormatter.formatExpression(expression, Optional.empty()));
+            jsonGenerator.writeString(ExpressionFormatter.formatExpression(expression));
         }
     }
 

--- a/presto-main/src/main/java/io/prestosql/sql/SqlFormatterUtil.java
+++ b/presto-main/src/main/java/io/prestosql/sql/SqlFormatterUtil.java
@@ -17,11 +17,7 @@ import io.prestosql.spi.PrestoException;
 import io.prestosql.sql.parser.ParsingException;
 import io.prestosql.sql.parser.ParsingOptions;
 import io.prestosql.sql.parser.SqlParser;
-import io.prestosql.sql.tree.Expression;
 import io.prestosql.sql.tree.Statement;
-
-import java.util.List;
-import java.util.Optional;
 
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.prestosql.sql.parser.ParsingOptions.DecimalLiteralTreatment.REJECT;
@@ -30,9 +26,9 @@ public final class SqlFormatterUtil
 {
     private SqlFormatterUtil() {}
 
-    public static String getFormattedSql(Statement statement, SqlParser sqlParser, Optional<List<Expression>> parameters)
+    public static String getFormattedSql(Statement statement, SqlParser sqlParser)
     {
-        String sql = SqlFormatter.formatSql(statement, parameters);
+        String sql = SqlFormatter.formatSql(statement);
 
         // verify round-trip
         Statement parsed;

--- a/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowQueriesRewrite.java
@@ -433,7 +433,7 @@ final class ShowQueriesRewrite
                 Identifier tableName = parts.get(0);
                 Identifier schemaName = (parts.size() > 1) ? parts.get(1) : new Identifier(objectName.getSchemaName());
                 Identifier catalogName = (parts.size() > 2) ? parts.get(2) : new Identifier(objectName.getCatalogName());
-                String sql = formatSql(new CreateView(QualifiedName.of(ImmutableList.of(catalogName, schemaName, tableName)), query, false, Optional.empty()), Optional.of(parameters)).trim();
+                String sql = formatSql(new CreateView(QualifiedName.of(ImmutableList.of(catalogName, schemaName, tableName)), query, false, Optional.empty())).trim();
                 return singleValueQuery("Create View", sql);
             }
 
@@ -469,7 +469,7 @@ final class ShowQueriesRewrite
                         false,
                         propertyNodes,
                         connectorTableMetadata.getComment());
-                return singleValueQuery("Create Table", formatSql(createTable, Optional.of(parameters)).trim());
+                return singleValueQuery("Create Table", formatSql(createTable).trim());
             }
 
             throw new UnsupportedOperationException("SHOW CREATE only supported for tables and views");

--- a/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
@@ -1515,7 +1515,7 @@ public class TestExpressionInterpreter
     {
         ParsingOptions parsingOptions = createParsingOptions(TEST_SESSION);
         Expression parsed = SQL_PARSER.createExpression(expression, parsingOptions);
-        String formatted = formatExpression(parsed, Optional.empty());
+        String formatted = formatExpression(parsed);
         assertEquals(parsed, SQL_PARSER.createExpression(formatted, parsingOptions));
     }
 

--- a/presto-parser/src/main/java/io/prestosql/sql/testing/TreeAssertions.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/testing/TreeAssertions.java
@@ -25,7 +25,6 @@ import io.prestosql.sql.tree.Statement;
 import javax.annotation.Nullable;
 
 import java.util.List;
-import java.util.Optional;
 
 import static io.prestosql.sql.SqlFormatter.formatSql;
 import static io.prestosql.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
@@ -43,11 +42,11 @@ public final class TreeAssertions
 
     public static void assertFormattedSql(SqlParser sqlParser, ParsingOptions parsingOptions, Node expected)
     {
-        String formatted = formatSql(expected, Optional.empty());
+        String formatted = formatSql(expected);
 
         // verify round-trip of formatting already-formatted SQL
         Statement actual = parseFormatted(sqlParser, parsingOptions, formatted, expected);
-        assertEquals(formatSql(actual, Optional.empty()), formatted);
+        assertEquals(formatSql(actual), formatted);
 
         // compare parsed tree with parsed tree of formatted SQL
         if (!actual.equals(expected)) {

--- a/presto-parser/src/main/java/io/prestosql/sql/tree/Expression.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/Expression.java
@@ -37,6 +37,6 @@ public abstract class Expression
     @Override
     public final String toString()
     {
-        return ExpressionFormatter.formatExpression(this, Optional.empty()); // This will not replace parameters, but we don't have access to them here
+        return ExpressionFormatter.formatExpression(this);
     }
 }

--- a/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParser.java
@@ -2629,8 +2629,8 @@ public class TestSqlParser
         if (!parsed.equals(expected)) {
             fail(format("expected\n\n%s\n\nto parse as\n\n%s\n\nbut was\n\n%s\n",
                     indent(input),
-                    indent(formatSql(expected, Optional.empty())),
-                    indent(formatSql(parsed, Optional.empty()))));
+                    indent(formatSql(expected)),
+                    indent(formatSql(parsed))));
         }
     }
 

--- a/presto-parser/src/test/java/io/prestosql/sql/parser/TestStatementBuilder.java
+++ b/presto-parser/src/test/java/io/prestosql/sql/parser/TestStatementBuilder.java
@@ -21,7 +21,6 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Optional;
 
 import static com.google.common.base.Strings.repeat;
 import static io.prestosql.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
@@ -318,7 +317,7 @@ public class TestStatementBuilder
         println(statement.toString());
         println("");
 
-        println(SqlFormatter.formatSql(statement, Optional.empty()));
+        println(SqlFormatter.formatSql(statement));
         println("");
         assertFormattedSql(SQL_PARSER, statement);
 
@@ -329,7 +328,7 @@ public class TestStatementBuilder
     private static void assertSqlFormatter(String expression, String formatted)
     {
         Expression originalExpression = SQL_PARSER.createExpression(expression, new ParsingOptions());
-        String real = SqlFormatter.formatSql(originalExpression, Optional.empty());
+        String real = SqlFormatter.formatSql(originalExpression);
         assertEquals(real, formatted);
     }
 

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueries.java
@@ -2385,7 +2385,10 @@ public abstract class AbstractTestQueries
                 .addPreparedStatement("my_query", "SET SESSION foo = ?")
                 .build();
         MaterializedResult result = computeActual(session, "EXPLAIN (TYPE LOGICAL) EXECUTE my_query USING 7");
-        assertEquals(getOnlyElement(result.getOnlyColumnAsSet()), "SET SESSION foo = 7");
+        assertEquals(
+                getOnlyElement(result.getOnlyColumnAsSet()),
+                "SET SESSION foo = ?\n" +
+                "Parameters: [7]");
     }
 
     @Test

--- a/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/io/prestosql/tests/AbstractTestQueryFramework.java
@@ -317,7 +317,7 @@ public abstract class AbstractTestQueryFramework
 
     protected String formatSqlText(String sql)
     {
-        return formatSql(sqlParser.createStatement(sql, createParsingOptions(queryRunner.getDefaultSession())), Optional.empty());
+        return formatSql(sqlParser.createStatement(sql, createParsingOptions(queryRunner.getDefaultSession())));
     }
 
     //TODO: should WarningCollector be added?

--- a/presto-verifier/src/main/java/io/prestosql/verifier/QueryRewriter.java
+++ b/presto-verifier/src/main/java/io/prestosql/verifier/QueryRewriter.java
@@ -123,7 +123,7 @@ public class QueryRewriter
     {
         QualifiedName temporaryTableName = generateTemporaryTableName(statement.getName());
         Statement rewritten = new CreateTableAsSelect(temporaryTableName, statement.getQuery(), statement.isNotExists(), statement.getProperties(), statement.isWithData(), statement.getColumnAliases(), Optional.empty());
-        String createTableAsSql = formatSql(rewritten, Optional.empty());
+        String createTableAsSql = formatSql(rewritten);
         String checksumSql = checksumSql(getColumns(connection, statement), temporaryTableName);
         String dropTableSql = dropTableSql(temporaryTableName);
         return new Query(query.getCatalog(), query.getSchema(), ImmutableList.of(createTableAsSql), checksumSql, ImmutableList.of(dropTableSql), query.getUsername(), query.getPassword(), query.getSessionProperties());
@@ -134,8 +134,8 @@ public class QueryRewriter
     {
         QualifiedName temporaryTableName = generateTemporaryTableName(statement.getTarget());
         Statement createTemporaryTable = new CreateTable(temporaryTableName, ImmutableList.of(new LikeClause(statement.getTarget(), Optional.of(INCLUDING))), true, ImmutableList.of(), Optional.empty());
-        String createTemporaryTableSql = formatSql(createTemporaryTable, Optional.empty());
-        String insertSql = formatSql(new Insert(temporaryTableName, statement.getColumns(), statement.getQuery()), Optional.empty());
+        String createTemporaryTableSql = formatSql(createTemporaryTable);
+        String insertSql = formatSql(new Insert(temporaryTableName, statement.getColumns(), statement.getQuery()));
         String checksumSql = checksumSql(getColumnsForTable(connection, query.getCatalog(), query.getSchema(), statement.getTarget().toString()), temporaryTableName);
         String dropTableSql = dropTableSql(temporaryTableName);
         return new Query(query.getCatalog(), query.getSchema(), ImmutableList.of(createTemporaryTableSql, insertSql), checksumSql, ImmutableList.of(dropTableSql), query.getUsername(), query.getPassword(), query.getSessionProperties());
@@ -218,7 +218,7 @@ public class QueryRewriter
             ExecutorService executor = newSingleThreadExecutor();
             TimeLimiter limiter = SimpleTimeLimiter.create(executor);
             java.sql.Statement limitedStatement = limiter.newProxy(jdbcStatement, java.sql.Statement.class, timeout.toMillis(), TimeUnit.MILLISECONDS);
-            try (ResultSet resultSet = limitedStatement.executeQuery(formatSql(zeroRowsQuery, Optional.empty()))) {
+            try (ResultSet resultSet = limitedStatement.executeQuery(formatSql(zeroRowsQuery))) {
                 ResultSetMetaData metaData = resultSet.getMetaData();
                 for (int i = 1; i <= metaData.getColumnCount(); i++) {
                     String name = metaData.getColumnName(i);
@@ -253,12 +253,12 @@ public class QueryRewriter
         }
 
         Select select = new Select(false, selectItems.build());
-        return formatSql(new QuerySpecification(select, Optional.of(new Table(table)), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()), Optional.empty());
+        return formatSql(new QuerySpecification(select, Optional.of(new Table(table)), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty()));
     }
 
     private static String dropTableSql(QualifiedName table)
     {
-        return formatSql(new DropTable(table, true), Optional.empty());
+        return formatSql(new DropTable(table, true));
     }
 
     private static String escapeLikeExpression(Connection connection, String value)


### PR DESCRIPTION
This is the wrong place to do so. The formatter should do a literal
translation from the syntax tree to the textual representation.