### PR TITLE
Fix failure when aggregation contains quantified comparison

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/AggregationAnalyzer.java
@@ -50,6 +50,7 @@ import io.prestosql.sql.tree.NodeRef;
 import io.prestosql.sql.tree.NotExpression;
 import io.prestosql.sql.tree.NullIfExpression;
 import io.prestosql.sql.tree.Parameter;
+import io.prestosql.sql.tree.QuantifiedComparisonExpression;
 import io.prestosql.sql.tree.Row;
 import io.prestosql.sql.tree.SearchedCaseExpression;
 import io.prestosql.sql.tree.SimpleCaseExpression;
@@ -307,6 +308,12 @@ class AggregationAnalyzer
         protected Boolean visitInPredicate(InPredicate node, Void context)
         {
             return process(node.getValue(), context) && process(node.getValueList(), context);
+        }
+
+        @Override
+        protected Boolean visitQuantifiedComparisonExpression(QuantifiedComparisonExpression node, Void context)
+        {
+            return process(node.getValue(), context) && process(node.getSubquery(), context);
         }
 
         @Override

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestAggregation.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestAggregation.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.query;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestAggregation
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testQuantifiedComparison()
+    {
+        assertThatThrownBy(() -> assertions.query("SELECT v > ALL (VALUES 1) FROM (VALUES (1, 1), (1, 2)) t(k, v) GROUP BY k"))
+                .hasMessageContaining("must be an aggregate expression or appear in GROUP BY clause");
+
+        assertThatThrownBy(() -> assertions.query("SELECT v > ANY (VALUES 1) FROM (VALUES (1, 1), (1, 2)) t(k, v) GROUP BY k"))
+                .hasMessageContaining("must be an aggregate expression or appear in GROUP BY clause");
+
+        assertThatThrownBy(() -> assertions.query("SELECT v > SOME (VALUES 1) FROM (VALUES (1, 1), (1, 2)) t(k, v) GROUP BY k"))
+                .hasMessageContaining("must be an aggregate expression or appear in GROUP BY clause");
+
+        assertThat(assertions.query("SELECT count_if(v > ALL (VALUES 0, 1)) FROM (VALUES (1, 1), (1, 2)) t(k, v) GROUP BY k"))
+            .matches("VALUES BIGINT '1'");
+
+        assertThat(assertions.query("SELECT count_if(v > ANY (VALUES 0, 1)) FROM (VALUES (1, 1), (1, 2)) t(k, v) GROUP BY k"))
+                .matches("VALUES BIGINT '2'");
+
+        assertThatThrownBy(() -> assertions.query("SELECT 1 > ALL (VALUES k) FROM (VALUES (1, 1), (1, 2)) t(k, v) GROUP BY k"))
+                .hasMessageContaining("line 1:17: Given correlated subquery is not supported");
+    }
+}


### PR DESCRIPTION
The query fails with:

```
Query 20200621_235954_00000_gwqf5 failed: aggregation analysis not yet implemented for: io.prestosql.sql.tree.QuantifiedComparisonExpression
java.lang.UnsupportedOperationException: aggregation analysis not yet implemented for: io.prestosql.sql.tree.QuantifiedComparisonExpression
	at io.prestosql.sql.analyzer.AggregationAnalyzer$Visitor.visitExpression(AggregationAnalyzer.java:178)
	at io.prestosql.sql.analyzer.AggregationAnalyzer$Visitor.visitExpression(AggregationAnalyzer.java:172)
	at io.prestosql.sql.tree.AstVisitor.visitQuantifiedComparisonExpression(AstVisitor.java:767)
	at io.prestosql.sql.tree.QuantifiedComparisonExpression.accept(QuantifiedComparisonExpression.java:81)
	at io.prestosql.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.prestosql.sql.analyzer.AggregationAnalyzer$Visitor.process(AggregationAnalyzer.java:660)
	at io.prestosql.sql.analyzer.AggregationAnalyzer.analyze(AggregationAnalyzer.java:164)
	at io.prestosql.sql.analyzer.AggregationAnalyzer.verifySourceAggregations(AggregationAnalyzer.java:118)
	at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.analyzeAggregations(StatementAnalyzer.java:2377)
	at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:1329)
	at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.visitQuerySpecification(StatementAnalyzer.java:306)
	at io.prestosql.sql.tree.QuerySpecification.accept(QuerySpecification.java:144)
	at io.prestosql.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:323)
	at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.process(StatementAnalyzer.java:333)
	at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:918)
	at io.prestosql.sql.analyzer.StatementAnalyzer$Visitor.visitQuery(StatementAnalyzer.java:306)
	at io.prestosql.sql.tree.Query.accept(Query.java:107)
```