### PR TITLE
Remove unused BETWEEN operator

### DIFF
--- a/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
@@ -298,7 +298,6 @@ import static io.prestosql.type.DecimalCasts.REAL_TO_DECIMAL_CAST;
 import static io.prestosql.type.DecimalCasts.SMALLINT_TO_DECIMAL_CAST;
 import static io.prestosql.type.DecimalCasts.TINYINT_TO_DECIMAL_CAST;
 import static io.prestosql.type.DecimalCasts.VARCHAR_TO_DECIMAL_CAST;
-import static io.prestosql.type.DecimalInequalityOperators.DECIMAL_BETWEEN_OPERATOR;
 import static io.prestosql.type.DecimalInequalityOperators.DECIMAL_DISTINCT_FROM_OPERATOR;
 import static io.prestosql.type.DecimalInequalityOperators.DECIMAL_EQUAL_OPERATOR;
 import static io.prestosql.type.DecimalInequalityOperators.DECIMAL_GREATER_THAN_OPERATOR;
@@ -568,7 +567,6 @@ public class FunctionRegistry
                 .functions(DECIMAL_TO_INTEGER_SATURATED_FLOOR_CAST, INTEGER_TO_DECIMAL_SATURATED_FLOOR_CAST)
                 .functions(DECIMAL_TO_SMALLINT_SATURATED_FLOOR_CAST, SMALLINT_TO_DECIMAL_SATURATED_FLOOR_CAST)
                 .functions(DECIMAL_TO_TINYINT_SATURATED_FLOOR_CAST, TINYINT_TO_DECIMAL_SATURATED_FLOOR_CAST)
-                .function(DECIMAL_BETWEEN_OPERATOR)
                 .function(DECIMAL_DISTINCT_FROM_OPERATOR)
                 .function(new Histogram(featuresConfig.getHistogramGroupImplementation()))
                 .function(CHECKSUM_AGGREGATION)

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -136,7 +136,6 @@ import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentC
 import static io.prestosql.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.prestosql.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
@@ -1383,9 +1382,6 @@ public final class MetadataManager
                     if (!canResolveOperator(operator, BOOLEAN, ImmutableList.of(type, type))) {
                         missingOperators.put(type, operator);
                     }
-                }
-                if (!canResolveOperator(BETWEEN, BOOLEAN, ImmutableList.of(type, type, type))) {
-                    missingOperators.put(type, BETWEEN);
                 }
             }
         }

--- a/presto-main/src/main/java/io/prestosql/metadata/OperatorNotFoundException.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/OperatorNotFoundException.java
@@ -53,14 +53,11 @@ public class OperatorNotFoundException
     private static String formatErrorMessage(OperatorType operatorType, List<? extends Type> argumentTypes, Optional<TypeSignature> returnType)
     {
         String operatorString;
-        switch (operatorType) {
-            case BETWEEN:
-                return format("Cannot check if %s is BETWEEN %s and %s", argumentTypes.get(0), argumentTypes.get(1), argumentTypes.get(2));
-            case CAST:
-                operatorString = format("%s%s", operatorType.getOperator(), returnType.map(value -> " to " + value).orElse(""));
-                break;
-            default:
-                operatorString = format("'%s'%s", operatorType.getOperator(), returnType.map(value -> ":" + value).orElse(""));
+        if (operatorType == OperatorType.CAST) {
+            operatorString = format("%s%s", operatorType.getOperator(), returnType.map(value -> " to " + value).orElse(""));
+        }
+        else {
+            operatorString = format("'%s'%s", operatorType.getOperator(), returnType.map(value -> ":" + value).orElse(""));
         }
         return format("%s cannot be applied to %s", operatorString, Joiner.on(", ").join(argumentTypes));
     }

--- a/presto-main/src/main/java/io/prestosql/operator/annotations/FunctionsParserHelper.java
+++ b/presto-main/src/main/java/io/prestosql/operator/annotations/FunctionsParserHelper.java
@@ -54,7 +54,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.prestosql.operator.TypeSignatureParser.parseTypeSignature;
 import static io.prestosql.operator.annotations.ImplementationDependency.isImplementationDependencyAnnotation;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
@@ -69,7 +68,7 @@ import static io.prestosql.spi.function.OperatorType.XX_HASH_64;
 public final class FunctionsParserHelper
 {
     private static final Set<OperatorType> COMPARABLE_TYPE_OPERATORS = ImmutableSet.of(EQUAL, NOT_EQUAL, HASH_CODE, XX_HASH_64, IS_DISTINCT_FROM, INDETERMINATE);
-    private static final Set<OperatorType> ORDERABLE_TYPE_OPERATORS = ImmutableSet.of(LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL, BETWEEN);
+    private static final Set<OperatorType> ORDERABLE_TYPE_OPERATORS = ImmutableSet.of(LESS_THAN, LESS_THAN_OR_EQUAL, GREATER_THAN, GREATER_THAN_OR_EQUAL);
 
     private FunctionsParserHelper()
     {}

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/annotations/OperatorValidator.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/annotations/OperatorValidator.java
@@ -48,9 +48,6 @@ public final class OperatorValidator
             case GREATER_THAN_OR_EQUAL:
                 validateComparisonOperatorSignature(operatorType, returnType, argumentTypes, 2);
                 break;
-            case BETWEEN:
-                validateComparisonOperatorSignature(operatorType, returnType, argumentTypes, 3);
-                break;
             case CAST:
                 validateOperatorSignature(operatorType, returnType, argumentTypes, 1);
                 break;

--- a/presto-main/src/main/java/io/prestosql/sql/gen/BetweenCodeGenerator.java
+++ b/presto-main/src/main/java/io/prestosql/sql/gen/BetweenCodeGenerator.java
@@ -51,10 +51,10 @@ public class BetweenCodeGenerator
                 AND,
                 BOOLEAN,
                 call(
-                        standardFunctionResolution.comparisonFunction(Operator.GREATER_THAN_OR_EQUAL, value.getType(), min.getType()),
+                        standardFunctionResolution.comparisonFunction(Operator.LESS_THAN_OR_EQUAL, min.getType(), value.getType()),
                         BOOLEAN,
-                        valueReference,
-                        min),
+                        min,
+                        valueReference),
                 call(
                         standardFunctionResolution.comparisonFunction(Operator.LESS_THAN_OR_EQUAL, value.getType(), max.getType()),
                         BOOLEAN,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/ExpressionInterpreter.java
@@ -775,7 +775,7 @@ public class ExpressionInterpreter
 
             Boolean greaterOrEqualToMin = null;
             if (min != null) {
-                greaterOrEqualToMin = (Boolean) invokeOperator(OperatorType.GREATER_THAN_OR_EQUAL, types(node.getValue(), node.getMin()), ImmutableList.of(value, min));
+                greaterOrEqualToMin = (Boolean) invokeOperator(OperatorType.LESS_THAN_OR_EQUAL, types(node.getMin(), node.getValue()), ImmutableList.of(min, value));
             }
             Boolean lessThanOrEqualToMax = null;
             if (max != null) {

--- a/presto-main/src/main/java/io/prestosql/type/BigintOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/BigintOperators.java
@@ -34,7 +34,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.prestosql.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.prestosql.spi.function.OperatorType.ADD;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.DIVIDE;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
@@ -178,13 +177,6 @@ public final class BigintOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.BIGINT) long left, @SqlType(StandardTypes.BIGINT) long right)
     {
         return left >= right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.BIGINT) long value, @SqlType(StandardTypes.BIGINT) long min, @SqlType(StandardTypes.BIGINT) long max)
-    {
-        return min <= value && value <= max;
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/io/prestosql/type/BooleanOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/BooleanOperators.java
@@ -27,7 +27,6 @@ import io.prestosql.spi.function.SqlNullable;
 import io.prestosql.spi.function.SqlType;
 import io.prestosql.spi.type.StandardTypes;
 
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
@@ -97,13 +96,6 @@ public final class BooleanOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.BOOLEAN) boolean left, @SqlType(StandardTypes.BOOLEAN) boolean right)
     {
         return left || !right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.BOOLEAN) boolean value, @SqlType(StandardTypes.BOOLEAN) boolean min, @SqlType(StandardTypes.BOOLEAN) boolean max)
-    {
-        return (value && max) || (!value && !min);
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/io/prestosql/type/CharOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/CharOperators.java
@@ -25,7 +25,6 @@ import io.prestosql.spi.function.SqlNullable;
 import io.prestosql.spi.function.SqlType;
 import io.prestosql.spi.type.StandardTypes;
 
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
@@ -90,14 +89,6 @@ public final class CharOperators
     public static boolean greaterThanOrEqual(@SqlType("char(x)") Slice left, @SqlType("char(x)") Slice right)
     {
         return compareChars(left, right) >= 0;
-    }
-
-    @LiteralParameters("x")
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType("char(x)") Slice value, @SqlType("char(x)") Slice min, @SqlType("char(x)") Slice max)
-    {
-        return compareChars(min, value) <= 0 && compareChars(value, max) <= 0;
     }
 
     @LiteralParameters("x")

--- a/presto-main/src/main/java/io/prestosql/type/DateOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/DateOperators.java
@@ -35,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import static io.airlift.slice.SliceUtf8.trim;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
@@ -99,13 +98,6 @@ public final class DateOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.DATE) long left, @SqlType(StandardTypes.DATE) long right)
     {
         return left >= right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.DATE) long value, @SqlType(StandardTypes.DATE) long min, @SqlType(StandardTypes.DATE) long max)
-    {
-        return min <= value && value <= max;
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/io/prestosql/type/DecimalInequalityOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/DecimalInequalityOperators.java
@@ -36,7 +36,6 @@ import static io.prestosql.operator.scalar.ScalarFunctionImplementation.Argument
 import static io.prestosql.operator.scalar.ScalarFunctionImplementation.NullConvention.BLOCK_AND_POSITION;
 import static io.prestosql.operator.scalar.ScalarFunctionImplementation.NullConvention.USE_NULL_FLAG;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
@@ -67,7 +66,6 @@ public final class DecimalInequalityOperators
     public static final SqlScalarFunction DECIMAL_LESS_THAN_OR_EQUAL_OPERATOR = comparisonOperator(LESS_THAN_OR_EQUAL, IS_RESULT_LESS_THAN_OR_EQUAL);
     public static final SqlScalarFunction DECIMAL_GREATER_THAN_OPERATOR = comparisonOperator(GREATER_THAN, IS_RESULT_GREATER_THAN);
     public static final SqlScalarFunction DECIMAL_GREATER_THAN_OR_EQUAL_OPERATOR = comparisonOperator(GREATER_THAN_OR_EQUAL, IS_RESULT_GREATER_THAN_OR_EQUAL);
-    public static final SqlScalarFunction DECIMAL_BETWEEN_OPERATOR = betweenOperator();
     public static final SqlScalarFunction DECIMAL_DISTINCT_FROM_OPERATOR = distinctOperator();
 
     private DecimalInequalityOperators() {}
@@ -259,23 +257,6 @@ public final class DecimalInequalityOperators
             throwIfInstanceOf(t, PrestoException.class);
             throw new PrestoException(GENERIC_INTERNAL_ERROR, t);
         }
-    }
-
-    private static SqlScalarFunction betweenOperator()
-    {
-        Signature signature = Signature.builder()
-                .kind(SCALAR)
-                .operatorType(BETWEEN)
-                .argumentTypes(DECIMAL_SIGNATURE, DECIMAL_SIGNATURE, DECIMAL_SIGNATURE)
-                .returnType(BOOLEAN.getTypeSignature())
-                .build();
-        return SqlScalarFunction.builder(DecimalInequalityOperators.class)
-                .signature(signature)
-                .deterministic(true)
-                .choice(choice -> choice
-                        .implementation(methodsGroup -> methodsGroup
-                                .methods("betweenShortShortShort", "betweenLongLongLong")))
-                .build();
     }
 
     @UsedByGeneratedCode

--- a/presto-main/src/main/java/io/prestosql/type/DoubleOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/DoubleOperators.java
@@ -36,7 +36,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.prestosql.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.prestosql.spi.function.OperatorType.ADD;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.DIVIDE;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
@@ -164,13 +163,6 @@ public final class DoubleOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.DOUBLE) double left, @SqlType(StandardTypes.DOUBLE) double right)
     {
         return left >= right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.DOUBLE) double value, @SqlType(StandardTypes.DOUBLE) double min, @SqlType(StandardTypes.DOUBLE) double max)
-    {
-        return min <= value && value <= max;
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/io/prestosql/type/IntegerOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/IntegerOperators.java
@@ -33,7 +33,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.prestosql.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.prestosql.spi.function.OperatorType.ADD;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.DIVIDE;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
@@ -173,13 +172,6 @@ public final class IntegerOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.INTEGER) long left, @SqlType(StandardTypes.INTEGER) long right)
     {
         return left >= right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.INTEGER) long value, @SqlType(StandardTypes.INTEGER) long min, @SqlType(StandardTypes.INTEGER) long max)
-    {
-        return min <= value && value <= max;
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/io/prestosql/type/IntervalDayTimeOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/IntervalDayTimeOperators.java
@@ -31,7 +31,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.client.IntervalDayTime.formatMillis;
 import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.prestosql.spi.function.OperatorType.ADD;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.DIVIDE;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
@@ -161,16 +160,6 @@ public final class IntervalDayTimeOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long left, @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long right)
     {
         return left >= right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(
-            @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long value,
-            @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long min,
-            @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long max)
-    {
-        return min <= value && value <= max;
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/io/prestosql/type/IntervalYearMonthOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/IntervalYearMonthOperators.java
@@ -31,7 +31,6 @@ import io.prestosql.spi.type.StandardTypes;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.prestosql.spi.function.OperatorType.ADD;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.DIVIDE;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
@@ -162,16 +161,6 @@ public final class IntervalYearMonthOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long left, @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long right)
     {
         return left >= right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(
-            @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long value,
-            @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long min,
-            @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long max)
-    {
-        return min <= value && value <= max;
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/io/prestosql/type/IpAddressOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/IpAddressOperators.java
@@ -34,7 +34,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.prestosql.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
@@ -95,13 +94,6 @@ public final class IpAddressOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.IPADDRESS) Slice left, @SqlType(StandardTypes.IPADDRESS) Slice right)
     {
         return left.compareTo(right) >= 0;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.IPADDRESS) Slice value, @SqlType(StandardTypes.IPADDRESS) Slice min, @SqlType(StandardTypes.IPADDRESS) Slice max)
-    {
-        return min.compareTo(value) <= 0 && value.compareTo(max) <= 0;
     }
 
     @ScalarOperator(HASH_CODE)

--- a/presto-main/src/main/java/io/prestosql/type/RealOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/RealOperators.java
@@ -35,7 +35,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.prestosql.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.prestosql.spi.function.OperatorType.ADD;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.DIVIDE;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
@@ -160,14 +159,6 @@ public final class RealOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.REAL) long left, @SqlType(StandardTypes.REAL) long right)
     {
         return intBitsToFloat((int) left) >= intBitsToFloat((int) right);
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.REAL) long value, @SqlType(StandardTypes.REAL) long min, @SqlType(StandardTypes.REAL) long max)
-    {
-        return intBitsToFloat((int) min) <= intBitsToFloat((int) value) &&
-                intBitsToFloat((int) value) <= intBitsToFloat((int) max);
     }
 
     @ScalarOperator(HASH_CODE)

--- a/presto-main/src/main/java/io/prestosql/type/SmallintOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/SmallintOperators.java
@@ -33,7 +33,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.prestosql.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.prestosql.spi.function.OperatorType.ADD;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.DIVIDE;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
@@ -173,13 +172,6 @@ public final class SmallintOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.SMALLINT) long left, @SqlType(StandardTypes.SMALLINT) long right)
     {
         return left >= right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.SMALLINT) long value, @SqlType(StandardTypes.SMALLINT) long min, @SqlType(StandardTypes.SMALLINT) long max)
-    {
-        return min <= value && value <= max;
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/io/prestosql/type/TimeOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/TimeOperators.java
@@ -32,7 +32,6 @@ import org.joda.time.chrono.ISOChronology;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
@@ -104,13 +103,6 @@ public final class TimeOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.TIME) long left, @SqlType(StandardTypes.TIME) long right)
     {
         return left >= right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.TIME) long value, @SqlType(StandardTypes.TIME) long min, @SqlType(StandardTypes.TIME) long max)
-    {
-        return min <= value && value <= max;
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/io/prestosql/type/TimeWithTimeZoneOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/TimeWithTimeZoneOperators.java
@@ -33,7 +33,6 @@ import java.time.ZoneOffset;
 import java.time.temporal.ChronoField;
 
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
@@ -110,13 +109,6 @@ public final class TimeWithTimeZoneOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long left, @SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long right)
     {
         return unpackMillisUtc(left) >= unpackMillisUtc(right);
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long value, @SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long min, @SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long max)
-    {
-        return unpackMillisUtc(min) <= unpackMillisUtc(value) && unpackMillisUtc(value) <= unpackMillisUtc(max);
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/io/prestosql/type/TimestampOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/TimestampOperators.java
@@ -35,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import static io.airlift.slice.SliceUtf8.trim;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
@@ -109,13 +108,6 @@ public final class TimestampOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.TIMESTAMP) long left, @SqlType(StandardTypes.TIMESTAMP) long right)
     {
         return left >= right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.TIMESTAMP) long value, @SqlType(StandardTypes.TIMESTAMP) long min, @SqlType(StandardTypes.TIMESTAMP) long max)
-    {
-        return min <= value && value <= max;
     }
 
     @ScalarFunction("date")

--- a/presto-main/src/main/java/io/prestosql/type/TimestampWithTimeZoneOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/TimestampWithTimeZoneOperators.java
@@ -35,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 import static io.airlift.slice.SliceUtf8.trim;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
@@ -111,16 +110,6 @@ public final class TimestampWithTimeZoneOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long left, @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long right)
     {
         return unpackMillisUtc(left) >= unpackMillisUtc(right);
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(
-            @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long value,
-            @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long min,
-            @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long max)
-    {
-        return unpackMillisUtc(min) <= unpackMillisUtc(value) && unpackMillisUtc(value) <= unpackMillisUtc(max);
     }
 
     @ScalarFunction("date")

--- a/presto-main/src/main/java/io/prestosql/type/TinyintOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/TinyintOperators.java
@@ -32,7 +32,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.prestosql.spi.StandardErrorCode.DIVISION_BY_ZERO;
 import static io.prestosql.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.prestosql.spi.function.OperatorType.ADD;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.DIVIDE;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
@@ -171,13 +170,6 @@ public final class TinyintOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.TINYINT) long left, @SqlType(StandardTypes.TINYINT) long right)
     {
         return left >= right;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.TINYINT) long value, @SqlType(StandardTypes.TINYINT) long min, @SqlType(StandardTypes.TINYINT) long max)
-    {
-        return min <= value && value <= max;
     }
 
     @ScalarOperator(CAST)

--- a/presto-main/src/main/java/io/prestosql/type/UnknownOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/UnknownOperators.java
@@ -22,7 +22,6 @@ import io.prestosql.spi.function.SqlNullable;
 import io.prestosql.spi.function.SqlType;
 import io.prestosql.spi.type.StandardTypes;
 
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
@@ -78,13 +77,6 @@ public final class UnknownOperators
     @ScalarOperator(GREATER_THAN_OR_EQUAL)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean greaterThanOrEqual(@SqlType("unknown") boolean left, @SqlType("unknown") boolean right)
-    {
-        throw new AssertionError("value of unknown type should always be NULL");
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType("unknown") boolean value, @SqlType("unknown") boolean min, @SqlType("unknown") boolean max)
     {
         throw new AssertionError("value of unknown type should always be NULL");
     }

--- a/presto-main/src/main/java/io/prestosql/type/UuidOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/UuidOperators.java
@@ -33,7 +33,6 @@ import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.airlift.slice.Slices.wrappedLongArray;
 import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
@@ -103,13 +102,6 @@ public final class UuidOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.UUID) Slice left, @SqlType(StandardTypes.UUID) Slice right)
     {
         return left.compareTo(right) >= 0;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.UUID) Slice value, @SqlType(StandardTypes.UUID) Slice min, @SqlType(StandardTypes.UUID) Slice max)
-    {
-        return min.compareTo(value) <= 0 && value.compareTo(max) <= 0;
     }
 
     @ScalarOperator(HASH_CODE)

--- a/presto-main/src/main/java/io/prestosql/type/VarbinaryOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/VarbinaryOperators.java
@@ -24,7 +24,6 @@ import io.prestosql.spi.function.SqlNullable;
 import io.prestosql.spi.function.SqlType;
 import io.prestosql.spi.type.StandardTypes;
 
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN_OR_EQUAL;
@@ -82,13 +81,6 @@ public final class VarbinaryOperators
     public static boolean greaterThanOrEqual(@SqlType(StandardTypes.VARBINARY) Slice left, @SqlType(StandardTypes.VARBINARY) Slice right)
     {
         return left.compareTo(right) >= 0;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType(StandardTypes.VARBINARY) Slice value, @SqlType(StandardTypes.VARBINARY) Slice min, @SqlType(StandardTypes.VARBINARY) Slice max)
-    {
-        return min.compareTo(value) <= 0 && value.compareTo(max) <= 0;
     }
 
     @ScalarOperator(HASH_CODE)

--- a/presto-main/src/main/java/io/prestosql/type/VarcharOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/VarcharOperators.java
@@ -27,7 +27,6 @@ import io.prestosql.spi.function.SqlType;
 import io.prestosql.spi.type.StandardTypes;
 
 import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
@@ -93,14 +92,6 @@ public final class VarcharOperators
     public static boolean greaterThanOrEqual(@SqlType("varchar(x)") Slice left, @SqlType("varchar(x)") Slice right)
     {
         return left.compareTo(right) >= 0;
-    }
-
-    @LiteralParameters("x")
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType("varchar(x)") Slice value, @SqlType("varchar(x)") Slice min, @SqlType("varchar(x)") Slice max)
-    {
-        return min.compareTo(value) <= 0 && value.compareTo(max) <= 0;
     }
 
     @LiteralParameters("x")

--- a/presto-main/src/test/java/io/prestosql/operator/TestFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/io/prestosql/operator/TestFilterAndProjectOperator.java
@@ -40,8 +40,8 @@ import static io.prestosql.SessionTestUtils.TEST_SESSION;
 import static io.prestosql.metadata.MetadataManager.createTestMetadataManager;
 import static io.prestosql.operator.OperatorAssertion.assertOperatorEquals;
 import static io.prestosql.spi.function.OperatorType.ADD;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
+import static io.prestosql.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.BooleanType.BOOLEAN;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -86,11 +86,10 @@ public class TestFilterAndProjectOperator
 
         Metadata metadata = createTestMetadataManager();
         RowExpression filter = call(
-                metadata.resolveOperator(BETWEEN, ImmutableList.of(BIGINT, BIGINT, BIGINT)),
+                metadata.resolveOperator(LESS_THAN_OR_EQUAL, ImmutableList.of(BIGINT, BIGINT)),
                 BOOLEAN,
                 field(1, BIGINT),
-                constant(10L, BIGINT),
-                constant(19L, BIGINT));
+                constant(9L, BIGINT));
 
         RowExpression field0 = field(0, VARCHAR);
         RowExpression add5 = call(
@@ -111,16 +110,17 @@ public class TestFilterAndProjectOperator
                 0);
 
         MaterializedResult expected = MaterializedResult.resultBuilder(driverContext.getSession(), VARCHAR, BIGINT)
-                .row("10", 15L)
-                .row("11", 16L)
-                .row("12", 17L)
-                .row("13", 18L)
-                .row("14", 19L)
-                .row("15", 20L)
-                .row("16", 21L)
-                .row("17", 22L)
-                .row("18", 23L)
-                .row("19", 24L)
+                .row("0", 5L)
+                .row("1", 6L)
+                .row("2", 7L)
+                .row("3", 8L)
+                .row("4", 9L)
+                .row("5", 10L)
+                .row("6", 11L)
+                .row("7", 12L)
+                .row("8", 13L)
+                .row("9", 14L)
+
                 .build();
 
         assertOperatorEquals(operatorFactory, driverContext, input, expected);

--- a/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/ObjectIdFunctions.java
+++ b/presto-mongodb/src/main/java/io/prestosql/plugin/mongodb/ObjectIdFunctions.java
@@ -29,7 +29,6 @@ import io.prestosql.spi.type.StandardTypes;
 import org.bson.types.ObjectId;
 
 import static io.airlift.slice.Slices.utf8Slice;
-import static io.prestosql.spi.function.OperatorType.BETWEEN;
 import static io.prestosql.spi.function.OperatorType.CAST;
 import static io.prestosql.spi.function.OperatorType.EQUAL;
 import static io.prestosql.spi.function.OperatorType.GREATER_THAN;
@@ -141,13 +140,6 @@ public final class ObjectIdFunctions
     public static boolean lessThanOrEqual(@SqlType("ObjectId") Slice left, @SqlType("ObjectId") Slice right)
     {
         return compareTo(left, right) <= 0;
-    }
-
-    @ScalarOperator(BETWEEN)
-    @SqlType(StandardTypes.BOOLEAN)
-    public static boolean between(@SqlType("ObjectId") Slice value, @SqlType("ObjectId") Slice min, @SqlType("ObjectId") Slice max)
-    {
-        return compareTo(value, min) >= 0 && compareTo(value, max) <= 0;
     }
 
     @ScalarOperator(HASH_CODE)

--- a/presto-spi/src/main/java/io/prestosql/spi/function/OperatorType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/function/OperatorType.java
@@ -27,7 +27,6 @@ public enum OperatorType
     LESS_THAN_OR_EQUAL("<=", 2),
     GREATER_THAN(">", 2),
     GREATER_THAN_OR_EQUAL(">=", 2),
-    BETWEEN("BETWEEN", 3),
     CAST("CAST", 1),
     SUBSCRIPT("[]", 2),
     HASH_CODE("HASH CODE", 1),


### PR DESCRIPTION
It was only being used during analysis to check for support
for the operator. At runtime, it gets desugard into a comparison
using the "less than or equal" operator.

Remove usages of the "between" operator and check for existance
of "less than or equal" operator instead.