### PR TITLE
Handle multiple values in X-Forwarded-Proto

### DIFF
--- a/presto-main/src/main/java/io/prestosql/dispatcher/LocalCoordinatorLocation.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/LocalCoordinatorLocation.java
@@ -17,7 +17,7 @@ import javax.ws.rs.core.UriInfo;
 
 import java.net.URI;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.prestosql.dispatcher.QueuedStatementResource.getScheme;
 
 public class LocalCoordinatorLocation
         implements CoordinatorLocation
@@ -25,7 +25,7 @@ public class LocalCoordinatorLocation
     @Override
     public URI getUri(UriInfo uriInfo, String xForwardedProto)
     {
-        String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
+        String scheme = getScheme(xForwardedProto, uriInfo);
         return uriInfo.getRequestUriBuilder()
                 .scheme(scheme)
                 .replacePath("")

--- a/presto-main/src/main/java/io/prestosql/dispatcher/QueuedStatementResource.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/QueuedStatementResource.java
@@ -32,7 +32,6 @@ import io.prestosql.server.SessionContext;
 import io.prestosql.server.protocol.Slug;
 import io.prestosql.spi.ErrorCode;
 import io.prestosql.spi.QueryId;
-import org.assertj.core.util.VisibleForTesting;
 
 import javax.annotation.PreDestroy;
 import javax.annotation.concurrent.GuardedBy;
@@ -244,7 +243,6 @@ public class QueuedStatementResource
                 .build();
     }
 
-    @VisibleForTesting
     public static String getScheme(String xForwardedProto, @Context UriInfo uriInfo)
     {
         if (!isNullOrEmpty(xForwardedProto)) {

--- a/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/ExecutingStatementResource.java
@@ -57,7 +57,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.Threads.threadsNamed;
@@ -73,6 +72,7 @@ import static io.prestosql.client.PrestoHeaders.PRESTO_SET_ROLE;
 import static io.prestosql.client.PrestoHeaders.PRESTO_SET_SCHEMA;
 import static io.prestosql.client.PrestoHeaders.PRESTO_SET_SESSION;
 import static io.prestosql.client.PrestoHeaders.PRESTO_STARTED_TRANSACTION_ID;
+import static io.prestosql.dispatcher.QueuedStatementResource.getScheme;
 import static io.prestosql.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.prestosql.server.protocol.Slug.Context.EXECUTING_QUERY;
 import static java.util.Objects.requireNonNull;
@@ -158,10 +158,7 @@ public class ExecutingStatementResource
             @Suspended AsyncResponse asyncResponse)
     {
         Query query = getQuery(queryId, slug, token);
-        if (isNullOrEmpty(proto)) {
-            proto = uriInfo.getRequestUri().getScheme();
-        }
-
+        proto = getScheme(proto, uriInfo);
         asyncQueryResults(query, token, maxWait, targetResultSize, uriInfo, proto, asyncResponse);
     }
 

--- a/presto-main/src/test/java/io/prestosql/dispatcher/TestQueuedStatementResource.java
+++ b/presto-main/src/test/java/io/prestosql/dispatcher/TestQueuedStatementResource.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.dispatcher;
+
+import io.airlift.jaxrs.testing.MockUriInfo;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.UriInfo;
+
+import static io.prestosql.dispatcher.QueuedStatementResource.getScheme;
+import static org.testng.Assert.assertEquals;
+
+public class TestQueuedStatementResource
+{
+    @Test
+    public void testGetScheme()
+    {
+        UriInfo uriInfo = MockUriInfo.from("http://example.com");
+        assertEquals(getScheme("https", uriInfo), "https");
+        assertEquals(getScheme("https,http", uriInfo), "https");
+        assertEquals(getScheme("", uriInfo), "http");
+        assertEquals(getScheme(null, uriInfo), "http");
+        assertEquals(getScheme(",https", uriInfo), "https");
+    }
+}


### PR DESCRIPTION
Return the first value in X-Forwarded-Proto.
This is because X-Forwarded-For will return the first address.

Fixes #1699 