### PR TITLE
Validation of session properties set by the plugin

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
+++ b/presto-main/src/main/java/io/prestosql/server/ServerMainModule.java
@@ -210,6 +210,7 @@ public class ServerMainModule
         binder.bind(SessionPropertyManager.class).in(Scopes.SINGLETON);
         binder.bind(SystemSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(SessionPropertyDefaults.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(SessionPropertyDefaults.class).withGeneratedName();
 
         // schema properties
         binder.bind(SchemaPropertyManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -301,9 +301,17 @@ public class LocalQueryRunner
                 notificationExecutor);
         this.nodePartitioningManager = new NodePartitioningManager(nodeScheduler);
 
+        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(
+                new SystemSessionProperties(
+                        new QueryManagerConfig(),
+                        taskManagerConfig,
+                        new MemoryManagerConfig(),
+                        featuresConfig,
+                        new NodeMemoryConfig()));
+
         this.metadata = new MetadataManager(
                 featuresConfig,
-                new SessionPropertyManager(new SystemSessionProperties(new QueryManagerConfig(), taskManagerConfig, new MemoryManagerConfig(), featuresConfig, new NodeMemoryConfig())),
+                sessionPropertyManager,
                 new SchemaPropertyManager(),
                 new TablePropertyManager(),
                 new ColumnPropertyManager(),
@@ -362,7 +370,7 @@ public class LocalQueryRunner
                 accessControl,
                 new PasswordAuthenticatorManager(),
                 new EventListenerManager(),
-                new SessionPropertyDefaults(nodeInfo));
+                new SessionPropertyDefaults(nodeInfo, sessionPropertyManager));
 
         connectorManager.addConnectorFactory(globalSystemConnectorFactory);
         connectorManager.createConnection(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());


### PR DESCRIPTION
An externally implemented `SessionPropertyConfigurationManagerPlugin` can set invalid session property values (by mistake) in Presto. A bad configuration can cause potentially all queries on the cluster to fail, without any changes on the user's end. This is more likely to happen in a configuration that keeps getting refreshed from an external source, eg `DbSessionPropertyConfigurationManager` in #1055. This PR adds a validation step for properties being externally set by the plugins in order to prevent this from happening. cc @electrum 