### PR TITLE
Adding "X-Pack/Basic Authentication" section to elasticsearch connector documentation

### DIFF
--- a/presto-docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/presto-docs/src/main/sphinx/connector/elasticsearch.rst
@@ -293,3 +293,15 @@ Property Name                                    Description
 ``elasticsearch.aws.secret-key``                 AWS secret key to use to connect to the Elasticsearch domain.
 ================================================ ==================================================================
 
+X-Pack/Basic Authentication
+---------------------------
+
+To enable basic authentication using X-Pack, the ``elasticsearch.security`` option needs to be set to ``PASSWORD``.
+Additionally the following options need to be configured appropriately:
+
+================================================ ==================================================================
+Property Name                                    Description
+================================================ ==================================================================
+``elasticsearch.auth.user``                      Elasticsearch Username for basic authentication.
+``elasticsearch.auth.password``                  Elasticsearch password for basic authentication.
+================================================ ==================================================================

--- a/presto-docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/presto-docs/src/main/sphinx/connector/elasticsearch.rst
@@ -302,6 +302,6 @@ Additionally the following options need to be configured appropriately:
 ================================================ ==================================================================
 Property Name                                    Description
 ================================================ ==================================================================
-``elasticsearch.auth.user``                      Elasticsearch Username for basic authentication.
+``elasticsearch.auth.user``                      Elasticsearch username for basic authentication.
 ``elasticsearch.auth.password``                  Elasticsearch password for basic authentication.
 ================================================ ==================================================================


### PR DESCRIPTION
Adding "X-Pack/Basic Authentication" section to elasticsearch connector documentation according to #4165 pull request.