### PR TITLE
Add option to list all objects under an S3 location prefix.

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Config.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/HiveS3Config.java
@@ -62,6 +62,7 @@ public class HiveS3Config
     private PrestoS3AclType s3AclType = PrestoS3AclType.PRIVATE;
     private boolean skipGlacierObjects;
     private boolean requesterPaysEnabled;
+    private boolean usePseudoDirectories = true;
 
     public String getS3AwsAccessKey()
     {
@@ -455,6 +456,18 @@ public class HiveS3Config
     public HiveS3Config setRequesterPaysEnabled(boolean requesterPaysEnabled)
     {
         this.requesterPaysEnabled = requesterPaysEnabled;
+        return this;
+    }
+
+    public boolean isUsePseudoDirectories()
+    {
+        return usePseudoDirectories;
+    }
+
+    @Config("hive.s3.use-pseudo-directories")
+    public HiveS3Config setUsePseudoDirectories(boolean usePseudoDirectories)
+    {
+        this.usePseudoDirectories = usePseudoDirectories;
         return this;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3ConfigurationInitializer.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3ConfigurationInitializer.java
@@ -52,6 +52,7 @@ import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_STAGING_DIRECTOR
 import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_STORAGE_CLASS;
 import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_USER_AGENT_PREFIX;
 import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_USE_INSTANCE_CREDENTIALS;
+import static io.prestosql.plugin.hive.s3.PrestoS3FileSystem.S3_USE_PSEUDO_DIRECTORIES;
 
 public class PrestoS3ConfigurationInitializer
         implements ConfigurationInitializer
@@ -86,6 +87,7 @@ public class PrestoS3ConfigurationInitializer
     private final String signerClass;
     private final boolean requesterPaysEnabled;
     private final boolean skipGlacierObjects;
+    private final boolean usePseudoDirectories;
 
     @Inject
     public PrestoS3ConfigurationInitializer(HiveS3Config config)
@@ -120,6 +122,7 @@ public class PrestoS3ConfigurationInitializer
         this.aclType = config.getS3AclType();
         this.skipGlacierObjects = config.isSkipGlacierObjects();
         this.requesterPaysEnabled = config.isRequesterPaysEnabled();
+        this.usePseudoDirectories = config.isUsePseudoDirectories();
     }
 
     @Override
@@ -178,5 +181,6 @@ public class PrestoS3ConfigurationInitializer
         config.set(S3_ACL_TYPE, aclType.name());
         config.setBoolean(S3_SKIP_GLACIER_OBJECTS, skipGlacierObjects);
         config.setBoolean(S3_REQUESTER_PAYS_ENABLED, requesterPaysEnabled);
+        config.setBoolean(S3_USE_PSEUDO_DIRECTORIES, usePseudoDirectories);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -249,7 +249,7 @@ public class PrestoS3FileSystem
         this.skipGlacierObjects = conf.getBoolean(S3_SKIP_GLACIER_OBJECTS, defaults.isSkipGlacierObjects());
         this.requesterPaysEnabled = conf.getBoolean(S3_REQUESTER_PAYS_ENABLED, defaults.isRequesterPaysEnabled());
         this.s3StorageClass = conf.getEnum(S3_STORAGE_CLASS, defaults.getS3StorageClass());
-        this.usePseudoDirectories = conf.getBoolean(S3_USE_PSEUDO_DIRECTORIES, defaults.isUsePseudoDirectories());
+        this.usePseudoDirectories = conf.getBoolean(S3_USE_PSEUDO_DIRECTORIES, true);
 
         ClientConfiguration configuration = new ClientConfiguration()
                 .withMaxErrorRetry(maxErrorRetries)

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/s3/PrestoS3FileSystem.java
@@ -537,7 +537,6 @@ public class PrestoS3FileSystem
 
         STATS.newListObjectsCall();
         ListObjectsV2Result listObjectsV2 = s3.listObjectsV2(request);
-        log.debug(listObjectsV2.getObjectSummaries().toString());
         Iterator<ListObjectsV2Result> listings = new AbstractSequentialIterator<ListObjectsV2Result>(listObjectsV2)
         {
             @Override

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestHiveS3Config.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/s3/TestHiveS3Config.java
@@ -63,7 +63,8 @@ public class TestHiveS3Config
                 .setS3UserAgentPrefix("")
                 .setS3AclType(PrestoS3AclType.PRIVATE)
                 .setSkipGlacierObjects(false)
-                .setRequesterPaysEnabled(false));
+                .setRequesterPaysEnabled(false)
+                .setUsePseudoDirectories(true));
     }
 
     @Test
@@ -100,6 +101,7 @@ public class TestHiveS3Config
                 .put("hive.s3.upload-acl-type", "PUBLIC_READ")
                 .put("hive.s3.skip-glacier-objects", "true")
                 .put("hive.s3.requester-pays.enabled", "true")
+                .put("hive.s3.use-pseudo-directories", "false")
                 .build();
 
         HiveS3Config expected = new HiveS3Config()
@@ -132,7 +134,8 @@ public class TestHiveS3Config
                 .setS3UserAgentPrefix("user-agent-prefix")
                 .setS3AclType(PrestoS3AclType.PUBLIC_READ)
                 .setSkipGlacierObjects(true)
-                .setRequesterPaysEnabled(true);
+                .setRequesterPaysEnabled(true)
+                .setUsePseudoDirectories(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Using hive.recursive-directories=true results in one S3 listObjects call per subdirectory under a partition location. These calls are made serially, which can be significant for short duration queries. Setting `hive.s3.use-pseudo-directories = false` allows one to instead list all objects under an S3 prefix with a single call.