### PR TITLE
Use Instant to track session start time

### DIFF
--- a/presto-main/src/main/java/io/prestosql/FullConnectorSession.java
+++ b/presto-main/src/main/java/io/prestosql/FullConnectorSession.java
@@ -21,6 +21,7 @@ import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.security.ConnectorIdentity;
 import io.prestosql.spi.type.TimeZoneKey;
 
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -105,9 +106,9 @@ public class FullConnectorSession
     }
 
     @Override
-    public long getStartTime()
+    public Instant getStart()
     {
-        return session.getStartTime();
+        return session.getStart();
     }
 
     @Override
@@ -142,7 +143,7 @@ public class FullConnectorSession
                 .add("traceToken", getTraceToken().orElse(null))
                 .add("timeZoneKey", getTimeZoneKey())
                 .add("locale", getLocale())
-                .add("startTime", getStartTime())
+                .add("start", getStart())
                 .add("properties", properties)
                 .omitNullValues()
                 .toString();

--- a/presto-main/src/main/java/io/prestosql/Session.java
+++ b/presto-main/src/main/java/io/prestosql/Session.java
@@ -36,6 +36,7 @@ import io.prestosql.transaction.TransactionId;
 import io.prestosql.transaction.TransactionManager;
 
 import java.security.Principal;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -73,7 +74,7 @@ public final class Session
     private final Set<String> clientTags;
     private final Set<String> clientCapabilities;
     private final ResourceEstimates resourceEstimates;
-    private final long startTime;
+    private final Instant start;
     private final Map<String, String> systemProperties;
     private final Map<CatalogName, Map<String, String>> connectorProperties;
     private final Map<String, Map<String, String>> unprocessedCatalogProperties;
@@ -98,7 +99,7 @@ public final class Session
             Set<String> clientTags,
             Set<String> clientCapabilities,
             ResourceEstimates resourceEstimates,
-            long startTime,
+            Instant start,
             Map<String, String> systemProperties,
             Map<CatalogName, Map<String, String>> connectorProperties,
             Map<String, Map<String, String>> unprocessedCatalogProperties,
@@ -122,7 +123,7 @@ public final class Session
         this.clientTags = ImmutableSet.copyOf(requireNonNull(clientTags, "clientTags is null"));
         this.clientCapabilities = ImmutableSet.copyOf(requireNonNull(clientCapabilities, "clientCapabilities is null"));
         this.resourceEstimates = requireNonNull(resourceEstimates, "resourceEstimates is null");
-        this.startTime = startTime;
+        this.start = start;
         this.systemProperties = ImmutableMap.copyOf(requireNonNull(systemProperties, "systemProperties is null"));
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.preparedStatements = requireNonNull(preparedStatements, "preparedStatements is null");
@@ -224,9 +225,9 @@ public final class Session
         return resourceEstimates;
     }
 
-    public long getStartTime()
+    public Instant getStart()
     {
-        return startTime;
+        return start;
     }
 
     public Optional<TransactionId> getTransactionId()
@@ -367,7 +368,7 @@ public final class Session
                 clientTags,
                 clientCapabilities,
                 resourceEstimates,
-                startTime,
+                start,
                 systemProperties,
                 connectorProperties.build(),
                 ImmutableMap.of(),
@@ -418,7 +419,7 @@ public final class Session
                 clientTags,
                 clientCapabilities,
                 resourceEstimates,
-                startTime,
+                start,
                 systemProperties,
                 ImmutableMap.of(),
                 connectorProperties,
@@ -471,7 +472,7 @@ public final class Session
                 clientTags,
                 clientCapabilities,
                 resourceEstimates,
-                startTime,
+                start,
                 systemProperties,
                 connectorProperties,
                 unprocessedCatalogProperties,
@@ -500,7 +501,7 @@ public final class Session
                 .add("clientTags", clientTags)
                 .add("clientCapabilities", clientCapabilities)
                 .add("resourceEstimates", resourceEstimates)
-                .add("startTime", startTime)
+                .add("start", start)
                 .omitNullValues()
                 .toString();
     }
@@ -540,7 +541,7 @@ public final class Session
         private Set<String> clientTags = ImmutableSet.of();
         private Set<String> clientCapabilities = ImmutableSet.of();
         private ResourceEstimates resourceEstimates;
-        private long startTime = System.currentTimeMillis();
+        private Instant start = Instant.now();
         private final Map<String, String> systemProperties = new HashMap<>();
         private final Map<String, Map<String, String>> catalogSessionProperties = new HashMap<>();
         private final SessionPropertyManager sessionPropertyManager;
@@ -571,7 +572,7 @@ public final class Session
             this.userAgent = session.userAgent.orElse(null);
             this.clientInfo = session.clientInfo.orElse(null);
             this.clientTags = ImmutableSet.copyOf(session.clientTags);
-            this.startTime = session.startTime;
+            this.start = session.start;
             this.systemProperties.putAll(session.systemProperties);
             this.catalogSessionProperties.putAll(session.unprocessedCatalogProperties);
             this.preparedStatements.putAll(session.preparedStatements);
@@ -638,9 +639,9 @@ public final class Session
             return this;
         }
 
-        public SessionBuilder setStartTime(long startTime)
+        public SessionBuilder setStart(Instant start)
         {
-            this.startTime = startTime;
+            this.start = start;
             return this;
         }
 
@@ -733,7 +734,7 @@ public final class Session
                     clientTags,
                     clientCapabilities,
                     Optional.ofNullable(resourceEstimates).orElse(new ResourceEstimateBuilder().build()),
-                    startTime,
+                    start,
                     systemProperties,
                     ImmutableMap.of(),
                     catalogSessionProperties,

--- a/presto-main/src/main/java/io/prestosql/SessionRepresentation.java
+++ b/presto-main/src/main/java/io/prestosql/SessionRepresentation.java
@@ -27,6 +27,7 @@ import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.sql.SqlPath;
 import io.prestosql.transaction.TransactionId;
 
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -56,7 +57,7 @@ public final class SessionRepresentation
     private final Optional<String> clientInfo;
     private final Set<String> clientTags;
     private final Set<String> clientCapabilities;
-    private final long startTime;
+    private final Instant start;
     private final ResourceEstimates resourceEstimates;
     private final Map<String, String> systemProperties;
     private final Map<CatalogName, Map<String, String>> catalogProperties;
@@ -85,7 +86,7 @@ public final class SessionRepresentation
             @JsonProperty("clientTags") Set<String> clientTags,
             @JsonProperty("clientCapabilities") Set<String> clientCapabilities,
             @JsonProperty("resourceEstimates") ResourceEstimates resourceEstimates,
-            @JsonProperty("startTime") long startTime,
+            @JsonProperty("start") Instant start,
             @JsonProperty("systemProperties") Map<String, String> systemProperties,
             @JsonProperty("catalogProperties") Map<CatalogName, Map<String, String>> catalogProperties,
             @JsonProperty("unprocessedCatalogProperties") Map<String, Map<String, String>> unprocessedCatalogProperties,
@@ -111,7 +112,7 @@ public final class SessionRepresentation
         this.clientTags = requireNonNull(clientTags, "clientTags is null");
         this.clientCapabilities = requireNonNull(clientCapabilities, "clientCapabilities is null");
         this.resourceEstimates = requireNonNull(resourceEstimates, "resourceEstimates is null");
-        this.startTime = startTime;
+        this.start = start;
         this.systemProperties = ImmutableMap.copyOf(systemProperties);
         this.roles = ImmutableMap.copyOf(roles);
         this.preparedStatements = ImmutableMap.copyOf(preparedStatements);
@@ -238,9 +239,9 @@ public final class SessionRepresentation
     }
 
     @JsonProperty
-    public long getStartTime()
+    public Instant getStart()
     {
-        return startTime;
+        return start;
     }
 
     @JsonProperty
@@ -309,7 +310,7 @@ public final class SessionRepresentation
                 clientTags,
                 clientCapabilities,
                 resourceEstimates,
-                startTime,
+                start,
                 systemProperties,
                 catalogProperties,
                 unprocessedCatalogProperties,

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -2845,7 +2845,7 @@ class StatementAnalyzer
                 .setRemoteUserAddress(session.getRemoteUserAddress().orElse(null))
                 .setUserAgent(session.getUserAgent().orElse(null))
                 .setClientInfo(session.getClientInfo().orElse(null))
-                .setStartTime(session.getStartTime())
+                .setStart(session.getStart())
                 .build();
     }
 

--- a/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/io/prestosql/testing/LocalQueryRunner.java
@@ -398,7 +398,7 @@ public class LocalQueryRunner
                 defaultSession.getClientTags(),
                 defaultSession.getClientCapabilities(),
                 defaultSession.getResourceEstimates(),
-                defaultSession.getStartTime(),
+                defaultSession.getStart(),
                 defaultSession.getSystemProperties(),
                 defaultSession.getConnectorProperties(),
                 defaultSession.getUnprocessedCatalogProperties(),

--- a/presto-main/src/main/java/io/prestosql/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/io/prestosql/testing/TestingConnectorSession.java
@@ -24,6 +24,7 @@ import io.prestosql.spi.session.PropertyMetadata;
 import io.prestosql.spi.type.TimeZoneKey;
 import io.prestosql.sql.analyzer.FeaturesConfig;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -48,7 +49,7 @@ public class TestingConnectorSession
     private final TimeZoneKey timeZoneKey;
     private final Locale locale;
     private final Optional<String> traceToken;
-    private final long startTime;
+    private final Instant start;
     private final Map<String, PropertyMetadata<?>> properties;
     private final Map<String, Object> propertyValues;
     private final boolean isLegacyTimestamp;
@@ -59,7 +60,7 @@ public class TestingConnectorSession
             Optional<String> traceToken,
             TimeZoneKey timeZoneKey,
             Locale locale,
-            long startTime,
+            Instant start,
             List<PropertyMetadata<?>> propertyMetadatas,
             Map<String, Object> propertyValues,
             boolean isLegacyTimestamp)
@@ -69,7 +70,7 @@ public class TestingConnectorSession
         this.traceToken = requireNonNull(traceToken, "traceToken is null");
         this.timeZoneKey = requireNonNull(timeZoneKey, "timeZoneKey is null");
         this.locale = requireNonNull(locale, "locale is null");
-        this.startTime = startTime;
+        this.start = start;
         this.properties = Maps.uniqueIndex(propertyMetadatas, PropertyMetadata::getName);
         this.propertyValues = ImmutableMap.copyOf(propertyValues);
         this.isLegacyTimestamp = isLegacyTimestamp;
@@ -106,9 +107,9 @@ public class TestingConnectorSession
     }
 
     @Override
-    public long getStartTime()
+    public Instant getStart()
     {
-        return startTime;
+        return start;
     }
 
     @Override
@@ -146,7 +147,7 @@ public class TestingConnectorSession
                 .add("traceToken", traceToken.orElse(null))
                 .add("timeZoneKey", timeZoneKey)
                 .add("locale", locale)
-                .add("startTime", startTime)
+                .add("start", start)
                 .add("properties", propertyValues)
                 .omitNullValues()
                 .toString();
@@ -164,7 +165,7 @@ public class TestingConnectorSession
         private TimeZoneKey timeZoneKey = UTC_KEY;
         private final Locale locale = ENGLISH;
         private final Optional<String> traceToken = Optional.empty();
-        private Optional<Long> startTime = Optional.empty();
+        private Optional<Instant> start = Optional.empty();
         private List<PropertyMetadata<?>> propertyMetadatas = ImmutableList.of();
         private Map<String, Object> propertyValues = ImmutableMap.of();
         private boolean isLegacyTimestamp = new FeaturesConfig().isLegacyTimestamp();
@@ -181,9 +182,9 @@ public class TestingConnectorSession
             return this;
         }
 
-        public Builder setStartTime(long startTime)
+        public Builder setStart(Instant start)
         {
-            this.startTime = Optional.of(startTime);
+            this.start = Optional.of(start);
             return this;
         }
 
@@ -215,7 +216,7 @@ public class TestingConnectorSession
                     traceToken,
                     timeZoneKey,
                     locale,
-                    startTime.orElse(System.currentTimeMillis()),
+                    start.orElse(Instant.now()),
                     propertyMetadatas,
                     propertyValues,
                     isLegacyTimestamp);

--- a/presto-main/src/test/java/io/prestosql/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/io/prestosql/execution/TestQueryStateMachine.java
@@ -529,7 +529,7 @@ public class TestQueryStateMachine
         assertEquals(actual.getLocale(), expected.getLocale());
         assertEquals(actual.getRemoteUserAddress(), expected.getRemoteUserAddress());
         assertEquals(actual.getUserAgent(), expected.getUserAgent());
-        assertEquals(actual.getStartTime(), expected.getStartTime());
+        assertEquals(actual.getStart(), expected.getStart());
         assertEquals(actual.getSystemProperties(), expected.getSystemProperties());
         assertEquals(actual.getConnectorProperties(), expected.getConnectorProperties());
     }

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctions.java
@@ -20,6 +20,8 @@ import io.prestosql.spi.type.TimestampType;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
+import java.time.Instant;
+
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarcharType.createVarcharType;
@@ -50,7 +52,7 @@ public class TestDateTimeFunctions
     public void testLocalTime()
     {
         Session localSession = Session.builder(session)
-                .setStartTime(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis())
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis()))
                 .build();
         try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
             localAssertion.assertFunctionString("LOCALTIME", TimeType.TIME, "14:30:00.000");
@@ -64,7 +66,7 @@ public class TestDateTimeFunctions
                 // we use Asia/Kathmandu here to test the difference in semantic change of current_time
                 // between legacy and non-legacy timestamp
                 .setTimeZoneKey(KATHMANDU_ZONE_KEY)
-                .setStartTime(new DateTime(2017, 3, 1, 15, 45, 0, 0, KATHMANDU_ZONE).getMillis())
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 15, 45, 0, 0, KATHMANDU_ZONE).getMillis()))
                 .build();
         try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
             localAssertion.assertFunctionString("CURRENT_TIME", TIME_WITH_TIME_ZONE, "15:45:00.000 Asia/Kathmandu");
@@ -75,7 +77,7 @@ public class TestDateTimeFunctions
     public void testLocalTimestamp()
     {
         Session localSession = Session.builder(session)
-                .setStartTime(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis())
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis()))
                 .build();
         try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
             localAssertion.assertFunctionString("LOCALTIMESTAMP", TimestampType.TIMESTAMP, "2017-03-01 14:30:00.000");
@@ -86,7 +88,7 @@ public class TestDateTimeFunctions
     public void testCurrentTimestamp()
     {
         Session localSession = Session.builder(session)
-                .setStartTime(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis())
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis()))
                 .build();
         try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
             localAssertion.assertFunctionString("CURRENT_TIMESTAMP", TIMESTAMP_WITH_TIME_ZONE, "2017-03-01 14:30:00.000 " + DATE_TIME_ZONE.getID());

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsLegacy.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestDateTimeFunctionsLegacy.java
@@ -20,6 +20,8 @@ import io.prestosql.spi.type.TimestampType;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
 
+import java.time.Instant;
+
 import static io.prestosql.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -49,7 +51,7 @@ public class TestDateTimeFunctionsLegacy
     public void testLocalTime()
     {
         Session localSession = Session.builder(session)
-                .setStartTime(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis())
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis()))
                 .build();
         try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
             localAssertion.assertFunctionString("LOCALTIME", TimeType.TIME, "13:30:00.000");
@@ -63,7 +65,7 @@ public class TestDateTimeFunctionsLegacy
                 // we use Asia/Kathmandu here to test the difference in semantic change of current_time
                 // between legacy and non-legacy timestamp
                 .setTimeZoneKey(KATHMANDU_ZONE_KEY)
-                .setStartTime(new DateTime(2017, 3, 1, 15, 45, 0, 0, KATHMANDU_ZONE).getMillis())
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 15, 45, 0, 0, KATHMANDU_ZONE).getMillis()))
                 .build();
         try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
             localAssertion.assertFunctionString("CURRENT_TIME", TIME_WITH_TIME_ZONE, "15:30:00.000 Asia/Kathmandu");
@@ -74,7 +76,7 @@ public class TestDateTimeFunctionsLegacy
     public void testLocalTimestamp()
     {
         Session localSession = Session.builder(session)
-                .setStartTime(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis())
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis()))
                 .build();
         try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
             localAssertion.assertFunctionString("LOCALTIMESTAMP", TimestampType.TIMESTAMP, "2017-03-01 14:30:00.000");
@@ -85,7 +87,7 @@ public class TestDateTimeFunctionsLegacy
     public void testCurrentTimestamp()
     {
         Session localSession = Session.builder(session)
-                .setStartTime(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis())
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 3, 1, 14, 30, 0, 0, DATE_TIME_ZONE).getMillis()))
                 .build();
         try (FunctionAssertions localAssertion = new FunctionAssertions(localSession)) {
             localAssertion.assertFunctionString("CURRENT_TIMESTAMP", TIMESTAMP_WITH_TIME_ZONE, "2017-03-01 14:30:00.000 " + DATE_TIME_ZONE.getID());

--- a/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
+++ b/presto-main/src/test/java/io/prestosql/sql/TestExpressionInterpreter.java
@@ -523,7 +523,7 @@ public class TestExpressionInterpreter
     @Test
     public void testCurrentTimestamp()
     {
-        double current = TEST_SESSION.getStartTime() / 1000.0;
+        double current = TEST_SESSION.getStart().toEpochMilli() / 1000.0;
         assertOptimizedEquals("current_timestamp = from_unixtime(" + current + ")", "true");
         double future = current + TimeUnit.MINUTES.toSeconds(1);
         assertOptimizedEquals("current_timestamp > from_unixtime(" + future + ")", "false");

--- a/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
+++ b/presto-main/src/test/java/io/prestosql/sql/gen/TestExpressionCompiler.java
@@ -1503,8 +1503,8 @@ public class TestExpressionCompiler
     public void testFunctionWithSessionCall()
             throws Exception
     {
-        assertExecute("now()", TIMESTAMP_WITH_TIME_ZONE, new SqlTimestampWithTimeZone(TEST_SESSION.getStartTime(), TEST_SESSION.getTimeZoneKey()));
-        assertExecute("current_timestamp", TIMESTAMP_WITH_TIME_ZONE, new SqlTimestampWithTimeZone(TEST_SESSION.getStartTime(), TEST_SESSION.getTimeZoneKey()));
+        assertExecute("now()", TIMESTAMP_WITH_TIME_ZONE, new SqlTimestampWithTimeZone(TEST_SESSION.getStart().toEpochMilli(), TEST_SESSION.getTimeZoneKey()));
+        assertExecute("current_timestamp", TIMESTAMP_WITH_TIME_ZONE, new SqlTimestampWithTimeZone(TEST_SESSION.getStart().toEpochMilli(), TEST_SESSION.getTimeZoneKey()));
 
         Futures.allAsList(futures).get();
     }

--- a/presto-main/src/test/java/io/prestosql/type/TestDateTimeOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestDateTimeOperators.java
@@ -23,6 +23,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
+import java.time.Instant;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -194,7 +195,7 @@ public class TestDateTimeOperators
     {
         Session localSession = testSessionBuilder()
                 .setTimeZoneKey(getTimeZoneKey("America/Los_Angeles"))
-                .setStartTime(date.getMillis())
+                .setStart(Instant.ofEpochMilli(date.getMillis()))
                 .setSystemProperty("legacy_timestamp", "false")
                 .build();
 

--- a/presto-main/src/test/java/io/prestosql/type/TestDateTimeOperatorsLegacy.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestDateTimeOperatorsLegacy.java
@@ -23,6 +23,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
+import java.time.Instant;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -228,7 +229,7 @@ public class TestDateTimeOperatorsLegacy
     {
         Session localSession = testSessionBuilder()
                 .setTimeZoneKey(getTimeZoneKey("America/Los_Angeles"))
-                .setStartTime(date.getMillis())
+                .setStart(Instant.ofEpochMilli(date.getMillis()))
                 .setSystemProperty("legacy_timestamp", "true")
                 .build();
 

--- a/presto-main/src/test/java/io/prestosql/type/TestTimeBase.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTimeBase.java
@@ -24,6 +24,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
+import java.time.Instant;
+
 import static io.prestosql.spi.StandardErrorCode.INVALID_LITERAL;
 import static io.prestosql.spi.function.OperatorType.INDETERMINATE;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
@@ -166,7 +168,7 @@ public abstract class TestTimeBase
         // For simplicity we have to use time zone that is going forward when entering DST zone with 1970-01-01
         Session session = Session.builder(this.session)
                 .setTimeZoneKey(getTimeZoneKey("Australia/Sydney"))
-                .setStartTime(new DateTime(2017, 10, 1, 1, 59, 59, 999, getDateTimeZone(getTimeZoneKey("Australia/Sydney"))).getMillis())
+                .setStart(Instant.ofEpochMilli(new DateTime(2017, 10, 1, 1, 59, 59, 999, getDateTimeZone(getTimeZoneKey("Australia/Sydney"))).getMillis()))
                 .build();
         try (FunctionAssertions localAssertions = new FunctionAssertions(session)) {
             localAssertions.assertFunctionString("cast(TIME '12:00:00.000' as time with time zone)", TIME_WITH_TIME_ZONE, "12:00:00.000 Australia/Sydney");

--- a/presto-pinot/src/test/java/io/prestosql/pinot/TestPinotSplitManager.java
+++ b/presto-pinot/src/test/java/io/prestosql/pinot/TestPinotSplitManager.java
@@ -23,6 +23,7 @@ import io.prestosql.sql.analyzer.FeaturesConfig;
 import io.prestosql.testing.TestingConnectorSession;
 import org.testng.annotations.Test;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -114,7 +115,7 @@ public class TestPinotSplitManager
     {
         return TestingConnectorSession.builder()
                 .setTimeZoneKey(UTC_KEY)
-                .setStartTime(System.currentTimeMillis())
+                .setStart(Instant.now())
                 .setPropertyMetadata(new PinotSessionProperties(pinotConfig).getSessionProperties())
                 .setPropertyValues(ImmutableMap.<String, Object>builder()
                         .put(PinotSessionProperties.SEGMENTS_PER_SPLIT, numSegmentsPerSplit)

--- a/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorMetadata.java
+++ b/presto-raptor-legacy/src/main/java/io/prestosql/plugin/raptor/legacy/RaptorMetadata.java
@@ -486,7 +486,7 @@ public class RaptorMetadata
         String type = column.getType().getTypeId().getId();
         daoTransaction(dbi, MetadataDao.class, dao -> {
             dao.insertColumn(table.getTableId(), columnId, column.getName(), ordinalPosition, type, null, null);
-            dao.updateTableVersion(table.getTableId(), session.getStartTime());
+            dao.updateTableVersion(table.getTableId(), session.getStart().toEpochMilli());
         });
 
         shardManager.addColumn(table.getTableId(), new ColumnInfo(columnId, column.getType()));
@@ -499,7 +499,7 @@ public class RaptorMetadata
         RaptorColumnHandle sourceColumn = (RaptorColumnHandle) source;
         daoTransaction(dbi, MetadataDao.class, dao -> {
             dao.renameColumn(table.getTableId(), sourceColumn.getColumnId(), target);
-            dao.updateTableVersion(table.getTableId(), session.getStartTime());
+            dao.updateTableVersion(table.getTableId(), session.getStart().toEpochMilli());
         });
     }
 
@@ -534,7 +534,7 @@ public class RaptorMetadata
 
         daoTransaction(dbi, MetadataDao.class, dao -> {
             dao.dropColumn(table.getTableId(), raptorColumn.getColumnId());
-            dao.updateTableVersion(table.getTableId(), session.getStartTime());
+            dao.updateTableVersion(table.getTableId(), session.getStart().toEpochMilli());
         });
 
         // TODO: drop column from index table
@@ -657,7 +657,7 @@ public class RaptorMetadata
     {
         RaptorOutputTableHandle table = (RaptorOutputTableHandle) outputTableHandle;
         long transactionId = table.getTransactionId();
-        long updateTime = session.getStartTime();
+        long updateTime = session.getStart().toEpochMilli();
 
         long newTableId = runTransaction(dbi, (dbiHandle, status) -> {
             MetadataDao dao = dbiHandle.attach(MetadataDao.class);
@@ -763,7 +763,7 @@ public class RaptorMetadata
         long tableId = handle.getTableId();
         Optional<String> externalBatchId = handle.getExternalBatchId();
         List<ColumnInfo> columns = handle.getColumnHandles().stream().map(ColumnInfo::fromHandle).collect(toList());
-        long updateTime = session.getStartTime();
+        long updateTime = session.getStart().toEpochMilli();
 
         Collection<ShardInfo> shards = parseFragments(fragments);
         log.info("Committing insert into tableId %s (queryId: %s, shards: %s, columns: %s)", handle.getTableId(), session.getQueryId(), shards.size(), columns.size());
@@ -828,7 +828,7 @@ public class RaptorMetadata
 
         Set<UUID> oldShardUuids = oldShardUuidsBuilder.build();
         List<ShardInfo> newShards = newShardsBuilder.build();
-        OptionalLong updateTime = OptionalLong.of(session.getStartTime());
+        OptionalLong updateTime = OptionalLong.of(session.getStart().toEpochMilli());
 
         log.info("Finishing delete for tableId %s (removed: %s, rewritten: %s)", tableId, oldShardUuids.size() - newShards.size(), newShards.size());
         shardManager.replaceShardUuids(transactionId, tableId, columns, oldShardUuids, newShards, updateTime);

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorSession.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorSession.java
@@ -16,6 +16,7 @@ package io.prestosql.spi.connector;
 import io.prestosql.spi.security.ConnectorIdentity;
 import io.prestosql.spi.type.TimeZoneKey;
 
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -38,7 +39,16 @@ public interface ConnectorSession
 
     Optional<String> getTraceToken();
 
-    long getStartTime();
+    /**
+     * @deprecated use {@link #getStart()} instead
+     */
+    @Deprecated
+    default long getStartTime()
+    {
+        return getStart().toEpochMilli();
+    }
+
+    Instant getStart();
 
     boolean isLegacyTimestamp();
 

--- a/presto-spi/src/test/java/io/prestosql/spi/block/TestingSession.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/block/TestingSession.java
@@ -18,6 +18,7 @@ import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.security.ConnectorIdentity;
 import io.prestosql.spi.type.TimeZoneKey;
 
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
 
@@ -60,9 +61,9 @@ public final class TestingSession
         }
 
         @Override
-        public long getStartTime()
+        public Instant getStart()
         {
-            return 0;
+            return Instant.ofEpochMilli(0);
         }
 
         @Override

--- a/presto-tests/src/test/java/io/prestosql/tests/AbstractTestEngineOnlyQueries.java
+++ b/presto-tests/src/test/java/io/prestosql/tests/AbstractTestEngineOnlyQueries.java
@@ -2925,7 +2925,7 @@ public abstract class AbstractTestEngineOnlyQueries
                 getSession().getClientTags(),
                 getSession().getClientCapabilities(),
                 getSession().getResourceEstimates(),
-                getSession().getStartTime(),
+                getSession().getStart(),
                 ImmutableMap.<String, String>builder()
                         .put("test_string", "foo string")
                         .put("test_long", "424242")


### PR DESCRIPTION
This is needed for higher precision version of the special
datetime functions (localtimestamp, current_timestamp, etc),
since Instant can provide nanosecond precision vs the current
value in milliseconds.