### PR TITLE
Expose planningCpu time in QueryStats

### DIFF
--- a/presto-main/src/main/java/io/prestosql/connector/system/QuerySystemTable.java
+++ b/presto-main/src/main/java/io/prestosql/connector/system/QuerySystemTable.java
@@ -67,6 +67,7 @@ public class QuerySystemTable
             .column("queued_time_ms", BIGINT)
             .column("analysis_time_ms", BIGINT)
             .column("planning_time_ms", BIGINT)
+            .column("planning_cpu_time_ms", BIGINT)
 
             .column("created", TIMESTAMP)
             .column("started", TIMESTAMP)
@@ -125,6 +126,7 @@ public class QuerySystemTable
                     toMillis(queryStats.getQueuedTime()),
                     toMillis(queryStats.getAnalysisTime()),
                     toMillis(queryStats.getPlanningTime()),
+                    toMillis(queryStats.getPlanningCpuTime()),
 
                     toTimeStamp(queryStats.getCreateTime()),
                     toTimeStamp(queryStats.getExecutionStartTime()),

--- a/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQuery.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQuery.java
@@ -250,6 +250,7 @@ public class FailedDispatchQuery
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
+                new Duration(0, MILLISECONDS),
                 0,
                 0,
                 0,

--- a/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStateMachine.java
@@ -547,6 +547,7 @@ public class QueryStateMachine
                 queryStateTimer.getExecutionTime(),
                 queryStateTimer.getAnalysisTime(),
                 queryStateTimer.getPlanningTime(),
+                queryStateTimer.getPlanningCpuTime(),
                 queryStateTimer.getFinishingTime(),
 
                 totalTasks,
@@ -1071,6 +1072,7 @@ public class QueryStateMachine
                 queryStats.getExecutionTime(),
                 queryStats.getAnalysisTime(),
                 queryStats.getPlanningTime(),
+                queryStats.getPlanningCpuTime(),
                 queryStats.getFinishingTime(),
                 queryStats.getTotalTasks(),
                 queryStats.getRunningTasks(),

--- a/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
@@ -51,6 +51,7 @@ public class QueryStats
     private final Duration executionTime;
     private final Duration analysisTime;
     private final Duration planningTime;
+    private final Duration planningCpuTime;
     private final Duration finishingTime;
 
     private final int totalTasks;
@@ -117,6 +118,7 @@ public class QueryStats
             @JsonProperty("executionTime") Duration executionTime,
             @JsonProperty("analysisTime") Duration analysisTime,
             @JsonProperty("planningTime") Duration planningTime,
+            @JsonProperty("planningCpuTime") Duration planningCpuTime,
             @JsonProperty("finishingTime") Duration finishingTime,
 
             @JsonProperty("totalTasks") int totalTasks,
@@ -181,6 +183,7 @@ public class QueryStats
         this.executionTime = requireNonNull(executionTime, "executionTime is null");
         this.analysisTime = requireNonNull(analysisTime, "analysisTime is null");
         this.planningTime = requireNonNull(planningTime, "planningTime is null");
+        this.planningCpuTime = requireNonNull(planningCpuTime, "planningCpuTime is null");
         this.finishingTime = requireNonNull(finishingTime, "finishingTime is null");
 
         checkArgument(totalTasks >= 0, "totalTasks is negative");
@@ -311,6 +314,12 @@ public class QueryStats
     public Duration getPlanningTime()
     {
         return planningTime;
+    }
+
+    @JsonProperty
+    public Duration getPlanningCpuTime()
+    {
+        return planningCpuTime;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/io/prestosql/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/io/prestosql/execution/SqlQueryExecution.java
@@ -69,6 +69,8 @@ import org.joda.time.DateTime;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -96,6 +98,7 @@ public class SqlQueryExecution
     private static final Logger log = Logger.get(SqlQueryExecution.class);
 
     private static final OutputBufferId OUTPUT_BUFFER_ID = new OutputBufferId(0);
+    private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
     private final QueryStateMachine stateMachine;
     private final Slug slug;
@@ -353,6 +356,11 @@ public class SqlQueryExecution
                 throwIfInstanceOf(e, Error.class);
             }
         }
+    }
+
+    private static long currentThreadCpuTime()
+    {
+        return THREAD_MX_BEAN.getCurrentThreadCpuTime();
     }
 
     @Override

--- a/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -1302,6 +1302,14 @@ export class QueryDetail extends React.Component {
                             </tr>
                             <tr>
                                 <td className="info-title">
+                                    Planning CPU Time
+                                </td>
+                                <td className="info-text">
+                                    {query.queryStats.planningCpuTime}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td className="info-title">
                                     Execution Time
                                 </td>
                                 <td className="info-text">

--- a/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
@@ -170,6 +170,7 @@ public class MockManagedQueryExecution
                         new Duration(8, NANOSECONDS),
 
                         new Duration(100, NANOSECONDS),
+                        new Duration(150, NANOSECONDS),
                         new Duration(200, NANOSECONDS),
 
                         9,

--- a/presto-main/src/test/java/io/prestosql/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestQueryStateMachine.java
@@ -446,6 +446,7 @@ public class TestQueryStateMachine
         assertNotNull(queryStats.getDispatchingTime());
         assertNotNull(queryStats.getExecutionTime());
         assertNotNull(queryStats.getPlanningTime());
+        assertNotNull(queryStats.getPlanningCpuTime());
         assertNotNull(queryStats.getFinishingTime());
 
         assertNotNull(queryStats.getCreateTime());

--- a/presto-main/src/test/java/io/prestosql/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestQueryStats.java
@@ -168,6 +168,7 @@ public class TestQueryStats
             new Duration(33, NANOSECONDS),
 
             new Duration(100, NANOSECONDS),
+            new Duration(150, NANOSECONDS),
             new Duration(200, NANOSECONDS),
 
             9,
@@ -253,6 +254,7 @@ public class TestQueryStats
         assertEquals(actual.getAnalysisTime(), new Duration(33, NANOSECONDS));
 
         assertEquals(actual.getPlanningTime(), new Duration(100, NANOSECONDS));
+        assertEquals(actual.getPlanningCpuTime(), new Duration(150, NANOSECONDS));
         assertEquals(actual.getFinishingTime(), new Duration(200, NANOSECONDS));
 
         assertEquals(actual.getTotalTasks(), 9);

--- a/presto-main/src/test/java/io/prestosql/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestBasicQueryInfo.java
@@ -64,6 +64,7 @@ public class TestBasicQueryInfo
                                 Duration.valueOf("44m"),
                                 Duration.valueOf("9m"),
                                 Duration.valueOf("99s"),
+                                Duration.valueOf("1s"),
                                 Duration.valueOf("12m"),
                                 13,
                                 14,

--- a/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfo.java
@@ -115,6 +115,7 @@ public class TestQueryStateInfo
                         Duration.valueOf("9m"),
                         Duration.valueOf("10m"),
                         Duration.valueOf("11m"),
+                        Duration.valueOf("1s"),
                         Duration.valueOf("12m"),
                         13,
                         14,

--- a/presto-product-tests/src/test/resources/io/prestosql/tests/querystats/single_query_info_response.json
+++ b/presto-product-tests/src/test/resources/io/prestosql/tests/querystats/single_query_info_response.json
@@ -33,6 +33,7 @@
     "executionTime": "13.00ms",
     "analysisTime": "1.47ms",
     "planningTime": "9.99ms",
+    "planningCpuTime": "1s",
     "finishingTime": "17.00ms",
     "totalTasks": 1,
     "runningTasks": 0,


### PR DESCRIPTION
This is for https://github.com/prestosql/presto/issues/2579

I have a few questions, hope can have some ideas on what should be improved in this PR:

1. Is this the right way to measure CPU? I borrowed it from other places in the repo. And the underlying assumption is the planning is performed by a single thread.

2. Should we update this QueryCompleteEvent API to incorporate this as well? However `planning time` is not in the API as well.

3. Do you think we should have a standalone unit test for this change (my answer is that it is not needed)?