### PR TITLE
Fix index out of bounds during parser error handling

### DIFF
--- a/presto-parser/src/main/java/io/prestosql/sql/parser/ErrorHandler.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/parser/ErrorHandler.java
@@ -293,7 +293,11 @@ class ErrorHandler
                             labels = labels.complement(IntervalSet.of(Token.MIN_USER_TOKEN_TYPE, atn.maxTokenType));
                         }
 
-                        if (labels.contains(currentToken)) {
+                        // Surprisingly, TokenStream (i.e. BufferedTokenStream) may not have loaded all the tokens from the
+                        // underlying stream. TokenStream.get() does not force tokens to be buffered -- it just returns what's
+                        // in the current buffer, or fail with an IndexOutOfBoundsError. Since Antlr decided the error occurred
+                        // within the current set of buffered tokens, stop when we reach the end of the buffer.
+                        if (labels.contains(currentToken) && tokenIndex < stream.size() - 1) {
                             activeStates.push(new ParsingState(transition.target, tokenIndex + 1, false, parser));
                         }
                         else {

--- a/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParserErrorHandling.java
+++ b/presto-parser/src/test/java/io/prestosql/sql/parser/TestSqlParserErrorHandling.java
@@ -136,6 +136,10 @@ public class TestSqlParserErrorHandling
                         "line 1:15: Zero-length delimited identifier not allowed"},
                 {"SELECT a FROM \"\".s.t",
                         "line 1:15: Zero-length delimited identifier not allowed"},
+                {"WITH t AS (SELECT 1 SELECT t.* FROM t",
+                        "line 1:21: mismatched input 'SELECT'. Expecting: '%', '(', ')', '*', '+', ',', '-', '.', '/', 'AND', 'AS', 'AT', 'EXCEPT', 'FETCH', 'FROM', " +
+                                "'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'OR', 'ORDER', 'SELECT', 'TABLE', 'UNION', 'VALUES', 'WHERE', '[', '||', <EOF>, " +
+                                "<identifier>, <predicate>"}
         };
     }
 


### PR DESCRIPTION
Stop once we reach the end of the token stream.