### PR TITLE
Use filter clause for Elasticsearch queries

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchQueryBuilder.java
@@ -63,7 +63,7 @@ public final class ElasticsearchQueryBuilder
 
                 checkArgument(!domain.isNone(), "Unexpected NONE domain for %s", column.getName());
                 if (!domain.isAll()) {
-                    queryBuilder.must(new BoolQueryBuilder().must(buildPredicate(session, column.getName(), domain, column.getType())));
+                    queryBuilder.filter(new BoolQueryBuilder().must(buildPredicate(session, column.getName(), domain, column.getType())));
                 }
             }
         }
@@ -107,10 +107,10 @@ public final class ElasticsearchQueryBuilder
                 if (!range.getLow().isLowerUnbounded()) {
                     switch (range.getLow().getBound()) {
                         case ABOVE:
-                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).gt(getValue(session, type, range.getLow().getValue())));
+                            rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).gt(getValue(session, type, range.getLow().getValue())));
                             break;
                         case EXACTLY:
-                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).gte(getValue(session, type, range.getLow().getValue())));
+                            rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).gte(getValue(session, type, range.getLow().getValue())));
                             break;
                         case BELOW:
                             throw new IllegalArgumentException("Low marker should never use BELOW bound");
@@ -121,10 +121,10 @@ public final class ElasticsearchQueryBuilder
                 if (!range.getHigh().isUpperUnbounded()) {
                     switch (range.getHigh().getBound()) {
                         case EXACTLY:
-                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).lte(getValue(session, type, range.getHigh().getValue())));
+                            rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).lte(getValue(session, type, range.getHigh().getValue())));
                             break;
                         case BELOW:
-                            rangeQueryBuilder.must(new RangeQueryBuilder(columnName).lt(getValue(session, type, range.getHigh().getValue())));
+                            rangeQueryBuilder.filter(new RangeQueryBuilder(columnName).lt(getValue(session, type, range.getHigh().getValue())));
                             break;
                         case ABOVE:
                             throw new IllegalArgumentException("High marker should never use ABOVE bound");
@@ -135,7 +135,7 @@ public final class ElasticsearchQueryBuilder
             }
 
             if (valuesToInclude.size() == 1) {
-                rangeQueryBuilder.must(new TermQueryBuilder(columnName, getValue(session, type, getOnlyElement(valuesToInclude))));
+                rangeQueryBuilder.filter(new TermQueryBuilder(columnName, getValue(session, type, getOnlyElement(valuesToInclude))));
             }
             queryBuilder.should(rangeQueryBuilder);
         }


### PR DESCRIPTION
Filter clauses are more efficient to compute (they ignore scoring),
and can be cached by Elasticsearch.