### PR TITLE
Prune unnest mappings using lambda expressions

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/PlanOptimizers.java
@@ -105,6 +105,7 @@ import io.prestosql.sql.planner.iterative.rule.PruneTopNRowNumberColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneUnionColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneUnionSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneUnnestColumns;
+import io.prestosql.sql.planner.iterative.rule.PruneUnnestMappings;
 import io.prestosql.sql.planner.iterative.rule.PruneUnnestSourceColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneValuesColumns;
 import io.prestosql.sql.planner.iterative.rule.PruneWindowColumns;
@@ -333,7 +334,8 @@ public class PlanOptimizers
                 new PushDownDereferencesThroughWindow(typeAnalyzer),
                 new PushDownDereferencesThroughTopN(typeAnalyzer),
                 new PushDownDereferencesThroughRowNumber(typeAnalyzer),
-                new PushDownDereferencesThroughTopNRowNumber(typeAnalyzer));
+                new PushDownDereferencesThroughTopNRowNumber(typeAnalyzer),
+                new PruneUnnestMappings(typeAnalyzer, metadata));
 
         IterativeOptimizer inlineProjections = new IterativeOptimizer(
                 ruleStats,

--- a/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneUnnestMappings.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/iterative/rule/PruneUnnestMappings.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.Session;
+import io.prestosql.matching.Capture;
+import io.prestosql.matching.Captures;
+import io.prestosql.matching.Pattern;
+import io.prestosql.metadata.Metadata;
+import io.prestosql.spi.type.ArrayType;
+import io.prestosql.spi.type.MapType;
+import io.prestosql.spi.type.RowType;
+import io.prestosql.spi.type.Type;
+import io.prestosql.sql.planner.FunctionCallBuilder;
+import io.prestosql.sql.planner.Symbol;
+import io.prestosql.sql.planner.SymbolAllocator;
+import io.prestosql.sql.planner.SymbolsExtractor;
+import io.prestosql.sql.planner.TypeAnalyzer;
+import io.prestosql.sql.planner.iterative.Rule;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.ProjectNode;
+import io.prestosql.sql.planner.plan.UnnestNode;
+import io.prestosql.sql.tree.DereferenceExpression;
+import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.LambdaArgumentDeclaration;
+import io.prestosql.sql.tree.LambdaExpression;
+import io.prestosql.sql.tree.QualifiedName;
+import io.prestosql.sql.tree.Row;
+import io.prestosql.sql.tree.SymbolReference;
+import io.prestosql.type.FunctionType;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.prestosql.matching.Capture.newCapture;
+import static io.prestosql.sql.QueryUtil.identifier;
+import static io.prestosql.sql.planner.ExpressionNodeInliner.replaceExpression;
+import static io.prestosql.sql.planner.iterative.rule.DereferencePushdown.extractDereferences;
+import static io.prestosql.sql.planner.iterative.rule.DereferencePushdown.getBase;
+import static io.prestosql.sql.planner.plan.Patterns.project;
+import static io.prestosql.sql.planner.plan.Patterns.source;
+import static io.prestosql.sql.planner.plan.Patterns.unnest;
+import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.groupingBy;
+
+/**
+ * Transforms:
+ * <pre>
+ *  Project(D := f1(A), E := f2(B_VARCHAR), G := f3(B_ROW.X))
+ *      Unnest(replicate = [A], unnest = (B_ARRAY -> [B_BIGINT, B_VARCHAR, B_ROW]))
+ *          Source(
+ *              A bigint,
+ *              B_ARRAY array(row(_bigint bigint, _varchar varchar, _row row(x bigint, y bigint))))
+ *  </pre>
+ * to:
+ * <pre>
+ *  Project(D := f1(A), E := f2(B_VARCHAR), G := f3(B_ROW_X))
+ *      Unnest(replicate = [A], unnest = (transformed -> [B_VARCHAR, B_ROW_X]))
+ *          Project(A, transformed := transform(e -> row(e._varchar, e._row.x)))
+ *              Source(A, B_ARAAY)
+ * </pre>
+ * <p>
+ */
+public class PruneUnnestMappings
+        implements Rule<ProjectNode>
+{
+    private static final Capture<UnnestNode> CHILD = newCapture();
+    private final TypeAnalyzer typeAnalyzer;
+    private final Metadata metadata;
+
+    public PruneUnnestMappings(TypeAnalyzer typeAnalyzer, Metadata metadata)
+    {
+        this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public Pattern<ProjectNode> getPattern()
+    {
+        return project()
+                .with(source().matching(unnest().capturedAs(CHILD)));
+    }
+
+    @Override
+    public Result apply(ProjectNode projectNode, Captures captures, Context context)
+    {
+        UnnestNode unnestNode = captures.get(CHILD);
+
+        // Extract expressions in project node's assignments and unnest node's filter
+        ImmutableList.Builder<Expression> expressionsBuilder = ImmutableList.<Expression>builder()
+                .addAll(projectNode.getAssignments().getExpressions());
+        unnestNode.getFilter().ifPresent(expressionsBuilder::add);
+        List<Expression> expressions = expressionsBuilder.build();
+
+        // Collect referenced symbols and dereference projections
+        Set<Symbol> symbolsReferenced = SymbolsExtractor.extractUnique(expressions);
+        Set<DereferenceExpression> dereferences = extractDereferences(expressions, false);
+
+        // Transform mappings with lambda representations
+        List<Optional<Transformation>> transformations = unnestNode.getMappings().stream()
+                .map(mapping -> {
+                    // Do not prune mappings for which input is being referred
+                    Symbol input = mapping.getInput();
+                    if (unnestNode.getReplicateSymbols().contains(input) || symbolsReferenced.contains(input)) {
+                        return Optional.<Transformation>empty();
+                    }
+
+                    Type inputType = context.getSymbolAllocator().getTypes().get(input);
+                    if (inputType instanceof MapType) {
+                        // TODO: Transform map values
+                        return Optional.<Transformation>empty();
+                    }
+
+                    return transformArray(mapping, symbolsReferenced, dereferences, context.getSession(), context.getSymbolAllocator());
+                })
+                .collect(toImmutableList());
+
+        if (transformations.stream().allMatch(Optional::isEmpty)) {
+            return Result.empty();
+        }
+
+        ImmutableList.Builder<UnnestNode.Mapping> newMappingsBuilder = ImmutableList.builder();
+        Assignments.Builder projectionsBuilder = Assignments.builder();
+
+        // Prepare new mappings
+        for (int i = 0; i < unnestNode.getMappings().size(); i++) {
+            UnnestNode.Mapping original = unnestNode.getMappings().get(i);
+
+            if (transformations.get(i).isEmpty()) {
+                newMappingsBuilder.add(original);
+                projectionsBuilder.putIdentity(original.getInput());
+                continue;
+            }
+
+            Transformation transformation = transformations.get(i).get();
+            UnnestNode.Mapping newMapping = transformation.getMapping();
+            newMappingsBuilder.add(newMapping);
+            projectionsBuilder.put(newMapping.getInput(), transformation.getProjection());
+        }
+
+        Map<Expression, SymbolReference> expressionReplacements = transformations.stream()
+                .filter(Optional::isPresent)
+                .flatMap(transformation -> transformation.get().getExpressionReplacements().entrySet().stream())
+                .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        ProjectNode newProjectNode = new ProjectNode(
+                context.getIdAllocator().getNextId(),
+                new UnnestNode(
+                        context.getIdAllocator().getNextId(),
+                        new ProjectNode(
+                                context.getIdAllocator().getNextId(),
+                                unnestNode.getSource(),
+                                projectionsBuilder
+                                        .putIdentities(unnestNode.getReplicateSymbols())
+                                        .build()),
+                        unnestNode.getReplicateSymbols(),
+                        newMappingsBuilder.build(),
+                        unnestNode.getOrdinalitySymbol(),
+                        unnestNode.getJoinType(),
+                        unnestNode.getFilter()
+                                .map(filter -> replaceExpression(filter, expressionReplacements))),
+                projectNode.getAssignments()
+                        .rewrite(expression -> replaceExpression(expression, expressionReplacements)));
+
+        return Result.ofPlanNode(newProjectNode);
+    }
+
+    private Optional<Transformation> transformArray(
+            UnnestNode.Mapping mapping,
+            Set<Symbol> referredSymbols,
+            Set<DereferenceExpression> dereferences,
+            Session session,
+            SymbolAllocator symbolAllocator)
+    {
+        Type inputType = symbolAllocator.getTypes().get(mapping.getInput());
+        checkArgument(inputType instanceof ArrayType, "Unexpected input type");
+        ArrayType arrayType = (ArrayType) inputType;
+
+        // Exclude primitive arrays
+        if (!(arrayType.getElementType() instanceof RowType)) {
+            return Optional.empty();
+        }
+
+        List<Symbol> outputSymbols = mapping.getOutputs();
+
+        // Prepare symbols to remove or prune
+        Set<Symbol> removeSymbols = outputSymbols.stream()
+                .filter(symbol -> !referredSymbols.contains(symbol))
+                .collect(toImmutableSet());
+        Map<Symbol, List<DereferenceExpression>> pruneSymbols = dereferences.stream()
+                .filter(expression -> outputSymbols.contains(getBase(expression)))
+                .collect(groupingBy(expression -> getBase(expression)));
+
+        if (outputSymbols.stream().allMatch(symbol -> !removeSymbols.contains(symbol) && !pruneSymbols.containsKey(symbol))) {
+            // Nothing to remove or prune
+            return Optional.empty();
+        }
+
+        // Create new symbols for dereferences to pushdown
+        Assignments dereferenceAssignments = Assignments.of(
+                pruneSymbols.values().stream()
+                    .flatMap(Collection::stream)
+                    .collect(toImmutableSet()),
+                session,
+                symbolAllocator,
+                typeAnalyzer);
+        Map<Expression, SymbolReference> dereferenceReplacements = dereferenceAssignments.getMap().entrySet().stream()
+                .collect(toImmutableMap(entry -> entry.getValue(), entry -> entry.getKey().toSymbolReference()));
+
+        // Prepare projections for transforming the array through a lambda expression
+        ImmutableList.Builder<Symbol> newOutputSymbolsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<Expression> newRowFieldsBuilder = ImmutableList.builder();
+
+        for (Symbol outputSymbol : outputSymbols) {
+            // Remove symbol if not referenced
+            if (removeSymbols.contains(outputSymbol)) {
+                continue;
+            }
+
+            // Prune Symbol if dereferences are available
+            List<DereferenceExpression> symbolDereferences = pruneSymbols.getOrDefault(outputSymbol, ImmutableList.of());
+            if (!symbolDereferences.isEmpty()) {
+                symbolDereferences.forEach(projection -> {
+                    newOutputSymbolsBuilder.add(Symbol.from(dereferenceReplacements.get(projection)));
+                    newRowFieldsBuilder.add(projection);
+                });
+                continue;
+            }
+
+            // Full Symbol is being referenced
+            newOutputSymbolsBuilder.add(outputSymbol);
+            newRowFieldsBuilder.add(outputSymbol.toSymbolReference());
+        }
+
+        List<Symbol> newOutputSymbols = newOutputSymbolsBuilder.build();
+        List<Expression> newRowFields = newRowFieldsBuilder.build();
+
+        // Retain at least one output if everything is removed
+        // TODO: replace with a constant
+        if (newOutputSymbols.isEmpty()) {
+            newOutputSymbols = ImmutableList.of(outputSymbols.get(0));
+            newRowFields = ImmutableList.of(outputSymbols.get(0).toSymbolReference());
+        }
+
+        // Construct the new element type
+        List<Type> newOutputTypes = newOutputSymbols.stream()
+                .map(symbol -> symbolAllocator.getTypes().get(symbol))
+                .collect(toImmutableList());
+
+        Type prunedElementType;
+        if (newOutputTypes.size() == 1) {
+            // Do not construct a row for a single element
+            prunedElementType = newOutputTypes.get(0);
+        }
+        else {
+            prunedElementType = RowType.from(
+                    IntStream.range(0, newOutputSymbols.size()).boxed()
+                            .map(fieldIndex -> RowType.field("f" + fieldIndex, newOutputTypes.get(fieldIndex)))
+                            .collect(toImmutableList()));
+        }
+
+        // Create new lambda expression for pruned element
+        RowType elementRowType = (RowType) (arrayType.getElementType());
+        Symbol lambdaSymbol = symbolAllocator.newSymbol("transformarray$element", arrayType.getElementType());
+        LambdaExpression lambdaExpression = createLambdaExpression(lambdaSymbol, elementRowType.getFields(), newRowFields, outputSymbols);
+
+        // Construct a transformed array using transform function
+        Expression transformedArray = new FunctionCallBuilder(metadata)
+                .setName(QualifiedName.of("transform"))
+                .addArgument(new ArrayType(elementRowType), mapping.getInput().toSymbolReference())
+                .addArgument(new FunctionType(singletonList(elementRowType), prunedElementType), lambdaExpression)
+                .build();
+
+        Symbol newInputSymbol = symbolAllocator.newSymbol(transformedArray, new ArrayType(prunedElementType));
+
+        return Optional.of(new Transformation(
+                new UnnestNode.Mapping(newInputSymbol, newOutputSymbols),
+                transformedArray,
+                dereferenceReplacements));
+    }
+
+    private LambdaExpression createLambdaExpression(
+            Symbol lambdaSymbol,
+            List<RowType.Field> originalFields,
+            List<Expression> newFields,
+            List<Symbol> outputSymbols)
+    {
+        Map<Expression, Expression> lambdaMapping = IntStream.range(0, outputSymbols.size()).boxed()
+                .collect(toImmutableMap(
+                        fieldIndex -> outputSymbols.get(fieldIndex).toSymbolReference(),
+                        fieldIndex -> {
+                            RowType.Field field = originalFields.get(fieldIndex);
+                            return new DereferenceExpression(lambdaSymbol.toSymbolReference(), identifier(field.getName().get()));
+                        }));
+
+        List<Expression> rowFieldsForLambda = newFields.stream()
+                .map(projection -> replaceExpression(projection, lambdaMapping))
+                .collect(toImmutableList());
+
+        Expression elementTransformation;
+        if (newFields.size() == 1) {
+            elementTransformation = rowFieldsForLambda.get(0);
+        }
+        else {
+            elementTransformation = new Row(rowFieldsForLambda);
+        }
+
+        return new LambdaExpression(
+                ImmutableList.of(new LambdaArgumentDeclaration(identifier(lambdaSymbol.getName()))),
+                elementTransformation);
+    }
+
+    private static class Transformation
+    {
+        private final UnnestNode.Mapping mapping;
+        private final Expression projection;
+        private final Map<Expression, SymbolReference> expressionReplacements;
+
+        Transformation(
+                UnnestNode.Mapping mapping,
+                Expression projection,
+                Map<Expression, SymbolReference> expressionReplacements)
+        {
+            this.mapping = mapping;
+            this.projection = projection;
+            this.expressionReplacements = expressionReplacements;
+        }
+
+        UnnestNode.Mapping getMapping()
+        {
+            return mapping;
+        }
+
+        Expression getProjection()
+        {
+            return projection;
+        }
+
+        Map<Expression, SymbolReference> getExpressionReplacements()
+        {
+            return expressionReplacements;
+        }
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/ExpressionTestUtils.java
+++ b/presto-main/src/test/java/io/prestosql/sql/ExpressionTestUtils.java
@@ -28,7 +28,6 @@ import io.prestosql.sql.planner.DesugarArrayConstructorRewriter;
 import io.prestosql.sql.planner.DesugarLikeRewriter;
 import io.prestosql.sql.planner.TypeAnalyzer;
 import io.prestosql.sql.planner.TypeProvider;
-import io.prestosql.sql.planner.assertions.ExpressionVerifier;
 import io.prestosql.sql.planner.assertions.SymbolAliases;
 import io.prestosql.sql.planner.iterative.rule.CanonicalizeExpressionRewriter;
 import io.prestosql.sql.tree.Cast;
@@ -49,6 +48,7 @@ import static io.prestosql.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferen
 import static io.prestosql.sql.ParsingUtil.createParsingOptions;
 import static io.prestosql.sql.analyzer.SemanticExceptions.semanticException;
 import static io.prestosql.sql.analyzer.TypeSignatureTranslator.toSqlType;
+import static io.prestosql.sql.planner.assertions.ExpressionVerifier.verify;
 import static io.prestosql.transaction.TransactionBuilder.transaction;
 import static org.testng.internal.EclipseInterface.ASSERT_LEFT;
 import static org.testng.internal.EclipseInterface.ASSERT_MIDDLE;
@@ -76,8 +76,7 @@ public final class ExpressionTestUtils
 
     public static void assertExpressionEquals(Expression actual, Expression expected, SymbolAliases symbolAliases)
     {
-        ExpressionVerifier verifier = new ExpressionVerifier(symbolAliases);
-        if (!verifier.process(actual, expected)) {
+        if (!verify(actual, expected, symbolAliases)) {
             failNotEqual(actual, expected, null);
         }
     }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestDesugarTryExpressionRewriter.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestDesugarTryExpressionRewriter.java
@@ -15,7 +15,6 @@ package io.prestosql.sql.planner;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.operator.scalar.TryFunction;
-import io.prestosql.sql.planner.assertions.ExpressionVerifier;
 import io.prestosql.sql.planner.assertions.SymbolAliases;
 import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.prestosql.sql.tree.ArithmeticBinaryExpression;
@@ -28,6 +27,7 @@ import io.prestosql.type.FunctionType;
 import org.testng.annotations.Test;
 
 import static io.prestosql.spi.type.DecimalType.createDecimalType;
+import static io.prestosql.sql.planner.assertions.ExpressionVerifier.verify;
 import static io.prestosql.sql.tree.ArithmeticBinaryExpression.Operator.ADD;
 import static org.testng.Assert.assertTrue;
 
@@ -58,7 +58,6 @@ public class TestDesugarTryExpressionRewriter
                         .addArgument(new FunctionType(ImmutableList.of(), createDecimalType(1)), new LambdaExpression(ImmutableList.of(), new DecimalLiteral("2")))
                         .build());
 
-        ExpressionVerifier verifier = new ExpressionVerifier(new SymbolAliases());
-        assertTrue(verifier.process(rewritten, expected));
+        assertTrue(verify(rewritten, expected, new SymbolAliases()));
     }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/DynamicFilterMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/DynamicFilterMatcher.java
@@ -35,6 +35,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.prestosql.sql.DynamicFilters.extractDynamicFilters;
 import static io.prestosql.sql.ExpressionUtils.combineConjuncts;
+import static io.prestosql.sql.planner.assertions.ExpressionVerifier.verify;
 import static java.util.Objects.requireNonNull;
 
 public class DynamicFilterMatcher
@@ -78,9 +79,8 @@ public class DynamicFilterMatcher
         this.symbolAliases = symbolAliases;
 
         boolean staticFilterMatches = expectedStaticFilter.map(filter -> {
-            ExpressionVerifier verifier = new ExpressionVerifier(symbolAliases);
             Expression staticFilter = combineConjuncts(metadata, extractDynamicFilters(filterNode.getPredicate()).getStaticConjuncts());
-            return verifier.process(staticFilter, filter);
+            return verify(staticFilter, filter, symbolAliases);
         }).orElse(true);
 
         return new MatchResult(match(metadata) && staticFilterMatches);

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ExpressionMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/ExpressionMatcher.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.prestosql.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
+import static io.prestosql.sql.planner.assertions.ExpressionVerifier.verify;
 import static java.util.Objects.requireNonNull;
 
 public class ExpressionMatcher
@@ -75,10 +76,8 @@ public class ExpressionMatcher
             return result;
         }
 
-        ExpressionVerifier verifier = new ExpressionVerifier(symbolAliases);
-
         for (Map.Entry<Symbol, Expression> assignment : assignments.entrySet()) {
-            if (verifier.process(assignment.getValue(), expression)) {
+            if (verify(assignment.getValue(), expression, symbolAliases)) {
                 result = Optional.of(assignment.getKey());
                 matchesBuilder.add(assignment.getValue());
             }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/JoinMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/JoinMatcher.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.prestosql.sql.planner.assertions.ExpressionVerifier.verify;
 import static io.prestosql.sql.planner.assertions.MatchResult.NO_MATCH;
 import static java.util.Objects.requireNonNull;
 
@@ -84,7 +85,7 @@ final class JoinMatcher
             if (joinNode.getFilter().isEmpty()) {
                 return NO_MATCH;
             }
-            if (!new ExpressionVerifier(symbolAliases).process(joinNode.getFilter().get(), filter.get())) {
+            if (!verify(joinNode.getFilter().get(), filter.get(), symbolAliases)) {
                 return NO_MATCH;
             }
         }

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/SpatialJoinMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/SpatialJoinMatcher.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.sql.planner.assertions.ExpressionVerifier.verify;
 import static io.prestosql.sql.planner.assertions.MatchResult.NO_MATCH;
 import static io.prestosql.sql.planner.assertions.MatchResult.match;
 import static java.util.Objects.requireNonNull;
@@ -65,7 +66,7 @@ public class SpatialJoinMatcher
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 
         SpatialJoinNode joinNode = (SpatialJoinNode) node;
-        if (!new ExpressionVerifier(symbolAliases).process(joinNode.getFilter(), filter)) {
+        if (!verify(joinNode.getFilter(), filter, symbolAliases)) {
             return NO_MATCH;
         }
         if (!joinNode.getKdbTree().equals(kdbTree)) {

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/TestExpressionVerifier.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/TestExpressionVerifier.java
@@ -111,6 +111,37 @@ public class TestExpressionVerifier
         assertTrue(verify("y IS DISTINCT FROM x", "b IS DISTINCT FROM a", symbolAliases));
     }
 
+    @Test
+    public void testLambdaExpressions()
+    {
+        SymbolAliases symbolAliases = SymbolAliases.builder()
+                .put("a", new SymbolReference("x"))
+                .put("b", new SymbolReference("y"))
+                .build();
+
+        assertTrue(verify(
+                "transform(x, p -> p.f0.f0 + y)",
+                "transform(a, q -> q.f0.f0 + b)",
+                symbolAliases));
+
+        // The same identifier used in multiple lambda expressions
+        assertTrue(verify(
+                "transform(x, p -> p.f0.f0) || transform(y, p -> p + 2)",
+                "transform(a, q -> q.f0.f0) || transform(b, q -> q + 2)",
+                symbolAliases));
+
+        assertTrue(verify(
+                "transform(x, p -> p.f0.f0) || transform(y, p -> p + 2)",
+                "transform(a, q -> q.f0.f0) || transform(b, r -> r + 2)",
+                symbolAliases));
+
+        // Nested lambda expressions
+        assertTrue(verify(
+                "transform(x, p -> transform(array[p], q -> q + 1 + f(p)))",
+                "transform(a, q -> transform(array[q], s -> s + 1 + f(q)))",
+                symbolAliases));
+    }
+
     private static void assertThrows(Runnable runnable)
     {
         try {

--- a/presto-main/src/test/java/io/prestosql/sql/planner/assertions/UnnestMatcher.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/assertions/UnnestMatcher.java
@@ -30,6 +30,7 @@ import java.util.stream.IntStream;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.prestosql.sql.planner.assertions.ExpressionVerifier.verify;
 import static io.prestosql.sql.planner.assertions.MatchResult.NO_MATCH;
 import static java.util.Objects.requireNonNull;
 
@@ -106,7 +107,7 @@ final class UnnestMatcher
         if (filter.isEmpty()) {
             return MatchResult.match();
         }
-        if (!new ExpressionVerifier(symbolAliases).process(unnestNode.getFilter().get(), filter.get())) {
+        if (!verify(unnestNode.getFilter().get(), filter.get(), symbolAliases)) {
             return NO_MATCH;
         }
 

--- a/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneUnnestMapping.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/iterative/rule/TestPruneUnnestMapping.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.block.MethodHandleUtil;
+import io.prestosql.spi.type.ArrayType;
+import io.prestosql.spi.type.MapType;
+import io.prestosql.spi.type.RowType;
+import io.prestosql.sql.planner.assertions.PlanMatchPattern;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.planner.plan.Assignments;
+import io.prestosql.sql.planner.plan.UnnestNode;
+import org.testng.annotations.Test;
+
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.RowType.field;
+import static io.prestosql.spi.type.RowType.rowType;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.UnnestMapping.unnestMapping;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.strictProject;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.unnest;
+import static io.prestosql.sql.planner.assertions.PlanMatchPattern.values;
+import static io.prestosql.sql.planner.iterative.rule.test.PlanBuilder.expression;
+
+public class TestPruneUnnestMapping
+        extends BaseRuleTest
+{
+    private static final RowType simpleRowType = rowType(field("f1", BIGINT), field("f2", BIGINT));
+    private static final RowType nestedRowType = rowType(field("f1", BIGINT), field("f2", simpleRowType));
+    private static final ArrayType nestedArrayType = new ArrayType(nestedRowType);
+
+    @Test
+    public void testDoesNotFire()
+    {
+        MapType nestedMapType = new MapType(
+                BIGINT,
+                nestedRowType,
+                MethodHandleUtil.methodHandle(TestPruneUnnestMapping.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestPruneUnnestMapping.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestPruneUnnestMapping.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestPruneUnnestMapping.class, "throwUnsupportedOperation"));
+
+        // Does not fire for maps
+        tester().assertThat(new PruneUnnestMappings(tester().getTypeAnalyzer(), tester().getMetadata()))
+                .on(p ->
+                        p.project(
+                                Assignments.of(p.symbol("expr", BIGINT), expression("unnested_value.f2")),
+                                p.unnest(
+                                        ImmutableList.of(p.symbol("replicate", BIGINT)),
+                                        ImmutableList.of(
+                                                new UnnestNode.Mapping(
+                                                        p.symbol("nested_map", nestedMapType),
+                                                        ImmutableList.of(p.symbol("unnested_key", BIGINT), p.symbol("unnested_value", nestedRowType)))),
+                                        p.values(
+                                                p.symbol("replicate", BIGINT),
+                                                p.symbol("nested_map", nestedMapType)))))
+                .doesNotFire();
+
+        // Does not fire if unnest symbol is also used as replicate symbol
+        tester().assertThat(new PruneUnnestMappings(tester().getTypeAnalyzer(), tester().getMetadata()))
+                .on(p ->
+                        p.project(
+                                Assignments.builder()
+                                        .put(p.symbol("expr", BIGINT), expression("unnested_row.f2"))
+                                        .build(),
+                                p.unnest(
+                                        ImmutableList.of(p.symbol("replicate", BIGINT), p.symbol("nested_array", nestedArrayType)),
+                                        ImmutableList.of(
+                                                new UnnestNode.Mapping(
+                                                        p.symbol("nested_array", nestedArrayType),
+                                                        ImmutableList.of(p.symbol("unnested_bigint", BIGINT), p.symbol("unnested_row", nestedRowType)))),
+                                        p.values(
+                                                p.symbol("replicate", BIGINT),
+                                                p.symbol("nested_array", nestedArrayType)))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testSimple()
+    {
+        // Test with dereferences on unnested column
+        tester().assertThat(new PruneUnnestMappings(tester().getTypeAnalyzer(), tester().getMetadata()))
+                .on(p ->
+                        p.project(
+                                Assignments.builder()
+                                        .put(p.symbol("expr", BIGINT), expression("unnested_row.f2"))
+                                        .build(),
+                                p.unnest(
+                                        ImmutableList.of(p.symbol("replicate", BIGINT)),
+                                        ImmutableList.of(
+                                                new UnnestNode.Mapping(
+                                                        p.symbol("nested_array", nestedArrayType),
+                                                        ImmutableList.of(p.symbol("unnested_bigint", BIGINT), p.symbol("unnested_row", nestedRowType)))),
+                                        p.values(
+                                                p.symbol("replicate", BIGINT),
+                                                p.symbol("nested_array", nestedArrayType)))))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of(
+                                        "expr", PlanMatchPattern.expression("unnested_row_f2")),
+                                unnest(
+                                        ImmutableList.of("replicate"),
+                                        ImmutableList.of(unnestMapping("nested_array_transformed", ImmutableList.of("unnested_row_f2"))),
+                                        strictProject(
+                                                ImmutableMap.of(
+                                                        "nested_array_transformed", PlanMatchPattern.expression("transform(nested_array, x -> x.f2.f2)"),
+                                                        "replicate", PlanMatchPattern.expression("replicate")),
+                                                values("replicate", "nested_array")))));
+    }
+
+    @Test
+    public void testMultipleMappings()
+    {
+        // Test with dereferences on unnested column
+        tester().assertThat(new PruneUnnestMappings(tester().getTypeAnalyzer(), tester().getMetadata()))
+                .on(p ->
+                        p.project(
+                                Assignments.of(
+                                        p.symbol("expr", BIGINT), expression("row_1.f2"),
+                                        p.symbol("expr_2", BIGINT), expression("bigint_1")),
+                                p.unnest(
+                                        ImmutableList.of(p.symbol("replicate", BIGINT)),
+                                        ImmutableList.of(
+                                                new UnnestNode.Mapping(
+                                                        p.symbol("array_1", nestedArrayType),
+                                                        ImmutableList.of(p.symbol("bigint_1", BIGINT), p.symbol("row_1", nestedRowType))),
+                                                new UnnestNode.Mapping(
+                                                        p.symbol("array_2", nestedArrayType),
+                                                        ImmutableList.of(p.symbol("bigint_2", BIGINT), p.symbol("row_2", nestedRowType)))),
+                                        p.values(
+                                                p.symbol("replicate", BIGINT),
+                                                p.symbol("array_1", nestedArrayType),
+                                                p.symbol("array_2", nestedArrayType)))))
+                .matches(
+                        strictProject(
+                                ImmutableMap.of(
+                                        "expr", PlanMatchPattern.expression("unnested_row_f2"),
+                                        "expr_2", PlanMatchPattern.expression("unnested_bigint")),
+                                unnest(
+                                        ImmutableList.of("replicate"),
+                                        ImmutableList.of(
+                                                unnestMapping("transformed_array_1", ImmutableList.of("unnested_bigint", "unnested_row_f2")),
+                                                unnestMapping("transformed_array_2", ImmutableList.of("unused_symbol"))),
+                                        strictProject(
+                                                ImmutableMap.of(
+                                                        "replicate", PlanMatchPattern.expression("replicate"),
+                                                        "transformed_array_1", PlanMatchPattern.expression("transform(array_1, x -> ROW(x.f1, x.f2.f2))"),
+                                                        "transformed_array_2", PlanMatchPattern.expression("transform(array_2, x -> x.f1)")),
+                                                values("replicate", "array_1", "array_2")))));
+    }
+
+    public static void throwUnsupportedOperation()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestUnnest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestUnnest.java
@@ -199,4 +199,17 @@ public class TestUnnest
                 "SELECT * FROM (VALUES 1) t, UNNEST(ARRAY['a', 'b'], ARRAY['a', 'b']) u (x, y)"))
                 .matches("VALUES (1, 'a', 'a'), (1, 'b', 'b')");
     }
+
+    @Test
+    public void testDereferencesWithUnnest()
+    {
+        assertThat(assertions.query(
+                "SELECT x, z.f1 FROM (" +
+                        "VALUES (" +
+                        "   ARRAY[CAST(ROW(1, 2, ROW(3, 4)) AS ROW(a INTEGER, b INTEGER, c ROW(f1 INTEGER, f2 INTEGER)))], " +
+                        "   ARRAY[CAST(ROW(1,2) AS ROW(x INTEGER, y INTEGER))])) " +
+                        "AS t(a, b) " +
+                        "CROSS JOIN UNNEST(a, b) t(x, y, z, w, u)"))
+                .matches("VALUES (1, 3)");
+    }
 }

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestUnnest.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestUnnest.java
@@ -211,5 +211,14 @@ public class TestUnnest
                         "AS t(a, b) " +
                         "CROSS JOIN UNNEST(a, b) t(x, y, z, w, u)"))
                 .matches("VALUES (1, 3)");
+
+        // Dereference without named subfields
+        assertThat(assertions.query(
+                "SELECT x, z.a FROM (" +
+                        "VALUES (" +
+                        "   ARRAY[ROW(1, 2, CAST(ROW(3, 4) AS ROW(a INTEGER, b INTEGER)))])) " +
+                        "AS t(a) " +
+                        "CROSS JOIN UNNEST(a) t(x, y, z)"))
+                .matches("VALUES (1, 3)");
     }
 }


### PR DESCRIPTION
(For enhancement discussed in #3925)

Accomplishes the following two things by transforming an array of rows before UNNEST operation:

1) Remove unreferenced output symbols (eg. `B_BIGINT` in the example below)
2) Project sufficient subfields in case of dereferences (i.e. removal of `y` from `B_ROW`)

Example:

transforms 
```
   Project(D := f1(A), E := f2(B_VARCHAR), G := f3(B_ROW.X))
       Unnest(replicate = [A], unnest = (B_ARRAY -> [B_BIGINT, B_VARCHAR, B_ROW]))
           Source(
               A bigint,
               B_ARRAY array(row(_bigint bigint, _varchar varchar, _row row(x bigint, y bigint))))
```

to 

```
   Project(D := f1(A), E := f2(B_VARCHAR), G := f3(B_ROW_X))
       Unnest(replicate = [A], unnest = (transformed -> [B_VARCHAR, B_ROW_X]))
           Project(A, transformed := transform(e -> row(e._varchar, e._row.x)))
               Source(A, B_ARAAY)
```

(Avoided creating two separate rules to prevent creating lambda expressions twice.)

Some special cases:

1) If the array element type is primitive, no pruning occurs.
2) If no fields are getting projected or used, we still keep at least one field in the mapping, since cardinality of the array is useful. We can replace it with a constant, but I'm not sure if the execution can be optimized to smartly create a ReplicateBlock for constant lambdas, and avoid copies.
3) If exactly one field is projected from the mapping, we do not wrap it with `ROW` construction, and instead kept as a primitive array.


the first two commits extend `ExpressionVerifier` to support verification of lambda expressions: https://github.com/prestosql/presto/pull/4270/commits/74a854c7cb9416e94e5a32b81768c497cd2d70d9#diff-51d1193486ad31af4d3dc949a1a9d401L511