### PR TITLE
Retry to get a connection in JDBC connectors

### DIFF
--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -98,6 +98,11 @@
             <artifactId>jmxutils</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+        </dependency>
+
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -182,6 +187,13 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.2.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ForRetryJdbc.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/ForRetryJdbc.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+@interface ForRetryJdbc
+{
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcDiagnosticModule.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcDiagnosticModule.java
@@ -76,7 +76,7 @@ public class JdbcDiagnosticModule
     @Provides
     @Singleton
     @StatsCollecting
-    public static ConnectionFactory createConnectionFactoryWithStats(@ForBaseJdbc ConnectionFactory connectionFactory)
+    public static ConnectionFactory createConnectionFactoryWithStats(@ForRetryJdbc ConnectionFactory connectionFactory)
     {
         return new StatisticsAwareConnectionFactory(connectionFactory);
     }

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcModule.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/JdbcModule.java
@@ -57,12 +57,14 @@ public class JdbcModule
         binder.bind(JdbcConnector.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(JdbcMetadataConfig.class);
         configBinder(binder).bindConfig(BaseJdbcConfig.class);
+        configBinder(binder).bindConfig(RetryJdbcConfig.class);
 
         configBinder(binder).bindConfig(TypeHandlingJdbcConfig.class);
         bindSessionPropertiesProvider(binder, TypeHandlingJdbcSessionProperties.class);
         bindSessionPropertiesProvider(binder, JdbcMetadataSessionProperties.class);
 
         binder.bind(JdbcClient.class).to(CachingJdbcClient.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectionFactory.class).annotatedWith(ForRetryJdbc.class).to(RetryableConnectionFactory.class);
         binder.bind(ConnectionFactory.class).to(Key.get(ConnectionFactory.class, StatsCollecting.class));
     }
 

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RetryJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RetryJdbcConfig.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import io.airlift.configuration.Config;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
+
+public class RetryJdbcConfig
+{
+    private Duration delay = new Duration(1, TimeUnit.SECONDS);
+    private Duration maxDelay = new Duration(1, TimeUnit.MINUTES);
+    private int maxRetries = 10;
+    private double delayFactor = 2.0;
+
+    @NotNull
+    @MinDuration("0ms")
+    public Duration getDelay()
+    {
+        return delay;
+    }
+
+    @Config("connect.retry-delay")
+    public RetryJdbcConfig setDelay(Duration delay)
+    {
+        this.delay = delay;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("0ms")
+    public Duration getMaxDelay()
+    {
+        return maxDelay;
+    }
+
+    @Config("connect.max-retry-delay")
+    public RetryJdbcConfig setMaxDelay(Duration maxDelay)
+    {
+        this.maxDelay = maxDelay;
+        return this;
+    }
+
+    @Min(0)
+    public int getMaxRetries()
+    {
+        return maxRetries;
+    }
+
+    @Config("connect.max-retries")
+    public RetryJdbcConfig setMaxRetries(int maxRetries)
+    {
+        this.maxRetries = maxRetries;
+        return this;
+    }
+
+    @Min(0)
+    public double getDelayFactor()
+    {
+        return delayFactor;
+    }
+
+    @Config("connect.retry-delay-factor")
+    public RetryJdbcConfig setDelayFactor(double delayFactor)
+    {
+        this.delayFactor = delayFactor;
+        return this;
+    }
+}

--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RetryableConnectionFactory.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/RetryableConnectionFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import io.airlift.units.Duration;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.FailsafeException;
+import net.jodah.failsafe.RetryPolicy;
+
+import javax.inject.Inject;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.temporal.ChronoUnit;
+
+import static java.util.Objects.requireNonNull;
+
+public class RetryableConnectionFactory
+        implements ConnectionFactory
+{
+    private final ConnectionFactory delegate;
+    private final long delay;
+    private final long maxDelay;
+    private final int maxRetries;
+    private final double delayFactor;
+
+    @Inject
+    public RetryableConnectionFactory(@ForBaseJdbc ConnectionFactory delegate, RetryJdbcConfig config)
+    {
+        this(delegate, config.getDelay(), config.getMaxDelay(), config.getMaxRetries(), config.getDelayFactor());
+    }
+
+    public RetryableConnectionFactory(ConnectionFactory delegate, Duration delay, Duration maxDelay, int maxRetries, double delayFactor)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+        this.delay = requireNonNull(delay).toMillis();
+        this.maxDelay = requireNonNull(maxDelay).toMillis();
+        this.maxRetries = maxRetries;
+        this.delayFactor = delayFactor;
+    }
+
+    @Override
+    public Connection openConnection(JdbcIdentity identity) throws SQLException
+    {
+        RetryPolicy<Object> retryPolicy = new RetryPolicy<>()
+                .handle(SQLException.class)
+                .withBackoff(delay, maxDelay, ChronoUnit.MILLIS, delayFactor)
+                .withMaxRetries(maxRetries)
+                .withJitter(0.2);
+
+        try {
+            return Failsafe.with(retryPolicy).get(() -> delegate.openConnection(identity));
+        }
+        catch (FailsafeException e) {
+            throw new SQLException(e);
+        }
+    }
+
+    @Override
+    public void close()
+            throws SQLException
+    {
+        delegate.close();
+    }
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestRetryJdbcConfig.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestRetryJdbcConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestRetryJdbcConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(RetryJdbcConfig.class)
+                .setDelay(Duration.valueOf("1s"))
+                .setMaxDelay(Duration.valueOf("1m"))
+                .setMaxRetries(10)
+                .setDelayFactor(2.0));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("connect.retry-delay", "2s")
+                .put("connect.max-retry-delay", "5m")
+                .put("connect.max-retries", "20")
+                .put("connect.retry-delay-factor", "1.5")
+                .build();
+
+        RetryJdbcConfig expected = new RetryJdbcConfig()
+                .setDelay(Duration.valueOf("2s"))
+                .setMaxDelay(Duration.valueOf("5m"))
+                .setMaxRetries(20)
+                .setDelayFactor(1.5);
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestRetryableConnectionFactory.java
+++ b/presto-base-jdbc/src/test/java/io/prestosql/plugin/jdbc/TestRetryableConnectionFactory.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import io.prestosql.spi.testing.InterfaceTestUtils;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Optional;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class TestRetryableConnectionFactory
+{
+    @Test
+    public void testEverythingImplemented()
+    {
+        InterfaceTestUtils.assertAllMethodsOverridden(ConnectionFactory.class, RetryableConnectionFactory.class);
+    }
+
+    @Test
+    public void testRetryConnection() throws SQLException
+    {
+        TestConnectionFactory delegate = new TestConnectionFactory(2);
+        RetryJdbcConfig config = new RetryJdbcConfig();
+
+        // Max retries = 3 by default
+        ConnectionFactory connectionFactory = new RetryableConnectionFactory(delegate, config);
+
+        Connection conn = connectionFactory.openConnection(new JdbcIdentity("test", Optional.empty(), ImmutableMap.of()));
+
+        assertNotNull(conn);
+        assertEquals(delegate.counter, 3);
+    }
+
+    @Test(expectedExceptions = SQLException.class)
+    public void testGiveUpToRetryConnection() throws SQLException
+    {
+        TestConnectionFactory delegate = new TestConnectionFactory(3);
+
+        // Set max retries = 2
+        ConnectionFactory connectionFactory = new RetryableConnectionFactory(delegate, Duration.valueOf("1s"), Duration.valueOf("1m"), 2, 2.0);
+
+        Connection conn = connectionFactory.openConnection(new JdbcIdentity("test", Optional.empty(), ImmutableMap.of()));
+    }
+
+    private static class TestConnectionFactory
+            implements ConnectionFactory
+    {
+        private int numberOfFailure;
+        int counter;
+
+        public TestConnectionFactory(int numberOfFailure)
+        {
+            this.numberOfFailure = numberOfFailure;
+        }
+
+        @Override
+        public Connection openConnection(JdbcIdentity identity)
+                throws SQLException
+        {
+            counter++;
+            if (counter <= numberOfFailure) {
+                throw new SQLException("Failed to connect");
+            }
+            return mock(Connection.class);
+        }
+
+        @Override
+        public void close()
+                throws SQLException
+        {
+        }
+    }
+}

--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -123,11 +123,5 @@
             <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>net.jodah</groupId>
-            <artifactId>failsafe</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
JDBC connector consumes one JDBC connection per table scan. So, if a single query contains tens or hundreds of table scans, it can hit the max connection limit in the database side. In this case, the connection pooling usually can be a solution, however, in Presto, there are various of worker instances in a single cluster, so simply introducing the connection pooling doesn't work.

Retrying to get JDBC connection can make JDBC connector more robust. It would work as an alternative to the connection pooling. 