### PR TITLE
Derive effective predicate unconditionally

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/EffectivePredicateExtractor.java
@@ -224,8 +224,7 @@ public class EffectivePredicateExtractor
             Map<ColumnHandle, Symbol> assignments = ImmutableBiMap.copyOf(node.getAssignments()).inverse();
 
             TupleDomain<ColumnHandle> predicate = node.getEnforcedConstraint();
-            if (useTableProperties && !node.getEnforcedConstraint().isAll()) {
-                // extract table properties only when predicate has been pushed to table scan at least once
+            if (useTableProperties) {
                 predicate = metadata.getTableProperties(session, node.getTable()).getPredicate();
             }
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/AbstractPredicatePushdownTest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/AbstractPredicatePushdownTest.java
@@ -527,5 +527,19 @@ public abstract class AbstractPredicatePushdownTest
                                         tableScan(
                                                 "orders",
                                                 ImmutableMap.of("ORDERSTATUS", "orderstatus"))))));
+
+        assertPlan(
+                "SELECT * FROM orders JOIN nation ON orderstatus = CAST(nation.name AS varchar(1))",
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(
+                                        filter("CAST(NAME AS varchar(1)) IN ('F', 'O', 'P')",
+                                                tableScan(
+                                                        "nation",
+                                                        ImmutableMap.of("NAME", "name")))),
+                                anyTree(
+                                        tableScan(
+                                                "orders",
+                                                ImmutableMap.of("ORDERSTATUS", "orderstatus"))))));
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestEffectivePredicateExtractor.java
@@ -493,7 +493,7 @@ public class TestEffectivePredicateExtractor
                 assignments,
                 TupleDomain.all());
         effectivePredicate = effectivePredicateExtractor.extract(SESSION, node, TypeProvider.empty(), typeAnalyzer);
-        assertEquals(effectivePredicate, BooleanLiteral.TRUE_LITERAL);
+        assertEquals(effectivePredicate, and(equals(AE, bigintLiteral(1)), equals(BE, bigintLiteral(2))));
 
         node = new TableScanNode(
                 newId(),


### PR DESCRIPTION
For queries without where clause, the enforced predicate associated
with the table scan is always ALL, as there's nothing to push down.
This prevents deriving a predicate from the properties of the table.
E.g., if the table is partitioned.