### PR TITLE
Add hive 3 missing privileges and principal

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePrincipal.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePrincipal.java
@@ -53,6 +53,11 @@ public class HivePrincipal
         return new HivePrincipal(PrincipalType.ROLE, role);
     }
 
+    private static HivePrincipal ofGroup(String group)
+    {
+        return new HivePrincipal(PrincipalType.GROUP, group);
+    }
+
     public static Set<HivePrincipal> from(Set<PrestoPrincipal> prestoPrincipals)
     {
         return prestoPrincipals.stream()
@@ -79,6 +84,9 @@ public class HivePrincipal
         }
         else if (type == PrincipalType.ROLE) {
             // In Hive role names are case insensitive
+            this.name = name.toLowerCase(ENGLISH);
+        }
+        else if (type == PrincipalType.GROUP) {
             this.name = name.toLowerCase(ENGLISH);
         }
         else {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePrivilegeInfo.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/HivePrivilegeInfo.java
@@ -36,7 +36,13 @@ public class HivePrivilegeInfo
 {
     public enum HivePrivilege
     {
-        SELECT, INSERT, UPDATE, DELETE, OWNERSHIP
+        CREATE,
+        DROP,
+        INDEX,
+        LOCK,
+        WRITE,
+        READ,
+        /**/
     }
 
     private final HivePrivilege hivePrivilege;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -104,11 +104,18 @@ import static io.prestosql.plugin.hive.metastore.HiveColumnStatistics.createDeci
 import static io.prestosql.plugin.hive.metastore.HiveColumnStatistics.createDoubleColumnStatistics;
 import static io.prestosql.plugin.hive.metastore.HiveColumnStatistics.createIntegerColumnStatistics;
 import static io.prestosql.plugin.hive.metastore.HiveColumnStatistics.createStringColumnStatistics;
+import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.CREATE;
 import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.DELETE;
+import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.DROP;
+import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.INDEX;
 import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.INSERT;
+import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.LOCK;
 import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
+import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.READ;
 import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.SELECT;
 import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.UPDATE;
+import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.WRITE;
+import static io.prestosql.spi.security.PrincipalType.GROUP;
 import static io.prestosql.spi.security.PrincipalType.ROLE;
 import static io.prestosql.spi.security.PrincipalType.USER;
 import static io.prestosql.spi.statistics.ColumnStatisticType.MAX_VALUE;
@@ -225,6 +232,8 @@ public final class ThriftMetastoreUtil
                 return org.apache.hadoop.hive.metastore.api.PrincipalType.USER;
             case ROLE:
                 return org.apache.hadoop.hive.metastore.api.PrincipalType.ROLE;
+            case GROUP:
+                return org.apache.hadoop.hive.metastore.api.PrincipalType.GROUP;
             default:
                 throw new IllegalArgumentException("Unsupported principal type: " + principalType);
         }
@@ -662,6 +671,8 @@ public final class ThriftMetastoreUtil
                 return org.apache.hadoop.hive.metastore.api.PrincipalType.USER;
             case ROLE:
                 return org.apache.hadoop.hive.metastore.api.PrincipalType.ROLE;
+            case GROUP:
+                return org.apache.hadoop.hive.metastore.api.PrincipalType.GROUP;
             default:
                 throw new IllegalArgumentException("Unsupported principal type: " + principalType);
         }
@@ -675,6 +686,8 @@ public final class ThriftMetastoreUtil
                 return USER;
             case ROLE:
                 return ROLE;
+            case GROUP:
+                return GROUP;
             default:
                 throw new IllegalArgumentException("Unsupported principal type: " + principalType);
         }
@@ -758,6 +771,18 @@ public final class ThriftMetastoreUtil
                 return ImmutableSet.of(new HivePrivilegeInfo(UPDATE, grantOption, grantor, grantee.orElse(grantor)));
             case "DELETE":
                 return ImmutableSet.of(new HivePrivilegeInfo(DELETE, grantOption, grantor, grantee.orElse(grantor)));
+            case "CREATE":
+                return ImmutableSet.of(new HivePrivilegeInfo(CREATE, grantOption, grantor, grantee.orElse(grantor)));
+            case "DROP":
+                return ImmutableSet.of(new HivePrivilegeInfo(DROP, grantOption, grantor, grantee.orElse(grantor)));
+            case "INDEX":
+                return ImmutableSet.of(new HivePrivilegeInfo(INDEX, grantOption, grantor, grantee.orElse(grantor)));
+            case "LOCK":
+                return ImmutableSet.of(new HivePrivilegeInfo(LOCK, grantOption, grantor, grantee.orElse(grantor)));
+            case "WRITE":
+                return ImmutableSet.of(new HivePrivilegeInfo(WRITE, grantOption, grantor, grantee.orElse(grantor)));
+            case "READ":
+                return ImmutableSet.of(new HivePrivilegeInfo(READ, grantOption, grantor, grantee.orElse(grantor)));
             case "OWNERSHIP":
                 return ImmutableSet.of(new HivePrivilegeInfo(OWNERSHIP, grantOption, grantor, grantee.orElse(grantor)));
             default:

--- a/presto-spi/src/main/java/io/prestosql/spi/security/PrincipalType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/security/PrincipalType.java
@@ -15,5 +15,5 @@ package io.prestosql.spi.security;
 
 public enum PrincipalType
 {
-    USER, ROLE
+    USER, ROLE, GROUP
 }


### PR DESCRIPTION
I was testing kolosing's PR: https://github.com/prestosql/presto/pull/4254, then I encountered these errors below:
```
Query 20200701_000714_00003_5si9e failed: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Unsupported privilege name: CREATE
Query 20200701_005028_00003_x42iu failed: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Unsupported privilege name: DROP
Query 20200701_011500_00002_6tdhc failed: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Unsupported privilege name: INDEX
Query 20200701_061040_00004_6vhcm failed: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Unsupported privilege name: LOCK
Query 20200701_063758_00004_aiyms failed: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Unsupported privilege name: WRITE
Query 20200701_204738_00001_jq7w9 failed: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Unsupported privilege name: READ


Query 20200701_070112_00004_jz78b failed: com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalArgumentException: Unsupported principal type: GROUP
```

I made changes on top of kokosing's PR and tested with my hive-3-metastore-service (hadoop 3.2.1, hive 3.1.2), now I am able to run presto queries.

Please merge kokosing's PR first. This PR added extra privileges and principal on top of his PR. Thanks a lot. @electrum 