### PR TITLE
Avoid trivial exchanges for constant projections

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddLocalExchanges.java
@@ -57,6 +57,7 @@ import io.prestosql.sql.planner.plan.TopNNode;
 import io.prestosql.sql.planner.plan.TopNRowNumberNode;
 import io.prestosql.sql.planner.plan.UnionNode;
 import io.prestosql.sql.planner.plan.WindowNode;
+import io.prestosql.sql.tree.Literal;
 import io.prestosql.sql.tree.SymbolReference;
 
 import java.util.ArrayList;
@@ -173,9 +174,9 @@ public class AddLocalExchanges
         @Override
         public PlanWithProperties visitProject(ProjectNode node, StreamPreferredProperties parentPreferences)
         {
-            // Special handling for trivial projections. Applies to identity and renaming projections.
+            // Special handling for trivial projections. Applies to identity and renaming projections, and constants
             // It might be extended to handle other low-cost projections.
-            if (node.getAssignments().getExpressions().stream().allMatch(SymbolReference.class::isInstance)) {
+            if (node.getAssignments().getExpressions().stream().allMatch(expression -> expression instanceof SymbolReference || expression instanceof Literal)) {
                 if (parentPreferences.isSingleStreamPreferred()) {
                     // Do not enforce gathering exchange below project:
                     // - if project's source is single stream, no exchanges will be added around project,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/optimizations/AddLocalExchanges.java
@@ -582,7 +582,7 @@ public class AddLocalExchanges
         {
             // Union is replaced with an exchange which does not retain streaming properties from the children
             List<PlanWithProperties> sourcesWithProperties = node.getSources().stream()
-                    .map(source -> source.accept(this, defaultParallelism(session)))
+                    .map(source -> source.accept(this, any()))
                     .collect(toImmutableList());
 
             List<PlanNode> sources = sourcesWithProperties.stream()

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PlanMatchPattern.java
@@ -237,6 +237,18 @@ public final class PlanMatchPattern
     }
 
     public static PlanMatchPattern aggregation(
+            Map<String, ExpectedValueProvider<FunctionCall>> aggregations,
+            Predicate<AggregationNode> predicate,
+            PlanMatchPattern source)
+    {
+        PlanMatchPattern result = node(AggregationNode.class, source)
+                .with(new PredicateMatcher(predicate));
+        aggregations.entrySet().forEach(
+                aggregation -> result.withAlias(aggregation.getKey(), new AggregationFunctionMatcher(aggregation.getValue())));
+        return result;
+    }
+
+    public static PlanMatchPattern aggregation(
             GroupingSetDescriptor groupingSets,
             Map<Optional<String>, ExpectedValueProvider<FunctionCall>> aggregations,
             Map<Symbol, Symbol> masks,

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PredicateMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/PredicateMatcher.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.assertions;
+
+import io.prestosql.Session;
+import io.prestosql.cost.StatsProvider;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.sql.planner.plan.PlanNode;
+
+import java.util.function.Predicate;
+
+import static io.prestosql.sql.planner.assertions.MatchResult.match;
+
+public class PredicateMatcher<T extends PlanNode>
+        implements Matcher
+{
+    private final Predicate<T> predicate;
+
+    public PredicateMatcher(Predicate<T> predicate)
+    {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        return predicate.test((T) node);
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        return match();
+    }
+
+    @Override
+    public String toString()
+    {
+        return "(predicated)";
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestAddExchangesPlans.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestAddExchangesPlans.java
@@ -428,6 +428,17 @@ public class TestAddExchangesPlans
                 anyTree(
                         project(
                                 values("a"))));
+
+        assertPlan(
+                "SELECT 1 UNION ALL SELECT 1",
+                anyTree(
+                        exchange(
+                                LOCAL,
+                                REPARTITION,
+                                project(
+                                        values()),
+                                project(
+                                        values()))));
     }
 
     private Session spillEnabledWithJoinDistributionType(JoinDistributionType joinDistributionType)

--- a/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestAddExchangesPlans.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/optimizations/TestAddExchangesPlans.java
@@ -422,6 +422,12 @@ public class TestAddExchangesPlans
                                                         LOCAL,
                                                         REPARTITION,
                                                         values("a", "b")))))));
+
+        assertPlan(
+                "SELECT 10, a FROM (VALUES 1) t(a)",
+                anyTree(
+                        project(
+                                values("a"))));
     }
 
     private Session spillEnabledWithJoinDistributionType(JoinDistributionType joinDistributionType)

--- a/presto-main/src/test/java/io/prestosql/sql/query/QueryAssertions.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/QueryAssertions.java
@@ -29,7 +29,6 @@ import org.intellij.lang.annotations.Language;
 
 import java.io.Closeable;
 import java.util.List;
-import java.util.function.Consumer;
 
 import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
@@ -79,14 +78,12 @@ class QueryAssertions
     public void assertQueryAndPlan(
             @Language("SQL") String actual,
             @Language("SQL") String expected,
-            PlanMatchPattern pattern,
-            Consumer<Plan> planValidator)
+            PlanMatchPattern pattern)
     {
         assertQuery(actual, expected);
 
         Plan plan = runner.executeWithPlan(runner.getDefaultSession(), actual, WarningCollector.NOOP).getQueryPlan();
         PlanAssert.assertPlan(runner.getDefaultSession(), runner.getMetadata(), runner.getStatsCalculator(), plan, pattern);
-        planValidator.accept(plan);
     }
 
     public void assertQuery(@Language("SQL") String actual, @Language("SQL") String expected)

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
@@ -63,11 +63,9 @@ public class TestSubqueries
                                 node(JoinNode.class,
                                         anyTree(
                                                 values("y")),
-                                        anyTree(
-                                                project(
-                                                        ImmutableMap.of("NON_NULL", expression("true")),
-                                                        anyTree(
-                                                                values("x"))))))));
+                                        project(
+                                                ImmutableMap.of("NON_NULL", expression("true")),
+                                                values("x"))))));
 
         assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES null) t(x) WHERE y > x OR y + 10 > x) FROM (VALUES 11 + if(rand() >= 0, 0)) t2(y)",
@@ -79,11 +77,9 @@ public class TestSubqueries
                                 node(JoinNode.class,
                                         anyTree(
                                                 values("y")),
-                                        anyTree(
-                                                project(
-                                                        ImmutableMap.of("NON_NULL", expression("true")),
-                                                        anyTree(
-                                                                values("x"))))))));
+                                        project(
+                                                ImmutableMap.of("NON_NULL", expression("true")),
+                                                values("x"))))));
     }
 
     @Test

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestSubqueries.java
@@ -15,32 +15,21 @@ package io.prestosql.sql.query;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.prestosql.sql.planner.Plan;
-import io.prestosql.sql.planner.assertions.PlanMatchPattern;
-import io.prestosql.sql.planner.plan.AggregationNode;
 import io.prestosql.sql.planner.plan.JoinNode;
-import io.prestosql.sql.planner.plan.ProjectNode;
-import io.prestosql.sql.planner.plan.ValuesNode;
-import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.function.Consumer;
-
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.anyTree;
-import static io.prestosql.sql.planner.assertions.PlanMatchPattern.exchange;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.functionCall;
 import static io.prestosql.sql.planner.assertions.PlanMatchPattern.node;
-import static io.prestosql.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.project;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
 import static io.prestosql.sql.planner.plan.AggregationNode.Step.FINAL;
 import static io.prestosql.sql.planner.plan.AggregationNode.Step.PARTIAL;
 import static io.prestosql.sql.planner.plan.AggregationNode.Step.SINGLE;
-import static io.prestosql.sql.planner.plan.ExchangeNode.Scope.LOCAL;
-import static io.prestosql.sql.planner.plan.ExchangeNode.Type.REPARTITION;
-import static org.testng.Assert.assertEquals;
 
 public class TestSubqueries
 {
@@ -64,14 +53,37 @@ public class TestSubqueries
     @Test
     public void testCorrelatedExistsSubqueriesWithOrPredicateAndNull()
     {
-        assertExistsRewrittenToAggregationAboveJoin(
+        assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES null, 10) t(x) WHERE y > x OR y + 10 > x) FROM (values 11 + if(rand() >= 0, 0)) t2(y)",
                 "VALUES true",
-                false);
-        assertExistsRewrittenToAggregationAboveJoin(
+                anyTree(
+                        aggregation(
+                                ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of("NON_NULL"))),
+                                aggregation -> aggregation.isStreamable() && aggregation.getStep() == SINGLE,
+                                node(JoinNode.class,
+                                        anyTree(
+                                                values("y")),
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("NON_NULL", expression("true")),
+                                                        anyTree(
+                                                                values("x"))))))));
+
+        assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES null) t(x) WHERE y > x OR y + 10 > x) FROM (VALUES 11 + if(rand() >= 0, 0)) t2(y)",
                 "VALUES false",
-                false);
+                anyTree(
+                        aggregation(
+                                ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of("NON_NULL"))),
+                                aggregation -> aggregation.isStreamable() && aggregation.getStep() == SINGLE,
+                                node(JoinNode.class,
+                                        anyTree(
+                                                values("y")),
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("NON_NULL", expression("true")),
+                                                        anyTree(
+                                                                values("x"))))))));
     }
 
     @Test
@@ -130,18 +142,39 @@ public class TestSubqueries
         assertions.assertQuery(
                 "SELECT (SELECT count(*) FROM (SELECT t.a FROM (VALUES 1, 1, null, 3) t(a) WHERE t.a=t2.b LIMIT 1)) FROM (VALUES 1, 2) t2(b)",
                 "VALUES BIGINT '1', BIGINT '0'");
-        assertExistsRewrittenToAggregationBelowJoin(
+
+        assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES 1, 1, 3) t(a) WHERE t.a=t2.b LIMIT 1) FROM (VALUES 1, 2) t2(b)",
                 "VALUES true, false",
-                false);
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(
+                                        values("b")),
+                                anyTree(
+                                        aggregation(ImmutableMap.of(), FINAL,
+                                                anyTree(
+                                                        aggregation(ImmutableMap.of(), PARTIAL,
+                                                                anyTree(
+                                                                        values("a")))))))));
+
         assertions.assertQuery(
                 "SELECT (SELECT count(*) FROM (VALUES 1, 1, 3) t(a) WHERE t.a=t2.b LIMIT 1) FROM (VALUES 1) t2(b)",
                 "VALUES BIGINT '2'");
-        assertExistsRewrittenToAggregationBelowJoin(
-                "SELECT EXISTS(SELECT 1 FROM (VALUES ('x', 1)) u(x, cid) WHERE x = 'x' AND t.cid = cid LIMIT 1) " +
-                        "FROM (VALUES 1) t(cid)",
+
+        assertions.assertQueryAndPlan(
+                "SELECT EXISTS(SELECT 1 FROM (VALUES ('x', 1)) u(x, cid) WHERE x = 'x' AND t.cid = cid LIMIT 1) FROM (VALUES 1) t(cid)",
                 "VALUES true",
-                false);
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(
+                                        values("t_cid")),
+                                anyTree(
+                                        aggregation(ImmutableMap.of(), FINAL,
+                                                anyTree(
+                                                        aggregation(ImmutableMap.of(), PARTIAL,
+                                                                anyTree(
+                                                                        values("u_x", "u_cid")))))))));
+
         assertions.assertFails(
                 "SELECT (SELECT t.a FROM (VALUES 1, 2, 3) t(a) WHERE t.a = t2.b ORDER BY a FETCH FIRST ROW WITH TIES) FROM (VALUES 1) t2(b)",
                 UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
@@ -279,42 +312,133 @@ public class TestSubqueries
         assertions.assertQuery(
                 "SELECT (SELECT count(*) FROM (VALUES 1, 1, 2, 3, null) t(a) WHERE t.a<t2.b GROUP BY t.a HAVING count(*) > 1) FROM (VALUES 1, 2) t2(b)",
                 "VALUES null, BIGINT '2'");
-        assertExistsRewrittenToAggregationBelowJoin(
+
+        assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES 1, 1, 3) t(a) WHERE t.a=t2.b GROUP BY t.a) FROM (VALUES 1, 2) t2(b)",
                 "VALUES true, false",
-                false);
-        assertExistsRewrittenToAggregationBelowJoin(
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(
+                                        values("b")),
+                                anyTree(
+                                        aggregation(ImmutableMap.of(), FINAL,
+                                                anyTree(
+                                                        aggregation(ImmutableMap.of(), PARTIAL,
+                                                                anyTree(
+                                                                        values("a")))))))));
+
+        assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES (1, 2), (1, 2), (null, null), (3, 3)) t(a, b) WHERE t.a=t2.b GROUP BY t.a, t.b) FROM (VALUES 1, 2) t2(b)",
                 "VALUES true, false",
-                true);
-        assertExistsRewrittenToAggregationAboveJoin(
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(
+                                        values("t2_b")),
+                                anyTree(
+                                        aggregation(ImmutableMap.of(), FINAL,
+                                                anyTree(
+                                                        aggregation(ImmutableMap.of(), PARTIAL,
+                                                                anyTree(
+                                                                        aggregation(ImmutableMap.of(), FINAL,
+                                                                                anyTree(
+                                                                                        aggregation(ImmutableMap.of(), PARTIAL,
+                                                                                                anyTree(
+                                                                                                        values("t_a", "t_b")))))))))))));
+
+        assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES (1, 2), (1, 2), (null, null), (3, 3)) t(a, b) WHERE t.a<t2.b GROUP BY t.a, t.b) FROM (VALUES 1, 2) t2(b)",
                 "VALUES false, true",
-                true);
+                anyTree(
+                        aggregation(
+                                ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of("NON_NULL"))),
+                                aggregation -> aggregation.isStreamable() && aggregation.getStep() == SINGLE,
+                                node(JoinNode.class,
+                                        anyTree(
+                                                values("t2_b")),
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("NON_NULL", expression("true")),
+                                                        anyTree(
+                                                                aggregation(
+                                                                        ImmutableMap.of(),
+                                                                        FINAL,
+                                                                        anyTree(
+                                                                                values("t_a", "t_b"))))))))));
+
         // t.b is not a "constant" column, cannot be pushed above aggregation
         assertions.assertFails(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES (1, 1), (1, 1), (null, null), (3, 3)) t(a, b) WHERE t.a+t.b<t2.b GROUP BY t.a) FROM (VALUES 1, 2) t2(b)",
                 UNSUPPORTED_CORRELATED_SUBQUERY_ERROR_MSG);
-        assertExistsRewrittenToAggregationAboveJoin(
+
+        assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES (1, 1), (1, 1), (null, null), (3, 3)) t(a, b) WHERE t.a+t.b<t2.b GROUP BY t.a, t.b) FROM (VALUES 1, 4) t2(b)",
                 "VALUES false, true",
-                true);
-        assertExistsRewrittenToAggregationBelowJoin(
+                anyTree(
+                        aggregation(
+                                ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of("NON_NULL"))),
+                                aggregation -> aggregation.isStreamable() && aggregation.getStep() == SINGLE,
+                                node(JoinNode.class,
+                                        anyTree(
+                                                values("t2_b")),
+                                        anyTree(
+                                                project(
+                                                        ImmutableMap.of("NON_NULL", expression("true")),
+                                                        aggregation(
+                                                                ImmutableMap.of(),
+                                                                FINAL,
+                                                                anyTree(
+                                                                        values("t_a", "t_b")))))))));
+
+        assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT 1 FROM (VALUES (1, 2), (1, 2), (null, null), (3, 3)) t(a, b) WHERE t.a=t2.b GROUP BY t.b) FROM (VALUES 1, 2) t2(b)",
                 "VALUES true, false",
-                true);
-        assertExistsRewrittenToAggregationBelowJoin(
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(
+                                        values("t2_b")),
+                                anyTree(
+                                        aggregation(ImmutableMap.of(), FINAL,
+                                                anyTree(
+                                                        aggregation(ImmutableMap.of(), PARTIAL,
+                                                                anyTree(
+                                                                        aggregation(ImmutableMap.of(), FINAL,
+                                                                                anyTree(
+                                                                                        aggregation(ImmutableMap.of(), PARTIAL,
+                                                                                                anyTree(
+                                                                                                        values("t_a", "t_b")))))))))))));
+
+        assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT * FROM (VALUES 1, 1, 2, 3) t(a) WHERE t.a=t2.b GROUP BY t.a HAVING count(*) > 1) FROM (VALUES 1, 2) t2(b)",
                 "VALUES true, false",
-                false);
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(
+                                        values("b")),
+                                anyTree(
+                                        aggregation(ImmutableMap.of(), FINAL,
+                                                anyTree(
+                                                        aggregation(ImmutableMap.of(), PARTIAL,
+                                                                anyTree(
+                                                                        values("a")))))))));
+
         assertions.assertQuery(
                 "SELECT EXISTS(SELECT * FROM (SELECT t.a FROM (VALUES (1, 1), (1, 1), (1, 2), (1, 2), (3, 3)) t(a, b) WHERE t.b=t2.b GROUP BY t.a HAVING count(*) > 1) t WHERE t.a=t2.b)" +
                         " FROM (VALUES 1, 2) t2(b)",
                 "VALUES true, false");
-        assertExistsRewrittenToAggregationBelowJoin(
+
+        assertions.assertQueryAndPlan(
                 "SELECT EXISTS(SELECT * FROM (VALUES 1, 1, 2, 3) t(a) WHERE t.a=t2.b GROUP BY (t.a) HAVING count(*) > 1) FROM (VALUES 1, 2) t2(b)",
                 "VALUES true, false",
-                false);
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(
+                                        values("b")),
+                                anyTree(
+                                        aggregation(ImmutableMap.of(), FINAL,
+                                                anyTree(
+                                                        aggregation(ImmutableMap.of(), PARTIAL,
+                                                                anyTree(
+                                                                        values("a")))))))));
     }
 
     @Test
@@ -474,63 +598,5 @@ public class TestSubqueries
                 "VALUES (1, 2), (2, null), (3, null), (null, null)");
 
         assertions.assertQueryReturnsEmptyResult("SELECT * FROM (SELECT 1 where 0 = 1) t(a) LEFT JOIN LATERAL (SELECT 2 WHERE a = 1 ) t2(b) ON TRUE");
-    }
-
-    private void assertExistsRewrittenToAggregationBelowJoin(@Language("SQL") String actual, @Language("SQL") String expected, boolean extraAggregation)
-    {
-        PlanMatchPattern source = node(ValuesNode.class);
-        if (extraAggregation) {
-            source = aggregation(ImmutableMap.of(),
-                    exchange(LOCAL, REPARTITION,
-                            aggregation(ImmutableMap.of(),
-                                    anyTree(
-                                            node(ValuesNode.class)))));
-        }
-        assertions.assertQueryAndPlan(actual, expected,
-                anyTree(
-                        node(JoinNode.class,
-                                anyTree(
-                                        node(ValuesNode.class)),
-                                anyTree(
-                                        aggregation(ImmutableMap.of(), FINAL,
-                                                exchange(LOCAL, REPARTITION,
-                                                        aggregation(ImmutableMap.of(), PARTIAL,
-                                                                anyTree(source))))))),
-                plan -> assertEquals(countFinalAggregationNodes(plan), extraAggregation ? 2 : 1));
-    }
-
-    private void assertExistsRewrittenToAggregationAboveJoin(@Language("SQL") String actual, @Language("SQL") String expected, boolean extraAggregation)
-    {
-        Consumer<Plan> singleStreamingAggregationValidator = plan -> assertEquals(countSingleStreamingAggregations(plan), 1);
-        Consumer<Plan> finalAggregationValidator = plan -> assertEquals(countFinalAggregationNodes(plan), extraAggregation ? 1 : 0);
-
-        assertions.assertQueryAndPlan(actual, expected,
-                anyTree(
-                        aggregation(
-                                ImmutableMap.of("COUNT", functionCall("count", ImmutableList.of("NON_NULL"))),
-                                SINGLE,
-                                node(JoinNode.class,
-                                        anyTree(
-                                                node(ValuesNode.class)),
-                                        anyTree(
-                                                node(ProjectNode.class,
-                                                        anyTree(
-                                                                node(ValuesNode.class)))
-                                                        .withAlias("NON_NULL", expression("true")))))),
-                singleStreamingAggregationValidator.andThen(finalAggregationValidator));
-    }
-
-    private static int countFinalAggregationNodes(Plan plan)
-    {
-        return searchFrom(plan.getRoot())
-                .where(node -> node instanceof AggregationNode && ((AggregationNode) node).getStep() == FINAL)
-                .count();
-    }
-
-    private static int countSingleStreamingAggregations(Plan plan)
-    {
-        return searchFrom(plan.getRoot())
-                .where(node -> node instanceof AggregationNode && ((AggregationNode) node).getStep() == SINGLE && ((AggregationNode) node).isStreamable())
-                .count();
     }
 }


### PR DESCRIPTION
A query like

    SELECT 10, a FROM (VALUES 1) t(a)

is planned as:

    Output[_col0, a]
    │   Layout: [expr_2:integer, field:integer]
    │   Estimates: {rows: 1 (10B), cpu: 15, memory: 0B, network: 0B}
    │   _col0 := expr_2
    │   a := field
    └─ Project[]
       │   Layout: [expr_2:integer, field:integer]
       │   Estimates: {rows: 1 (10B), cpu: 15, memory: 0B, network: 0B}
       │   expr_2 := 10
       └─ LocalExchange[ROUND_ROBIN] ()
          │   Layout: [field:integer]
          │   Estimates: {rows: 1 (5B), cpu: 5, memory: 0B, network: 0B}
          └─ Values
                 Layout: [field:integer]
                 Estimates: {rows: 1 (5B), cpu: 0, memory: 0B, network: 0B}
                 (1)

The local round-robin exchange is unnecessary in that case.