### PR TITLE
(WIP) Expose rule stats in QueryStats

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -129,6 +129,7 @@ public final class SystemSessionProperties
     public static final String REQUIRED_WORKERS_COUNT = "required_workers_count";
     public static final String REQUIRED_WORKERS_MAX_WAIT_TIME = "required_workers_max_wait_time";
     public static final String COST_ESTIMATION_WORKER_COUNT = "cost_estimation_worker_count";
+    public static final String QUERY_RULE_STATS_TOP_N = "query_rule_stats_top_n";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -564,7 +565,12 @@ public final class SystemSessionProperties
                         COST_ESTIMATION_WORKER_COUNT,
                         "Set the estimate count of workers while planning",
                         null,
-                        true));
+                        true),
+                integerProperty(
+                        QUERY_RULE_STATS_TOP_N,
+                        "Top N of most expensive rule during the query planning (set to negative to turn off)",
+                        queryManagerConfig.getQueryRuleStatsTopN(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1013,5 +1019,10 @@ public final class SystemSessionProperties
     public static Integer getCostEstimationWorkerCount(Session session)
     {
         return session.getSystemProperty(COST_ESTIMATION_WORKER_COUNT, Integer.class);
+    }
+
+    public static int getQueryRuleStatsTopN(Session session)
+    {
+        return session.getSystemProperty(QUERY_RULE_STATS_TOP_N, Integer.class);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQuery.java
+++ b/presto-main/src/main/java/io/prestosql/dispatcher/FailedDispatchQuery.java
@@ -32,6 +32,7 @@ import io.prestosql.spi.resourcegroups.ResourceGroupId;
 import org.joda.time.DateTime;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 
@@ -249,6 +250,7 @@ public class FailedDispatchQuery
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
+                new HashMap<>(),
                 new Duration(0, MILLISECONDS),
                 0,
                 0,

--- a/presto-main/src/main/java/io/prestosql/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryManagerConfig.java
@@ -64,6 +64,8 @@ public class QueryManagerConfig
     private int requiredWorkers = 1;
     private Duration requiredWorkersMaxWait = new Duration(5, TimeUnit.MINUTES);
 
+    private int queryRuleStatsTopN = -1;
+
     @Min(1)
     public int getScheduleSplitBatchSize()
     {
@@ -346,6 +348,19 @@ public class QueryManagerConfig
     public QueryManagerConfig setRequiredWorkersMaxWait(Duration requiredWorkersMaxWait)
     {
         this.requiredWorkersMaxWait = requiredWorkersMaxWait;
+        return this;
+    }
+
+    public int getQueryRuleStatsTopN()
+    {
+        return queryRuleStatsTopN;
+    }
+
+    @Config("query.query-rule-stats-top-n")
+    @ConfigDescription("Top N of most expensive rule during the query planning (set to negative to turn off)")
+    public QueryManagerConfig setQueryRuleStatsTopN(int queryRuleStatsTopN)
+    {
+        this.queryRuleStatsTopN = queryRuleStatsTopN;
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
+++ b/presto-main/src/main/java/io/prestosql/execution/QueryStats.java
@@ -23,11 +23,13 @@ import io.prestosql.operator.BlockedReason;
 import io.prestosql.operator.OperatorStats;
 import io.prestosql.operator.TableWriterOperator;
 import io.prestosql.spi.eventlistener.StageGcStatistics;
+import io.prestosql.sql.planner.iterative.QueryRuleStats;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalDouble;
 import java.util.Set;
 
@@ -51,6 +53,7 @@ public class QueryStats
     private final Duration executionTime;
     private final Duration analysisTime;
     private final Duration planningTime;
+    Map<Class<?>, QueryRuleStats> planningRuleStats;
     private final Duration finishingTime;
 
     private final int totalTasks;
@@ -117,6 +120,7 @@ public class QueryStats
             @JsonProperty("executionTime") Duration executionTime,
             @JsonProperty("analysisTime") Duration analysisTime,
             @JsonProperty("planningTime") Duration planningTime,
+            @JsonProperty("planningRuleStats") Map<Class<?>, QueryRuleStats> planningRuleStats,
             @JsonProperty("finishingTime") Duration finishingTime,
 
             @JsonProperty("totalTasks") int totalTasks,
@@ -181,6 +185,7 @@ public class QueryStats
         this.executionTime = requireNonNull(executionTime, "executionTime is null");
         this.analysisTime = requireNonNull(analysisTime, "analysisTime is null");
         this.planningTime = requireNonNull(planningTime, "planningTime is null");
+        this.planningRuleStats = requireNonNull(planningRuleStats, "planningRuleStats is null");
         this.finishingTime = requireNonNull(finishingTime, "finishingTime is null");
 
         checkArgument(totalTasks >= 0, "totalTasks is negative");
@@ -311,6 +316,12 @@ public class QueryStats
     public Duration getPlanningTime()
     {
         return planningTime;
+    }
+
+    @JsonProperty
+    public Map<Class<?>, QueryRuleStats> getPlanningRuleStats()
+    {
+        return planningRuleStats;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.sql.planner;
 
+import com.google.common.cache.Cache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.prestosql.cost.CostCalculator;
@@ -22,9 +23,11 @@ import io.prestosql.cost.StatsCalculator;
 import io.prestosql.cost.TaskCountEstimator;
 import io.prestosql.execution.TaskManagerConfig;
 import io.prestosql.metadata.Metadata;
+import io.prestosql.spi.QueryId;
 import io.prestosql.split.PageSourceManager;
 import io.prestosql.split.SplitManager;
 import io.prestosql.sql.planner.iterative.IterativeOptimizer;
+import io.prestosql.sql.planner.iterative.QueryRuleStats;
 import io.prestosql.sql.planner.iterative.Rule;
 import io.prestosql.sql.planner.iterative.rule.AddExchangesBelowPartialAggregationOverGroupIdRuleSet;
 import io.prestosql.sql.planner.iterative.rule.AddIntermediateAggregations;
@@ -176,6 +179,7 @@ import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class PlanOptimizers
@@ -673,5 +677,10 @@ public class PlanOptimizers
     public List<PlanOptimizer> get()
     {
         return optimizers;
+    }
+
+    public Cache<QueryId, Map<Class<?>, QueryRuleStats>> getQueryRuleStats()
+    {
+        return ruleStats.getQueryRuleStats();
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/IterativeOptimizer.java
@@ -166,10 +166,10 @@ public class IterativeOptimizer
                 duration = System.nanoTime() - start;
             }
             catch (RuntimeException e) {
-                stats.recordFailure(rule);
+                stats.recordFailure(rule, ruleContext(context).getSession().getQueryId());
                 throw e;
             }
-            stats.record(rule, duration, !result.isEmpty());
+            stats.record(rule, duration, !result.isEmpty(), ruleContext(context).getSession().getQueryId());
 
             if (result.getTransformedPlan().isPresent()) {
                 return result;

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/QueryRuleStats.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/QueryRuleStats.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class QueryRuleStats
+{
+    final boolean failure;
+    final boolean match;
+    final long time;
+
+    private QueryRuleStats()
+    {
+        this.failure = true;
+        this.match = false;
+        this.time = 0;
+    }
+
+    private QueryRuleStats(boolean match, long time)
+    {
+        this.failure = false;
+        this.match = match;
+        this.time = time;
+    }
+
+    @JsonCreator
+    public QueryRuleStats(
+            @JsonProperty("match") boolean match,
+            @JsonProperty("failure") boolean failure,
+            @JsonProperty("time") long time)
+    {
+        this.match = match;
+        this.failure = failure;
+        this.time = time;
+    }
+
+    @JsonProperty
+    public boolean getMatch()
+    {
+        return match;
+    }
+
+    @JsonProperty
+    public boolean getFailure()
+    {
+        return failure;
+    }
+
+    @JsonProperty
+    public long getTime()
+    {
+        return time;
+    }
+
+    public static QueryRuleStats createFailureQueryRuleStats()
+    {
+        return new QueryRuleStats();
+    }
+
+    public static QueryRuleStats createQueryRuleStats(boolean match, long time)
+    {
+        return new QueryRuleStats(match, time);
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/io/prestosql/execution/MockManagedQueryExecution.java
@@ -170,6 +170,7 @@ public class MockManagedQueryExecution
                         new Duration(8, NANOSECONDS),
 
                         new Duration(100, NANOSECONDS),
+                        ImmutableMap.of(),
                         new Duration(200, NANOSECONDS),
 
                         9,

--- a/presto-main/src/test/java/io/prestosql/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestQueryManagerConfig.java
@@ -50,7 +50,8 @@ public class TestQueryManagerConfig
                 .setQueryMaxExecutionTime(new Duration(100, TimeUnit.DAYS))
                 .setQueryMaxCpuTime(new Duration(1_000_000_000, TimeUnit.DAYS))
                 .setRequiredWorkers(1)
-                .setRequiredWorkersMaxWait(new Duration(5, TimeUnit.MINUTES)));
+                .setRequiredWorkersMaxWait(new Duration(5, TimeUnit.MINUTES))
+                .setQueryRuleStatsTopN(-1));
     }
 
     @Test
@@ -78,6 +79,7 @@ public class TestQueryManagerConfig
                 .put("query.max-cpu-time", "2d")
                 .put("query-manager.required-workers", "333")
                 .put("query-manager.required-workers-max-wait", "33m")
+                .put("query.query-rule-stats-top-n", "1")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -101,7 +103,8 @@ public class TestQueryManagerConfig
                 .setQueryMaxExecutionTime(new Duration(3, TimeUnit.HOURS))
                 .setQueryMaxCpuTime(new Duration(2, TimeUnit.DAYS))
                 .setRequiredWorkers(333)
-                .setRequiredWorkersMaxWait(new Duration(33, TimeUnit.MINUTES));
+                .setRequiredWorkersMaxWait(new Duration(33, TimeUnit.MINUTES))
+                .setQueryRuleStatsTopN(1);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/io/prestosql/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestBasicQueryInfo.java
@@ -64,6 +64,7 @@ public class TestBasicQueryInfo
                                 Duration.valueOf("44m"),
                                 Duration.valueOf("9m"),
                                 Duration.valueOf("99s"),
+                                ImmutableMap.of(),
                                 Duration.valueOf("12m"),
                                 13,
                                 14,

--- a/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestQueryStateInfo.java
@@ -115,6 +115,7 @@ public class TestQueryStateInfo
                         Duration.valueOf("9m"),
                         Duration.valueOf("10m"),
                         Duration.valueOf("11m"),
+                        ImmutableMap.of(),
                         Duration.valueOf("12m"),
                         13,
                         14,

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/FakRules.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/FakRules.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule.test;
+
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.PlanNode;
+
+public class FakRules
+{
+    public static class FakeRule1
+            implements Rule<PlanNode>
+    {
+        @Override
+        public Pattern<PlanNode> getPattern()
+        {
+            return null;
+        }
+
+        @Override
+        public Result apply(PlanNode node, Captures captures, Context context)
+        {
+            return null;
+        }
+    }
+
+    public static class FakeRule2
+            implements Rule<PlanNode>
+    {
+        @Override
+        public Pattern<PlanNode> getPattern()
+        {
+            return null;
+        }
+
+        @Override
+        public Result apply(PlanNode node, Captures captures, Context context)
+        {
+            return null;
+        }
+    }
+
+    public static class FakeRule3
+            implements Rule<PlanNode>
+    {
+        @Override
+        public Pattern<PlanNode> getPattern()
+        {
+            return null;
+        }
+
+        @Override
+        public Result apply(PlanNode node, Captures captures, Context context)
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This is for issue https://github.com/prestosql/presto/issues/2578, I want to ask for input on:

1. how should we write unit tests for it?
2. I am creating a cache to store the quer ystats, I am concerned about the case when the item is evicted before it is accessed.

Can you share your thoughts? Thanks!