### PR TITLE
Remove non-sensical time vs interval operations

### DIFF
--- a/presto-main/src/main/java/io/prestosql/type/DateTimeOperators.java
+++ b/presto-main/src/main/java/io/prestosql/type/DateTimeOperators.java
@@ -100,34 +100,6 @@ public final class DateTimeOperators
         return datePlusIntervalYearToMonth(date, interval);
     }
 
-    @ScalarOperator(ADD)
-    @SqlType(StandardTypes.TIME)
-    public static long timePlusIntervalYearToMonth(@SqlType(StandardTypes.TIME) long time, @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long interval)
-    {
-        return time;
-    }
-
-    @ScalarOperator(ADD)
-    @SqlType(StandardTypes.TIME)
-    public static long intervalYearToMonthPlusTime(@SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long interval, @SqlType(StandardTypes.TIME) long time)
-    {
-        return time;
-    }
-
-    @ScalarOperator(ADD)
-    @SqlType(StandardTypes.TIME_WITH_TIME_ZONE)
-    public static long timeWithTimeZonePlusIntervalYearToMonth(@SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long time, @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long interval)
-    {
-        return time;
-    }
-
-    @ScalarOperator(ADD)
-    @SqlType(StandardTypes.TIME_WITH_TIME_ZONE)
-    public static long intervalYearToMonthPlusTimeWithTimeZone(@SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long interval, @SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long time)
-    {
-        return time;
-    }
-
     @ScalarOperator(SUBTRACT)
     @SqlType(StandardTypes.DATE)
     public static long dateMinusIntervalDayToSecond(@SqlType(StandardTypes.DATE) long date, @SqlType(StandardTypes.INTERVAL_DAY_TO_SECOND) long interval)
@@ -157,20 +129,6 @@ public final class DateTimeOperators
     public static long dateMinusIntervalYearToMonth(@SqlType(StandardTypes.DATE) long date, @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long interval)
     {
         return datePlusIntervalYearToMonth(date, -interval);
-    }
-
-    @ScalarOperator(SUBTRACT)
-    @SqlType(StandardTypes.TIME)
-    public static long timeMinusIntervalYearToMonth(@SqlType(StandardTypes.TIME) long time, @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long interval)
-    {
-        return time;
-    }
-
-    @ScalarOperator(SUBTRACT)
-    @SqlType(StandardTypes.TIME_WITH_TIME_ZONE)
-    public static long timeWithTimeZoneMinusIntervalYearToMonth(@SqlType(StandardTypes.TIME_WITH_TIME_ZONE) long time, @SqlType(StandardTypes.INTERVAL_YEAR_TO_MONTH) long interval)
-    {
-        return time;
     }
 
     public static int modulo24Hour(ISOChronology chronology, long millis)

--- a/presto-main/src/test/java/io/prestosql/type/TestDateTimeOperatorsBase.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestDateTimeOperatorsBase.java
@@ -77,10 +77,6 @@ public abstract class TestDateTimeOperatorsBase
         assertFunction("INTERVAL '3' hour + TIME '03:04:05.321'", TIME, sqlTimeOf(6, 4, 5, 321, session));
         assertFunction("TIME '03:04:05.321' + INTERVAL '3' day", TIME, sqlTimeOf(3, 4, 5, 321, session));
         assertFunction("INTERVAL '3' day + TIME '03:04:05.321'", TIME, sqlTimeOf(3, 4, 5, 321, session));
-        assertFunction("TIME '03:04:05.321' + INTERVAL '3' month", TIME, sqlTimeOf(3, 4, 5, 321, session));
-        assertFunction("INTERVAL '3' month + TIME '03:04:05.321'", TIME, sqlTimeOf(3, 4, 5, 321, session));
-        assertFunction("TIME '03:04:05.321' + INTERVAL '3' year", TIME, sqlTimeOf(3, 4, 5, 321, session));
-        assertFunction("INTERVAL '3' year + TIME '03:04:05.321'", TIME, sqlTimeOf(3, 4, 5, 321, session));
 
         assertFunction("TIME '03:04:05.321' + INTERVAL '27' hour", TIME, sqlTimeOf(6, 4, 5, 321, session));
         assertFunction("INTERVAL '27' hour + TIME '03:04:05.321'", TIME, sqlTimeOf(6, 4, 5, 321, session));
@@ -95,18 +91,6 @@ public abstract class TestDateTimeOperatorsBase
                 TIME_WITH_TIME_ZONE,
                 new SqlTimeWithTimeZone(new DateTime(1970, 1, 1, 3, 4, 5, 321, WEIRD_TIME_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
         assertFunction("INTERVAL '3' day + TIME '03:04:05.321 +05:09'",
-                TIME_WITH_TIME_ZONE,
-                new SqlTimeWithTimeZone(new DateTime(1970, 1, 1, 3, 4, 5, 321, WEIRD_TIME_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
-        assertFunction("TIME '03:04:05.321 +05:09' + INTERVAL '3' month",
-                TIME_WITH_TIME_ZONE,
-                new SqlTimeWithTimeZone(new DateTime(1970, 1, 1, 3, 4, 5, 321, WEIRD_TIME_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
-        assertFunction("INTERVAL '3' month + TIME '03:04:05.321 +05:09'",
-                TIME_WITH_TIME_ZONE,
-                new SqlTimeWithTimeZone(new DateTime(1970, 1, 1, 3, 4, 5, 321, WEIRD_TIME_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
-        assertFunction("TIME '03:04:05.321 +05:09' + INTERVAL '3' year",
-                TIME_WITH_TIME_ZONE,
-                new SqlTimeWithTimeZone(new DateTime(1970, 1, 1, 3, 4, 5, 321, WEIRD_TIME_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
-        assertFunction("INTERVAL '3' year + TIME '03:04:05.321 +05:09'",
                 TIME_WITH_TIME_ZONE,
                 new SqlTimeWithTimeZone(new DateTime(1970, 1, 1, 3, 4, 5, 321, WEIRD_TIME_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
 
@@ -185,8 +169,6 @@ public abstract class TestDateTimeOperatorsBase
     {
         assertFunction("TIME '03:04:05.321' - INTERVAL '3' hour", TIME, sqlTimeOf(0, 4, 5, 321, session));
         assertFunction("TIME '03:04:05.321' - INTERVAL '3' day", TIME, sqlTimeOf(3, 4, 5, 321, session));
-        assertFunction("TIME '03:04:05.321' - INTERVAL '3' month", TIME, sqlTimeOf(3, 4, 5, 321, session));
-        assertFunction("TIME '03:04:05.321' - INTERVAL '3' year", TIME, sqlTimeOf(3, 4, 5, 321, session));
 
         assertFunction("TIME '03:04:05.321' - INTERVAL '6' hour", TIME, sqlTimeOf(21, 4, 5, 321, session));
 
@@ -194,12 +176,6 @@ public abstract class TestDateTimeOperatorsBase
                 TIME_WITH_TIME_ZONE,
                 new SqlTimeWithTimeZone(new DateTime(1970, 1, 1, 0, 4, 5, 321, WEIRD_TIME_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
         assertFunction("TIME '03:04:05.321 +05:09' - INTERVAL '3' day",
-                TIME_WITH_TIME_ZONE,
-                new SqlTimeWithTimeZone(new DateTime(1970, 1, 1, 3, 4, 5, 321, WEIRD_TIME_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
-        assertFunction("TIME '03:04:05.321 +05:09' - INTERVAL '3' month",
-                TIME_WITH_TIME_ZONE,
-                new SqlTimeWithTimeZone(new DateTime(1970, 1, 1, 3, 4, 5, 321, WEIRD_TIME_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
-        assertFunction("TIME '03:04:05.321 +05:09' - INTERVAL '3' year",
                 TIME_WITH_TIME_ZONE,
                 new SqlTimeWithTimeZone(new DateTime(1970, 1, 1, 3, 4, 5, 321, WEIRD_TIME_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
         assertFunction("TIME '03:04:05.321 +05:09' - INTERVAL '6' hour",


### PR DESCRIPTION
TIME and INTERVAL YEAR TO MONTH are incompatible with each other.
There are no reasonable semantics for adding or subracting them from
each other.