### PR TITLE
Fix incorrect description

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/scalar/time/TimeFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/time/TimeFunctions.java
@@ -79,7 +79,7 @@ public class TimeFunctions
         return time / PICOSECONDS_PER_HOUR;
     }
 
-    @Description("Truncate to the specified precision in the session timezone")
+    @Description("Truncate to the specified precision")
     @ScalarFunction("date_trunc")
     @LiteralParameters({"x", "p"})
     @SqlType("time(p)")

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/horology_functions/checkHorologyFunctionsRegistered.result
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/horology_functions/checkHorologyFunctionsRegistered.result
@@ -16,7 +16,7 @@
  date_format | varchar | timestamp(p), varchar(x) | scalar | true | Formats the given timestamp by the given format |
  date_parse | timestamp(3) | varchar(x), varchar(y) | scalar | true | |
  date_trunc | date | varchar(x), date | scalar | true | Truncate to the specified precision in the session timezone |
- date_trunc | time(p) | varchar(x), time(p) | scalar | true | Truncate to the specified precision in the session timezone |
+ date_trunc | time(p) | varchar(x), time(p) | scalar | true | Truncate to the specified precision |
  date_trunc | time with time zone | varchar(x), time with time zone | scalar | true | Truncate to the specified precision |
  date_trunc | timestamp(p) | varchar(x), timestamp(p) | scalar | true | Truncate to the specified precision in the session timezone |
  date_trunc | timestamp(p) with time zone | varchar(x), timestamp(p) with time zone | scalar | true | Truncate to the specified precision |


### PR DESCRIPTION
Session timezone no longer plays a role in TIME type