### PR TITLE
Pre-fetching of parquet data pages

### DIFF
--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -39,6 +39,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/ParquetReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/ParquetReader.java
@@ -13,7 +13,6 @@
  */
 package io.prestosql.parquet.reader;
 
-import io.airlift.concurrent.Threads;
 import io.airlift.slice.Slice;
 import io.prestosql.memory.context.AggregatedMemoryContext;
 import io.prestosql.parquet.ChunkKey;
@@ -53,18 +52,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.prestosql.parquet.ParquetValidationUtils.validateParquet;
 import static io.prestosql.parquet.reader.ListColumnReader.calculateCollectionOffsets;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.Executors.newCachedThreadPool;
 
 public class ParquetReader
         implements Closeable

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/ParquetReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/ParquetReader.java
@@ -13,6 +13,7 @@
  */
 package io.prestosql.parquet.reader;
 
+import io.airlift.concurrent.Threads;
 import io.airlift.slice.Slice;
 import io.prestosql.memory.context.AggregatedMemoryContext;
 import io.prestosql.parquet.ChunkKey;
@@ -52,14 +53,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.prestosql.parquet.ParquetValidationUtils.validateParquet;
 import static io.prestosql.parquet.reader.ListColumnReader.calculateCollectionOffsets;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newCachedThreadPool;
 
 public class ParquetReader
         implements Closeable

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/PrimitiveColumnReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/PrimitiveColumnReader.java
@@ -264,7 +264,8 @@ public abstract class PrimitiveColumnReader
         return true;
     }
 
-    private void prefetchNextPage() {
+    private void prefetchNextPage()
+    {
         nextPageFuture = prefetchPageService.submit(() -> pageReader.readPage());
     }
 

--- a/presto-parquet/src/main/java/io/prestosql/parquet/reader/PrimitiveColumnReader.java
+++ b/presto-parquet/src/main/java/io/prestosql/parquet/reader/PrimitiveColumnReader.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -51,7 +52,6 @@ import static io.prestosql.parquet.ValuesType.REPETITION_LEVEL;
 import static io.prestosql.parquet.ValuesType.VALUES;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.Executors.newCachedThreadPool;
 
 public abstract class PrimitiveColumnReader
 {
@@ -72,7 +72,7 @@ public abstract class PrimitiveColumnReader
     private DataPage page;
     private int remainingValueCountInPage;
     private int readOffset;
-    private final ExecutorService prefetchPageService = newCachedThreadPool(daemonThreadsNamed("parquet-fetch-page-%s"));
+    private static final ExecutorService prefetchPageService = Executors.newFixedThreadPool(4, daemonThreadsNamed("parquet-fetch-page-%s"));
     private Future<DataPage> nextPageFuture;
 
     protected abstract void readValue(BlockBuilder blockBuilder, Type type);


### PR DESCRIPTION
While working on in the iceberg-spark vectorized read path, I noticed in the profiling that significant amount of CPU time is spent on decompressing the Parquet data pages. Implementing pre-fetching helped boost the JMH measured ops/second by up to 60%. I think a similar opportunity exists in the presto parquet read path where in the next data page to be read can be prefetched eagerly using a thread pool. Parking my patch here to see if it didn't break any tests. If tests are green, I would like to figure out what benchmarks I could possibly run or build to measure the performance impact of this change. 