### PR TITLE
Adding changes for adding _timestamp field in kafka topic metadata.

### DIFF
--- a/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
@@ -153,6 +153,7 @@ built-in ones:
           Column       |  Type   | Extra |                   Comment
     -------------------+---------+-------+---------------------------------------------
      _partition_id     | bigint  |       | Partition Id
+     _timestamp        | bigint  |       | Message creation timestamp
      _partition_offset | bigint  |       | Offset for the message within the partition
      _segment_start    | bigint  |       | Segment start offset
      _segment_end      | bigint  |       | Segment end offset
@@ -230,6 +231,7 @@ The customer table now has an additional column: ``kafka_key``.
     -------------------+---------+-------+---------------------------------------------
      kafka_key         | bigint  |       |
      _partition_id     | bigint  |       | Partition Id
+     _timestamp        | bigint  |       | Message creation timestamp
      _partition_offset | bigint  |       | Offset for the message within the partition
      _segment_start    | bigint  |       | Segment start offset
      _segment_end      | bigint  |       | Segment end offset
@@ -356,6 +358,7 @@ the sum query from earlier can operate on the ``account_balance`` column directl
      market_segment    | varchar |       |
      comment           | varchar |       |
      _partition_id     | bigint  |       | Partition Id
+     _timestamp        | bigint  |       | Message creation timestamp
      _partition_offset | bigint  |       | Offset for the message within the partition
      _segment_start    | bigint  |       | Segment start offset
      _segment_end      | bigint  |       | Segment end offset

--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -142,6 +142,7 @@ For each defined table, the connector maintains the following columns:
 Column name             Type      Description
 ======================= ========= =============================
 ``_partition_id``       BIGINT    ID of the Kafka partition which contains this row.
+``_timestamp``          BIGINT    Message creation timestamp
 ``_partition_offset``   BIGINT    Offset within the Kafka partition for this row.
 ``_segment_start``      BIGINT    Lowest offset in the segment (inclusive) which contains this row. This offset is partition specific.
 ``_segment_end``        BIGINT    Highest offset in the segment (exclusive) which contains this row. The offset is partition specific. This is the same value as ``_segment_start`` of the next segment (if it exists).

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaInternalFieldDescription.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaInternalFieldDescription.java
@@ -43,6 +43,11 @@ public enum KafkaInternalFieldDescription
     PARTITION_ID_FIELD("_partition_id", BigintType.BIGINT, "Partition Id"),
 
     /**
+     * <tt>_timestamp</tt> - Kafka message timestamp.
+     */
+    TIMESTAMP_FIELD("_timestamp", BigintType.BIGINT, "Message creation timestamp"),
+
+    /**
      * <tt>_partition_offset</tt> - The current offset of the message in the partition.
      */
     PARTITION_OFFSET_FIELD("_partition_offset", BigintType.BIGINT, "Offset for the message within the partition"),

--- a/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSet.java
+++ b/presto-kafka/src/main/java/io/prestosql/plugin/kafka/KafkaRecordSet.java
@@ -200,6 +200,9 @@ public class KafkaRecordSet
                 if (columnHandle.isInternal()) {
                     KafkaInternalFieldDescription fieldDescription = KafkaInternalFieldDescription.forColumnName(columnHandle.getName());
                     switch (fieldDescription) {
+                        case TIMESTAMP_FIELD:
+                            currentRowValuesMap.put(columnHandle, longValueProvider(messageAndOffset.message().timestamp()));
+                            break;
                         case SEGMENT_COUNT_FIELD:
                             currentRowValuesMap.put(columnHandle, longValueProvider(totalMessages));
                             break;


### PR DESCRIPTION
This PR covers below enhancement,
Adding _timestamp field in Kafka topic metadata in presto-Kafka connector.
