### PR TITLE
Fix incorrect result when querying timestamp in Cassandra

### DIFF
--- a/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/io/prestosql/plugin/cassandra/CassandraType.java
@@ -411,7 +411,7 @@ public enum CassandraType
                 // Otherwise partition id doesn't match
                 return new BigDecimal(prestoNativeValue.toString());
             case TIMESTAMP:
-                return new Date((Long) prestoNativeValue);
+                return new Date(unpackMillisUtc((Long) prestoNativeValue));
             case DATE:
                 return LocalDate.fromDaysSinceEpoch(((Long) prestoNativeValue).intValue());
             case UUID:


### PR DESCRIPTION
The CQL was being generated from the packed timestamp+timezone Presto
native value.

Fixes https://github.com/prestosql/presto/issues/5023