### PR TITLE
Add rpm for trino-cli

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1411,6 +1411,18 @@
                     <artifactId>provisio-maven-plugin</artifactId>
                     <version>1.0.9</version>
                 </plugin>
+
+                <plugin>
+                    <groupId>io.airlift.maven.plugins</groupId>
+                    <artifactId>redlinerpm-maven-plugin</artifactId>
+                    <version>2.1.6</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -117,6 +117,19 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <!-- jline-terminal-jna depends on a different version of jna -->
+                <exclusion>
+                    <groupId>net.java.dev.jna</groupId>
+                    <artifactId>jna</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -161,6 +174,100 @@
                         <phase>package</phase>
                         <goals>
                             <goal>really-executable-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>io.airlift.maven.plugins</groupId>
+                <artifactId>redlinerpm-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <performCheckingForExtraFiles>false</performCheckingForExtraFiles>
+                    <buildPath>${project.build.directory}</buildPath>
+
+                    <packages>
+                        <package>
+                            <name>presto-cli-rpm</name>
+                            <nameOverride>presto-cli-rpm-${project.version}.noarch.rpm</nameOverride>
+                            <version>${project.version}</version>
+                            <release>1</release>
+
+                            <group>Applications/Databases</group>
+                            <description>Presto CLI RPM Package.</description>
+                            <architecture>noarch</architecture>
+
+                            <links>
+                                <link>
+                                    <path>/usr/local/bin/presto</path>
+                                    <target>/usr/lib/presto-cli/presto-cli-${project.version}-executable.jar</target>
+                                </link>
+                            </links>
+
+                            <rules>
+                                <rule>
+                                    <destination>/usr/lib/presto-cli</destination>
+                                    <!-- make sure jar is executable -->
+                                    <fileMode>0755</fileMode>
+                                    <includes>
+                                        <include>presto-cli-${project.version}-executable.jar</include>
+                                    </includes>
+                                </rule>
+                            </rules>
+                        </package>
+                    </packages>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-file-size</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireFilesSize>
+                                    <!-- we expect the RPM and executable JAR to not be too large (max 20MB) -->
+                                    <maxsize>20971520</maxsize>
+                                    <files>
+                                        <file>${project.build.directory}/presto-cli-rpm-${project.version}.noarch.rpm</file>
+                                        <file>${project.build.directory}/presto-cli-${project.version}-executable.jar</file>
+                                    </files>
+                                </requireFilesSize>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <rpm>${project.build.directory}/presto-cli-rpm-${project.version}.noarch.rpm</rpm>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/presto-cli/src/test/java/io/prestosql/cli/rpm/ClientIT.java
+++ b/presto-cli/src/test/java/io/prestosql/cli/rpm/ClientIT.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.cli.rpm;
+
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.time.Duration;
+
+import static org.testcontainers.containers.wait.strategy.Wait.forLogMessage;
+
+@Test(singleThreaded = true)
+public class ClientIT
+{
+    @Parameters("rpm")
+    @Test
+    public void testWithJava11(String rpm)
+    {
+        testClient("prestodev/centos7-oj11", rpm);
+    }
+
+    private static void testClient(String baseImage, String rpmHostPath)
+    {
+        String rpm = "/" + new File(rpmHostPath).getName();
+
+        String command = "" +
+                // install RPM
+                "yum localinstall -y " + rpm + "\n" +
+                "presto --help\n";
+
+        try (GenericContainer<?> container = new GenericContainer<>(baseImage)) {
+            container.withFileSystemBind(rpmHostPath, rpm, BindMode.READ_ONLY)
+                    .withCommand("sh", "-xeuc", command)
+                    .waitingFor(forLogMessage(".*presto - Presto command line interface.*", 1).withStartupTimeout(Duration.ofMinutes(1)))
+                    .start();
+        }
+    }
+}

--- a/presto-server-rpm/pom.xml
+++ b/presto-server-rpm/pom.xml
@@ -136,7 +136,6 @@
             <plugin>
                 <groupId>io.airlift.maven.plugins</groupId>
                 <artifactId>redlinerpm-maven-plugin</artifactId>
-                <version>2.1.7</version>
                 <extensions>true</extensions>
 
                 <configuration>
@@ -309,7 +308,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>2.22.2</version>
                         <configuration>
                             <systemPropertyVariables>
                                 <rpm>${project.build.directory}/${project.build.finalName}.x86_64.rpm</rpm>


### PR DESCRIPTION
Adds the rpm-maven-plugin to the package phase to create an RPM that
will install the presto-cli executable jar as presto-cli to
/usr/local/bin. Fixes #1882.