### PR TITLE
Build Arm supporting docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
           ./bin/retry ./mvnw verify -B -P ci -pl presto-server-rpm
       - name: Clean Maven Output
         run: ./mvnw clean -pl '!presto-server,!presto-cli'
+      - uses: crazy-max/ghaction-docker-buildx@v3
+        with:
+          buildx-version: latest
+          qemu-version: latest
       - name: Test Docker Image
         run: docker/build-local.sh
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,11 +15,13 @@ FROM centos:centos8
 LABEL maintainer="Presto community <https://prestosql.io/community.html>"
 
 ENV JAVA_HOME /usr/lib/jvm/zulu11
+ENV PATH $PATH:$JAVA_HOME/bin
+
 RUN \
     set -xeu && \
-    dnf -y -q install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
     dnf -y -q update && \
-    dnf -y -q install zulu11 less python3 && \
+    dnf -y -q install less python3 && \
+    dnf -q clean all && \
     alternatives --set python /usr/bin/python3 && \
     dnf -q clean all && \
     rm -rf /var/cache/dnf && \
@@ -28,6 +30,19 @@ RUN \
     useradd presto --uid 1000 --gid 1000 && \
     mkdir -p /usr/lib/presto /data/presto && \
     chown -R "presto:presto" /usr/lib/presto /data/presto
+
+ARG TARGETPLATFORM
+RUN if [[ "$TARGETPLATFORM" == "linux/arm64" ]] ; then \
+      mkdir -p $JAVA_HOME && \
+      curl -sS 'https://cdn.azul.com/zulu-embedded/bin/zulu11.41.75-ca-jdk11.0.8-linux_aarch64.tar.gz' | \
+              tar --strip-components=1 -xz -C $JAVA_HOME ; \
+    elif [[ "$TARGETPLATFORM" == "linux/amd64" ]] ; then \
+        dnf -y -q install https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-1.noarch.rpm && \
+          dnf -y -q update && \
+          dnf -y -q install zulu11 ; \
+    else \
+       echo "Unsupported platform: $TARGETPLATFORM" && exit 1 ; \
+    fi
 
 ARG PRESTO_VERSION
 COPY presto-cli-${PRESTO_VERSION}-executable.jar /usr/bin/presto

--- a/docker/README.md
+++ b/docker/README.md
@@ -26,6 +26,17 @@ INFO	main	io.prestosql.server.Server	======== SERVER STARTED ========
 
 The Presto server is now running on `localhost:8080` (the default port).
 
+#### Image supporting ARM64
+
+You can also launch a container supporting Arm architecture as well. 
+Since we publish the image supporting `linux/arm64` architecture, Docker engine transparently pulls the image corresponding to your platform.
+
+A script `push-images.sh` upload the images supporting `linux/amd64` and `linux/arm64` to Dockerhub.
+
+```
+$ ./push-images.sh <Presto Version>
+```  
+
 ### Run the Presto CLI
 
 Run the [Presto CLI](https://prestosql.io/docs/current/installation/cli.html),

--- a/docker/build-local.sh
+++ b/docker/build-local.sh
@@ -19,7 +19,8 @@ cp -R bin default ${WORK_DIR}/presto-server-${PRESTO_VERSION}
 
 cp ../presto-cli/target/presto-cli-${PRESTO_VERSION}-executable.jar ${WORK_DIR}
 
-docker build ${WORK_DIR} --pull -f Dockerfile --build-arg "PRESTO_VERSION=${PRESTO_VERSION}" -t "presto:${PRESTO_VERSION}"
+# Loading multi-arch images is not supported
+DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build ${WORK_DIR} --platform linux/amd64 -f Dockerfile --build-arg "PRESTO_VERSION=${PRESTO_VERSION}" -t "presto:${PRESTO_VERSION}" --load
 
 rm -r ${WORK_DIR}
 

--- a/docker/push-images.sh
+++ b/docker/push-images.sh
@@ -25,13 +25,10 @@ cp -R bin default ${WORK_DIR}/presto-server-${PRESTO_VERSION}
 curl -o ${WORK_DIR}/presto-cli-${PRESTO_VERSION}-executable.jar ${CLIENT_LOCATION}
 chmod +x ${WORK_DIR}/presto-cli-${PRESTO_VERSION}-executable.jar
 
-# Loading multi-arch images is not supported
-DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build ${WORK_DIR} --platform linux/amd64  -f Dockerfile --build-arg "PRESTO_VERSION=${PRESTO_VERSION}" -t "presto:${PRESTO_VERSION}" --load
-
-rm -r ${WORK_DIR}
-
-# Source common testing functions
-. container-test.sh
-
-test_container "presto:${PRESTO_VERSION}"
-
+# Push multi-arch images supporting amd64 and arm64 architecture.
+DOCKER_CLI_EXPERIMENTAL=enabled \
+    docker buildx build ${WORK_DIR} \
+    --platform linux/amd64,linux/arm64/v8 \
+    -f Dockerfile \
+    --build-arg "PRESTO_VERSION=${PRESTO_VERSION}" \
+    -t "prestosql/presto:${PRESTO_VERSION}" --push


### PR DESCRIPTION
Since Presto now supports Arm architecture officially, it would be great if we could also try the Arm platform with docker out-of-the-box. This change introduces a new docker image suffixed with `-arm64v8` supporting Arm platform. I confirmed the image works well with [the Graviton2](https://aws.amazon.com/ec2/graviton/) processor in AWS. 

It's related to https://github.com/prestosql/presto/issues/2262.

Although I assumed `build-remote.sh` would distribute the image in the DockerHub, it might not be correct because I could not find the usage of the script in the repository. Does just building an image with `built-remote.sh` correctly push it to DockerHub?