### PR TITLE
Implement getTableProperties for Iceberg Connector

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -215,6 +215,13 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-parser</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -17,6 +17,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import io.airlift.json.JsonCodec;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
@@ -49,6 +50,7 @@ import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableProperties;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.DiscretePredicates;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.MaterializedViewNotFoundException;
 import io.trino.spi.connector.SchemaNotFoundException;
@@ -57,6 +59,7 @@ import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ComputedStatistics;
@@ -66,6 +69,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
@@ -74,7 +78,9 @@ import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
@@ -94,6 +100,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
+import java.util.function.Function;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -118,10 +125,12 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPER
 import static io.trino.plugin.iceberg.IcebergTableProperties.getFileFormat;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getTableLocation;
+import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumns;
 import static io.trino.plugin.iceberg.IcebergUtil.getDataPath;
 import static io.trino.plugin.iceberg.IcebergUtil.getFileFormat;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTable;
+import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
 import static io.trino.plugin.iceberg.IcebergUtil.getTableComment;
 import static io.trino.plugin.iceberg.IcebergUtil.isIcebergTable;
 import static io.trino.plugin.iceberg.PartitionFields.parsePartitionFields;
@@ -270,7 +279,67 @@ public class IcebergMetadata
     @Override
     public ConnectorTableProperties getTableProperties(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        return new ConnectorTableProperties();
+        IcebergTableHandle table = (IcebergTableHandle) tableHandle;
+        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+
+        TupleDomain<IcebergColumnHandle> enforcedPredicate = table.getEnforcedPredicate();
+
+        TableScan tableScan = icebergTable.newScan()
+                .useSnapshot(table.getSnapshotId().get())
+                .filter(toIcebergExpression(enforcedPredicate))
+                .includeColumnStats();
+
+        CloseableIterable<FileScanTask> files = tableScan.planFiles();
+
+        // Extract identity partition fields that are present in all partition specs, for creating the discrete predicates.
+        Set<Integer> partitionSourceIds = identityPartitionColumnsInAllSpecs(icebergTable);
+
+        DiscretePredicates discretePredicates = null;
+        if (!partitionSourceIds.isEmpty()) {
+            // Extract identity partition columns
+            Map<Integer, IcebergColumnHandle> columns = getColumns(icebergTable.schema(), typeManager).stream()
+                    .filter(column -> partitionSourceIds.contains(column.getId()))
+                    .collect(toImmutableMap(IcebergColumnHandle::getId, Function.identity()));
+
+            Iterable<TupleDomain<ColumnHandle>> discreteTupleDomain = Iterables.transform(files, fileScan -> {
+                // Extract partition values in the data file
+                Map<Integer, String> partitionColumnValueStrings = getPartitionKeys(fileScan);
+                Map<ColumnHandle, NullableValue> partitionValues = partitionSourceIds.stream()
+                        .filter(partitionColumnValueStrings::containsKey)
+                        .collect(toImmutableMap(
+                                columns::get,
+                                columnId -> {
+                                    IcebergColumnHandle column = columns.get(columnId);
+                                    Object prestoValue = deserializePartitionValue(
+                                            column.getType(),
+                                            partitionColumnValueStrings.get(columnId),
+                                            column.getName(),
+                                            session.getTimeZoneKey());
+
+                                    return NullableValue.of(column.getType(), prestoValue);
+                                }));
+
+                return TupleDomain.fromFixedValues(partitionValues);
+            });
+
+            discretePredicates = new DiscretePredicates(
+                    columns.values().stream()
+                            .map(ColumnHandle.class::cast)
+                            .collect(toImmutableList()),
+                    discreteTupleDomain);
+        }
+
+        return new ConnectorTableProperties(
+                // Using the predicate here directly avoids eagerly loading all partition values. Logically, this
+                // still keeps predicate and discretePredicates evaluation the same on every row of the table. This
+                // can be further optimized by intersecting with partition values at the cost of iterating
+                // over all tableScan.planFiles() and caching partition values in table handle.
+                enforcedPredicate.transform(ColumnHandle.class::cast),
+                // TODO: implement table partitioning
+                Optional.empty(),
+                Optional.empty(),
+                Optional.ofNullable(discretePredicates),
+                ImmutableList.of());
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
@@ -13,51 +13,23 @@
  */
 package io.trino.plugin.iceberg;
 
-import io.airlift.slice.Slice;
-import io.airlift.slice.SliceUtf8;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.predicate.Utils;
-import io.trino.spi.type.DecimalType;
-import io.trino.spi.type.Decimals;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.VarbinaryType;
-import io.trino.spi.type.VarcharType;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Throwables.throwIfInstanceOf;
-import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
-import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_PARTITION_VALUE;
-import static io.trino.plugin.iceberg.util.Timestamps.timestampTzFromMicros;
-import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
-import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.BooleanType.BOOLEAN;
-import static io.trino.spi.type.DateType.DATE;
-import static io.trino.spi.type.Decimals.isLongDecimal;
-import static io.trino.spi.type.Decimals.isShortDecimal;
-import static io.trino.spi.type.DoubleType.DOUBLE;
-import static io.trino.spi.type.IntegerType.INTEGER;
-import static io.trino.spi.type.RealType.REAL;
-import static io.trino.spi.type.TimeType.TIME_MICROS;
-import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
-import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
-import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
-import static java.lang.Double.parseDouble;
-import static java.lang.Float.floatToRawIntBits;
-import static java.lang.Float.parseFloat;
-import static java.lang.Long.parseLong;
-import static java.lang.String.format;
+import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergPageSource
@@ -178,78 +150,5 @@ public class IcebergPageSource
                 throwable.addSuppressed(e);
             }
         }
-    }
-
-    private static Object deserializePartitionValue(Type type, String valueString, String name, TimeZoneKey timeZoneKey)
-    {
-        if (valueString == null) {
-            return null;
-        }
-
-        try {
-            if (type.equals(BOOLEAN)) {
-                if (valueString.equalsIgnoreCase("true")) {
-                    return true;
-                }
-                if (valueString.equalsIgnoreCase("false")) {
-                    return false;
-                }
-                throw new IllegalArgumentException();
-            }
-            if (type.equals(INTEGER)) {
-                return parseLong(valueString);
-            }
-            if (type.equals(BIGINT)) {
-                return parseLong(valueString);
-            }
-            if (type.equals(REAL)) {
-                return (long) floatToRawIntBits(parseFloat(valueString));
-            }
-            if (type.equals(DOUBLE)) {
-                return parseDouble(valueString);
-            }
-            if (type.equals(DATE)) {
-                return parseLong(valueString);
-            }
-            if (type.equals(TIME_MICROS)) {
-                return parseLong(valueString) * PICOSECONDS_PER_MICROSECOND;
-            }
-            if (type.equals(TIMESTAMP_MICROS)) {
-                return parseLong(valueString);
-            }
-            if (type.equals(TIMESTAMP_TZ_MICROS)) {
-                return timestampTzFromMicros(parseLong(valueString), timeZoneKey);
-            }
-            if (type instanceof VarcharType) {
-                Slice value = utf8Slice(valueString);
-                VarcharType varcharType = (VarcharType) type;
-                if (!varcharType.isUnbounded() && SliceUtf8.countCodePoints(value) > varcharType.getBoundedLength()) {
-                    throw new IllegalArgumentException();
-                }
-                return value;
-            }
-            if (type.equals(VarbinaryType.VARBINARY)) {
-                return utf8Slice(valueString);
-            }
-            if (isShortDecimal(type) || isLongDecimal(type)) {
-                DecimalType decimalType = (DecimalType) type;
-                BigDecimal decimal = new BigDecimal(valueString);
-                decimal = decimal.setScale(decimalType.getScale(), BigDecimal.ROUND_UNNECESSARY);
-                if (decimal.precision() > decimalType.getPrecision()) {
-                    throw new IllegalArgumentException();
-                }
-                BigInteger unscaledValue = decimal.unscaledValue();
-                return isShortDecimal(type) ? unscaledValue.longValue() : Decimals.encodeUnscaledValue(unscaledValue);
-            }
-        }
-        catch (IllegalArgumentException e) {
-            throw new TrinoException(ICEBERG_INVALID_PARTITION_VALUE, format(
-                    "Invalid partition value '%s' for %s partition key: %s",
-                    valueString,
-                    type.getDisplayName(),
-                    name));
-        }
-        // Iceberg tables don't partition by non-primitive-type columns.
-        throw new TrinoException(GENERIC_INTERNAL_ERROR, "Invalid partition type " + type.toString());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -14,6 +14,8 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceUtf8;
 import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.trino.plugin.hive.authentication.HiveIdentity;
@@ -21,16 +23,29 @@ import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -39,14 +54,37 @@ import java.util.regex.Pattern;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Lists.reverse;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
+import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_PARTITION_VALUE;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPSHOT_ID;
 import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
+import static io.trino.plugin.iceberg.util.Timestamps.timestampTzFromMicros;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.Decimals.isLongDecimal;
+import static io.trino.spi.type.Decimals.isShortDecimal;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static java.lang.Double.parseDouble;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.parseFloat;
+import static java.lang.Long.parseLong;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+import static org.apache.iceberg.types.Type.TypeID.BINARY;
+import static org.apache.iceberg.types.Type.TypeID.FIXED;
 
 final class IcebergUtil
 {
@@ -135,5 +173,110 @@ final class IcebergUtil
             return name;
         }
         return '"' + name.replace("\"", "\"\"") + '"';
+    }
+
+    public static Object deserializePartitionValue(Type type, String valueString, String name, TimeZoneKey timeZoneKey)
+    {
+        if (valueString == null) {
+            return null;
+        }
+
+        try {
+            if (type.equals(BOOLEAN)) {
+                if (valueString.equalsIgnoreCase("true")) {
+                    return true;
+                }
+                if (valueString.equalsIgnoreCase("false")) {
+                    return false;
+                }
+                throw new IllegalArgumentException();
+            }
+            if (type.equals(INTEGER)) {
+                return parseLong(valueString);
+            }
+            if (type.equals(BIGINT)) {
+                return parseLong(valueString);
+            }
+            if (type.equals(REAL)) {
+                return (long) floatToRawIntBits(parseFloat(valueString));
+            }
+            if (type.equals(DOUBLE)) {
+                return parseDouble(valueString);
+            }
+            if (type.equals(DATE)) {
+                return parseLong(valueString);
+            }
+            if (type.equals(TIME_MICROS)) {
+                return parseLong(valueString) * PICOSECONDS_PER_MICROSECOND;
+            }
+            if (type.equals(TIMESTAMP_MICROS)) {
+                return parseLong(valueString);
+            }
+            if (type.equals(TIMESTAMP_TZ_MICROS)) {
+                return timestampTzFromMicros(parseLong(valueString), timeZoneKey);
+            }
+            if (type instanceof VarcharType) {
+                Slice value = utf8Slice(valueString);
+                VarcharType varcharType = (VarcharType) type;
+                if (!varcharType.isUnbounded() && SliceUtf8.countCodePoints(value) > varcharType.getBoundedLength()) {
+                    throw new IllegalArgumentException();
+                }
+                return value;
+            }
+            if (type.equals(VarbinaryType.VARBINARY)) {
+                return utf8Slice(valueString);
+            }
+            if (isShortDecimal(type) || isLongDecimal(type)) {
+                DecimalType decimalType = (DecimalType) type;
+                BigDecimal decimal = new BigDecimal(valueString);
+                decimal = decimal.setScale(decimalType.getScale(), BigDecimal.ROUND_UNNECESSARY);
+                if (decimal.precision() > decimalType.getPrecision()) {
+                    throw new IllegalArgumentException();
+                }
+                BigInteger unscaledValue = decimal.unscaledValue();
+                return isShortDecimal(type) ? unscaledValue.longValue() : Decimals.encodeUnscaledValue(unscaledValue);
+            }
+        }
+        catch (IllegalArgumentException e) {
+            throw new TrinoException(ICEBERG_INVALID_PARTITION_VALUE, format(
+                    "Invalid partition value '%s' for %s partition key: %s",
+                    valueString,
+                    type.getDisplayName(),
+                    name));
+        }
+        // Iceberg tables don't partition by non-primitive-type columns.
+        throw new TrinoException(GENERIC_INTERNAL_ERROR, "Invalid partition type " + type.toString());
+    }
+
+    public static Map<Integer, String> getPartitionKeys(FileScanTask scanTask)
+    {
+        StructLike partition = scanTask.file().partition();
+        PartitionSpec spec = scanTask.spec();
+        Map<PartitionField, Integer> fieldToIndex = getIdentityPartitions(spec);
+        Map<Integer, String> partitionKeys = new HashMap<>();
+
+        fieldToIndex.forEach((field, index) -> {
+            int id = field.sourceId();
+            org.apache.iceberg.types.Type type = spec.schema().findType(id);
+            Class<?> javaClass = type.typeId().javaClass();
+            Object value = partition.get(index, javaClass);
+
+            if (value == null) {
+                partitionKeys.put(id, null);
+            }
+            else {
+                String partitionValue;
+                if (type.typeId() == FIXED || type.typeId() == BINARY) {
+                    // this is safe because Iceberg PartitionData directly wraps the byte array
+                    partitionValue = new String(((ByteBuffer) value).array(), UTF_8);
+                }
+                else {
+                    partitionValue = value.toString();
+                }
+                partitionKeys.put(id, partitionValue);
+            }
+        });
+
+        return Collections.unmodifiableMap(partitionKeys);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+import io.trino.Session;
+import io.trino.plugin.hive.authentication.HiveIdentity;
+import io.trino.plugin.hive.metastore.Database;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.iceberg.TestingIcebergConnectorFactory;
+import io.trino.spi.security.PrincipalType;
+import io.trino.sql.planner.assertions.BasePushdownPlanTest;
+import io.trino.sql.tree.LongLiteral;
+import io.trino.testing.LocalQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+
+public class TestMetadataQueryOptimization
+        extends BasePushdownPlanTest
+{
+    private static final String ICEBERG_CATALOG = "iceberg";
+    private static final String SCHEMA_NAME = "test_schema";
+    private File baseDir;
+
+    @Override
+    protected LocalQueryRunner createLocalQueryRunner()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(ICEBERG_CATALOG)
+                .setSchema(SCHEMA_NAME)
+                .build();
+
+        baseDir = Files.createTempDir();
+        HiveMetastore metastore = createTestingFileHiveMetastore(baseDir);
+        LocalQueryRunner queryRunner = LocalQueryRunner.create(session);
+
+        queryRunner.createCatalog(
+                ICEBERG_CATALOG,
+                new TestingIcebergConnectorFactory(Optional.of(metastore)),
+                ImmutableMap.of());
+
+        Database database = Database.builder()
+                .setDatabaseName(SCHEMA_NAME)
+                .setOwnerName("public")
+                .setOwnerType(PrincipalType.ROLE)
+                .build();
+        metastore.createDatabase(new HiveIdentity(session.toConnectorSession()), database);
+
+        return queryRunner;
+    }
+
+    @Test
+    public void testOptimization()
+    {
+        String testTable = "test_metadata_optimization";
+
+        getQueryRunner().execute(format(
+                "CREATE TABLE %s (a, b, c) WITH (PARTITIONING = ARRAY['b', 'c']) AS VALUES (5, 6, 7), (8, 9, 10)",
+                testTable));
+
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setSystemProperty("optimize_metadata_queries", "true")
+                .build();
+
+        assertPlan(
+                format("SELECT DISTINCT b, c FROM %s ORDER BY b", testTable),
+                session,
+                anyTree(values(
+                        ImmutableList.of("b", "c"),
+                        ImmutableList.of(
+                                ImmutableList.of(new LongLiteral("6"), new LongLiteral("7")),
+                                ImmutableList.of(new LongLiteral("9"), new LongLiteral("10"))))));
+
+        assertPlan(
+                format("SELECT DISTINCT b, c FROM %s WHERE b > 7", testTable),
+                session,
+                anyTree(values(
+                        ImmutableList.of("b", "c"),
+                        ImmutableList.of(ImmutableList.of(new LongLiteral("9"), new LongLiteral("10"))))));
+
+        assertPlan(
+                format("SELECT DISTINCT b, c FROM %s WHERE b > 7 AND c < 8", testTable),
+                session,
+                anyTree(
+                        values(ImmutableList.of("b", "c"), ImmutableList.of())));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void cleanup()
+            throws Exception
+    {
+        if (baseDir != null) {
+            deleteRecursively(baseDir.toPath(), ALLOW_INSECURE);
+        }
+    }
+}


### PR DESCRIPTION
Hive Queries performing aggregation on partition columns are optimized through `MetadataQueryOptimizer` using a config. Similar queries on Iceberg can take much longer since they end up performing the table scan. This PR adds a `getTableProperties` implementation to optimize such iceberg queries.

Usage of `MetadataQueryOptimizer` can return incorrect behavior for an aggregation query:

For hive connector:
- if a registered hive partition does not have any corresponding data, usage of this optimizer can return rows corresponding to such empty partitions. 

For Iceberg Connector:
- If a data file was deleted or corrupted (bypassing iceberg), usage of this optimizer makes the query succeed, which would otherwise fail.

The PR adds a test for metadata-delete operation. Once row level deletes are supported with iceberg v2, that should be tested too.