### PR TITLE
Add InferNotNullThroughJoin rule

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -37,6 +37,7 @@ import static io.prestosql.plugin.base.session.PropertyMetadataUtil.dataSizeProp
 import static io.prestosql.plugin.base.session.PropertyMetadataUtil.durationProperty;
 import static io.prestosql.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
+import static io.prestosql.spi.session.PropertyMetadata.doubleProperty;
 import static io.prestosql.spi.session.PropertyMetadata.enumProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
 import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
@@ -132,6 +133,8 @@ public final class SystemSessionProperties
     public static final String REQUIRED_WORKERS_MAX_WAIT_TIME = "required_workers_max_wait_time";
     public static final String COST_ESTIMATION_WORKER_COUNT = "cost_estimation_worker_count";
     public static final String OMIT_DATETIME_TYPE_PRECISION = "omit_datetime_type_precision";
+    public static final String OPTIMIZED_NULLS_IN_JOIN = "optimize_nulls_in_join";
+    public static final String OPTIMIZED_NULLS_IN_JOIN_THRESHOLD = "optimize_nulls_in_join_threshold";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -587,7 +590,17 @@ public final class SystemSessionProperties
                         OMIT_DATETIME_TYPE_PRECISION,
                         "Omit precision when rendering datetime type names with default precision",
                         featuresConfig.isOmitDateTimeTypePrecision(),
-                        false));
+                        false),
+                booleanProperty(
+                    OPTIMIZED_NULLS_IN_JOIN,
+                    "When true, the optimizer would infer not-null predicates for join keys through join",
+                    featuresConfig.isOptimizeNullsInJoin(),
+                    false),
+                doubleProperty(
+                    OPTIMIZED_NULLS_IN_JOIN_THRESHOLD,
+                    "A join key would be inferred only when the nulls fraction is greater than or equal to the threshold. 'optimize_nulls_in_join' must be enabled. Default 0.5",
+                    featuresConfig.getOptimizeNullsInJoinThreshold(),
+                    false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1051,5 +1064,15 @@ public final class SystemSessionProperties
     public static boolean isOmitDateTimeTypePrecision(Session session)
     {
         return session.getSystemProperty(OMIT_DATETIME_TYPE_PRECISION, Boolean.class);
+    }
+
+    public static boolean isOptimizeNullsInJoin(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZED_NULLS_IN_JOIN, Boolean.class);
+    }
+
+    public static Double getOptimizeNullsThreshold(Session session)
+    {
+        return session.getSystemProperty(OPTIMIZED_NULLS_IN_JOIN_THRESHOLD, Double.class);
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
@@ -132,6 +132,8 @@ public class FeaturesConfig
     private boolean predicatePushdownUseTableProperties = true;
     private boolean ignoreDownstreamPreferences;
     private boolean iterativeRuleBasedColumnPruning = true;
+    private boolean optimizeNullsInJoin = true;
+    private double optimizeNullsInJoinThreshold = 0.5;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
     private boolean enableDynamicFiltering = true;
@@ -1075,6 +1077,30 @@ public class FeaturesConfig
     public FeaturesConfig setIterativeRuleBasedColumnPruning(boolean iterativeRuleBasedColumnPruning)
     {
         this.iterativeRuleBasedColumnPruning = iterativeRuleBasedColumnPruning;
+        return this;
+    }
+
+    public boolean isOptimizeNullsInJoin()
+    {
+        return optimizeNullsInJoin;
+    }
+
+    @Config("optimizer.optimize-nulls-in-join")
+    public FeaturesConfig setOptimizeNullsInJoin(boolean optimizeNullsInJoin)
+    {
+        this.optimizeNullsInJoin = optimizeNullsInJoin;
+        return this;
+    }
+
+    public double getOptimizeNullsInJoinThreshold()
+    {
+        return optimizeNullsInJoinThreshold;
+    }
+
+    @Config("optimizer.optimize-nulls-in-join-threshold")
+    public FeaturesConfig setOptimizeNullsInJoinThreshold(double optimizeNullsInJoinThreshold)
+    {
+        this.optimizeNullsInJoinThreshold = optimizeNullsInJoinThreshold;
         return this;
     }
 }

--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -52,6 +52,7 @@ import io.prestosql.sql.planner.iterative.rule.ImplementFilteredAggregations;
 import io.prestosql.sql.planner.iterative.rule.ImplementIntersectAsUnion;
 import io.prestosql.sql.planner.iterative.rule.ImplementLimitWithTies;
 import io.prestosql.sql.planner.iterative.rule.ImplementOffset;
+import io.prestosql.sql.planner.iterative.rule.InferNotNullThroughJoin;
 import io.prestosql.sql.planner.iterative.rule.InlineProjections;
 import io.prestosql.sql.planner.iterative.rule.MergeExcept;
 import io.prestosql.sql.planner.iterative.rule.MergeFilters;
@@ -627,6 +628,7 @@ public class PlanOptimizers
                 statsCalculator,
                 estimatedExchangesCostCalculator,
                 ImmutableSet.of(
+                        new InferNotNullThroughJoin(),
                         new CreatePartialTopN(),
                         new PushTopNThroughProject(),
                         new PushTopNThroughOuterJoin(),

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/InferNotNullThroughJoin.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/InferNotNullThroughJoin.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import io.prestosql.Session;
+import io.prestosql.cost.PlanNodeStatsEstimate;
+import io.prestosql.cost.StatsProvider;
+import io.prestosql.cost.SymbolStatsEstimate;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.JoinNode;
+import io.prestosql.sql.planner.plan.JoinNode.EquiJoinClause;
+import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.IsNotNullPredicate;
+import io.prestosql.sql.tree.LogicalBinaryExpression;
+import io.prestosql.sql.tree.SymbolReference;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static io.prestosql.SystemSessionProperties.getOptimizeNullsThreshold;
+import static io.prestosql.SystemSessionProperties.isOptimizeNullsInJoin;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.FULL;
+import static io.prestosql.sql.planner.plan.Patterns.join;
+
+public class InferNotNullThroughJoin
+        implements Rule<JoinNode>
+{
+    private static final Pattern<JoinNode> PATTERN = join()
+            .matching(joinNode -> joinNode.getType() != FULL && !joinNode.getCriteria().isEmpty());
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isOptimizeNullsInJoin(session);
+    }
+
+    @Override
+    public Result apply(JoinNode joinNode, Captures captures, Context context)
+    {
+        Expression filter = joinNode.getFilter().orElse(null);
+        HashSet<Symbol> filteredSymbols = new HashSet<>();
+        extractNotNullSymbols(filteredSymbols, filter);
+        List<Symbol> leftSymbols = joinKeys(joinNode, EquiJoinClause::getLeft, filteredSymbols);
+        List<Symbol> rightSymbols = joinKeys(joinNode, EquiJoinClause::getRight, filteredSymbols);
+
+        StatsProvider statsProvider = context.getStatsProvider();
+        PlanNodeStatsEstimate leftStatsEstimate = statsProvider.getStats(joinNode.getLeft());
+        PlanNodeStatsEstimate rightStatsEstimate = statsProvider.getStats(joinNode.getRight());
+
+        double threshold = getOptimizeNullsThreshold(context.getSession());
+        Expression newFilter = filter;
+        switch (joinNode.getType()) {
+            case INNER:
+                newFilter = inferPredicatesIfNecessary(newFilter, leftSymbols, leftStatsEstimate, threshold);
+                newFilter = inferPredicatesIfNecessary(newFilter, rightSymbols, rightStatsEstimate, threshold);
+                break;
+            case LEFT:
+                newFilter = inferPredicatesIfNecessary(newFilter, rightSymbols, rightStatsEstimate, threshold);
+                break;
+            case RIGHT:
+                newFilter = inferPredicatesIfNecessary(newFilter, leftSymbols, leftStatsEstimate, threshold);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unsupported join type: " + joinNode.getType());
+        }
+        if (newFilter == filter) {
+            return Result.empty();
+        }
+        else {
+            return Result.ofPlanNode(joinNode.withFilter(newFilter));
+        }
+    }
+
+    private List<Symbol> joinKeys(JoinNode joinNode, Function<EquiJoinClause, Symbol> extractor, Set<Symbol> filteredSymbols)
+    {
+        return joinNode.getCriteria().stream()
+                .map(extractor)
+                .filter(key -> !filteredSymbols.contains(key))
+                .collect(Collectors.toList());
+    }
+
+    private Expression inferPredicatesIfNecessary(Expression filter, List<Symbol> symbols, PlanNodeStatsEstimate statsEstimate, double threshold)
+    {
+        Expression newFilter = filter;
+        for (Symbol symbol : symbols) {
+            SymbolStatsEstimate symbolStats = statsEstimate.getSymbolStatistics(symbol);
+            double nullsFraction = symbolStats.isUnknown() ? 0 : symbolStats.getNullsFraction();
+            if (nullsFraction >= threshold) {
+                IsNotNullPredicate predicate = new IsNotNullPredicate(new SymbolReference(symbol.getName()));
+                newFilter = newFilter == null ? predicate : LogicalBinaryExpression.and(newFilter, predicate);
+            }
+        }
+        return newFilter;
+    }
+
+    private void extractNotNullSymbols(HashSet<Symbol> result, Expression expression)
+    {
+        if (expression instanceof LogicalBinaryExpression) {
+            LogicalBinaryExpression logicalBinaryExpression = (LogicalBinaryExpression) expression;
+            Expression left = logicalBinaryExpression.getLeft();
+            Expression right = logicalBinaryExpression.getRight();
+
+            extractNotNullSymbols(result, left);
+            extractNotNullSymbols(result, right);
+        }
+        else if (expression instanceof IsNotNullPredicate) {
+            Expression predicateExpression = ((IsNotNullPredicate) expression).getValue();
+            if (predicateExpression instanceof SymbolReference) {
+                String symbolName = ((SymbolReference) predicateExpression).getName();
+                result.add(new Symbol(symbolName));
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/plan/JoinNode.java
@@ -342,6 +342,11 @@ public class JoinNode
         return new JoinNode(getId(), type, left, right, criteria, leftOutputSymbols, rightOutputSymbols, filter, leftHashSymbol, rightHashSymbol, distributionType, spillable, dynamicFilters, Optional.of(statsAndCost));
     }
 
+    public JoinNode withFilter(Expression filter)
+    {
+        return new JoinNode(getId(), type, left, right, criteria, leftOutputSymbols, rightOutputSymbols, Optional.of(filter), leftHashSymbol, rightHashSymbol, distributionType, spillable, dynamicFilters, reorderJoinStatsAndCost);
+    }
+
     public boolean isCrossJoin()
     {
         return criteria.isEmpty() && filter.isEmpty() && type == INNER;

--- a/presto-main/src/main/java/io/prestosql/testing/TestingSession.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestingSession.java
@@ -32,6 +32,7 @@ import io.prestosql.sql.SqlPath;
 
 import java.util.Optional;
 
+import static io.prestosql.SystemSessionProperties.OPTIMIZED_NULLS_IN_JOIN;
 import static io.prestosql.connector.CatalogName.createInformationSchemaCatalogName;
 import static io.prestosql.connector.CatalogName.createSystemTablesCatalogName;
 import static java.util.Locale.ENGLISH;
@@ -69,7 +70,8 @@ public final class TestingSession
                 .setTimeZoneKey(DEFAULT_TIME_ZONE_KEY)
                 .setLocale(ENGLISH)
                 .setRemoteUserAddress("address")
-                .setUserAgent("agent");
+                .setUserAgent("agent")
+                .setSystemProperty(OPTIMIZED_NULLS_IN_JOIN, "false");
     }
 
     public static Catalog createBogusTestingCatalog(String catalogName)

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
@@ -116,7 +116,9 @@ public class TestFeaturesConfig
                 .setDynamicFilteringRefreshInterval(new Duration(200, MILLISECONDS))
                 .setIgnoreDownstreamPreferences(false)
                 .setOmitDateTimeTypePrecision(false)
-                .setIterativeRuleBasedColumnPruning(true));
+                .setIterativeRuleBasedColumnPruning(true)
+                .setOptimizeNullsInJoin(true)
+                .setOptimizeNullsInJoinThreshold(0.5));
     }
 
     @Test
@@ -194,6 +196,8 @@ public class TestFeaturesConfig
                 .put("optimizer.ignore-downstream-preferences", "true")
                 .put("deprecated.omit-datetime-type-precision", "true")
                 .put("optimizer.iterative-rule-based-column-pruning", "false")
+                .put("optimizer.optimize-nulls-in-join", "false")
+                .put("optimizer.optimize-nulls-in-join-threshold", "0.2")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -267,7 +271,9 @@ public class TestFeaturesConfig
                 .setDynamicFilteringRefreshInterval(new Duration(300, MILLISECONDS))
                 .setIgnoreDownstreamPreferences(true)
                 .setOmitDateTimeTypePrecision(true)
-                .setIterativeRuleBasedColumnPruning(false);
+                .setIterativeRuleBasedColumnPruning(false)
+                .setOptimizeNullsInJoin(false)
+                .setOptimizeNullsInJoinThreshold(0.2);
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestInferNotNullThroughJoin.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestInferNotNullThroughJoin.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.iterative.rule.test.PlanBuilder;
+import io.prestosql.sql.planner.plan.JoinNode;
+import io.prestosql.sql.planner.plan.JoinNode.Type;
+import io.prestosql.sql.planner.plan.PlanNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.prestosql.SystemSessionProperties.OPTIMIZED_NULLS_IN_JOIN;
+import static io.prestosql.SystemSessionProperties.OPTIMIZED_NULLS_IN_JOIN_THRESHOLD;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.join;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expressions;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.FULL;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.INNER;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.LEFT;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.RIGHT;
+
+public class TestInferNotNullThroughJoin
+        extends BaseRuleTest
+{
+    private PlanNode buildPlan(PlanBuilder planBuilder, Type joinType)
+    {
+        return planBuilder.join(
+                joinType,
+                planBuilder.values(ImmutableList.of(planBuilder.symbol("COL1")), ImmutableList.of(expressions("10"), expressions("NULL"))),
+                planBuilder.values(ImmutableList.of(planBuilder.symbol("COL2")), ImmutableList.of(expressions("10"), expressions("20"), expressions("NULL"))),
+                ImmutableList.of(new JoinNode.EquiJoinClause(planBuilder.symbol("COL1"), planBuilder.symbol("COL2"))),
+                ImmutableList.of(planBuilder.symbol("COL1")),
+                ImmutableList.of(planBuilder.symbol("COL2")),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    @Test
+    public void testInnerJoinWithOptimize()
+    {
+        tester().assertThat(new InferNotNullThroughJoin())
+                .setSystemProperty(OPTIMIZED_NULLS_IN_JOIN_THRESHOLD, "0")
+                .on(p -> buildPlan(p, INNER))
+                .matches(join(
+                        INNER,
+                        ImmutableList.of(equiJoinClause("COL1", "COL2")),
+                        Optional.of("COL1 IS NOT NULL AND COL2 IS NOT NULL"),
+                        values(ImmutableList.of("COL1"), ImmutableList.of(expressions("10"), expressions("NULL"))),
+                        values(ImmutableList.of("COL2"), ImmutableList.of(expressions("10"), expressions("20"), expressions("NULL")))));
+
+        tester().assertThat(new InferNotNullThroughJoin())
+                .setSystemProperty(OPTIMIZED_NULLS_IN_JOIN_THRESHOLD, "0.34")
+                .on(p -> buildPlan(p, INNER))
+                .matches(join(
+                        INNER,
+                        ImmutableList.of(equiJoinClause("COL1", "COL2")),
+                        Optional.of("COL1 IS NOT NULL"),
+                        values(ImmutableList.of("COL1"), ImmutableList.of(expressions("10"), expressions("NULL"))),
+                        values(ImmutableList.of("COL2"), ImmutableList.of(expressions("10"), expressions("20"), expressions("NULL")))));
+    }
+
+    @Test
+    public void testDoesNotFireForInnerJoin()
+    {
+        tester().assertThat(new InferNotNullThroughJoin())
+                .setSystemProperty(OPTIMIZED_NULLS_IN_JOIN, "false")
+                .on(p -> buildPlan(p, INNER))
+                .doesNotFire();
+
+        tester().assertThat(new InferNotNullThroughJoin())
+                .setSystemProperty(OPTIMIZED_NULLS_IN_JOIN_THRESHOLD, "0.51")
+                .on(p -> buildPlan(p, INNER))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testLeftJoinWithOptimize()
+    {
+        tester().assertThat(new InferNotNullThroughJoin())
+                .setSystemProperty(OPTIMIZED_NULLS_IN_JOIN_THRESHOLD, "0")
+                .on(p -> buildPlan(p, LEFT))
+                .matches(join(
+                        LEFT,
+                        ImmutableList.of(equiJoinClause("COL1", "COL2")),
+                        Optional.of("COL2 IS NOT NULL"),
+                        values(ImmutableList.of("COL1"), ImmutableList.of(expressions("10"), expressions("NULL"))),
+                        values(ImmutableList.of("COL2"), ImmutableList.of(expressions("10"), expressions("20"), expressions("NULL")))));
+    }
+
+    @Test
+    public void testDoesNotFireForLeftJoin()
+    {
+        tester().assertThat(new InferNotNullThroughJoin())
+                .setSystemProperty(OPTIMIZED_NULLS_IN_JOIN, "false")
+                .on(p -> buildPlan(p, LEFT))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testRightJoinWithOptimize()
+    {
+        tester().assertThat(new InferNotNullThroughJoin())
+                .setSystemProperty(OPTIMIZED_NULLS_IN_JOIN_THRESHOLD, "0")
+                .on(p -> buildPlan(p, RIGHT))
+                .matches(join(
+                        RIGHT,
+                        ImmutableList.of(equiJoinClause("COL1", "COL2")),
+                        Optional.of("COL1 IS NOT NULL"),
+                        values(ImmutableList.of("COL1"), ImmutableList.of(expressions("10"), expressions("NULL"))),
+                        values(ImmutableList.of("COL2"), ImmutableList.of(expressions("10"), expressions("20"), expressions("NULL")))));
+    }
+
+    @Test
+    public void testDoesNotFireForRightJoin()
+    {
+        tester().assertThat(new InferNotNullThroughJoin())
+                .setSystemProperty(OPTIMIZED_NULLS_IN_JOIN, "false")
+                .on(p -> buildPlan(p, RIGHT))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoesNotFireForFullJoin()
+    {
+        tester().assertThat(new InferNotNullThroughJoin())
+                .setSystemProperty(OPTIMIZED_NULLS_IN_JOIN, "false")
+                .on(p -> buildPlan(p, FULL))
+                .doesNotFire();
+
+        tester().assertThat(new InferNotNullThroughJoin())
+                .setSystemProperty(OPTIMIZED_NULLS_IN_JOIN_THRESHOLD, "0")
+                .on(p -> buildPlan(p, FULL))
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/BaseRuleTest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/test/BaseRuleTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.airlift.testing.Closeables.closeAllRuntimeException;
+import static io.prestosql.SystemSessionProperties.OPTIMIZED_NULLS_IN_JOIN;
 import static io.prestosql.sql.planner.iterative.rule.test.RuleTester.defaultRuleTester;
 
 public abstract class BaseRuleTest
@@ -46,7 +47,7 @@ public abstract class BaseRuleTest
             tester = new RuleTester(localQueryRunner.get());
         }
         else {
-            tester = defaultRuleTester(plugins, ImmutableMap.of(), Optional.empty());
+            tester = defaultRuleTester(plugins, ImmutableMap.of(OPTIMIZED_NULLS_IN_JOIN, "true"), Optional.empty());
         }
     }
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestInferNotNullThroughJoin.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestInferNotNullThroughJoin.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.optimizations;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.sql.planner.assertions.BasePlanTest;
+import io.prestosql.sql.planner.assertions.PlanMatchPattern;
+import org.testng.annotations.Test;
+
+import static io.prestosql.SystemSessionProperties.OPTIMIZED_NULLS_IN_JOIN;
+import static io.prestosql.SystemSessionProperties.OPTIMIZED_NULLS_IN_JOIN_THRESHOLD;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.join;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.FULL;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.INNER;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.LEFT;
+import static io.prestosql.sql.planner.plan.JoinNode.Type.RIGHT;
+
+public class TestInferNotNullThroughJoin
+        extends BasePlanTest
+{
+    private static final PlanMatchPattern ORDERS_TABLESCAN = tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"));
+    private static final PlanMatchPattern LINEITEM_TABLESCAN = tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey"));
+
+    public TestInferNotNullThroughJoin()
+    {
+        super(ImmutableMap.of(OPTIMIZED_NULLS_IN_JOIN, "true", OPTIMIZED_NULLS_IN_JOIN_THRESHOLD, "0"));
+    }
+
+    @Test
+    public void testInnerJoinWithOptimize()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey",
+                anyTree(join(INNER, ImmutableList.of(equiJoinClause("O_ORDERKEY", "L_ORDERKEY")),
+                        anyTree(filter("NOT (O_ORDERKEY IS NULL)", ORDERS_TABLESCAN)),
+                        anyTree(filter("NOT (L_ORDERKEY IS NULL)", LINEITEM_TABLESCAN)))));
+    }
+
+    @Test
+    public void testLeftJoinWithOptimize()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o LEFT JOIN lineitem l on l.orderkey = o.orderkey",
+                anyTree(join(LEFT, ImmutableList.of(equiJoinClause("O_ORDERKEY", "L_ORDERKEY")),
+                        // NO filter here
+                        project(ORDERS_TABLESCAN),
+                        anyTree(filter("NOT (L_ORDERKEY IS NULL)", LINEITEM_TABLESCAN)))));
+    }
+
+    @Test
+    public void testRightJoinWithOptimize()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o RIGHT JOIN lineitem l on l.orderkey = o.orderkey",
+                anyTree(join(RIGHT, ImmutableList.of(equiJoinClause("O_ORDERKEY", "L_ORDERKEY")),
+                        anyTree(filter("NOT (O_ORDERKEY IS NULL)", ORDERS_TABLESCAN)),
+                        // NO filter here
+                        anyTree(project(LINEITEM_TABLESCAN)))));
+    }
+
+    @Test
+    public void testFullJoinWithOptimize()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o FULL JOIN lineitem l on l.orderkey = o.orderkey",
+                anyTree(join(FULL, ImmutableList.of(equiJoinClause("O_ORDERKEY", "L_ORDERKEY")),
+                        project(ORDERS_TABLESCAN),
+                        anyTree(project(LINEITEM_TABLESCAN)))));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestShowQueries.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestShowQueries.java
@@ -107,7 +107,7 @@ public class TestShowQueries
     {
         assertThat(assertions.query(
                 "SHOW SESSION LIKE '%page_row_c%'"))
-                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(118)))");
+                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(154)))");
     }
 
     @Test
@@ -119,7 +119,7 @@ public class TestShowQueries
                 .hasMessage("Escape string must be a single character");
         assertThat(assertions.query(
                 "SHOW SESSION LIKE '%page$_row$_c%' ESCAPE '$'"))
-                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(118)))");
+                .matches("VALUES ('filter_and_project_min_output_page_row_count', cast('256' as VARCHAR(14)), cast('256' as VARCHAR(14)), 'integer', cast('Experimental: Minimum output page row count for filter and project operators' as VARCHAR(154)))");
     }
 
     @Test


### PR DESCRIPTION
This rule is to add filter by join type and join key, which could reduce useless data before join or exchange.