### PR TITLE
Use univocity CSV parser instead of opencsv

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -829,9 +829,9 @@
             </dependency>
 
             <dependency>
-                <groupId>net.sf.opencsv</groupId>
-                <artifactId>opencsv</artifactId>
-                <version>2.3</version>
+                <groupId>com.univocity</groupId>
+                <artifactId>univocity-parsers</artifactId>
+                <version>2.8.4</version>
             </dependency>
 
             <dependency>

--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -99,8 +99,8 @@
         </dependency>
 
         <dependency>
-            <groupId>net.sf.opencsv</groupId>
-            <artifactId>opencsv</artifactId>
+            <groupId>com.univocity</groupId>
+            <artifactId>univocity-parsers</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -340,6 +340,11 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.univocity</groupId>
+            <artifactId>univocity-parsers</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -32,6 +32,7 @@ import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.prestosql.plugin.hive.HiveApplyProjectionUtil.ProjectedColumnRepresentation;
 import io.prestosql.plugin.hive.LocationService.WriteInfo;
 import io.prestosql.plugin.hive.authentication.HiveIdentity;
+import io.prestosql.plugin.hive.csv.BetterCsvSerde;
 import io.prestosql.plugin.hive.metastore.Column;
 import io.prestosql.plugin.hive.metastore.Database;
 import io.prestosql.plugin.hive.metastore.HiveColumnStatistics;
@@ -97,7 +98,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.serde.serdeConstants;
-import org.apache.hadoop.hive.serde2.OpenCSVSerde;
 import org.apache.hadoop.mapred.JobConf;
 import org.joda.time.DateTimeZone;
 
@@ -274,9 +274,9 @@ public class HiveMetadata
     public static final String SPARK_TABLE_PROVIDER_KEY = "spark.sql.sources.provider";
     public static final String DELTA_LAKE_PROVIDER = "delta";
 
-    private static final String CSV_SEPARATOR_KEY = OpenCSVSerde.SEPARATORCHAR;
-    private static final String CSV_QUOTE_KEY = OpenCSVSerde.QUOTECHAR;
-    private static final String CSV_ESCAPE_KEY = OpenCSVSerde.ESCAPECHAR;
+    private static final String CSV_SEPARATOR_KEY = BetterCsvSerde.SEPARATORCHAR;
+    private static final String CSV_QUOTE_KEY = BetterCsvSerde.QUOTECHAR;
+    private static final String CSV_ESCAPE_KEY = BetterCsvSerde.ESCAPECHAR;
 
     private final boolean allowCorruptWritesForTesting;
     private final CatalogName catalogName;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveStorageFormat.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveStorageFormat.java
@@ -15,6 +15,7 @@ package io.prestosql.plugin.hive;
 
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
+import io.prestosql.plugin.hive.csv.BetterCsvSerde;
 import io.prestosql.spi.PrestoException;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat;
@@ -28,7 +29,6 @@ import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
-import org.apache.hadoop.hive.serde2.OpenCSVSerde;
 import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
 import org.apache.hadoop.hive.serde2.columnar.ColumnarSerDe;
 import org.apache.hadoop.hive.serde2.columnar.LazyBinaryColumnarSerDe;
@@ -91,7 +91,7 @@ public enum HiveStorageFormat
             HiveIgnoreKeyTextOutputFormat.class.getName(),
             DataSize.of(8, Unit.MEGABYTE)),
     CSV(
-            OpenCSVSerde.class.getName(),
+            BetterCsvSerde.class.getName(),
             TextInputFormat.class.getName(),
             HiveIgnoreKeyTextOutputFormat.class.getName(),
             DataSize.of(8, Unit.MEGABYTE));

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/csv/BetterCsvSerde.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/csv/BetterCsvSerde.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.prestosql.plugin.hive.csv;
+
+import com.univocity.parsers.csv.CsvFormat;
+import com.univocity.parsers.csv.CsvParser;
+import com.univocity.parsers.csv.CsvParserSettings;
+import com.univocity.parsers.csv.CsvWriter;
+import com.univocity.parsers.csv.CsvWriterSettings;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.AbstractSerDe;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.hive.serde2.SerDeSpec;
+import org.apache.hadoop.hive.serde2.SerDeStats;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * BetterCsvSerde use univocity to deserialize CSV format.
+ * Users can specify custom separator, quote or escape characters. And the default separator(,),
+ * quote("), and escape characters(") are the same as the univocity library defaults.
+ *
+ */
+@SerDeSpec(schemaProps = {
+        serdeConstants.LIST_COLUMNS,
+        BetterCsvSerde.SEPARATORCHAR, BetterCsvSerde.QUOTECHAR, BetterCsvSerde.ESCAPECHAR})
+public class BetterCsvSerde
+        extends AbstractSerDe
+{
+    private ObjectInspector inspector;
+    private String[] outputFields;
+    private int numCols;
+    private List<String> row;
+
+    private char separatorChar;
+    private char quoteChar;
+    private char escapeChar;
+
+    private CsvParser csvParser;
+    private CsvWriterSettings csvWriterSettings;
+
+    public static final String SEPARATORCHAR = "separatorChar";
+    public static final String QUOTECHAR = "quoteChar";
+    public static final String ESCAPECHAR = "escapeChar";
+
+    @Override
+    public void initialize(final Configuration conf, final Properties tbl) throws SerDeException
+    {
+        final List<String> columnNames = Arrays.asList(tbl.getProperty(serdeConstants.LIST_COLUMNS)
+                .split(","));
+
+        numCols = columnNames.size();
+
+        final List<ObjectInspector> columnOIs = new ArrayList<ObjectInspector>(numCols);
+
+        for (int i = 0; i < numCols; i++) {
+            columnOIs.add(PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+        }
+
+        inspector = ObjectInspectorFactory.getStandardStructObjectInspector(columnNames, columnOIs);
+        outputFields = new String[numCols];
+        row = new ArrayList<String>(numCols);
+
+        for (int i = 0; i < numCols; i++) {
+            row.add(null);
+        }
+
+        separatorChar = getProperty(tbl, SEPARATORCHAR, ',');
+        quoteChar = getProperty(tbl, QUOTECHAR, '"');
+        escapeChar = getProperty(tbl, ESCAPECHAR, '"');
+
+        CsvFormat format = new CsvFormat();
+        format.setQuote(quoteChar);
+        format.setQuoteEscape(escapeChar);
+        format.setDelimiter(separatorChar);
+        CsvParserSettings settings = new CsvParserSettings();
+        settings.setFormat(format);
+        settings.setNullValue("");
+        csvParser = new CsvParser(settings);
+
+        csvWriterSettings = new CsvWriterSettings();
+        csvWriterSettings.setFormat(format);
+    }
+
+    private char getProperty(final Properties tbl, final String property, final char def)
+    {
+        final String val = tbl.getProperty(property);
+
+        if (val != null) {
+            return val.charAt(0);
+        }
+
+        return def;
+    }
+
+    @Override
+    public Writable serialize(Object obj, ObjectInspector objInspector) throws SerDeException
+    {
+        final StructObjectInspector outputRowOI = (StructObjectInspector) objInspector;
+        final List<? extends StructField> outputFieldRefs = outputRowOI.getAllStructFieldRefs();
+
+        if (outputFieldRefs.size() != numCols) {
+            throw new SerDeException("Cannot serialize the object because there are "
+                            + outputFieldRefs.size() + " fields but the table has " + numCols + " columns.");
+        }
+
+        // Get all data out.
+        for (int c = 0; c < numCols; c++) {
+            final Object field = outputRowOI.getStructFieldData(obj, outputFieldRefs.get(c));
+            final ObjectInspector fieldOI = outputFieldRefs.get(c).getFieldObjectInspector();
+
+            // The data must be of type String
+            final StringObjectInspector fieldStringOI = (StringObjectInspector) fieldOI;
+
+            // Convert the field to Java class String, because objects of String type
+            // can be stored in String, Text, or some other classes.
+            outputFields[c] = fieldStringOI.getPrimitiveJavaObject(field);
+        }
+
+        final StringWriter writer = new StringWriter();
+        final CsvWriter csv = new CsvWriter(writer, csvWriterSettings);
+        csv.writeRow(outputFields);
+        csv.close();
+        return new Text(writer.toString().stripTrailing());
+    }
+
+    @Override
+    public Object deserialize(final Writable blob) throws SerDeException
+    {
+        Text rowText = (Text) blob;
+        final String[] read = csvParser.parseLine(rowText.toString());
+
+        for (int i = 0; i < numCols; i++) {
+            if (read != null && i < read.length) {
+                row.set(i, read[i]);
+            }
+            else {
+                row.set(i, null);
+            }
+        }
+        return row;
+    }
+
+    @Override
+    public ObjectInspector getObjectInspector() throws SerDeException
+    {
+        return inspector;
+    }
+
+    @Override
+    public Class<? extends Writable> getSerializedClass()
+    {
+        return Text.class;
+    }
+
+    @Override
+    public SerDeStats getSerDeStats()
+    {
+        return null;
+    }
+}

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -42,8 +42,8 @@
         </dependency>
 
         <dependency>
-            <groupId>net.sf.opencsv</groupId>
-            <artifactId>opencsv</artifactId>
+            <groupId>com.univocity</groupId>
+            <artifactId>univocity-parsers</artifactId>
         </dependency>
 
         <dependency>

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/csv/CsvRowDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/csv/CsvRowDecoder.java
@@ -13,7 +13,8 @@
  */
 package io.prestosql.decoder.csv;
 
-import au.com.bytecode.opencsv.CSVParser;
+import com.univocity.parsers.csv.CsvParser;
+import com.univocity.parsers.csv.CsvParserSettings;
 import io.prestosql.decoder.DecoderColumnHandle;
 import io.prestosql.decoder.FieldValueProvider;
 import io.prestosql.decoder.RowDecoder;
@@ -28,7 +29,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
 /**
- * Decode row as CSV. This is an extremely primitive CSV decoder using {@link au.com.bytecode.opencsv.CSVParser]}.
+ * Decode row as CSV. This is an extremely primitive CSV decoder using {@link com.univocity.parsers.csv.CsvParser]}.
  */
 public class CsvRowDecoder
         implements RowDecoder
@@ -36,13 +37,16 @@ public class CsvRowDecoder
     public static final String NAME = "csv";
 
     private final Map<DecoderColumnHandle, CsvColumnDecoder> columnDecoders;
-    private final CSVParser parser = new CSVParser();
+    private final CsvParser parser;
 
     public CsvRowDecoder(Set<DecoderColumnHandle> columnHandles)
     {
         requireNonNull(columnHandles, "columnHandles is null");
         columnDecoders = columnHandles.stream()
                 .collect(toImmutableMap(identity(), this::createColumnDecoder));
+        CsvParserSettings settings = new CsvParserSettings();
+        settings.setNullValue(""); // todo crlf too?
+        parser = new CsvParser(settings);
     }
 
     private CsvColumnDecoder createColumnDecoder(DecoderColumnHandle columnHandle)

--- a/presto-server/NOTICE
+++ b/presto-server/NOTICE
@@ -126,7 +126,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----
 
-The following software may be included in this product: Apache Avro, Apache BVal, Apache Commons BeanUtils Core, Apache Commons CLI, Apache Commons Codec, Apache Commons Configuration, Apache Commons IO, Apache Commons Lang, Apache Commons Logging, Apache Hadoop, Apache Hive, Apache HttpClient, Apache Maven, Apache Thrift, Apache XBean, Bean Validation API, Code Generation Library, Guava, Jackson, Jetty, Joda time, Log4j Implemented Over SLF4J, Ning Asynchronous Http Client, Plexus, airlift, airlift resolver, airlift slice, fastutil, jDBI, javax.inject, jmxutils, jQuery, opencsv, snappy, vis.js.
+The following software may be included in this product: Apache Avro, Apache BVal, Apache Commons BeanUtils Core, Apache Commons CLI, Apache Commons Codec, Apache Commons Configuration, Apache Commons IO, Apache Commons Lang, Apache Commons Logging, Apache Hadoop, Apache Hive, Apache HttpClient, Apache Maven, Apache Thrift, Apache XBean, Bean Validation API, Code Generation Library, Guava, Jackson, Jetty, Joda time, Log4j Implemented Over SLF4J, Ning Asynchronous Http Client, Plexus, airlift, airlift resolver, airlift slice, fastutil, jDBI, javax.inject, jmxutils, jQuery, snappy, univocity, vis.js.
 This software contains the following license and notice below:
 
 


### PR DESCRIPTION
* replace all usages of the OpenCSV library with Univocity
  * implement a new Hive Serde for CSV using Univocity
  * `presto-record-decoder`
  * printer for `presto-cli`
* should hopefully provide significant speedup to reading CSV data
  * https://github.com/uniVocity/csv-parsers-comparison#jdk-9


TODO
---

* should this be implemented for the Hive connector as a configurable property to use this serde or the old OpenCSVSerde?
* different PRs / commits for replacing OpenCSV usage in `presto-record-decoder` and `presto-cli`?