### PR TITLE
Add execution user as a session property

### DIFF
--- a/presto-main/src/main/java/io/prestosql/Session.java
+++ b/presto-main/src/main/java/io/prestosql/Session.java
@@ -79,6 +79,7 @@ public final class Session
     private final Map<String, Map<String, String>> unprocessedCatalogProperties;
     private final SessionPropertyManager sessionPropertyManager;
     private final Map<String, String> preparedStatements;
+    private final Optional<String> originalUser;
 
     public Session(
             QueryId queryId,
@@ -103,7 +104,8 @@ public final class Session
             Map<CatalogName, Map<String, String>> connectorProperties,
             Map<String, Map<String, String>> unprocessedCatalogProperties,
             SessionPropertyManager sessionPropertyManager,
-            Map<String, String> preparedStatements)
+            Map<String, String> preparedStatements,
+            Optional<String> originalUser)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
@@ -126,6 +128,7 @@ public final class Session
         this.systemProperties = ImmutableMap.copyOf(requireNonNull(systemProperties, "systemProperties is null"));
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.preparedStatements = requireNonNull(preparedStatements, "preparedStatements is null");
+        this.originalUser = requireNonNull(originalUser, "originalUser is null");
 
         ImmutableMap.Builder<CatalogName, Map<String, String>> catalogPropertiesBuilder = ImmutableMap.builder();
         connectorProperties.entrySet().stream()
@@ -287,6 +290,11 @@ public final class Session
         return sql;
     }
 
+    public Optional<String> getOriginalUser()
+    {
+        return originalUser;
+    }
+
     public Session beginTransactionId(TransactionId transactionId, TransactionManager transactionManager, AccessControl accessControl)
     {
         requireNonNull(transactionId, "transactionId is null");
@@ -372,7 +380,8 @@ public final class Session
                 connectorProperties.build(),
                 ImmutableMap.of(),
                 sessionPropertyManager,
-                preparedStatements);
+                preparedStatements,
+                originalUser);
     }
 
     public Session withDefaultProperties(Map<String, String> systemPropertyDefaults, Map<String, Map<String, String>> catalogPropertyDefaults)
@@ -423,7 +432,8 @@ public final class Session
                 ImmutableMap.of(),
                 connectorProperties,
                 sessionPropertyManager,
-                preparedStatements);
+                preparedStatements,
+                originalUser);
     }
 
     public ConnectorSession toConnectorSession()
@@ -544,6 +554,7 @@ public final class Session
         private final Map<String, Map<String, String>> catalogSessionProperties = new HashMap<>();
         private final SessionPropertyManager sessionPropertyManager;
         private final Map<String, String> preparedStatements = new HashMap<>();
+        private String originalUser;
 
         private SessionBuilder(SessionPropertyManager sessionPropertyManager)
         {
@@ -706,6 +717,12 @@ public final class Session
             return this;
         }
 
+        public SessionBuilder setOriginalUser(String originalUser)
+        {
+            this.originalUser = originalUser;
+            return this;
+        }
+
         public SessionBuilder addPreparedStatement(String statementName, String query)
         {
             this.preparedStatements.put(statementName, query);
@@ -737,7 +754,8 @@ public final class Session
                     ImmutableMap.of(),
                     catalogSessionProperties,
                     sessionPropertyManager,
-                    preparedStatements);
+                    preparedStatements,
+                    Optional.ofNullable(originalUser));
         }
     }
 

--- a/presto-main/src/main/java/io/prestosql/SessionRepresentation.java
+++ b/presto-main/src/main/java/io/prestosql/SessionRepresentation.java
@@ -304,6 +304,7 @@ public final class SessionRepresentation
                 catalogProperties,
                 unprocessedCatalogProperties,
                 sessionPropertyManager,
-                preparedStatements);
+                preparedStatements,
+                Optional.empty());
     }
 }

--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -125,6 +125,7 @@ public final class SystemSessionProperties
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_ROW_COUNT = "dynamic_filtering_max_per_driver_row_count";
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE = "dynamic_filtering_max_per_driver_size";
     public static final String IGNORE_DOWNSTREAM_PREFERENCES = "ignore_downstream_preferences";
+    public static final String EXECUTION_USER = "execution_user";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -552,6 +553,11 @@ public final class SystemSessionProperties
                         IGNORE_DOWNSTREAM_PREFERENCES,
                         "Ignore Parent's PreferredProperties in AddExchange optimizer",
                         featuresConfig.isIgnoreDownstreamPreferences(),
+                        false),
+                stringProperty(
+                        EXECUTION_USER,
+                        "User to execute query as",
+                        "",
                         false));
     }
 
@@ -976,6 +982,11 @@ public final class SystemSessionProperties
     public static DataSize getDynamicFilteringMaxPerDriverSize(Session session)
     {
         return session.getSystemProperty(DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE, DataSize.class);
+    }
+
+    public static String getExecutionUser(Session session)
+    {
+        return session.getSystemProperty(EXECUTION_USER, String.class);
     }
 
     public static boolean ignoreDownStreamPreferences(Session session)

--- a/presto-main/src/main/java/io/prestosql/server/QuerySessionSupplier.java
+++ b/presto-main/src/main/java/io/prestosql/server/QuerySessionSupplier.java
@@ -84,7 +84,8 @@ public class QuerySessionSupplier
                 .setClientTags(context.getClientTags())
                 .setClientCapabilities(context.getClientCapabilities())
                 .setTraceToken(context.getTraceToken())
-                .setResourceEstimates(context.getResourceEstimates());
+                .setResourceEstimates(context.getResourceEstimates())
+                .setOriginalUser(context.getOriginalUser());
 
         defaultCatalog.ifPresent(sessionBuilder::setCatalog);
         defaultSchema.ifPresent(sessionBuilder::setSchema);

--- a/presto-main/src/main/java/io/prestosql/server/SessionContext.java
+++ b/presto-main/src/main/java/io/prestosql/server/SessionContext.java
@@ -70,4 +70,9 @@ public interface SessionContext
     Optional<String> getTraceToken();
 
     boolean supportClientTransaction();
+
+    default String getOriginalUser()
+    {
+        return getIdentity().getUser();
+    }
 }

--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -407,7 +407,8 @@ public class LocalQueryRunner
                 defaultSession.getConnectorProperties(),
                 defaultSession.getUnprocessedCatalogProperties(),
                 metadata.getSessionPropertyManager(),
-                defaultSession.getPreparedStatements());
+                defaultSession.getPreparedStatements(),
+                Optional.empty());
 
         dataDefinitionTask = ImmutableMap.<Class<? extends Statement>, DataDefinitionTask<?>>builder()
                 .put(CreateTable.class, new CreateTableTask())

--- a/presto-main/src/test/java/io/prestosql/server/TestHttpRequestSessionContext.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestHttpRequestSessionContext.java
@@ -25,6 +25,7 @@ import javax.ws.rs.WebApplicationException;
 import java.util.Optional;
 
 import static com.google.common.net.HttpHeaders.X_FORWARDED_FOR;
+import static io.prestosql.SystemSessionProperties.EXECUTION_USER;
 import static io.prestosql.SystemSessionProperties.HASH_PARTITION_COUNT;
 import static io.prestosql.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static io.prestosql.SystemSessionProperties.QUERY_MAX_MEMORY;
@@ -70,6 +71,7 @@ public class TestHttpRequestSessionContext
                         .put(PRESTO_ROLE, "foobar_connector=ROLE{role}")
                         .put(PRESTO_EXTRA_CREDENTIAL, "test.token.foo=bar")
                         .put(PRESTO_EXTRA_CREDENTIAL, "test.token.abc=xyz")
+                        .put(PRESTO_SESSION, EXECUTION_USER + "=user")
                         .build(),
                 "testRemote");
 
@@ -78,7 +80,7 @@ public class TestHttpRequestSessionContext
         assertEquals(context.getCatalog(), "testCatalog");
         assertEquals(context.getSchema(), "testSchema");
         assertEquals(context.getPath(), "testPath");
-        assertEquals(context.getIdentity(), Identity.ofUser("testUser"));
+        assertEquals(context.getIdentity(), Identity.ofUser("user"));
         assertEquals(context.getClientInfo(), "client-info");
         assertEquals(context.getLanguage(), "zh-TW");
         assertEquals(context.getTimeZoneId(), "Asia/Taipei");
@@ -86,7 +88,8 @@ public class TestHttpRequestSessionContext
                 QUERY_MAX_MEMORY, "1GB",
                 JOIN_DISTRIBUTION_TYPE, "partitioned",
                 HASH_PARTITION_COUNT, "43",
-                "some_session_property", "some value with , comma"));
+                "some_session_property", "some value with , comma",
+                EXECUTION_USER, "user"));
         assertEquals(context.getPreparedStatements(), ImmutableMap.of("query1", "select * from foo", "query2", "select * from bar"));
         assertEquals(context.getIdentity().getRoles(), ImmutableMap.of(
                 "foo_connector", new SelectedRole(SelectedRole.Type.ALL, Optional.empty()),

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestQueries.java
@@ -2756,7 +2756,8 @@ public abstract class AbstractTestQueries
                         .put("connector_long", "11")
                         .build()),
                 getQueryRunner().getMetadata().getSessionPropertyManager(),
-                getSession().getPreparedStatements());
+                getSession().getPreparedStatements(),
+                Optional.empty());
         MaterializedResult result = computeActual(session, "SHOW SESSION");
 
         ImmutableMap<String, MaterializedRow> properties = Maps.uniqueIndex(result.getMaterializedRows(), input -> {

--- a/presto-tests/src/test/java/io/prestosql/tests/TestExecutionUserSessionProperty.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/TestExecutionUserSessionProperty.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests;
+
+import io.prestosql.Session;
+import io.prestosql.spi.security.AccessDeniedException;
+import io.prestosql.spi.security.BasicPrincipal;
+import io.prestosql.spi.security.SystemAccessControl;
+import io.prestosql.spi.security.SystemSecurityContext;
+import io.prestosql.testing.DistributedQueryRunner;
+import io.prestosql.testing.MaterializedResult;
+import io.prestosql.testing.assertions.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.security.Principal;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static io.prestosql.testing.assertions.Assert.assertEquals;
+
+public class TestExecutionUserSessionProperty
+{
+    private DistributedQueryRunner queryRunner;
+    private Optional<Principal> principal;
+    private final Optional<Principal> impersonatingService = Optional.of(new BasicPrincipal("impersonatingService"));
+    private final Optional<Principal> user = Optional.of(new BasicPrincipal("user"));
+
+    @BeforeClass
+    private void setUp() throws Exception
+    {
+        Session session = testSessionBuilder().build();
+        queryRunner = DistributedQueryRunner.builder(session).setNodeCount(1).build();
+        queryRunner.getAccessControl().setTestingSystemAccessControl(new TestingExecutionUserSessionProperty());
+    }
+
+    @AfterClass(alwaysRun = true)
+    private void tearDown()
+    {
+        queryRunner.close();
+    }
+
+    @Test
+    public void testImpersonationSettingExecutionUser()
+    {
+        principal = impersonatingService;
+        queryRunner.execute("SET SESSION execution_user = 'headless_account1'");
+        try {
+            queryRunner.execute("SET SESSION execution_user = 'headless_account2'");
+        }
+        catch (Exception e) {
+            Assert.assertEquals(e.getMessage(), "Access Denied: Principal impersonatingService cannot become user headless_account2");
+        }
+    }
+
+    @Test
+    public void testImpersonationSecurityIssue()
+    {
+        principal = impersonatingService;
+        try {
+            queryRunner.execute("SET SESSION execution_user = 'user2'");
+        }
+        catch (Exception e) {
+            assertEquals(e.getMessage(), "Access Denied: Principal user cannot become user user2");
+        }
+    }
+
+    @Test
+    public void testSelfSettingExecutionUser()
+    {
+        principal = user;
+        MaterializedResult materializedResult = queryRunner.execute("SET SESSION execution_user = 'headless_account1'");
+        assertEquals(materializedResult.getSetSessionProperties().get("execution_user"), "headless_account1");
+        materializedResult = queryRunner.execute("SET SESSION execution_user = 'user'");
+        assertEquals(materializedResult.getSetSessionProperties().get("execution_user"), "user");
+        try {
+            queryRunner.execute("SET SESSION execution_user = 'user2'");
+        }
+        catch (Exception e) {
+            assertEquals(e.getMessage(), "Access Denied: Principal user cannot become user user2");
+        }
+
+        try {
+            queryRunner.execute("SET SESSION execution_user = reverse('abc')");
+        }
+        catch (Exception e) {
+            assertEquals(e.getMessage(), "Access Denied: Principal user cannot become user cba");
+        }
+
+        materializedResult = queryRunner.execute("SET SESSION execution_user = reverse('resu')");
+        assertEquals(materializedResult.getSetSessionProperties().get("execution_user"), "user");
+    }
+
+    private class TestingExecutionUserSessionProperty
+            implements SystemAccessControl
+    {
+        private final Map<String, Set<String>> canBeSetMapping = new HashMap<>();
+
+        public TestingExecutionUserSessionProperty()
+        {
+            canBeSetMapping.put("user", new HashSet<>(Arrays.asList("user", "headless_account1")));
+            canBeSetMapping.put("impersonatingService", new HashSet<>(Arrays.asList("user", "user2", "headless_account1")));
+        }
+
+        @Override
+        public void checkCanSetUser(Optional<Principal> principal, String userName)
+        {
+            if (!principal.isPresent()) {
+                principal = TestExecutionUserSessionProperty.this.principal;
+            }
+            Set<String> userNames = canBeSetMapping.get(principal.get().getName());
+            if (userNames == null || userNames.isEmpty()) {
+                AccessDeniedException.denySetUser(principal, userName);
+            }
+
+            if (userNames.contains(userName)) {
+                return;
+            }
+            AccessDeniedException.denySetUser(principal, userName);
+        }
+
+        @Override
+        public void checkCanSetSystemSessionProperty(SystemSecurityContext context, String propertyName)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Adds execution user as a session property. If it is set, it will override the current user. #2308 

**Service Impersonation security issue:**

We currently use external services to impersonate users and execute sql scripts.

Let's say an impersonating service can be set to User1. User1 can then set the execution user to User2 in the script, and execute queries on datasets that only User2 may own that User1 doesn't.
The AccessControlManager only checks the principal to the user, so if the impersonating service can impersonate User1 and User2, then the access control plugin won't deny access.

**Solution:**
When a "SET SESSION execution_user = '?'" query is run, 3 checks will be made:
1. the principal will be checked against the user (to see if the query can be run)
2. the principal will be checked against the execution user (to see if the principal can be set to the new user)
3. the user can be set to the executionUser (in the above case, User1 cannot be set to User2)

If any of them fails, deny access.