### PR TITLE
Rename LateralJoin to CorrelatedJoin

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -117,13 +117,13 @@ import io.prestosql.sql.planner.iterative.rule.SimplifyCountOverConstant;
 import io.prestosql.sql.planner.iterative.rule.SimplifyExpressions;
 import io.prestosql.sql.planner.iterative.rule.SingleDistinctAggregationToGroupBy;
 import io.prestosql.sql.planner.iterative.rule.TransformCorrelatedInPredicateToJoin;
-import io.prestosql.sql.planner.iterative.rule.TransformCorrelatedLateralJoinToJoin;
+import io.prestosql.sql.planner.iterative.rule.TransformCorrelatedJoinToJoin;
 import io.prestosql.sql.planner.iterative.rule.TransformCorrelatedScalarAggregationToJoin;
 import io.prestosql.sql.planner.iterative.rule.TransformCorrelatedScalarSubquery;
 import io.prestosql.sql.planner.iterative.rule.TransformCorrelatedSingleRowSubqueryToProject;
-import io.prestosql.sql.planner.iterative.rule.TransformExistsApplyToLateralNode;
+import io.prestosql.sql.planner.iterative.rule.TransformExistsApplyToCorrelatedJoin;
 import io.prestosql.sql.planner.iterative.rule.TransformUncorrelatedInPredicateSubqueryToSemiJoin;
-import io.prestosql.sql.planner.iterative.rule.TransformUncorrelatedLateralToJoin;
+import io.prestosql.sql.planner.iterative.rule.TransformUncorrelatedSubqueryToJoin;
 import io.prestosql.sql.planner.iterative.rule.UnwrapCastInComparison;
 import io.prestosql.sql.planner.optimizations.AddExchanges;
 import io.prestosql.sql.planner.optimizations.AddLocalExchanges;
@@ -142,7 +142,7 @@ import io.prestosql.sql.planner.optimizations.ReplicateSemiJoinInDelete;
 import io.prestosql.sql.planner.optimizations.SetFlatteningOptimizer;
 import io.prestosql.sql.planner.optimizations.StatsRecordingPlanOptimizer;
 import io.prestosql.sql.planner.optimizations.TableDeleteOptimizer;
-import io.prestosql.sql.planner.optimizations.TransformQuantifiedComparisonApplyToLateralJoin;
+import io.prestosql.sql.planner.optimizations.TransformQuantifiedComparisonApplyToCorrelatedJoin;
 import io.prestosql.sql.planner.optimizations.UnaliasSymbolReferences;
 import io.prestosql.sql.planner.optimizations.WindowFilterPushDown;
 import org.weakref.jmx.MBeanExporter;
@@ -366,18 +366,18 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        ImmutableSet.of(new TransformExistsApplyToLateralNode(metadata))),
-                new TransformQuantifiedComparisonApplyToLateralJoin(metadata),
+                        ImmutableSet.of(new TransformExistsApplyToCorrelatedJoin(metadata))),
+                new TransformQuantifiedComparisonApplyToCorrelatedJoin(metadata),
                 new IterativeOptimizer(
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(
                                 new RemoveUnreferencedScalarLateralNodes(),
-                                new TransformUncorrelatedLateralToJoin(),
+                                new TransformUncorrelatedSubqueryToJoin(),
                                 new TransformUncorrelatedInPredicateSubqueryToSemiJoin(),
                                 new TransformCorrelatedScalarAggregationToJoin(metadata),
-                                new TransformCorrelatedLateralJoinToJoin())),
+                                new TransformCorrelatedJoinToJoin())),
                 new IterativeOptimizer(
                         ruleStats,
                         statsCalculator,
@@ -386,7 +386,7 @@ public class PlanOptimizers
                                 new RemoveUnreferencedScalarApplyNodes(),
                                 new TransformCorrelatedInPredicateToJoin(), // must be run after PruneUnreferencedOutputs
                                 new TransformCorrelatedScalarSubquery(metadata), // must be run after TransformCorrelatedScalarAggregationToJoin
-                                new TransformCorrelatedLateralJoinToJoin(),
+                                new TransformCorrelatedJoinToJoin(),
                                 new ImplementFilteredAggregations())),
                 new IterativeOptimizer(
                         ruleStats,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/SubqueryPlanner.java
@@ -22,9 +22,9 @@ import io.prestosql.sql.analyzer.Analysis;
 import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
 import io.prestosql.sql.planner.plan.FilterNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.ProjectNode;
 import io.prestosql.sql.planner.plan.SimplePlanRewriter;
@@ -227,10 +227,10 @@ class SubqueryPlanner
         }
 
         // The subquery's EnforceSingleRowNode always produces a row, so the join is effectively INNER
-        return appendLateralJoin(subPlan, subqueryPlan, scalarSubquery.getQuery(), correlationAllowed, LateralJoinNode.Type.INNER, TRUE_LITERAL);
+        return appendCorrelatedJoin(subPlan, subqueryPlan, scalarSubquery.getQuery(), correlationAllowed, CorrelatedJoinNode.Type.INNER, TRUE_LITERAL);
     }
 
-    public PlanBuilder appendLateralJoin(PlanBuilder subPlan, PlanBuilder subqueryPlan, Query query, boolean correlationAllowed, LateralJoinNode.Type type, Expression filterCondition)
+    public PlanBuilder appendCorrelatedJoin(PlanBuilder subPlan, PlanBuilder subqueryPlan, Query query, boolean correlationAllowed, CorrelatedJoinNode.Type type, Expression filterCondition)
     {
         PlanNode subqueryNode = subqueryPlan.getRoot();
         Map<Expression, Expression> correlation = extractCorrelation(subPlan, subqueryNode);
@@ -241,7 +241,7 @@ class SubqueryPlanner
 
         return new PlanBuilder(
                 subPlan.copyTranslations(),
-                new LateralJoinNode(
+                new CorrelatedJoinNode(
                         idAllocator.getNextId(),
                         subPlan.getRoot(),
                         subqueryNode,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveUnreferencedScalarLateralNodes.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/RemoveUnreferencedScalarLateralNodes.java
@@ -17,31 +17,31 @@ import io.prestosql.matching.Captures;
 import io.prestosql.matching.Pattern;
 import io.prestosql.sql.planner.iterative.Lookup;
 import io.prestosql.sql.planner.iterative.Rule;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 
 import static io.prestosql.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
-import static io.prestosql.sql.planner.plan.Patterns.LateralJoin.filter;
-import static io.prestosql.sql.planner.plan.Patterns.lateralJoin;
+import static io.prestosql.sql.planner.plan.Patterns.CorrelatedJoin.filter;
+import static io.prestosql.sql.planner.plan.Patterns.correlatedJoin;
 import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
 
 public class RemoveUnreferencedScalarLateralNodes
-        implements Rule<LateralJoinNode>
+        implements Rule<CorrelatedJoinNode>
 {
-    private static final Pattern<LateralJoinNode> PATTERN = lateralJoin()
+    private static final Pattern<CorrelatedJoinNode> PATTERN = correlatedJoin()
             .with(filter().equalTo(TRUE_LITERAL));
 
     @Override
-    public Pattern<LateralJoinNode> getPattern()
+    public Pattern<CorrelatedJoinNode> getPattern()
     {
         return PATTERN;
     }
 
     @Override
-    public Result apply(LateralJoinNode lateralJoinNode, Captures captures, Context context)
+    public Result apply(CorrelatedJoinNode correlatedJoinNode, Captures captures, Context context)
     {
-        PlanNode input = lateralJoinNode.getInput();
-        PlanNode subquery = lateralJoinNode.getSubquery();
+        PlanNode input = correlatedJoinNode.getInput();
+        PlanNode subquery = correlatedJoinNode.getSubquery();
 
         if (isUnreferencedScalar(input, context.getLookup())) {
             return Result.ofPlanNode(subquery);

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedScalarAggregationToJoin.java
@@ -20,8 +20,8 @@ import io.prestosql.sql.planner.iterative.Lookup;
 import io.prestosql.sql.planner.iterative.Rule;
 import io.prestosql.sql.planner.optimizations.ScalarAggregationToJoinRewriter;
 import io.prestosql.sql.planner.plan.AggregationNode;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.ProjectNode;
 
@@ -30,9 +30,9 @@ import java.util.Optional;
 import static io.prestosql.matching.Pattern.nonEmpty;
 import static io.prestosql.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static io.prestosql.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
-import static io.prestosql.sql.planner.plan.Patterns.LateralJoin.correlation;
-import static io.prestosql.sql.planner.plan.Patterns.LateralJoin.filter;
-import static io.prestosql.sql.planner.plan.Patterns.lateralJoin;
+import static io.prestosql.sql.planner.plan.Patterns.CorrelatedJoin.correlation;
+import static io.prestosql.sql.planner.plan.Patterns.CorrelatedJoin.filter;
+import static io.prestosql.sql.planner.plan.Patterns.correlatedJoin;
 import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static io.prestosql.util.MorePredicates.isInstanceOfAny;
 import static java.util.Objects.requireNonNull;
@@ -46,7 +46,7 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * From:
  * <pre>
- * - LateralJoin (with correlation list: [C])
+ * - CorrelatedJoin (with correlation list: [C])
  *   - (input) plan which produces symbols: [A, B, C]
  *   - (subquery) Aggregation(GROUP BY (); functions: [sum(F), count(), ...]
  *     - Filter(D = C AND E > 5)
@@ -66,14 +66,14 @@ import static java.util.Objects.requireNonNull;
  * Note that only conjunction predicates in FilterNode are supported
  */
 public class TransformCorrelatedScalarAggregationToJoin
-        implements Rule<LateralJoinNode>
+        implements Rule<CorrelatedJoinNode>
 {
-    private static final Pattern<LateralJoinNode> PATTERN = lateralJoin()
+    private static final Pattern<CorrelatedJoinNode> PATTERN = correlatedJoin()
             .with(nonEmpty(correlation()))
             .with(filter().equalTo(TRUE_LITERAL)); // todo non-trivial join filter: adding filter/project on top of aggregation
 
     @Override
-    public Pattern<LateralJoinNode> getPattern()
+    public Pattern<CorrelatedJoinNode> getPattern()
     {
         return PATTERN;
     }
@@ -86,9 +86,9 @@ public class TransformCorrelatedScalarAggregationToJoin
     }
 
     @Override
-    public Result apply(LateralJoinNode lateralJoinNode, Captures captures, Context context)
+    public Result apply(CorrelatedJoinNode correlatedJoinNode, Captures captures, Context context)
     {
-        PlanNode subquery = lateralJoinNode.getSubquery();
+        PlanNode subquery = correlatedJoinNode.getSubquery();
 
         if (!isScalar(subquery, context.getLookup())) {
             return Result.empty();
@@ -101,9 +101,9 @@ public class TransformCorrelatedScalarAggregationToJoin
 
         ScalarAggregationToJoinRewriter rewriter = new ScalarAggregationToJoinRewriter(metadata, context.getSymbolAllocator(), context.getIdAllocator(), context.getLookup());
 
-        PlanNode rewrittenNode = rewriter.rewriteScalarAggregation(lateralJoinNode, aggregation.get());
+        PlanNode rewrittenNode = rewriter.rewriteScalarAggregation(correlatedJoinNode, aggregation.get());
 
-        if (rewrittenNode instanceof LateralJoinNode) {
+        if (rewrittenNode instanceof CorrelatedJoinNode) {
             return Result.empty();
         }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedScalarSubquery.java
@@ -25,9 +25,9 @@ import io.prestosql.sql.planner.Symbol;
 import io.prestosql.sql.planner.iterative.Rule;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
 import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
 import io.prestosql.sql.planner.plan.FilterNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.ProjectNode;
@@ -47,10 +47,10 @@ import static io.prestosql.spi.type.StandardTypes.BOOLEAN;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
 import static io.prestosql.sql.planner.optimizations.QueryCardinalityUtil.extractCardinality;
-import static io.prestosql.sql.planner.plan.LateralJoinNode.Type.LEFT;
-import static io.prestosql.sql.planner.plan.Patterns.LateralJoin.correlation;
-import static io.prestosql.sql.planner.plan.Patterns.LateralJoin.filter;
-import static io.prestosql.sql.planner.plan.Patterns.lateralJoin;
+import static io.prestosql.sql.planner.plan.CorrelatedJoinNode.Type.LEFT;
+import static io.prestosql.sql.planner.plan.Patterns.CorrelatedJoin.correlation;
+import static io.prestosql.sql.planner.plan.Patterns.CorrelatedJoin.filter;
+import static io.prestosql.sql.planner.plan.Patterns.correlatedJoin;
 import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static java.util.Objects.requireNonNull;
 
@@ -64,7 +64,7 @@ import static java.util.Objects.requireNonNull;
  * <p>
  * From:
  * <pre>
- * - LateralJoin (with correlation list: [C])
+ * - CorrelatedJoin (with correlation list: [C])
  *   - (input) plan which produces symbols: [A, B, C]
  *   - (scalar subquery) Project F
  *     - Filter(D = C AND E > 5)
@@ -74,7 +74,7 @@ import static java.util.Objects.requireNonNull;
  * <pre>
  * - Filter(CASE isDistinct WHEN true THEN true ELSE fail('Scalar sub-query has returned multiple rows'))
  *   - MarkDistinct(isDistinct)
- *     - LateralJoin (with correlation list: [C])
+ *     - CorrelatedJoin (with correlation list: [C])
  *       - AssignUniqueId(adds symbol U)
  *         - (input) plan which produces symbols: [A, B, C]
  *       - non scalar subquery
@@ -83,9 +83,9 @@ import static java.util.Objects.requireNonNull;
  * This must be run after {@link TransformCorrelatedScalarAggregationToJoin}
  */
 public class TransformCorrelatedScalarSubquery
-        implements Rule<LateralJoinNode>
+        implements Rule<CorrelatedJoinNode>
 {
-    private static final Pattern<LateralJoinNode> PATTERN = lateralJoin()
+    private static final Pattern<CorrelatedJoinNode> PATTERN = correlatedJoin()
             .with(nonEmpty(correlation()))
             .with(filter().equalTo(TRUE_LITERAL));
 
@@ -97,15 +97,15 @@ public class TransformCorrelatedScalarSubquery
     }
 
     @Override
-    public Pattern<LateralJoinNode> getPattern()
+    public Pattern<CorrelatedJoinNode> getPattern()
     {
         return PATTERN;
     }
 
     @Override
-    public Result apply(LateralJoinNode lateralJoinNode, Captures captures, Context context)
+    public Result apply(CorrelatedJoinNode correlatedJoinNode, Captures captures, Context context)
     {
-        PlanNode subquery = context.getLookup().resolve(lateralJoinNode.getSubquery());
+        PlanNode subquery = context.getLookup().resolve(correlatedJoinNode.getSubquery());
 
         if (!searchFrom(subquery, context.getLookup())
                 .where(EnforceSingleRowNode.class::isInstance)
@@ -123,36 +123,36 @@ public class TransformCorrelatedScalarSubquery
         boolean producesAtMostOneRow = Range.closed(0L, 1L).encloses(subqueryCardinality);
         if (producesAtMostOneRow) {
             boolean producesSingleRow = Range.singleton(1L).encloses(subqueryCardinality);
-            return Result.ofPlanNode(new LateralJoinNode(
+            return Result.ofPlanNode(new CorrelatedJoinNode(
                     context.getIdAllocator().getNextId(),
-                    lateralJoinNode.getInput(),
+                    correlatedJoinNode.getInput(),
                     rewrittenSubquery,
-                    lateralJoinNode.getCorrelation(),
-                    producesSingleRow ? lateralJoinNode.getType() : LEFT,
-                    lateralJoinNode.getFilter(),
-                    lateralJoinNode.getOriginSubquery()));
+                    correlatedJoinNode.getCorrelation(),
+                    producesSingleRow ? correlatedJoinNode.getType() : LEFT,
+                    correlatedJoinNode.getFilter(),
+                    correlatedJoinNode.getOriginSubquery()));
         }
 
         Symbol unique = context.getSymbolAllocator().newSymbol("unique", BigintType.BIGINT);
 
-        LateralJoinNode rewrittenLateralJoinNode = new LateralJoinNode(
+        CorrelatedJoinNode rewrittenCorrelatedJoinNode = new CorrelatedJoinNode(
                 context.getIdAllocator().getNextId(),
                 new AssignUniqueId(
                         context.getIdAllocator().getNextId(),
-                        lateralJoinNode.getInput(),
+                        correlatedJoinNode.getInput(),
                         unique),
                 rewrittenSubquery,
-                lateralJoinNode.getCorrelation(),
+                correlatedJoinNode.getCorrelation(),
                 LEFT,
-                lateralJoinNode.getFilter(),
-                lateralJoinNode.getOriginSubquery());
+                correlatedJoinNode.getFilter(),
+                correlatedJoinNode.getOriginSubquery());
 
         Symbol isDistinct = context.getSymbolAllocator().newSymbol("is_distinct", BooleanType.BOOLEAN);
         MarkDistinctNode markDistinctNode = new MarkDistinctNode(
                 context.getIdAllocator().getNextId(),
-                rewrittenLateralJoinNode,
+                rewrittenCorrelatedJoinNode,
                 isDistinct,
-                rewrittenLateralJoinNode.getInput().getOutputSymbols(),
+                rewrittenCorrelatedJoinNode.getInput().getOutputSymbols(),
                 Optional.empty());
 
         FilterNode filterNode = new FilterNode(
@@ -173,6 +173,6 @@ public class TransformCorrelatedScalarSubquery
         return Result.ofPlanNode(new ProjectNode(
                 context.getIdAllocator().getNextId(),
                 filterNode,
-                Assignments.identity(lateralJoinNode.getOutputSymbols())));
+                Assignments.identity(correlatedJoinNode.getOutputSymbols())));
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedSingleRowSubqueryToProject.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/TransformCorrelatedSingleRowSubqueryToProject.java
@@ -17,7 +17,7 @@ import io.prestosql.matching.Captures;
 import io.prestosql.matching.Pattern;
 import io.prestosql.sql.planner.iterative.Rule;
 import io.prestosql.sql.planner.plan.Assignments;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.ProjectNode;
 import io.prestosql.sql.planner.plan.ValuesNode;
@@ -25,8 +25,8 @@ import io.prestosql.sql.planner.plan.ValuesNode;
 import java.util.List;
 
 import static io.prestosql.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
-import static io.prestosql.sql.planner.plan.Patterns.LateralJoin.filter;
-import static io.prestosql.sql.planner.plan.Patterns.lateralJoin;
+import static io.prestosql.sql.planner.plan.Patterns.CorrelatedJoin.filter;
+import static io.prestosql.sql.planner.plan.Patterns.correlatedJoin;
 import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
 
 /**
@@ -47,19 +47,19 @@ import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
  */
 
 public class TransformCorrelatedSingleRowSubqueryToProject
-        implements Rule<LateralJoinNode>
+        implements Rule<CorrelatedJoinNode>
 {
-    private static final Pattern<LateralJoinNode> PATTERN = lateralJoin()
+    private static final Pattern<CorrelatedJoinNode> PATTERN = correlatedJoin()
             .with(filter().equalTo(TRUE_LITERAL));
 
     @Override
-    public Pattern<LateralJoinNode> getPattern()
+    public Pattern<CorrelatedJoinNode> getPattern()
     {
         return PATTERN;
     }
 
     @Override
-    public Result apply(LateralJoinNode parent, Captures captures, Context context)
+    public Result apply(CorrelatedJoinNode parent, Captures captures, Context context)
     {
         List<ValuesNode> values = searchFrom(parent.getSubquery(), context.getLookup())
                 .recurseOnlyWhen(ProjectNode.class::isInstance)

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddExchanges.java
@@ -40,6 +40,7 @@ import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.Assignments;
 import io.prestosql.sql.planner.plan.ChildReplacer;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
 import io.prestosql.sql.planner.plan.ExchangeNode;
@@ -49,7 +50,6 @@ import io.prestosql.sql.planner.plan.GroupIdNode;
 import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.IndexSourceNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OutputNode;
@@ -1173,7 +1173,7 @@ public class AddExchanges
         }
 
         @Override
-        public PlanWithProperties visitLateralJoin(LateralJoinNode node, PreferredProperties preferredProperties)
+        public PlanWithProperties visitCorrelatedJoin(CorrelatedJoinNode node, PreferredProperties preferredProperties)
         {
             throw new IllegalStateException("Unexpected node: " + node.getClass().getName());
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddLocalExchanges.java
@@ -33,13 +33,13 @@ import io.prestosql.sql.planner.TypeProvider;
 import io.prestosql.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties;
 import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.ApplyNode;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
 import io.prestosql.sql.planner.plan.ExchangeNode;
 import io.prestosql.sql.planner.plan.ExplainAnalyzeNode;
 import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OutputNode;
@@ -141,7 +141,7 @@ public class AddLocalExchanges
         }
 
         @Override
-        public PlanWithProperties visitLateralJoin(LateralJoinNode node, StreamPreferredProperties parentPreferences)
+        public PlanWithProperties visitCorrelatedJoin(CorrelatedJoinNode node, StreamPreferredProperties parentPreferences)
         {
             throw new IllegalStateException("Unexpected node: " + node.getClass().getName());
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/CheckSubqueryNodesAreRewritten.java
@@ -22,7 +22,7 @@ import io.prestosql.sql.planner.Symbol;
 import io.prestosql.sql.planner.SymbolAllocator;
 import io.prestosql.sql.planner.TypeProvider;
 import io.prestosql.sql.planner.plan.ApplyNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.tree.Node;
 
@@ -45,11 +45,11 @@ public class CheckSubqueryNodesAreRewritten
                     throw error(applyNode.getCorrelation(), applyNode.getOriginSubquery());
                 });
 
-        searchFrom(plan).where(LateralJoinNode.class::isInstance)
+        searchFrom(plan).where(CorrelatedJoinNode.class::isInstance)
                 .findFirst()
                 .ifPresent(node -> {
-                    LateralJoinNode lateralJoinNode = (LateralJoinNode) node;
-                    throw error(lateralJoinNode.getCorrelation(), lateralJoinNode.getOriginSubquery());
+                    CorrelatedJoinNode correlatedJoinNode = (CorrelatedJoinNode) node;
+                    throw error(correlatedJoinNode.getCorrelation(), correlatedJoinNode.getOriginSubquery());
                 });
 
         return plan;

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -37,6 +37,7 @@ import io.prestosql.sql.planner.TypeProvider;
 import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
 import io.prestosql.sql.planner.plan.ExchangeNode;
@@ -44,7 +45,6 @@ import io.prestosql.sql.planner.plan.GroupIdNode;
 import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.IndexJoinNode.EquiJoinClause;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.PlanVisitor;
@@ -156,9 +156,9 @@ public class HashGenerationOptimizer
         }
 
         @Override
-        public PlanWithProperties visitLateralJoin(LateralJoinNode node, HashComputationSet context)
+        public PlanWithProperties visitCorrelatedJoin(CorrelatedJoinNode node, HashComputationSet context)
         {
-            // Lateral join node is not supported by execution, so do not rewrite it
+            // Correlated join node is not supported by execution, so do not rewrite it
             // that way query will fail in sanity checkers
             return new PlanWithProperties(node, ImmutableMap.of());
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PropertyDerivations.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PropertyDerivations.java
@@ -42,6 +42,7 @@ import io.prestosql.sql.planner.optimizations.ActualProperties.Global;
 import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DeleteNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
@@ -52,7 +53,6 @@ import io.prestosql.sql.planner.plan.GroupIdNode;
 import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.IndexSourceNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OutputNode;
@@ -213,7 +213,7 @@ public final class PropertyDerivations
         }
 
         @Override
-        public ActualProperties visitLateralJoin(LateralJoinNode node, List<ActualProperties> inputProperties)
+        public ActualProperties visitCorrelatedJoin(CorrelatedJoinNode node, List<ActualProperties> inputProperties)
         {
             throw new IllegalArgumentException("Unexpected node: " + node.getClass().getName());
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -35,6 +35,7 @@ import io.prestosql.sql.planner.plan.AggregationNode.Aggregation;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
 import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DeleteNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.ExceptNode;
@@ -46,7 +47,6 @@ import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.IndexSourceNode;
 import io.prestosql.sql.planner.plan.IntersectNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OffsetNode;
@@ -89,9 +89,9 @@ import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Sets.intersection;
 import static io.prestosql.sql.planner.optimizations.QueryCardinalityUtil.isAtMostScalar;
 import static io.prestosql.sql.planner.optimizations.QueryCardinalityUtil.isScalar;
-import static io.prestosql.sql.planner.plan.LateralJoinNode.Type.INNER;
-import static io.prestosql.sql.planner.plan.LateralJoinNode.Type.LEFT;
-import static io.prestosql.sql.planner.plan.LateralJoinNode.Type.RIGHT;
+import static io.prestosql.sql.planner.plan.CorrelatedJoinNode.Type.INNER;
+import static io.prestosql.sql.planner.plan.CorrelatedJoinNode.Type.LEFT;
+import static io.prestosql.sql.planner.plan.CorrelatedJoinNode.Type.RIGHT;
 import static io.prestosql.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static java.util.Objects.requireNonNull;
 
@@ -835,7 +835,7 @@ public class PruneUnreferencedOutputs
         }
 
         @Override
-        public PlanNode visitLateralJoin(LateralJoinNode node, RewriteContext<Set<Symbol>> context)
+        public PlanNode visitCorrelatedJoin(CorrelatedJoinNode node, RewriteContext<Set<Symbol>> context)
         {
             Set<Symbol> expectedFilterSymbols = SymbolsExtractor.extractUnique(node.getFilter());
 
@@ -886,7 +886,7 @@ public class PruneUnreferencedOutputs
                 }
             }
 
-            return new LateralJoinNode(node.getId(), input, subquery, newCorrelation, node.getType(), node.getFilter(), node.getOriginSubquery());
+            return new CorrelatedJoinNode(node.getId(), input, subquery, newCorrelation, node.getType(), node.getFilter(), node.getOriginSubquery());
         }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/ScalarAggregationToJoinRewriter.java
@@ -28,9 +28,9 @@ import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.AggregationNode.Aggregation;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
 import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 import io.prestosql.sql.planner.plan.ProjectNode;
 import io.prestosql.sql.tree.Expression;
@@ -67,12 +67,12 @@ public class ScalarAggregationToJoinRewriter
         this.planNodeDecorrelator = new PlanNodeDecorrelator(idAllocator, lookup);
     }
 
-    public PlanNode rewriteScalarAggregation(LateralJoinNode lateralJoinNode, AggregationNode aggregation)
+    public PlanNode rewriteScalarAggregation(CorrelatedJoinNode correlatedJoinNode, AggregationNode aggregation)
     {
-        List<Symbol> correlation = lateralJoinNode.getCorrelation();
+        List<Symbol> correlation = correlatedJoinNode.getCorrelation();
         Optional<DecorrelatedNode> source = planNodeDecorrelator.decorrelateFilters(lookup.resolve(aggregation.getSource()), correlation);
         if (!source.isPresent()) {
-            return lateralJoinNode;
+            return correlatedJoinNode;
         }
 
         Symbol nonNull = symbolAllocator.newSymbol("non_null", BooleanType.BOOLEAN);
@@ -86,7 +86,7 @@ public class ScalarAggregationToJoinRewriter
                 scalarAggregationSourceAssignments);
 
         return rewriteScalarAggregation(
-                lateralJoinNode,
+                correlatedJoinNode,
                 aggregation,
                 scalarAggregationSourceWithNonNullableSymbol,
                 source.get().getCorrelatedPredicates(),
@@ -94,7 +94,7 @@ public class ScalarAggregationToJoinRewriter
     }
 
     private PlanNode rewriteScalarAggregation(
-            LateralJoinNode lateralJoinNode,
+            CorrelatedJoinNode correlatedJoinNode,
             AggregationNode scalarAggregation,
             PlanNode scalarAggregationSource,
             Optional<Expression> joinExpression,
@@ -102,7 +102,7 @@ public class ScalarAggregationToJoinRewriter
     {
         AssignUniqueId inputWithUniqueColumns = new AssignUniqueId(
                 idAllocator.getNextId(),
-                lateralJoinNode.getInput(),
+                correlatedJoinNode.getInput(),
                 symbolAllocator.newSymbol("unique", BigintType.BIGINT));
 
         JoinNode leftOuterJoin = new JoinNode(
@@ -128,15 +128,15 @@ public class ScalarAggregationToJoinRewriter
                 nonNull);
 
         if (!aggregationNode.isPresent()) {
-            return lateralJoinNode;
+            return correlatedJoinNode;
         }
 
-        Optional<ProjectNode> subqueryProjection = searchFrom(lateralJoinNode.getSubquery(), lookup)
+        Optional<ProjectNode> subqueryProjection = searchFrom(correlatedJoinNode.getSubquery(), lookup)
                 .where(ProjectNode.class::isInstance)
                 .recurseOnlyWhen(EnforceSingleRowNode.class::isInstance)
                 .findFirst();
 
-        List<Symbol> aggregationOutputSymbols = getTruncatedAggregationSymbols(lateralJoinNode, aggregationNode.get());
+        List<Symbol> aggregationOutputSymbols = getTruncatedAggregationSymbols(correlatedJoinNode, aggregationNode.get());
 
         if (subqueryProjection.isPresent()) {
             Assignments assignments = Assignments.builder()
@@ -157,9 +157,9 @@ public class ScalarAggregationToJoinRewriter
         }
     }
 
-    private static List<Symbol> getTruncatedAggregationSymbols(LateralJoinNode lateralJoinNode, AggregationNode aggregationNode)
+    private static List<Symbol> getTruncatedAggregationSymbols(CorrelatedJoinNode correlatedJoinNode, AggregationNode aggregationNode)
     {
-        Set<Symbol> applySymbols = new HashSet<>(lateralJoinNode.getOutputSymbols());
+        Set<Symbol> applySymbols = new HashSet<>(correlatedJoinNode.getOutputSymbols());
         return aggregationNode.getOutputSymbols().stream()
                 .filter(applySymbols::contains)
                 .collect(toImmutableList());

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -30,6 +30,7 @@ import io.prestosql.sql.planner.TypeProvider;
 import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DeleteNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
@@ -40,7 +41,6 @@ import io.prestosql.sql.planner.plan.GroupIdNode;
 import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.IndexSourceNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OutputNode;
@@ -565,7 +565,7 @@ public final class StreamPropertyDerivations
         }
 
         @Override
-        public StreamProperties visitLateralJoin(LateralJoinNode node, List<StreamProperties> inputProperties)
+        public StreamProperties visitCorrelatedJoin(CorrelatedJoinNode node, List<StreamProperties> inputProperties)
         {
             throw new IllegalStateException("Unexpected node: " + node.getClass());
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -35,6 +35,7 @@ import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
 import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DeleteNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
@@ -47,7 +48,6 @@ import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.IndexSourceNode;
 import io.prestosql.sql.planner.plan.IntersectNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OffsetNode;
@@ -465,13 +465,13 @@ public class UnaliasSymbolReferences
         }
 
         @Override
-        public PlanNode visitLateralJoin(LateralJoinNode node, RewriteContext<Void> context)
+        public PlanNode visitCorrelatedJoin(CorrelatedJoinNode node, RewriteContext<Void> context)
         {
             PlanNode source = context.rewrite(node.getInput());
             PlanNode subquery = context.rewrite(node.getSubquery());
             List<Symbol> canonicalCorrelation = canonicalizeAndDistinct(node.getCorrelation());
 
-            return new LateralJoinNode(node.getId(), source, subquery, canonicalCorrelation, node.getType(), canonicalize(node.getFilter()), node.getOriginSubquery());
+            return new CorrelatedJoinNode(node.getId(), source, subquery, canonicalCorrelation, node.getType(), canonicalize(node.getFilter()), node.getOriginSubquery());
         }
 
         @Override

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/CorrelatedJoinNode.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/CorrelatedJoinNode.java
@@ -36,7 +36,7 @@ import static java.util.Objects.requireNonNull;
  * LEFT - does return input completed with NULL values when subquery relation is empty
  */
 @Immutable
-public class LateralJoinNode
+public class CorrelatedJoinNode
         extends PlanNode
 {
     public enum Type
@@ -94,7 +94,7 @@ public class LateralJoinNode
     private final Node originSubquery;
 
     @JsonCreator
-    public LateralJoinNode(
+    public CorrelatedJoinNode(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("input") PlanNode input,
             @JsonProperty("subquery") PlanNode subquery,
@@ -176,12 +176,12 @@ public class LateralJoinNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         checkArgument(newChildren.size() == 2, "expected newChildren to contain 2 nodes");
-        return new LateralJoinNode(getId(), newChildren.get(0), newChildren.get(1), correlation, type, filter, originSubquery);
+        return new CorrelatedJoinNode(getId(), newChildren.get(0), newChildren.get(1), correlation, type, filter, originSubquery);
     }
 
     @Override
     public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
     {
-        return visitor.visitLateralJoin(this, context);
+        return visitor.visitCorrelatedJoin(this, context);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/Patterns.java
@@ -82,9 +82,9 @@ public final class Patterns
         return typeOf(SpatialJoinNode.class);
     }
 
-    public static Pattern<LateralJoinNode> lateralJoin()
+    public static Pattern<CorrelatedJoinNode> correlatedJoin()
     {
-        return typeOf(LateralJoinNode.class);
+        return typeOf(CorrelatedJoinNode.class);
     }
 
     public static Pattern<OffsetNode> offset()
@@ -241,21 +241,21 @@ public final class Patterns
         }
     }
 
-    public static final class LateralJoin
+    public static final class CorrelatedJoin
     {
-        public static Property<LateralJoinNode, Lookup, List<Symbol>> correlation()
+        public static Property<CorrelatedJoinNode, Lookup, List<Symbol>> correlation()
         {
-            return property("correlation", LateralJoinNode::getCorrelation);
+            return property("correlation", CorrelatedJoinNode::getCorrelation);
         }
 
-        public static Property<LateralJoinNode, Lookup, PlanNode> subquery()
+        public static Property<CorrelatedJoinNode, Lookup, PlanNode> subquery()
         {
-            return property("subquery", LateralJoinNode::getSubquery);
+            return property("subquery", CorrelatedJoinNode::getSubquery);
         }
 
-        public static Property<LateralJoinNode, Lookup, Expression> filter()
+        public static Property<CorrelatedJoinNode, Lookup, Expression> filter()
         {
-            return property("filter", LateralJoinNode::getFilter);
+            return property("filter", CorrelatedJoinNode::getFilter);
         }
     }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/PlanNode.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/PlanNode.java
@@ -61,7 +61,7 @@ import static java.util.Objects.requireNonNull;
         @JsonSubTypes.Type(value = ExplainAnalyzeNode.class, name = "explainAnalyze"),
         @JsonSubTypes.Type(value = ApplyNode.class, name = "apply"),
         @JsonSubTypes.Type(value = AssignUniqueId.class, name = "assignUniqueId"),
-        @JsonSubTypes.Type(value = LateralJoinNode.class, name = "lateralJoin"),
+        @JsonSubTypes.Type(value = CorrelatedJoinNode.class, name = "correlatedJoin"),
         @JsonSubTypes.Type(value = StatisticsWriterNode.class, name = "statisticsWriterNode"),
 })
 public abstract class PlanNode

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/PlanVisitor.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/PlanVisitor.java
@@ -209,7 +209,7 @@ public abstract class PlanVisitor<R, C>
         return visitPlan(node, context);
     }
 
-    public R visitLateralJoin(LateralJoinNode node, C context)
+    public R visitCorrelatedJoin(CorrelatedJoinNode node, C context)
     {
         return visitPlan(node, context);
     }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/planprinter/PlanPrinter.java
@@ -55,6 +55,7 @@ import io.prestosql.sql.planner.plan.AggregationNode.Aggregation;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
 import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DeleteNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
@@ -68,7 +69,6 @@ import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.IndexSourceNode;
 import io.prestosql.sql.planner.plan.IntersectNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OffsetNode;
@@ -1096,7 +1096,7 @@ public class PlanPrinter
         }
 
         @Override
-        public Void visitLateralJoin(LateralJoinNode node, Void context)
+        public Void visitCorrelatedJoin(CorrelatedJoinNode node, Void context)
         {
             addNode(node,
                     "Lateral",

--- a/presto-main/src/main/java/io/prestosql/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -26,6 +26,7 @@ import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.AggregationNode.Aggregation;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DeleteNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
@@ -38,7 +39,6 @@ import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.IndexSourceNode;
 import io.prestosql.sql.planner.plan.IntersectNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OffsetNode;
@@ -637,7 +637,7 @@ public final class ValidateDependenciesChecker
         }
 
         @Override
-        public Void visitLateralJoin(LateralJoinNode node, Set<Symbol> boundSymbols)
+        public Void visitCorrelatedJoin(CorrelatedJoinNode node, Set<Symbol> boundSymbols)
         {
             Set<Symbol> subqueryCorrelation = ImmutableSet.<Symbol>builder()
                     .addAll(boundSymbols)

--- a/presto-main/src/main/java/io/prestosql/util/GraphvizPrinter.java
+++ b/presto-main/src/main/java/io/prestosql/util/GraphvizPrinter.java
@@ -26,6 +26,7 @@ import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.AggregationNode.Aggregation;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
 import io.prestosql.sql.planner.plan.ExchangeNode;
@@ -34,7 +35,6 @@ import io.prestosql.sql.planner.plan.GroupIdNode;
 import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.IndexSourceNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OutputNode;
@@ -509,7 +509,7 @@ public final class GraphvizPrinter
         }
 
         @Override
-        public Void visitLateralJoin(LateralJoinNode node, Void context)
+        public Void visitCorrelatedJoin(CorrelatedJoinNode node, Void context)
         {
             String correlationSymbols = Joiner.on(",").join(node.getCorrelation());
             String filterExpression = "";
@@ -517,7 +517,7 @@ public final class GraphvizPrinter
                 filterExpression = " " + node.getFilter().toString();
             }
 
-            printNode(node, "LateralJoin", correlationSymbols + filterExpression, NODE_COLORS.get(NodeType.JOIN));
+            printNode(node, "CorrelatedJoin", correlationSymbols + filterExpression, NODE_COLORS.get(NodeType.JOIN));
 
             node.getInput().accept(this, context);
             node.getSubquery().accept(this, context);

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestLogicalPlanner.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestLogicalPlanner.java
@@ -27,13 +27,13 @@ import io.prestosql.sql.planner.optimizations.CheckSubqueryNodesAreRewritten;
 import io.prestosql.sql.planner.optimizations.PlanOptimizer;
 import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.ApplyNode;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
 import io.prestosql.sql.planner.plan.ExchangeNode;
 import io.prestosql.sql.planner.plan.FilterNode;
 import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.PlanNode;
@@ -446,7 +446,7 @@ public class TestLogicalPlanner
 
     private void assertPlanContainsNoApplyOrAnyJoin(String sql)
     {
-        assertPlanDoesNotContain(sql, ApplyNode.class, JoinNode.class, IndexJoinNode.class, SemiJoinNode.class, LateralJoinNode.class);
+        assertPlanDoesNotContain(sql, ApplyNode.class, JoinNode.class, IndexJoinNode.class, SemiJoinNode.class, CorrelatedJoinNode.class);
     }
 
     private void assertPlanDoesNotContain(String sql, Class<?>... classes)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/CorrelationMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/CorrelationMatcher.java
@@ -18,7 +18,7 @@ import io.prestosql.cost.StatsProvider;
 import io.prestosql.metadata.Metadata;
 import io.prestosql.sql.planner.Symbol;
 import io.prestosql.sql.planner.plan.ApplyNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.PlanNode;
 
 import java.util.List;
@@ -42,7 +42,7 @@ public class CorrelationMatcher
     @Override
     public boolean shapeMatches(PlanNode node)
     {
-        return node instanceof ApplyNode || node instanceof LateralJoinNode;
+        return node instanceof ApplyNode || node instanceof CorrelatedJoinNode;
     }
 
     @Override
@@ -72,8 +72,8 @@ public class CorrelationMatcher
         if (node instanceof ApplyNode) {
             return ((ApplyNode) node).getCorrelation();
         }
-        else if (node instanceof LateralJoinNode) {
-            return ((LateralJoinNode) node).getCorrelation();
+        else if (node instanceof CorrelatedJoinNode) {
+            return ((CorrelatedJoinNode) node).getCorrelation();
         }
         else {
             throw new IllegalStateException("Unexpected plan node: " + node);

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
@@ -31,6 +31,7 @@ import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.AggregationNode.Step;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
 import io.prestosql.sql.planner.plan.ExceptNode;
 import io.prestosql.sql.planner.plan.ExchangeNode;
@@ -39,7 +40,6 @@ import io.prestosql.sql.planner.plan.GroupIdNode;
 import io.prestosql.sql.planner.plan.IndexSourceNode;
 import io.prestosql.sql.planner.plan.IntersectNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OffsetNode;
@@ -512,7 +512,7 @@ public final class PlanMatchPattern
 
     public static PlanMatchPattern lateral(List<String> correlationSymbolAliases, PlanMatchPattern inputPattern, PlanMatchPattern subqueryPattern)
     {
-        return node(LateralJoinNode.class, inputPattern, subqueryPattern)
+        return node(CorrelatedJoinNode.class, inputPattern, subqueryPattern)
                 .with(new CorrelationMatcher(correlationSymbolAliases));
     }
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestRemoveUnreferencedScalarLateralNodes.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestRemoveUnreferencedScalarLateralNodes.java
@@ -28,7 +28,7 @@ public class TestRemoveUnreferencedScalarLateralNodes
     public void testRemoveUnreferencedInput()
     {
         tester().assertThat(new RemoveUnreferencedScalarLateralNodes())
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         emptyList(),
                         p.values(p.symbol("x", BigintType.BIGINT)),
                         p.values(emptyList(), ImmutableList.of(emptyList()))))
@@ -39,7 +39,7 @@ public class TestRemoveUnreferencedScalarLateralNodes
     public void testRemoveUnreferencedSubquery()
     {
         tester().assertThat(new RemoveUnreferencedScalarLateralNodes())
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         emptyList(),
                         p.values(emptyList(), ImmutableList.of(emptyList())),
                         p.values(p.symbol("x", BigintType.BIGINT))))
@@ -50,7 +50,7 @@ public class TestRemoveUnreferencedScalarLateralNodes
     public void testDoesNotFire()
     {
         tester().assertThat(new RemoveUnreferencedScalarLateralNodes())
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         emptyList(),
                         p.values(),
                         p.values()))

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformCorrelatedScalarAggregationToJoin.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformCorrelatedScalarAggregationToJoin.java
@@ -45,7 +45,7 @@ public class TestTransformCorrelatedScalarAggregationToJoin
     public void doesNotFireOnCorrelatedWithoutAggregation()
     {
         tester().assertThat(new TransformCorrelatedScalarAggregationToJoin(tester().getMetadata()))
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.of(p.symbol("corr")),
                         p.values(p.symbol("corr")),
                         p.values(p.symbol("a"))))
@@ -56,7 +56,7 @@ public class TestTransformCorrelatedScalarAggregationToJoin
     public void doesNotFireOnUncorrelated()
     {
         tester().assertThat(new TransformCorrelatedScalarAggregationToJoin(tester().getMetadata()))
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.of(),
                         p.values(p.symbol("a")),
                         p.values(p.symbol("b"))))
@@ -67,7 +67,7 @@ public class TestTransformCorrelatedScalarAggregationToJoin
     public void doesNotFireOnCorrelatedWithNonScalarAggregation()
     {
         tester().assertThat(new TransformCorrelatedScalarAggregationToJoin(tester().getMetadata()))
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.of(p.symbol("corr")),
                         p.values(p.symbol("corr")),
                         p.aggregation(ab -> ab
@@ -81,7 +81,7 @@ public class TestTransformCorrelatedScalarAggregationToJoin
     public void rewritesOnSubqueryWithoutProjection()
     {
         tester().assertThat(new TransformCorrelatedScalarAggregationToJoin(tester().getMetadata()))
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.of(p.symbol("corr")),
                         p.values(p.symbol("corr")),
                         p.aggregation(ab -> ab
@@ -103,7 +103,7 @@ public class TestTransformCorrelatedScalarAggregationToJoin
     public void rewritesOnSubqueryWithProjection()
     {
         tester().assertThat(new TransformCorrelatedScalarAggregationToJoin(tester().getMetadata()))
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.of(p.symbol("corr")),
                         p.values(p.symbol("corr")),
                         p.project(Assignments.of(p.symbol("expr"), p.expression("sum + 1")),
@@ -126,7 +126,7 @@ public class TestTransformCorrelatedScalarAggregationToJoin
     public void testSubqueryWithCount()
     {
         tester().assertThat(new TransformCorrelatedScalarAggregationToJoin(tester().getMetadata()))
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.of(p.symbol("corr")),
                         p.values(p.symbol("corr")),
                         p.aggregation(ab -> ab

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformCorrelatedScalarSubquery.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformCorrelatedScalarSubquery.java
@@ -69,7 +69,7 @@ public class TestTransformCorrelatedScalarSubquery
     public void doesNotFireOnCorrelatedNonScalar()
     {
         tester().assertThat(rule)
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.of(p.symbol("corr")),
                         p.values(p.symbol("corr")),
                         p.values(p.symbol("a"))))
@@ -80,7 +80,7 @@ public class TestTransformCorrelatedScalarSubquery
     public void doesNotFireOnUncorrelated()
     {
         tester().assertThat(rule)
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.<Symbol>of(),
                         p.values(p.symbol("a")),
                         p.values(ImmutableList.of(p.symbol("b")), ImmutableList.of(expressions("1")))))
@@ -91,7 +91,7 @@ public class TestTransformCorrelatedScalarSubquery
     public void rewritesOnSubqueryWithoutProjection()
     {
         tester().assertThat(rule)
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.of(p.symbol("corr")),
                         p.values(p.symbol("corr")),
                         p.enforceSingleRow(
@@ -119,7 +119,7 @@ public class TestTransformCorrelatedScalarSubquery
     public void rewritesOnSubqueryWithProjection()
     {
         tester().assertThat(rule)
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.of(p.symbol("corr")),
                         p.values(p.symbol("corr")),
                         p.enforceSingleRow(
@@ -149,7 +149,7 @@ public class TestTransformCorrelatedScalarSubquery
     public void rewritesOnSubqueryWithProjectionOnTopEnforceSingleNode()
     {
         tester().assertThat(rule)
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.of(p.symbol("corr")),
                         p.values(p.symbol("corr")),
                         p.project(
@@ -185,7 +185,7 @@ public class TestTransformCorrelatedScalarSubquery
     public void rewritesScalarSubquery()
     {
         tester().assertThat(rule)
-                .on(p -> p.lateral(
+                .on(p -> p.correlatedJoin(
                         ImmutableList.of(p.symbol("corr")),
                         p.values(p.symbol("corr")),
                         p.enforceSingleRow(

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformCorrelatedSingleRowSubqueryToProject.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformCorrelatedSingleRowSubqueryToProject.java
@@ -49,7 +49,7 @@ public class TestTransformCorrelatedSingleRowSubqueryToProject
     {
         tester().assertThat(new TransformCorrelatedSingleRowSubqueryToProject())
                 .on(p ->
-                        p.lateral(
+                        p.correlatedJoin(
                                 ImmutableList.of(p.symbol("l_nationkey")),
                                 p.tableScan(
                                         new TableHandle(
@@ -78,7 +78,7 @@ public class TestTransformCorrelatedSingleRowSubqueryToProject
     {
         tester().assertThat(new TransformCorrelatedSingleRowSubqueryToProject())
                 .on(p ->
-                        p.lateral(
+                        p.correlatedJoin(
                                 ImmutableList.of(p.symbol("a")),
                                 p.values(p.symbol("a")),
                                 p.values(p.symbol("a"))))

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformExistsApplyToCorrelatedJoin.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformExistsApplyToCorrelatedJoin.java
@@ -31,19 +31,19 @@ import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
 import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expression;
 
-public class TestTransformExistsApplyToLateralJoin
+public class TestTransformExistsApplyToCorrelatedJoin
         extends BaseRuleTest
 {
     @Test
     public void testDoesNotFire()
     {
-        tester().assertThat(new TransformExistsApplyToLateralNode(tester().getMetadata()))
+        tester().assertThat(new TransformExistsApplyToCorrelatedJoin(tester().getMetadata()))
                 .on(p -> p.values(p.symbol("a")))
                 .doesNotFire();
 
-        tester().assertThat(new TransformExistsApplyToLateralNode(tester().getMetadata()))
+        tester().assertThat(new TransformExistsApplyToCorrelatedJoin(tester().getMetadata()))
                 .on(p ->
-                        p.lateral(
+                        p.correlatedJoin(
                                 ImmutableList.of(p.symbol("a")),
                                 p.values(p.symbol("a")),
                                 p.values(p.symbol("a"))))
@@ -53,7 +53,7 @@ public class TestTransformExistsApplyToLateralJoin
     @Test
     public void testRewrite()
     {
-        tester().assertThat(new TransformExistsApplyToLateralNode(tester().getMetadata()))
+        tester().assertThat(new TransformExistsApplyToCorrelatedJoin(tester().getMetadata()))
                 .on(p ->
                         p.apply(
                                 Assignments.of(p.symbol("b", BOOLEAN), expression("EXISTS(SELECT TRUE)")),
@@ -72,7 +72,7 @@ public class TestTransformExistsApplyToLateralJoin
     @Test
     public void testRewritesToLimit()
     {
-        tester().assertThat(new TransformExistsApplyToLateralNode(tester().getMetadata()))
+        tester().assertThat(new TransformExistsApplyToCorrelatedJoin(tester().getMetadata()))
                 .on(p ->
                         p.apply(
                                 Assignments.of(p.symbol("b", BOOLEAN), expression("EXISTS(SELECT TRUE)")),

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformUncorrelatedSubqueryToJoin.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestTransformUncorrelatedSubqueryToJoin.java
@@ -23,15 +23,15 @@ import static io.prestosql.sql.planner.assertions.PlanMatchPattern.join;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
 import static java.util.Collections.emptyList;
 
-public class TestTransformUncorrelatedLateralToJoin
+public class TestTransformUncorrelatedSubqueryToJoin
         extends BaseRuleTest
 {
     @Test
     public void test()
     {
         tester()
-                .assertThat(new TransformUncorrelatedLateralToJoin())
-                .on(p -> p.lateral(emptyList(), p.values(), p.values()))
+                .assertThat(new TransformUncorrelatedSubqueryToJoin())
+                .on(p -> p.correlatedJoin(emptyList(), p.values(), p.values()))
                 .matches(join(JoinNode.Type.INNER, emptyList(), values(), values()));
     }
 
@@ -40,8 +40,8 @@ public class TestTransformUncorrelatedLateralToJoin
     {
         Symbol symbol = new Symbol("x");
         tester()
-                .assertThat(new TransformUncorrelatedLateralToJoin())
-                .on(p -> p.lateral(ImmutableList.of(symbol), p.values(symbol), p.values()))
+                .assertThat(new TransformUncorrelatedSubqueryToJoin())
+                .on(p -> p.correlatedJoin(ImmutableList.of(symbol), p.values(symbol), p.values()))
                 .doesNotFire();
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -47,6 +47,7 @@ import io.prestosql.sql.planner.plan.AggregationNode.Step;
 import io.prestosql.sql.planner.plan.ApplyNode;
 import io.prestosql.sql.planner.plan.AssignUniqueId;
 import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.CorrelatedJoinNode;
 import io.prestosql.sql.planner.plan.DeleteNode;
 import io.prestosql.sql.planner.plan.DistinctLimitNode;
 import io.prestosql.sql.planner.plan.EnforceSingleRowNode;
@@ -57,7 +58,6 @@ import io.prestosql.sql.planner.plan.IndexJoinNode;
 import io.prestosql.sql.planner.plan.IndexSourceNode;
 import io.prestosql.sql.planner.plan.IntersectNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.LateralJoinNode;
 import io.prestosql.sql.planner.plan.LimitNode;
 import io.prestosql.sql.planner.plan.MarkDistinctNode;
 import io.prestosql.sql.planner.plan.OffsetNode;
@@ -418,15 +418,15 @@ public class PlanBuilder
         return new AssignUniqueId(idAllocator.getNextId(), source, unique);
     }
 
-    public LateralJoinNode lateral(List<Symbol> correlation, PlanNode input, PlanNode subquery)
+    public CorrelatedJoinNode correlatedJoin(List<Symbol> correlation, PlanNode input, PlanNode subquery)
     {
-        return lateral(correlation, input, LateralJoinNode.Type.INNER, TRUE_LITERAL, subquery);
+        return correlatedJoin(correlation, input, CorrelatedJoinNode.Type.INNER, TRUE_LITERAL, subquery);
     }
 
-    public LateralJoinNode lateral(List<Symbol> correlation, PlanNode input, LateralJoinNode.Type type, Expression filter, PlanNode subquery)
+    public CorrelatedJoinNode correlatedJoin(List<Symbol> correlation, PlanNode input, CorrelatedJoinNode.Type type, Expression filter, PlanNode subquery)
     {
         NullLiteral originSubquery = new NullLiteral(); // does not matter for tests
-        return new LateralJoinNode(idAllocator.getNextId(), input, subquery, correlation, type, filter, originSubquery);
+        return new CorrelatedJoinNode(idAllocator.getNextId(), input, subquery, correlation, type, filter, originSubquery);
     }
 
     public TableScanNode tableScan(List<Symbol> symbols, Map<Symbol, ColumnHandle> assignments)


### PR DESCRIPTION
"Lateral" a SQL language construct that indicates that tables on
the left (lexicographically) in a join are visible in the scope
of the subquery. The proper name for such construct is a
"lateral derived table". There's no such a thing as a
"lateral join" -- it's just a join between tables, some of which
can be regular table references, subqueries or lateral
derived tables.

At the IR level, the better way to think about how we model a JOIN
involving a lateral derived table in the earlier stages of a query
is a "correlated join", or a join involving a correlated subquery.