### PR TITLE
Add support for datetimes exposed as numbers in Elasticsearch

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/TimestampDecoder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/TimestampDecoder.java
@@ -19,17 +19,21 @@ import io.prestosql.spi.connector.ConnectorSession;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.search.SearchHit;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.function.Supplier;
 
+import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP;
+import static java.lang.String.format;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 
 public class TimestampDecoder
         implements Decoder
 {
+    private static final ZoneId ZULU = ZoneId.of("Z");
     private final String path;
     private final ZoneId zoneId;
 
@@ -50,11 +54,27 @@ public class TimestampDecoder
             throw new PrestoException(TYPE_MISMATCH, "Expected single value for column: " + path);
         }
         else {
-            TIMESTAMP.writeLong(output,
-                    ISO_DATE_TIME.parse(documentField.getValue(), LocalDateTime::from)
-                            .atZone(zoneId)
-                            .toInstant()
-                            .toEpochMilli());
+            Object value = documentField.getValue();
+
+            LocalDateTime timestamp;
+            if (value instanceof String) {
+                timestamp = ISO_DATE_TIME.parse((String) value, LocalDateTime::from);
+            }
+            else if (value instanceof Number) {
+                timestamp = LocalDateTime.ofInstant(Instant.ofEpochMilli(((Number) value).longValue()), ZULU);
+            }
+            else {
+                throw new PrestoException(NOT_SUPPORTED, format(
+                        "Unsupported representation for timestamp type: %s [%s]",
+                        value.getClass().getSimpleName(),
+                        value));
+            }
+
+            long epochMillis = timestamp.atZone(zoneId)
+                    .toInstant()
+                    .toEpochMilli();
+
+            TIMESTAMP.writeLong(output, epochMillis);
         }
     }
 }


### PR DESCRIPTION
Older version of Elasticsearch use epoch millis instead of ISO-8601
when formatting datetime fields in document fields output.