### PR TITLE
Rewrite LIKE patterns to string matching

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
@@ -926,6 +926,18 @@ public final class StringFunctions
         return source.compareTo(source.length() - suffix.length(), suffix.length(), suffix, 0, suffix.length()) == 0;
     }
 
+    @Description("Determine whether source contains fragment or not")
+    @ScalarFunction
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean contains(@SqlType("varchar(x)") Slice source, @SqlType("varchar(y)") Slice fragment)
+    {
+        if (source.length() < fragment.length()) {
+            return false;
+        }
+        return source.indexOf(fragment) >= 0;
+    }
+
     @Description("Translate characters from the source string based on original and translations strings")
     @ScalarFunction
     @LiteralParameters({"x", "y", "z"})

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/StringFunctions.java
@@ -914,6 +914,18 @@ public final class StringFunctions
         return source.compareTo(0, prefix.length(), prefix, 0, prefix.length()) == 0;
     }
 
+    @Description("Determine whether source ends with suffix or not")
+    @ScalarFunction
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean endsWith(@SqlType("varchar(x)") Slice source, @SqlType("varchar(y)") Slice suffix)
+    {
+        if (source.length() < suffix.length()) {
+            return false;
+        }
+        return source.compareTo(source.length() - suffix.length(), suffix.length(), suffix, 0, suffix.length()) == 0;
+    }
+
     @Description("Translate characters from the source string based on original and translations strings")
     @ScalarFunction
     @LiteralParameters({"x", "y", "z"})

--- a/presto-main/src/main/java/io/prestosql/sql/planner/DesugarLikeRewriter.java
+++ b/presto-main/src/main/java/io/prestosql/sql/planner/DesugarLikeRewriter.java
@@ -24,13 +24,17 @@ import io.prestosql.sql.tree.FunctionCall;
 import io.prestosql.sql.tree.LikePredicate;
 import io.prestosql.sql.tree.NodeRef;
 import io.prestosql.sql.tree.QualifiedName;
+import io.prestosql.sql.tree.StringLiteral;
 import io.prestosql.sql.tree.SymbolReference;
 
 import java.util.Map;
+import java.util.Optional;
 
+import static io.prestosql.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
 import static io.prestosql.type.LikeFunctions.LIKE_PATTERN_FUNCTION_NAME;
 import static io.prestosql.type.LikePatternType.LIKE_PATTERN;
+import static io.prestosql.util.Failures.checkCondition;
 import static java.util.Objects.requireNonNull;
 
 public final class DesugarLikeRewriter
@@ -72,6 +76,16 @@ public final class DesugarLikeRewriter
         {
             LikePredicate rewritten = treeRewriter.defaultRewrite(node, context);
 
+            Optional<FunctionCall> startsWithFunctionCall = tryRewriteToStartsWith(node, rewritten);
+            if (startsWithFunctionCall.isPresent()) {
+                return startsWithFunctionCall.get();
+            }
+
+            Optional<FunctionCall> endsWithFunctionCall = tryRewriteToEndsWith(node, rewritten);
+            if (endsWithFunctionCall.isPresent()) {
+                return endsWithFunctionCall.get();
+            }
+
             FunctionCall patternCall;
             if (rewritten.getEscape().isPresent()) {
                 patternCall = new FunctionCallBuilder(metadata)
@@ -97,6 +111,112 @@ public final class DesugarLikeRewriter
         private Type getType(Expression expression)
         {
             return expressionTypes.get(NodeRef.of(expression));
+        }
+
+        private Optional<FunctionCall> tryRewriteToStartsWith(LikePredicate node, LikePredicate rewritten)
+        {
+            if (canRewrite(rewritten)) {
+                String patternString = ((StringLiteral) rewritten.getPattern()).getValue();
+                char escapeChar = (char) -1;
+                if (rewritten.getEscape().isPresent()) {
+                    escapeChar = getEscapeCharacter(((StringLiteral) rewritten.getEscape().get()).getValue());
+                }
+
+                Optional<String> prefix = getSearchPrefix(patternString, escapeChar);
+                if (prefix.isPresent()) {
+                    FunctionCall functionCall = new FunctionCallBuilder(metadata)
+                            .setName(QualifiedName.of("STARTS_WITH"))
+                            .addArgument(getType(node.getValue()), rewritten.getValue())
+                            .addArgument(VARCHAR, new StringLiteral(prefix.get()))
+                            .build();
+                    return Optional.of(functionCall);
+                }
+            }
+            return Optional.empty();
+        }
+
+        private Optional<FunctionCall> tryRewriteToEndsWith(LikePredicate node, LikePredicate rewritten)
+        {
+            if (canRewrite(rewritten)) {
+                String patternString = ((StringLiteral) rewritten.getPattern()).getValue();
+                char escapeChar = (char) -1;
+                if (rewritten.getEscape().isPresent()) {
+                    escapeChar = getEscapeCharacter(((StringLiteral) rewritten.getEscape().get()).getValue());
+                }
+
+                Optional<String> suffix = getSearchSuffix(patternString, escapeChar);
+                if (suffix.isPresent()) {
+                    FunctionCall functionCall = new FunctionCallBuilder(metadata)
+                            .setName(QualifiedName.of("ENDS_WITH"))
+                            .addArgument(getType(node.getValue()), rewritten.getValue())
+                            .addArgument(VARCHAR, new StringLiteral(suffix.get()))
+                            .build();
+                    return Optional.of(functionCall);
+                }
+            }
+            return Optional.empty();
+        }
+
+        private static boolean canRewrite(LikePredicate rewritten)
+        {
+            return rewritten.getPattern() instanceof StringLiteral && (rewritten.getEscape().isEmpty() || rewritten.getEscape().get() instanceof StringLiteral);
+        }
+
+        private static char getEscapeCharacter(String stringEscape)
+        {
+            if (stringEscape.isEmpty()) {
+                return (char) -1;
+            }
+            checkCondition(stringEscape.length() == 1, INVALID_FUNCTION_ARGUMENT, "Escape string must be a single character");
+            return stringEscape.charAt(0);
+        }
+
+        private static Optional<String> getSearchPrefix(String patternString, char escapeChar)
+        {
+            int len = patternString.length();
+            if (len >= 2 && patternString.charAt(len - 1) == '%' && (escapeChar == -1 || patternString.charAt(len - 2) != escapeChar)) {
+                return convertToSearchString(patternString.substring(0, len - 1), escapeChar);
+            }
+            return Optional.empty();
+        }
+
+        private static Optional<String> getSearchSuffix(String patternString, char escapeChar)
+        {
+            int len = patternString.length();
+            if (len >= 2 && patternString.charAt(0) == '%') {
+                return convertToSearchString(patternString.substring(1, len), escapeChar);
+            }
+            return Optional.empty();
+        }
+
+        private static Optional<String> convertToSearchString(String pattern, char escapeChar)
+        {
+            boolean escaped = false;
+            StringBuilder sb = new StringBuilder();
+            for (char currentChar : pattern.toCharArray()) {
+                checkEscape(!escaped || currentChar == '%' || currentChar == '_' || currentChar == escapeChar);
+                if (!escaped && currentChar == escapeChar) {
+                    escaped = true;
+                }
+                else {
+                    switch (currentChar) {
+                        case '%':
+                        case '_':
+                            if (!escaped) {
+                                return Optional.empty();
+                            }
+                        default:
+                    }
+                    sb.append(currentChar);
+                    escaped = false;
+                }
+            }
+            return Optional.of(sb.toString());
+        }
+
+        private static void checkEscape(boolean condition)
+        {
+            checkCondition(condition, INVALID_FUNCTION_ARGUMENT, "Escape character must be followed by '%%', '_' or the escape character itself");
         }
     }
 }

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestStringFunctions.java
@@ -294,6 +294,17 @@ public class TestStringFunctions
         assertFunction("STARTS_WITH('信念 爱 希望', '信念')", BOOLEAN, true);
         assertFunction("STARTS_WITH('信念 爱 希望', '爱')", BOOLEAN, false);
 
+        assertFunction("ENDS_WITH('foo', 'foo')", BOOLEAN, true);
+        assertFunction("ENDS_WITH('foo', 'bar')", BOOLEAN, false);
+        assertFunction("ENDS_WITH('foo', '')", BOOLEAN, true);
+        assertFunction("ENDS_WITH('', 'foo')", BOOLEAN, false);
+        assertFunction("ENDS_WITH('', '')", BOOLEAN, true);
+        assertFunction("ENDS_WITH('foo_bar_baz', 'baz')", BOOLEAN, true);
+        assertFunction("ENDS_WITH('foo_bar_baz', 'bar')", BOOLEAN, false);
+        assertFunction("ENDS_WITH('foo', 'foo_bar_baz')", BOOLEAN, false);
+        assertFunction("ENDS_WITH('信念 爱 希望', '希望')", BOOLEAN, true);
+        assertFunction("ENDS_WITH('信念 爱 希望', '爱')", BOOLEAN, false);
+
         assertFunction("STRPOS(NULL, '')", BIGINT, null);
         assertFunction("STRPOS('', NULL)", BIGINT, null);
         assertFunction("STRPOS(NULL, NULL)", BIGINT, null);

--- a/presto-main/src/test/java/io/prestosql/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/operator/scalar/TestStringFunctions.java
@@ -305,6 +305,17 @@ public class TestStringFunctions
         assertFunction("ENDS_WITH('信念 爱 希望', '希望')", BOOLEAN, true);
         assertFunction("ENDS_WITH('信念 爱 希望', '爱')", BOOLEAN, false);
 
+        assertFunction("CONTAINS('foo', 'foo')", BOOLEAN, true);
+        assertFunction("CONTAINS('foo', 'bar')", BOOLEAN, false);
+        assertFunction("CONTAINS('foo', '')", BOOLEAN, true);
+        assertFunction("CONTAINS('', 'foo')", BOOLEAN, false);
+        assertFunction("CONTAINS('', '')", BOOLEAN, true);
+        assertFunction("CONTAINS('foo_bar_baz', 'baz')", BOOLEAN, true);
+        assertFunction("CONTAINS('foo_bar_baz', 'bar')", BOOLEAN, true);
+        assertFunction("CONTAINS('foo', 'foo_bar_baz')", BOOLEAN, false);
+        assertFunction("CONTAINS('信念 爱 希望', '希望')", BOOLEAN, true);
+        assertFunction("CONTAINS('信念 爱 希望', '爱')", BOOLEAN, true);
+
         assertFunction("STRPOS(NULL, '')", BIGINT, null);
         assertFunction("STRPOS('', NULL)", BIGINT, null);
         assertFunction("STRPOS(NULL, NULL)", BIGINT, null);

--- a/presto-main/src/test/java/io/prestosql/sql/planner/TestDesugarLikeRewriter.java
+++ b/presto-main/src/test/java/io/prestosql/sql/planner/TestDesugarLikeRewriter.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.sql.planner;
+
+import com.google.common.collect.ImmutableMap;
+import io.prestosql.spi.type.Type;
+import io.prestosql.sql.planner.assertions.ExpressionVerifier;
+import io.prestosql.sql.planner.assertions.SymbolAliases;
+import io.prestosql.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.prestosql.sql.tree.Expression;
+import io.prestosql.sql.tree.LikePredicate;
+import io.prestosql.sql.tree.QualifiedName;
+import io.prestosql.sql.tree.StringLiteral;
+import io.prestosql.sql.tree.SymbolReference;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static io.prestosql.type.LikeFunctions.LIKE_PATTERN_FUNCTION_NAME;
+import static io.prestosql.type.LikePatternType.LIKE_PATTERN;
+import static org.testng.Assert.assertTrue;
+
+public class TestDesugarLikeRewriter
+        extends BaseRuleTest
+{
+    private static final Map<Symbol, Type> symbols = ImmutableMap.<Symbol, Type>builder()
+            .put(new Symbol("x"), VARCHAR)
+            .build();
+
+    private static final TypeProvider TYPE_PROVIDER = TypeProvider.copyOf(symbols);
+    private static final SymbolAliases SYMBOL_ALIASES = SymbolAliases.builder().put("x", new SymbolReference("x")).build();
+
+    @Test
+    public void testStartsWithOptimization()
+    {
+        Expression initial = new LikePredicate(
+                new SymbolReference("x"),
+                new StringLiteral("test%"),
+                Optional.empty());
+
+        Expression rewritten = tryRewrite(initial);
+
+        Expression expected = new FunctionCallBuilder(tester().getMetadata())
+                .setName(QualifiedName.of("STARTS_WITH"))
+                .addArgument(VARCHAR, new SymbolReference("x"))
+                .addArgument(VARCHAR, new StringLiteral("test"))
+                .build();
+
+        ExpressionVerifier verifier = new ExpressionVerifier(SYMBOL_ALIASES);
+        assertTrue(verifier.process(rewritten, expected));
+    }
+
+    @Test
+    public void testStartsWithOptimizationWithEscape()
+    {
+        Expression initial = new LikePredicate(
+                new SymbolReference("x"),
+                new StringLiteral("test\\_test%"),
+                Optional.of(new StringLiteral("\\")));
+
+        Expression rewritten = tryRewrite(initial);
+
+        Expression expected = new FunctionCallBuilder(tester().getMetadata())
+                .setName(QualifiedName.of("STARTS_WITH"))
+                .addArgument(VARCHAR, new SymbolReference("x"))
+                .addArgument(VARCHAR, new StringLiteral("test_test"))
+                .build();
+
+        ExpressionVerifier verifier = new ExpressionVerifier(SYMBOL_ALIASES);
+        assertTrue(verifier.process(rewritten, expected));
+    }
+
+    @Test
+    public void testEndsWithOptimization()
+    {
+        Expression initial = new LikePredicate(
+                new SymbolReference("x"),
+                new StringLiteral("%test"),
+                Optional.empty());
+
+        Expression rewritten = tryRewrite(initial);
+
+        Expression expected = new FunctionCallBuilder(tester().getMetadata())
+                .setName(QualifiedName.of("ENDS_WITH"))
+                .addArgument(VARCHAR, new SymbolReference("x"))
+                .addArgument(VARCHAR, new StringLiteral("test"))
+                .build();
+
+        ExpressionVerifier verifier = new ExpressionVerifier(SYMBOL_ALIASES);
+        assertTrue(verifier.process(rewritten, expected));
+    }
+
+    @Test
+    public void testEndsWithOptimizationWithEscape()
+    {
+        Expression initial = new LikePredicate(
+                new SymbolReference("x"),
+                new StringLiteral("%test\\_test"),
+                Optional.of(new StringLiteral("\\")));
+
+        Expression rewritten = tryRewrite(initial);
+
+        Expression expected = new FunctionCallBuilder(tester().getMetadata())
+                .setName(QualifiedName.of("ENDS_WITH"))
+                .addArgument(VARCHAR, new SymbolReference("x"))
+                .addArgument(VARCHAR, new StringLiteral("test_test"))
+                .build();
+
+        ExpressionVerifier verifier = new ExpressionVerifier(SYMBOL_ALIASES);
+        assertTrue(verifier.process(rewritten, expected));
+    }
+
+    @Test
+    public void testNotOptimized()
+    {
+        Expression initial = new LikePredicate(
+                new SymbolReference("x"),
+                new StringLiteral("test_test%"),
+                Optional.empty());
+
+        Expression rewritten = tryRewrite(initial);
+
+        Expression expected = new FunctionCallBuilder(tester().getMetadata())
+                .setName(QualifiedName.of("LIKE"))
+                .addArgument(VARCHAR, new SymbolReference("x"))
+                .addArgument(LIKE_PATTERN, new FunctionCallBuilder(tester().getMetadata())
+                        .setName(QualifiedName.of(LIKE_PATTERN_FUNCTION_NAME))
+                        .addArgument(VARCHAR, new StringLiteral("test_test%"))
+                        .build())
+                .build();
+
+        ExpressionVerifier verifier = new ExpressionVerifier(SYMBOL_ALIASES);
+        assertTrue(verifier.process(rewritten, expected));
+    }
+
+    private Expression tryRewrite(Expression expression)
+    {
+        Expression rewritten = DesugarLikeRewriter.rewrite(
+                expression,
+                tester().getSession(),
+                tester().getMetadata(),
+                tester().getTypeAnalyzer(),
+                TYPE_PROVIDER);
+
+        return rewritten;
+    }
+}


### PR DESCRIPTION
Improve `LIKE` predicates performance by rewriting to UDFs which don't use a regular expression.

- Add `ENDS_WITH` and `CONTAINS` functions
- Rewrite `LIKE` predicates to `STARTS_WITH`, `ENDS_WITH` or `CONTAINS` if possible
