### PR TITLE
Support file caching in the Iceberg connector

### DIFF
--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
@@ -21,6 +21,7 @@ import io.prestosql.plugin.tpch.TpchPlugin;
 import io.prestosql.testing.DistributedQueryRunner;
 import io.prestosql.tpch.TpchTable;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
@@ -57,12 +58,17 @@ public final class IcebergQueryRunner
         queryRunner.installPlugin(new TpchPlugin());
         queryRunner.createCatalog("tpch", "tpch");
 
-        Path dataDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data");
-
         queryRunner.installPlugin(new IcebergPlugin());
+
+        Path dataDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data");
+        Path cacheDir = dataDir.resolve("hive_cache");
+        Files.createDirectories(cacheDir);
+
         Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
                 .put("hive.metastore", "file")
                 .put("hive.metastore.catalog.dir", dataDir.toString())
+                .put("hive.cache.location", cacheDir.toString())
+                .put("hive.cache.enabled", "true")
                 .build();
 
         queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);


### PR DESCRIPTION
This commit adds support for file caching in the Iceberg
connector, which is turned off by default, but unconditionally
enabled in the IcebergQueryRunner.

However, when I run the tests in TestIcebergSmoke, though I see
the caching layer getting initialized, the cache read endpoints
aren't getting called.  I suspect this is because the caching
layer only works on remote files.  It needs to be explained.

@electrum, do you know why the caching read endpoints aren't
getting called in tests?