### PR TITLE
Support kerberos authentication for Kudu connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/kudu.rst
+++ b/presto-docs/src/main/sphinx/connector/kudu.rst
@@ -64,6 +64,22 @@ replacing the properties as appropriate:
        ## Disable Kudu client's collection of statistics.
        #kudu.client.disable-statistics = false
 
+       #######################
+       ### Advanced Kudu Kerberos authentication configuration
+       #######################
+
+       ## Whether to enable kerberos authentication, default is false
+       #kudu.kerberos-auth.enabled=true
+
+       # whether to output kerberos debug information, default is false
+       #kudu.kerberos-auth.debug.enabled=true
+
+       # The Kerberos principal that Presto will use when connecting to Kudu
+       #kudu.kerberos-auth.principal=xxx
+
+       # Kudu client keytab location
+       #kudu.kerberos-auth.keytab=xxx.keytab
+
 
 Querying Data
 -------------
@@ -625,4 +641,3 @@ Known limitations
 -----------------
 
 -  Only lower case table and column names in Kudu are supported.
--  Using a secured Kudu cluster has not been tested.

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -168,6 +168,11 @@
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>io.prestosql.hadoop</groupId>
+            <artifactId>hadoop-apache</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduClientConfig.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduClientConfig.java
@@ -40,6 +40,10 @@ public class KuduClientConfig
     private boolean disableStatistics;
     private boolean schemaEmulationEnabled;
     private String schemaEmulationPrefix = "presto::";
+    private boolean kerberosAuthEnabled;
+    private String kerberosPrincipal;
+    private String kerberosKeytab;
+    private boolean kerberosAuthDebugEnabled;
 
     @NotNull
     @Size(min = 1)
@@ -136,6 +140,54 @@ public class KuduClientConfig
     public KuduClientConfig setSchemaEmulationEnabled(boolean enabled)
     {
         this.schemaEmulationEnabled = enabled;
+        return this;
+    }
+
+    public boolean isKerberosAuthEnabled()
+    {
+        return kerberosAuthEnabled;
+    }
+
+    @Config("kudu.kerberos-auth.enabled")
+    public KuduClientConfig setKerberosAuthEnabled(boolean enabled)
+    {
+        this.kerberosAuthEnabled = enabled;
+        return this;
+    }
+
+    public String getKerberosPrincipal()
+    {
+        return kerberosPrincipal;
+    }
+
+    @Config("kudu.kerberos-auth.principal")
+    public KuduClientConfig setKerberosPrincipal(String principal)
+    {
+        this.kerberosPrincipal = principal;
+        return this;
+    }
+
+    public String getKerberosKeytab()
+    {
+        return kerberosKeytab;
+    }
+
+    @Config("kudu.kerberos-auth.keytab")
+    public KuduClientConfig setKerberosKeytab(String keytab)
+    {
+        this.kerberosKeytab = keytab;
+        return this;
+    }
+
+    public boolean isKerberosAuthDebugEnabled()
+    {
+        return kerberosAuthDebugEnabled;
+    }
+
+    @Config("kudu.kerberos-auth.debug.enabled")
+    public KuduClientConfig setKerberosAuthDebugEnabled(boolean enabled)
+    {
+        this.kerberosAuthDebugEnabled = enabled;
         return this;
     }
 }

--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduModule.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduModule.java
@@ -83,14 +83,14 @@ public class KuduModule
     {
         requireNonNull(config, "config is null");
 
-        KuduClient.KuduClientBuilder builder = new KuduClient.KuduClientBuilder(config.getMasterAddresses());
-        builder.defaultAdminOperationTimeoutMs(config.getDefaultAdminOperationTimeout().toMillis());
-        builder.defaultOperationTimeoutMs(config.getDefaultOperationTimeout().toMillis());
-        builder.defaultSocketReadTimeoutMs(config.getDefaultSocketReadTimeout().toMillis());
-        if (config.isDisableStatistics()) {
-            builder.disableStatistics();
+        KuduClient client;
+        if (!config.isKerberosAuthEnabled()) {
+            client = KuduUtil.createKuduClient(config);
         }
-        KuduClient client = builder.build();
+        else {
+            KuduUtil.initKerberosENV(config.getKerberosPrincipal(), config.getKerberosKeytab(), config.isKerberosAuthDebugEnabled());
+            client = KuduUtil.createKuduKerberosClient(config);
+        }
 
         SchemaEmulation strategy;
         if (config.isSchemaEmulationEnabled()) {
@@ -99,6 +99,6 @@ public class KuduModule
         else {
             strategy = new NoSchemaEmulation();
         }
-        return new KuduClientSession(client, strategy);
+        return new KuduClientSession(client, strategy, config.isKerberosAuthEnabled());
     }
 }

--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduUtil.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/KuduUtil.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.kudu;
+
+import io.airlift.log.Logger;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.kudu.client.KuduClient;
+
+import java.io.IOException;
+import java.security.PrivilegedExceptionAction;
+
+public class KuduUtil
+{
+    private static final Logger log = Logger.get(KuduUtil.class);
+
+    private KuduUtil()
+    {
+        // not allowed to be called to initialize instance
+    }
+
+    /**
+     * Initialize kerberos authentication
+     */
+    static void initKerberosENV(String principal, String keytab, boolean debugEnabled)
+    {
+        try {
+            Configuration conf = new Configuration(false);
+            conf.set("hadoop.security.authentication", "kerberos");
+            if (debugEnabled) {
+                System.setProperty("sun.security.krb5.debug", "true");
+            }
+            UserGroupInformation.setConfiguration(conf);
+            UserGroupInformation.loginUserFromKeytab(principal, keytab);
+            log.info("Connecting to kudu with kerberos authentication");
+            log.info("Current user: " + UserGroupInformation.getCurrentUser());
+            log.info("Login user: " + UserGroupInformation.getLoginUser());
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static KuduClient createKuduKerberosClient(KuduClientConfig config)
+    {
+        KuduClient client = null;
+        try {
+            reTryKerberos(true);
+            client = UserGroupInformation.getLoginUser().doAs(
+                    (PrivilegedExceptionAction<KuduClient>) () -> createKuduClient(config));
+            return client;
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static KuduClient createKuduClient(KuduClientConfig config)
+    {
+        KuduClient.KuduClientBuilder builder = new KuduClient.KuduClientBuilder(config.getMasterAddresses());
+        builder.defaultAdminOperationTimeoutMs(config.getDefaultAdminOperationTimeout().toMillis());
+        builder.defaultOperationTimeoutMs(config.getDefaultOperationTimeout().toMillis());
+        builder.defaultSocketReadTimeoutMs(config.getDefaultSocketReadTimeout().toMillis());
+        if (config.isDisableStatistics()) {
+            builder.disableStatistics();
+        }
+        return builder.build();
+    }
+
+    static void reTryKerberos(boolean enabled)
+    {
+        if (enabled) {
+            log.debug("Try relogin kerberos at first!");
+            try {
+                if (UserGroupInformation.isLoginKeytabBased()) {
+                    UserGroupInformation.getLoginUser().reloginFromKeytab();
+                }
+                else if (UserGroupInformation.isLoginTicketBased()) {
+                    UserGroupInformation.getLoginUser().reloginFromTicketCache();
+                }
+            }
+            catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add the following configuration to etc/catalog/kudu.properties to enable kerberos authentication:

>        ## Whether to enable kerberos authentication, default is false
>        kudu.kerberos-auth.enabled=true
> 
>        # whether to output kerberos debug information, default is false
>        kudu.kerberos-auth.debug.enabled=true
> 
>        # The Kerberos principal that Presto will use when connecting to Kudu
>        kudu.kerberos-auth.principal=xxx
> 
>        # Kudu client keytab location
>        kudu.kerberos-auth.keytab=xxx.keytab

```
Kudu Changes

support kerberos authentication
```

Fixes #1237