### PR TITLE
Use file extension based on the file format

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -1359,7 +1359,7 @@ public class HiveMetadata
         HdfsContext hdfsContext = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
         JobConf conf = toJobConf(hdfsEnvironment.getConfiguration(hdfsContext, targetPath));
         configureCompression(conf, getCompressionCodec(session));
-        String fileExtension = HiveWriterFactory.getFileExtension(conf, fromHiveStorageFormat(storageFormat));
+        String fileExtension = HiveStorageFormat.getFileExtension(conf, fromHiveStorageFormat(storageFormat));
         Set<String> fileNames = ImmutableSet.copyOf(partitionUpdate.getFileNames());
         ImmutableList.Builder<String> missingFileNamesBuilder = ImmutableList.builder();
         for (int i = 0; i < bucketCount; i++) {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/StorageFormat.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/StorageFormat.java
@@ -35,12 +35,19 @@ public class StorageFormat
     private final String serDe;
     private final String inputFormat;
     private final String outputFormat;
+    private final String fileExtension;
 
     private StorageFormat(String serDe, String inputFormat, String outputFormat)
+    {
+        this(serDe, inputFormat, outputFormat, null);
+    }
+
+    private StorageFormat(String serDe, String inputFormat, String outputFormat, String fileExtension)
     {
         this.serDe = serDe;
         this.inputFormat = inputFormat;
         this.outputFormat = outputFormat;
+        this.fileExtension = fileExtension;
     }
 
     public String getSerDe()
@@ -67,6 +74,11 @@ public class StorageFormat
         return outputFormat;
     }
 
+    public String getFileExtension()
+    {
+        return fileExtension;
+    }
+
     @JsonProperty("serDe")
     public String getSerDeNullable()
     {
@@ -87,7 +99,7 @@ public class StorageFormat
 
     public static StorageFormat fromHiveStorageFormat(HiveStorageFormat hiveStorageFormat)
     {
-        return new StorageFormat(hiveStorageFormat.getSerDe(), hiveStorageFormat.getInputFormat(), hiveStorageFormat.getOutputFormat());
+        return new StorageFormat(hiveStorageFormat.getSerDe(), hiveStorageFormat.getInputFormat(), hiveStorageFormat.getOutputFormat(), hiveStorageFormat.getFileExtension());
     }
 
     public static StorageFormat create(String serde, String inputFormat, String outputFormat)


### PR DESCRIPTION
Tried to fix #2721 , added the file extension for other file formats while storing in hadoop.

Currently only text files are stored with .gz extension at hadoop through hive, this change will add respective extension for other file formats(orc,parquet,rc,sequence file,avro) based on the file format.

