### PR TITLE
Improve performance of FirstValue, LastValue, Lead, Lag functions with IGNORE NULLS.

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/window/FirstValueFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/window/FirstValueFunction.java
@@ -51,13 +51,10 @@ public class FirstValueFunction
             output.appendNull();
             return;
         }
-        int returnInd;
+        int returnInd = frameStart;
 
         if (ignoreNulls) {
             returnInd = searchWindowAndUpdateIndices(frameStart, frameEnd);
-        }
-        else {
-            returnInd = frameStart;
         }
         windowIndex.appendTo(argumentChannel, returnInd, output);
     }

--- a/presto-main/src/main/java/io/prestosql/operator/window/LagFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/window/LagFunction.java
@@ -26,7 +26,6 @@ import static java.lang.Math.toIntExact;
 @WindowFunctionSignature(name = "lag", typeVariable = "T", returnType = "T", argumentTypes = "T")
 @WindowFunctionSignature(name = "lag", typeVariable = "T", returnType = "T", argumentTypes = {"T", "bigint"})
 @WindowFunctionSignature(name = "lag", typeVariable = "T", returnType = "T", argumentTypes = {"T", "bigint", "T"})
-@WindowFunctionSignature(name = "lag", typeVariable = "T", returnType = "T", argumentTypes = {"bigint", "T", "boolean"})
 public class LagFunction
         extends ValueWindowFunction
 {
@@ -48,9 +47,6 @@ public class LagFunction
         this.offsetChannel = (argumentChannels.size() > 1) ? argumentChannels.get(1) : -1;
         this.defaultChannel = (argumentChannels.size() > 2) ? argumentChannels.get(2) : -1;
         this.ignoreNulls = ignoreNulls;
-        if (this.ignoreNulls) {
-            this.lastNonNull = 0;
-        }
     }
 
     @Override

--- a/presto-main/src/main/java/io/prestosql/operator/window/LastValueFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/window/LastValueFunction.java
@@ -54,12 +54,9 @@ public class LastValueFunction
             return;
         }
 
-        int returnInd;
+        int returnInd = frameEnd;
         if (ignoreNulls) {
             returnInd = searchWindowAndUpdateIndices(frameStart, frameEnd);
-        }
-        else {
-            returnInd = frameEnd;
         }
         windowIndex.appendTo(argumentChannel, returnInd, output);
     }

--- a/presto-main/src/main/java/io/prestosql/operator/window/LeadFunction.java
+++ b/presto-main/src/main/java/io/prestosql/operator/window/LeadFunction.java
@@ -33,6 +33,13 @@ public class LeadFunction
     private final int offsetChannel;
     private final int defaultChannel;
     private final boolean ignoreNulls;
+    private long lastNonNull = -1;
+
+    @Override
+    public void reset()
+    {
+        lastNonNull = -1;
+    }
 
     public LeadFunction(List<Integer> argumentChannels, boolean ignoreNulls)
     {
@@ -55,8 +62,11 @@ public class LeadFunction
             long valuePosition;
 
             if (ignoreNulls && (offset > 0)) {
-                long count = 0;
-                valuePosition = currentPosition + 1;
+                if (lastNonNull <= currentPosition) {
+                    lastNonNull = currentPosition + 1;
+                }
+                long count = lastNonNull - currentPosition - 1;
+                valuePosition = lastNonNull;
                 while (withinPartition(valuePosition)) {
                     if (!windowIndex.isNull(valueChannel, toIntExact(valuePosition))) {
                         count++;
@@ -66,6 +76,7 @@ public class LeadFunction
                     }
                     valuePosition++;
                 }
+                lastNonNull = valuePosition;
             }
             else {
                 valuePosition = currentPosition + offset;


### PR DESCRIPTION
The current implementations rescan each window, potentially leading to O(N**2) performance. These implementations should only scan the new rows in each window, giving O(N) complexity.