### PR TITLE
Compare datetime types with equals()

### DIFF
--- a/presto-kudu/src/main/java/io/prestosql/plugin/kudu/TypeHelper.java
+++ b/presto-kudu/src/main/java/io/prestosql/plugin/kudu/TypeHelper.java
@@ -52,7 +52,7 @@ public final class TypeHelper
         if (type instanceof VarcharType) {
             return org.apache.kudu.Type.STRING;
         }
-        if (type == TimestampType.TIMESTAMP) {
+        if (type.equals(TimestampType.TIMESTAMP)) {
             return org.apache.kudu.Type.UNIXTIME_MICROS;
         }
         if (type == BigintType.BIGINT) {
@@ -131,7 +131,7 @@ public final class TypeHelper
         if (type instanceof VarcharType) {
             return ((Slice) nativeValue).toStringUtf8();
         }
-        if (type == TimestampType.TIMESTAMP) {
+        if (type.equals(TimestampType.TIMESTAMP)) {
             return ((Long) nativeValue) * 1000;
         }
         if (type == BigintType.BIGINT) {
@@ -177,7 +177,7 @@ public final class TypeHelper
         if (type instanceof VarcharType) {
             return row.getString(field);
         }
-        if (type == TimestampType.TIMESTAMP) {
+        if (type.equals(TimestampType.TIMESTAMP)) {
             return row.getLong(field) / 1000;
         }
         if (type == BigintType.BIGINT) {
@@ -212,7 +212,7 @@ public final class TypeHelper
 
     public static long getLong(Type type, RowResult row, int field)
     {
-        if (type == TimestampType.TIMESTAMP) {
+        if (type.equals(TimestampType.TIMESTAMP)) {
             return row.getLong(field) / 1000;
         }
         if (type == BigintType.BIGINT) {

--- a/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
+++ b/presto-orc/src/main/java/io/prestosql/orc/TupleDomainOrcPredicate.java
@@ -154,7 +154,7 @@ public class TupleDomainOrcPredicate
     @VisibleForTesting
     public static boolean checkInBloomFilter(BloomFilter bloomFilter, Object predicateValue, Type sqlType)
     {
-        if (sqlType == TINYINT || sqlType == SMALLINT || sqlType == INTEGER || sqlType == BIGINT || sqlType == DATE || sqlType == TIMESTAMP) {
+        if (sqlType == TINYINT || sqlType == SMALLINT || sqlType == INTEGER || sqlType == BIGINT || sqlType == DATE || sqlType.equals(TIMESTAMP)) {
             return bloomFilter.testLong(((Number) predicateValue).longValue());
         }
 

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorPageSink.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorPageSink.java
@@ -101,7 +101,7 @@ public class RaptorPageSink
         if (temporalColumnHandle.isPresent() && columnIds.contains(temporalColumnHandle.get().getColumnId())) {
             temporalColumnIndex = OptionalInt.of(columnIds.indexOf(temporalColumnHandle.get().getColumnId()));
             temporalColumnType = Optional.of(columnTypes.get(temporalColumnIndex.getAsInt()));
-            checkArgument(temporalColumnType.get() == DATE || temporalColumnType.get() == TIMESTAMP,
+            checkArgument(temporalColumnType.get() == DATE || temporalColumnType.get().equals(TIMESTAMP),
                     "temporalColumnType can only be DATE or TIMESTAMP");
         }
         else {

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/OrcStorageManager.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/storage/OrcStorageManager.java
@@ -553,7 +553,7 @@ public class OrcStorageManager
     static Type toOrcFileType(Type raptorType, TypeManager typeManager)
     {
         // TIMESTAMPS are stored as BIGINT to void the poor encoding in ORC
-        if (raptorType == TimestampType.TIMESTAMP) {
+        if (raptorType.equals(TimestampType.TIMESTAMP)) {
             return BIGINT;
         }
         if (raptorType instanceof ArrayType) {

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/AbstractDateTimeJsonValueProvider.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/AbstractDateTimeJsonValueProvider.java
@@ -55,7 +55,7 @@ public abstract class AbstractDateTimeJsonValueProvider
 
         Type type = columnHandle.getType();
 
-        if (type == TIME || type == TIME_WITH_TIME_ZONE) {
+        if (type.equals(TIME) || type.equals(TIME_WITH_TIME_ZONE)) {
             if (millis < 0 || millis >= TimeUnit.DAYS.toMillis(1)) {
                 throw new PrestoException(
                         DECODER_CONVERSION_NOT_SUPPORTED,

--- a/presto-record-decoder/src/main/java/io/prestosql/decoder/json/ISO8601JsonFieldDecoder.java
+++ b/presto-record-decoder/src/main/java/io/prestosql/decoder/json/ISO8601JsonFieldDecoder.java
@@ -103,22 +103,22 @@ public class ISO8601JsonFieldDecoder
 
             try {
                 String textValue = value.asText();
-                if (columnType == TIMESTAMP) {
+                if (columnType.equals(TIMESTAMP)) {
                     // Equivalent to: ISO_DATE_TIME.parse(textValue, LocalDateTime::from).toInstant(UTC).toEpochMilli();
                     TemporalAccessor parseResult = ISO_DATE_TIME.parse(textValue);
                     return TimeUnit.DAYS.toMillis(parseResult.getLong(EPOCH_DAY)) + parseResult.getLong(MILLI_OF_DAY);
                 }
-                if (columnType == TIMESTAMP_WITH_TIME_ZONE) {
+                if (columnType.equals(TIMESTAMP_WITH_TIME_ZONE)) {
                     // Equivalent to:
                     // ZonedDateTime dateTime = ISO_OFFSET_DATE_TIME.parse(textValue, ZonedDateTime::from);
                     // packDateTimeWithZone(dateTime.toInstant().toEpochMilli(), getTimeZoneKey(dateTime.getZone().getId()));
                     TemporalAccessor parseResult = ISO_OFFSET_DATE_TIME.parse(textValue);
                     return packDateTimeWithZone(parseResult.getLong(INSTANT_SECONDS) * 1000 + parseResult.getLong(MILLI_OF_SECOND), getTimeZoneKey(ZoneId.from(parseResult).getId()));
                 }
-                if (columnType == TIME) {
+                if (columnType.equals(TIME)) {
                     return ISO_TIME.parse(textValue).getLong(MILLI_OF_DAY);
                 }
-                if (columnType == TIME_WITH_TIME_ZONE) {
+                if (columnType.equals(TIME_WITH_TIME_ZONE)) {
                     TemporalAccessor parseResult = ISO_OFFSET_TIME.parse(textValue);
                     return packDateTimeWithZone(parseResult.get(MILLI_OF_DAY), getTimeZoneKey(ZoneId.from(parseResult).getId()));
                 }


### PR DESCRIPTION
These types are about to become parametric, so comparing them
based on identity is not appropriate.