### PR TITLE
Remove inner classes of GroupTypedHistogram

### DIFF
--- a/presto-main/src/test/java/io/prestosql/operator/aggregation/groupby/AggregationTestInput.java
+++ b/presto-main/src/test/java/io/prestosql/operator/aggregation/groupby/AggregationTestInput.java
@@ -46,13 +46,11 @@ public class AggregationTestInput
 
     public void runPagesOnAccumulatorWithAssertion(long groupId, GroupedAccumulator groupedAccumulator, AggregationTestOutput expectedValue)
     {
-        GroupedAccumulator accumulator = Suppliers.ofInstance(groupedAccumulator).get();
-
         for (Page page : getPages()) {
-            accumulator.addInput(getGroupIdBlock(groupId, page), page);
+            groupedAccumulator.addInput(getGroupIdBlock(groupId, page), page);
         }
 
-        expectedValue.validateAccumulator(accumulator, groupId);
+        expectedValue.validateAccumulator(groupedAccumulator, groupId);
     }
 
     public GroupedAccumulator runPagesOnAccumulator(long groupId, GroupedAccumulator groupedAccumulator)

--- a/presto-main/src/test/java/io/prestosql/operator/aggregation/groupby/AggregationTestOutput.java
+++ b/presto-main/src/test/java/io/prestosql/operator/aggregation/groupby/AggregationTestOutput.java
@@ -38,9 +38,10 @@ public class AggregationTestOutput
     }
 
     private static BiConsumer<Object, Object> createEqualAssertion(Object expectedValue, long groupId)
-
     {
-        BiConsumer<Object, Object> equalAssertion = (actual, expected) -> assertEquals(actual, expected, format("failure on group %s", groupId));
+        BiConsumer<Object, Object> equalAssertion = (actual, expected) -> {
+            assertEquals(actual, expected, format("failure on group %s", groupId));
+        };
 
         if (expectedValue instanceof Double && !expectedValue.equals(Double.NaN)) {
             equalAssertion = (actual, expected) -> assertEquals((double) actual, (double) expected, 1e-10);


### PR DESCRIPTION
Motivation: these classes are unnecessary and produce measurable
additional GC pressure. Depending on the portion of the query load that
use the histogram() function, the percent of objects has been observed
to be between 2-4%. While the abstractions of "nodes" as this is
basically an open-addressed, linear probe hash table, even the
readability is debatable as unnecessary abstraction.

This removes the unnecessary classes and GC pressure and arguably
improves readability.

Also enhance TestHistogram to deterministically catch collision 
resolution bugs

closes #1040