### PR TITLE
Iterate over Elasticsearch documents in index order

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSource.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSource.java
@@ -123,13 +123,23 @@ public class ElasticsearchPageSource
                 .filter(name -> !BuiltinColumns.NAMES.contains(name))
                 .collect(toList());
 
+        // sorting by _doc (index order) get special treatment in Elasticsearch and is more efficient
+        Optional<String> sort = Optional.of("_doc");
+
+        if (table.getQuery().isPresent()) {
+            // However, if we're using a custom Elasticsearch query, use default sorting.
+            // Documents will be scored and returned based on relevance
+            sort = Optional.empty();
+        }
+
         long start = System.nanoTime();
         SearchResponse searchResponse = client.beginSearch(
                 split.getIndex(),
                 split.getShard(),
                 buildSearchQuery(session, table.getConstraint().transform(ElasticsearchColumnHandle.class::cast), table.getQuery()),
                 needAllFields ? Optional.empty() : Optional.of(requiredFields),
-                documentFields);
+                documentFields,
+                sort);
         readTimeNanos += System.nanoTime() - start;
         this.iterator = new SearchHitIterator(client, () -> searchResponse);
     }

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/client/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/client/ElasticsearchClient.java
@@ -513,11 +513,13 @@ public class ElasticsearchClient
         return jsonNode.get(name);
     }
 
-    public SearchResponse beginSearch(String index, int shard, QueryBuilder query, Optional<List<String>> fields, List<String> documentFields)
+    public SearchResponse beginSearch(String index, int shard, QueryBuilder query, Optional<List<String>> fields, List<String> documentFields, Optional<String> sort)
     {
         SearchSourceBuilder sourceBuilder = SearchSourceBuilder.searchSource()
                 .query(query)
                 .size(scrollSize);
+
+        sort.ifPresent(sourceBuilder::sort);
 
         fields.ifPresent(values -> {
             if (values.isEmpty()) {

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -426,7 +426,7 @@ public class TestElasticsearchIntegrationSmokeTest
                 .actionGet();
 
         // _score column
-        assertQuery("SELECT count(*) FROM filter_pushdown WHERE _score = 1.0", "VALUES 1");
+        assertQuery("SELECT count(*) FROM \"filter_pushdown: cool\" WHERE _score > 0", "VALUES 1");
 
         // boolean
         assertQuery("SELECT count(*) FROM filter_pushdown WHERE boolean_column = true", "VALUES 1");


### PR DESCRIPTION
This can improve performance of scroll queries.