### PR TITLE
Simplify calling structure

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionTreeUtils.java
@@ -35,7 +35,7 @@ public final class ExpressionTreeUtils
 
     static List<FunctionCall> extractAggregateFunctions(Iterable<? extends Node> nodes, Metadata metadata)
     {
-        return extractExpressions(nodes, FunctionCall.class, isAggregationPredicate(metadata));
+        return extractExpressions(nodes, FunctionCall.class, function -> isAggregation(function, metadata));
     }
 
     static List<FunctionCall> extractWindowFunctions(Iterable<? extends Node> nodes)
@@ -50,11 +50,11 @@ public final class ExpressionTreeUtils
         return extractExpressions(nodes, clazz, alwaysTrue());
     }
 
-    private static Predicate<FunctionCall> isAggregationPredicate(Metadata metadata)
+    private static boolean isAggregation(FunctionCall functionCall, Metadata metadata)
     {
-        return ((functionCall) -> (metadata.isAggregationFunction(functionCall.getName())
-                || functionCall.getFilter().isPresent()) && !functionCall.getWindow().isPresent()
-                || functionCall.getOrderBy().isPresent());
+        return ((metadata.isAggregationFunction(functionCall.getName()) || functionCall.getFilter().isPresent())
+                && !functionCall.getWindow().isPresent())
+                || functionCall.getOrderBy().isPresent();
     }
 
     private static boolean isWindowFunction(FunctionCall functionCall)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestEqualityInference.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestEqualityInference.java
@@ -202,17 +202,17 @@ public class TestEqualityInference
         // There should be equalities in the scope, that only use c1 and are all inferrable equalities
         assertFalse(equalityPartition.getScopeEqualities().isEmpty());
         assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), matchesSymbolScope(matchesSymbols("c1"))));
-        assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), EqualityInference.isInferenceCandidate()));
+        assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), EqualityInference::isInferenceCandidate));
 
         // There should be equalities in the inverse scope, that never use c1 and are all inferrable equalities
         assertFalse(equalityPartition.getScopeComplementEqualities().isEmpty());
         assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), matchesSymbolScope(not(matchesSymbols("c1")))));
-        assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), EqualityInference.isInferenceCandidate()));
+        assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), EqualityInference::isInferenceCandidate));
 
         // There should be equalities in the straddling scope, that should use both c1 and not c1 symbols
         assertFalse(equalityPartition.getScopeStraddlingEqualities().isEmpty());
         assertTrue(Iterables.any(equalityPartition.getScopeStraddlingEqualities(), matchesStraddlingScope(matchesSymbols("c1"))));
-        assertTrue(Iterables.all(equalityPartition.getScopeStraddlingEqualities(), EqualityInference.isInferenceCandidate()));
+        assertTrue(Iterables.all(equalityPartition.getScopeStraddlingEqualities(), EqualityInference::isInferenceCandidate));
 
         // There should be a "full cover" of all of the equalities used
         // THUS, we should be able to plug the generated equalities back in and get an equivalent set of equalities back the next time around
@@ -249,17 +249,17 @@ public class TestEqualityInference
         // There should be equalities in the scope, that only use a* and b* symbols and are all inferrable equalities
         assertFalse(equalityPartition.getScopeEqualities().isEmpty());
         assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), matchesSymbolScope(symbolBeginsWith("a", "b"))));
-        assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), EqualityInference.isInferenceCandidate()));
+        assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), EqualityInference::isInferenceCandidate));
 
         // There should be equalities in the inverse scope, that never use a* and b* symbols and are all inferrable equalities
         assertFalse(equalityPartition.getScopeComplementEqualities().isEmpty());
         assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), matchesSymbolScope(not(symbolBeginsWith("a", "b")))));
-        assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), EqualityInference.isInferenceCandidate()));
+        assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), EqualityInference::isInferenceCandidate));
 
         // There should be equalities in the straddling scope, that should use both c1 and not c1 symbols
         assertFalse(equalityPartition.getScopeStraddlingEqualities().isEmpty());
         assertTrue(Iterables.any(equalityPartition.getScopeStraddlingEqualities(), matchesStraddlingScope(symbolBeginsWith("a", "b"))));
-        assertTrue(Iterables.all(equalityPartition.getScopeStraddlingEqualities(), EqualityInference.isInferenceCandidate()));
+        assertTrue(Iterables.all(equalityPartition.getScopeStraddlingEqualities(), EqualityInference::isInferenceCandidate));
 
         // Again, there should be a "full cover" of all of the equalities used
         // THUS, we should be able to plug the generated equalities back in and get an equivalent set of equalities back the next time around


### PR DESCRIPTION
Returning a Predicate is unnecessary and makes the code harder to follow