### PR TITLE
Fix failure for IN expression in join criteria

### DIFF
--- a/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/RelationPlanner.java
@@ -409,7 +409,7 @@ class RelationPlanner
 
         if (node.getType() != INNER) {
             for (Expression complexExpression : complexJoinExpressions) {
-                Set<QualifiedName> dependencies = SymbolsExtractor.extractNames(complexExpression, analysis.getColumnReferences());
+                Set<QualifiedName> dependencies = SymbolsExtractor.extractNamesNoSubqueries(complexExpression, analysis.getColumnReferences());
 
                 // This is for handling uncorreled subqueries. Correlated subqueries are not currently supported and are dealt with
                 // during analysis.

--- a/presto-main/src/test/java/io/prestosql/sql/query/TestJoin.java
+++ b/presto-main/src/test/java/io/prestosql/sql/query/TestJoin.java
@@ -66,6 +66,16 @@ public class TestJoin
     @Test
     public void testInPredicateInJoinCriteria()
     {
+        // IN with subquery containing column references
+        assertThat(assertions.query("" +
+                "WITH " +
+                "    t(x, y) AS (VALUES (1, 10), (2, 20)), " +
+                "    u(x) AS (VALUES 1, 2), " +
+                "    w(z) AS (VALUES 10, 20) " +
+                "SELECT *\n" +
+                "FROM t LEFT JOIN u ON t.x = u.x AND t.y IN (SELECT z FROM w)"))
+                .matches("VALUES (2, 20, 2), (1, 10, 1)");
+
         assertThat(assertions.query("SELECT * FROM (VALUES 1, 2, NULL) t(x) JOIN (VALUES 1, 3, NULL) u(x) ON t.x IN (VALUES 1)"))
                 .matches("VALUES (1, 1), (1, 3), (1, NULL)");
 


### PR DESCRIPTION
The planner was making a decision of whether to plan the subquery on the
left or right depending on whether all the columns in the expression
could be satisfied by either side. However, it was not excluding
columns in the subquery.

Fixes https://github.com/prestosql/presto/issues/4380