### PR TITLE
Establish an outer query scope for insert and create

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -319,7 +319,7 @@ class StatementAnalyzer
             }
 
             // analyze the query that creates the data
-            Scope queryScope = process(insert.getQuery(), scope);
+            Scope queryScope = analyze(insert.getQuery(), createScope(scope));
 
             analysis.setUpdateType("INSERT");
 
@@ -502,7 +502,7 @@ class StatementAnalyzer
             accessControl.checkCanCreateTable(session.toSecurityContext(), targetTable);
 
             // analyze the query that creates the table
-            Scope queryScope = process(node.getQuery(), scope);
+            Scope queryScope = analyze(node.getQuery(), createScope(scope));
 
             ImmutableList.Builder<ColumnMetadata> columns = ImmutableList.builder();
 


### PR DESCRIPTION
This is necessary for the engine to reason about the effects
of some operations like ORDER BY when a query is part of
an INSERT or CREATE TABLE AS ...