### PR TITLE
Migrate WindowFilterPushdown to rule framework

### DIFF
--- a/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
+++ b/presto-main/src/main/java/io/prestosql/SystemSessionProperties.java
@@ -127,6 +127,7 @@ public final class SystemSessionProperties
     public static final String REQUIRED_WORKERS_MAX_WAIT_TIME = "required_workers_max_wait_time";
     public static final String COST_ESTIMATION_WORKER_COUNT = "cost_estimation_worker_count";
     public static final String OMIT_DATETIME_TYPE_PRECISION = "omit_datetime_type_precision";
+    public static final String USE_LEGACY_WINDOW_FILTER_PUSHDOWN = "use_legacy_window_filter_pushdown";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -567,6 +568,11 @@ public final class SystemSessionProperties
                         OMIT_DATETIME_TYPE_PRECISION,
                         "Omit precision when rendering datetime type names with default precision",
                         featuresConfig.isOmitDateTimeTypePrecision(),
+                        false),
+                booleanProperty(
+                        USE_LEGACY_WINDOW_FILTER_PUSHDOWN,
+                        "Use legacy window filter pushdown optimizer",
+                        featuresConfig.isUseLegacyWindowFilterPushdown(),
                         false));
     }
 
@@ -881,6 +887,11 @@ public final class SystemSessionProperties
             return OptionalInt.empty();
         }
         return OptionalInt.of(value);
+    }
+
+    public static boolean useLegacyWindowFilterPushdown(Session session)
+    {
+        return session.getSystemProperty(USE_LEGACY_WINDOW_FILTER_PUSHDOWN, Boolean.class);
     }
 
     private static void validateValueIsPowerOfTwo(Object value, String property)

--- a/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/io/prestosql/sql/analyzer/FeaturesConfig.java
@@ -127,6 +127,7 @@ public class FeaturesConfig
     private boolean ignoreDownstreamPreferences;
     private boolean iterativeRuleBasedColumnPruning = true;
     private boolean rewriteFilteringSemiJoinToInnerJoin = true;
+    private boolean useLegacyWindowFilterPushdown;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
     private DataSize filterAndProjectMinOutputPageSize = DataSize.of(500, KILOBYTE);
@@ -962,6 +963,18 @@ public class FeaturesConfig
     public FeaturesConfig setIterativeRuleBasedColumnPruning(boolean iterativeRuleBasedColumnPruning)
     {
         this.iterativeRuleBasedColumnPruning = iterativeRuleBasedColumnPruning;
+        return this;
+    }
+
+    public boolean isUseLegacyWindowFilterPushdown()
+    {
+        return useLegacyWindowFilterPushdown;
+    }
+
+    @Config("optimizer.use-legacy-window-filter-pushdown")
+    public FeaturesConfig setUseLegacyWindowFilterPushdown(boolean useLegacyWindowFilterPushdown)
+    {
+        this.useLegacyWindowFilterPushdown = useLegacyWindowFilterPushdown;
         return this;
     }
 

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushdownFilterIntoRowNumber.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushdownFilterIntoRowNumber.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.Session;
+import io.prestosql.matching.Capture;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.Range;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.predicate.ValueSet;
+import io.prestosql.spi.type.TypeOperators;
+import io.prestosql.sql.ExpressionUtils;
+import io.prestosql.sql.planner.DomainTranslator;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.TypeProvider;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.FilterNode;
+import io.prestosql.sql.planner.plan.RowNumberNode;
+import io.prestosql.sql.planner.plan.ValuesNode;
+import io.prestosql.sql.tree.BooleanLiteral;
+import io.prestosql.sql.tree.Expression;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.base.Verify.verify;
+import static io.prestosql.matching.Capture.newCapture;
+import static io.prestosql.spi.predicate.Marker.Bound.BELOW;
+import static io.prestosql.spi.predicate.Range.range;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.sql.planner.DomainTranslator.fromPredicate;
+import static io.prestosql.sql.planner.plan.Patterns.filter;
+import static io.prestosql.sql.planner.plan.Patterns.rowNumber;
+import static io.prestosql.sql.planner.plan.Patterns.source;
+import static java.lang.Math.toIntExact;
+
+public class PushdownFilterIntoRowNumber
+        implements Rule<FilterNode>
+{
+    private static final Capture<RowNumberNode> CHILD = newCapture();
+    private static final Pattern<FilterNode> PATTERN = filter().with(source().matching(rowNumber().capturedAs(CHILD)));
+    private final Metadata metadata;
+    private final DomainTranslator domainTranslator;
+    private final TypeOperators typeOperators;
+
+    public PushdownFilterIntoRowNumber(Metadata metadata, TypeOperators typeOperators)
+    {
+        this.metadata = metadata;
+        this.domainTranslator = new DomainTranslator(metadata);
+        this.typeOperators = typeOperators;
+    }
+
+    @Override
+    public Pattern<FilterNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(FilterNode node, Captures captures, Context context)
+    {
+        Session session = context.getSession();
+        TypeProvider types = context.getSymbolAllocator().getTypes();
+
+        DomainTranslator.ExtractionResult extractionResult = fromPredicate(metadata, typeOperators, session, node.getPredicate(), types);
+        TupleDomain<Symbol> tupleDomain = extractionResult.getTupleDomain();
+
+        RowNumberNode source = captures.get(CHILD);
+        Symbol rowNumberSymbol = source.getRowNumberSymbol();
+        OptionalInt upperBound = extractUpperBound(tupleDomain, rowNumberSymbol);
+
+        if (upperBound.isEmpty()) {
+            return Result.empty();
+        }
+
+        if (upperBound.getAsInt() <= 0) {
+            return Result.ofPlanNode(new ValuesNode(node.getId(), node.getOutputSymbols(), ImmutableList.of()));
+        }
+
+        boolean needRewriteSource = true;
+        if (source.getMaxRowCountPerPartition().isPresent()) {
+            int newRowCountPerPartition = Math.min(source.getMaxRowCountPerPartition().get(), upperBound.getAsInt());
+            // No need to rewrite only source node if rowCountPerPartition results in identical.
+            needRewriteSource = source.getMaxRowCountPerPartition().get() != newRowCountPerPartition;
+            if (needRewriteSource) {
+                source = new RowNumberNode(
+                        source.getId(),
+                        source.getSource(),
+                        source.getPartitionBy(),
+                        source.isOrderSensitive(),
+                        source.getRowNumberSymbol(),
+                        Optional.of(newRowCountPerPartition),
+                        source.getHashSymbol());
+            }
+        }
+        else {
+            // Pushdown the upper bound of the filter
+            source = new RowNumberNode(
+                    source.getId(),
+                    source.getSource(),
+                    source.getPartitionBy(),
+                    source.isOrderSensitive(),
+                    source.getRowNumberSymbol(),
+                    Optional.of(upperBound.getAsInt()),
+                    source.getHashSymbol());
+        }
+
+        if (!allRowNumberValuesInDomain(tupleDomain, rowNumberSymbol, source.getMaxRowCountPerPartition().get())) {
+            if (needRewriteSource) {
+                return Result.ofPlanNode(new FilterNode(node.getId(), source, node.getPredicate()));
+            }
+            else {
+                return Result.empty();
+            }
+        }
+
+        TupleDomain<Symbol> newTupleDomain = tupleDomain.filter((symbol, domain) -> !symbol.equals(rowNumberSymbol));
+        Expression newPredicate = ExpressionUtils.combineConjuncts(
+                metadata,
+                extractionResult.getRemainingExpression(),
+                domainTranslator.toPredicate(newTupleDomain));
+
+        if (newPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
+            return Result.ofPlanNode(source);
+        }
+
+        if (!newPredicate.equals(node.getPredicate())) {
+            return Result.ofPlanNode(new FilterNode(node.getId(), source, newPredicate));
+        }
+
+        return Result.empty();
+    }
+
+    private static boolean allRowNumberValuesInDomain(TupleDomain<Symbol> tupleDomain, Symbol symbol, long upperBound)
+    {
+        if (tupleDomain.isNone()) {
+            return false;
+        }
+        Domain domain = tupleDomain.getDomains().get().get(symbol);
+        if (domain == null) {
+            return true;
+        }
+        return domain.getValues().contains(ValueSet.ofRanges(range(domain.getType(), 1L, true, upperBound, true)));
+    }
+
+    private static OptionalInt extractUpperBound(TupleDomain<Symbol> tupleDomain, Symbol symbol)
+    {
+        if (tupleDomain.isNone()) {
+            return OptionalInt.empty();
+        }
+
+        Domain rowNumberDomain = tupleDomain.getDomains().get().get(symbol);
+        if (rowNumberDomain == null) {
+            return OptionalInt.empty();
+        }
+        ValueSet values = rowNumberDomain.getValues();
+        if (values.isAll() || values.isNone() || values.getRanges().getRangeCount() <= 0) {
+            return OptionalInt.empty();
+        }
+
+        Range span = values.getRanges().getSpan();
+
+        if (span.getHigh().isUpperUnbounded()) {
+            return OptionalInt.empty();
+        }
+
+        verify(rowNumberDomain.getType().equals(BIGINT));
+        long upperBound = (Long) span.getHigh().getValue();
+        if (span.getHigh().getBound() == BELOW) {
+            upperBound--;
+        }
+
+        if (upperBound >= Integer.MIN_VALUE && upperBound <= Integer.MAX_VALUE) {
+            return OptionalInt.of(toIntExact(upperBound));
+        }
+        return OptionalInt.empty();
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushdownFilterIntoWindow.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushdownFilterIntoWindow.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.Session;
+import io.prestosql.matching.Capture;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.metadata.FunctionId;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.spi.predicate.Domain;
+import io.prestosql.spi.predicate.Range;
+import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.spi.predicate.ValueSet;
+import io.prestosql.spi.type.TypeOperators;
+import io.prestosql.sql.ExpressionUtils;
+import io.prestosql.sql.planner.DomainTranslator;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.TypeProvider;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.FilterNode;
+import io.prestosql.sql.planner.plan.TopNRowNumberNode;
+import io.prestosql.sql.planner.plan.ValuesNode;
+import io.prestosql.sql.planner.plan.WindowNode;
+import io.prestosql.sql.tree.BooleanLiteral;
+import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.QualifiedName;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.prestosql.SystemSessionProperties.isOptimizeTopNRowNumber;
+import static io.prestosql.matching.Capture.newCapture;
+import static io.prestosql.spi.predicate.Marker.Bound.BELOW;
+import static io.prestosql.spi.predicate.Range.range;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.sql.planner.DomainTranslator.fromPredicate;
+import static io.prestosql.sql.planner.plan.Patterns.filter;
+import static io.prestosql.sql.planner.plan.Patterns.source;
+import static io.prestosql.sql.planner.plan.Patterns.window;
+import static java.lang.Math.toIntExact;
+
+public class PushdownFilterIntoWindow
+        implements Rule<FilterNode>
+{
+    private final Capture<WindowNode> childCapture;
+    private final Pattern<FilterNode> pattern;
+
+    private final Metadata metadata;
+    private final DomainTranslator domainTranslator;
+    private final FunctionId rowNumberFunctionId;
+    private final TypeOperators typeOperators;
+
+    public PushdownFilterIntoWindow(Metadata metadata, TypeOperators typeOperators)
+    {
+        this.metadata = metadata;
+        this.domainTranslator = new DomainTranslator(metadata);
+        this.rowNumberFunctionId = metadata.resolveFunction(QualifiedName.of("row_number"), ImmutableList.of()).getFunctionId();
+        this.childCapture = newCapture();
+        this.pattern = filter()
+                .with(source().matching(window()
+                        .matching(window -> window.getWindowFunctions().size() == 1 && getOnlyElement(window.getWindowFunctions().values()).getResolvedFunction().getFunctionId().equals(rowNumberFunctionId))
+                        .capturedAs(childCapture)));
+        this.typeOperators = typeOperators;
+    }
+
+    @Override
+    public Pattern<FilterNode> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isOptimizeTopNRowNumber(session);
+    }
+
+    @Override
+    public Result apply(FilterNode node, Captures captures, Context context)
+    {
+        Session session = context.getSession();
+        TypeProvider types = context.getSymbolAllocator().getTypes();
+
+        WindowNode windowNode = captures.get(childCapture);
+
+        DomainTranslator.ExtractionResult extractionResult = fromPredicate(metadata, typeOperators, session, node.getPredicate(), types);
+        TupleDomain<Symbol> tupleDomain = extractionResult.getTupleDomain();
+
+        Symbol rowNumberSymbol = getOnlyElement(windowNode.getWindowFunctions().entrySet()).getKey();
+        OptionalInt upperBound = extractUpperBound(tupleDomain, rowNumberSymbol);
+
+        if (upperBound.isPresent()) {
+            if (upperBound.getAsInt() <= 0) {
+                return Result.ofPlanNode(new ValuesNode(node.getId(), node.getOutputSymbols(), ImmutableList.of()));
+            }
+            if (windowNode.getOrderingScheme().isPresent()) {
+                TopNRowNumberNode newSource = new TopNRowNumberNode(
+                        windowNode.getId(),
+                        windowNode.getSource(),
+                        windowNode.getSpecification(),
+                        getOnlyElement(windowNode.getWindowFunctions().keySet()),
+                        upperBound.getAsInt(),
+                        false,
+                        Optional.empty());
+
+                if (!allRowNumberValuesInDomain(tupleDomain, rowNumberSymbol, upperBound.getAsInt())) {
+                    return Result.ofPlanNode(new FilterNode(node.getId(), newSource, node.getPredicate()));
+                }
+
+                // Remove the row number domain because it is absorbed into the node
+                TupleDomain<Symbol> newTupleDomain = tupleDomain.filter((symbol, domain) -> !symbol.equals(rowNumberSymbol));
+                Expression newPredicate = ExpressionUtils.combineConjuncts(
+                        metadata,
+                        extractionResult.getRemainingExpression(),
+                        domainTranslator.toPredicate(newTupleDomain));
+
+                if (newPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
+                    return Result.ofPlanNode(newSource);
+                }
+                return Result.ofPlanNode(new FilterNode(node.getId(), newSource, newPredicate));
+            }
+        }
+        return Result.empty();
+    }
+
+    private static boolean allRowNumberValuesInDomain(TupleDomain<Symbol> tupleDomain, Symbol symbol, long upperBound)
+    {
+        if (tupleDomain.isNone()) {
+            return false;
+        }
+        Domain domain = tupleDomain.getDomains().get().get(symbol);
+        if (domain == null) {
+            return true;
+        }
+        return domain.getValues().contains(ValueSet.ofRanges(range(domain.getType(), 1L, true, upperBound, true)));
+    }
+
+    private static OptionalInt extractUpperBound(TupleDomain<Symbol> tupleDomain, Symbol symbol)
+    {
+        if (tupleDomain.isNone()) {
+            return OptionalInt.empty();
+        }
+
+        Domain rowNumberDomain = tupleDomain.getDomains().get().get(symbol);
+        if (rowNumberDomain == null) {
+            return OptionalInt.empty();
+        }
+        ValueSet values = rowNumberDomain.getValues();
+        if (values.isAll() || values.isNone() || values.getRanges().getRangeCount() <= 0) {
+            return OptionalInt.empty();
+        }
+
+        Range span = values.getRanges().getSpan();
+
+        if (span.getHigh().isUpperUnbounded()) {
+            return OptionalInt.empty();
+        }
+
+        verify(rowNumberDomain.getType().equals(BIGINT));
+        long upperBound = (Long) span.getHigh().getValue();
+        if (span.getHigh().getBound() == BELOW) {
+            upperBound--;
+        }
+
+        if (upperBound >= Integer.MIN_VALUE && upperBound <= Integer.MAX_VALUE) {
+            return OptionalInt.of(toIntExact(upperBound));
+        }
+        return OptionalInt.empty();
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushdownLimitIntoRowNumber.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushdownLimitIntoRowNumber.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.matching.Capture;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.LimitNode;
+import io.prestosql.sql.planner.plan.RowNumberNode;
+
+import java.util.Optional;
+
+import static io.prestosql.matching.Capture.newCapture;
+import static io.prestosql.sql.planner.plan.ChildReplacer.replaceChildren;
+import static io.prestosql.sql.planner.plan.Patterns.limit;
+import static io.prestosql.sql.planner.plan.Patterns.rowNumber;
+import static io.prestosql.sql.planner.plan.Patterns.source;
+import static java.lang.Math.toIntExact;
+
+public class PushdownLimitIntoRowNumber
+        implements Rule<LimitNode>
+{
+    private static final Capture<RowNumberNode> CHILD = newCapture();
+    private static final Pattern<LimitNode> PATTERN = limit()
+            .matching(limit -> !limit.isWithTies() && limit.getCount() != 0 && limit.getCount() <= Integer.MAX_VALUE)
+            .with(source().matching(rowNumber().capturedAs(CHILD)));
+
+    @Override
+    public Pattern<LimitNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(LimitNode node, Captures captures, Context context)
+    {
+        RowNumberNode source = captures.get(CHILD);
+        int limit = toIntExact(node.getCount());
+        RowNumberNode rowNumberNode = mergeLimit(source, limit);
+        if (rowNumberNode.getPartitionBy().isEmpty()) {
+            return Result.ofPlanNode(rowNumberNode);
+        }
+        if (source.getMaxRowCountPerPartition().isPresent()) {
+            if (rowNumberNode.getMaxRowCountPerPartition().get().equals(source.getMaxRowCountPerPartition().get())) {
+                // No need to replace the source node.
+                return Result.empty();
+            }
+        }
+        return Result.ofPlanNode(replaceChildren(node, ImmutableList.of(rowNumberNode)));
+    }
+
+    private static RowNumberNode mergeLimit(RowNumberNode node, int newRowCountPerPartition)
+    {
+        if (node.getMaxRowCountPerPartition().isPresent()) {
+            newRowCountPerPartition = Math.min(node.getMaxRowCountPerPartition().get(), newRowCountPerPartition);
+        }
+        return new RowNumberNode(
+                node.getId(),
+                node.getSource(),
+                node.getPartitionBy(),
+                node.isOrderSensitive(),
+                node.getRowNumberSymbol(),
+                Optional.of(newRowCountPerPartition),
+                node.getHashSymbol());
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushdownLimitIntoWindow.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PushdownLimitIntoWindow.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.Session;
+import io.prestosql.matching.Capture;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.metadata.FunctionId;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.LimitNode;
+import io.prestosql.sql.planner.plan.TopNRowNumberNode;
+import io.prestosql.sql.planner.plan.WindowNode;
+import io.prestosql.sql.tree.QualifiedName;
+
+import java.util.Optional;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.prestosql.SystemSessionProperties.isOptimizeTopNRowNumber;
+import static io.prestosql.matching.Capture.newCapture;
+import static io.prestosql.sql.planner.plan.ChildReplacer.replaceChildren;
+import static io.prestosql.sql.planner.plan.Patterns.limit;
+import static io.prestosql.sql.planner.plan.Patterns.source;
+import static io.prestosql.sql.planner.plan.Patterns.window;
+import static java.lang.Math.toIntExact;
+
+public class PushdownLimitIntoWindow
+        implements Rule<LimitNode>
+{
+    private final Capture<WindowNode> childCapture;
+    private final Pattern<LimitNode> pattern;
+
+    private final FunctionId rowNumberFunctionId;
+
+    public PushdownLimitIntoWindow(Metadata metadata)
+    {
+        this.rowNumberFunctionId = metadata.resolveFunction(QualifiedName.of("row_number"), ImmutableList.of()).getFunctionId();
+        this.childCapture = newCapture();
+        this.pattern = limit()
+                .matching(limit -> !limit.isWithTies() && limit.getCount() != 0 && limit.getCount() <= Integer.MAX_VALUE)
+                .with(source().matching(window()
+                        .matching(window -> window.getOrderingScheme().isPresent())
+                        .matching(window -> window.getWindowFunctions().size() == 1 && getOnlyElement(window.getWindowFunctions().values()).getResolvedFunction().getFunctionId().equals(rowNumberFunctionId))
+                        .capturedAs(childCapture)));
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isOptimizeTopNRowNumber(session);
+    }
+
+    @Override
+    public Pattern<LimitNode> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Result apply(LimitNode node, Captures captures, Context context)
+    {
+        WindowNode source = captures.get(childCapture);
+        int limit = toIntExact(node.getCount());
+        TopNRowNumberNode topNRowNumberNode = new TopNRowNumberNode(
+                source.getId(),
+                source.getSource(),
+                source.getSpecification(),
+                getOnlyElement(source.getWindowFunctions().keySet()),
+                limit,
+                false,
+                Optional.empty());
+        if (source.getPartitionBy().isEmpty()) {
+            return Result.ofPlanNode(topNRowNumberNode);
+        }
+        return Result.ofPlanNode(replaceChildren(node, ImmutableList.of(topNRowNumberNode)));
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ReplaceWindowWithRowNumber.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/ReplaceWindowWithRowNumber.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.RowNumberNode;
+import io.prestosql.sql.planner.plan.WindowNode;
+import io.prestosql.sql.tree.QualifiedName;
+
+import java.util.Optional;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.prestosql.sql.planner.plan.Patterns.window;
+
+public class ReplaceWindowWithRowNumber
+        implements Rule<WindowNode>
+{
+    private final Pattern<WindowNode> pattern;
+
+    public ReplaceWindowWithRowNumber(Metadata metadata)
+    {
+        this.pattern = window()
+                .matching(window -> window.getWindowFunctions().size() == 1 && getOnlyElement(window.getWindowFunctions().values()).getResolvedFunction().getFunctionId().equals(metadata.resolveFunction(QualifiedName.of("row_number"), ImmutableList.of()).getFunctionId()))
+                .matching(window -> window.getOrderingScheme().isEmpty());
+    }
+
+    @Override
+    public Pattern<WindowNode> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Result apply(WindowNode node, Captures captures, Context context)
+    {
+        return Result.ofPlanNode(new RowNumberNode(
+                node.getId(),
+                node.getSource(),
+                node.getPartitionBy(),
+                false,
+                getOnlyElement(node.getWindowFunctions().keySet()),
+                Optional.empty(),
+                Optional.empty()));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/io/prestosql/sql/analyzer/TestFeaturesConfig.java
@@ -105,7 +105,8 @@ public class TestFeaturesConfig
                 .setIgnoreDownstreamPreferences(false)
                 .setOmitDateTimeTypePrecision(false)
                 .setIterativeRuleBasedColumnPruning(true)
-                .setRewriteFilteringSemiJoinToInnerJoin(true));
+                .setRewriteFilteringSemiJoinToInnerJoin(true)
+                .setUseLegacyWindowFilterPushdown(false));
     }
 
     @Test
@@ -176,6 +177,7 @@ public class TestFeaturesConfig
                 .put("deprecated.omit-datetime-type-precision", "true")
                 .put("optimizer.iterative-rule-based-column-pruning", "false")
                 .put("optimizer.rewrite-filtering-semi-join-to-inner-join", "false")
+                .put("optimizer.use-legacy-window-filter-pushdown", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -242,7 +244,9 @@ public class TestFeaturesConfig
                 .setIgnoreDownstreamPreferences(true)
                 .setOmitDateTimeTypePrecision(true)
                 .setIterativeRuleBasedColumnPruning(false)
-                .setRewriteFilteringSemiJoinToInnerJoin(false);
+                .setRewriteFilteringSemiJoinToInnerJoin(false)
+                .setUseLegacyWindowFilterPushdown(true);
+
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushdownFilterIntoRowNumber.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushdownFilterIntoRowNumber.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.spi.type.TypeOperators;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.assertions.RowNumberSymbolMatcher;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.rowNumber;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expression;
+
+public class TestPushdownFilterIntoRowNumber
+        extends BaseRuleTest
+{
+    @Test
+    public void testSourceRowNumber()
+    {
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(
+                            expression("row_number_1 < cast(100 as bigint)"),
+                            p.rowNumber(
+                                    ImmutableList.of(a),
+                                    Optional.empty(),
+                                    rowNumberSymbol,
+                                    p.values(a)));
+                })
+                .matches(
+                        rowNumber(rowNumber -> rowNumber
+                                        .maxRowCountPerPartition(Optional.of(99))
+                                        .partitionBy(ImmutableList.of("a")),
+                        values("a")));
+
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(
+                            expression("row_number_1 < cast(100 as bigint)"),
+                            p.rowNumber(
+                                    ImmutableList.of(a),
+                                    Optional.of(10),
+                                    rowNumberSymbol,
+                                    p.values(a)));
+                })
+                .matches(
+                        rowNumber(rowNumber -> rowNumber
+                                        .maxRowCountPerPartition(Optional.of(10))
+                                        .partitionBy(ImmutableList.of("a")),
+                        values("a")));
+
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(
+                            expression("cast(3 as bigint) < row_number_1 and row_number_1 < cast(5 as bigint)"),
+                            p.rowNumber(
+                                    ImmutableList.of(a),
+                                    Optional.of(10),
+                                    rowNumberSymbol,
+                                    p.values(a)));
+                })
+                .matches(
+                        filter(
+                                "cast(3 as bigint) < row_number_1 and row_number_1 < cast(5 as bigint)",
+                                rowNumber(rowNumber -> rowNumber
+                                                .maxRowCountPerPartition(Optional.of(4))
+                                                .partitionBy(ImmutableList.of("a")),
+                                        values("a"))
+                                        .withAlias("row_number_1", new RowNumberSymbolMatcher())));
+
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(
+                            expression("row_number_1 < cast(5 as bigint) and a = 1"),
+                            p.rowNumber(
+                                    ImmutableList.of(a),
+                                    Optional.of(10),
+                                    rowNumberSymbol,
+                                    p.values(a)));
+                })
+                .matches(
+                        filter(
+                                "a = 1",
+                                rowNumber(rowNumber -> rowNumber
+                                                .maxRowCountPerPartition(Optional.of(4))
+                                                .partitionBy(ImmutableList.of("a")),
+                                        values("a"))
+                                        .withAlias("row_number_1", new RowNumberSymbolMatcher())));
+    }
+
+    @Test
+    public void testNoOutputsThroughRowNumber()
+    {
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(expression("row_number_1 < cast(-100 as bigint)"),
+                            p.rowNumber(ImmutableList.of(p.symbol("a")), Optional.empty(), rowNumberSymbol,
+                                    p.values(p.symbol("a"))));
+                })
+                .matches(values("a", "row_number_1"));
+    }
+
+    @Test
+    public void testDoNotFire()
+    {
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(expression("not_row_number < cast(100 as bigint)"),
+                            p.rowNumber(ImmutableList.of(p.symbol("a")), Optional.empty(), rowNumberSymbol,
+                                    p.values(p.symbol("a"), p.symbol("not_row_number"))));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(expression("row_number_1 > cast(100 as bigint)"),
+                            p.rowNumber(ImmutableList.of(p.symbol("a")), Optional.empty(), rowNumberSymbol,
+                                    p.values(p.symbol("a"))));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(
+                            expression("cast(3 as bigint) < row_number_1 and row_number_1 < cast(5 as bigint)"),
+                            p.rowNumber(
+                                    ImmutableList.of(a),
+                                    Optional.of(4),
+                                    rowNumberSymbol,
+                                    p.values(a)));
+                })
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushdownFilterIntoWindow.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushdownFilterIntoWindow.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.metadata.ResolvedFunction;
+import io.prestosql.spi.connector.SortOrder;
+import io.prestosql.spi.type.TypeOperators;
+import io.prestosql.sql.planner.OrderingScheme;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.assertions.TopNRowNumberSymbolMatcher;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.ValuesNode;
+import io.prestosql.sql.planner.plan.WindowNode;
+import io.prestosql.sql.tree.QualifiedName;
+import io.prestosql.sql.tree.WindowFrame;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.node;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.topNRowNumber;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static io.prestosql.sql.tree.FrameBound.Type.CURRENT_ROW;
+import static io.prestosql.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
+
+public class TestPushdownFilterIntoWindow
+        extends BaseRuleTest
+{
+    @Test
+    public void testEliminateFilter()
+    {
+        ResolvedFunction rowNumber = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownFilterIntoWindow(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    Symbol a = p.symbol("a", BIGINT);
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.filter(expression("row_number_1 < cast(100 as bigint)"), p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumber, a)),
+                            p.values(p.symbol("a"))));
+                })
+                .matches(topNRowNumber(pattern -> pattern
+                                .maxRowCountPerPartition(99)
+                                .partial(false),
+                        values("a")));
+    }
+
+    @Test
+    public void testKeepFilter()
+    {
+        ResolvedFunction rowNumber = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownFilterIntoWindow(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    Symbol a = p.symbol("a", BIGINT);
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.filter(expression("cast(3 as bigint) < row_number_1 and row_number_1 < cast(100 as bigint)"), p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumber, a)),
+                            p.values(p.symbol("a"))));
+                })
+                .matches(filter(
+                        "cast(3 as bigint) < row_number_1 and row_number_1 < cast(100 as bigint)",
+                        topNRowNumber(pattern -> pattern
+                                .partial(false)
+                                .maxRowCountPerPartition(99)
+                                .specification(
+                                        ImmutableList.of("a"),
+                                        ImmutableList.of("a"),
+                                        ImmutableMap.of("a", SortOrder.ASC_NULLS_FIRST)),
+                                values("a")).withAlias("row_number_1", new TopNRowNumberSymbolMatcher())));
+
+        tester().assertThat(new PushdownFilterIntoWindow(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    Symbol a = p.symbol("a", BIGINT);
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.filter(expression("row_number_1 < cast(100 as bigint) and a = 1"), p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumber, a)),
+                            p.values(p.symbol("a"))));
+                })
+                .matches(filter(
+                        "a = 1",
+                        topNRowNumber(pattern -> pattern
+                                        .partial(false)
+                                        .maxRowCountPerPartition(99)
+                                        .specification(
+                                                ImmutableList.of("a"),
+                                                ImmutableList.of("a"),
+                                                ImmutableMap.of("a", SortOrder.ASC_NULLS_FIRST)),
+                                values("a")).withAlias("row_number_1", new TopNRowNumberSymbolMatcher())));
+    }
+
+    @Test
+    public void testNoOutputsThroughWindow()
+    {
+        ResolvedFunction rowNumber = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownFilterIntoWindow(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    Symbol a = p.symbol("a");
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.filter(
+                            expression("row_number_1 < cast(-100 as bigint)"),
+                            p.window(
+                                    new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                                    ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumber, a)),
+                                    p.values(a)));
+                })
+                .matches(node(ValuesNode.class));
+    }
+
+    @Test
+    public void testNoUpperBound()
+    {
+        ResolvedFunction rowNumber = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownFilterIntoWindow(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    Symbol a = p.symbol("a");
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.filter(
+                            expression("cast(3 as bigint) < row_number_1"),
+                            p.window(
+                                    new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                                    ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumber, a)),
+                                    p.values(a)));
+                })
+                .doesNotFire();
+    }
+
+    private static WindowNode.Function newWindowNodeFunction(ResolvedFunction resolvedFunction, Symbol symbol)
+    {
+        return new WindowNode.Function(
+                resolvedFunction,
+                ImmutableList.of(symbol.toSymbolReference()),
+                new WindowNode.Frame(
+                        WindowFrame.Type.RANGE,
+                        UNBOUNDED_PRECEDING,
+                        Optional.empty(),
+                        Optional.empty(),
+                        CURRENT_ROW,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                false);
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushdownLimitIntoRowNumber.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushdownLimitIntoRowNumber.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.limit;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.rowNumber;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPushdownLimitIntoRowNumber
+        extends BaseRuleTest
+{
+    @Test
+    public void testLimitAboveRowNumber()
+    {
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p ->
+                        p.limit(
+                                3,
+                                p.rowNumber(
+                                ImmutableList.of(),
+                                Optional.of(5),
+                                p.symbol("row_number"),
+                                p.values(p.symbol("a")))))
+                .matches(
+                        rowNumber(rowNumber -> rowNumber
+                                        .partitionBy(ImmutableList.of())
+                                        .maxRowCountPerPartition(Optional.of(3)),
+                        values("a")));
+
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    return p.limit(
+                            3,
+                            p.rowNumber(
+                            ImmutableList.of(a),
+                            Optional.of(5),
+                            p.symbol("row_number"), p.values(a)));
+                })
+                .matches(
+                        limit(
+                                3,
+                                rowNumber(rowNumber -> rowNumber
+                                                .partitionBy(ImmutableList.of("a"))
+                                                .maxRowCountPerPartition(Optional.of(3)),
+                        values("a"))));
+
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    return p.limit(
+                            3,
+                            p.rowNumber(
+                            ImmutableList.of(a),
+                            Optional.empty(),
+                            p.symbol("row_number"), p.values(a)));
+                })
+                .matches(
+                        limit(
+                                3,
+                                rowNumber(rowNumber -> rowNumber
+                                                .partitionBy(ImmutableList.of("a"))
+                                                .maxRowCountPerPartition(Optional.of(3)),
+                        values("a"))));
+
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    return p.limit(
+                            5,
+                            p.rowNumber(
+                            ImmutableList.of(),
+                            Optional.of(3),
+                            p.symbol("row_number"), p.values(a)));
+                })
+                .matches(
+                        rowNumber(rowNumber -> rowNumber
+                                        .partitionBy(ImmutableList.of())
+                                        .maxRowCountPerPartition(Optional.of(3)),
+                        values("a")));
+    }
+
+    @Test
+    public void testZeroLimit()
+    {
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p ->
+                        p.limit(
+                                0,
+                                p.rowNumber(ImmutableList.of(), Optional.of(5),
+                                p.symbol("row_number"), p.values(p.symbol("a")))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testTiesLimit()
+    {
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p ->
+                        p.limit(
+                                0,
+                                ImmutableList.of(p.symbol("a")),
+                                p.rowNumber(
+                                        ImmutableList.of(),
+                                        Optional.of(5),
+                                        p.symbol("row_number"),
+                                        p.values(p.symbol("a")))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testIdenticalLimit()
+    {
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p ->
+                        p.limit(
+                                5,
+                                ImmutableList.of(p.symbol("a")),
+                                p.rowNumber(
+                                        ImmutableList.of(),
+                                        Optional.of(5),
+                                        p.symbol("row_number"),
+                                        p.values(p.symbol("a")))))
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushdownLimitIntoWindow.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPushdownLimitIntoWindow.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.metadata.ResolvedFunction;
+import io.prestosql.spi.connector.SortOrder;
+import io.prestosql.sql.planner.OrderingScheme;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.WindowNode;
+import io.prestosql.sql.tree.QualifiedName;
+import io.prestosql.sql.tree.WindowFrame;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.prestosql.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.limit;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.topNRowNumber;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.tree.FrameBound.Type.CURRENT_ROW;
+import static io.prestosql.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
+
+public class TestPushdownLimitIntoWindow
+        extends BaseRuleTest
+{
+    @Test
+    public void testLimitAboveWindow()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownLimitIntoWindow(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.limit(
+                            3,
+                            p.window(
+                                    new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                                    ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction, a)),
+                                    p.values(a)));
+                })
+                .matches(
+                        limit(3, topNRowNumber(
+                                pattern -> pattern
+                                        .specification(
+                                                ImmutableList.of("a"),
+                                                ImmutableList.of("a"),
+                                                ImmutableMap.of("a", SortOrder.ASC_NULLS_FIRST))
+                                        .maxRowCountPerPartition(3)
+                                        .partial(false), values("a"))));
+    }
+
+    @Test
+    public void testConvertToTopNRowNumber()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownLimitIntoWindow(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.limit(3, p.window(
+                            new WindowNode.Specification(ImmutableList.of(), Optional.of(orderingScheme)),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction, a)),
+                            p.values(a)));
+                })
+                .matches(
+                        topNRowNumber(pattern -> pattern
+                                .specification(
+                                        ImmutableList.of(),
+                                        ImmutableList.of("a"),
+                                        ImmutableMap.of("a", SortOrder.ASC_NULLS_FIRST))
+                        .maxRowCountPerPartition(3)
+                        .partial(false), values("a")));
+    }
+
+    @Test
+    public void testZeroLimit()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownLimitIntoWindow(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.limit(
+                            0,
+                            p.window(
+                                    new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                                    ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction, a)),
+                                    p.values(a)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testWindowNotOrdered()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownLimitIntoWindow(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.limit(
+                            3,
+                            p.window(
+                                    new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                                    ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction, a)),
+                                    p.values(a)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testMultipleWindowFunctions()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        ResolvedFunction rankFunction = tester().getMetadata().resolveFunction(QualifiedName.of("rank"), fromTypes());
+        tester().assertThat(new PushdownLimitIntoWindow(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    Symbol rankSymbol = p.symbol("rank_1");
+                    return p.limit(
+                            3,
+                            p.window(
+                                    new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                                    ImmutableMap.of(
+                                            rowNumberSymbol,
+                                            newWindowNodeFunction(rowNumberFunction, a),
+                                            rankSymbol,
+                                            newWindowNodeFunction(rankFunction, a)),
+                                    p.values(a)));
+                })
+                .doesNotFire();
+    }
+
+    private static WindowNode.Function newWindowNodeFunction(ResolvedFunction resolvedFunction, Symbol symbol)
+    {
+        return new WindowNode.Function(
+                resolvedFunction,
+                ImmutableList.of(symbol.toSymbolReference()),
+                new WindowNode.Frame(
+                        WindowFrame.Type.RANGE,
+                        UNBOUNDED_PRECEDING,
+                        Optional.empty(),
+                        Optional.empty(),
+                        CURRENT_ROW,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                false);
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestReplaceWindowWithRowNumber.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestReplaceWindowWithRowNumber.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.metadata.ResolvedFunction;
+import io.prestosql.spi.connector.SortOrder;
+import io.prestosql.sql.planner.OrderingScheme;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.WindowNode;
+import io.prestosql.sql.tree.QualifiedName;
+import io.prestosql.sql.tree.WindowFrame;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.prestosql.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.rowNumber;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.tree.FrameBound.Type.CURRENT_ROW;
+import static io.prestosql.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
+
+public class TestReplaceWindowWithRowNumber
+        extends BaseRuleTest
+{
+    @Test
+    public void test()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new ReplaceWindowWithRowNumber(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction, a)),
+                            p.values(a));
+                })
+                .matches(rowNumber(
+                        pattern -> pattern
+                                .maxRowCountPerPartition(Optional.empty())
+                                .partitionBy(ImmutableList.of("a")),
+                        values("a")));
+
+        tester().assertThat(new ReplaceWindowWithRowNumber(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.window(
+                            new WindowNode.Specification(ImmutableList.of(), Optional.empty()),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction, a)),
+                            p.values(a));
+                })
+                .matches(rowNumber(
+                        pattern -> pattern
+                                .maxRowCountPerPartition(Optional.empty())
+                                .partitionBy(ImmutableList.of()),
+                        values("a")));
+    }
+
+    @Test
+    public void testDoNotFire()
+    {
+        ResolvedFunction rank = tester().getMetadata().resolveFunction(QualifiedName.of("rank"), fromTypes());
+        tester().assertThat(new ReplaceWindowWithRowNumber(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rank1 = p.symbol("rank_1");
+                    return p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                                ImmutableMap.of(rank1, newWindowNodeFunction(rank, a)),
+                                p.values(a));
+                })
+                .doesNotFire();
+
+        ResolvedFunction rowNumber = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new ReplaceWindowWithRowNumber(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumber1 = p.symbol("row_number_1");
+                    Symbol rank1 = p.symbol("rank_1");
+                    return p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                            ImmutableMap.of(rowNumber1, newWindowNodeFunction(rowNumber, a), rank1, newWindowNodeFunction(rank, a)),
+                            p.values(a));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new ReplaceWindowWithRowNumber(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    OrderingScheme orderingScheme = new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    Symbol rowNumber1 = p.symbol("row_number_1");
+                    return p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            ImmutableMap.of(rowNumber1, newWindowNodeFunction(rowNumber, a)),
+                            p.values(a));
+                })
+                .doesNotFire();
+    }
+
+    private static WindowNode.Function newWindowNodeFunction(ResolvedFunction resolvedFunction, Symbol symbol)
+    {
+        return new WindowNode.Function(
+                resolvedFunction,
+                ImmutableList.of(symbol.toSymbolReference()),
+                new WindowNode.Frame(
+                        WindowFrame.Type.RANGE,
+                        UNBOUNDED_PRECEDING,
+                        Optional.empty(),
+                        Optional.empty(),
+                        CURRENT_ROW,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                false);
+    }
+}


### PR DESCRIPTION
Migrate WindowFilterPushdown rule to new iterative rule framework keeping the optimization behavior as it is. WindowFilterPushdown is decomposed into

- PushdownFilterThroughRowNumber
- PushdownFilterThroughWindow
- PushdownLimitThroughRowNumber
- PushdownLimitThroughWindow
- ReplaceWindowWithRowNumber

See: https://github.com/prestosql/presto/issues/811