### PR TITLE
Disable testLargeIn in plan determinism tester

### DIFF
--- a/presto-tests/src/test/java/io/prestosql/tests/TestQueryPlanDeterminism.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestQueryPlanDeterminism.java
@@ -23,6 +23,7 @@ import io.prestosql.testing.LocalQueryRunner;
 import io.prestosql.testing.MaterializedResult;
 import io.prestosql.testing.TestingAccessControlManager;
 import org.intellij.lang.annotations.Language;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -268,5 +269,12 @@ public class TestQueryPlanDeterminism
                 "    (SELECT avg(j.quantity)\n" +
                 "     FROM lineitem j\n" +
                 "    )\n");
+    }
+
+    @Override
+    public void testLargeIn()
+    {
+        // testLargeIn is expensive
+        throw new SkipException("Skipping testLargeIn");
     }
 }


### PR DESCRIPTION
This test is inherently expensive. Running it multiple times
causes build times to increased significantly.