### PR TITLE
Add format_number function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionRegistry.java
@@ -108,6 +108,7 @@ import io.trino.operator.scalar.DataSizeFunctions;
 import io.trino.operator.scalar.DateTimeFunctions;
 import io.trino.operator.scalar.EmptyMapConstructor;
 import io.trino.operator.scalar.FailureFunction;
+import io.trino.operator.scalar.FormatNumberFunction;
 import io.trino.operator.scalar.GenericComparisonOperator;
 import io.trino.operator.scalar.GenericDistinctFromOperator;
 import io.trino.operator.scalar.GenericEqualOperator;
@@ -504,6 +505,7 @@ public class FunctionRegistry
                 .scalars(ArrayFunctions.class)
                 .scalars(HmacFunctions.class)
                 .scalars(DataSizeFunctions.class)
+                .scalars(FormatNumberFunction.class)
                 .scalar(ArrayCardinalityFunction.class)
                 .scalar(ArrayContains.class)
                 .scalar(ArrayContainsSequence.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/FormatNumberFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/FormatNumberFunction.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
+
+import static io.airlift.slice.Slices.utf8Slice;
+
+public final class FormatNumberFunction
+{
+    private final DecimalFormat format3Number;
+    private final DecimalFormat format2Number;
+    private final DecimalFormat format1Number;
+
+    public FormatNumberFunction()
+    {
+        format3Number = new DecimalFormat("#.##");
+        format3Number.setRoundingMode(RoundingMode.HALF_UP);
+        format2Number = new DecimalFormat("#.#");
+        format2Number.setRoundingMode(RoundingMode.HALF_UP);
+        format1Number = new DecimalFormat("#");
+        format1Number.setRoundingMode(RoundingMode.HALF_UP);
+    }
+
+    @ScalarFunction
+    @Description("Formats large number using a unit symbol")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice formatNumber(@SqlType(StandardTypes.BIGINT) long value)
+    {
+        return utf8Slice(format(value));
+    }
+
+    @ScalarFunction
+    @Description("Formats large number using a unit symbol")
+    @SqlType(StandardTypes.VARCHAR)
+    public Slice formatNumber(@SqlType(StandardTypes.DOUBLE) double value)
+    {
+        return utf8Slice(format((long) value));
+    }
+
+    private String format(long count)
+    {
+        double fractional = count;
+        String unit = "";
+        if (fractional >= 1000 || fractional <= -1000) {
+            fractional /= 1000;
+            unit = "K";
+        }
+        if (fractional >= 1000 || fractional <= -1000) {
+            fractional /= 1000;
+            unit = "M";
+        }
+        if (fractional >= 1000 || fractional <= -1000) {
+            fractional /= 1000;
+            unit = "B";
+        }
+        if (fractional >= 1000 || fractional <= -1000) {
+            fractional /= 1000;
+            unit = "T";
+        }
+        if (fractional >= 1000 || fractional <= -1000) {
+            fractional /= 1000;
+            unit = "Q";
+        }
+
+        return getFormat(fractional).format(fractional) + unit;
+    }
+
+    private DecimalFormat getFormat(double value)
+    {
+        if (value < 10) {
+            // show up to two decimals to get 3 significant digits
+            return format3Number;
+        }
+        if (value < 100) {
+            // show up to one decimal to get 3 significant digits
+            return format2Number;
+        }
+        // show no decimals -- we have enough digits in the integer part
+        return format1Number;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ScalarFromAnnotationsParser.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ScalarFromAnnotationsParser.java
@@ -59,7 +59,7 @@ public final class ScalarFromAnnotationsParser
         for (ScalarHeaderAndMethods methods : findScalarsInFunctionSetClass(clazz)) {
             boolean deprecated = methods.getMethods().iterator().next().getAnnotationsByType(Deprecated.class).length > 0;
             // Non-static function only makes sense in classes annotated with @ScalarFunction or @ScalarOperator.
-            builder.add(parseParametricScalar(methods, Optional.empty(), deprecated));
+            builder.add(parseParametricScalar(methods, FunctionsParserHelper.findConstructor(clazz), deprecated));
         }
         return builder.build();
     }

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestFormatNumberFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestFormatNumberFunction.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.scalar;
+
+import org.testng.annotations.Test;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+public class TestFormatNumberFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testFormatNumber()
+    {
+        assertFunction("format_number(TINYINT '123')", VARCHAR, "123");
+        assertFunction("format_number(SMALLINT '12345')", VARCHAR, "12.3K");
+        assertFunction("format_number(SMALLINT '12399')", VARCHAR, "12.4K");
+        assertFunction("format_number(INTEGER '12345678')", VARCHAR, "12.3M");
+        assertFunction("format_number(INTEGER '12399999')", VARCHAR, "12.4M");
+        assertFunction("format_number(BIGINT '12345678901')", VARCHAR, "12.3B");
+        assertFunction("format_number(BIGINT '12399999999')", VARCHAR, "12.4B");
+
+        assertFunction("format_number(DOUBLE '1234.5')", VARCHAR, "1.23K");
+        assertFunction("format_number(DOUBLE '1239.9')", VARCHAR, "1.24K");
+        assertFunction("format_number(REAL '1234567.8')", VARCHAR, "1.23M");
+        assertFunction("format_number(REAL '1239999.9')", VARCHAR, "1.24M");
+        assertFunction("format_number(DECIMAL '1234567890.1')", VARCHAR, "1.23B");
+        assertFunction("format_number(DECIMAL '1239999999.9')", VARCHAR, "1.24B");
+
+        assertFunction("format_number(-999)", VARCHAR, "-999");
+        assertFunction("format_number(-1000)", VARCHAR, "-1K");
+        assertFunction("format_number(-999999)", VARCHAR, "-1000K");
+        assertFunction("format_number(-1000000)", VARCHAR, "-1M");
+        assertFunction("format_number(-999999999)", VARCHAR, "-1000M");
+        assertFunction("format_number(-1000000000)", VARCHAR, "-1B");
+        assertFunction("format_number(-999999999999)", VARCHAR, "-1000B");
+        assertFunction("format_number(-1000000000000)", VARCHAR, "-1T");
+        assertFunction("format_number(-999999999999999)", VARCHAR, "-1000T");
+        assertFunction("format_number(-1000000000000000)", VARCHAR, "-1Q");
+        assertFunction("format_number(-9223372036854775808)", VARCHAR, "-9223.37Q");
+
+        assertFunction("format_number(0)", VARCHAR, "0");
+        assertFunction("format_number(999)", VARCHAR, "999");
+        assertFunction("format_number(1000)", VARCHAR, "1K");
+        assertFunction("format_number(999999)", VARCHAR, "1000K");
+        assertFunction("format_number(1000000)", VARCHAR, "1M");
+        assertFunction("format_number(999999999)", VARCHAR, "1000M");
+        assertFunction("format_number(1000000000)", VARCHAR, "1B");
+        assertFunction("format_number(999999999999)", VARCHAR, "1000B");
+        assertFunction("format_number(1000000000000)", VARCHAR, "1T");
+        assertFunction("format_number(999999999999999)", VARCHAR, "1000T");
+        assertFunction("format_number(1000000000000000)", VARCHAR, "1Q");
+        assertFunction("format_number(9223372036854775807)", VARCHAR, "9223Q");
+
+        assertFunction("format_number(CAST(NULL AS TINYINT))", VARCHAR, null);
+        assertFunction("format_number(CAST(NULL AS SMALLINT))", VARCHAR, null);
+        assertFunction("format_number(CAST(NULL AS INTEGER))", VARCHAR, null);
+        assertFunction("format_number(CAST(NULL AS DOUBLE))", VARCHAR, null);
+        assertFunction("format_number(CAST(NULL AS REAL))", VARCHAR, null);
+        assertFunction("format_number(CAST(NULL AS DECIMAL))", VARCHAR, null);
+    }
+}

--- a/docs/src/main/sphinx/functions/conversion.rst
+++ b/docs/src/main/sphinx/functions/conversion.rst
@@ -52,6 +52,13 @@ Formatting
         SELECT format('%1$tA, %1$tB %1$te, %1$tY', date '2006-07-04');
         -- 'Tuesday, July 4, 2006'
 
+.. function:: format_number(number) -> varchar
+
+    Returns a formatted string using a unit symbol::
+
+        SELECT format_number(123456); -- '123K'
+        SELECT format_number(1000000); -- '1M'
+
 Data size
 ---------
 

--- a/docs/src/main/sphinx/functions/list.rst
+++ b/docs/src/main/sphinx/functions/list.rst
@@ -159,6 +159,7 @@ F
 - :func:`floor`
 - :func:`format`
 - ``format_datetime``
+- :func:`format_number`
 - :func:`from_base`
 - :func:`from_base64`
 - :func:`from_base64url`


### PR DESCRIPTION
Fixes #1878 

If we reuse [FormatUtils.java](https://github.com/prestosql/presto/blob/master/presto-cli/src/main/java/io/prestosql/cli/FormatUtils.java), some value won't be abbreviated as `-1000K`. 