### PR TITLE
Add support to redirect from a Hive catalog to an Iceberg catalog

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -134,6 +134,9 @@ public class HiveConfig
 
     private boolean projectionPushdownEnabled = true;
 
+    private boolean redirectToIcebergEnabled;
+    private String redirectToIcebergCatalog = "iceberg";
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -975,6 +978,33 @@ public class HiveConfig
     public HiveConfig setProjectionPushdownEnabled(boolean projectionPushdownEnabled)
     {
         this.projectionPushdownEnabled = projectionPushdownEnabled;
+        return this;
+    }
+
+    public boolean isRedirectToIcebergEnabled()
+    {
+        return redirectToIcebergEnabled;
+    }
+
+    @Config("hive.redirect-to-iceberg-enabled")
+    @ConfigDescription("Redirect to a catalog configured with Iceberg Connector")
+    public HiveConfig setRedirectToIcebergEnabled(boolean redirectToIcebergEnabled)
+    {
+        this.redirectToIcebergEnabled = redirectToIcebergEnabled;
+        return this;
+    }
+
+    @NotNull
+    public String getRedirectToIcebergCatalog()
+    {
+        return redirectToIcebergCatalog;
+    }
+
+    @Config("hive.redirect-to-iceberg-catalog")
+    @ConfigDescription("The Iceberg catalog to redirect to")
+    public HiveConfig setRedirectToIcebergCatalog(String redirectToIcebergCatalog)
+    {
+        this.redirectToIcebergCatalog = redirectToIcebergCatalog;
         return this;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -91,6 +91,8 @@ public final class HiveSessionProperties
     private static final String QUERY_PARTITION_FILTER_REQUIRED = "query_partition_filter_required";
     private static final String PROJECTION_PUSHDOWN_ENABLED = "projection_pushdown_enabled";
     private static final String PARQUET_OPTIMIZED_WRITER_ENABLED = "parquet_optimized_writer_enabled";
+    private static final String REDIRECT_TO_ICEBERG_ENABLED = "redirect_to_iceberg_enabled";
+    private static final String REDIRECT_TO_ICEBERG_CATALOG = "redirect_to_iceberg_catalog";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -369,6 +371,16 @@ public final class HiveSessionProperties
                         PARQUET_OPTIMIZED_WRITER_ENABLED,
                         "Experimental: Enable optimized writer",
                         parquetWriterConfig.isParquetOptimizedWriterEnabled(),
+                        false),
+                booleanProperty(
+                        REDIRECT_TO_ICEBERG_ENABLED,
+                        "Enable redirecting to a catalog configured with Iceberg Connector",
+                        hiveConfig.isRedirectToIcebergEnabled(),
+                        false),
+                stringProperty(
+                        REDIRECT_TO_ICEBERG_CATALOG,
+                        "The target Iceberg catalog for redirection",
+                        hiveConfig.getRedirectToIcebergCatalog(),
                         false));
     }
 
@@ -634,5 +646,15 @@ public final class HiveSessionProperties
     public static boolean isParquetOptimizedWriterEnabled(ConnectorSession session)
     {
         return session.getProperty(PARQUET_OPTIMIZED_WRITER_ENABLED, Boolean.class);
+    }
+
+    public static boolean isRedirectToIcebergEnabled(ConnectorSession session)
+    {
+        return session.getProperty(REDIRECT_TO_ICEBERG_ENABLED, Boolean.class);
+    }
+
+    public static String getRedirectToIcebergCatalog(ConnectorSession session)
+    {
+        return session.getProperty(REDIRECT_TO_ICEBERG_CATALOG, String.class);
     }
 }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
@@ -96,7 +96,9 @@ public class TestHiveConfig
                 .setAllowRegisterPartition(false)
                 .setQueryPartitionFilterRequired(false)
                 .setPartitionUseColumnNames(false)
-                .setProjectionPushdownEnabled(true));
+                .setProjectionPushdownEnabled(true)
+                .setRedirectToIcebergEnabled(false)
+                .setRedirectToIcebergCatalog("iceberg"));
     }
 
     @Test
@@ -166,6 +168,8 @@ public class TestHiveConfig
                 .put("hive.query-partition-filter-required", "true")
                 .put("hive.partition-use-column-names", "true")
                 .put("hive.projection-pushdown-enabled", "false")
+                .put("hive.redirect-to-iceberg-enabled", "true")
+                .put("hive.redirect-to-iceberg-catalog", "myiceberg")
                 .build();
 
         HiveConfig expected = new HiveConfig()
@@ -231,7 +235,9 @@ public class TestHiveConfig
                 .setAllowRegisterPartition(true)
                 .setQueryPartitionFilterRequired(true)
                 .setPartitionUseColumnNames(true)
-                .setProjectionPushdownEnabled(false);
+                .setProjectionPushdownEnabled(false)
+                .setRedirectToIcebergEnabled(true)
+                .setRedirectToIcebergCatalog("myiceberg");
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/main/java/io/prestosql/execution/CommentTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/CommentTask.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.prestosql.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.prestosql.metadata.MetadataUtil.redirectToNewCatalogIfNecessary;
 import static io.prestosql.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static io.prestosql.spi.StandardErrorCode.MISSING_TABLE;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -53,6 +54,7 @@ public class CommentTask
 
         if (statement.getType() == Comment.Type.TABLE) {
             QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
+            tableName = redirectToNewCatalogIfNecessary(session, tableName, metadata);
             Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
             if (tableHandle.isEmpty()) {
                 throw semanticException(TABLE_NOT_FOUND, statement, "Table does not exist: %s", tableName);
@@ -69,6 +71,7 @@ public class CommentTask
             }
 
             QualifiedObjectName tableName = createQualifiedObjectName(session, statement, prefix.get());
+            tableName = redirectToNewCatalogIfNecessary(session, tableName, metadata);
             Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
             if (tableHandle.isEmpty()) {
                 throw semanticException(TABLE_NOT_FOUND, statement, "Table does not exist: " + tableName);

--- a/presto-main/src/main/java/io/prestosql/execution/CreateViewTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/CreateViewTask.java
@@ -37,6 +37,7 @@ import java.util.Optional;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.prestosql.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.prestosql.metadata.MetadataUtil.redirectToNewCatalogIfNecessary;
 import static io.prestosql.spi.connector.ConnectorViewDefinition.ViewColumn;
 import static io.prestosql.sql.ParameterUtils.parameterExtractor;
 import static io.prestosql.sql.SqlFormatterUtil.getFormattedSql;
@@ -72,7 +73,7 @@ public class CreateViewTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
-
+        name = redirectToNewCatalogIfNecessary(session, name, metadata);
         accessControl.checkCanCreateView(session.toSecurityContext(), name);
 
         String sql = getFormattedSql(statement.getQuery(), sqlParser);

--- a/presto-main/src/main/java/io/prestosql/execution/DropColumnTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/DropColumnTask.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.prestosql.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.prestosql.metadata.MetadataUtil.redirectToNewCatalogIfNecessary;
 import static io.prestosql.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.TABLE_NOT_FOUND;
@@ -49,6 +50,7 @@ public class DropColumnTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable());
+        tableName = redirectToNewCatalogIfNecessary(session, tableName, metadata);
         Optional<TableHandle> tableHandleOptional = metadata.getTableHandle(session, tableName);
 
         if (tableHandleOptional.isEmpty()) {

--- a/presto-main/src/main/java/io/prestosql/execution/DropTableTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/DropTableTask.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.prestosql.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.prestosql.metadata.MetadataUtil.redirectToNewCatalogIfNecessary;
 import static io.prestosql.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.prestosql.sql.analyzer.SemanticExceptions.semanticException;
 
@@ -45,6 +46,7 @@ public class DropTableTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
+        tableName = redirectToNewCatalogIfNecessary(session, tableName, metadata);
 
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (tableHandle.isEmpty()) {

--- a/presto-main/src/main/java/io/prestosql/execution/DropViewTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/DropViewTask.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.prestosql.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.prestosql.metadata.MetadataUtil.redirectToNewCatalogIfNecessary;
 import static io.prestosql.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.prestosql.sql.analyzer.SemanticExceptions.semanticException;
 
@@ -45,6 +46,7 @@ public class DropViewTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
+        name = redirectToNewCatalogIfNecessary(session, name, metadata);
 
         Optional<ConnectorViewDefinition> view = metadata.getView(session, name);
         if (view.isEmpty()) {

--- a/presto-main/src/main/java/io/prestosql/execution/GrantTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/GrantTask.java
@@ -33,6 +33,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.prestosql.metadata.MetadataUtil.createPrincipal;
 import static io.prestosql.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.prestosql.metadata.MetadataUtil.redirectToNewCatalogIfNecessary;
 import static io.prestosql.spi.StandardErrorCode.INVALID_PRIVILEGE;
 import static io.prestosql.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.prestosql.sql.analyzer.SemanticExceptions.semanticException;
@@ -51,6 +52,7 @@ public class GrantTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
+        tableName = redirectToNewCatalogIfNecessary(session, tableName, metadata);
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (tableHandle.isEmpty()) {
             throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);

--- a/presto-main/src/main/java/io/prestosql/execution/RenameColumnTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/RenameColumnTask.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.prestosql.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.prestosql.metadata.MetadataUtil.redirectToNewCatalogIfNecessary;
 import static io.prestosql.spi.StandardErrorCode.COLUMN_ALREADY_EXISTS;
 import static io.prestosql.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -51,6 +52,7 @@ public class RenameColumnTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable());
+        tableName = redirectToNewCatalogIfNecessary(session, tableName, metadata);
         Optional<TableHandle> tableHandleOptional = metadata.getTableHandle(session, tableName);
         if (tableHandleOptional.isEmpty()) {
             if (!statement.isTableExists()) {

--- a/presto-main/src/main/java/io/prestosql/execution/RevokeTask.java
+++ b/presto-main/src/main/java/io/prestosql/execution/RevokeTask.java
@@ -33,6 +33,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.prestosql.metadata.MetadataUtil.createPrincipal;
 import static io.prestosql.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.prestosql.metadata.MetadataUtil.redirectToNewCatalogIfNecessary;
 import static io.prestosql.spi.StandardErrorCode.INVALID_PRIVILEGE;
 import static io.prestosql.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.prestosql.sql.analyzer.SemanticExceptions.semanticException;
@@ -51,6 +52,7 @@ public class RevokeTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
+        tableName = redirectToNewCatalogIfNecessary(session, tableName, metadata);
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (tableHandle.isEmpty()) {
             throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);

--- a/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/Metadata.java
@@ -533,4 +533,9 @@ public interface Metadata
     ColumnPropertyManager getColumnPropertyManager();
 
     AnalyzePropertyManager getAnalyzePropertyManager();
+
+    /**
+     * Redirects to another catalog which may or may not use the same connector
+     */
+    Optional<String> redirectCatalog(Session session, QualifiedObjectName tableName);
 }

--- a/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/MetadataManager.java
@@ -1796,6 +1796,28 @@ public final class MetadataManager
         return analyzePropertyManager;
     }
 
+    @Override
+    public Optional<String> redirectCatalog(Session session, QualifiedObjectName tableName)
+    {
+        requireNonNull(tableName, "tableName is null");
+
+        if (tableName.getCatalogName().isEmpty() || tableName.getSchemaName().isEmpty() || tableName.getObjectName().isEmpty()) {
+            return Optional.empty();
+        }
+
+        Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, tableName.getCatalogName());
+        if (catalog.isPresent()) {
+            CatalogMetadata catalogMetadata = catalog.get();
+            CatalogName catalogName = catalogMetadata.getConnectorId(session, tableName);
+            ConnectorMetadata metadata = catalogMetadata.getMetadataFor(catalogName);
+
+            ConnectorSession connectorSession = session.toConnectorSession(catalogName);
+            return metadata.redirectCatalog(connectorSession, tableName.asSchemaTableName());
+        }
+
+        return Optional.empty();
+    }
+
     //
     // Helpers
     //

--- a/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowStatsRewrite.java
+++ b/presto-main/src/main/java/io/prestosql/sql/rewrite/ShowStatsRewrite.java
@@ -75,6 +75,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.prestosql.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.prestosql.metadata.MetadataUtil.redirectToNewCatalogIfNecessary;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.prestosql.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.prestosql.spi.type.DateType.DATE;
@@ -142,6 +143,7 @@ public class ShowStatsRewrite
 
             Table table = getTable(node, specification);
             QualifiedObjectName tableName = createQualifiedObjectName(session, node, table.getName());
+            tableName = redirectToNewCatalogIfNecessary(session, tableName, metadata);
             TableHandle tableHandle = metadata.getTableHandle(session, tableName)
                     .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, node, "Table '%s' not found", table.getName()));
             TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle);

--- a/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/io/prestosql/metadata/AbstractMockMetadata.java
@@ -749,4 +749,10 @@ public abstract class AbstractMockMetadata
     {
         return Optional.empty();
     }
+
+    @Override
+    public Optional<String> redirectCatalog(Session session, QualifiedObjectName tableName)
+    {
+        return Optional.empty();
+    }
 }

--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -740,4 +740,12 @@ public class ClassLoaderSafeConnectorMetadata
             delegate.validateScan(session, handle);
         }
     }
+
+    @Override
+    public Optional<String> redirectCatalog(ConnectorSession session, SchemaTableName tableName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.redirectCatalog(session, tableName);
+        }
+    }
 }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeHiveRedirectionToIceberg.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodeHiveRedirectionToIceberg.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.env.environment;
+
+import com.google.common.collect.ImmutableList;
+import io.prestosql.tests.product.launcher.docker.DockerFiles;
+import io.prestosql.tests.product.launcher.env.Environment;
+import io.prestosql.tests.product.launcher.env.common.AbstractEnvironmentProvider;
+import io.prestosql.tests.product.launcher.env.common.Hadoop;
+import io.prestosql.tests.product.launcher.env.common.Standard;
+import io.prestosql.tests.product.launcher.env.common.TestsEnvironment;
+
+import javax.inject.Inject;
+
+import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_HIVE_PROPERTIES;
+import static io.prestosql.tests.product.launcher.env.common.Hadoop.CONTAINER_PRESTO_ICEBERG_PROPERTIES;
+import static java.util.Objects.requireNonNull;
+import static org.testcontainers.utility.MountableFile.forHostPath;
+
+@TestsEnvironment
+public class SinglenodeHiveRedirectionToIceberg
+        extends AbstractEnvironmentProvider
+{
+    private final DockerFiles dockerFiles;
+
+    @Inject
+    public SinglenodeHiveRedirectionToIceberg(DockerFiles dockerFiles, Standard standard, Hadoop hadoop)
+    {
+        super(ImmutableList.of(standard, hadoop));
+        this.dockerFiles = requireNonNull(dockerFiles, "dockerFiles is null");
+    }
+
+    @Override
+    protected void extendEnvironment(Environment.Builder builder)
+    {
+        builder.configureContainer("presto-master", container -> container
+                .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-hive-redirection-to-iceberg/hive.properties")), CONTAINER_PRESTO_HIVE_PROPERTIES)
+                .withCopyFileToContainer(forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-hive-redirection-to-iceberg/iceberg.properties")), CONTAINER_PRESTO_ICEBERG_PROPERTIES));
+    }
+}

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite7NonGeneric.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/suite/suites/Suite7NonGeneric.java
@@ -15,6 +15,7 @@ package io.prestosql.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.tests.product.launcher.env.EnvironmentDefaults;
+import io.prestosql.tests.product.launcher.env.environment.SinglenodeHiveRedirectionToIceberg;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeKerberosHdfsImpersonationCrossRealm;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeLdapBindDn;
 import io.prestosql.tests.product.launcher.env.environment.SinglenodeMysql;
@@ -78,6 +79,14 @@ public class Suite7NonGeneric
                  *     || suite_exit_code=1
                  */
                 testOnEnvironment(SinglenodeSparkIceberg.class).withGroups("iceberg").withExcludedGroups("storage_formats").build(),
+
+                /**
+                 * presto-product-tests-launcher/bin/run-launcher test run \
+                 *     --environment singlenode-hive-redirection-to-iceberg \
+                 *     -- -g hive_redirection_to_iceberg \
+                 *     || suite_exit_code=1
+                 */
+                testOnEnvironment(SinglenodeHiveRedirectionToIceberg.class).withGroups("hive_redirection_to_iceberg").build(),
 
                 /**
                  * Environment not set up on CDH. (TODO run on HDP 2.6 and HDP 3.1)

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-redirection-to-iceberg/hive.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-redirection-to-iceberg/hive.properties
@@ -1,0 +1,17 @@
+connector.name=hive-hadoop2
+hive.metastore.uri=thrift://hadoop-master:9083
+hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+hive.allow-add-column=true
+hive.allow-drop-column=true
+hive.allow-rename-column=true
+hive.allow-comment-table=true
+hive.allow-comment-column=true
+hive.allow-drop-table=true
+hive.allow-rename-table=true
+hive.allow-register-partition-procedure=true
+hive.metastore-cache-ttl=0s
+hive.fs.cache.max-size=10
+hive.max-partitions-per-scan=100
+hive.translate-hive-views=true
+hive.redirect-to-iceberg-enabled=true
+hive.redirect-to-iceberg-catalog=iceberg

--- a/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-redirection-to-iceberg/iceberg.properties
+++ b/presto-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-redirection-to-iceberg/iceberg.properties
@@ -1,0 +1,4 @@
+connector.name=iceberg
+hive.metastore.uri=thrift://hadoop-master:9083
+hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+iceberg.file-format=PARQUET

--- a/presto-product-tests/src/main/java/io/prestosql/tests/TestGroups.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/TestGroups.java
@@ -43,6 +43,7 @@ public final class TestGroups
     public static final String HIVE_VIEWS = "hive_views";
     public static final String HIVE_CACHING = "hive_caching";
     public static final String HIVE_WITH_EXTERNAL_WRITES = "hive_with_external_writes";
+    public static final String HIVE_REDIRECTION_TO_ICEBERG = "hive_redirection_to_iceberg";
     public static final String AUTHORIZATION = "authorization";
     public static final String HIVE_COERCION = "hive_coercion";
     public static final String CASSANDRA = "cassandra";

--- a/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveRedirectionToIceberg.java
+++ b/presto-product-tests/src/main/java/io/prestosql/tests/hive/TestHiveRedirectionToIceberg.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.assertj.core.api.Condition;
+import org.testng.annotations.Test;
+
+import java.sql.Date;
+import java.util.List;
+import java.util.Set;
+
+import static io.prestosql.tempto.assertions.QueryAssert.Row;
+import static io.prestosql.tempto.assertions.QueryAssert.Row.row;
+import static io.prestosql.tempto.assertions.QueryAssert.assertThat;
+import static io.prestosql.tempto.query.QueryExecutor.query;
+import static io.prestosql.tests.TestGroups.HIVE_REDIRECTION_TO_ICEBERG;
+import static io.prestosql.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.prestosql.tests.utils.QueryExecutors.onPresto;
+import static java.lang.String.format;
+
+public class TestHiveRedirectionToIceberg
+        extends HiveProductTest
+{
+    private static final String CREATE_ICEBERG_TABLE_TEMPLATE = "CREATE TABLE %s (_string VARCHAR, _bigint BIGINT, _date DATE) WITH (partitioning = ARRAY['_bigint', '_date'])";
+    private static final String CREATE_HIVE_TABLE_TEMPLATE = "CREATE TABLE %s (_string VARCHAR, _bigint BIGINT, _date DATE) WITH (partitioned_by = ARRAY['_bigint', '_date'])";
+    private static final String INSERT_TEMPLATE = "INSERT INTO %s VALUES " +
+            "(NULL, NULL, NULL), " +
+            "('abc', 1, DATE '2020-08-04'), " +
+            "('abcdefghijklmnopqrstuvwxyz', 2, DATE '2020-08-04')";
+    private static final List<Row> EXPECTED_ROWS = ImmutableList.<Row>builder()
+            .add(row(null, null, null))
+            .add(row("abc", 1, Date.valueOf("2020-08-04")))
+            .add(row("abcdefghijklmnopqrstuvwxyz", 2, Date.valueOf("2020-08-04")))
+            .build();
+
+    @Test(groups = {HIVE_REDIRECTION_TO_ICEBERG, PROFILE_SPECIFIC_TESTS})
+    public void testSelectAndDrop()
+    {
+        onPresto().executeQuery(format(CREATE_ICEBERG_TABLE_TEMPLATE, "iceberg.default.test_select_drop"));
+        onPresto().executeQuery(format(INSERT_TEMPLATE, "iceberg.default.test_select_drop"));
+        assertThat(onPresto().executeQuery("SELECT * FROM iceberg.default.test_select_drop")).containsOnly(EXPECTED_ROWS);
+        assertThat(onPresto().executeQuery("SELECT * FROM hive.default.test_select_drop")).containsOnly(EXPECTED_ROWS);
+        assertThat(onPresto().executeQuery("SELECT _bigint, _date FROM hive.default.\"test_select_drop$partitions\"")).containsOnly(
+                row(null, null),
+                row(1, Date.valueOf("2020-08-04")),
+                row(2, Date.valueOf("2020-08-04")));
+        onPresto().executeQuery("DROP TABLE hive.default.test_select_drop");
+        assertThat(() -> query("SELECT * FROM hive.default.test_select_drop"))
+                .failsWithMessage("Table 'hive.default.test_select_drop' does not exist");
+        assertThat(() -> query("SELECT * FROM iceberg.default.test_select_drop"))
+                .failsWithMessage("Table 'iceberg.default.test_select_drop' does not exist");
+    }
+
+    @Test(groups = {HIVE_REDIRECTION_TO_ICEBERG, PROFILE_SPECIFIC_TESTS})
+    public void testInsert()
+    {
+        onPresto().executeQuery(format(CREATE_ICEBERG_TABLE_TEMPLATE, "iceberg.default.test_insert"));
+        onPresto().executeQuery(format(INSERT_TEMPLATE, "hive.default.test_insert"));
+        assertThat(onPresto().executeQuery("SELECT * FROM iceberg.default.test_insert")).containsOnly(EXPECTED_ROWS);
+        assertThat(onPresto().executeQuery("SELECT * FROM hive.default.test_insert")).containsOnly(EXPECTED_ROWS);
+        onPresto().executeQuery("DROP TABLE iceberg.default.test_insert");
+    }
+
+    @Test(groups = {HIVE_REDIRECTION_TO_ICEBERG, PROFILE_SPECIFIC_TESTS})
+    public void testDescribe()
+    {
+        onPresto().executeQuery(format(CREATE_ICEBERG_TABLE_TEMPLATE, "iceberg.default.test_describe"));
+        assertThat(onPresto().executeQuery("DESCRIBE hive.default.test_describe"))
+                .satisfies(new Condition<>(queryResult -> {
+                    Set<String> actualColumns = ImmutableSet.copyOf(queryResult.column(1));
+                    Set<String> expectedColumns = ImmutableSet.of("_string", "_bigint", "_date");
+                    return actualColumns.equals(expectedColumns);
+                }, "equals"));
+        onPresto().executeQuery("DROP TABLE iceberg.default.test_describe");
+    }
+
+    @Test(groups = {HIVE_REDIRECTION_TO_ICEBERG, PROFILE_SPECIFIC_TESTS})
+    public void testShowCreateTable()
+    {
+        onPresto().executeQuery(format(CREATE_ICEBERG_TABLE_TEMPLATE, "iceberg.default.test_show_create"));
+        assertThat(onPresto().executeQuery("SHOW CREATE TABLE hive.default.test_show_create")).hasRowsCount(1);
+        onPresto().executeQuery("DROP TABLE iceberg.default.test_show_create");
+    }
+
+    @Test(groups = {HIVE_REDIRECTION_TO_ICEBERG, PROFILE_SPECIFIC_TESTS})
+    public void testAlterTable()
+    {
+        onPresto().executeQuery(format(CREATE_ICEBERG_TABLE_TEMPLATE, "iceberg.default.test_alter_table"));
+        onPresto().executeQuery(format(INSERT_TEMPLATE, "iceberg.default.test_alter_table"));
+
+        onPresto().executeQuery("ALTER TABLE hive.default.test_alter_table RENAME TO default.test_alter_table_new");
+        assertThat(onPresto().executeQuery("SELECT * FROM iceberg.default.test_alter_table_new")).containsOnly(EXPECTED_ROWS);
+        assertThat(onPresto().executeQuery("SELECT * FROM hive.default.test_alter_table_new")).containsOnly(EXPECTED_ROWS);
+
+        onPresto().executeQuery("ALTER TABLE hive.default.test_alter_table_new ADD COLUMN _double DOUBLE");
+        onPresto().executeQuery("ALTER TABLE hive.default.test_alter_table_new DROP COLUMN _string");
+        onPresto().executeQuery("ALTER TABLE hive.default.test_alter_table_new RENAME COLUMN _bigint TO _bi");
+        assertThat(onPresto().executeQuery("DESCRIBE hive.default.test_alter_table_new"))
+                .satisfies(new Condition<>(queryResult -> {
+                    Set<String> actualColumns = ImmutableSet.copyOf(queryResult.column(1));
+                    Set<String> expectedColumns = ImmutableSet.of("_bi", "_date", "_double");
+                    return actualColumns.equals(expectedColumns);
+                }, "equals"));
+
+        onPresto().executeQuery("DROP TABLE iceberg.default.test_alter_table_new");
+    }
+
+    @Test(groups = {HIVE_REDIRECTION_TO_ICEBERG, PROFILE_SPECIFIC_TESTS})
+    public void testCreateHiveTable()
+    {
+        onPresto().executeQuery(format(CREATE_HIVE_TABLE_TEMPLATE, "hive.default.test_create_hive_table"));
+        onPresto().executeQuery(format(INSERT_TEMPLATE, "hive.default.test_create_hive_table"));
+        assertThat(onPresto().executeQuery("SELECT * FROM hive.default.test_create_hive_table")).containsOnly(EXPECTED_ROWS);
+        assertThat(() -> query("SELECT * FROM iceberg.default.test_create_hive_table"))
+                .failsWithMessage("Not an Iceberg table: default.test_create_hive_table");
+        onPresto().executeQuery("DROP TABLE hive.default.test_create_hive_table");
+    }
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/connector/ConnectorMetadata.java
@@ -965,4 +965,12 @@ public interface ConnectorMetadata
      * <p>
      */
     default void validateScan(ConnectorSession session, ConnectorTableHandle handle) {}
+
+    /**
+     * Redirects to another catalog which may or may not use the same connector
+     */
+    default Optional<String> redirectCatalog(ConnectorSession session, SchemaTableName tableName)
+    {
+        return Optional.empty();
+    }
 }


### PR DESCRIPTION
**Add catalog redirection support to SPI**
Add a catalog redirection method to connector SPI. It allows a connector
to redirect to another catalog which may or may not use the same
connector.

Catalog redirection is tried whenever a table or view is accessed, e.g.,
in SELECT, INSERT, DROP TABLE, ALTER TABLE, GRANT, etc., queries. However,
it's not tried with procedures.

Multi-stop redirection without loop is allowed within a max depth.

**Add support to redirect from Hive to an Iceberg catalog**
When enabled, Hive Connector would redirect a table access to an Iceberg
catalog when the table is an Iceberg table.

----
Issue: #4442 
Umbrella issue: #1324 


Some notes:
 - Access control is enforced on the eventual table.
 - Information schema queries (`show tables`, `select * from information_schema.columns`) stay the same. They won't include results from other catalogs. Having said that, in the Hive/Iceberg case, a Hive catalog does include results of Iceberg tables inherently.
 - I thought about adding warning messages for users. Can work on that as a follow-up if it makes sense.