### PR TITLE
Add option to disable internal JWT

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/InternalCommunicationConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/InternalCommunicationConfig.java
@@ -24,12 +24,12 @@ import java.util.Optional;
 
 @DefunctConfig({
         "internal-communication.kerberos.enabled",
-        "internal-communication.kerberos.use-canonical-hostname",
-        "internal-communication.jwt.enabled",
+        "internal-communication.kerberos.use-canonical-hostname"
 })
 public class InternalCommunicationConfig
 {
     private String sharedSecret;
+    private boolean internalJwtEnabled = true;
     private boolean httpsRequired;
     private String keyStorePath;
     private String keyStorePassword;
@@ -47,6 +47,18 @@ public class InternalCommunicationConfig
     public InternalCommunicationConfig setSharedSecret(String sharedSecret)
     {
         this.sharedSecret = sharedSecret;
+        return this;
+    }
+
+    public boolean isInternalJwtEnabled()
+    {
+        return internalJwtEnabled;
+    }
+
+    @Config("internal-communication.jwt.enabled")
+    public InternalCommunicationConfig setInternalJwtEnabled(boolean internalJwtEnabled)
+    {
+        this.internalJwtEnabled = internalJwtEnabled;
         return this;
     }
 

--- a/presto-main/src/test/java/io/prestosql/server/TestInternalCommunicationConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/TestInternalCommunicationConfig.java
@@ -29,6 +29,7 @@ public class TestInternalCommunicationConfig
     {
         assertRecordedDefaults(recordDefaults(InternalCommunicationConfig.class)
                 .setSharedSecret(null)
+                .setInternalJwtEnabled(true)
                 .setHttpsRequired(false)
                 .setKeyStorePath(null)
                 .setKeyStorePassword(null)
@@ -41,6 +42,7 @@ public class TestInternalCommunicationConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("internal-communication.shared-secret", "secret")
+                .put("internal-communication.jwt.enabled", "false")
                 .put("internal-communication.https.required", "true")
                 .put("internal-communication.https.keystore.path", "key-path")
                 .put("internal-communication.https.keystore.key", "key-key")
@@ -50,6 +52,7 @@ public class TestInternalCommunicationConfig
 
         InternalCommunicationConfig expected = new InternalCommunicationConfig()
                 .setSharedSecret("secret")
+                .setInternalJwtEnabled(false)
                 .setHttpsRequired(true)
                 .setKeyStorePath("key-path")
                 .setKeyStorePassword("key-key")


### PR DESCRIPTION
Fixes https://github.com/prestosql/presto/issues/3518 and https://github.com/prestosql/presto/issues/3594

Presto is already flexible on choices like authentication/authorization, no SSL for client, self signed SSL, impersonation rules. This allows flexibility within nodes in a cluster, useful because there can already be other safeguards in place like VPC, firewall, ingress rules.etc