### PR TITLE
Update GlueToPrestoConverter.java

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/converter/GlueToPrestoConverter.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/glue/converter/GlueToPrestoConverter.java
@@ -125,10 +125,17 @@ public final class GlueToPrestoConverter
                 .build();
     }
 
-    private static Column convertColumn(com.amazonaws.services.glue.model.Column glueColumn)
-    {
-        return new Column(glueColumn.getName(), HiveType.valueOf(glueColumn.getType().toLowerCase(Locale.ENGLISH)), Optional.ofNullable(glueColumn.getComment()));
-    }
+	private static Column convertColumn(com.amazonaws.services.glue.model.Column glueColumn, StorageDescriptor storageDescriptor)
+	{
+		if(storageDescriptor.getSerdeInfo().getName() != null &&
+		! ((storageDescriptor.getSerdeInfo().getName().contains("csv")) ||
+		(storageDescriptor.getSerdeInfo().getName().contains("CSV")))) {
+		return new Column(glueColumn.getName(), HiveType.valueOf(glueColumn.getType().toLowerCase(Locale.ENGLISH)), Optional.ofNullable(glueColumn.getComment()));
+		}
+		else{
+		return new Column(glueColumn.getName(), HiveType. HIVE_STRING, Optional.ofNullable(glueColumn.getComment()));
+		}
+	}
 
     public static Partition convertPartition(com.amazonaws.services.glue.model.Partition gluePartition, Map<String, String> tableParameters)
     {


### PR DESCRIPTION
Column type to string for CSV tables on Glue metastore #4531
Check for "csv", "CSV" in the serdename to check for CSV Serde and convert all columns to String.