### PR TITLE
Allow case-insensitive fieldname matching for struct coercion in hive connector

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -293,7 +293,10 @@ public class OrcPageSourceFactory
                         .collect(Collectors.groupingBy(
                                 HiveColumnHandle::getBaseColumnName,
                                 mapping(
-                                        column -> column.getHiveColumnProjectionInfo().map(HiveColumnProjectionInfo::getDereferenceNames).orElse(ImmutableList.<String>of()),
+                                        column -> column.getHiveColumnProjectionInfo()
+                                                .map(HiveColumnProjectionInfo::getDereferenceNames)
+                                                .map(names -> names.stream().map(name -> name.toLowerCase(ENGLISH)).collect(toUnmodifiableList()))
+                                                .orElse(ImmutableList.<String>of()),
                                         toList())));
             }
             else {
@@ -301,7 +304,10 @@ public class OrcPageSourceFactory
                         .collect(Collectors.groupingBy(
                                 HiveColumnHandle::getBaseHiveColumnIndex,
                                 mapping(
-                                        column -> column.getHiveColumnProjectionInfo().map(HiveColumnProjectionInfo::getDereferenceNames).orElse(ImmutableList.<String>of()),
+                                        column -> column.getHiveColumnProjectionInfo()
+                                                .map(HiveColumnProjectionInfo::getDereferenceNames)
+                                                .map(names -> names.stream().map(name -> name.toLowerCase(ENGLISH)).collect(toUnmodifiableList()))
+                                                .orElse(ImmutableList.<String>of()),
                                         toList())));
             }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveCoercionPolicy.java
@@ -122,7 +122,7 @@ public final class HiveCoercionPolicy
         // * For all other field indices, the corresponding fields must have
         //   the same name, and the type must be coercible.
         for (int i = 0; i < min(fromFieldTypes.size(), toFieldTypes.size()); i++) {
-            if (!fromFieldNames.get(i).equals(toFieldNames.get(i))) {
+            if (!fromFieldNames.get(i).equalsIgnoreCase(toFieldNames.get(i))) {
                 return false;
             }
             if (!fromFieldTypes.get(i).equals(toFieldTypes.get(i)) && !canCoerce(fromFieldTypes.get(i), toFieldTypes.get(i))) {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveCoercion.java
@@ -43,6 +43,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -73,6 +74,7 @@ import static java.sql.JDBCType.STRUCT;
 import static java.sql.JDBCType.VARCHAR;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
 public class TestHiveCoercion
@@ -110,7 +112,7 @@ public class TestHiveCoercion
                 .setCreateTableDDLTemplate("" +
                         "CREATE TABLE %NAME%(" +
                         // all nested primitive/varchar coercions and adding/removing tailing nested fields are covered across row_to_row, list_to_list, and map_to_map
-                        "    row_to_row                 STRUCT<keep: STRING, ti2si: TINYINT, si2int: SMALLINT, int2bi: INT, bi2vc: BIGINT>, " +
+                        "    row_to_row                 STRUCT<keep: STRING, ti2si: TINYINT, si2int: SMALLINT, int2bi: INT, bi2vc: BIGINT, lower2uppercase: BIGINT>, " +
                         "    list_to_list               ARRAY<STRUCT<ti2int: TINYINT, si2bi: SMALLINT, bi2vc: BIGINT, remove: STRING>>, " +
                         "    map_to_map                 MAP<TINYINT, STRUCT<ti2bi: TINYINT, int2bi: INT, float2double: " + floatType + ">>, " +
                         "    tinyint_to_smallint        TINYINT," +
@@ -284,7 +286,7 @@ public class TestHiveCoercion
         query(format(
                 "INSERT INTO %1$s VALUES " +
                         "(" +
-                        "  CAST(ROW ('as is', -1, 100, 2323, 12345) AS ROW(keep VARCHAR, ti2si TINYINT, si2int SMALLINT, int2bi INTEGER, bi2vc BIGINT)), " +
+                        "  CAST(ROW ('as is', -1, 100, 2323, 12345, 2) AS ROW(keep VARCHAR, ti2si TINYINT, si2int SMALLINT, int2bi INTEGER, bi2vc BIGINT, lower2uppercase BIGINT)), " +
                         "  ARRAY [CAST(ROW (2, -101, 12345, 'removed') AS ROW (ti2int TINYINT, si2bi SMALLINT, bi2vc BIGINT, remove VARCHAR))], " +
                         "  MAP (ARRAY [TINYINT '2'], ARRAY [CAST(ROW (-3, 2323, REAL '0.5') AS ROW (ti2bi TINYINT, int2bi INTEGER, float2double %2$s))]), " +
                         "  TINYINT '-1', " +
@@ -308,7 +310,7 @@ public class TestHiveCoercion
                         "  'abc', " +
                         "  1), " +
                         "(" +
-                        "  CAST(ROW (NULL, 1, -100, -2323, -12345) AS ROW(keep VARCHAR, ti2si TINYINT, si2int SMALLINT, int2bi INTEGER, bi2vc BIGINT)), " +
+                        "  CAST(ROW (NULL, 1, -100, -2323, -12345, 2) AS ROW(keep VARCHAR, ti2si TINYINT, si2int SMALLINT, int2bi INTEGER, bi2vc BIGINT, lower2uppercase BIGINT)), " +
                         "  ARRAY [CAST(ROW (-2, 101, -12345, NULL) AS ROW (ti2int TINYINT, si2bi SMALLINT, bi2vc BIGINT, remove VARCHAR))], " +
                         "  MAP (ARRAY [TINYINT '-2'], ARRAY [CAST(ROW (null, -2323, REAL '-1.5') AS ROW (ti2bi TINYINT, int2bi INTEGER, float2double %2$s))]), " +
                         "  TINYINT '1', " +
@@ -362,6 +364,19 @@ public class TestHiveCoercion
                 "varchar_to_smaller_varchar",
                 "id");
 
+        // Document case-sensitivity related behavior for nested fields in hive
+        String hiveValueForCaseChangeField;
+        Predicate<String> isFormat = formatName -> tableName.toLowerCase(Locale.ENGLISH).contains(formatName);
+        if (isFormat.test("rctext") || isFormat.test("textfile")) {
+            hiveValueForCaseChangeField = "\"lower2uppercase\":2";
+        }
+        else if (getHiveVersionMajor() == 3 && isFormat.test("orc")) {
+            hiveValueForCaseChangeField = "\"LOWER2UPPERCASE\":null";
+        }
+        else {
+            hiveValueForCaseChangeField = "\"LOWER2UPPERCASE\":2";
+        }
+
         Function<Engine, Map<String, List<Object>>> expected = engine -> {
             return ImmutableMap.<String, List<Object>>builder()
                     .put("row_to_row", Arrays.asList(
@@ -372,9 +387,17 @@ public class TestHiveCoercion
                                             .addField("si2int", 100)
                                             .addField("int2bi", 2323L)
                                             .addField("bi2vc", "12345")
+                                            .addField("lower2uppercase", 2L)
                                             .build() :
                                     // TODO: Compare structures for hive executor instead of serialized representation
-                                    "{\"keep\":\"as is\",\"ti2si\":-1,\"si2int\":100,\"int2bi\":2323,\"bi2vc\":\"12345\"}",
+                                    "{" +
+                                            "\"keep\":\"as is\"," +
+                                            "\"ti2si\":-1," +
+                                            "\"si2int\":100," +
+                                            "\"int2bi\":2323," +
+                                            "\"bi2vc\":\"12345\"," +
+                                            hiveValueForCaseChangeField +
+                                            "}",
                             engine == Engine.PRESTO ?
                                     rowBuilder()
                                             .addField("keep", null)
@@ -382,8 +405,16 @@ public class TestHiveCoercion
                                             .addField("si2int", -100)
                                             .addField("int2bi", -2323L)
                                             .addField("bi2vc", "-12345")
+                                            .addField("lower2uppercase", 2L)
                                             .build() :
-                                    "{\"keep\":null,\"ti2si\":1,\"si2int\":-100,\"int2bi\":-2323,\"bi2vc\":\"-12345\"}"))
+                                    "{" +
+                                            "\"keep\":null," +
+                                            "\"ti2si\":1," +
+                                            "\"si2int\":-100," +
+                                            "\"int2bi\":-2323," +
+                                            "\"bi2vc\":\"-12345\"," +
+                                            hiveValueForCaseChangeField +
+                                            "}"))
                     .put("list_to_list", Arrays.asList(
                             engine == Engine.PRESTO ?
                                     ImmutableList.of(rowBuilder()
@@ -483,6 +514,56 @@ public class TestHiveCoercion
         Map<String, List<Object>> expectedHiveResults = expected.apply(Engine.HIVE);
         String hiveSelectQuery = format("SELECT %s FROM %s", String.join(", ", hiveReadColumns), tableName);
         assertQueryResults(Engine.HIVE, hiveSelectQuery, expectedHiveResults, hiveReadColumns, 2, tableName);
+
+        assertNestedSubFields(tableName);
+    }
+
+    private void assertNestedSubFields(String tableName)
+    {
+        String subfieldQueryLowerCase = format("SELECT row_to_row.lower2uppercase nested_field FROM %s", tableName);
+        String subfieldQueryUpperCase = format("SELECT row_to_row.LOWER2UPPERCASE nested_field FROM %s", tableName);
+        Map<String, List<Object>> expectedNestedFieldPresto = ImmutableMap.of("nested_field", ImmutableList.of(2L, 2L));
+        List<String> expectedColumns = ImmutableList.of("nested_field");
+
+        // Assert Presto's behavior
+        assertQueryResults(Engine.PRESTO, subfieldQueryUpperCase, expectedNestedFieldPresto, expectedColumns, 2, tableName);
+        assertQueryResults(Engine.PRESTO, subfieldQueryLowerCase, expectedNestedFieldPresto, expectedColumns, 2, tableName);
+
+        // Assert Hive's behavior
+        Predicate<String> isFormat = formatName -> tableName.toLowerCase(Locale.ENGLISH).contains(formatName);
+        Map<String, List<Object>> expectedNestedFieldHive;
+        if (getHiveVersionMajor() == 3 && isFormat.test("orc")) {
+            expectedNestedFieldHive = ImmutableMap.of("nested_field", Arrays.asList(null, null));
+        }
+        else {
+            expectedNestedFieldHive = expectedNestedFieldPresto;
+        }
+
+        if (isFormat.test("rcbinary")) {
+            assertThatThrownBy(() -> assertQueryResults(Engine.HIVE, subfieldQueryUpperCase, expectedNestedFieldHive, expectedColumns, 2, tableName))
+                    .hasMessageContaining("org.apache.hadoop.hive.ql.metadata.HiveException");
+            assertThatThrownBy(() -> assertQueryResults(Engine.HIVE, subfieldQueryLowerCase, expectedNestedFieldHive, expectedColumns, 2, tableName))
+                    .hasMessageContaining("org.apache.hadoop.hive.ql.metadata.HiveException");
+            return;
+        }
+
+        if (isFormat.test("parquet") && getHiveVersionMajor() == 1) {
+            if (getHiveVersionMinor() == 2) {
+                assertQueryResults(Engine.HIVE, subfieldQueryUpperCase, expectedNestedFieldHive, expectedColumns, 2, tableName);
+            }
+            else {
+                assertThatThrownBy(() -> assertQueryResults(Engine.HIVE, subfieldQueryUpperCase, expectedNestedFieldHive,
+                        expectedColumns, 2, tableName)).hasMessageContaining("java.sql.SQLException");
+            }
+
+            assertThatThrownBy(() -> assertQueryResults(Engine.HIVE, subfieldQueryLowerCase, expectedNestedFieldHive, expectedColumns, 2, tableName))
+                    .hasMessageContaining("java.sql.SQLException");
+
+            return;
+        }
+
+        assertQueryResults(Engine.HIVE, subfieldQueryUpperCase, expectedNestedFieldHive, expectedColumns, 2, tableName);
+        assertQueryResults(Engine.HIVE, subfieldQueryLowerCase, expectedNestedFieldHive, expectedColumns, 2, tableName);
     }
 
     private List<String> removeUnsupportedColumnsForHive(List<String> columns, String tableName)
@@ -606,7 +687,8 @@ public class TestHiveCoercion
         String floatType = tableName.toLowerCase(Locale.ENGLISH).contains("parquet") ? "double" : "real";
 
         assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactly(
-                row("row_to_row", "row(keep varchar, ti2si smallint, si2int integer, int2bi bigint, bi2vc varchar)"),
+                // The field lower2uppercase in the row is recorded in upper case in hive, but Presto converts it to lower case
+                row("row_to_row", "row(keep varchar, ti2si smallint, si2int integer, int2bi bigint, bi2vc varchar, lower2uppercase bigint)"),
                 row("list_to_list", "array(row(ti2int integer, si2bi bigint, bi2vc varchar))"),
                 row("map_to_map", "map(integer, row(ti2bi bigint, int2bi bigint, float2double double, add tinyint))"),
                 row("tinyint_to_smallint", "smallint"),
@@ -669,6 +751,7 @@ public class TestHiveCoercion
                 .put("varchar_to_bigger_varchar", VARCHAR)
                 .put("varchar_to_smaller_varchar", VARCHAR)
                 .put("id", BIGINT)
+                .put("nested_field", BIGINT)
                 .build();
 
         assertThat(queryResult)
@@ -679,7 +762,7 @@ public class TestHiveCoercion
     {
         String floatType = tableName.toLowerCase(Locale.ENGLISH).contains("parquet") ? "double" : "float";
 
-        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN row_to_row row_to_row struct<keep:string, ti2si:smallint, si2int:int, int2bi:bigint, bi2vc:string>", tableName));
+        onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN row_to_row row_to_row struct<keep:string, ti2si:smallint, si2int:int, int2bi:bigint, bi2vc:string, LOWER2UPPERCASE:bigint>", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN list_to_list list_to_list array<struct<ti2int:int, si2bi:bigint, bi2vc:string>>", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN map_to_map map_to_map map<int,struct<ti2bi:bigint, int2bi:bigint, float2double:double, add:tinyint>>", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN tinyint_to_smallint tinyint_to_smallint smallint", tableName));


### PR DESCRIPTION
Co-authored-by: Xingyuan Lin @lxynov 

Hive also performs case insensitive matching for struct field names: 
* https://cwiki.apache.org/confluence/display/Hive/User+FAQ#UserFAQ-AreHiveSQLidentifiers(e.g.tablenames,columnnames,etc)casesensitive?
* https://github.com/apache/hive/blob/master/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/StructTypeInfo.java#L106-L116