### PR TITLE
Optimize Elasticsearch queries that fetch no columns

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/CountQueryPageSource.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/CountQueryPageSource.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.elasticsearch;
+
+import io.prestosql.elasticsearch.client.ElasticsearchClient;
+import io.prestosql.spi.Page;
+import io.prestosql.spi.connector.ConnectorPageSource;
+import io.prestosql.spi.connector.ConnectorSession;
+
+import static io.prestosql.elasticsearch.ElasticsearchQueryBuilder.buildSearchQuery;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+class CountQueryPageSource
+        implements ConnectorPageSource
+{
+    // This implementation of the page source is used whenever a query doesn't reference any columns
+    // from the ES table. We need to limit the number of rows per page in case there are projections
+    // in the query that can cause page sizes to explode. For example: SELECT rand() FROM some_table
+    private static final int BATCH_SIZE = 10000;
+
+    private final long readTimeNanos;
+    private long remaining;
+
+    public CountQueryPageSource(ElasticsearchClient client, ConnectorSession session, ElasticsearchTableHandle table, ElasticsearchSplit split)
+    {
+        requireNonNull(client, "client is null");
+        requireNonNull(session, "session is null");
+        requireNonNull(table, "table is null");
+        requireNonNull(split, "split is null");
+
+        long start = System.nanoTime();
+        long count = client.count(
+                split.getIndex(),
+                split.getShard(),
+                buildSearchQuery(session, table.getConstraint().transform(ElasticsearchColumnHandle.class::cast), table.getQuery()));
+        readTimeNanos = System.nanoTime() - start;
+
+        if (table.getLimit().isPresent()) {
+            count = Math.min(table.getLimit().getAsLong(), count);
+        }
+
+        remaining = count;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return remaining == 0;
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        int batch = toIntExact(Math.min(BATCH_SIZE, remaining));
+        remaining -= batch;
+
+        return new Page(batch);
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return 0;
+    }
+
+    @Override
+    public void close()
+    {
+    }
+}

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSourceProvider.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSourceProvider.java
@@ -53,10 +53,18 @@ public class ElasticsearchPageSourceProvider
         requireNonNull(split, "split is null");
         requireNonNull(table, "table is null");
 
-        return new ElasticsearchPageSource(
+        ElasticsearchTableHandle elasticsearchTable = (ElasticsearchTableHandle) table;
+        ElasticsearchSplit elasticsearchSplit = (ElasticsearchSplit) split;
+
+        if (columns.isEmpty()) {
+            return new CountQueryPageSource(client, session, elasticsearchTable, elasticsearchSplit);
+        }
+
+        return new ScanQueryPageSource(
                 client,
                 session,
-                (ElasticsearchTableHandle) table, (ElasticsearchSplit) split,
+                elasticsearchTable,
+                elasticsearchSplit,
                 columns.stream()
                         .map(ElasticsearchColumnHandle.class::cast)
                         .collect(toImmutableList()));

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ScanQueryPageSource.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ScanQueryPageSource.java
@@ -75,10 +75,10 @@ import static java.util.Objects.requireNonNull;
 import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toList;
 
-public class ElasticsearchPageSource
+public class ScanQueryPageSource
         implements ConnectorPageSource
 {
-    private static final Logger LOG = Logger.get(ElasticsearchPageSource.class);
+    private static final Logger LOG = Logger.get(ScanQueryPageSource.class);
 
     private final List<Decoder> decoders;
 
@@ -87,9 +87,8 @@ public class ElasticsearchPageSource
     private final List<ElasticsearchColumnHandle> columns;
     private long totalBytes;
     private long readTimeNanos;
-    private boolean finished;
 
-    public ElasticsearchPageSource(
+    public ScanQueryPageSource(
             ElasticsearchClient client,
             ConnectorSession session,
             ElasticsearchTableHandle table,
@@ -163,7 +162,7 @@ public class ElasticsearchPageSource
     @Override
     public boolean isFinished()
     {
-        return finished || !iterator.hasNext();
+        return !iterator.hasNext();
     }
 
     @Override
@@ -181,18 +180,6 @@ public class ElasticsearchPageSource
     @Override
     public Page getNextPage()
     {
-        if (columnBuilders.length == 0) {
-            // TODO: emit "count" query against Elasticsearch
-            int count = 0;
-            while (iterator.hasNext()) {
-                iterator.next();
-                count++;
-            }
-
-            finished = true;
-            return new Page(count);
-        }
-
         long size = 0;
         while (size < PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES && iterator.hasNext()) {
             SearchHit hit = iterator.next();

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/client/CountResponse.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/client/CountResponse.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.elasticsearch.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CountResponse
+{
+    private final long count;
+
+    @JsonCreator
+    public CountResponse(@JsonProperty("count") long count)
+    {
+        this.count = count;
+    }
+
+    @JsonProperty
+    public long getCount()
+    {
+        return count;
+    }
+}

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/RowDecoder.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/decoders/RowDecoder.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static io.prestosql.elasticsearch.ElasticsearchPageSource.getField;
+import static io.prestosql.elasticsearch.ScanQueryPageSource.getField;
 import static io.prestosql.spi.StandardErrorCode.TYPE_MISMATCH;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/BaseElasticsearchSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/BaseElasticsearchSmokeTest.java
@@ -713,6 +713,7 @@ public abstract class BaseElasticsearchSmokeTest
     @Test
     public void testQueryStringError()
     {
+        assertQueryFails("SELECT orderkey FROM \"orders: ++foo AND\"", "\\QFailed to parse query [ ++foo and]\\E");
         assertQueryFails("SELECT count(*) FROM \"orders: ++foo AND\"", "\\QFailed to parse query [ ++foo and]\\E");
     }
 

--- a/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
+++ b/presto-testing/src/main/java/io/prestosql/testing/AbstractTestIntegrationSmokeTest.java
@@ -62,6 +62,9 @@ public abstract class AbstractTestIntegrationSmokeTest
     public void testCountAll()
     {
         assertQuery("SELECT COUNT(*) FROM orders");
+        assertQuery("SELECT count(*) FROM orders WHERE orderkey > 10");
+        assertQuery("SELECT count(*) FROM (SELECT * FROM orders LIMIT 10)");
+        assertQuery("SELECT count(*) FROM (SELECT * FROM orders WHERE orderkey > 10 LIMIT 10)");
     }
 
     @Test


### PR DESCRIPTION
In that case, the connector only needs to produce pages with
a row count. We leverage Elasticsearch's count API.