### PR TITLE
Add partitioned_by property to SHOW CREATE TABLE in BigQuery

### DIFF
--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryConnector.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryConnector.java
@@ -19,9 +19,12 @@ import io.prestosql.spi.connector.ConnectorMetadata;
 import io.prestosql.spi.connector.ConnectorPageSourceProvider;
 import io.prestosql.spi.connector.ConnectorSplitManager;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
+import io.prestosql.spi.session.PropertyMetadata;
 import io.prestosql.spi.transaction.IsolationLevel;
 
 import javax.inject.Inject;
+
+import java.util.List;
 
 import static io.prestosql.spi.transaction.IsolationLevel.READ_COMMITTED;
 import static io.prestosql.spi.transaction.IsolationLevel.checkConnectorSupports;
@@ -35,16 +38,19 @@ public class BigQueryConnector
     private final BigQueryMetadata metadata;
     private final BigQuerySplitManager splitManager;
     private final BigQueryPageSourceProvider pageSourceProvider;
+    private final BigQueryTableProperties tableProperties;
 
     @Inject
     public BigQueryConnector(
             BigQueryMetadata metadata,
             BigQuerySplitManager splitManager,
-            BigQueryPageSourceProvider pageSourceProvider)
+            BigQueryPageSourceProvider pageSourceProvider,
+            BigQueryTableProperties tableProperties)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+        this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
     }
 
     @Override
@@ -71,5 +77,11 @@ public class BigQueryConnector
     public ConnectorPageSourceProvider getPageSourceProvider()
     {
         return pageSourceProvider;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties.getTableProperties();
     }
 }

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryConnectorModule.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryConnectorModule.java
@@ -58,6 +58,7 @@ public class BigQueryConnectorModule
         binder.bind(BigQueryMetadata.class).in(Scopes.SINGLETON);
         binder.bind(BigQuerySplitManager.class).in(Scopes.SINGLETON);
         binder.bind(BigQueryPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(BigQueryTableProperties.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(BigQueryConfig.class);
     }
 

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryMetadata.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryMetadata.java
@@ -54,6 +54,8 @@ import java.util.Set;
 import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
 import static com.google.cloud.bigquery.TableDefinition.Type.VIEW;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.plugin.bigquery.BigQueryTableProperties.PARTITIONED_BY_PROPERTY;
+import static io.prestosql.plugin.bigquery.BigQueryTableProperties.getPartitionedBy;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -157,7 +159,12 @@ public class BigQueryMetadata
                 schema.getFields().stream()
                         .map(Conversions::toColumnMetadata)
                         .collect(toImmutableList());
-        return new ConnectorTableMetadata(schemaTableName, columns);
+
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+        getPartitionedBy(table.getDefinition())
+                .ifPresent(partitionedBy -> properties.put(PARTITIONED_BY_PROPERTY, partitionedBy));
+
+        return new ConnectorTableMetadata(schemaTableName, columns, properties.build());
     }
 
     @Override

--- a/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryTableProperties.java
+++ b/presto-bigquery/src/main/java/io/prestosql/plugin/bigquery/BigQueryTableProperties.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.bigquery;
+
+import com.google.cloud.bigquery.RangePartitioning;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TimePartitioning;
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.session.PropertyMetadata;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
+
+public class BigQueryTableProperties
+{
+    public static final String PARTITIONED_BY_PROPERTY = "partitioned_by";
+
+    private final List<PropertyMetadata<?>> tableProperties;
+
+    public BigQueryTableProperties()
+    {
+        tableProperties = ImmutableList.of(
+                stringProperty(
+                        PARTITIONED_BY_PROPERTY,
+                        "Partition column",
+                        null,
+                        false));
+    }
+
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
+    }
+
+    public static Optional<String> getPartitionedBy(TableDefinition tableDefinition)
+    {
+        if (tableDefinition instanceof StandardTableDefinition) {
+            StandardTableDefinition standardTableDefinition = (StandardTableDefinition) tableDefinition;
+
+            RangePartitioning rangePartition = standardTableDefinition.getRangePartitioning();
+            if (rangePartition != null) {
+                return Optional.of(rangePartition.getField());
+            }
+
+            TimePartitioning timePartition = standardTableDefinition.getTimePartitioning();
+            if (timePartition != null) {
+                return Optional.ofNullable(timePartition.getField());
+            }
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
Fixes #3640

We may want to add 5 properties instead of `partitioned_by` since we need to support `start`, `interval` & `end` for range partition as: 
1. `time_partitioned_by`
2. `range_partitioned_by`
3. `range_partitioned_start`
4. `range_partitioned_interval`
5. `range_partitioned_end`

```sh
# Time partition
presto> show create table bigquery.ebyhr.test_part;
              Create Table
-----------------------------------------
 CREATE TABLE bigquery.ebyhr.test_part (
    company varchar,
    value double,
    ds date
 )
 WITH (
    partitioned_by = 'ds'
 )

# Range partition
presto> show create table bigquery.ebyhr.test_part2;
               Create Table
------------------------------------------
 CREATE TABLE bigquery.ebyhr.test_part2 (
    company varchar,
    year bigint,
    ds date
 )
 WITH (
    partitioned_by = 'year'
 )
```