### PR TITLE
Make TimeZoneKey case-sensitive

### DIFF
--- a/presto-spi/src/test/java/io/prestosql/spi/type/TestTimeZoneKey.java
+++ b/presto-spi/src/test/java/io/prestosql/spi/type/TestTimeZoneKey.java
@@ -24,7 +24,6 @@ import java.util.SortedSet;
 import static io.prestosql.spi.type.TimeZoneKey.MAX_TIME_ZONE_KEY;
 import static io.prestosql.spi.type.TimeZoneKey.UTC_KEY;
 import static java.util.Comparator.comparingInt;
-import static java.util.Locale.ENGLISH;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
@@ -48,8 +47,6 @@ public class TestTimeZoneKey
         // verify UTC equivalent zones map to UTC
         assertSame(TimeZoneKey.getTimeZoneKey("Z"), UTC_KEY);
         assertSame(TimeZoneKey.getTimeZoneKey("Zulu"), UTC_KEY);
-        assertSame(TimeZoneKey.getTimeZoneKey("zulu"), UTC_KEY);
-        assertSame(TimeZoneKey.getTimeZoneKey("ZULU"), UTC_KEY);
         assertSame(TimeZoneKey.getTimeZoneKey("UT"), UTC_KEY);
         assertSame(TimeZoneKey.getTimeZoneKey("UCT"), UTC_KEY);
         assertSame(TimeZoneKey.getTimeZoneKey("Universal"), UTC_KEY);
@@ -63,15 +60,14 @@ public class TestTimeZoneKey
         assertSame(TimeZoneKey.getTimeZoneKey("-00:00"), UTC_KEY);
         assertSame(TimeZoneKey.getTimeZoneKey("+0000"), UTC_KEY);
         assertSame(TimeZoneKey.getTimeZoneKey("-0000"), UTC_KEY);
-        assertSame(TimeZoneKey.getTimeZoneKey("etc/utc"), UTC_KEY);
-        assertSame(TimeZoneKey.getTimeZoneKey("etc/gmt"), UTC_KEY);
-        assertSame(TimeZoneKey.getTimeZoneKey("etc/gmt+0"), UTC_KEY);
-        assertSame(TimeZoneKey.getTimeZoneKey("etc/gmt+00:00"), UTC_KEY);
-        assertSame(TimeZoneKey.getTimeZoneKey("etc/gmt-00:00"), UTC_KEY);
-        assertSame(TimeZoneKey.getTimeZoneKey("etc/ut"), UTC_KEY);
-        assertSame(TimeZoneKey.getTimeZoneKey("etc/UT"), UTC_KEY);
-        assertSame(TimeZoneKey.getTimeZoneKey("etc/UCT"), UTC_KEY);
-        assertSame(TimeZoneKey.getTimeZoneKey("etc/Universal"), UTC_KEY);
+        assertSame(TimeZoneKey.getTimeZoneKey("Etc/UTC"), UTC_KEY);
+        assertSame(TimeZoneKey.getTimeZoneKey("Etc/GMT"), UTC_KEY);
+        assertSame(TimeZoneKey.getTimeZoneKey("Etc/GMT+0"), UTC_KEY);
+        assertSame(TimeZoneKey.getTimeZoneKey("Etc/GMT+00:00"), UTC_KEY);
+        assertSame(TimeZoneKey.getTimeZoneKey("Etc/GMT-00:00"), UTC_KEY);
+        assertSame(TimeZoneKey.getTimeZoneKey("Etc/UT"), UTC_KEY);
+        assertSame(TimeZoneKey.getTimeZoneKey("Etc/UCT"), UTC_KEY);
+        assertSame(TimeZoneKey.getTimeZoneKey("Etc/Universal"), UTC_KEY);
     }
 
     @Test
@@ -163,8 +159,6 @@ public class TestTimeZoneKey
         for (TimeZoneKey timeZoneKey : TimeZoneKey.getTimeZoneKeys()) {
             assertSame(TimeZoneKey.getTimeZoneKey(timeZoneKey.getKey()), timeZoneKey);
             assertSame(TimeZoneKey.getTimeZoneKey(timeZoneKey.getId()), timeZoneKey);
-            assertSame(TimeZoneKey.getTimeZoneKey(timeZoneKey.getId().toUpperCase(ENGLISH)), timeZoneKey);
-            assertSame(TimeZoneKey.getTimeZoneKey(timeZoneKey.getId().toLowerCase(ENGLISH)), timeZoneKey);
         }
     }
 


### PR DESCRIPTION
Time zones are case sensitive and case-insensitive time zones
are not actually supported by Joda or the JDK, so there's
no point in allowing that in TimeZoneKey.