### PR TITLE
Add support for HDFS only iceberg tables

### DIFF
--- a/cccs/Dockerfile
+++ b/cccs/Dockerfile
@@ -1,0 +1,2 @@
+FROM prestosql/presto:345
+COPY presto-iceberg-346-SNAPSHOT.jar /usr/lib/presto/plugin/iceberg/presto-iceberg-345.jar

--- a/cccs/azure-pipelines.yml
+++ b/cccs/azure-pipelines.yml
@@ -1,0 +1,85 @@
+# Maven
+# Build your Java project and run tests with Apache Maven.
+# Add steps that analyze code, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/java
+
+trigger:
+- iceberg_hadoop_catalog
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  imageRepository: "cccs/prestosql/presto"
+  containerRegistry: "cruchimera"
+  dockerfilePath: "$(Build.sourcesDirectory)/cccs"
+  buildId: "$(Build.BuildId)"
+  branch: "$(Build.SourceBranchName)"
+
+jobs:
+- job: BuilMavenArtifact
+  timeoutInMinutes: 0
+  steps:
+  - task: Maven@3
+    inputs:
+      mavenPomFile: 'pom.xml'
+      mavenOptions: '-Xmx3072m -DskipTests'
+      javaHomeOption: 'JDKVersion'
+      jdkVersionOption: '1.11'
+      jdkArchitectureOption: 'x64'
+      publishJUnitResults: false
+      testResultsFiles: '**/surefire-reports/TEST-*.xml'
+      goals: 'package'
+      options: '-DskipTests'
+  - bash: |
+      mkdir $(Build.SourcesDirectory)/publish
+      mv $(Build.SourcesDirectory)/presto-iceberg/target/presto-iceberg-346-SNAPSHOT.jar $(Build.SourcesDirectory)/publish/
+  - task: PublishBuildArtifacts@1
+    inputs:
+      PathtoPublish: "$(Build.SourcesDirectory)/publish/"
+      ArtifactName: "presto-iceberg"
+      publishLocation: "Container"
+- job: BuildDockerImage
+  dependsOn: BuilMavenArtifact
+  steps:
+    - task: DownloadBuildArtifacts@0
+      inputs:
+        buildType: 'current'
+        downloadType: 'single'
+        artifactName: 'presto-iceberg'
+        downloadPath: '$(Build.SourcesDirectory)/cccs'
+    - bash: |
+        mv $(Build.SourcesDirectory)/cccs/presto-iceberg/* $(Build.SourcesDirectory)/cccs/
+      displayName: "Move downloaded artifact to expected location."
+    - bash: |
+        COMMIT=$(Build.SourceVersion)
+        COMMIT_SHORT=${COMMIT:0:8}
+        echo commit: $COMMIT
+        echo commitShort: $COMMIT_SHORT
+        echo "##vso[task.setvariable variable=commitShort]$COMMIT_SHORT"
+      displayName: "Extract commit short sha."
+    - task: Docker@2
+      displayName: "Build presto docker image."
+      inputs:
+        containerRegistry: $(containerRegistry)
+        repository: $(imageRepository)
+        command: "buildAndPush"
+        tags: |
+          latest
+          $(branch)_$(buildId)_$(commitShort)
+          $(branch)
+          $(buildId)
+    - task: Docker@2
+      displayName: "Build presto docker image."
+      inputs:
+        containerRegistry: cranalyticalplatform
+        repository: $(imageRepository)
+        command: "buildAndPush"
+        tags: |
+          latest
+          $(branch)_$(buildId)_$(commitShort)
+          $(branch)
+          $(buildId)
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <module>presto-cassandra</module>
         <module>presto-cli</module>
         <module>presto-client</module>
-        <module>presto-docs</module>
+        <!--<module>presto-docs</module>-->
         <module>presto-druid</module>
         <module>presto-elasticsearch</module>
         <module>presto-example-http</module>

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergCatalogType.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergCatalogType.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.prestosql.plugin.iceberg;
 
 public enum IcebergCatalogType {

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergCatalogType.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergCatalogType.java
@@ -1,0 +1,6 @@
+package io.prestosql.plugin.iceberg;
+
+public enum IcebergCatalogType {
+    HIVE,
+    HADOOP
+}

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
@@ -20,13 +20,14 @@ import org.apache.iceberg.FileFormat;
 import javax.validation.constraints.NotNull;
 
 import static io.prestosql.plugin.hive.HiveCompressionCodec.GZIP;
+import static io.prestosql.plugin.iceberg.IcebergCatalogType.HIVE;
 import static io.prestosql.plugin.iceberg.IcebergFileFormat.ORC;
 
 public class IcebergConfig
 {
     private IcebergFileFormat fileFormat = ORC;
     private HiveCompressionCodec compressionCodec = GZIP;
-    private boolean hadoopMode;
+    private IcebergCatalogType type = HIVE;
 
     @NotNull
     public FileFormat getFileFormat()
@@ -54,15 +55,16 @@ public class IcebergConfig
         return this;
     }
 
-    public boolean isHadoopMode()
+    @NotNull
+    public IcebergCatalogType getCatalogType()
     {
-        return hadoopMode;
+        return type;
     }
 
-    @Config("iceberg.hadoopmode")
-    public IcebergConfig setHadoopMode(boolean hadoopMode)
+    @Config("iceberg.catalog-type")
+    public IcebergConfig setCatalogType(IcebergCatalogType type)
     {
-        this.hadoopMode = hadoopMode;
+        this.type = type;
         return this;
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
@@ -26,7 +26,6 @@ public class IcebergConfig
 {
     private IcebergFileFormat fileFormat = ORC;
     private HiveCompressionCodec compressionCodec = GZIP;
-    private String warehouse;
     private boolean hadoopMode;
 
     @NotNull
@@ -52,18 +51,6 @@ public class IcebergConfig
     public IcebergConfig setCompressionCodec(HiveCompressionCodec compressionCodec)
     {
         this.compressionCodec = compressionCodec;
-        return this;
-    }
-
-    public String getWarehouse()
-    {
-        return warehouse;
-    }
-
-    @Config("iceberg.warehouse")
-    public IcebergConfig setWarehouse(String warehouse)
-    {
-        this.warehouse = warehouse;
         return this;
     }
 

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergConfig.java
@@ -26,6 +26,8 @@ public class IcebergConfig
 {
     private IcebergFileFormat fileFormat = ORC;
     private HiveCompressionCodec compressionCodec = GZIP;
+    private String warehouse;
+    private boolean hadoopMode;
 
     @NotNull
     public FileFormat getFileFormat()
@@ -50,6 +52,30 @@ public class IcebergConfig
     public IcebergConfig setCompressionCodec(HiveCompressionCodec compressionCodec)
     {
         this.compressionCodec = compressionCodec;
+        return this;
+    }
+
+    public String getWarehouse()
+    {
+        return warehouse;
+    }
+
+    @Config("iceberg.warehouse")
+    public IcebergConfig setWarehouse(String warehouse)
+    {
+        this.warehouse = warehouse;
+        return this;
+    }
+
+    public boolean isHadoopMode()
+    {
+        return hadoopMode;
+    }
+
+    @Config("iceberg.hadoopmode")
+    public IcebergConfig setHadoopMode(boolean hadoopMode)
+    {
+        this.hadoopMode = hadoopMode;
         return this;
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergHadoopMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergHadoopMetadata.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static io.prestosql.plugin.hive.HiveMetadata.TABLE_COMMENT;
@@ -144,13 +145,19 @@ public class IcebergHadoopMetadata
     @Override
     public Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName)
     {
-        throw new UnsupportedOperationException();
+        HadoopCatalog hadoopCatalog = getHadoopCatalog(session);
+        Namespace namespace = Namespace.of(schemaName.getSchemaName());
+        Map<String, String> namespaceMetadata = hadoopCatalog.loadNamespaceMetadata(namespace);
+        return namespaceMetadata.entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        e -> e.getValue()));
     }
 
     @Override
     public Optional<PrestoPrincipal> getSchemaOwner(ConnectorSession session, CatalogSchemaName schemaName)
     {
-        throw new UnsupportedOperationException();
+        return Optional.empty();
     }
 
     @Override

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergHadoopMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergHadoopMetadata.java
@@ -1,0 +1,332 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
+import io.prestosql.plugin.hive.HdfsEnvironment;
+import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.prestosql.plugin.hive.TableAlreadyExistsException;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.CatalogSchemaName;
+import io.prestosql.spi.connector.ConnectorNewTableLayout;
+import io.prestosql.spi.connector.ConnectorOutputTableHandle;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTableHandle;
+import io.prestosql.spi.connector.ConnectorTableMetadata;
+import io.prestosql.spi.connector.SchemaNotFoundException;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.connector.TableNotFoundException;
+import io.prestosql.spi.security.PrestoPrincipal;
+import io.prestosql.spi.type.TypeManager;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.hadoop.HadoopCatalog;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
+import static io.prestosql.plugin.hive.HiveMetadata.TABLE_COMMENT;
+import static io.prestosql.plugin.iceberg.IcebergSchemaProperties.getSchemaLocation;
+import static io.prestosql.plugin.iceberg.IcebergTableProperties.getFileFormat;
+import static io.prestosql.plugin.iceberg.IcebergTableProperties.getPartitioning;
+import static io.prestosql.plugin.iceberg.IcebergTableProperties.getTableLocation;
+import static io.prestosql.plugin.iceberg.PartitionFields.parsePartitionFields;
+import static io.prestosql.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
+
+public class IcebergHadoopMetadata
+        extends IcebergMetadata
+{
+    private final HdfsEnvironment hdfsEnvironment;
+
+    public IcebergHadoopMetadata(
+            HdfsEnvironment hdfsEnvironment,
+            TypeManager typeManager,
+            JsonCodec<CommitTaskData> commitTaskCodec)
+    {
+        super(hdfsEnvironment, typeManager, commitTaskCodec);
+        this.hdfsEnvironment = hdfsEnvironment;
+    }
+
+    @Override
+    public Table getIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        TableIdentifier tableIdentifier = TableIdentifier.of(schemaTableName.getSchemaName(), schemaTableName.getTableName());
+        try {
+            HadoopCatalog hadoopCatalog = getHadoopCatalog(session);
+            return hadoopCatalog.loadTable(tableIdentifier);
+        }
+        catch(NoSuchTableException e) {
+            throw new TableNotFoundException(schemaTableName);
+        }
+    }
+
+    private HadoopCatalog getHadoopCatalog(ConnectorSession session)
+    {
+        HdfsContext hdfsContext = new HdfsContext(session, "not used");
+        Path path = new Path("/");
+        Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
+        String warehouse = configuration.get("hive.metastore.warehouse.dir");
+        if (warehouse == null || warehouse.isEmpty()) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, format("hive.metastore.warehouse.dir not set"));
+        }
+        return getHadoopCatalog(session, warehouse);
+    }
+
+    private HadoopCatalog getHadoopCatalog(ConnectorSession session, String location)
+    {
+        HdfsContext hdfsContext = new HdfsContext(session, "not used");
+        Path path = new Path(location);
+        Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
+        return new HadoopCatalog(configuration, location);
+    }
+
+    private boolean icebergSchemaExists(ConnectorSession session, String schemaName)
+    {
+        try {
+            HadoopCatalog hadoopCatalog = getHadoopCatalog(session);
+            Namespace namespace = Namespace.of(schemaName);
+            hadoopCatalog.loadNamespaceMetadata(namespace);
+            return true;
+        }
+        catch (NoSuchNamespaceException e) {
+            return false;
+        }
+    }
+
+    private boolean icebergTableExists(ConnectorSession session, SchemaTableName table)
+    {
+        try {
+            TableIdentifier tableIdentifier = TableIdentifier.of(table.getSchemaName(), table.getTableName());
+            HadoopCatalog hadoopCatalog = getHadoopCatalog(session);
+            hadoopCatalog.loadTable(tableIdentifier);
+            return true;
+        }
+        catch (NoSuchTableException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        HadoopCatalog hadoopCatalog = getHadoopCatalog(session);
+        try {
+            List<Namespace> namespaces = hadoopCatalog.listNamespaces(Namespace.empty());
+            return namespaces.stream()
+                    .map(namespace -> namespace.toString())
+                    .collect(toList());
+        }
+        catch (NoSuchNamespaceException e) {
+            return ImmutableList.of();
+        }
+    }
+
+    @Override
+    public Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<PrestoPrincipal> getSchemaOwner(ConnectorSession session, CatalogSchemaName schemaName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        HadoopCatalog hadoopCatalog = getHadoopCatalog(session);
+        List<Namespace> namespaces = hadoopCatalog.listNamespaces(Namespace.empty());
+        return namespaces.stream()
+                .flatMap(namespace -> hadoopCatalog.listTables(namespace).stream()
+                        .map(tableIdentifier -> new SchemaTableName(tableIdentifier.namespace().toString(), tableIdentifier.name()))
+                        .collect(toList())
+                        .stream())
+                .collect(toList());
+    }
+
+    @Override
+    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
+    {
+        Optional<String> location = getSchemaLocation(properties).map(uri -> {
+            try {
+                hdfsEnvironment.getFileSystem(new HdfsContext(session, schemaName), new Path(uri));
+            }
+            catch (IOException | IllegalArgumentException e) {
+                throw new PrestoException(INVALID_SCHEMA_PROPERTY, "Invalid location URI: " + uri, e);
+            }
+            return uri;
+        });
+
+        if (location.isEmpty()) {
+            HadoopCatalog hadoopCatalog = getHadoopCatalog(session);
+            hadoopCatalog.createNamespace(Namespace.of(schemaName));
+        }
+        else {
+            HadoopCatalog hadoopCatalog = getHadoopCatalog(session, location.get());
+            hadoopCatalog.createNamespace(Namespace.of(schemaName));
+        }
+    }
+
+    @Override
+    public void dropSchema(ConnectorSession session, String schemaName)
+    {
+        HadoopCatalog hadoopCatalog = getHadoopCatalog(session);
+        hadoopCatalog.dropNamespace(Namespace.of(schemaName));
+    }
+
+    @Override
+    public void renameSchema(ConnectorSession session, String source, String target)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSchemaAuthorization(ConnectorSession session, String source, PrestoPrincipal principal)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTableComment(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<String> comment)
+    {
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
+        if (comment.isEmpty()) {
+            icebergTable.updateProperties().remove(TABLE_COMMENT).commit();
+        }
+        else {
+            icebergTable.updateProperties().set(TABLE_COMMENT, comment.get()).commit();
+        }
+    }
+
+    @Override
+    public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
+    {
+        SchemaTableName schemaTableName = tableMetadata.getTable();
+        String schemaName = schemaTableName.getSchemaName();
+        String tableName = schemaTableName.getTableName();
+
+        if (!icebergSchemaExists(session, schemaName)) {
+            throw new SchemaNotFoundException(schemaName);
+        }
+        if (icebergTableExists(session, schemaTableName)) {
+            throw new TableAlreadyExistsException(schemaTableName);
+        }
+
+        HdfsContext hdfsContext = new HdfsContext(session, schemaName, tableName);
+        String targetPath = getTableLocation(tableMetadata.getProperties());
+        HadoopCatalog catalog;
+        if (targetPath == null) {
+            catalog = getHadoopCatalog(session);
+        }
+        else {
+            catalog = getHadoopCatalog(session, targetPath);
+        }
+
+        Schema schema = toIcebergSchema(tableMetadata.getColumns());
+        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
+
+        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(2);
+        FileFormat fileFormat = getFileFormat(tableMetadata.getProperties());
+        propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toString());
+        if (tableMetadata.getComment().isPresent()) {
+            propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
+        }
+        Map<String, String> properties = propertiesBuilder.build();
+        TableIdentifier tableIdentifier = TableIdentifier.of(schemaName, tableName);
+        transaction = catalog.newCreateTableTransaction(tableIdentifier, schema, partitionSpec, properties);
+
+        return new IcebergWritableTableHandle(
+                schemaName,
+                tableName,
+                SchemaParser.toJson(transaction.table().schema()),
+                PartitionSpecParser.toJson(transaction.table().spec()),
+                getColumns(transaction.table().schema(), typeManager),
+                transaction.table().location(),
+                fileFormat);
+    }
+
+    @Override
+    public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        TableIdentifier tableIdentifier = TableIdentifier.of(handle.getSchemaName(), handle.getTableName());
+        getHadoopCatalog(session).dropTable(tableIdentifier, false);
+    }
+
+    @Override
+    public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTable)
+    {
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        TableIdentifier tableIdentifier = TableIdentifier.of(handle.getSchemaName(), handle.getTableName());
+        TableIdentifier newTableIdentifier = TableIdentifier.of(newTable.getSchemaName(), newTable.getTableName());
+        getHadoopCatalog(session).renameTable(tableIdentifier, newTableIdentifier);
+    }
+
+
+//    protected ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName table)
+//    {
+//        if (!icebergTableExists(hdfsEnvironment, session, table)) {
+//            throw new TableNotFoundException(table);
+//        }
+//
+//        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table);
+//
+//        List<ColumnMetadata> columns = getColumnMetadatas(icebergTable);
+//
+//        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+//        properties.put(FILE_FORMAT_PROPERTY, getFileFormat(icebergTable));
+//        if (!icebergTable.spec().fields().isEmpty()) {
+//            properties.put(PARTITIONING_PROPERTY, toPartitionFields(icebergTable.spec()));
+//        }
+//
+//        return new ConnectorTableMetadata(table, columns, properties.build(), getTableComment(icebergTable));
+//    }
+
+//    private List<ColumnMetadata> getColumnMetadatas(org.apache.iceberg.Table table)
+//    {
+//        return table.schema().columns().stream()
+//                .map(column -> {
+//                    return ColumnMetadata.builder()
+//                            .setName(column.name())
+//                            .setType(toPrestoType(column.type(), typeManager))
+//                            .setNullable(column.isOptional())
+//                            .setComment(Optional.ofNullable(column.doc()))
+//                            .build();
+//                })
+//                .collect(toImmutableList());
+//    }
+
+}

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergHiveMetadata.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
+import io.prestosql.plugin.hive.HdfsEnvironment;
+import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.prestosql.plugin.hive.HiveSchemaProperties;
+import io.prestosql.plugin.hive.TableAlreadyExistsException;
+import io.prestosql.plugin.hive.authentication.HiveIdentity;
+import io.prestosql.plugin.hive.metastore.Database;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.HivePrincipal;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.connector.CatalogSchemaName;
+import io.prestosql.spi.connector.ConnectorNewTableLayout;
+import io.prestosql.spi.connector.ConnectorOutputTableHandle;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.connector.ConnectorTableHandle;
+import io.prestosql.spi.connector.ConnectorTableMetadata;
+import io.prestosql.spi.connector.SchemaNotFoundException;
+import io.prestosql.spi.connector.SchemaTableName;
+import io.prestosql.spi.connector.TableNotFoundException;
+import io.prestosql.spi.security.PrestoPrincipal;
+import io.prestosql.spi.type.TypeManager;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.prestosql.plugin.hive.HiveMetadata.TABLE_COMMENT;
+import static io.prestosql.plugin.hive.util.HiveWriteUtils.getTableDefaultLocation;
+import static io.prestosql.plugin.iceberg.IcebergSchemaProperties.getSchemaLocation;
+import static io.prestosql.plugin.iceberg.IcebergTableProperties.getFileFormat;
+import static io.prestosql.plugin.iceberg.IcebergTableProperties.getPartitioning;
+import static io.prestosql.plugin.iceberg.IcebergTableProperties.getTableLocation;
+import static io.prestosql.plugin.iceberg.IcebergUtil.getColumns;
+import static io.prestosql.plugin.iceberg.IcebergUtil.isIcebergTable;
+import static io.prestosql.plugin.iceberg.IcebergUtil.quotedTableName;
+import static io.prestosql.plugin.iceberg.PartitionFields.parsePartitionFields;
+import static io.prestosql.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
+import static io.prestosql.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
+import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static org.apache.iceberg.TableMetadata.newTableMetadata;
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
+import static org.apache.iceberg.Transactions.createTableTransaction;
+
+public class IcebergHiveMetadata
+        extends IcebergMetadata
+{
+    private final HiveMetastore metastore;
+
+    public IcebergHiveMetadata(
+            HiveMetastore metastore,
+            HdfsEnvironment hdfsEnvironment,
+            TypeManager typeManager,
+            JsonCodec<CommitTaskData> commitTaskCodec)
+    {
+        super(hdfsEnvironment, typeManager, commitTaskCodec);
+        this.metastore = requireNonNull(metastore, "metastore is null");
+    }
+
+    @Override
+    public org.apache.iceberg.Table getIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        Optional<io.prestosql.plugin.hive.metastore.Table> hiveTable = metastore.getTable(new HiveIdentity(session), schemaTableName.getSchemaName(), schemaTableName.getTableName());
+        if (hiveTable.isEmpty()) {
+            throw new TableNotFoundException(schemaTableName);
+        }
+        if (!isIcebergTable(hiveTable.get())) {
+            throw new UnknownTableTypeException(schemaTableName);
+        }
+
+        SchemaTableName schemaTableName1 = hiveTable.get().getSchemaTableName();
+        if(!schemaTableName1.equals(schemaTableName)){
+            System.out.println("HERE");
+        }
+
+//        if (metastore.getTable(new HiveIdentity(session), schemaTableName.getSchemaName(), schemaTableName.getTableName()).isEmpty()) {
+//            throw new TableNotFoundException(schemaTableName);
+//        }
+//
+        HdfsContext hdfsContext = new HdfsContext(session, schemaTableName.getSchemaName(), schemaTableName.getTableName());
+        HiveIdentity identity = new HiveIdentity(session);
+        TableOperations operations = new HiveTableOperations(metastore, hdfsEnvironment, hdfsContext, identity, schemaTableName.getSchemaName(), schemaTableName.getTableName());
+        return new BaseTable(operations, quotedTableName(schemaTableName));
+    }
+
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        return metastore.getAllDatabases();
+    }
+
+    @Override
+    public Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName)
+    {
+        Optional<Database> db = metastore.getDatabase(schemaName.getSchemaName());
+        if (db.isPresent()) {
+            return HiveSchemaProperties.fromDatabase(db.get());
+        }
+
+        throw new SchemaNotFoundException(schemaName.getSchemaName());
+    }
+
+    @Override
+    public Optional<PrestoPrincipal> getSchemaOwner(ConnectorSession session, CatalogSchemaName schemaName)
+    {
+        Optional<Database> database = metastore.getDatabase(schemaName.getSchemaName());
+        if (database.isPresent()) {
+            return database.flatMap(db -> Optional.of(new PrestoPrincipal(db.getOwnerType(), db.getOwnerName())));
+        }
+
+        throw new SchemaNotFoundException(schemaName.getSchemaName());
+    }
+
+
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName) {
+        return schemaName.map(Collections::singletonList)
+                .orElseGet(metastore::getAllDatabases)
+                .stream()
+                .flatMap(schema -> metastore.getTablesWithParameter(schema, TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE).stream()
+                        .map(table -> new SchemaTableName(schema, table))
+                        .collect(toList())
+                        .stream())
+                .collect(toList());
+    }
+
+    @Override
+    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
+    {
+        Optional<String> location = getSchemaLocation(properties).map(uri -> {
+            try {
+                hdfsEnvironment.getFileSystem(new HdfsContext(session, schemaName), new Path(uri));
+            }
+            catch (IOException | IllegalArgumentException e) {
+                throw new PrestoException(INVALID_SCHEMA_PROPERTY, "Invalid location URI: " + uri, e);
+            }
+            return uri;
+        });
+
+        Database database = Database.builder()
+                .setDatabaseName(schemaName)
+                .setLocation(location)
+                .setOwnerType(owner.getType())
+                .setOwnerName(owner.getName())
+                .build();
+
+        metastore.createDatabase(new HiveIdentity(session), database);
+    }
+
+    @Override
+    public void dropSchema(ConnectorSession session, String schemaName)
+    {
+        // basic sanity check to provide a better error message
+        if (!listTables(session, Optional.of(schemaName)).isEmpty() ||
+                !listViews(session, Optional.of(schemaName)).isEmpty()) {
+            throw new PrestoException(SCHEMA_NOT_EMPTY, "Schema not empty: " + schemaName);
+        }
+        metastore.dropDatabase(new HiveIdentity(session), schemaName);
+    }
+
+    @Override
+    public void renameSchema(ConnectorSession session, String source, String target)
+    {
+        metastore.renameDatabase(new HiveIdentity(session), source, target);
+    }
+
+    @Override
+    public void setSchemaAuthorization(ConnectorSession session, String source, PrestoPrincipal principal)
+    {
+        metastore.setDatabaseOwner(new HiveIdentity(session), source, HivePrincipal.from(principal));
+    }
+
+
+    @Override
+    public void setTableComment(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<String> comment)
+    {
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        metastore.commentTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), comment);
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
+        if (comment.isEmpty()) {
+            icebergTable.updateProperties().remove(TABLE_COMMENT).commit();
+        }
+        else {
+            icebergTable.updateProperties().set(TABLE_COMMENT, comment.get()).commit();
+        }
+    }
+
+    @Override
+    public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
+    {
+        SchemaTableName schemaTableName = tableMetadata.getTable();
+        String schemaName = schemaTableName.getSchemaName();
+        String tableName = schemaTableName.getTableName();
+
+        Schema schema = toIcebergSchema(tableMetadata.getColumns());
+
+        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
+
+        Database database = metastore.getDatabase(schemaName)
+                .orElseThrow(() -> new SchemaNotFoundException(schemaName));
+
+        HdfsContext hdfsContext = new HdfsContext(session, schemaName, tableName);
+        HiveIdentity identity = new HiveIdentity(session);
+        String targetPath = getTableLocation(tableMetadata.getProperties());
+        if (targetPath == null) {
+            targetPath = getTableDefaultLocation(database, hdfsContext, hdfsEnvironment, schemaName, tableName).toString();
+        }
+
+        TableOperations operations = new HiveTableOperations(metastore, hdfsEnvironment, hdfsContext, identity, schemaName, tableName, session.getUser(), targetPath);
+        if (operations.current() != null) {
+            throw new TableAlreadyExistsException(schemaTableName);
+        }
+
+        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(2);
+        FileFormat fileFormat = getFileFormat(tableMetadata.getProperties());
+        propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toString());
+        if (tableMetadata.getComment().isPresent()) {
+            propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
+        }
+
+        TableMetadata metadata = newTableMetadata(schema, partitionSpec, targetPath, propertiesBuilder.build());
+
+        transaction = createTableTransaction(tableName, operations, metadata);
+
+        return new IcebergWritableTableHandle(
+                schemaName,
+                tableName,
+                SchemaParser.toJson(metadata.schema()),
+                PartitionSpecParser.toJson(metadata.spec()),
+                getColumns(metadata.schema(), typeManager),
+                targetPath,
+                fileFormat);
+    }
+
+
+    @Override
+    public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        metastore.dropTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), true);
+    }
+
+    @Override
+    public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTable)
+    {
+        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
+        metastore.renameTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), newTable.getSchemaName(), newTable.getTableName());
+    }
+
+
+
+}

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadata.java
@@ -21,14 +21,7 @@ import io.airlift.slice.Slice;
 import io.prestosql.plugin.base.classloader.ClassLoaderSafeSystemTable;
 import io.prestosql.plugin.hive.HdfsEnvironment;
 import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
-import io.prestosql.plugin.hive.HiveSchemaProperties;
 import io.prestosql.plugin.hive.HiveWrittenPartitions;
-import io.prestosql.plugin.hive.TableAlreadyExistsException;
-import io.prestosql.plugin.hive.authentication.HiveIdentity;
-import io.prestosql.plugin.hive.metastore.Database;
-import io.prestosql.plugin.hive.metastore.HiveMetastore;
-import io.prestosql.plugin.hive.metastore.HivePrincipal;
-import io.prestosql.plugin.hive.metastore.Table;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.CatalogSchemaName;
 import io.prestosql.spi.connector.ColumnHandle;
@@ -44,7 +37,6 @@ import io.prestosql.spi.connector.ConnectorTableMetadata;
 import io.prestosql.spi.connector.ConnectorTableProperties;
 import io.prestosql.spi.connector.Constraint;
 import io.prestosql.spi.connector.ConstraintApplicationResult;
-import io.prestosql.spi.connector.SchemaNotFoundException;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.connector.SchemaTablePrefix;
 import io.prestosql.spi.connector.SystemTable;
@@ -58,29 +50,20 @@ import io.prestosql.spi.type.TypeManager;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFiles;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Snapshot;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
-import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.NoSuchNamespaceException;
-import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -94,241 +77,155 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static io.prestosql.plugin.hive.HiveMetadata.TABLE_COMMENT;
-import static io.prestosql.plugin.hive.util.HiveWriteUtils.getTableDefaultLocation;
 import static io.prestosql.plugin.iceberg.ExpressionConverter.toIcebergExpression;
-import static io.prestosql.plugin.iceberg.IcebergSchemaProperties.getSchemaLocation;
 import static io.prestosql.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static io.prestosql.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
-import static io.prestosql.plugin.iceberg.IcebergTableProperties.getFileFormat;
-import static io.prestosql.plugin.iceberg.IcebergTableProperties.getPartitioning;
-import static io.prestosql.plugin.iceberg.IcebergTableProperties.getTableLocation;
 import static io.prestosql.plugin.iceberg.IcebergUtil.getColumns;
 import static io.prestosql.plugin.iceberg.IcebergUtil.getDataPath;
 import static io.prestosql.plugin.iceberg.IcebergUtil.getFileFormat;
-import static io.prestosql.plugin.iceberg.IcebergUtil.getHadoopCatalog;
-import static io.prestosql.plugin.iceberg.IcebergUtil.getIcebergTable;
 import static io.prestosql.plugin.iceberg.IcebergUtil.getTableComment;
-import static io.prestosql.plugin.iceberg.IcebergUtil.icebergSchemaExists;
-import static io.prestosql.plugin.iceberg.IcebergUtil.icebergTableExists;
-import static io.prestosql.plugin.iceberg.IcebergUtil.isIcebergTable;
-import static io.prestosql.plugin.iceberg.IcebergUtil.useMetastore;
-import static io.prestosql.plugin.iceberg.PartitionFields.parsePartitionFields;
 import static io.prestosql.plugin.iceberg.PartitionFields.toPartitionFields;
 import static io.prestosql.plugin.iceberg.TableType.DATA;
 import static io.prestosql.plugin.iceberg.TypeConverter.toIcebergType;
 import static io.prestosql.plugin.iceberg.TypeConverter.toPrestoType;
-import static io.prestosql.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
 import static io.prestosql.spi.StandardErrorCode.NOT_SUPPORTED;
-import static io.prestosql.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toList;
-import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
-import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
-import static org.apache.iceberg.TableMetadata.newTableMetadata;
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
-import static org.apache.iceberg.Transactions.createTableTransaction;
 
-public class IcebergMetadata
+public abstract class IcebergMetadata
         implements ConnectorMetadata
 {
-    private final HiveMetastore metastore;
-    private final HdfsEnvironment hdfsEnvironment;
-    private final TypeManager typeManager;
+    protected final HdfsEnvironment hdfsEnvironment;
+    protected final TypeManager typeManager;
     private final JsonCodec<CommitTaskData> commitTaskCodec;
 
     private final Map<String, Optional<Long>> snapshotIds = new ConcurrentHashMap<>();
 
-    private Transaction transaction;
+    protected Transaction transaction;
 
     public IcebergMetadata(
-            HiveMetastore metastore,
             HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
             JsonCodec<CommitTaskData> commitTaskCodec)
     {
-        this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
     }
 
-    @Override
-    public List<String> listSchemaNames(ConnectorSession session)
+    public static List<IcebergColumnHandle> getColumns(Schema schema, TypeManager typeManager)
     {
-        if (useMetastore(session)) {
-            return metastore.getAllDatabases();
-        }
-        else {
-            HadoopCatalog hadoopCatalog = getHadoopCatalog(hdfsEnvironment, session);
-            try {
-                List<Namespace> namespaces = hadoopCatalog.listNamespaces(Namespace.empty());
-                return namespaces.stream()
-                        .map(namespace -> namespace.toString())
-                        .collect(toList());
-            }
-            catch (NoSuchNamespaceException e) {
-                return ImmutableList.of();
-            }
-        }
+        return schema.columns().stream()
+                .map(column -> new IcebergColumnHandle(
+                        column.fieldId(),
+                        column.name(),
+                        toPrestoType(column.type(), typeManager),
+                        Optional.ofNullable(column.doc())))
+                .collect(toImmutableList());
     }
 
-    @Override
-    public Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName)
-    {
-        Optional<Database> db = metastore.getDatabase(schemaName.getSchemaName());
-        if (db.isPresent()) {
-            return HiveSchemaProperties.fromDatabase(db.get());
-        }
-
-        throw new SchemaNotFoundException(schemaName.getSchemaName());
-    }
+    public abstract Table getIcebergTable(ConnectorSession session, SchemaTableName schemaTableName) throws TableNotFoundException, UnknownTableTypeException;
 
     @Override
-    public Optional<PrestoPrincipal> getSchemaOwner(ConnectorSession session, CatalogSchemaName schemaName)
-    {
-        Optional<Database> database = metastore.getDatabase(schemaName.getSchemaName());
-        if (database.isPresent()) {
-            return database.flatMap(db -> Optional.of(new PrestoPrincipal(db.getOwnerType(), db.getOwnerName())));
-        }
-
-        throw new SchemaNotFoundException(schemaName.getSchemaName());
-    }
+    public abstract List<String> listSchemaNames(ConnectorSession session);
 
     @Override
-    public IcebergTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+    public abstract  Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName);
+
+    @Override
+    public abstract Optional<PrestoPrincipal> getSchemaOwner(ConnectorSession session, CatalogSchemaName schemaName);
+
+    @Override
+    public final IcebergTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
         verify(name.getTableType() == DATA, "Wrong table type: " + name.getTableType());
 
-        org.apache.iceberg.Table table;
-        if (useMetastore(session)) {
-            Optional<Table> hiveTable = metastore.getTable(new HiveIdentity(session), tableName.getSchemaName(), name.getTableName());
-            if (hiveTable.isEmpty()) {
-                return null;
-            }
-            if (!isIcebergTable(hiveTable.get())) {
-                throw new UnknownTableTypeException(tableName);
-            }
-            table = getIcebergTable(metastore, hdfsEnvironment, session, hiveTable.get().getSchemaTableName());
+        try {
+            org.apache.iceberg.Table table = getIcebergTable(session, tableName);
+            Optional<Long> snapshotId = getSnapshotId(table, name.getSnapshotId());
+
+            return new IcebergTableHandle(
+                    tableName.getSchemaName(),
+                    name.getTableName(),
+                    name.getTableType(),
+                    snapshotId,
+                    TupleDomain.all());
         }
-        else {
-            if (!icebergTableExists(hdfsEnvironment, session, tableName)) {
-                return null;
-            }
-            table = getIcebergTable(metastore, hdfsEnvironment, session, tableName);
+        catch(TableNotFoundException | UnknownTableTypeException e){
+            return null;
         }
 
-        Optional<Long> snapshotId = getSnapshotId(table, name.getSnapshotId());
-
-        return new IcebergTableHandle(
-                tableName.getSchemaName(),
-                name.getTableName(),
-                name.getTableType(),
-                snapshotId,
-                TupleDomain.all());
     }
 
     @Override
-    public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
+    public final Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
         return getRawSystemTable(session, tableName)
                 .map(systemTable -> new ClassLoaderSafeSystemTable(systemTable, getClass().getClassLoader()));
     }
 
-    private Optional<SystemTable> getRawSystemTable(ConnectorSession session, SchemaTableName tableName)
+    protected final Optional<SystemTable> getRawSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
 
-        org.apache.iceberg.Table table;
+        try {
+            org.apache.iceberg.Table table = getIcebergTable(session, tableName);
 
-        if (useMetastore(session)) {
-            Optional<Table> hiveTable = metastore.getTable(new HiveIdentity(session), tableName.getSchemaName(), name.getTableName());
-            if (hiveTable.isEmpty() || !isIcebergTable(hiveTable.get())) {
-                return Optional.empty();
+            SchemaTableName systemTableName = new SchemaTableName(tableName.getSchemaName(), name.getTableNameWithType());
+            switch (name.getTableType()) {
+                case HISTORY:
+                    if (name.getSnapshotId().isPresent()) {
+                        throw new PrestoException(NOT_SUPPORTED, "Snapshot ID not supported for history table: " + systemTableName);
+                    }
+                    return Optional.of(new HistoryTable(systemTableName, table));
+                case SNAPSHOTS:
+                    if (name.getSnapshotId().isPresent()) {
+                        throw new PrestoException(NOT_SUPPORTED, "Snapshot ID not supported for snapshots table: " + systemTableName);
+                    }
+                    return Optional.of(new SnapshotsTable(systemTableName, typeManager, table));
+                case PARTITIONS:
+                    return Optional.of(new PartitionTable(systemTableName, typeManager, table, getSnapshotId(table, name.getSnapshotId())));
+                case MANIFESTS:
+                    return Optional.of(new ManifestsTable(systemTableName, table, getSnapshotId(table, name.getSnapshotId())));
+                case FILES:
+                    return Optional.of(new FilesTable(systemTableName, typeManager, table, getSnapshotId(table, name.getSnapshotId())));
             }
-            table = getIcebergTable(metastore, hdfsEnvironment, session, hiveTable.get().getSchemaTableName());
+            return Optional.empty();
         }
-        else {
-            if (!icebergTableExists(hdfsEnvironment, session, tableName)) {
-                return Optional.empty();
-            }
-            table = getIcebergTable(metastore, hdfsEnvironment, session, tableName);
+        catch (TableNotFoundException | UnknownTableTypeException e){
+            return Optional.empty();
         }
-
-        SchemaTableName systemTableName = new SchemaTableName(tableName.getSchemaName(), name.getTableNameWithType());
-        switch (name.getTableType()) {
-            case HISTORY:
-                if (name.getSnapshotId().isPresent()) {
-                    throw new PrestoException(NOT_SUPPORTED, "Snapshot ID not supported for history table: " + systemTableName);
-                }
-                return Optional.of(new HistoryTable(systemTableName, table));
-            case SNAPSHOTS:
-                if (name.getSnapshotId().isPresent()) {
-                    throw new PrestoException(NOT_SUPPORTED, "Snapshot ID not supported for snapshots table: " + systemTableName);
-                }
-                return Optional.of(new SnapshotsTable(systemTableName, typeManager, table));
-            case PARTITIONS:
-                return Optional.of(new PartitionTable(systemTableName, typeManager, table, getSnapshotId(table, name.getSnapshotId())));
-            case MANIFESTS:
-                return Optional.of(new ManifestsTable(systemTableName, table, getSnapshotId(table, name.getSnapshotId())));
-            case FILES:
-                return Optional.of(new FilesTable(systemTableName, typeManager, table, getSnapshotId(table, name.getSnapshotId())));
-        }
-        return Optional.empty();
     }
 
     @Override
-    public ConnectorTableProperties getTableProperties(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public final ConnectorTableProperties getTableProperties(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         return new ConnectorTableProperties();
     }
 
     @Override
-    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+    public final ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
-        return getTableMetadata(session, ((IcebergTableHandle) table).getSchemaTableName());
+        return getIcebergTableMetadata(session, ((IcebergTableHandle) table).getSchemaTableName());
     }
 
     @Override
-    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
-    {
-        if (useMetastore(session)) {
-            return schemaName.map(Collections::singletonList)
-                    .orElseGet(metastore::getAllDatabases)
-                    .stream()
-                    .flatMap(schema -> metastore.getTablesWithParameter(schema, TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE).stream()
-                            .map(table -> new SchemaTableName(schema, table))
-                            .collect(toList())
-                            .stream())
-                    .collect(toList());
-        }
-        else {
-            HadoopCatalog hadoopCatalog = getHadoopCatalog(hdfsEnvironment, session);
-            List<Namespace> namespaces = hadoopCatalog.listNamespaces(Namespace.empty());
-            return namespaces.stream()
-                    .flatMap(namespace -> hadoopCatalog.listTables(namespace).stream()
-                            .map(tableIdentifier -> new SchemaTableName(tableIdentifier.namespace().toString(), tableIdentifier.name()))
-                            .collect(toList())
-                            .stream())
-                    .collect(toList());
-        }
-    }
+    public abstract List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName);
 
     @Override
-    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public final Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
         return getColumns(icebergTable.schema(), typeManager).stream()
                 .collect(toImmutableMap(IcebergColumnHandle::getName, identity()));
     }
 
     @Override
-    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    public final ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
     {
         IcebergColumnHandle column = (IcebergColumnHandle) columnHandle;
         return ColumnMetadata.builder()
@@ -339,7 +236,7 @@ public class IcebergMetadata
     }
 
     @Override
-    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    public final Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
     {
         List<SchemaTableName> tables = prefix.getTable()
                 .map(ignored -> singletonList(prefix.toSchemaTableName()))
@@ -348,7 +245,7 @@ public class IcebergMetadata
         ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
         for (SchemaTableName table : tables) {
             try {
-                columns.put(table, getTableMetadata(session, table).getColumns());
+                columns.put(table, getIcebergTableMetadata(session, table).getColumns());
             }
             catch (TableNotFoundException e) {
                 // table disappeared during listing operation
@@ -361,188 +258,41 @@ public class IcebergMetadata
     }
 
     @Override
-    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner)
-    {
-        Optional<String> location = getSchemaLocation(properties).map(uri -> {
-            try {
-                hdfsEnvironment.getFileSystem(new HdfsContext(session, schemaName), new Path(uri));
-            }
-            catch (IOException | IllegalArgumentException e) {
-                throw new PrestoException(INVALID_SCHEMA_PROPERTY, "Invalid location URI: " + uri, e);
-            }
-            return uri;
-        });
-
-        if (useMetastore(session)) {
-            Database database = Database.builder()
-                    .setDatabaseName(schemaName)
-                    .setLocation(location)
-                    .setOwnerType(owner.getType())
-                    .setOwnerName(owner.getName())
-                    .build();
-
-            metastore.createDatabase(new HiveIdentity(session), database);
-        }
-        else {
-            if (location.isEmpty()) {
-                HadoopCatalog hadoopCatalog = getHadoopCatalog(hdfsEnvironment, session);
-                hadoopCatalog.createNamespace(Namespace.of(schemaName));
-            }
-            else {
-                HadoopCatalog hadoopCatalog = getHadoopCatalog(hdfsEnvironment, session, location.get());
-                hadoopCatalog.createNamespace(Namespace.of(schemaName));
-            }
-        }
-    }
+    public abstract void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, PrestoPrincipal owner);
 
     @Override
-    public void dropSchema(ConnectorSession session, String schemaName)
-    {
-        if (useMetastore(session)) {
-            // basic sanity check to provide a better error message
-            if (!listTables(session, Optional.of(schemaName)).isEmpty() ||
-                    !listViews(session, Optional.of(schemaName)).isEmpty()) {
-                throw new PrestoException(SCHEMA_NOT_EMPTY, "Schema not empty: " + schemaName);
-            }
-            metastore.dropDatabase(new HiveIdentity(session), schemaName);
-        }
-        else {
-            HadoopCatalog hadoopCatalog = getHadoopCatalog(hdfsEnvironment, session);
-            hadoopCatalog.dropNamespace(Namespace.of(schemaName));
-        }
-    }
+    public abstract void dropSchema(ConnectorSession session, String schemaName);
 
     @Override
-    public void renameSchema(ConnectorSession session, String source, String target)
-    {
-        metastore.renameDatabase(new HiveIdentity(session), source, target);
-    }
+    public abstract void renameSchema(ConnectorSession session, String source, String target);
 
     @Override
-    public void setSchemaAuthorization(ConnectorSession session, String source, PrestoPrincipal principal)
-    {
-        metastore.setDatabaseOwner(new HiveIdentity(session), source, HivePrincipal.from(principal));
-    }
+    public abstract void setSchemaAuthorization(ConnectorSession session, String source, PrestoPrincipal principal);
 
     @Override
-    public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    public final void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
     {
         Optional<ConnectorNewTableLayout> layout = getNewTableLayout(session, tableMetadata);
         finishCreateTable(session, beginCreateTable(session, tableMetadata, layout), ImmutableList.of(), ImmutableList.of());
     }
 
     @Override
-    public void setTableComment(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<String> comment)
-    {
-        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        metastore.commentTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), comment);
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
-        if (comment.isEmpty()) {
-            icebergTable.updateProperties().remove(TABLE_COMMENT).commit();
-        }
-        else {
-            icebergTable.updateProperties().set(TABLE_COMMENT, comment.get()).commit();
-        }
-    }
+    public abstract void setTableComment(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<String> comment);
 
     @Override
-    public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
-    {
-        SchemaTableName schemaTableName = tableMetadata.getTable();
-        String schemaName = schemaTableName.getSchemaName();
-        String tableName = schemaTableName.getTableName();
-
-        Schema schema = toIcebergSchema(tableMetadata.getColumns());
-
-        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
-
-        if (useMetastore(session)) {
-            Database database = metastore.getDatabase(schemaName)
-                    .orElseThrow(() -> new SchemaNotFoundException(schemaName));
-
-            HdfsContext hdfsContext = new HdfsContext(session, schemaName, tableName);
-            HiveIdentity identity = new HiveIdentity(session);
-            String targetPath = getTableLocation(tableMetadata.getProperties());
-            if (targetPath == null) {
-                targetPath = getTableDefaultLocation(database, hdfsContext, hdfsEnvironment, schemaName, tableName).toString();
-            }
-
-            TableOperations operations = new HiveTableOperations(metastore, hdfsEnvironment, hdfsContext, identity, schemaName, tableName, session.getUser(), targetPath);
-            if (operations.current() != null) {
-                throw new TableAlreadyExistsException(schemaTableName);
-            }
-
-            ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(2);
-            FileFormat fileFormat = getFileFormat(tableMetadata.getProperties());
-            propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toString());
-            if (tableMetadata.getComment().isPresent()) {
-                propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
-            }
-
-            TableMetadata metadata = newTableMetadata(schema, partitionSpec, targetPath, propertiesBuilder.build());
-
-            transaction = createTableTransaction(tableName, operations, metadata);
-
-            return new IcebergWritableTableHandle(
-                    schemaName,
-                    tableName,
-                    SchemaParser.toJson(metadata.schema()),
-                    PartitionSpecParser.toJson(metadata.spec()),
-                    getColumns(metadata.schema(), typeManager),
-                    targetPath,
-                    fileFormat);
-        }
-        else {
-            if (!icebergSchemaExists(hdfsEnvironment, session, schemaName)) {
-                throw new SchemaNotFoundException(schemaName);
-            }
-            if (icebergTableExists(hdfsEnvironment, session, schemaTableName)) {
-                throw new TableAlreadyExistsException(schemaTableName);
-            }
-
-            ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(2);
-            FileFormat fileFormat = getFileFormat(tableMetadata.getProperties());
-            propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toString());
-            if (tableMetadata.getComment().isPresent()) {
-                propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
-            }
-
-            HdfsContext hdfsContext = new HdfsContext(session, schemaName, tableName);
-            String targetPath = getTableLocation(tableMetadata.getProperties());
-            HadoopCatalog catalog;
-            if (targetPath == null) {
-                catalog = getHadoopCatalog(hdfsEnvironment, session);
-            }
-            else {
-                catalog = getHadoopCatalog(hdfsEnvironment, session, targetPath);
-            }
-
-            Map<String, String> properties = propertiesBuilder.build();
-            TableIdentifier tableIdentifier = TableIdentifier.of(schemaName, tableName);
-            transaction = catalog.newCreateTableTransaction(tableIdentifier, schema, partitionSpec, properties);
-
-            return new IcebergWritableTableHandle(
-                    schemaName,
-                    tableName,
-                    SchemaParser.toJson(transaction.table().schema()),
-                    PartitionSpecParser.toJson(transaction.table().spec()),
-                    getColumns(transaction.table().schema(), typeManager),
-                    transaction.table().location(),
-                    fileFormat);
-        }
-    }
+    public abstract ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout);
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public final Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         return finishInsert(session, (IcebergWritableTableHandle) tableHandle, fragments, computedStatistics);
     }
 
     @Override
-    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public final ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
 
         transaction = icebergTable.newTransaction();
 
@@ -556,8 +306,9 @@ public class IcebergMetadata
                 getFileFormat(icebergTable));
     }
 
+
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public final Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         IcebergWritableTableHandle table = (IcebergWritableTableHandle) insertHandle;
         org.apache.iceberg.Table icebergTable = transaction.table();
@@ -598,85 +349,53 @@ public class IcebergMetadata
     }
 
     @Override
-    public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public final ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         return new IcebergColumnHandle(0, "$row_id", BIGINT, Optional.empty());
     }
 
     @Override
-    public Optional<Object> getInfo(ConnectorTableHandle tableHandle)
+    public final Optional<Object> getInfo(ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
         return Optional.of(new IcebergInputInfo(table.getSnapshotId()));
     }
 
     @Override
-    public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
-    {
-        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        if (useMetastore(session)) {
-            metastore.dropTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), true);
-        }
-        else {
-            TableIdentifier tableIdentifier = TableIdentifier.of(handle.getSchemaName(), handle.getTableName());
-            getHadoopCatalog(hdfsEnvironment, session).dropTable(tableIdentifier, false);
-        }
-    }
+    public abstract void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle);
 
     @Override
-    public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTable)
-    {
-        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        if (useMetastore(session)) {
-            metastore.renameTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), newTable.getSchemaName(), newTable.getTableName());
-        }
-        else {
-            TableIdentifier tableIdentifier = TableIdentifier.of(handle.getSchemaName(), handle.getTableName());
-            TableIdentifier newTableIdentifier = TableIdentifier.of(newTable.getSchemaName(), newTable.getTableName());
-            getHadoopCatalog(hdfsEnvironment, session).renameTable(tableIdentifier, newTableIdentifier);
-        }
-    }
+    public abstract void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTable);
 
     @Override
-    public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
+    public final void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
         icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType())).commit();
     }
 
     @Override
-    public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
+    public final void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
     {
         IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
         IcebergColumnHandle handle = (IcebergColumnHandle) column;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, icebergTableHandle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, icebergTableHandle.getSchemaTableName());
         icebergTable.updateSchema().deleteColumn(handle.getName()).commit();
     }
 
     @Override
-    public void renameColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle source, String target)
+    public final void renameColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle source, String target)
     {
         IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
         IcebergColumnHandle columnHandle = (IcebergColumnHandle) source;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, icebergTableHandle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, icebergTableHandle.getSchemaTableName());
         icebergTable.updateSchema().renameColumn(columnHandle.getName(), target).commit();
     }
 
-    private ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName table)
+    private final ConnectorTableMetadata getIcebergTableMetadata(ConnectorSession session, SchemaTableName table) throws TableNotFoundException, UnknownTableTypeException
     {
-        if (useMetastore(session)) {
-            if (metastore.getTable(new HiveIdentity(session), table.getSchemaName(), table.getTableName()).isEmpty()) {
-                throw new TableNotFoundException(table);
-            }
-        }
-        else {
-            if (!icebergTableExists(hdfsEnvironment, session, table)) {
-                throw new TableNotFoundException(table);
-            }
-        }
-
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table);
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table);
 
         List<ColumnMetadata> columns = getColumnMetadatas(icebergTable);
 
@@ -689,7 +408,7 @@ public class IcebergMetadata
         return new ConnectorTableMetadata(table, columns, properties.build(), getTableComment(icebergTable));
     }
 
-    private List<ColumnMetadata> getColumnMetadatas(org.apache.iceberg.Table table)
+    private final List<ColumnMetadata> getColumnMetadatas(org.apache.iceberg.Table table)
     {
         return table.schema().columns().stream()
                 .map(column -> {
@@ -703,7 +422,7 @@ public class IcebergMetadata
                 .collect(toImmutableList());
     }
 
-    private static Schema toIcebergSchema(List<ColumnMetadata> columns)
+    protected final static Schema toIcebergSchema(List<ColumnMetadata> columns)
     {
         List<NestedField> icebergColumns = new ArrayList<>();
         for (ColumnMetadata column : columns) {
@@ -723,50 +442,50 @@ public class IcebergMetadata
     }
 
     @Override
-    public Optional<ConnectorTableHandle> applyDelete(ConnectorSession session, ConnectorTableHandle handle)
+    public final Optional<ConnectorTableHandle> applyDelete(ConnectorSession session, ConnectorTableHandle handle)
     {
         return Optional.of(handle);
     }
 
     @Override
-    public ConnectorTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public final ConnectorTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         throw new PrestoException(NOT_SUPPORTED, "This connector only supports delete where one or more partitions are deleted entirely");
     }
 
     @Override
-    public OptionalLong executeDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public final OptionalLong executeDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
+        try {
+            org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
 
-        icebergTable.newDelete()
-                .deleteFromRowFilter(toIcebergExpression(handle.getPredicate()))
-                .commit();
+            icebergTable.newDelete()
+                    .deleteFromRowFilter(toIcebergExpression(handle.getPredicate()))
+                    .commit();
 
-        // TODO: it should be possible to return number of deleted records
-        return OptionalLong.empty();
+            // TODO: it should be possible to return number of deleted records
+            return OptionalLong.empty();
+        }
+        catch(TableNotFoundException | UnknownTableTypeException e){
+            return OptionalLong.empty();
+        }
     }
 
     @Override
-    public boolean usesLegacyTableLayouts()
+    public final boolean usesLegacyTableLayouts()
     {
         return false;
     }
 
-    public HiveMetastore getMetastore()
-    {
-        return metastore;
-    }
-
-    public void rollback()
+    public final void rollback()
     {
         // TODO: cleanup open transaction
     }
 
     @Override
-    public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
+    public final Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
     {
         IcebergTableHandle table = (IcebergTableHandle) handle;
 
@@ -783,7 +502,7 @@ public class IcebergMetadata
             return Optional.empty();
         }
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
 
         List<PartitionField> fields = icebergTable.spec().fields().stream()
                 .filter(field -> field.transform().isIdentity())
@@ -813,17 +532,18 @@ public class IcebergMetadata
     }
 
     @Override
-    public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
+    public final TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
         return TableStatisticsMaker.getTableStatistics(typeManager, constraint, handle, icebergTable);
     }
 
-    private Optional<Long> getSnapshotId(org.apache.iceberg.Table table, Optional<Long> snapshotId)
+    protected final Optional<Long> getSnapshotId(org.apache.iceberg.Table table, Optional<Long> snapshotId)
     {
         return snapshotIds.computeIfAbsent(table.toString(), ignored -> snapshotId
                 .map(id -> IcebergUtil.resolveSnapshotId(table, id))
                 .or(() -> Optional.ofNullable(table.currentSnapshot()).map(Snapshot::snapshotId)));
     }
+
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadataFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadataFactory.java
@@ -28,6 +28,7 @@ public class IcebergMetadataFactory
     private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
     private final JsonCodec<CommitTaskData> commitTaskCodec;
+    private IcebergCatalogType type = IcebergCatalogType.HIVE;
 
     @Inject
     public IcebergMetadataFactory(
@@ -54,6 +55,16 @@ public class IcebergMetadataFactory
 
     public IcebergMetadata create()
     {
-        return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, commitTaskCodec);
+        if (type == IcebergCatalogType.HIVE) {
+            return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, commitTaskCodec);
+        }
+        else {
+            return new IcebergHadoopMetadata(hdfsEnvironment, typeManager, commitTaskCodec);
+        }
+    }
+
+    public void setCatalogType(IcebergCatalogType type)
+    {
+        this.type = type;
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadataFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergMetadataFactory.java
@@ -54,6 +54,6 @@ public class IcebergMetadataFactory
 
     public IcebergMetadata create()
     {
-        return new IcebergMetadata(metastore, hdfsEnvironment, typeManager, commitTaskCodec);
+        return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, commitTaskCodec);
     }
 }

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
@@ -43,7 +43,6 @@ import static java.lang.String.format;
 public final class IcebergSessionProperties
 {
     private static final String HADOOP_MODE = "hadoopmode";
-    private static final String WAREHOUSE_LOCATION = "warehouse";
     private static final String COMPRESSION_CODEC = "compression_codec";
     private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
     private static final String ORC_MAX_MERGE_DISTANCE = "orc_max_merge_distance";
@@ -75,11 +74,6 @@ public final class IcebergSessionProperties
             ParquetWriterConfig parquetWriterConfig)
     {
         sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
-                .add(stringProperty(
-                        WAREHOUSE_LOCATION,
-                        "Location of warehouse in hadoop mode",
-                        icebergConfig.getWarehouse(),
-                        false))
                 .add(booleanProperty(
                         HADOOP_MODE,
                         "Use hadoop file system to store schema/table information.",
@@ -201,11 +195,6 @@ public final class IcebergSessionProperties
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
-    }
-
-    public static String getWarehouseLocation(ConnectorSession session)
-    {
-        return session.getProperty(WAREHOUSE_LOCATION, String.class);
     }
 
     public static boolean isHadoopMode(ConnectorSession session)

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
@@ -37,7 +37,6 @@ import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
 import static io.prestosql.spi.session.PropertyMetadata.doubleProperty;
 import static io.prestosql.spi.session.PropertyMetadata.enumProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
-import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static java.lang.String.format;
 
 public final class IcebergSessionProperties

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
@@ -41,7 +41,11 @@ import static java.lang.String.format;
 
 public final class IcebergSessionProperties
 {
+<<<<<<< HEAD
     private static final String HADOOP_MODE = "hadoopmode";
+=======
+    private static final String CATALOG_TYPE = "catalog_type";
+>>>>>>> Add support for HDFS only iceberg tables
     private static final String COMPRESSION_CODEC = "compression_codec";
     private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
     private static final String ORC_MAX_MERGE_DISTANCE = "orc_max_merge_distance";
@@ -79,8 +83,14 @@ public final class IcebergSessionProperties
                         icebergConfig.isHadoopMode(),
                         false))
                 .add(enumProperty(
+                        CATALOG_TYPE,
+                        "The iceber catalog type to use (either hive or hadoop)",
+                        IcebergCatalogType.class,
+                        icebergConfig.getCatalogType(),
+                        false))
+                .add(enumProperty(
                         COMPRESSION_CODEC,
-                        "Compression codec to use when writing files",
+                        "Compression codec to use when writing fsiles",
                         HiveCompressionCodec.class,
                         icebergConfig.getCompressionCodec(),
                         false))
@@ -196,9 +206,9 @@ public final class IcebergSessionProperties
         return sessionProperties;
     }
 
-    public static boolean isHadoopMode(ConnectorSession session)
+    public static IcebergCatalogType getCatalogType(ConnectorSession session)
     {
-        return session.getProperty(HADOOP_MODE, Boolean.class);
+        return session.getProperty(CATALOG_TYPE, IcebergCatalogType.class);
     }
 
     public static boolean isOrcBloomFiltersEnabled(ConnectorSession session)

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
@@ -37,10 +37,13 @@ import static io.prestosql.spi.session.PropertyMetadata.booleanProperty;
 import static io.prestosql.spi.session.PropertyMetadata.doubleProperty;
 import static io.prestosql.spi.session.PropertyMetadata.enumProperty;
 import static io.prestosql.spi.session.PropertyMetadata.integerProperty;
+import static io.prestosql.spi.session.PropertyMetadata.stringProperty;
 import static java.lang.String.format;
 
 public final class IcebergSessionProperties
 {
+    private static final String HADOOP_MODE = "hadoopmode";
+    private static final String WAREHOUSE_LOCATION = "warehouse";
     private static final String COMPRESSION_CODEC = "compression_codec";
     private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
     private static final String ORC_MAX_MERGE_DISTANCE = "orc_max_merge_distance";
@@ -72,6 +75,16 @@ public final class IcebergSessionProperties
             ParquetWriterConfig parquetWriterConfig)
     {
         sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
+                .add(stringProperty(
+                        WAREHOUSE_LOCATION,
+                        "Location of warehouse in hadoop mode",
+                        icebergConfig.getWarehouse(),
+                        false))
+                .add(booleanProperty(
+                        HADOOP_MODE,
+                        "Use hadoop file system to store schema/table information.",
+                        icebergConfig.isHadoopMode(),
+                        false))
                 .add(enumProperty(
                         COMPRESSION_CODEC,
                         "Compression codec to use when writing files",
@@ -188,6 +201,16 @@ public final class IcebergSessionProperties
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
+    }
+
+    public static String getWarehouseLocation(ConnectorSession session)
+    {
+        return session.getProperty(WAREHOUSE_LOCATION, String.class);
+    }
+
+    public static boolean isHadoopMode(ConnectorSession session)
+    {
+        return session.getProperty(HADOOP_MODE, Boolean.class);
     }
 
     public static boolean isOrcBloomFiltersEnabled(ConnectorSession session)

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSessionProperties.java
@@ -41,11 +41,7 @@ import static java.lang.String.format;
 
 public final class IcebergSessionProperties
 {
-<<<<<<< HEAD
-    private static final String HADOOP_MODE = "hadoopmode";
-=======
     private static final String CATALOG_TYPE = "catalog_type";
->>>>>>> Add support for HDFS only iceberg tables
     private static final String COMPRESSION_CODEC = "compression_codec";
     private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
     private static final String ORC_MAX_MERGE_DISTANCE = "orc_max_merge_distance";
@@ -77,11 +73,6 @@ public final class IcebergSessionProperties
             ParquetWriterConfig parquetWriterConfig)
     {
         sessionProperties = ImmutableList.<PropertyMetadata<?>>builder()
-                .add(booleanProperty(
-                        HADOOP_MODE,
-                        "Use hadoop file system to store schema/table information.",
-                        icebergConfig.isHadoopMode(),
-                        false))
                 .add(enumProperty(
                         CATALOG_TYPE,
                         "The iceber catalog type to use (either hive or hadoop)",

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplitManager.java
@@ -16,7 +16,6 @@ package io.prestosql.plugin.iceberg;
 import com.google.common.collect.ImmutableList;
 import io.prestosql.plugin.base.classloader.ClassLoaderSafeConnectorSplitSource;
 import io.prestosql.plugin.hive.HdfsEnvironment;
-import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.ConnectorSplitManager;
 import io.prestosql.spi.connector.ConnectorSplitSource;

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergSplitManager.java
@@ -30,7 +30,6 @@ import org.apache.iceberg.TableScan;
 import javax.inject.Inject;
 
 import static io.prestosql.plugin.iceberg.ExpressionConverter.toIcebergExpression;
-import static io.prestosql.plugin.iceberg.IcebergUtil.getIcebergTable;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergSplitManager
@@ -60,8 +59,7 @@ public class IcebergSplitManager
             return new FixedSplitSource(ImmutableList.of());
         }
 
-        HiveMetastore metastore = transactionManager.get(transaction).getMetastore();
-        Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        Table icebergTable = transactionManager.get(transaction).getIcebergTable(session, table.getSchemaTableName());
 
         TableScan tableScan = icebergTable.newScan()
                 .filter(toIcebergExpression(table.getPredicate()))

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergUtil.java
@@ -14,29 +14,16 @@
 package io.prestosql.plugin.iceberg;
 
 import com.google.common.collect.ImmutableMap;
-import io.prestosql.plugin.hive.HdfsEnvironment;
-import io.prestosql.plugin.hive.HdfsEnvironment.HdfsContext;
-import io.prestosql.plugin.hive.authentication.HiveIdentity;
-import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.spi.PrestoException;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.type.TypeManager;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HistoryEntry;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableOperations;
-import org.apache.iceberg.catalog.Namespace;
-import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.NoSuchNamespaceException;
-import org.apache.iceberg.exceptions.NoSuchTableException;
-import org.apache.iceberg.hadoop.HadoopCatalog;
 
 import java.util.List;
 import java.util.Locale;
@@ -46,7 +33,6 @@ import java.util.regex.Pattern;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Lists.reverse;
-import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static io.prestosql.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.prestosql.plugin.iceberg.IcebergCatalogType.HIVE;
 import static io.prestosql.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPSHOT_ID;
@@ -67,7 +53,6 @@ final class IcebergUtil
     {
         return ICEBERG_TABLE_TYPE_VALUE.equalsIgnoreCase(table.getParameters().get(TABLE_TYPE_PROP));
     }
-
 
     public static boolean useMetastore(ConnectorSession session)
     {

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/IcebergUtil.java
@@ -48,6 +48,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Lists.reverse;
 import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static io.prestosql.plugin.hive.HiveMetadata.TABLE_COMMENT;
+import static io.prestosql.plugin.iceberg.IcebergCatalogType.HIVE;
 import static io.prestosql.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPSHOT_ID;
 import static io.prestosql.plugin.iceberg.TypeConverter.toPrestoType;
 import static java.lang.String.format;
@@ -115,7 +116,7 @@ final class IcebergUtil
 
     public static boolean useMetastore(ConnectorSession session)
     {
-        return !IcebergSessionProperties.isHadoopMode(session);
+        return IcebergSessionProperties.getCatalogType(session) == HIVE;
     }
 
     public static Table getIcebergTable(HiveMetastore metastore, HdfsEnvironment hdfsEnvironment, ConnectorSession session, SchemaTableName table)

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/InternalIcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/InternalIcebergConnectorFactory.java
@@ -93,10 +93,10 @@ public final class InternalIcebergConnectorFactory
             IcebergTableProperties icebergTableProperties = injector.getInstance(IcebergTableProperties.class);
             Set<Procedure> procedures = injector.getInstance((Key<Set<Procedure>>) Key.get(Types.setOf(Procedure.class)));
 
-            //config.getOrDefault("iceberg.catalog-type", "hive")
+            String strType = config.getOrDefault("iceberg.catalog-type", "hive").toUpperCase();
+            IcebergCatalogType type = IcebergCatalogType.valueOf(strType);
+            metadataFactory.setCatalogType(type);
 
-
-            //IcebergSessionProperties.getCatalogType(session);
             return new IcebergConnector(
                     lifeCycleManager,
                     transactionManager,

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/InternalIcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/InternalIcebergConnectorFactory.java
@@ -93,6 +93,10 @@ public final class InternalIcebergConnectorFactory
             IcebergTableProperties icebergTableProperties = injector.getInstance(IcebergTableProperties.class);
             Set<Procedure> procedures = injector.getInstance((Key<Set<Procedure>>) Key.get(Types.setOf(Procedure.class)));
 
+            //config.getOrDefault("iceberg.catalog-type", "hive")
+
+
+            //IcebergSessionProperties.getCatalogType(session);
             return new IcebergConnector(
                     lifeCycleManager,
                     transactionManager,

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/RollbackToSnapshotProcedure.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/RollbackToSnapshotProcedure.java
@@ -15,7 +15,6 @@ package io.prestosql.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import io.prestosql.plugin.hive.HdfsEnvironment;
-import io.prestosql.plugin.hive.metastore.HiveMetastore;
 import io.prestosql.spi.connector.ConnectorSession;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.procedure.Procedure;

--- a/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/RollbackToSnapshotProcedure.java
+++ b/presto-iceberg/src/main/java/io/prestosql/plugin/iceberg/RollbackToSnapshotProcedure.java
@@ -26,7 +26,6 @@ import javax.inject.Provider;
 
 import java.lang.invoke.MethodHandle;
 
-import static io.prestosql.plugin.iceberg.IcebergUtil.getIcebergTable;
 import static io.prestosql.spi.block.MethodHandleUtil.methodHandle;
 import static io.prestosql.spi.type.BigintType.BIGINT;
 import static io.prestosql.spi.type.VarcharType.VARCHAR;
@@ -70,8 +69,7 @@ public class RollbackToSnapshotProcedure
     {
         SchemaTableName schemaTableName = new SchemaTableName(schema, table);
         IcebergMetadata metadata = metadataFactory.create();
-        HiveMetastore metastore = metadata.getMetastore();
-        Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, clientSession, schemaTableName);
+        Table icebergTable = metadata.getIcebergTable(clientSession, schemaTableName);
         icebergTable.rollback().toSnapshotId(snapshotId).commit();
     }
 }

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import static io.prestosql.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.prestosql.testing.QueryAssertions.copyTpchTables;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class IcebergQueryRunner
 {
@@ -81,7 +82,7 @@ public final class IcebergQueryRunner
                 "</property>\n" +
                 "</configuration>\n";
         FileOutputStream out = new FileOutputStream(hivesiteLocation);
-        out.write(hivesite.getBytes());
+        out.write(hivesite.getBytes(UTF_8));
         out.close();
 
         queryRunner.installPlugin(new IcebergPlugin());

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
@@ -27,7 +27,7 @@ import java.io.FileOutputStream;
 import java.nio.file.Path;
 import java.util.Map;
 
-import static io.prestosql.plugin.iceberg.IcebergCatalogType.HADOOP;
+import static io.prestosql.plugin.iceberg.IcebergCatalogType.HIVE;
 import static io.prestosql.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.prestosql.testing.QueryAssertions.copyTpchTables;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
@@ -72,7 +72,7 @@ public final class IcebergQueryRunner
         Path dataDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data");
         dataDir.toFile().mkdirs();
 
-        IcebergCatalogType type = HADOOP;
+        IcebergCatalogType type = HIVE;
 
         File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
         baseDir.mkdirs();

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/IcebergQueryRunner.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import static io.prestosql.plugin.iceberg.IcebergCatalogType.HADOOP;
-import static io.prestosql.plugin.iceberg.IcebergCatalogType.HIVE;
 import static io.prestosql.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.prestosql.testing.QueryAssertions.copyTpchTables;
 import static io.prestosql.testing.TestingSession.testSessionBuilder;
@@ -97,7 +96,6 @@ public final class IcebergQueryRunner
                 .put("iceberg.file-format", format.name())
                 .put("hive.config.resources", hivesiteLocation)
                 .put("iceberg.catalog-type", type.name());
-
 
         Map<String, String> icebergProperties = builder.build();
 

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergConfig.java
@@ -23,7 +23,8 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.prestosql.plugin.hive.HiveCompressionCodec.GZIP;
-import static io.prestosql.plugin.iceberg.IcebergCatalogType.*;
+import static io.prestosql.plugin.iceberg.IcebergCatalogType.HADOOP;
+import static io.prestosql.plugin.iceberg.IcebergCatalogType.HIVE;
 import static io.prestosql.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.prestosql.plugin.iceberg.IcebergFileFormat.PARQUET;
 

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergConfig.java
@@ -23,6 +23,7 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.prestosql.plugin.hive.HiveCompressionCodec.GZIP;
+import static io.prestosql.plugin.iceberg.IcebergCatalogType.*;
 import static io.prestosql.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.prestosql.plugin.iceberg.IcebergFileFormat.PARQUET;
 
@@ -32,6 +33,7 @@ public class TestIcebergConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(IcebergConfig.class)
+                .setCatalogType(HIVE)
                 .setFileFormat(ORC)
                 .setCompressionCodec(GZIP));
     }
@@ -40,11 +42,13 @@ public class TestIcebergConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("iceberg.catalog-type", "hadoop")
                 .put("iceberg.file-format", "Parquet")
                 .put("iceberg.compression-codec", "NONE")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
+                .setCatalogType(HADOOP)
                 .setFileFormat(PARQUET)
                 .setCompressionCodec(HiveCompressionCodec.NONE);
 

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
@@ -122,6 +122,6 @@ public class TestIcebergMetadataListing
     public void testTableValidation()
     {
         assertQuerySucceeds("SELECT * FROM iceberg.test_schema.iceberg_table1");
-        assertQueryFails("SELECT * FROM iceberg.test_schema.hive_table", "Table 'iceberg.test_schema.hive_table' does not exist");
+        assertQueryFails("SELECT * FROM iceberg.test_schema.hive_table", "line 1:15: Table 'iceberg.test_schema.hive_table' does not exist");
     }
 }

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListing.java
@@ -122,6 +122,6 @@ public class TestIcebergMetadataListing
     public void testTableValidation()
     {
         assertQuerySucceeds("SELECT * FROM iceberg.test_schema.iceberg_table1");
-        assertQueryFails("SELECT * FROM iceberg.test_schema.hive_table", "Not an Iceberg table: test_schema.hive_table");
+        assertQueryFails("SELECT * FROM iceberg.test_schema.hive_table", "Table 'iceberg.test_schema.hive_table' does not exist");
     }
 }

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.prestosql.Session;
+import io.prestosql.plugin.hive.HdfsConfig;
+import io.prestosql.plugin.hive.HdfsConfiguration;
+import io.prestosql.plugin.hive.HdfsConfigurationInitializer;
+import io.prestosql.plugin.hive.HdfsEnvironment;
+import io.prestosql.plugin.hive.HiveHdfsConfiguration;
+import io.prestosql.plugin.hive.authentication.NoHdfsAuthentication;
+import io.prestosql.plugin.hive.metastore.HiveMetastore;
+import io.prestosql.plugin.hive.metastore.MetastoreConfig;
+import io.prestosql.plugin.hive.metastore.file.FileHiveMetastore;
+import io.prestosql.plugin.hive.metastore.file.FileHiveMetastoreConfig;
+import io.prestosql.plugin.hive.testing.TestingHivePlugin;
+import io.prestosql.spi.security.Identity;
+import io.prestosql.spi.security.SelectedRole;
+import io.prestosql.testing.AbstractTestQueryFramework;
+import io.prestosql.testing.DistributedQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static io.prestosql.spi.security.SelectedRole.Type.ROLE;
+import static io.prestosql.testing.TestingSession.testSessionBuilder;
+
+public class TestIcebergMetadataListingHadoopMode
+        extends AbstractTestQueryFramework
+{
+    private HiveMetastore metastore;
+
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setIdentity(Identity.forUser("hive")
+                        .withRole("hive", new SelectedRole(ROLE, Optional.of("admin")))
+                        .build())
+                .build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
+        File baseHadoopDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_hadoop").toFile();
+
+        baseHadoopDir.mkdirs();
+
+        HdfsConfig hdfsConfig = new HdfsConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
+
+        metastore = new FileHiveMetastore(
+                hdfsEnvironment,
+                new MetastoreConfig(),
+                new FileHiveMetastoreConfig()
+                        .setCatalogDirectory(baseDir.toURI().toString())
+                        .setMetastoreUser("test"));
+
+        queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
+        queryRunner.createCatalog("iceberg", "iceberg", ImmutableMap.of("iceberg.warehouse", baseHadoopDir.getAbsolutePath(), "iceberg.hadoopmode", "true"));
+        queryRunner.installPlugin(new TestingHivePlugin(metastore));
+        queryRunner.createCatalog("hive", "hive", ImmutableMap.of("hive.security", "sql-standard"));
+
+        return queryRunner;
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        assertQuerySucceeds("CREATE SCHEMA hive.test_schema");
+        assertQuerySucceeds("CREATE SCHEMA iceberg.test_schema");
+        assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table1 (_string VARCHAR, _integer INTEGER)");
+        assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table2 (_double DOUBLE) WITH (partitioning = ARRAY['_double'])");
+        assertQuerySucceeds("CREATE TABLE hive.test_schema.hive_table (_double DOUBLE)");
+        //assertEquals(ImmutableSet.copyOf(metastore.getAllTables("test_schema")), ImmutableSet.of("iceberg_table1", "iceberg_table2", "hive_table"));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        assertQuerySucceeds("DROP TABLE IF EXISTS hive.test_schema.hive_table");
+        assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.iceberg_table2");
+        assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.iceberg_table1");
+        assertQuerySucceeds("DROP SCHEMA IF EXISTS hive.test_schema");
+    }
+
+    @Test
+    public void testTableListing()
+    {
+        assertQuery("SHOW TABLES FROM iceberg.test_schema", "VALUES 'iceberg_table1', 'iceberg_table2'");
+    }
+
+    @Test
+    public void testTableColumnListing()
+    {
+        // Verify information_schema.columns does not include columns from non-Iceberg tables
+        assertQuery("SELECT table_name, column_name FROM iceberg.information_schema.columns WHERE table_schema = 'test_schema'",
+                "VALUES ('iceberg_table1', '_string'), ('iceberg_table1', '_integer'), ('iceberg_table2', '_double')");
+    }
+
+    @Test
+    public void testTableDescribing()
+    {
+        assertQuery("DESCRIBE iceberg.test_schema.iceberg_table1", "VALUES ('_string', 'varchar', '', ''), ('_integer', 'integer', '', '')");
+    }
+
+    @Test
+    public void testTableValidation()
+    {
+        assertQuerySucceeds("SELECT * FROM iceberg.test_schema.iceberg_table1");
+        // jcc iceberg table not in hive catalog
+        // assertQueryFails("SELECT * FROM iceberg.test_schema.hive_table", "Not an Iceberg table: test_schema.hive_table");
+    }
+}

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
@@ -86,7 +86,7 @@ public class TestIcebergMetadataListingHadoopMode
                         .setMetastoreUser("test"));
 
         queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
-        queryRunner.createCatalog("iceberg", "iceberg", ImmutableMap.of("iceberg.hadoopmode", "true", "hive.config.resources", hivesiteLocation));
+        queryRunner.createCatalog("iceberg", "iceberg", ImmutableMap.of("iceberg.catalog-type", "hadoop", "hive.config.resources", hivesiteLocation));
         queryRunner.installPlugin(new TestingHivePlugin(metastore));
         queryRunner.createCatalog("hive", "hive", ImmutableMap.of("hive.security", "sql-standard"));
 

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
@@ -36,6 +36,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.util.Optional;
 
 import static io.prestosql.spi.security.SelectedRole.Type.ROLE;
@@ -58,9 +59,19 @@ public class TestIcebergMetadataListingHadoopMode
         DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
 
         File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
-        File baseHadoopDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_hadoop").toFile();
+        baseDir.mkdirs();
 
-        baseHadoopDir.mkdirs();
+        String hivesiteLocation = queryRunner.getCoordinator().getBaseDataDir() + "/hive-site.xml";
+        String hivesite = "<configuration>\n" +
+                "<property>\n" +
+                "  <name>hive.metastore.warehouse.dir</name>\n" +
+                "  <value>" + baseDir + "</value>\n" +
+                "  <description></description>\n" +
+                "</property>\n" +
+                "</configuration>\n";
+        FileOutputStream out = new FileOutputStream(hivesiteLocation);
+        out.write(hivesite.getBytes());
+        out.close();
 
         HdfsConfig hdfsConfig = new HdfsConfig();
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
@@ -74,7 +85,7 @@ public class TestIcebergMetadataListingHadoopMode
                         .setMetastoreUser("test"));
 
         queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
-        queryRunner.createCatalog("iceberg", "iceberg", ImmutableMap.of("iceberg.warehouse", baseHadoopDir.getAbsolutePath(), "iceberg.hadoopmode", "true"));
+        queryRunner.createCatalog("iceberg", "iceberg", ImmutableMap.of("iceberg.hadoopmode", "true", "hive.config.resources", hivesiteLocation));
         queryRunner.installPlugin(new TestingHivePlugin(metastore));
         queryRunner.createCatalog("hive", "hive", ImmutableMap.of("hive.security", "sql-standard"));
 
@@ -84,21 +95,20 @@ public class TestIcebergMetadataListingHadoopMode
     @BeforeClass
     public void setUp()
     {
-        assertQuerySucceeds("CREATE SCHEMA hive.test_schema");
         assertQuerySucceeds("CREATE SCHEMA iceberg.test_schema");
         assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table1 (_string VARCHAR, _integer INTEGER)");
         assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table2 (_double DOUBLE) WITH (partitioning = ARRAY['_double'])");
-        assertQuerySucceeds("CREATE TABLE hive.test_schema.hive_table (_double DOUBLE)");
+        //assertQuerySucceeds("CREATE TABLE iceberg.test_schema.hive_table (_double DOUBLE)");
         //assertEquals(ImmutableSet.copyOf(metastore.getAllTables("test_schema")), ImmutableSet.of("iceberg_table1", "iceberg_table2", "hive_table"));
     }
 
     @AfterClass(alwaysRun = true)
     public void tearDown()
     {
-        assertQuerySucceeds("DROP TABLE IF EXISTS hive.test_schema.hive_table");
+        //assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.hive_table");
         assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.iceberg_table2");
         assertQuerySucceeds("DROP TABLE IF EXISTS iceberg.test_schema.iceberg_table1");
-        assertQuerySucceeds("DROP SCHEMA IF EXISTS hive.test_schema");
+        assertQuerySucceeds("DROP SCHEMA IF EXISTS iceberg.test_schema");
     }
 
     @Test
@@ -126,6 +136,7 @@ public class TestIcebergMetadataListingHadoopMode
     {
         assertQuerySucceeds("SELECT * FROM iceberg.test_schema.iceberg_table1");
         // jcc iceberg table not in hive catalog
-        // assertQueryFails("SELECT * FROM iceberg.test_schema.hive_table", "Not an Iceberg table: test_schema.hive_table");
+        // what is returned is Table 'iceberg.test_schema.hive_table' does not exist"
+        //assertQueryFails("SELECT * FROM iceberg.test_schema.hive_table", "Not an Iceberg table: test_schema.hive_table");
     }
 }

--- a/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
+++ b/presto-iceberg/src/test/java/io/prestosql/plugin/iceberg/TestIcebergMetadataListingHadoopMode.java
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 
 import static io.prestosql.spi.security.SelectedRole.Type.ROLE;
@@ -70,7 +71,7 @@ public class TestIcebergMetadataListingHadoopMode
                 "</property>\n" +
                 "</configuration>\n";
         FileOutputStream out = new FileOutputStream(hivesiteLocation);
-        out.write(hivesite.getBytes());
+        out.write(hivesite.getBytes(StandardCharsets.UTF_8));
         out.close();
 
         HdfsConfig hdfsConfig = new HdfsConfig();


### PR DESCRIPTION
Add support for HDFS only iceberg tables issue: #5571

Added a flag iceberg.hadoopMode to use Iceberg's ability to leverage the file system to store the list of schema and table.

The location of the root directory is specified using a configuration property `hive.metastore.warehouse.dir` in the the hive-site.xml file.

Some operations are not yet supported:
setSchemaAuthorization
renameSchema
getSchemaProperties
getSchemaOwner