### PR TITLE
Allow merging consecutive 'long' values in SortedRangeSet

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/Ranges.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/Ranges.java
@@ -28,4 +28,9 @@ public interface Ranges
      * @return Single range encompassing all of allowed the ranges
      */
     Range getSpan();
+
+    /**
+     * Try to return a more compact representation (if possible).
+     */
+    ValueSet getCompactedRanges();
 }

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
@@ -744,6 +744,41 @@ public class TestSortedRangeSet
                 .isEqualTo(Optional.empty());
     }
 
+    @Test(dataProvider = "denseTypes")
+    public void testCompactForDenseType(Type type)
+    {
+        ValueSet values = ValueSet.ofRanges(
+                Range.equal(type, 0L),
+                Range.equal(type, 1L),
+                Range.equal(type, 3L),
+                Range.equal(type, 4L),
+                Range.equal(type, 5L),
+                Range.equal(type, 7L));
+        assertEquals(
+                values.getRanges().getCompactedRanges(),
+                ValueSet.ofRanges(List.of(
+                        Range.range(type, 0L, true, 1L, true),
+                        Range.range(type, 3L, true, 5L, true),
+                        Range.range(type, 7L, true, 7L, true))));
+    }
+
+    @Test
+    public void testCompactForReal()
+    {
+        ValueSet values = ValueSet.ofRanges(
+                Range.equal(REAL, 0L),
+                Range.equal(REAL, 1L),
+                Range.equal(REAL, 2L));
+        assertEquals(values.getRanges().getCompactedRanges(), values);
+    }
+
+    @Test
+    public void testCompactForNonDiscreteSet()
+    {
+        ValueSet values = ValueSet.ofRanges(Range.range(INTEGER, 0L, true, 10L, true));
+        assertEquals(values.getRanges().getCompactedRanges(), values);
+    }
+
     private void assertUnion(SortedRangeSet first, SortedRangeSet second, SortedRangeSet expected)
     {
         assertEquals(first.union(second), expected);


### PR DESCRIPTION
This can be useful when pushing down TupleDomains generated by dynamic filtering.

Fixes https://github.com/trinodb/trino/issues/6076