### PR TITLE
Improve tracking of origin field

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/ExpressionAnalyzer.java
@@ -414,9 +414,7 @@ public class ExpressionAnalyzer
                 }
             }
 
-            if (field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent()) {
-                tableColumnReferences.put(field.getOriginTable().get(), field.getOriginColumnName().get());
-            }
+            field.getOrigin().ifPresent(originField -> tableColumnReferences.put(originField.getTable(), originField.getColumn()));
 
             FieldId previous = columnReferences.put(NodeRef.of(node), fieldId);
             checkState(previous == null, "%s already known to refer to %s", node, previous);

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/Field.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/Field.java
@@ -23,20 +23,19 @@ import static java.util.Objects.requireNonNull;
 
 public class Field
 {
-    private final Optional<QualifiedObjectName> originTable;
-    private final Optional<String> originColumnName;
     private final Optional<QualifiedName> relationAlias;
     private final Optional<String> name;
     private final Type type;
     private final boolean hidden;
     private final boolean aliased;
+    private final Optional<Source> origin;
 
     public static Field newUnqualified(String name, Type type)
     {
         requireNonNull(name, "name is null");
         requireNonNull(type, "type is null");
 
-        return new Field(Optional.empty(), Optional.of(name), type, false, Optional.empty(), Optional.empty(), false);
+        return new Field(Optional.empty(), Optional.of(name), type, false, Optional.empty(), false);
     }
 
     public static Field newUnqualified(Optional<String> name, Type type)
@@ -44,53 +43,56 @@ public class Field
         requireNonNull(name, "name is null");
         requireNonNull(type, "type is null");
 
-        return new Field(Optional.empty(), name, type, false, Optional.empty(), Optional.empty(), false);
+        return new Field(Optional.empty(), name, type, false, Optional.empty(), false);
     }
 
-    public static Field newUnqualified(Optional<String> name, Type type, Optional<QualifiedObjectName> originTable, Optional<String> originColumn, boolean aliased)
+    public static Field newUnqualified(Optional<String> name, Type type, Optional<Source> origin, boolean aliased)
     {
         requireNonNull(name, "name is null");
         requireNonNull(type, "type is null");
-        requireNonNull(originTable, "originTable is null");
+        requireNonNull(origin, "origin is null");
 
-        return new Field(Optional.empty(), name, type, false, originTable, originColumn, aliased);
+        return new Field(Optional.empty(), name, type, false, origin, aliased);
     }
 
-    public static Field newQualified(QualifiedName relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originColumn, boolean aliased)
-    {
-        requireNonNull(relationAlias, "relationAlias is null");
-        requireNonNull(name, "name is null");
-        requireNonNull(type, "type is null");
-        requireNonNull(originTable, "originTable is null");
-
-        return new Field(Optional.of(relationAlias), name, type, hidden, originTable, originColumn, aliased);
-    }
-
-    public Field(Optional<QualifiedName> relationAlias, Optional<String> name, Type type, boolean hidden, Optional<QualifiedObjectName> originTable, Optional<String> originColumnName, boolean aliased)
+    public static Field newQualified(QualifiedName relationAlias, Optional<String> name, Type type, boolean hidden, Optional<Source> origin, boolean aliased)
     {
         requireNonNull(relationAlias, "relationAlias is null");
         requireNonNull(name, "name is null");
         requireNonNull(type, "type is null");
-        requireNonNull(originTable, "originTable is null");
-        requireNonNull(originColumnName, "originColumnName is null");
+        requireNonNull(origin, "originTable is null");
+
+        return new Field(Optional.of(relationAlias), name, type, hidden, origin, aliased);
+    }
+
+    public static Field newSourceField(QualifiedName relationAlias, QualifiedObjectName table, String name, Type type, boolean hidden)
+    {
+        requireNonNull(relationAlias, "relationAlias is null");
+        requireNonNull(table, "table is null");
+        requireNonNull(name, "name is null");
+        requireNonNull(type, "type is null");
+
+        return new Field(Optional.of(relationAlias), Optional.of(name), type, hidden, Optional.of(new Source(table, name)), false);
+    }
+
+    public Field(Optional<QualifiedName> relationAlias, Optional<String> name, Type type, boolean hidden, Optional<Source> origin, boolean aliased)
+    {
+        requireNonNull(relationAlias, "relationAlias is null");
+        requireNonNull(name, "name is null");
+        requireNonNull(type, "type is null");
+        requireNonNull(origin, "origin is null");
 
         this.relationAlias = relationAlias;
         this.name = name;
         this.type = type;
         this.hidden = hidden;
-        this.originTable = originTable;
-        this.originColumnName = originColumnName;
+        this.origin = origin;
         this.aliased = aliased;
     }
 
-    public Optional<QualifiedObjectName> getOriginTable()
+    public Optional<Source> getOrigin()
     {
-        return originTable;
-    }
-
-    public Optional<String> getOriginColumnName()
-    {
-        return originColumnName;
+        return origin;
     }
 
     public Optional<QualifiedName> getRelationAlias()
@@ -168,5 +170,27 @@ public class Field
                 .append(type);
 
         return result.toString();
+    }
+
+    public static class Source
+    {
+        private final QualifiedObjectName table;
+        private final String column;
+
+        public Source(QualifiedObjectName table, String column)
+        {
+            this.table = requireNonNull(table, "table is null");
+            this.column = requireNonNull(column, "column is null");
+        }
+
+        public QualifiedObjectName getTable()
+        {
+            return table;
+        }
+
+        public String getColumn()
+        {
+            return column;
+        }
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/RelationType.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/RelationType.java
@@ -179,8 +179,7 @@ public class RelationType
                         columnAlias,
                         field.getType(),
                         field.isHidden(),
-                        field.getOriginTable(),
-                        field.getOriginColumnName(),
+                        field.getOrigin(),
                         field.isAliased()));
             }
             else if (!field.isHidden()) {
@@ -192,8 +191,7 @@ public class RelationType
                         columnAlias,
                         field.getType(),
                         false,
-                        field.getOriginTable(),
-                        field.getOriginColumnName(),
+                        field.getOrigin(),
                         field.isAliased()));
             }
         }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
@@ -892,8 +892,7 @@ class RelationPlanner
                     oldField.getName(),
                     targetColumnTypes[i],
                     oldField.isHidden(),
-                    oldField.getOriginTable(),
-                    oldField.getOriginColumnName(),
+                    oldField.getOrigin(),
                     oldField.isAliased());
         }
         ProjectNode projectNode = new ProjectNode(idAllocator.getNextId(), plan.getRoot(), assignments.build());

--- a/presto-main/src/main/java/io/prestosql/sql/rewrite/DescribeOutputRewrite.java
+++ b/presto-main/src/main/java/io/prestosql/sql/rewrite/DescribeOutputRewrite.java
@@ -155,7 +155,7 @@ final class DescribeOutputRewrite
                 columnName = "_col" + columnIndex;
             }
 
-            Optional<QualifiedObjectName> originTable = field.getOriginTable();
+            Optional<QualifiedObjectName> originTable = field.getOrigin().map(Field.Source::getTable);
 
             return row(
                     new StringLiteral(columnName),

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestScope.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestScope.java
@@ -32,12 +32,12 @@ public class TestScope
     {
         Scope root = Scope.create();
 
-        Field outerColumn1 = Field.newQualified(QualifiedName.of("outer", "column1"), Optional.of("c1"), BIGINT, false, Optional.empty(), Optional.empty(), false);
-        Field outerColumn2 = Field.newQualified(QualifiedName.of("outer", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), Optional.empty(), false);
+        Field outerColumn1 = Field.newQualified(QualifiedName.of("outer", "column1"), Optional.of("c1"), BIGINT, false, Optional.empty(), false);
+        Field outerColumn2 = Field.newQualified(QualifiedName.of("outer", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), false);
         Scope outer = Scope.builder().withParent(root).withRelationType(RelationId.anonymous(), new RelationType(outerColumn1, outerColumn2)).build();
 
-        Field innerColumn2 = Field.newQualified(QualifiedName.of("inner", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), Optional.empty(), false);
-        Field innerColumn3 = Field.newQualified(QualifiedName.of("inner", "column3"), Optional.of("c3"), BIGINT, false, Optional.empty(), Optional.empty(), false);
+        Field innerColumn2 = Field.newQualified(QualifiedName.of("inner", "column2"), Optional.of("c2"), BIGINT, false, Optional.empty(), false);
+        Field innerColumn3 = Field.newQualified(QualifiedName.of("inner", "column3"), Optional.of("c3"), BIGINT, false, Optional.empty(), false);
         Scope inner = Scope.builder().withOuterQueryParent(outer).withRelationType(RelationId.anonymous(), new RelationType(innerColumn2, innerColumn3)).build();
 
         Expression c1 = name("c1");


### PR DESCRIPTION
The table and column fields cannot be present independently. Encapsulate
them in a single object instead.