### PR TITLE
Call applyProjection during table scan column pruning

### DIFF
--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/BasePlanTest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/BasePlanTest.java
@@ -24,6 +24,7 @@ import io.prestosql.sql.planner.LogicalPlanner;
 import io.prestosql.sql.planner.Plan;
 import io.prestosql.sql.planner.RuleStatsRecorder;
 import io.prestosql.sql.planner.SubPlan;
+import io.prestosql.sql.planner.TypeAnalyzer;
 import io.prestosql.sql.planner.iterative.IterativeOptimizer;
 import io.prestosql.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
 import io.prestosql.sql.planner.optimizations.PlanOptimizer;
@@ -156,7 +157,7 @@ public class BasePlanTest
     {
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new UnaliasSymbolReferences(getQueryRunner().getMetadata()),
-                new PruneUnreferencedOutputs(),
+                new PruneUnreferencedOutputs(queryRunner.getMetadata(), new TypeAnalyzer(queryRunner.getSqlParser(), queryRunner.getMetadata())),
                 new IterativeOptimizer(
                         new RuleStatsRecorder(),
                         queryRunner.getStatsCalculator(),

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneTableScanColumns.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneTableScanColumns.java
@@ -42,7 +42,7 @@ public class TestPruneTableScanColumns
     @Test
     public void testNotAllOutputsReferenced()
     {
-        tester().assertThat(new PruneTableScanColumns())
+        tester().assertThat(new PruneTableScanColumns(tester().getMetadata(), tester().getTypeAnalyzer()))
                 .on(p -> {
                     Symbol orderdate = p.symbol("orderdate", DATE);
                     Symbol totalprice = p.symbol("totalprice", DOUBLE);
@@ -68,7 +68,7 @@ public class TestPruneTableScanColumns
     @Test
     public void testAllOutputsReferenced()
     {
-        tester().assertThat(new PruneTableScanColumns())
+        tester().assertThat(new PruneTableScanColumns(tester().getMetadata(), tester().getTypeAnalyzer()))
                 .on(p ->
                         p.project(
                                 Assignments.of(p.symbol("y"), expression("x")),

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestEliminateSorts.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestEliminateSorts.java
@@ -88,10 +88,11 @@ public class TestEliminateSorts
 
     private void assertUnitPlan(@Language("SQL") String sql, PlanMatchPattern pattern)
     {
+        TypeAnalyzer typeAnalyzer = new TypeAnalyzer(new SqlParser(), getQueryRunner().getMetadata());
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new UnaliasSymbolReferences(getQueryRunner().getMetadata()),
-                new AddExchanges(getQueryRunner().getMetadata(), new TypeAnalyzer(new SqlParser(), getQueryRunner().getMetadata())),
-                new PruneUnreferencedOutputs(),
+                new AddExchanges(getQueryRunner().getMetadata(), typeAnalyzer),
+                new PruneUnreferencedOutputs(getQueryRunner().getMetadata(), typeAnalyzer),
                 new IterativeOptimizer(
                         new RuleStatsRecorder(),
                         getQueryRunner().getStatsCalculator(),

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestMergeWindows.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestMergeWindows.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.spi.block.SortOrder;
 import io.prestosql.sql.planner.RuleStatsRecorder;
+import io.prestosql.sql.planner.TypeAnalyzer;
 import io.prestosql.sql.planner.assertions.BasePlanTest;
 import io.prestosql.sql.planner.assertions.ExpectedValueProvider;
 import io.prestosql.sql.planner.assertions.PlanMatchPattern;
@@ -562,7 +563,7 @@ public class TestMergeWindows
                                 .add(new RemoveRedundantIdentityProjections())
                                 .addAll(GatherAndMergeWindows.rules())
                                 .build()),
-                new PruneUnreferencedOutputs());
+                new PruneUnreferencedOutputs(getQueryRunner().getMetadata(), new TypeAnalyzer(getQueryRunner().getSqlParser(), getQueryRunner().getMetadata())));
         assertPlan(sql, pattern, optimizers);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestOptimizeMixedDistinctAggregations.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestOptimizeMixedDistinctAggregations.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.SystemSessionProperties;
 import io.prestosql.sql.planner.RuleStatsRecorder;
+import io.prestosql.sql.planner.TypeAnalyzer;
 import io.prestosql.sql.planner.assertions.BasePlanTest;
 import io.prestosql.sql.planner.assertions.ExpectedValueProvider;
 import io.prestosql.sql.planner.assertions.PlanMatchPattern;
@@ -124,7 +125,7 @@ public class TestOptimizeMixedDistinctAggregations
                                 new SingleDistinctAggregationToGroupBy(),
                                 new MultipleDistinctAggregationToMarkDistinct())),
                 new OptimizeMixedDistinctAggregations(getQueryRunner().getMetadata()),
-                new PruneUnreferencedOutputs());
+                new PruneUnreferencedOutputs(getQueryRunner().getMetadata(), new TypeAnalyzer(getQueryRunner().getSqlParser(), getQueryRunner().getMetadata())));
         assertPlan(sql, pattern, optimizers);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestReorderWindows.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestReorderWindows.java
@@ -333,7 +333,7 @@ public class TestReorderWindows
                                 new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(0),
                                 new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(1),
                                 new GatherAndMergeWindows.SwapAdjacentWindowsBySpecifications(2))),
-                new PruneUnreferencedOutputs());
+                new PruneUnreferencedOutputs(getQueryRunner().getMetadata(), new TypeAnalyzer(getQueryRunner().getSqlParser(), getQueryRunner().getMetadata())));
         assertPlan(sql, pattern, optimizers);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestSetFlatteningOptimizer.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestSetFlatteningOptimizer.java
@@ -16,6 +16,7 @@ package io.prestosql.sql.planner.optimizations;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.sql.planner.RuleStatsRecorder;
+import io.prestosql.sql.planner.TypeAnalyzer;
 import io.prestosql.sql.planner.assertions.BasePlanTest;
 import io.prestosql.sql.planner.assertions.PlanMatchPattern;
 import io.prestosql.sql.planner.iterative.IterativeOptimizer;
@@ -128,7 +129,7 @@ public class TestSetFlatteningOptimizer
     {
         List<PlanOptimizer> optimizers = ImmutableList.of(
                 new UnaliasSymbolReferences(getQueryRunner().getMetadata()),
-                new PruneUnreferencedOutputs(),
+                new PruneUnreferencedOutputs(getQueryRunner().getMetadata(), new TypeAnalyzer(getQueryRunner().getSqlParser(), getQueryRunner().getMetadata())),
                 new IterativeOptimizer(
                         new RuleStatsRecorder(),
                         getQueryRunner().getStatsCalculator(),


### PR DESCRIPTION
The existing code was limiting the columns in the TableScan node
but wasn't providing this information to connectors. Some connectors
can leverage this information during split generation.