### PR TITLE
Add pattern for files ending with <query_id>.<number> to cleanup them during rollback

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveWriterFactory.java
@@ -101,7 +101,7 @@ import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.COMPRESSRESULT;
 public class HiveWriterFactory
 {
     private static final int MAX_BUCKET_COUNT = 100_000;
-    private static final int BUCKET_NUMBER_PADDING = Integer.toString(MAX_BUCKET_COUNT - 1).length();
+    public static final int BUCKET_NUMBER_PADDING = Integer.toString(MAX_BUCKET_COUNT - 1).length();
 
     private final Set<HiveFileWriterFactory> fileWriterFactories;
     private final String schemaName;


### PR DESCRIPTION
Fixes #2023