### PR TITLE
Refresh Elasticsearch index before test queries

### DIFF
--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -487,6 +487,12 @@ public class TestElasticsearchIntegrationSmokeTest
                                 .alias("orders_alias")))
                 .actionGet();
 
+        embeddedElasticsearchNode.getClient()
+                .admin()
+                .indices()
+                .refresh(refreshRequest("orders_alias"))
+                .actionGet();
+
         assertQuery(
                 "SELECT count(*) FROM orders_alias",
                 "SELECT count(*) FROM orders");
@@ -511,6 +517,12 @@ public class TestElasticsearchIntegrationSmokeTest
                         .addAliasAction(IndicesAliasesRequest.AliasActions.add()
                                 .index("region")
                                 .alias("multi_alias")))
+                .actionGet();
+
+        embeddedElasticsearchNode.getClient()
+                .admin()
+                .indices()
+                .refresh(refreshRequest("multi_alias"))
                 .actionGet();
 
         assertQuery(


### PR DESCRIPTION
Updates are done asychronously. This ensures the changes are visible
before the test queries execute to provide "read your own writes"
behavior.

Fixes https://github.com/prestosql/presto/issues/2428