### PR TITLE
Add connector table metadata warnings

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -160,6 +160,8 @@ public class HiveConfig
     private Duration fileStatusCacheExpireAfterWrite = new Duration(1, TimeUnit.MINUTES);
     private long fileStatusCacheMaxSize = 1000 * 1000;
     private List<String> fileStatusCacheTables = ImmutableList.of();
+    private HiveStorageFormat preferredFileFormat = HiveStorageFormat.ORC;
+    private int tooManyPartitionsLimit = 300;
 
     public int getMaxInitialSplits()
     {
@@ -1263,5 +1265,29 @@ public class HiveConfig
     public String getTemporaryStagingDirectoryPath()
     {
         return temporaryStagingDirectoryPath;
+    }
+
+    public HiveStorageFormat getPreferredFileFormat()
+    {
+        return preferredFileFormat;
+    }
+
+    @Config("hive.preferred-file-format")
+    public HiveConfig setPreferredFileFormat(HiveStorageFormat preferredFileFormat)
+    {
+        this.preferredFileFormat = preferredFileFormat;
+        return this;
+    }
+
+    public int getTooManyPartitionsLimit()
+    {
+        return tooManyPartitionsLimit;
+    }
+
+    @Config("hive.too-many-partitions-limit")
+    public HiveConfig setTooManyPartitionsLimit(int tooManyPartitionsLimit)
+    {
+        this.tooManyPartitionsLimit = tooManyPartitionsLimit;
+        return this;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -254,6 +254,7 @@ public class HiveMetadata
     private final String prestoVersion;
     private final HiveStatisticsProvider hiveStatisticsProvider;
     private final AccessControlMetadata accessControlMetadata;
+    private final HiveWarningManager hiveWarningManager;
 
     public HiveMetadata(
             SemiTransactionalHiveMetastore metastore,
@@ -269,7 +270,9 @@ public class HiveMetadata
             TypeTranslator typeTranslator,
             String prestoVersion,
             HiveStatisticsProvider hiveStatisticsProvider,
-            AccessControlMetadata accessControlMetadata)
+            AccessControlMetadata accessControlMetadata,
+            HiveWarningManager hiveWarningManager)
+
     {
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
 
@@ -286,6 +289,7 @@ public class HiveMetadata
         this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
         this.hiveStatisticsProvider = requireNonNull(hiveStatisticsProvider, "hiveStatisticsProvider is null");
         this.accessControlMetadata = requireNonNull(accessControlMetadata, "accessControlMetadata is null");
+        this.hiveWarningManager = requireNonNull(hiveWarningManager, "hiveWarningManager is null");
     }
 
     public SemiTransactionalHiveMetastore getMetastore()

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadataFactory.java
@@ -53,6 +53,7 @@ public class HiveMetadataFactory
     private final TypeTranslator typeTranslator;
     private final String prestoVersion;
     private final AccessControlMetadataFactory accessControlMetadataFactory;
+    private final HiveWarningManager hiveWarningManager;
 
     @Inject
     @SuppressWarnings("deprecation")
@@ -67,7 +68,8 @@ public class HiveMetadataFactory
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
             TypeTranslator typeTranslator,
             NodeVersion nodeVersion,
-            AccessControlMetadataFactory accessControlMetadataFactory)
+            AccessControlMetadataFactory accessControlMetadataFactory,
+            HiveWarningManager hiveWarningManager)
     {
         this(
                 metastore,
@@ -87,7 +89,8 @@ public class HiveMetadataFactory
                 executorService,
                 typeTranslator,
                 nodeVersion.toString(),
-                accessControlMetadataFactory);
+                accessControlMetadataFactory,
+                hiveWarningManager);
     }
 
     public HiveMetadataFactory(
@@ -108,7 +111,8 @@ public class HiveMetadataFactory
             ExecutorService executorService,
             TypeTranslator typeTranslator,
             String prestoVersion,
-            AccessControlMetadataFactory accessControlMetadataFactory)
+            AccessControlMetadataFactory accessControlMetadataFactory,
+            HiveWarningManager hiveWarningManager)
     {
         this.allowCorruptWritesForTesting = allowCorruptWritesForTesting;
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -127,6 +131,7 @@ public class HiveMetadataFactory
         this.typeTranslator = requireNonNull(typeTranslator, "typeTranslator is null");
         this.prestoVersion = requireNonNull(prestoVersion, "prestoVersion is null");
         this.accessControlMetadataFactory = requireNonNull(accessControlMetadataFactory, "accessControlMetadataFactory is null");
+        this.hiveWarningManager = requireNonNull(hiveWarningManager, "hiveWarningManager is null");
 
         if (!allowCorruptWritesForTesting && !timeZone.equals(DateTimeZone.getDefault())) {
             log.warn("Hive writes are disabled. " +
@@ -162,6 +167,7 @@ public class HiveMetadataFactory
                 typeTranslator,
                 prestoVersion,
                 new MetastoreHiveStatisticsProvider(metastore),
-                accessControlMetadataFactory.create(metastore));
+                accessControlMetadataFactory.create(metastore),
+                hiveWarningManager);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveModule.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveModule.java
@@ -108,6 +108,8 @@ public class HiveModule
         fileWriterFactoryBinder.addBinding().to(RcFileFileWriterFactory.class).in(Scopes.SINGLETON);
 
         configBinder(binder).bindConfig(ParquetFileWriterConfig.class);
+
+        binder.bind(HiveWarningManager.class).in(Scopes.SINGLETON);
     }
 
     @ForHive

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -78,6 +78,8 @@ public final class HiveSessionProperties
     private static final String S3_SELECT_PUSHDOWN_ENABLED = "s3_select_pushdown_enabled";
     private static final String TEMPORARY_STAGING_DIRECTORY_ENABLED = "temporary_staging_directory_enabled";
     private static final String TEMPORARY_STAGING_DIRECTORY_PATH = "temporary_staging_directory_path";
+    private static final String PREFERRED_FILE_FORMAT = "preferred_file_format";
+    private static final String TOO_MANY_PARTITIONS_LIMIT = "too_many_partitions_limit";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -308,6 +310,16 @@ public final class HiveSessionProperties
                         TEMPORARY_STAGING_DIRECTORY_PATH,
                         "Temporary staging directory location",
                         hiveConfig.getTemporaryStagingDirectoryPath(),
+                        false),
+                stringProperty(
+                        PREFERRED_FILE_FORMAT,
+                        "Preferred hive file format to use. Will trigger a warning otherwise",
+                        hiveConfig.getPreferredFileFormat().toString(),
+                        false),
+                integerProperty(
+                        TOO_MANY_PARTITIONS_LIMIT,
+                        "Number of partitions that can be used before a warning is triggered",
+                        hiveConfig.getTooManyPartitionsLimit(),
                         false));
     }
 
@@ -515,5 +527,15 @@ public final class HiveSessionProperties
     public static String getTemporaryStagingDirectoryPath(ConnectorSession session)
     {
         return session.getProperty(TEMPORARY_STAGING_DIRECTORY_PATH, String.class);
+    }
+
+    public static String getPreferredFileFormatSuggestion(ConnectorSession session)
+    {
+        return session.getProperty(PREFERRED_FILE_FORMAT, String.class);
+    }
+
+    public static int getTooManyPartitionsLimit(ConnectorSession session)
+    {
+        return session.getProperty(TOO_MANY_PARTITIONS_LIMIT, Integer.class);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWarningCode.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWarningCode.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import io.prestosql.spi.WarningCode;
+import io.prestosql.spi.WarningCodeSupplier;
+
+public enum HiveWarningCode
+        implements WarningCodeSupplier
+{
+    PREFERRED_FILE_FORMAT_SUGGESTION(0),
+    TOO_MANY_PARTITIONS(1);
+
+    private final WarningCode warningCode;
+
+    HiveWarningCode(int code)
+    {
+        warningCode = new WarningCode(code + 0x0100_0000, name());
+    }
+
+    @Override
+    public WarningCode toWarningCode()
+    {
+        return warningCode;
+    }
+}

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWarningManager.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWarningManager.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.PrestoWarning;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTableHandle;
+import io.prestosql.spi.connector.TableConnectorWarningContext;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.prestosql.plugin.hive.HiveSessionProperties.getPreferredFileFormatSuggestion;
+import static io.prestosql.plugin.hive.HiveSessionProperties.getTooManyPartitionsLimit;
+import static io.prestosql.plugin.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
+import static io.prestosql.plugin.hive.HiveWarningCode.PREFERRED_FILE_FORMAT_SUGGESTION;
+import static io.prestosql.plugin.hive.HiveWarningCode.TOO_MANY_PARTITIONS;
+import static java.lang.String.format;
+
+public class HiveWarningManager
+{
+    public List<PrestoWarning> generateHiveMetadataWarnings(
+            ConnectorSession session,
+            TableConnectorWarningContext tableConnectorWarningContext,
+            HiveMetadata hiveMetadata)
+    {
+        ImmutableList.Builder<PrestoWarning> hiveMetadataWarnings = new ImmutableList.Builder<>();
+
+        String preferredFileFormat = getPreferredFileFormatSuggestion(session);
+        Optional<String> storageFormatWarningsMessages =
+                generateStorageFormatWarningsMessages(hiveMetadata, session, tableConnectorWarningContext.getConnectorTableHandle(), preferredFileFormat);
+        if (storageFormatWarningsMessages.isPresent()) {
+            hiveMetadataWarnings.add(new PrestoWarning(PREFERRED_FILE_FORMAT_SUGGESTION, format("Try using %s for hive table %s", preferredFileFormat, storageFormatWarningsMessages.get())));
+        }
+
+        int partitionsLimit = getTooManyPartitionsLimit(session);
+        Optional<String> partitionsWarningsMessages = generatePartionsWarningsMessages(tableConnectorWarningContext.getConnectorTableHandle(), partitionsLimit);
+        if (partitionsWarningsMessages.isPresent()) {
+            hiveMetadataWarnings.add(new PrestoWarning(TOO_MANY_PARTITIONS, format("Using more than %s partitions for table %s", partitionsLimit, partitionsWarningsMessages.get())));
+        }
+        return hiveMetadataWarnings.build();
+    }
+
+    private Optional<String> generateStorageFormatWarningsMessages(
+            HiveMetadata hiveMetadata,
+            ConnectorSession connectorSession,
+            ConnectorTableHandle connectorTableHandle,
+            String preferredFileFormat)
+    {
+        HiveStorageFormat storageFormat =
+                (HiveStorageFormat) hiveMetadata
+                .getTableMetadata(connectorSession, connectorTableHandle)
+                .getProperties()
+                .get(STORAGE_FORMAT_PROPERTY);
+
+        if (!storageFormat.name().equals(preferredFileFormat)) {
+            String tableName = ((HiveTableHandle) connectorTableHandle).getTableName();
+            return Optional.of(tableName);
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<String> generatePartionsWarningsMessages(
+            ConnectorTableHandle connectorTableHandle,
+            int partitionsLimit)
+    {
+        HiveTableHandle hiveTableHandle = (HiveTableHandle) connectorTableHandle;
+        if (hiveTableHandle.getPartitions().isPresent()) {
+            List<HivePartition> partitions = hiveTableHandle.getPartitions().get();
+            if (partitions.size() > partitionsLimit) {
+                return Optional.of(hiveTableHandle.getTableName());
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -586,6 +586,7 @@ public abstract class AbstractTestHive
     protected ConnectorPageSourceProvider pageSourceProvider;
     protected ConnectorPageSinkProvider pageSinkProvider;
     protected ExecutorService executor;
+    protected HiveWarningManager hiveWarningManager;
 
     @BeforeClass
     public void setupClass()
@@ -718,6 +719,8 @@ public abstract class AbstractTestHive
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hiveConfig, new NoHdfsAuthentication());
         locationService = new HiveLocationService(hdfsEnvironment);
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);
+        hiveWarningManager = new HiveWarningManager();
+
         metadataFactory = new HiveMetadataFactory(
                 metastoreClient,
                 hdfsEnvironment,
@@ -736,7 +739,9 @@ public abstract class AbstractTestHive
                 newFixedThreadPool(2),
                 new HiveTypeTranslator(),
                 TEST_SERVER_VERSION,
-                SqlStandardAccessControlMetadata::new);
+                SqlStandardAccessControlMetadata::new,
+                hiveWarningManager);
+
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(
                 transactionHandle -> ((HiveMetadata) transactionManager.get(transactionHandle)).getMetastore(),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -120,6 +120,7 @@ public abstract class AbstractTestHiveFileSystem
     protected ConnectorSplitManager splitManager;
     protected ConnectorPageSinkProvider pageSinkProvider;
     protected ConnectorPageSourceProvider pageSourceProvider;
+    protected HiveWarningManager hiveWarningManager;
 
     private ExecutorService executor;
     private HiveConfig config;
@@ -170,6 +171,7 @@ public abstract class AbstractTestHiveFileSystem
                 hdfsEnvironment);
         locationService = new HiveLocationService(hdfsEnvironment);
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);
+        hiveWarningManager = new HiveWarningManager();
         metadataFactory = new HiveMetadataFactory(
                 config,
                 metastoreClient,
@@ -181,7 +183,9 @@ public abstract class AbstractTestHiveFileSystem
                 partitionUpdateCodec,
                 new HiveTypeTranslator(),
                 new NodeVersion("test_version"),
-                SqlStandardAccessControlMetadata::new);
+                SqlStandardAccessControlMetadata::new,
+                hiveWarningManager);
+
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(
                 transactionHandle -> ((HiveMetadata) transactionManager.get(transactionHandle)).getMetastore(),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveWarnings.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveWarnings.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.PrestoWarning;
+import io.prestosql.spi.QueryId;
+import io.prestosql.tests.AbstractTestQueryFramework;
+import io.prestosql.tests.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static io.prestosql.plugin.hive.HiveQueryRunner.createQueryRunner;
+import static io.prestosql.plugin.hive.HiveWarningCode.PREFERRED_FILE_FORMAT_SUGGESTION;
+import static io.prestosql.plugin.hive.HiveWarningCode.TOO_MANY_PARTITIONS;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiveWarnings
+        extends AbstractTestQueryFramework
+{
+    private DistributedQueryRunner adjustedHivePropertiesQueryRunner;
+
+    @SuppressWarnings("unused")
+    public TestHiveWarnings() throws Exception
+    {
+        this(() -> createQueryRunner(ORDERS));
+        adjustedHivePropertiesQueryRunner = createQueryRunner(
+                ImmutableList.of(ORDERS),
+                ImmutableMap.of(), "sql-standard",
+                ImmutableMap.of("hive.preferred-file-format", "AVRO", "hive.too-many-partitions-limit", "50"),
+                Optional.empty());
+    }
+
+    private TestHiveWarnings(QueryRunnerSupplier queryRunnerSupplier)
+    {
+        super(queryRunnerSupplier);
+    }
+
+    @Test
+    public void testFormatWarning()
+    {
+        computeActual("CREATE TABLE test_orders WITH ( format = 'AVRO', partitioned_by = ARRAY['orderkey'] ) AS select custkey, orderkey FROM orders where orderkey < 300");
+        DistributedQueryRunner distributedQueryRunner = (DistributedQueryRunner) getQueryRunner();
+        QueryId queryId = distributedQueryRunner.executeWithQueryId(getSession(), "SELECT * FROM test_orders").getQueryId();
+        List<PrestoWarning> warnings = distributedQueryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId).getWarnings();
+        assertWarning(warnings, ImmutableList.of(new PrestoWarning(PREFERRED_FILE_FORMAT_SUGGESTION, "Try using ORC for hive table test_orders")));
+
+        computeActual("CREATE TABLE test_Format2 WITH ( format = 'ORC', partitioned_by = ARRAY['orderkey'] ) AS select custkey, orderkey FROM orders where orderkey < 300");
+        QueryId queryId2 = distributedQueryRunner.executeWithQueryId(getSession(), "SELECT * FROM test_Format2").getQueryId();
+        List<PrestoWarning> warnings2 = distributedQueryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId2).getWarnings();
+        assertWarning(warnings2, ImmutableList.of());
+
+        QueryId queryId3 = distributedQueryRunner.executeWithQueryId(getSession(), "SELECT * FROM (SELECT * FROM test_orders) CROSS JOIN (SELECT * FROM test_orders)").getQueryId();
+        List<PrestoWarning> noDuplicateWarnings = distributedQueryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId3).getWarnings();
+        assertWarning(noDuplicateWarnings, ImmutableList.of(new PrestoWarning(PREFERRED_FILE_FORMAT_SUGGESTION, "Try using ORC for hive table test_orders")));
+
+        computeActual("CREATE TABLE test_orders2 WITH ( format = 'AVRO', partitioned_by = ARRAY['orderkey'] ) AS select custkey, orderkey FROM orders where orderkey < 300");
+
+        QueryId queryId4 = distributedQueryRunner.executeWithQueryId(getSession(), "SELECT * FROM (SELECT * FROM test_orders) CROSS JOIN (SELECT * FROM test_orders2)").getQueryId();
+        List<PrestoWarning> multipleWarnings = distributedQueryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId4).getWarnings();
+        assertWarning(multipleWarnings, ImmutableList.of(
+                new PrestoWarning(PREFERRED_FILE_FORMAT_SUGGESTION, "Try using ORC for hive table test_orders"),
+                new PrestoWarning(PREFERRED_FILE_FORMAT_SUGGESTION, "Try using ORC for hive table test_orders2")));
+    }
+
+    @Test
+    public void testAdjustedFormatWarning()
+    {
+        adjustedHivePropertiesQueryRunner.execute("CREATE TABLE test_orders WITH ( format = 'AVRO', partitioned_by = ARRAY['orderkey'] ) AS select custkey, orderkey FROM orders where orderkey < 10");
+
+        QueryId queryId = adjustedHivePropertiesQueryRunner.executeWithQueryId(getSession(), "SELECT * FROM test_orders").getQueryId();
+        List<PrestoWarning> warnings = adjustedHivePropertiesQueryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId).getWarnings();
+        assertWarning(warnings, ImmutableList.of());
+    }
+
+    @Test
+    public void testPartitionWarning()
+    {
+        computeActual("CREATE TABLE test_Partition WITH ( format = 'ORC', partitioned_by = ARRAY['orderkey'] ) AS select custkey, orderkey FROM orders where orderkey < 300");
+        int numberOfPartitions = 305;
+        while (numberOfPartitions > 0) {
+            computeActual(String.format("INSERT INTO test_Partition VALUES (%s,%s)", Integer.toString(numberOfPartitions), Integer.toString(numberOfPartitions)));
+            numberOfPartitions -= 1;
+        }
+        DistributedQueryRunner distributedQueryRunner = (DistributedQueryRunner) getQueryRunner();
+        QueryId queryId = distributedQueryRunner.executeWithQueryId(getSession(), "SELECT * FROM test_Partition").getQueryId();
+        List<PrestoWarning> warnings = distributedQueryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId).getWarnings();
+        assertWarning(warnings, ImmutableList.of(new PrestoWarning(TOO_MANY_PARTITIONS, "Using more than 300 partitions for table test_partition")));
+
+        computeActual("CREATE TABLE test_Partition2 WITH ( format = 'ORC', partitioned_by = ARRAY['orderkey'] ) AS select custkey, orderkey FROM orders where orderkey < 3");
+        QueryId queryId2 = distributedQueryRunner.executeWithQueryId(getSession(), "SELECT * FROM test_Partition2").getQueryId();
+        List<PrestoWarning> warnings2 = distributedQueryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId2).getWarnings();
+        assertWarning(warnings2, ImmutableList.of());
+
+        QueryId queryId3 = distributedQueryRunner.executeWithQueryId(getSession(), "SELECT * FROM test_Partition where orderkey >= (SELECT MIN (orderkey) FROM test_Partition2)").getQueryId();
+        List<PrestoWarning> warnings3 = distributedQueryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId3).getWarnings();
+        assertWarning(warnings3, ImmutableList.of(new PrestoWarning(TOO_MANY_PARTITIONS, "Using more than 300 partitions for table test_partition")));
+
+        QueryId queryId4 = distributedQueryRunner.executeWithQueryId(getSession(), "SELECT * FROM test_Partition WHERE orderkey BETWEEN 1 AND 75").getQueryId();
+        List<PrestoWarning> warning4 = distributedQueryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId4).getWarnings();
+        assertWarning(warning4, ImmutableList.of());
+    }
+
+    @Test
+    public void testAdjustedPartitionsWarning()
+    {
+        adjustedHivePropertiesQueryRunner.execute("CREATE TABLE test_Partition WITH ( format = 'AVRO', partitioned_by = ARRAY['orderkey'] ) AS select custkey, orderkey FROM orders where orderkey < 300");
+        int numberOfPartitions = 305;
+        while (numberOfPartitions > 0) {
+            adjustedHivePropertiesQueryRunner.execute(String.format("INSERT INTO test_Partition VALUES (%s,%s)", Integer.toString(numberOfPartitions), Integer.toString(numberOfPartitions)));
+            numberOfPartitions -= 1;
+        }
+
+        QueryId queryId = adjustedHivePropertiesQueryRunner.executeWithQueryId(getSession(), "SELECT * FROM test_Partition WHERE orderkey BETWEEN 1 AND 75").getQueryId();
+        List<PrestoWarning> warnings = adjustedHivePropertiesQueryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryId).getWarnings();
+        assertWarning(warnings, ImmutableList.of(new PrestoWarning(TOO_MANY_PARTITIONS, "Using more than 50 partitions for table test_partition")));
+    }
+
+    private void assertWarning(List<PrestoWarning> warningList, List<PrestoWarning> expectedWarnings)
+    {
+        assertTrue(warningList.size() == expectedWarnings.size());
+        for (PrestoWarning warning : warningList) {
+            assertTrue(expectedWarnings.contains(warning));
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/execution/warnings/WarningCollector.java
+++ b/presto-main/src/main/java/io/prestosql/execution/warnings/WarningCollector.java
@@ -31,9 +31,14 @@ public interface WarningCollector
                 {
                     return ImmutableList.of();
                 }
+
+                @Override
+                public void addConnectorMetadataWarning(String catalogName, PrestoWarning warning) {}
             };
 
     void add(PrestoWarning warning);
 
     List<PrestoWarning> getWarnings();
+
+    void addConnectorMetadataWarning(String catalogName, PrestoWarning warning);
 }

--- a/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
@@ -21,6 +21,7 @@ import io.prestosql.operator.aggregation.InternalAggregationFunction;
 import io.prestosql.operator.scalar.ScalarFunctionImplementation;
 import io.prestosql.operator.window.WindowFunctionSupplier;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.PrestoWarning;
 import io.prestosql.spi.block.BlockEncoding;
 import io.prestosql.spi.block.BlockEncodingSerde;
 import io.prestosql.spi.connector.CatalogSchemaName;
@@ -37,6 +38,7 @@ import io.prestosql.spi.connector.LimitApplicationResult;
 import io.prestosql.spi.connector.ProjectionApplicationResult;
 import io.prestosql.spi.connector.SampleType;
 import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.connector.TableConnectorWarningContext;
 import io.prestosql.spi.expression.ConnectorExpression;
 import io.prestosql.spi.function.OperatorType;
 import io.prestosql.spi.predicate.TupleDomain;
@@ -65,6 +67,8 @@ import java.util.Set;
 public interface Metadata
 {
     Set<ConnectorCapabilities> getConnectorCapabilities(Session session, CatalogName catalogName);
+
+    List<PrestoWarning> getWarnings(Session session, TableConnectorWarningContext tableConnectorWarningContext);
 
     boolean catalogExists(Session session, String catalogName);
 

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -27,6 +27,7 @@ import io.prestosql.operator.aggregation.InternalAggregationFunction;
 import io.prestosql.operator.scalar.ScalarFunctionImplementation;
 import io.prestosql.operator.window.WindowFunctionSupplier;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.PrestoWarning;
 import io.prestosql.spi.QueryId;
 import io.prestosql.spi.block.ArrayBlockEncoding;
 import io.prestosql.spi.block.BlockEncoding;
@@ -71,6 +72,7 @@ import io.prestosql.spi.connector.SampleType;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.connector.TableConnectorWarningContext;
 import io.prestosql.spi.expression.ConnectorExpression;
 import io.prestosql.spi.function.OperatorType;
 import io.prestosql.spi.predicate.TupleDomain;
@@ -224,6 +226,18 @@ public final class MetadataManager
     public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, CatalogName catalogName)
     {
         return getCatalogMetadata(session, catalogName).getConnectorCapabilities();
+    }
+
+    @Override
+    public List<PrestoWarning> getWarnings(Session session, TableConnectorWarningContext tableConnectorWarningContext)
+    {
+        Optional<CatalogMetadata> catalogMetadata = getOptionalCatalogMetadata(session, tableConnectorWarningContext.getCatalogName());
+        if (catalogMetadata.isPresent()) {
+            ConnectorMetadata metadata = catalogMetadata.get().getMetadata();
+            CatalogName catalogName = catalogMetadata.get().getCatalogName();
+            return metadata.getWarnings(session.toConnectorSession(catalogName), tableConnectorWarningContext);
+        }
+        return ImmutableList.of();
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/testing/TestingWarningCollector.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestingWarningCollector.java
@@ -23,9 +23,11 @@ import io.prestosql.spi.WarningCode;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.String.format;
@@ -37,6 +39,8 @@ public class TestingWarningCollector
 {
     @GuardedBy("this")
     private final Map<WarningCode, PrestoWarning> warnings = new LinkedHashMap<>();
+    @GuardedBy("this")
+    private final Map<String, Set<PrestoWarning>> connectorMetadataWarnings = new LinkedHashMap<>();
     private final WarningCollectorConfig config;
 
     private final boolean addWarnings;
@@ -69,7 +73,22 @@ public class TestingWarningCollector
         if (addWarnings) {
             add(createTestWarning(warningCode.incrementAndGet()));
         }
-        return ImmutableList.copyOf(warnings.values());
+
+        ImmutableList.Builder<PrestoWarning> allWarnings = new ImmutableList.Builder();
+        allWarnings.addAll(warnings.values());
+        for (String connector : connectorMetadataWarnings.keySet()) {
+            allWarnings.addAll(connectorMetadataWarnings.get(connector));
+        }
+        return allWarnings.build();
+    }
+
+    @Override
+    public synchronized void addConnectorMetadataWarning(String catalogName, PrestoWarning warning)
+    {
+        if (connectorMetadataWarnings.get(catalogName) == null) {
+            connectorMetadataWarnings.put(catalogName, new HashSet<>());
+        }
+        connectorMetadataWarnings.get(catalogName).add(warning);
     }
 
     @VisibleForTesting

--- a/presto-main/src/test/java/io/prestosql/execution/warnings/TestDefaultWarningCollector.java
+++ b/presto-main/src/test/java/io/prestosql/execution/warnings/TestDefaultWarningCollector.java
@@ -38,4 +38,15 @@ public class TestDefaultWarningCollector
         warningCollector.add(new PrestoWarning(new WarningCode(3, "3"), "warning 3"));
         assertEquals(warningCollector.getWarnings().size(), 2);
     }
+
+    @Test
+    public void testConnectorMetadataWarnings()
+    {
+        WarningCollector warningCollector = new DefaultWarningCollector(new WarningCollectorConfig().setMaxWarnings(2));
+        warningCollector.addConnectorMetadataWarning("hive", new PrestoWarning(new WarningCode(1, "1"), "warning 1"));
+        warningCollector.addConnectorMetadataWarning("hive", new PrestoWarning(new WarningCode(1, "1"), "warning 1"));
+        warningCollector.addConnectorMetadataWarning("hive", new PrestoWarning(new WarningCode(2, "2"), "warning 2"));
+        warningCollector.addConnectorMetadataWarning("tpch", new PrestoWarning(new WarningCode(1, "1"), "warning 1"));
+        assertEquals(warningCollector.getWarnings().size(), 3);
+    }
 }

--- a/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
@@ -23,6 +23,7 @@ import io.prestosql.operator.aggregation.InternalAggregationFunction;
 import io.prestosql.operator.scalar.ScalarFunctionImplementation;
 import io.prestosql.operator.window.WindowFunctionSupplier;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.PrestoWarning;
 import io.prestosql.spi.block.BlockEncoding;
 import io.prestosql.spi.block.BlockEncodingSerde;
 import io.prestosql.spi.connector.CatalogSchemaName;
@@ -39,6 +40,7 @@ import io.prestosql.spi.connector.LimitApplicationResult;
 import io.prestosql.spi.connector.ProjectionApplicationResult;
 import io.prestosql.spi.connector.SampleType;
 import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.connector.TableConnectorWarningContext;
 import io.prestosql.spi.expression.ConnectorExpression;
 import io.prestosql.spi.function.OperatorType;
 import io.prestosql.spi.predicate.TupleDomain;
@@ -420,6 +422,12 @@ public abstract class AbstractMockMetadata
     public Optional<TableHandle> applySample(Session session, TableHandle table, SampleType sampleType, double sampleRatio)
     {
         return Optional.empty();
+    }
+
+    @Override
+    public List<PrestoWarning> getWarnings(Session session, TableConnectorWarningContext tableConnectorWarningContext)
+    {
+        throw new UnsupportedOperationException();
     }
 
     //

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
@@ -15,6 +15,7 @@ package io.prestosql.spi.connector;
 
 import io.airlift.slice.Slice;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.PrestoWarning;
 import io.prestosql.spi.expression.ConnectorExpression;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.security.GrantInfo;
@@ -791,5 +792,10 @@ public interface ConnectorMetadata
     default Optional<ConnectorTableHandle> applySample(ConnectorSession session, ConnectorTableHandle handle, SampleType sampleType, double sampleRatio)
     {
         return Optional.empty();
+    }
+
+    default List<PrestoWarning> getWarnings(ConnectorSession session, TableConnectorWarningContext tableConnectorWarningContext)
+    {
+        return emptyList();
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/TableConnectorWarningContext.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/TableConnectorWarningContext.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi.connector;
+
+public class TableConnectorWarningContext
+{
+    private final ConnectorTableHandle connectorTableHandle;
+    private final String catalogName;
+
+    public TableConnectorWarningContext(ConnectorTableHandle connectorTableHandle, String catalogName)
+    {
+        this.connectorTableHandle = connectorTableHandle;
+        this.catalogName = catalogName;
+    }
+
+    public ConnectorTableHandle getConnectorTableHandle()
+    {
+        return connectorTableHandle;
+    }
+
+    public String getCatalogName()
+    {
+        return catalogName;
+    }
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -14,6 +14,7 @@
 package io.prestosql.spi.connector.classloader;
 
 import io.airlift.slice.Slice;
+import io.prestosql.spi.PrestoWarning;
 import io.prestosql.spi.classloader.ThreadContextClassLoader;
 import io.prestosql.spi.connector.ColumnHandle;
 import io.prestosql.spi.connector.ColumnMetadata;
@@ -40,6 +41,7 @@ import io.prestosql.spi.connector.SampleType;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.SystemTable;
+import io.prestosql.spi.connector.TableConnectorWarningContext;
 import io.prestosql.spi.expression.ConnectorExpression;
 import io.prestosql.spi.predicate.TupleDomain;
 import io.prestosql.spi.security.GrantInfo;
@@ -640,6 +642,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.applySample(session, table, sampleType, sampleRatio);
+        }
+    }
+
+    @Override
+    public List<PrestoWarning> getWarnings(ConnectorSession session, TableConnectorWarningContext tableConnectorWarningContext)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getWarnings(session, tableConnectorWarningContext);
         }
     }
 }


### PR DESCRIPTION
This PR introduces warnings into the connector. For now, I've only focused on the table metadata aspect. 

In a prior discussion https://github.com/prestosql/presto/issues/1140#issuecomment-513094440, it was suggested that, for a first set of warnings, we should make it configurable in connector.properties.

The TableConnectorWarningContext is used to pass the objects needed into the connectors. In the future, other objects like the column handle can be added.

I have added two warnings in this PR:

- Preferred File Format
Triggers a warning if a table uses a storage format different than the preferred one (configurable)

- Too Many Partitions
Triggers a warning if a table uses too many partitions (configurable)
