### PR TITLE
Use varchar for Elasticsearch passthrough query result

### DIFF
--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSourceProvider.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/ElasticsearchPageSourceProvider.java
@@ -22,10 +22,6 @@ import io.prestosql.spi.connector.ConnectorSplit;
 import io.prestosql.spi.connector.ConnectorTableHandle;
 import io.prestosql.spi.connector.ConnectorTransactionHandle;
 import io.prestosql.spi.predicate.TupleDomain;
-import io.prestosql.spi.type.StandardTypes;
-import io.prestosql.spi.type.Type;
-import io.prestosql.spi.type.TypeManager;
-import io.prestosql.spi.type.TypeSignature;
 
 import javax.inject.Inject;
 
@@ -39,13 +35,11 @@ public class ElasticsearchPageSourceProvider
         implements ConnectorPageSourceProvider
 {
     private final ElasticsearchClient client;
-    private final Type jsonType;
 
     @Inject
-    public ElasticsearchPageSourceProvider(ElasticsearchClient client, TypeManager typeManager)
+    public ElasticsearchPageSourceProvider(ElasticsearchClient client)
     {
         this.client = requireNonNull(client, "client is null");
-        this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
     }
 
     @Override
@@ -64,7 +58,7 @@ public class ElasticsearchPageSourceProvider
         ElasticsearchSplit elasticsearchSplit = (ElasticsearchSplit) split;
 
         if (elasticsearchTable.getType().equals(QUERY)) {
-            return new PassthroughQueryPageSource(client, elasticsearchTable, jsonType);
+            return new PassthroughQueryPageSource(client, elasticsearchTable);
         }
 
         if (columns.isEmpty()) {

--- a/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/PassthroughQueryPageSource.java
+++ b/presto-elasticsearch/src/main/java/io/prestosql/elasticsearch/PassthroughQueryPageSource.java
@@ -20,10 +20,10 @@ import io.prestosql.spi.Page;
 import io.prestosql.spi.PageBuilder;
 import io.prestosql.spi.block.BlockBuilder;
 import io.prestosql.spi.connector.ConnectorPageSource;
-import io.prestosql.spi.type.Type;
 
 import java.io.IOException;
 
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 
 public class PassthroughQueryPageSource
@@ -31,14 +31,12 @@ public class PassthroughQueryPageSource
 {
     private final long readTimeNanos;
     private final String result;
-    private final Type jsonType;
     private boolean done;
 
-    public PassthroughQueryPageSource(ElasticsearchClient client, ElasticsearchTableHandle table, Type jsonType)
+    public PassthroughQueryPageSource(ElasticsearchClient client, ElasticsearchTableHandle table)
     {
         requireNonNull(client, "client is null");
         requireNonNull(table, "table is null");
-        this.jsonType = requireNonNull(jsonType, "jsonType is null");
 
         long start = System.nanoTime();
         result = client.executeQuery(table.getIndex(), table.getQuery().get());
@@ -72,10 +70,10 @@ public class PassthroughQueryPageSource
 
         done = true;
 
-        PageBuilder page = new PageBuilder(1, ImmutableList.of(jsonType));
+        PageBuilder page = new PageBuilder(1, ImmutableList.of(VARCHAR));
         page.declarePosition();
         BlockBuilder column = page.getBlockBuilder(0);
-        jsonType.writeSlice(column, Slices.utf8Slice(result));
+        VARCHAR.writeSlice(column, Slices.utf8Slice(result));
         return page.build();
     }
 

--- a/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/BaseElasticsearchSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/io/prestosql/elasticsearch/BaseElasticsearchSmokeTest.java
@@ -763,7 +763,7 @@ public abstract class BaseElasticsearchSmokeTest
 
         assertQuery(
                 format("WITH data(r) AS (" +
-                        "   SELECT CAST(result AS ROW(aggregations ROW(max_orderkey ROW(value BIGINT), sum_orderkey ROW(value BIGINT)))) " +
+                        "   SELECT CAST(json_parse(result) AS ROW(aggregations ROW(max_orderkey ROW(value BIGINT), sum_orderkey ROW(value BIGINT)))) " +
                         "   FROM \"orders$query:%s\") " +
                         "SELECT r.aggregations.max_orderkey.value, r.aggregations.sum_orderkey.value " +
                         "FROM data", BaseEncoding.base32().encode(query.getBytes(UTF_8))),


### PR DESCRIPTION
Presto's JSON type imposes additional constraints that are not
desirable for this use case: JSON values must be equatable and
orderable. This requires parsing and re-organizing the document
to canonicalize field ordering.

Using VARCHAR will also play better with the SQL 2016 JSON features,
which operate on binary or string data directly.