### PR TITLE
Create scope for empty FROM clause during analysis

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/Analysis.java
@@ -100,6 +100,10 @@ public class Analysis
 
     private final Map<NodeRef<Table>, Query> namedQueries = new LinkedHashMap<>();
 
+    // Synthetic scope when a query does not have a FROM clause
+    // We need to track this separately because there's no node we can attach it to.
+    private final Map<NodeRef<QuerySpecification>, Scope> implicitFromScopes = new LinkedHashMap<>();
+
     private final Map<NodeRef<Node>, Scope> scopes = new LinkedHashMap<>();
     private final Map<NodeRef<Expression>, FieldId> columnReferences = new LinkedHashMap<>();
 
@@ -829,6 +833,16 @@ public class Analysis
     public FieldReference getRowIdField(Table table)
     {
         return rowIdField.get(NodeRef.of(table));
+    }
+
+    public void setImplicitFromScope(QuerySpecification node, Scope scope)
+    {
+        implicitFromScopes.put(NodeRef.of(node), scope);
+    }
+
+    public Scope getImplicitFromScope(QuerySpecification node)
+    {
+        return implicitFromScopes.get(NodeRef.of(node));
     }
 
     @Immutable

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/StatementAnalyzer.java
@@ -2334,7 +2334,9 @@ class StatementAnalyzer
                 return process(node.getFrom().get(), scope);
             }
 
-            return createScope(scope);
+            Scope result = createScope(scope);
+            analysis.setImplicitFromScope(node, result);
+            return result;
         }
 
         private void analyzeGroupingOperations(QuerySpecification node, List<Expression> outputExpressions, List<Expression> orderByExpressions)

--- a/presto-main/src/main/java/io/prestosql/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/QueryPlanner.java
@@ -304,7 +304,10 @@ class QueryPlanner
                     .process(node.getFrom().get(), null);
         }
         else {
-            relationPlan = planImplicitTable();
+            relationPlan = new RelationPlan(
+                    new ValuesNode(idAllocator.getNextId(), ImmutableList.of(), ImmutableList.of(ImmutableList.of())),
+                    analysis.getImplicitFromScope(node),
+                    ImmutableList.of());
         }
 
         return planBuilderFor(relationPlan);
@@ -333,16 +336,6 @@ class QueryPlanner
         translations.setFieldMappings(relationPlan.getFieldMappings());
 
         return new PlanBuilder(translations, relationPlan.getRoot());
-    }
-
-    private RelationPlan planImplicitTable()
-    {
-        List<Expression> emptyRow = ImmutableList.of();
-        Scope scope = Scope.create();
-        return new RelationPlan(
-                new ValuesNode(idAllocator.getNextId(), ImmutableList.of(), ImmutableList.of(emptyRow)),
-                scope,
-                ImmutableList.of());
     }
 
     private PlanBuilder filter(PlanBuilder subPlan, Expression predicate, Node node)


### PR DESCRIPTION
It's incorrect for scopes to be created during planning.
The hierarchical relationship between scopes matters, so they
need to be linked appropriately with the outer and dependent scopes.