### PR TITLE
Fix planning failure when lambda expressions are repeated

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/query/TestLambdaExpressions.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestLambdaExpressions.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.query;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class TestLambdaExpressions
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testDuplicateLambdaExpressions()
+    {
+        assertions.assertQuery("" +
+                        "SELECT cardinality(filter(a, x -> x > 0)) " +
+                        "FROM (VALUES " +
+                        "   ARRAY[1,2,3], " +
+                        "   ARRAY[0,1,2]," +
+                        "   ARRAY[0,0,0]" +
+                        ") AS t(a) " +
+                        "GROUP BY cardinality(filter(a, x -> x > 0))" +
+                        "ORDER BY cardinality(filter(a, x -> x > 0))",
+                "VALUES BIGINT '0', BIGINT '2', BIGINT '3'");
+
+        // same type
+        assertions.assertQuery("" +
+                        "SELECT transform(a, x -> x + 1), transform(b, x -> x + 1) " +
+                        "FROM (VALUES ROW(ARRAY[1, 2, 3], ARRAY[10, 20, 30])) t(a, b)",
+                "VALUES ROW(ARRAY[2, 3, 4], ARRAY[11, 21, 31])");
+
+        // different type
+        assertions.assertQuery("" +
+                        "SELECT transform(a, x -> x + 1), transform(b, x -> x + 1) " +
+                        "FROM (VALUES ROW(ARRAY[1, 2, 3], ARRAY[10e0, 20e0, 30e0])) t(a, b)",
+                "VALUES ROW(ARRAY[2, 3, 4], ARRAY[11e0, 21e0, 31e0])");
+    }
+
+    @Test
+    public void testNestedLambda()
+    {
+        // same argument name
+        assertions.assertQuery("" +
+                        "SELECT transform(a, x -> transform(ARRAY[x], x -> x + 1)) " +
+                        "FROM (VALUES ARRAY[1, 2, 3]) t(a)",
+                "VALUES ARRAY[ARRAY[2], ARRAY[3], ARRAY[4]]");
+
+        // different argument name
+        assertions.assertQuery("" +
+                        "SELECT transform(a, x -> transform(ARRAY[x], y -> y + 1)) " +
+                        "FROM (VALUES ARRAY[1, 2, 3]) t(a)",
+                "VALUES ARRAY[ARRAY[2], ARRAY[3], ARRAY[4]]");
+    }
+}


### PR DESCRIPTION
The planner was allocating different symbols for arguments
of syntactically similar lambda expressions. During planning,
it was rewriting the expressions based on those mappings, which
resulted in expressions not being found in TranslationMap.

This fix ensures that all lambda arguments with the same name
and type share the same symbol so the rewrites of sematically
equivalent lambda expressions (syntax + types) are equivalent
to each other.