### PR TITLE
Add 'location' and 'external' table properties for CREATE TABLE and CREATE TABLE AS SELECT

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -118,6 +118,8 @@ public class HiveConfig
     private long fileStatusCacheMaxSize = 1000 * 1000;
     private List<String> fileStatusCacheTables = ImmutableList.of();
 
+    private boolean tableCreatesWithLocationAllowed = true;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -650,6 +652,7 @@ public class HiveConfig
         return writesToNonManagedTablesEnabled;
     }
 
+    @Deprecated
     @Config("hive.non-managed-table-creates-enabled")
     @ConfigDescription("Enable non-managed (external) table creates")
     public HiveConfig setCreatesOfNonManagedTablesEnabled(boolean createsOfNonManagedTablesEnabled)
@@ -658,6 +661,7 @@ public class HiveConfig
         return this;
     }
 
+    @Deprecated
     public boolean getCreatesOfNonManagedTablesEnabled()
     {
         return createsOfNonManagedTablesEnabled;
@@ -804,5 +808,18 @@ public class HiveConfig
     public String getTemporaryStagingDirectoryPath()
     {
         return temporaryStagingDirectoryPath;
+    }
+
+    @Config("hive.table-creates-with-location-allowed")
+    @ConfigDescription("Allow setting table location in CREATE TABLE and CREATE TABLE AS SELECT statements")
+    public HiveConfig setTableCreatesWithLocationAllowed(boolean tableCreatesWithLocationAllowed)
+    {
+        this.tableCreatesWithLocationAllowed = tableCreatesWithLocationAllowed;
+        return this;
+    }
+
+    public boolean getTableCreatesWithLocationAllowed()
+    {
+        return tableCreatesWithLocationAllowed;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
@@ -52,10 +52,10 @@ public class HiveLocationService
     }
 
     @Override
-    public LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName)
+    public LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, Optional<String> location)
     {
         HdfsContext context = new HdfsContext(session, schemaName, tableName);
-        Path targetPath = getTableDefaultLocation(context, metastore, hdfsEnvironment, schemaName, tableName);
+        Path targetPath = location.map(Path::new).orElse(getTableDefaultLocation(context, metastore, hdfsEnvironment, schemaName, tableName));
 
         // verify the target directory for the table
         if (pathExists(context, hdfsEnvironment, targetPath)) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
@@ -41,6 +41,7 @@ public class HiveMetadataFactory
     private final boolean skipTargetCleanupOnRollback;
     private final boolean writesToNonManagedTablesEnabled;
     private final boolean createsOfNonManagedTablesEnabled;
+    private final boolean tableCreatesWithLocationAllowed;
     private final long perTransactionCacheMaximumSize;
     private final HiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
@@ -80,6 +81,7 @@ public class HiveMetadataFactory
                 hiveConfig.isSkipTargetCleanupOnRollback(),
                 hiveConfig.getWritesToNonManagedTablesEnabled(),
                 hiveConfig.getCreatesOfNonManagedTablesEnabled(),
+                hiveConfig.getTableCreatesWithLocationAllowed(),
                 hiveConfig.getPerTransactionMetastoreCacheMaximumSize(),
                 typeManager,
                 locationService,
@@ -101,6 +103,7 @@ public class HiveMetadataFactory
             boolean skipTargetCleanupOnRollback,
             boolean writesToNonManagedTablesEnabled,
             boolean createsOfNonManagedTablesEnabled,
+            boolean tableCreatesWithLocationAllowed,
             long perTransactionCacheMaximumSize,
             TypeManager typeManager,
             LocationService locationService,
@@ -115,6 +118,7 @@ public class HiveMetadataFactory
         this.skipTargetCleanupOnRollback = skipTargetCleanupOnRollback;
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
         this.createsOfNonManagedTablesEnabled = createsOfNonManagedTablesEnabled;
+        this.tableCreatesWithLocationAllowed = tableCreatesWithLocationAllowed;
         this.perTransactionCacheMaximumSize = perTransactionCacheMaximumSize;
 
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -156,6 +160,7 @@ public class HiveMetadataFactory
                 allowCorruptWritesForTesting,
                 writesToNonManagedTablesEnabled,
                 createsOfNonManagedTablesEnabled,
+                tableCreatesWithLocationAllowed,
                 typeManager,
                 locationService,
                 partitionUpdateCodec,

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/LocationService.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/LocationService.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 public interface LocationService
 {
-    LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName);
+    LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, Optional<String> location);
 
     LocationHandle forExistingTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, Table table);
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -733,6 +733,7 @@ public abstract class AbstractTestHive
                 false,
                 false,
                 true,
+                true,
                 1000,
                 TYPE_MANAGER,
                 locationService,

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -191,6 +191,7 @@ import static io.prestosql.plugin.hive.HiveStorageFormat.SEQUENCEFILE;
 import static io.prestosql.plugin.hive.HiveStorageFormat.TEXTFILE;
 import static io.prestosql.plugin.hive.HiveTableProperties.BUCKETED_BY_PROPERTY;
 import static io.prestosql.plugin.hive.HiveTableProperties.BUCKET_COUNT_PROPERTY;
+import static io.prestosql.plugin.hive.HiveTableProperties.IS_EXTERNAL_TABLE;
 import static io.prestosql.plugin.hive.HiveTableProperties.PARTITIONED_BY_PROPERTY;
 import static io.prestosql.plugin.hive.HiveTableProperties.SORTED_BY_PROPERTY;
 import static io.prestosql.plugin.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
@@ -2143,7 +2144,7 @@ public abstract class AbstractTestHive
         try {
             try (Transaction transaction = newTransaction()) {
                 LocationService locationService = getLocationService();
-                LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName);
+                LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName, Optional.empty());
                 targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
                 Table table = createSimpleTable(schemaTableName, columns, session, targetPath, "q1");
                 transaction.getMetastore()
@@ -2254,6 +2255,7 @@ public abstract class AbstractTestHive
                                     .add(new SortingColumn("value_asc", SortingColumn.Order.ASCENDING))
                                     .add(new SortingColumn("value_desc", SortingColumn.Order.DESCENDING))
                                     .build())
+                            .put(IS_EXTERNAL_TABLE, false)
                             .build());
 
             ConnectorOutputTableHandle outputHandle = metadata.beginCreateTable(session, tableMetadata, Optional.empty());
@@ -2642,7 +2644,7 @@ public abstract class AbstractTestHive
             String tableOwner = session.getUser();
             String schemaName = schemaTableName.getSchemaName();
             String tableName = schemaTableName.getTableName();
-            LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName);
+            LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName, Optional.empty());
             Path targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
             //create table whose storage format is null
             Table.Builder tableBuilder = Table.builder()
@@ -4375,6 +4377,7 @@ public abstract class AbstractTestHive
                 .put(BUCKETED_BY_PROPERTY, ImmutableList.of())
                 .put(BUCKET_COUNT_PROPERTY, 0)
                 .put(SORTED_BY_PROPERTY, ImmutableList.of())
+                .put(IS_EXTERNAL_TABLE, false)
                 .build();
     }
 
@@ -4411,7 +4414,7 @@ public abstract class AbstractTestHive
             String tableName = schemaTableName.getTableName();
 
             LocationService locationService = getLocationService();
-            LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName);
+            LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName, Optional.empty());
             targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
 
             Table.Builder tableBuilder = Table.builder()

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
@@ -85,7 +85,8 @@ public class TestHiveConfig
                 .setTemporaryStagingDirectoryPath("/tmp/presto-${USER}")
                 .setFileStatusCacheExpireAfterWrite(new Duration(1, TimeUnit.MINUTES))
                 .setFileStatusCacheMaxSize(1000 * 1000)
-                .setFileStatusCacheTables(""));
+                .setFileStatusCacheTables("")
+                .setTableCreatesWithLocationAllowed(true));
     }
 
     @Test
@@ -144,6 +145,7 @@ public class TestHiveConfig
                 .put("hive.file-status-cache-tables", "foo.bar1, foo.bar2")
                 .put("hive.file-status-cache-size", "1000")
                 .put("hive.file-status-cache-expire-time", "30m")
+                .put("hive.table-creates-with-location-allowed", "false")
                 .build();
 
         HiveConfig expected = new HiveConfig()
@@ -198,7 +200,8 @@ public class TestHiveConfig
                 .setTemporaryStagingDirectoryPath("updated")
                 .setFileStatusCacheTables("foo.bar1,foo.bar2")
                 .setFileStatusCacheMaxSize(1000)
-                .setFileStatusCacheExpireAfterWrite(new Duration(30, TimeUnit.MINUTES));
+                .setFileStatusCacheExpireAfterWrite(new Duration(30, TimeUnit.MINUTES))
+                .setTableCreatesWithLocationAllowed(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/main/java/io/prestosql/execution/CreateTableTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/CreateTableTask.java
@@ -158,7 +158,7 @@ public class CreateTableTask
                 TableHandle likeTable = metadata.getTableHandle(session, likeTableName)
                         .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, statement, "LIKE table '%s' does not exist", likeTableName));
 
-                TableMetadata likeTableMetadata = metadata.getTableMetadata(session, likeTable);
+                TableMetadata likeTableMetadata = metadata.getTableMetadata(session, likeTable, true);
 
                 Optional<LikeClause.PropertiesOption> propertiesOption = likeClause.getPropertiesOption();
                 if (propertiesOption.isPresent() && propertiesOption.get().equals(LikeClause.PropertiesOption.INCLUDING)) {

--- a/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
@@ -107,7 +107,12 @@ public interface Metadata
      *
      * @throws RuntimeException if table handle is no longer valid
      */
-    TableMetadata getTableMetadata(Session session, TableHandle tableHandle);
+    default TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
+    {
+        return getTableMetadata(session, tableHandle, false);
+    }
+
+    TableMetadata getTableMetadata(Session session, TableHandle tableHandle, boolean onlyInheritable);
 
     /**
      * Return statistics for specified table for given filtering contraint.

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -443,11 +443,11 @@ public final class MetadataManager
     }
 
     @Override
-    public TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
+    public TableMetadata getTableMetadata(Session session, TableHandle tableHandle, boolean onlyInheritable)
     {
         CatalogName catalogName = tableHandle.getCatalogName();
         ConnectorMetadata metadata = getMetadata(session, catalogName);
-        ConnectorTableMetadata tableMetadata = metadata.getTableMetadata(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle());
+        ConnectorTableMetadata tableMetadata = metadata.getTableMetadata(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle(), onlyInheritable);
         if (tableMetadata.getColumns().isEmpty()) {
             throw new PrestoException(NOT_SUPPORTED, "Table has no columns: " + tableHandle);
         }

--- a/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
@@ -147,7 +147,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
+    public TableMetadata getTableMetadata(Session session, TableHandle tableHandle, boolean onlyInheritable)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixMetadata.java
+++ b/presto-phoenix/src/main/java/io/prestosql/plugin/phoenix/PhoenixMetadata.java
@@ -134,10 +134,10 @@ public class PhoenixMetadata
     @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
-        return getTableMetadata(session, table, false);
+        return getRequiredTableMetadata(session, table, false);
     }
 
-    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table, boolean rowkeyRequired)
+    public ConnectorTableMetadata getRequiredTableMetadata(ConnectorSession session, ConnectorTableHandle table, boolean rowkeyRequired)
     {
         JdbcTableHandle handle = (JdbcTableHandle) table;
         List<ColumnMetadata> columnMetadata = phoenixClient.getColumns(session, handle).stream()

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/csv_table.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/csv_table.sql
@@ -11,10 +11,10 @@ c_varchar|varchar|||
 --! name: show create csv table
 SHOW CREATE TABLE csv_table
 --!
-CREATE TABLE hive.default.csv_table (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   external_location = 'hdfs://hadoop-master:9000/tmp/product-test/datasets/csv_table',\n   format = 'CSV'\n)
+CREATE TABLE hive.default.csv_table (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   external = true,\n   format = 'CSV',\n   location = 'hdfs://hadoop-master:9000/tmp/product-test/datasets/csv_table'\n)
 --! name: create table like
 DROP TABLE IF EXISTS like_csv_table;
 CREATE TABLE like_csv_table (LIKE csv_table INCLUDING PROPERTIES);
 SHOW CREATE TABLE like_csv_table
 --!
-CREATE TABLE hive.default.like_csv_table (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   external_location = 'hdfs://hadoop-master:9000/tmp/product-test/datasets/csv_table',\n   format = 'CSV'\n)
+CREATE TABLE hive.default.like_csv_table (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   external = false,\n   format = 'CSV',\n   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/like_csv_table'\n)

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/csv_table_with_custom_parameters.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/csv_table_with_custom_parameters.sql
@@ -11,10 +11,10 @@ c_varchar|varchar|||
 --! name: show create csv table
 SHOW CREATE TABLE csv_table_with_custom_parameters
 --!
-CREATE TABLE hive.default.csv_table_with_custom_parameters (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   csv_escape = 'E',\n   csv_quote = 'Q',\n   csv_separator = 'S',\n   external_location = 'hdfs://hadoop-master:9000/tmp/product-test/datasets/csv_table_with_custom_parameters',\n   format = 'CSV'\n)
+CREATE TABLE hive.default.csv_table_with_custom_parameters (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   csv_escape = 'E',\n   csv_quote = 'Q',\n   csv_separator = 'S',\n   external = true,\n   format = 'CSV',\n   location = 'hdfs://hadoop-master:9000/tmp/product-test/datasets/csv_table_with_custom_parameters'\n)
 --! name: create table like
 DROP TABLE IF EXISTS like_csv_table;
 CREATE TABLE like_csv_table (LIKE csv_table_with_custom_parameters INCLUDING PROPERTIES);
 SHOW CREATE TABLE like_csv_table
 --!
-CREATE TABLE hive.default.like_csv_table (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   csv_escape = 'E',\n   csv_quote = 'Q',\n   csv_separator = 'S',\n   external_location = 'hdfs://hadoop-master:9000/tmp/product-test/datasets/csv_table_with_custom_parameters',\n   format = 'CSV'\n)
+CREATE TABLE hive.default.like_csv_table (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   csv_escape = 'E',\n   csv_quote = 'Q',\n   csv_separator = 'S',\n   external = false,\n   format = 'CSV',\n   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/like_csv_table'\n)

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
@@ -169,6 +169,11 @@ public interface ConnectorMetadata
         throw new PrestoException(GENERIC_INTERNAL_ERROR, "ConnectorMetadata getTableHandle() is implemented without getTableMetadata()");
     }
 
+    default ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table, boolean onlyInheritable)
+    {
+        return getTableMetadata(session, table);
+    }
+
     /**
      * Return the connector-specific metadata for the specified table layout. This is the object that is passed to the event listener framework.
      *

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -212,6 +212,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table, boolean onlyInheritable)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableMetadata(session, table, onlyInheritable);
+        }
+    }
+
+    @Override
     public Optional<Object> getInfo(ConnectorTableLayoutHandle table)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
fixes #1277 

1. New table properties 'location' and 'external' are added to hive connector
2. CREATE TABLE and CREATE TABLE AS SELECT consumes these properties to set location for table (both managed and external) and set table type as managed or external
3. 'external_location' property is deprecated but supported for backward compatibility
4. SHOW CREATE TABLE shows both of these properties
