### PR TITLE
Quote row type field names

### DIFF
--- a/presto-client/src/main/java/io/prestosql/client/RowFieldName.java
+++ b/presto-client/src/main/java/io/prestosql/client/RowFieldName.java
@@ -23,27 +23,18 @@ import static java.util.Objects.requireNonNull;
 public class RowFieldName
 {
     private final String name;
-    private final boolean delimited;
 
     @JsonCreator
     public RowFieldName(
-            @JsonProperty("name") String name,
-            @JsonProperty("delimited") boolean delimited)
+            @JsonProperty("name") String name)
     {
         this.name = requireNonNull(name, "name is null");
-        this.delimited = delimited;
     }
 
     @JsonProperty
     public String getName()
     {
         return name;
-    }
-
-    @JsonProperty
-    public boolean isDelimited()
-    {
-        return delimited;
     }
 
     @Override
@@ -58,22 +49,18 @@ public class RowFieldName
 
         RowFieldName other = (RowFieldName) o;
 
-        return Objects.equals(this.name, other.name) &&
-                Objects.equals(this.delimited, other.delimited);
+        return Objects.equals(this.name, other.name);
     }
 
     @Override
     public String toString()
     {
-        if (!isDelimited()) {
-            return name;
-        }
         return '"' + name.replace("\"", "\"\"") + '"';
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, delimited);
+        return Objects.hash(name);
     }
 }

--- a/presto-client/src/test/java/io/prestosql/client/TestClientTypeSignature.java
+++ b/presto-client/src/test/java/io/prestosql/client/TestClientTypeSignature.java
@@ -48,8 +48,8 @@ public class TestClientTypeSignature
         assertJsonRoundTrip(new ClientTypeSignature(
                 "row",
                 ImmutableList.of(
-                        ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(Optional.of(new RowFieldName("foo", false)), bigint)),
-                        ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(Optional.of(new RowFieldName("bar", false)), bigint)))));
+                        ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(Optional.of(new RowFieldName("foo")), bigint)),
+                        ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(Optional.of(new RowFieldName("bar")), bigint)))));
     }
 
     @Test
@@ -64,8 +64,8 @@ public class TestClientTypeSignature
         ClientTypeSignature row = new ClientTypeSignature(
                 StandardTypes.ROW,
                 ImmutableList.of(
-                        ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(Optional.of(new RowFieldName("foo", false)), bigint)),
-                        ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(Optional.of(new RowFieldName("bar", false)), bigint))));
+                        ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(Optional.of(new RowFieldName("foo")), bigint)),
+                        ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(Optional.of(new RowFieldName("bar")), bigint))));
         assertEquals(row.toString(), "row(foo bigint,bar bigint)");
     }
 

--- a/presto-client/src/test/java/io/prestosql/client/TestFixJsonDataUtils.java
+++ b/presto-client/src/test/java/io/prestosql/client/TestFixJsonDataUtils.java
@@ -117,7 +117,7 @@ public class TestFixJsonDataUtils
             case NAMED_TYPE:
                 return ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(
                         parameter.getNamedTypeSignature().getFieldName().map(value ->
-                                new RowFieldName(value.getName(), value.isDelimited())),
+                                new RowFieldName(value.getName())),
                         toClientTypeSignature(parameter.getNamedTypeSignature().getTypeSignature())));
             case LONG:
                 return ClientTypeSignatureParameter.ofLong(parameter.getLongLiteral());

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveType.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveType.java
@@ -236,7 +236,7 @@ public final class HiveType
                     // Users can't work around this by casting in their queries because Presto parser always lower case types.
                     // TODO: This is a hack. Presto engine should be able to handle identifiers in a case insensitive way where necessary.
                     String rowFieldName = structFieldNames.get(i).toLowerCase(Locale.US);
-                    typeSignatureBuilder.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName(rowFieldName, false)), typeSignature)));
+                    typeSignatureBuilder.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName(rowFieldName)), typeSignature)));
                 }
                 return new TypeSignature(StandardTypes.ROW, typeSignatureBuilder.build());
         }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -283,9 +283,9 @@ public abstract class AbstractTestHive
     private static final Type ARRAY_TYPE = arrayType(createUnboundedVarcharType());
     private static final Type MAP_TYPE = mapType(createUnboundedVarcharType(), BIGINT);
     private static final Type ROW_TYPE = rowType(ImmutableList.of(
-            new NamedTypeSignature(Optional.of(new RowFieldName("f_string", false)), createUnboundedVarcharType().getTypeSignature()),
-            new NamedTypeSignature(Optional.of(new RowFieldName("f_bigint", false)), BIGINT.getTypeSignature()),
-            new NamedTypeSignature(Optional.of(new RowFieldName("f_boolean", false)), BOOLEAN.getTypeSignature())));
+            new NamedTypeSignature(Optional.of(new RowFieldName("f_string")), createUnboundedVarcharType().getTypeSignature()),
+            new NamedTypeSignature(Optional.of(new RowFieldName("f_bigint")), BIGINT.getTypeSignature()),
+            new NamedTypeSignature(Optional.of(new RowFieldName("f_boolean")), BOOLEAN.getTypeSignature())));
 
     private static final List<ColumnMetadata> CREATE_TABLE_COLUMNS = ImmutableList.<ColumnMetadata>builder()
             .add(new ColumnMetadata("id", BIGINT))
@@ -356,7 +356,7 @@ public abstract class AbstractTestHive
     private static RowType toRowType(List<ColumnMetadata> columns)
     {
         return rowType(columns.stream()
-                .map(col -> new NamedTypeSignature(Optional.of(new RowFieldName(format("f_%s", col.getName()), false)), col.getType().getTypeSignature()))
+                .map(col -> new NamedTypeSignature(Optional.of(new RowFieldName(format("f_%s", col.getName()))), col.getType().getTypeSignature()))
                 .collect(toImmutableList()));
     }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveTypeTranslator.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveTypeTranslator.java
@@ -94,7 +94,7 @@ public class TestHiveTypeTranslator
         assertInvalidTypeTranslation(
                 RowType.anonymous(ImmutableList.of(INTEGER, VARBINARY)),
                 NOT_SUPPORTED.toErrorCode(),
-                "Anonymous row type is not supported in Hive. Please give each field a name: row(integer,varbinary)");
+                "Anonymous row type is not supported in Hive. Please give each field a name: row(integer, varbinary)");
     }
 
     private void assertTypeTranslation(Type type, HiveType hiveType)

--- a/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
@@ -1029,11 +1029,7 @@ public class FunctionRegistry
         }
         catch (PrestoException e) {
             if (e.getErrorCode().getCode() == FUNCTION_NOT_FOUND.toErrorCode().getCode()) {
-                throw new OperatorNotFoundException(
-                        operatorType,
-                        argumentTypes.stream()
-                                .map(Type::getTypeSignature)
-                                .collect(toImmutableList()));
+                throw new OperatorNotFoundException(operatorType, argumentTypes);
             }
             else {
                 throw e;
@@ -1052,7 +1048,7 @@ public class FunctionRegistry
         }
         catch (PrestoException e) {
             if (e.getErrorCode().getCode() == FUNCTION_IMPLEMENTATION_MISSING.toErrorCode().getCode()) {
-                throw new OperatorNotFoundException(operatorType, ImmutableList.of(fromType.getTypeSignature()), toType.getTypeSignature());
+                throw new OperatorNotFoundException(operatorType, ImmutableList.of(fromType), toType.getTypeSignature());
             }
             throw e;
         }

--- a/presto-main/src/main/java/io/prestosql/metadata/OperatorNotFoundException.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/OperatorNotFoundException.java
@@ -17,6 +17,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.function.OperatorType;
+import io.prestosql.spi.type.Type;
 import io.prestosql.spi.type.TypeSignature;
 
 import java.util.List;
@@ -31,9 +32,9 @@ public class OperatorNotFoundException
 {
     private final OperatorType operatorType;
     private final TypeSignature returnType;
-    private final List<TypeSignature> argumentTypes;
+    private final List<Type> argumentTypes;
 
-    public OperatorNotFoundException(OperatorType operatorType, List<? extends TypeSignature> argumentTypes)
+    public OperatorNotFoundException(OperatorType operatorType, List<? extends Type> argumentTypes)
     {
         super(OPERATOR_NOT_FOUND, formatErrorMessage(operatorType, argumentTypes, Optional.empty()));
         this.operatorType = requireNonNull(operatorType, "operatorType is null");
@@ -41,7 +42,7 @@ public class OperatorNotFoundException
         this.argumentTypes = ImmutableList.copyOf(requireNonNull(argumentTypes, "argumentTypes is null"));
     }
 
-    public OperatorNotFoundException(OperatorType operatorType, List<? extends TypeSignature> argumentTypes, TypeSignature returnType)
+    public OperatorNotFoundException(OperatorType operatorType, List<? extends Type> argumentTypes, TypeSignature returnType)
     {
         super(OPERATOR_NOT_FOUND, formatErrorMessage(operatorType, argumentTypes, Optional.of(returnType)));
         this.operatorType = requireNonNull(operatorType, "operatorType is null");
@@ -49,7 +50,7 @@ public class OperatorNotFoundException
         this.returnType = requireNonNull(returnType, "returnType is null");
     }
 
-    private static String formatErrorMessage(OperatorType operatorType, List<? extends TypeSignature> argumentTypes, Optional<TypeSignature> returnType)
+    private static String formatErrorMessage(OperatorType operatorType, List<? extends Type> argumentTypes, Optional<TypeSignature> returnType)
     {
         String operatorString;
         switch (operatorType) {
@@ -74,7 +75,7 @@ public class OperatorNotFoundException
         return returnType;
     }
 
-    public List<TypeSignature> getArgumentTypes()
+    public List<Type> getArgumentTypes()
     {
         return argumentTypes;
     }

--- a/presto-main/src/main/java/io/prestosql/operator/TypeSignatureParser.java
+++ b/presto-main/src/main/java/io/prestosql/operator/TypeSignatureParser.java
@@ -194,7 +194,7 @@ public class TypeSignatureParser
                         verify(tokenStart >= 0, "Expect tokenStart to be non-negative");
                         verify(delimitedColumnName != null, "Expect delimitedColumnName to be non-null");
                         fields.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(
-                                Optional.of(new RowFieldName(delimitedColumnName, true)),
+                                Optional.of(new RowFieldName(delimitedColumnName)),
                                 parseTypeSignature(signature.substring(tokenStart, i).trim(), literalParameters))));
                         delimitedColumnName = null;
                         tokenStart = -1;
@@ -204,7 +204,7 @@ public class TypeSignatureParser
                         verify(tokenStart >= 0, "Expect tokenStart to be non-negative");
                         verify(delimitedColumnName != null, "Expect delimitedColumnName to be non-null");
                         fields.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(
-                                Optional.of(new RowFieldName(delimitedColumnName, true)),
+                                Optional.of(new RowFieldName(delimitedColumnName)),
                                 parseTypeSignature(signature.substring(tokenStart, i).trim(), literalParameters))));
                         delimitedColumnName = null;
                         tokenStart = -1;
@@ -238,7 +238,7 @@ public class TypeSignatureParser
         String firstPart = typeOrNamedType.substring(0, split);
         if (IDENTIFIER_PATTERN.matcher(firstPart).matches()) {
             return TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(
-                    Optional.of(new RowFieldName(firstPart, false)),
+                    Optional.of(new RowFieldName(firstPart)),
                     parseTypeSignature(typeOrNamedType.substring(split + 1).trim(), literalParameters)));
         }
 

--- a/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
+++ b/presto-main/src/main/java/io/prestosql/server/protocol/Query.java
@@ -594,7 +594,7 @@ class Query
             case NAMED_TYPE:
                 return ClientTypeSignatureParameter.ofNamedType(new NamedClientTypeSignature(
                         parameter.getNamedTypeSignature().getFieldName().map(value ->
-                                new RowFieldName(value.getName(), value.isDelimited())),
+                                new RowFieldName(value.getName())),
                         toClientTypeSignature(parameter.getNamedTypeSignature().getTypeSignature())));
             case LONG:
                 return ClientTypeSignatureParameter.ofLong(parameter.getLongLiteral());

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/TypeSignatureTranslator.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/TypeSignatureTranslator.java
@@ -110,7 +110,7 @@ public class TypeSignatureTranslator
                 .map(field -> namedTypeParameter(new NamedTypeSignature(
                         field.getName()
                                 .map(TypeSignatureTranslator::canonicalize)
-                                .map(value -> new RowFieldName(value, false)),
+                                .map(value -> new RowFieldName(value)),
                         toTypeSignature(field.getType()))))
                 .collect(toImmutableList());
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/DesugarRowSubscriptRewriter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/DesugarRowSubscriptRewriter.java
@@ -89,7 +89,7 @@ public final class DesugarRowSubscriptRewriter
 
                 // Do not cast if Row fields are named
                 if (fieldName.isPresent()) {
-                    result = new DereferenceExpression(base, new Identifier(fieldName.get()));
+                    result = new DereferenceExpression(base, new Identifier(fieldName.get(), true));
                 }
                 else {
                     // Cast to Row with named fields

--- a/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionInterpreter.java
@@ -181,8 +181,8 @@ public class ExpressionInterpreter
         Type actualType = analyzer.getExpressionTypes().get(NodeRef.of(expression));
         if (!new TypeCoercion(metadata::getType).canCoerce(actualType, expectedType)) {
             throw semanticException(TYPE_MISMATCH, expression, format("Cannot cast type %s to %s",
-                    actualType.getTypeSignature(),
-                    expectedType.getTypeSignature()));
+                    actualType.getDisplayName(),
+                    expectedType.getDisplayName()));
         }
 
         Map<NodeRef<Expression>, Type> coercions = ImmutableMap.<NodeRef<Expression>, Type>builder()

--- a/presto-main/src/test/java/io/prestosql/operator/TestTypeSignature.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestTypeSignature.java
@@ -64,32 +64,32 @@ public class TestTypeSignature
         // row signature with named fields
         assertRowSignature(
                 "row(a bigint,b varchar)",
-                rowSignature(namedParameter("a", false, signature("bigint")), namedParameter("b", false, varchar())));
+                rowSignature(namedParameter("a", signature("bigint")), namedParameter("b", varchar())));
         assertRowSignature(
                 "row(__a__ bigint,_b@_: _varchar)",
-                rowSignature(namedParameter("__a__", false, signature("bigint")), namedParameter("_b@_:", false, signature("_varchar"))));
+                rowSignature(namedParameter("__a__", signature("bigint")), namedParameter("_b@_:", signature("_varchar"))));
         assertRowSignature(
                 "row(a bigint,b array(bigint),c row(a bigint))",
                 rowSignature(
-                        namedParameter("a", false, signature("bigint")),
-                        namedParameter("b", false, array(signature("bigint"))),
-                        namedParameter("c", false, rowSignature(namedParameter("a", false, signature("bigint"))))));
+                        namedParameter("a", signature("bigint")),
+                        namedParameter("b", array(signature("bigint"))),
+                        namedParameter("c", rowSignature(namedParameter("a", signature("bigint"))))));
         assertRowSignature(
                 "row(a varchar(10),b row(a bigint))",
                 rowSignature(
-                        namedParameter("a", false, varchar(10)),
-                        namedParameter("b", false, rowSignature(namedParameter("a", false, signature("bigint"))))));
+                        namedParameter("a", varchar(10)),
+                        namedParameter("b", rowSignature(namedParameter("a", signature("bigint"))))));
         assertRowSignature(
                 "array(row(col0 bigint,col1 double))",
-                array(rowSignature(namedParameter("col0", false, signature("bigint")), namedParameter("col1", false, signature("double")))));
+                array(rowSignature(namedParameter("col0", signature("bigint")), namedParameter("col1", signature("double")))));
         assertRowSignature(
                 "row(col0 array(row(col0 bigint,col1 double)))",
-                rowSignature(namedParameter("col0", false, array(
-                        rowSignature(namedParameter("col0", false, signature("bigint")), namedParameter("col1", false, signature("double")))))));
+                rowSignature(namedParameter("col0", array(
+                        rowSignature(namedParameter("col0", signature("bigint")), namedParameter("col1", signature("double")))))));
         assertRowSignature(
                 "row(a decimal(p1,s1),b decimal(p2,s2))",
                 ImmutableSet.of("p1", "s1", "p2", "s2"),
-                rowSignature(namedParameter("a", false, decimal("p1", "s1")), namedParameter("b", false, decimal("p2", "s2"))));
+                rowSignature(namedParameter("a", decimal("p1", "s1")), namedParameter("b", decimal("p2", "s2"))));
 
         // row with mixed fields
         assertRowSignature(
@@ -100,40 +100,40 @@ public class TestTypeSignature
                 rowSignature(
                         unnamedParameter(signature("bigint")),
                         unnamedParameter(array(signature("bigint"))),
-                        unnamedParameter(rowSignature(namedParameter("a", false, signature("bigint"))))));
+                        unnamedParameter(rowSignature(namedParameter("a", signature("bigint"))))));
         assertRowSignature(
                 "row(varchar(10),b row(bigint))",
                 rowSignature(
                         unnamedParameter(varchar(10)),
-                        namedParameter("b", false, rowSignature(unnamedParameter(signature("bigint"))))));
+                        namedParameter("b", rowSignature(unnamedParameter(signature("bigint"))))));
         assertRowSignature(
                 "array(row(col0 bigint,double))",
-                array(rowSignature(namedParameter("col0", false, signature("bigint")), unnamedParameter(signature("double")))));
+                array(rowSignature(namedParameter("col0", signature("bigint")), unnamedParameter(signature("double")))));
         assertRowSignature(
                 "row(col0 array(row(bigint,double)))",
-                rowSignature(namedParameter("col0", false, array(
+                rowSignature(namedParameter("col0", array(
                         rowSignature(unnamedParameter(signature("bigint")), unnamedParameter(signature("double")))))));
         assertRowSignature(
                 "row(a decimal(p1,s1),decimal(p2,s2))",
                 ImmutableSet.of("p1", "s1", "p2", "s2"),
-                rowSignature(namedParameter("a", false, decimal("p1", "s1")), unnamedParameter(decimal("p2", "s2"))));
+                rowSignature(namedParameter("a", decimal("p1", "s1")), unnamedParameter(decimal("p2", "s2"))));
 
         // named fields of types with spaces
         assertRowSignature(
                 "row(time time with time zone)",
-                rowSignature(namedParameter("time", false, signature("time with time zone"))));
+                rowSignature(namedParameter("time", signature("time with time zone"))));
         assertRowSignature(
                 "row(time timestamp with time zone)",
-                rowSignature(namedParameter("time", false, signature("timestamp with time zone"))));
+                rowSignature(namedParameter("time", signature("timestamp with time zone"))));
         assertRowSignature(
                 "row(interval interval day to second)",
-                rowSignature(namedParameter("interval", false, signature("interval day to second"))));
+                rowSignature(namedParameter("interval", signature("interval day to second"))));
         assertRowSignature(
                 "row(interval interval year to month)",
-                rowSignature(namedParameter("interval", false, signature("interval year to month"))));
+                rowSignature(namedParameter("interval", signature("interval year to month"))));
         assertRowSignature(
                 "row(double double precision)",
-                rowSignature(namedParameter("double", false, signature("double precision"))));
+                rowSignature(namedParameter("double", signature("double precision"))));
 
         // unnamed fields of types with spaces
         assertRowSignature(
@@ -162,25 +162,25 @@ public class TestTypeSignature
         assertRowSignature(
                 "row(\"time with time zone\" time with time zone,\"double\" double)",
                 rowSignature(
-                        namedParameter("time with time zone", true, signature("time with time zone")),
-                        namedParameter("double", true, signature("double"))));
+                        namedParameter("time with time zone", signature("time with time zone")),
+                        namedParameter("double", signature("double"))));
 
         // allow spaces
         assertSignature(
                 "row( time  time with time zone, array( interval day to seconds ) )",
                 "row",
-                ImmutableList.of("time time with time zone", "array(interval day to seconds)"),
-                "row(time time with time zone,array(interval day to seconds))");
+                ImmutableList.of("\"time\" time with time zone", "array(interval day to seconds)"),
+                "row(\"time\" time with time zone,array(interval day to seconds))");
 
         // preserve base name case
         assertRowSignature(
                 "RoW(a bigint,b varchar)",
-                rowSignature(namedParameter("a", false, signature("bigint")), namedParameter("b", false, varchar())));
+                rowSignature(namedParameter("a", signature("bigint")), namedParameter("b", varchar())));
 
         // signature with invalid type
         assertRowSignature(
                 "row(\"time\" with time zone)",
-                rowSignature(namedParameter("time", true, signature("with time zone"))));
+                rowSignature(namedParameter("time", signature("with time zone"))));
     }
 
     private TypeSignature varchar()
@@ -204,9 +204,9 @@ public class TestTypeSignature
         return new TypeSignature("row", transform(asList(columns), TypeSignatureParameter::namedTypeParameter));
     }
 
-    private static NamedTypeSignature namedParameter(String name, boolean delimited, TypeSignature value)
+    private static NamedTypeSignature namedParameter(String name, TypeSignature value)
     {
-        return new NamedTypeSignature(Optional.of(new RowFieldName(name, delimited)), value);
+        return new NamedTypeSignature(Optional.of(new RowFieldName(name)), value);
     }
 
     private static NamedTypeSignature unnamedParameter(TypeSignature value)
@@ -302,7 +302,6 @@ public class TestTypeSignature
     {
         TypeSignature signature = parseTypeSignature(typeName, literalParameters);
         assertEquals(signature, expectedSignature);
-        assertEquals(signature.toString(), typeName);
     }
 
     private static void assertRowSignature(

--- a/presto-main/src/test/java/io/prestosql/type/TestJsonOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestJsonOperators.java
@@ -405,8 +405,8 @@ public class TestJsonOperators
         // Since we will not reformat the JSON string before parse and cast with the optimization,
         // these extra whitespaces in JSON string is to make sure the cast will work in such cases.
         assertCastWithJsonParse("{\"a\"\n:1,  \"b\":\t2}", "MAP(VARCHAR,INTEGER)", mapType(VARCHAR, INTEGER), ImmutableMap.of("a", 1, "b", 2));
-        assertInvalidCastWithJsonParse("{\"[1, 1]\":[2, 2]}", "MAP(ARRAY(INTEGER),ARRAY(INTEGER))", "Cannot cast JSON to map(array(integer),array(integer))");
-        assertInvalidCastWithJsonParse("{true: false, false:false}", "MAP(BOOLEAN,BOOLEAN)", "Cannot cast to map(boolean,boolean).\n{true: false, false:false}");
+        assertInvalidCastWithJsonParse("{\"[1, 1]\":[2, 2]}", "MAP(ARRAY(INTEGER),ARRAY(INTEGER))", "Cannot cast JSON to map(array(integer), array(integer))");
+        assertInvalidCastWithJsonParse("{true: false, false:false}", "MAP(BOOLEAN,BOOLEAN)", "Cannot cast to map(boolean, boolean).\n{true: false, false:false}");
 
         assertCastWithJsonParse(
                 "{\"a\"  \n  :1,  \"b\":  \t  [2, 3]}",
@@ -423,11 +423,11 @@ public class TestJsonOperators
         assertInvalidCastWithJsonParse(
                 "{\"a\" :1,  \"b\": {} }",
                 "ROW(a INTEGER, b ARRAY(INTEGER))",
-                "Cannot cast to row(a integer,b array(integer)). Expected a json array, but got {\n{\"a\" :1,  \"b\": {} }");
+                "Cannot cast to row(a integer, b array(integer)). Expected a json array, but got {\n{\"a\" :1,  \"b\": {} }");
         assertInvalidCastWithJsonParse(
                 "[  1,  {}  ]",
                 "ROW(INTEGER, ARRAY(INTEGER))",
-                "Cannot cast to row(integer,array(integer)). Expected a json array, but got {\n[  1,  {}  ]");
+                "Cannot cast to row(integer, array(integer)). Expected a json array, but got {\n[  1,  {}  ]");
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/type/TestMapOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestMapOperators.java
@@ -443,22 +443,22 @@ public class TestMapOperators
                                 null)));
 
         // invalid cast
-        assertInvalidCast("CAST(JSON '{\"[]\": 1}' AS MAP<ARRAY<BIGINT>, BIGINT>)", "Cannot cast JSON to map(array(bigint),bigint)");
+        assertInvalidCast("CAST(JSON '{\"[]\": 1}' AS MAP<ARRAY<BIGINT>, BIGINT>)", "Cannot cast JSON to map(array(bigint), bigint)");
 
-        assertInvalidCast("CAST(JSON '[1, 2]' AS MAP<BIGINT, BIGINT>)", "Cannot cast to map(bigint,bigint). Expected a json object, but got [\n[1,2]");
-        assertInvalidCast("CAST(JSON '{\"a\": 1, \"b\": 2}' AS MAP<VARCHAR, MAP<VARCHAR, BIGINT>>)", "Cannot cast to map(varchar,map(varchar,bigint)). Expected a json object, but got 1\n{\"a\":1,\"b\":2}");
-        assertInvalidCast("CAST(JSON '{\"a\": 1, \"b\": []}' AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar,bigint). Unexpected token when cast to bigint: [\n{\"a\":1,\"b\":[]}");
-        assertInvalidCast("CAST(JSON '{\"1\": {\"a\": 1}, \"2\": []}' AS MAP<VARCHAR, MAP<VARCHAR, BIGINT>>)", "Cannot cast to map(varchar,map(varchar,bigint)). Expected a json object, but got [\n{\"1\":{\"a\":1},\"2\":[]}");
+        assertInvalidCast("CAST(JSON '[1, 2]' AS MAP<BIGINT, BIGINT>)", "Cannot cast to map(bigint, bigint). Expected a json object, but got [\n[1,2]");
+        assertInvalidCast("CAST(JSON '{\"a\": 1, \"b\": 2}' AS MAP<VARCHAR, MAP<VARCHAR, BIGINT>>)", "Cannot cast to map(varchar, map(varchar, bigint)). Expected a json object, but got 1\n{\"a\":1,\"b\":2}");
+        assertInvalidCast("CAST(JSON '{\"a\": 1, \"b\": []}' AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar, bigint). Unexpected token when cast to bigint: [\n{\"a\":1,\"b\":[]}");
+        assertInvalidCast("CAST(JSON '{\"1\": {\"a\": 1}, \"2\": []}' AS MAP<VARCHAR, MAP<VARCHAR, BIGINT>>)", "Cannot cast to map(varchar, map(varchar, bigint)). Expected a json object, but got [\n{\"1\":{\"a\":1},\"2\":[]}");
 
-        assertInvalidCast("CAST(unchecked_to_json('\"a\": 1, \"b\": 2') AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar,bigint). Expected a json object, but got a\n\"a\": 1, \"b\": 2");
-        assertInvalidCast("CAST(unchecked_to_json('{\"a\": 1} 2') AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar,bigint). Unexpected trailing token: 2\n{\"a\": 1} 2");
-        assertInvalidCast("CAST(unchecked_to_json('{\"a\": 1') AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar,bigint).\n{\"a\": 1");
+        assertInvalidCast("CAST(unchecked_to_json('\"a\": 1, \"b\": 2') AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar, bigint). Expected a json object, but got a\n\"a\": 1, \"b\": 2");
+        assertInvalidCast("CAST(unchecked_to_json('{\"a\": 1} 2') AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar, bigint). Unexpected trailing token: 2\n{\"a\": 1} 2");
+        assertInvalidCast("CAST(unchecked_to_json('{\"a\": 1') AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar, bigint).\n{\"a\": 1");
 
-        assertInvalidCast("CAST(JSON '{\"a\": \"b\"}' AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar,bigint). Cannot cast 'b' to BIGINT\n{\"a\":\"b\"}");
-        assertInvalidCast("CAST(JSON '{\"a\": 1234567890123.456}' AS MAP<VARCHAR, INTEGER>)", "Cannot cast to map(varchar,integer). Out of range for integer: 1.234567890123456E12\n{\"a\":1.234567890123456E12}");
+        assertInvalidCast("CAST(JSON '{\"a\": \"b\"}' AS MAP<VARCHAR, BIGINT>)", "Cannot cast to map(varchar, bigint). Cannot cast 'b' to BIGINT\n{\"a\":\"b\"}");
+        assertInvalidCast("CAST(JSON '{\"a\": 1234567890123.456}' AS MAP<VARCHAR, INTEGER>)", "Cannot cast to map(varchar, integer). Out of range for integer: 1.234567890123456E12\n{\"a\":1.234567890123456E12}");
 
-        assertInvalidCast("CAST(JSON '{\"1\":1, \"01\": 2}' AS MAP<BIGINT, BIGINT>)", "Cannot cast to map(bigint,bigint). Duplicate keys are not allowed\n{\"01\":2,\"1\":1}");
-        assertInvalidCast("CAST(JSON '[{\"1\":1, \"01\": 2}]' AS ARRAY<MAP<BIGINT, BIGINT>>)", "Cannot cast to array(map(bigint,bigint)). Duplicate keys are not allowed\n[{\"01\":2,\"1\":1}]");
+        assertInvalidCast("CAST(JSON '{\"1\":1, \"01\": 2}' AS MAP<BIGINT, BIGINT>)", "Cannot cast to map(bigint, bigint). Duplicate keys are not allowed\n{\"01\":2,\"1\":1}");
+        assertInvalidCast("CAST(JSON '[{\"1\":1, \"01\": 2}]' AS ARRAY<MAP<BIGINT, BIGINT>>)", "Cannot cast to array(map(bigint, bigint)). Duplicate keys are not allowed\n[{\"01\":2,\"1\":1}]");
 
         // some other key/value type combinations
         assertFunction("CAST(JSON '{\"puppies\":\"kittens\"}' AS MAP<VARCHAR, VARCHAR>)",

--- a/presto-main/src/test/java/io/prestosql/type/TestRowOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestRowOperators.java
@@ -357,8 +357,8 @@ public class TestRowOperators
                         null, asList(1L, 2L, 3L, null)));
 
         // invalid cast
-        assertInvalidCast("CAST(unchecked_to_json('{\"a\":1,\"b\":2,\"a\":3}') AS ROW(a BIGINT, b BIGINT))", "Cannot cast to row(a bigint,b bigint). Duplicate field: a\n{\"a\":1,\"b\":2,\"a\":3}");
-        assertInvalidCast("CAST(unchecked_to_json('[{\"a\":1,\"b\":2,\"a\":3}]') AS ARRAY(ROW(a BIGINT, b BIGINT)))", "Cannot cast to array(row(a bigint,b bigint)). Duplicate field: a\n[{\"a\":1,\"b\":2,\"a\":3}]");
+        assertInvalidCast("CAST(unchecked_to_json('{\"a\":1,\"b\":2,\"a\":3}') AS ROW(a BIGINT, b BIGINT))", "Cannot cast to row(a bigint, b bigint). Duplicate field: a\n{\"a\":1,\"b\":2,\"a\":3}");
+        assertInvalidCast("CAST(unchecked_to_json('[{\"a\":1,\"b\":2,\"a\":3}]') AS ARRAY(ROW(a BIGINT, b BIGINT)))", "Cannot cast to array(row(a bigint, b bigint)). Duplicate field: a\n[{\"a\":1,\"b\":2,\"a\":3}]");
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/type/TestRowOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestRowOperators.java
@@ -481,7 +481,7 @@ public class TestRowOperators
         assertFunction("row(2, CAST(NULL AS INTEGER)) = row(1, 2)", BOOLEAN, false);
         assertFunction("row(2, CAST(NULL AS INTEGER)) != row(1, 2)", BOOLEAN, true);
         assertInvalidFunction("row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0])) > row(TRUE, ARRAY [1, 2], MAP(ARRAY[1, 3], ARRAY[2.0E0, 4.0E0]))",
-                TYPE_MISMATCH, "line 1:64: '>' cannot be applied to row(boolean,array(integer),map(integer,double)), row(boolean,array(integer),map(integer,double))");
+                TYPE_MISMATCH, "line 1:64: '>' cannot be applied to row(boolean, array(integer), map(integer, double)), row(boolean, array(integer), map(integer, double))");
 
         assertInvalidFunction("row(1, CAST(NULL AS INTEGER)) < row(1, 2)", StandardErrorCode.NOT_SUPPORTED);
 

--- a/presto-main/src/test/java/io/prestosql/type/TestRowParametricType.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestRowParametricType.java
@@ -40,8 +40,8 @@ public class TestRowParametricType
         TypeManager typeManager = new InternalTypeManager(createTestMetadataManager());
         TypeSignature typeSignature = new TypeSignature(
                 ROW,
-                TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName("col1", false)), BIGINT.getTypeSignature())),
-                TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName("col2", true)), DOUBLE.getTypeSignature())));
+                TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName("col1")), BIGINT.getTypeSignature())),
+                TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName("col2")), DOUBLE.getTypeSignature())));
         List<TypeParameter> parameters = typeSignature.getParameters().stream()
                 .map(parameter -> TypeParameter.of(parameter, typeManager))
                 .collect(Collectors.toList());

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/MongoSession.java
@@ -538,7 +538,7 @@ public class MongoSession
                 typeSignature = new TypeSignature(StandardTypes.ROW,
                         IntStream.range(0, subTypes.size())
                                 .mapToObj(idx -> TypeSignatureParameter.namedTypeParameter(
-                                        new NamedTypeSignature(Optional.of(new RowFieldName(format("%s%d", implicitPrefix, idx + 1), false)), subTypes.get(idx).get())))
+                                        new NamedTypeSignature(Optional.of(new RowFieldName(format("%s%d", implicitPrefix, idx + 1))), subTypes.get(idx).get())))
                                 .collect(toList()));
             }
         }
@@ -551,7 +551,7 @@ public class MongoSession
                     return Optional.empty();
                 }
 
-                parameters.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName(key, false)), fieldType.get())));
+                parameters.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName(key)), fieldType.get())));
             }
             typeSignature = new TypeSignature(StandardTypes.ROW, parameters);
         }

--- a/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/OrcTester.java
@@ -1109,7 +1109,7 @@ public class OrcTester
         for (int i = 0; i < fieldTypes.length; i++) {
             String filedName = "field_" + i;
             Type fieldType = fieldTypes[i];
-            typeSignatureParameters.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName(filedName, false)), fieldType.getTypeSignature())));
+            typeSignatureParameters.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName(filedName)), fieldType.getTypeSignature())));
         }
         return METADATA.getParameterizedType(StandardTypes.ROW, typeSignatureParameters.build());
     }

--- a/presto-orc/src/test/java/io/prestosql/orc/TestStructColumnReader.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestStructColumnReader.java
@@ -152,7 +152,7 @@ public class TestStructColumnReader
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp =
-            "ROW type does not have field names declared: row\\(varchar,varchar,varchar\\)")
+            "ROW type does not have field names declared: row\\(varchar, varchar, varchar\\)")
     public void testThrowsExceptionWhenFieldNameMissing()
             throws IOException
     {

--- a/presto-orc/src/test/java/io/prestosql/orc/TestStructColumnReader.java
+++ b/presto-orc/src/test/java/io/prestosql/orc/TestStructColumnReader.java
@@ -281,7 +281,7 @@ public class TestStructColumnReader
     {
         ImmutableList.Builder<TypeSignatureParameter> typeSignatureParameters = ImmutableList.builder();
         for (String fieldName : fieldNames) {
-            typeSignatureParameters.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName(fieldName, false)), TEST_DATA_TYPE.getTypeSignature())));
+            typeSignatureParameters.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(Optional.of(new RowFieldName(fieldName)), TEST_DATA_TYPE.getTypeSignature())));
         }
         return METADATA.getParameterizedType(StandardTypes.ROW, typeSignatureParameters.build());
     }

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/OrcStorageManager.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/OrcStorageManager.java
@@ -542,7 +542,7 @@ public class OrcStorageManager
                 ImmutableList.Builder<TypeSignatureParameter> fieldTypes = ImmutableList.builder();
                 for (int i = 0; i < type.getFieldCount(); i++) {
                     fieldTypes.add(TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(
-                            Optional.of(new RowFieldName(fieldNames.get(i), false)),
+                            Optional.of(new RowFieldName(fieldNames.get(i))),
                             getType(types, type.getFieldTypeIndex(i)).getTypeSignature())));
                 }
                 return typeManager.getParameterizedType(StandardTypes.ROW, fieldTypes.build());

--- a/presto-spi/src/main/java/io/prestosql/spi/type/AbstractType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/AbstractType.java
@@ -156,7 +156,7 @@ public abstract class AbstractType
     @Override
     public String toString()
     {
-        return getTypeSignature().toString();
+        return getDisplayName();
     }
 
     @Override

--- a/presto-spi/src/main/java/io/prestosql/spi/type/NamedTypeSignature.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/NamedTypeSignature.java
@@ -65,7 +65,7 @@ public class NamedTypeSignature
     public String toString()
     {
         if (fieldName.isPresent()) {
-            return format("%s %s", fieldName.get(), typeSignature);
+            return format("\"%s\" %s", fieldName.get().getName().replace("\"", "\"\""), typeSignature);
         }
         return typeSignature.toString();
     }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/RowFieldName.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/RowFieldName.java
@@ -20,23 +20,15 @@ import static java.util.Objects.requireNonNull;
 public class RowFieldName
 {
     private final String name;
-    private final boolean delimited;
 
-    public RowFieldName(String name, boolean delimited)
+    public RowFieldName(String name)
     {
         this.name = requireNonNull(name, "name is null");
-        this.delimited = delimited;
     }
 
     public String getName()
     {
         return name;
-    }
-
-    @Deprecated
-    public boolean isDelimited()
-    {
-        return delimited;
     }
 
     @Override
@@ -51,22 +43,18 @@ public class RowFieldName
 
         RowFieldName other = (RowFieldName) o;
 
-        return Objects.equals(this.name, other.name) &&
-                Objects.equals(this.delimited, other.delimited);
+        return Objects.equals(this.name, other.name);
     }
 
     @Override
     public String toString()
     {
-        if (!isDelimited()) {
-            return name;
-        }
         return '"' + name.replace("\"", "\"\"") + '"';
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, delimited);
+        return Objects.hash(name);
     }
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/RowType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/RowType.java
@@ -98,7 +98,7 @@ public class RowType
         }
 
         List<TypeSignatureParameter> parameters = fields.stream()
-                .map(field -> TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(field.getName().map(name -> new RowFieldName(name, false)), field.getType().getTypeSignature())))
+                .map(field -> TypeSignatureParameter.namedTypeParameter(new NamedTypeSignature(field.getName().map(name -> new RowFieldName(name)), field.getType().getTypeSignature())))
                 .collect(Collectors.toList());
 
         return new TypeSignature(ROW, parameters);

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TypeSignatureParameter.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TypeSignatureParameter.java
@@ -41,7 +41,7 @@ public class TypeSignatureParameter
 
     public static TypeSignatureParameter namedField(String name, TypeSignature type)
     {
-        return new TypeSignatureParameter(ParameterKind.NAMED_TYPE, new NamedTypeSignature(Optional.of(new RowFieldName(name, false)), type));
+        return new TypeSignatureParameter(ParameterKind.NAMED_TYPE, new NamedTypeSignature(Optional.of(new RowFieldName(name)), type));
     }
 
     public static TypeSignatureParameter anonymousField(TypeSignature type)

--- a/presto-tests/src/test/java/io/prestosql/tests/TestTpchDistributedQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestTpchDistributedQueries.java
@@ -155,6 +155,16 @@ public class TestTpchDistributedQueries
                 "VALUES 1");
     }
 
+    @Test
+    public void testRowTypeWithReservedKeyword()
+    {
+        // This test is here because it only reproduces the issue (https://github.com/prestosql/presto/issues/1962)
+        // when running in distributed mode
+        assertQuery(
+                "SELECT cast(row(1) AS row(\"cross\" bigint)).\"cross\"",
+                "VALUES 1");
+    }
+
     private Session createSession(String schemaName)
     {
         return testSessionBuilder()

--- a/presto-tests/src/test/java/io/prestosql/tests/TestTpchDistributedQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestTpchDistributedQueries.java
@@ -145,6 +145,16 @@ public class TestTpchDistributedQueries
         assertQueryFails("SHOW TABLES FROM sf0", "line 1:1: Schema 'sf0' does not exist");
     }
 
+    @Test
+    public void testRowSubscriptWithReservedKeyword()
+    {
+        // Subscript over field named after reserved keyword. This test needs to run in distributed
+        // mode, as it uncovers a problem during deserialization plan expressions
+        assertQuery(
+                "SELECT cast(row(1) AS row(\"cross\" bigint))[1]",
+                "VALUES 1");
+    }
+
     private Session createSession(String schemaName)
     {
         return testSessionBuilder()


### PR DESCRIPTION
Since row type field names can match reserved SQL keywords, names
need to be quoted when rendering them.

Fixes https://github.com/prestosql/presto/issues/1962