### PR TITLE
Feature/add sortkey distkey redshift

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/BaseJdbcClient.java
@@ -444,7 +444,7 @@ public class BaseJdbcClient
         }
     }
 
-    private String getColumnSql(ConnectorSession session, ColumnMetadata column, String columnName)
+    protected String getColumnSql(ConnectorSession session, ColumnMetadata column, String columnName)
     {
         StringBuilder sb = new StringBuilder()
                 .append(quoted(columnName))

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcConnector.java
@@ -54,6 +54,7 @@ public class JdbcConnector
     private final Optional<ConnectorAccessControl> accessControl;
     private final Set<Procedure> procedures;
     private final List<PropertyMetadata<?>> sessionProperties;
+    private final List<PropertyMetadata<?>> tableProperties;
 
     private final ConcurrentMap<ConnectorTransactionHandle, JdbcMetadata> transactions = new ConcurrentHashMap<>();
 
@@ -66,7 +67,8 @@ public class JdbcConnector
             JdbcPageSinkProvider jdbcPageSinkProvider,
             Optional<ConnectorAccessControl> accessControl,
             Set<Procedure> procedures,
-            Set<SessionPropertiesProvider> sessionProperties)
+            Set<SessionPropertiesProvider> sessionProperties,
+            Set<TablePropertiesProvider> tableProperties)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.jdbcMetadataFactory = requireNonNull(jdbcMetadataFactory, "jdbcMetadataFactory is null");
@@ -77,6 +79,9 @@ public class JdbcConnector
         this.procedures = ImmutableSet.copyOf(requireNonNull(procedures, "procedures is null"));
         this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null").stream()
                 .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
+                .collect(toImmutableList());
+        this.tableProperties = requireNonNull(tableProperties, "tableProperties is null").stream()
+                .flatMap(tablePropertiesProvider -> tablePropertiesProvider.getTableProperties().stream())
                 .collect(toImmutableList());
     }
 
@@ -151,6 +156,12 @@ public class JdbcConnector
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcModule.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcModule.java
@@ -43,6 +43,7 @@ public class JdbcModule
         newOptionalBinder(binder, ConnectorAccessControl.class);
         newSetBinder(binder, Procedure.class);
         newSetBinder(binder, SessionPropertiesProvider.class).addBinding().to(BaseJdbcPropertiesProvider.class);
+        newSetBinder(binder, TablePropertiesProvider.class);
         binder.bind(JdbcMetadataFactory.class).in(Scopes.SINGLETON);
         binder.bind(JdbcSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/TablePropertiesProvider.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/TablePropertiesProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import io.prestosql.spi.session.PropertyMetadata;
+
+import java.util.List;
+
+public interface TablePropertiesProvider
+{
+    List<PropertyMetadata<?>> getTableProperties();
+}

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -46,7 +46,8 @@ plugin.bundles=\
   ../presto-postgresql/pom.xml, \
   ../presto-thrift/pom.xml, \
   ../presto-tpcds/pom.xml, \
-  ../presto-google-sheets/pom.xml
+  ../presto-google-sheets/pom.xml, \
+  ../presto-redshift/pom.xml
 
 presto.version=testversion
 node-scheduler.include-coordinator=true

--- a/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
+++ b/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClient.java
@@ -13,24 +13,35 @@
  */
 package io.prestosql.plugin.redshift;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
 import io.prestosql.plugin.jdbc.BaseJdbcClient;
 import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.JdbcIdentity;
+import io.prestosql.plugin.jdbc.JdbcOutputTableHandle;
 import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.ColumnMetadata;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTableMetadata;
 import io.prestosql.spi.connector.SchemaTableName;
-
-import javax.inject.Inject;
+import io.prestosql.spi.type.Type;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.prestosql.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
+import static io.prestosql.spi.StandardErrorCode.NOT_FOUND;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.util.Locale.ENGLISH;
 
 public class RedshiftClient
         extends BaseJdbcClient
@@ -58,6 +69,77 @@ public class RedshiftClient
         }
         catch (SQLException e) {
             throw new PrestoException(JDBC_ERROR, e);
+        }
+    }
+
+    @VisibleForTesting
+    static String generateCreateTableSql(String fullyQualifiedTableName, ImmutableList<String> columnList, Optional<String> distKey, Optional<String> compoundSortKeys, Optional<String> interleavedSortKeys)
+    {
+        checkArgument(!(compoundSortKeys.isPresent() && interleavedSortKeys.isPresent()), "Cannot set both a compound sortkey and an interleaved sortkey in a Redshift table");
+
+        String distKeyString = distKey.map(k -> format("distkey(%s) ", k)).orElse("");
+        String compoundSortKeysString = compoundSortKeys.map(k -> format("compound sortkey(%s) ", k)).orElse("");
+        String interleavedSortKeysString = interleavedSortKeys.map(k -> format("interleaved sortkey(%s) ", k)).orElse("");
+
+        return format(
+                "CREATE TABLE %s (%s) %s%s%s",
+                fullyQualifiedTableName,
+                join(", ", columnList),
+                distKeyString,
+                compoundSortKeysString,
+                interleavedSortKeysString);
+    }
+
+    @Override
+    protected JdbcOutputTableHandle createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, String tableName)
+            throws SQLException
+    {
+        SchemaTableName schemaTableName = tableMetadata.getTable();
+        Map<String, Object> tableProperties = tableMetadata.getProperties();
+
+        Optional<String> distKey = RedshiftTableProperties.getDistKey(tableProperties);
+        Optional<String> compoundSortKeys = RedshiftTableProperties.getCompoundSortKeys(tableProperties);
+        Optional<String> interleavedSortKeys = RedshiftTableProperties.getInterleavedSortKeys(tableProperties);
+
+        JdbcIdentity identity = JdbcIdentity.from(session);
+        if (!getSchemaNames(identity).contains(schemaTableName.getSchemaName())) {
+            throw new PrestoException(NOT_FOUND, "Schema not found: " + schemaTableName.getSchemaName());
+        }
+
+        try (Connection connection = connectionFactory.openConnection(identity)) {
+            boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
+            String remoteSchema = toRemoteSchemaName(identity, connection, schemaTableName.getSchemaName());
+            String remoteTable = toRemoteTableName(identity, connection, remoteSchema, schemaTableName.getTableName());
+            if (uppercase) {
+                tableName = tableName.toUpperCase(ENGLISH);
+            }
+            String catalog = connection.getCatalog();
+
+            ImmutableList.Builder<String> columnNames = ImmutableList.builder();
+            ImmutableList.Builder<Type> columnTypes = ImmutableList.builder();
+            ImmutableList.Builder<String> columnList = ImmutableList.builder();
+            for (ColumnMetadata column : tableMetadata.getColumns()) {
+                String columnName = column.getName();
+                if (uppercase) {
+                    columnName = columnName.toUpperCase(ENGLISH);
+                }
+                columnNames.add(columnName);
+                columnTypes.add(column.getType());
+                columnList.add(getColumnSql(session, column, columnName));
+            }
+
+            String sql = generateCreateTableSql(
+                    quoted(catalog, remoteSchema, tableName), columnList.build(), distKey, compoundSortKeys, interleavedSortKeys);
+            execute(connection, sql);
+
+            return new JdbcOutputTableHandle(
+                    catalog,
+                    remoteSchema,
+                    remoteTable,
+                    columnNames.build(),
+                    columnTypes.build(),
+                    Optional.empty(),
+                    tableName);
         }
     }
 

--- a/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClientModule.java
+++ b/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftClientModule.java
@@ -19,14 +19,17 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
+import com.google.inject.multibindings.Multibinder;
 import io.prestosql.plugin.jdbc.BaseJdbcConfig;
 import io.prestosql.plugin.jdbc.ConnectionFactory;
 import io.prestosql.plugin.jdbc.DriverConnectionFactory;
 import io.prestosql.plugin.jdbc.ForBaseJdbc;
 import io.prestosql.plugin.jdbc.JdbcClient;
+import io.prestosql.plugin.jdbc.TablePropertiesProvider;
 import io.prestosql.plugin.jdbc.credential.CredentialProvider;
 import org.postgresql.Driver;
 
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class RedshiftClientModule
@@ -35,8 +38,9 @@ public class RedshiftClientModule
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(Key.get(JdbcClient.class, ForBaseJdbc.class))
-                .to(RedshiftClient.class).in(Scopes.SINGLETON);
+        binder.bind(Key.get(JdbcClient.class, ForBaseJdbc.class)).to(RedshiftClient.class).in(Scopes.SINGLETON);
+        Multibinder<TablePropertiesProvider> tablePropertiesProviderBinder = newSetBinder(binder, TablePropertiesProvider.class);
+        tablePropertiesProviderBinder.addBinding().to(RedshiftTableProperties.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(BaseJdbcConfig.class);
     }
 

--- a/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftTableProperties.java
+++ b/presto-redshift/src/main/java/io/prestosql/plugin/redshift/RedshiftTableProperties.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.redshift;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.plugin.jdbc.TablePropertiesProvider;
+import io.prestosql.spi.session.PropertyMetadata;
+import io.prestosql.spi.type.TypeManager;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Class contains all table properties for the Redshift connector. Used when creating a table:
+ * <p>
+ * <pre>CREATE TABLE foo WITH (DISTKEY = 'col_one') as SELECT col_one, col_two FROM table;</pre>
+ */
+public final class RedshiftTableProperties
+        implements TablePropertiesProvider
+{
+    private static final String DISTKEY = "distkey";
+    private static final String COMPOUND_SORTKEYS = "compound_sortkeys";
+    private static final String INTERLEAVED_SORTKEYS = "interleaved_sortkeys";
+
+    private final List<PropertyMetadata<?>> tableProperties;
+
+    @Inject
+    public RedshiftTableProperties(TypeManager typeManager)
+    {
+        this.tableProperties = ImmutableList.of(
+                stringProperty(
+                        DISTKEY,
+                        "The column name of the distkey column.",
+                        null,
+                        false),
+                stringProperty(
+                        COMPOUND_SORTKEYS,
+                        "A column separated list of columns to use for a compound sortkey.",
+                        null,
+                        false),
+                stringProperty(
+                        INTERLEAVED_SORTKEYS,
+                        "A column separated list of columns to use for an interleaved sortkey",
+                        null,
+                        false));
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
+    }
+
+    private static Optional<String> maybeGetString(Map<String, Object> tableProperties, String key)
+    {
+        requireNonNull(tableProperties);
+
+        String value = (String) tableProperties.get(key);
+        if (value == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(value);
+    }
+
+    public static Optional<String> getDistKey(Map<String, Object> tableProperties)
+    {
+        return maybeGetString(tableProperties, DISTKEY);
+    }
+
+    public static Optional<String> getCompoundSortKeys(Map<String, Object> tableProperties)
+    {
+        return maybeGetString(tableProperties, COMPOUND_SORTKEYS);
+    }
+
+    public static Optional<String> getInterleavedSortKeys(Map<String, Object> tableProperties)
+    {
+        return maybeGetString(tableProperties, INTERLEAVED_SORTKEYS);
+    }
+}

--- a/presto-redshift/src/test/java/io/prestosql/plugin/redshift/TestRedshiftClient.java
+++ b/presto-redshift/src/test/java/io/prestosql/plugin/redshift/TestRedshiftClient.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.redshift;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class TestRedshiftClient
+{
+    @Test
+    public void testGenerateCreateTableSqlWithCompoundSortKey()
+    {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        builder.add("col_one integer");
+        builder.add("col_two varchar");
+        ImmutableList<String> colList = builder.build();
+
+        Optional<String> distKey = Optional.empty();
+        Optional<String> compoundSortKey = Optional.of("col_one,col_two");
+        Optional<String> interleavedSortKey = Optional.empty();
+
+        String sql = RedshiftClient.generateCreateTableSql("schema.table_name", colList, distKey, compoundSortKey, interleavedSortKey);
+
+        assertEquals(sql, "CREATE TABLE schema.table_name (col_one integer, col_two varchar) compound sortkey(col_one,col_two) ");
+    }
+
+    @Test
+    public void testGenerateCreateTableSqlWithInterleavedSortKey()
+    {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        builder.add("col_one integer");
+        builder.add("col_two varchar");
+        ImmutableList<String> colList = builder.build();
+
+        Optional<String> distKey = Optional.empty();
+        Optional<String> compoundSortKey = Optional.empty();
+        Optional<String> interleavedSortKey = Optional.of("col_one,col_two");
+
+        String sql = RedshiftClient.generateCreateTableSql("schema.table_name", colList, distKey, compoundSortKey, interleavedSortKey);
+
+        assertEquals(sql, "CREATE TABLE schema.table_name (col_one integer, col_two varchar) interleaved sortkey(col_one,col_two) ");
+    }
+
+    @Test
+    public void testGenerateCreateTableSqlWithDistKey()
+    {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        builder.add("col_one integer");
+        builder.add("col_two varchar");
+        ImmutableList<String> colList = builder.build();
+
+        Optional<String> distKey = Optional.of("col_one");
+        Optional<String> compoundSortKey = Optional.empty();
+        Optional<String> interleavedSortKey = Optional.empty();
+
+        String sql = RedshiftClient.generateCreateTableSql("schema.table_name", colList, distKey, compoundSortKey, interleavedSortKey);
+
+        assertEquals(sql, "CREATE TABLE schema.table_name (col_one integer, col_two varchar) distkey(col_one) ");
+    }
+
+    @Test
+    public void testGenerateCreateTableSqlWithDistKeyAndSortKey()
+    {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        builder.add("col_one integer");
+        builder.add("col_two varchar");
+        ImmutableList<String> colList = builder.build();
+
+        Optional<String> distKey = Optional.of("col_one");
+        Optional<String> compoundSortKey = Optional.empty();
+        Optional<String> interleavedSortKey = Optional.of("col_one,col_two");
+
+        String sql = RedshiftClient.generateCreateTableSql("schema.table_name", colList, distKey, compoundSortKey, interleavedSortKey);
+
+        assertEquals(sql, "CREATE TABLE schema.table_name (col_one integer, col_two varchar) distkey(col_one) interleaved sortkey(col_one,col_two) ");
+    }
+
+    @Test
+    public void testGenerateCreateTableSqlWithBothCompoundAndInterleavedSortKeyFails()
+    {
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        builder.add("col_one integer");
+        builder.add("col_two varchar");
+        ImmutableList<String> colList = builder.build();
+
+        Optional<String> distKey = Optional.empty();
+        Optional<String> compoundSortKey = Optional.of("col_one");
+        Optional<String> interleavedSortKey = Optional.of("col_one");
+
+        assertThrows(IllegalArgumentException.class, () -> RedshiftClient.generateCreateTableSql("schema.table_name", colList, distKey, compoundSortKey, interleavedSortKey));
+    }
+}


### PR DESCRIPTION
Adds in support for creating sortkeys (compound and interleaved) as well as distkeys while creating a redshift table through presto. 

PR fixes this issue: https://github.com/prestosql/presto/issues/1477

Context around this PR is here:
https://prestosql.slack.com/archives/CGB0QHWSW/p1568050177177600

This is my first PR contributing to Presto so any links to style guides/contribution guides would be handy. 

Fixes #1477