### PR TITLE
Check for null before reading mask value

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/gen/CompilerOperations.java
+++ b/presto-main/src/main/java/io/prestosql/sql/gen/CompilerOperations.java
@@ -65,6 +65,9 @@ public final class CompilerOperations
     public static boolean testMask(@Nullable Block masks, int index)
     {
         if (masks != null) {
+            if (masks.isNull(index)) {
+                return false;
+            }
             return BOOLEAN.getBoolean(masks, index);
         }
         return true;


### PR DESCRIPTION
The aggregation mask check was not properly checking whether
the mask was null before testing its value. The result of reading
a position marked as null is undefined. This can cause the aggregation
to incorrectly consider a mask as "true" when it's null.