### PR TITLE
Fix planning failure due to incomplete pushdown

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -103,13 +103,16 @@ public class UnwrapCastInComparison
         requireNonNull(metadata, "metadata is null");
         requireNonNull(typeAnalyzer, "typeAnalyzer is null");
 
-        return (expression, context) -> {
-            if (SystemSessionProperties.isUnwrapCasts(context.getSession())) {
-                return ExpressionTreeRewriter.rewriteWith(new Visitor(metadata, typeAnalyzer, context.getSession(), context.getSymbolAllocator().getTypes()), expression);
-            }
+        return (expression, context) -> unwrapCasts(context.getSession(), metadata, typeAnalyzer, context.getSymbolAllocator().getTypes(), expression);
+    }
 
-            return expression;
-        };
+    public static Expression unwrapCasts(Session session, Metadata metadata, TypeAnalyzer typeAnalyzer, TypeProvider types, Expression expression)
+    {
+        if (SystemSessionProperties.isUnwrapCasts(session)) {
+            return ExpressionTreeRewriter.rewriteWith(new Visitor(metadata, typeAnalyzer, session, types), expression);
+        }
+
+        return expression;
     }
 
     private static class Visitor

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestReorderWindows.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestReorderWindows.java
@@ -248,7 +248,7 @@ public class TestReorderWindows
                                         .specification(windowA)
                                         .addFunction(functionCall("avg", commonFrame, ImmutableList.of(QUANTITY_ALIAS))),
                                 project(
-                                        filter(RECEIPTDATE_ALIAS + " IS NOT NULL",
+                                        filter("NOT (" + RECEIPTDATE_ALIAS + " IS NULL)",
                                                 window(windowMatcherBuilder -> windowMatcherBuilder
                                                                 .specification(windowApp)
                                                                 .addFunction(functionCall("avg", commonFrame, ImmutableList.of(DISCOUNT_ALIAS))),

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestJoinQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestJoinQueries.java
@@ -2256,6 +2256,21 @@ public abstract class AbstractTestJoinQueries
                 "WITH small_part AS (SELECT * FROM part WHERE name = 'a') SELECT lineitem.orderkey FROM small_part RIGHT JOIN lineitem ON  small_part.partkey = lineitem.partkey");
     }
 
+    @Test
+    public void testEquijoinOnDifferentTypesWithFilter()
+    {
+        // Exercises a join on integer vs bigint with a filter on the integer column that can be pushed down
+        // below the join. Needs to run in distributed mode to reproduce the issue (i.e., with AddExchanges enabled)
+        assertQuery("" +
+                "WITH" +
+                "   t1 AS (SELECT linenumber AS id1 FROM lineitem), " +
+                "   t2 AS (SELECT nationkey AS id2 FROM nation) " +
+                "SELECT id1 " +
+                "FROM t1 " +
+                "JOIN t2 ON id1 = id2 " +
+                "WHERE id1 = 10");
+    }
+
     private Session noJoinReordering()
     {
         return Session.builder(getSession())

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestJoinQueries.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestJoinQueries.java
@@ -2269,6 +2269,18 @@ public abstract class AbstractTestJoinQueries
                 "FROM t1 " +
                 "JOIN t2 ON id1 = id2 " +
                 "WHERE id1 = 10");
+
+        assertQuery("" +
+                "WITH " +
+                "   t1 AS (SELECT linenumber AS id1 FROM lineitem), " +
+                "   t2 AS (SELECT nationkey AS id2 FROM nation), " +
+                "   t3 AS (SELECT linenumber AS id3 FROM lineitem), " +
+                "   t4 AS (SELECT nationkey AS id4 FROM nation) " +
+                "SELECT id3 " +
+                "FROM (SELECT * FROM t1 JOIN t2 ON id1 = id2) u " +
+                "JOIN (SELECT * FROM t3 JOIN t4 ON id3 = id4) v " +
+                "ON id1 = id4 " +
+                "WHERE id3 = 10");
     }
 
     private Session noJoinReordering()


### PR DESCRIPTION
Given these tables:

```
CREATE TABLE t1(id integer);
CREATE TABLE t2(id bigint);
```
The following query fails with "Equi criteria are empty, so INNER join should not have PARTITIONED distribution type"

```
SELECT t1.id
FROM t1
JOIN t2 ON t1.id = t2.id
WHERE t1.id = 10
```

This occurs because PredicatePushdown cannot derive an equivalence during the first pass that helps
it infer that the join condition is always true. By the time the join distribution strategy is picked,
the join is still an equi-join, so the planner chooses PARTITIONED. Later on, during another pass of
PredicatePushdown, the condition is determined to be always true, and that implicitly converts the
Join to a cross join.

This change enhances PredicatePushdown to consider the predicate above the join to simplify the
effective predicate of the left/right branches of the join before engaging in the usual inference
logic. This is equivalent to inlining equalities defined by the predicate into the left/right
predicates and allows the equivalence inferencer to "infer more" and push predicates across the
branches of the join.

Fixes https://github.com/prestosql/presto/issues/2320