### PR TITLE
Support scanning sub directories in hive connector using session property

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/BackgroundHiveSplitLoader.java
@@ -102,6 +102,7 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_UNKNOWN_ERROR;
 import static io.prestosql.plugin.hive.HivePartitionManager.partitionMatches;
 import static io.prestosql.plugin.hive.HiveSessionProperties.getMaxInitialSplitSize;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isForceLocalScheduling;
+import static io.prestosql.plugin.hive.HiveSessionProperties.isRecursiveDirWalkerEnabled;
 import static io.prestosql.plugin.hive.HiveSessionProperties.isValidateBucketing;
 import static io.prestosql.plugin.hive.metastore.MetastoreUtil.getHiveSchema;
 import static io.prestosql.plugin.hive.metastore.MetastoreUtil.getPartitionLocation;
@@ -198,7 +199,6 @@ public class BackgroundHiveSplitLoader
             DirectoryLister directoryLister,
             Executor executor,
             int loaderConcurrency,
-            boolean recursiveDirWalkerEnabled,
             boolean ignoreAbsentPartitions,
             boolean optimizeSymlinkListing,
             Optional<ValidWriteIdList> validWriteIds)
@@ -215,7 +215,7 @@ public class BackgroundHiveSplitLoader
         this.hdfsEnvironment = hdfsEnvironment;
         this.namenodeStats = namenodeStats;
         this.directoryLister = directoryLister;
-        this.recursiveDirWalkerEnabled = recursiveDirWalkerEnabled;
+        this.recursiveDirWalkerEnabled = isRecursiveDirWalkerEnabled(session);
         this.ignoreAbsentPartitions = ignoreAbsentPartitions;
         this.optimizeSymlinkListing = optimizeSymlinkListing;
         this.executor = executor;
@@ -1025,7 +1025,6 @@ public class BackgroundHiveSplitLoader
         private DirectoryLister directoryLister;
         private Executor executor;
         private int loaderConcurrency;
-        private boolean recursiveDirWalkerEnabled;
         private boolean ignoreAbsentPartitions;
         private boolean optimizeSymlinkListing;
         private Optional<ValidWriteIdList> validWriteIds;
@@ -1114,12 +1113,6 @@ public class BackgroundHiveSplitLoader
             return this;
         }
 
-        public Builder setRecursiveDirWalkerEnabled(boolean recursiveDirWalkerEnabled)
-        {
-            this.recursiveDirWalkerEnabled = recursiveDirWalkerEnabled;
-            return this;
-        }
-
         public Builder setIgnoreAbsentPartitions(boolean ignoreAbsentPartitions)
         {
             this.ignoreAbsentPartitions = ignoreAbsentPartitions;
@@ -1171,7 +1164,6 @@ public class BackgroundHiveSplitLoader
                     directoryLister,
                     executor,
                     loaderConcurrency,
-                    recursiveDirWalkerEnabled,
                     ignoreAbsentPartitions,
                     optimizeSymlinkListing,
                     validWriteIds);

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -286,7 +286,7 @@ public class HiveConfig
         return this;
     }
 
-    public boolean getRecursiveDirWalkerEnabled()
+    public boolean isRecursiveDirWalkerEnabled()
     {
         return recursiveDirWalkerEnabled;
     }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSessionProperties.java
@@ -96,6 +96,7 @@ public final class HiveSessionProperties
     private static final String DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT = "dynamic_filtering_probe_blocking_timeout";
     private static final String OPTIMIZE_SYMLINK_LISTING = "optimize_symlink_listing";
     private static final String LEGACY_HIVE_VIEW_TRANSLATION = "legacy_hive_view_translation";
+    private static final String RECURSIVE_DIRECTORIES = "recursive_directories";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -402,6 +403,11 @@ public final class HiveSessionProperties
                         LEGACY_HIVE_VIEW_TRANSLATION,
                         "Use legacy Hive view translation mechanism",
                         hiveConfig.isLegacyHiveViewTranslation(),
+                        false),
+                booleanProperty(
+                        RECURSIVE_DIRECTORIES,
+                        "Recurse into sub directories for data",
+                        hiveConfig.isRecursiveDirWalkerEnabled(),
                         false));
     }
 
@@ -687,5 +693,10 @@ public final class HiveSessionProperties
     public static boolean isLegacyHiveViewTranslation(ConnectorSession session)
     {
         return session.getProperty(LEGACY_HIVE_VIEW_TRANSLATION, Boolean.class);
+    }
+
+    public static boolean isRecursiveDirWalkerEnabled(ConnectorSession session)
+    {
+        return session.getProperty(RECURSIVE_DIRECTORIES, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveSplitManager.java
@@ -102,7 +102,6 @@ public class HiveSplitManager
     private final int maxInitialSplits;
     private final int splitLoaderConcurrency;
     private final int maxSplitsPerSecond;
-    private final boolean recursiveDfsWalkerEnabled;
     private final CounterStat highMemorySplitSourceCounter;
     private final TypeManager typeManager;
 
@@ -133,7 +132,6 @@ public class HiveSplitManager
                 hiveConfig.getMaxInitialSplits(),
                 hiveConfig.getSplitLoaderConcurrency(),
                 hiveConfig.getMaxSplitsPerSecond(),
-                hiveConfig.getRecursiveDirWalkerEnabled(),
                 typeManager);
     }
 
@@ -152,7 +150,6 @@ public class HiveSplitManager
             int maxInitialSplits,
             int splitLoaderConcurrency,
             @Nullable Integer maxSplitsPerSecond,
-            boolean recursiveDfsWalkerEnabled,
             TypeManager typeManager)
     {
         this.metastoreProvider = requireNonNull(metastoreProvider, "metastore is null");
@@ -170,7 +167,6 @@ public class HiveSplitManager
         this.maxInitialSplits = maxInitialSplits;
         this.splitLoaderConcurrency = splitLoaderConcurrency;
         this.maxSplitsPerSecond = firstNonNull(maxSplitsPerSecond, Integer.MAX_VALUE);
-        this.recursiveDfsWalkerEnabled = recursiveDfsWalkerEnabled;
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
@@ -235,7 +231,6 @@ public class HiveSplitManager
                 .setDirectoryLister(directoryLister)
                 .setExecutor(executor)
                 .setLoaderConcurrency(concurrency)
-                .setRecursiveDirWalkerEnabled(recursiveDfsWalkerEnabled)
                 .setIgnoreAbsentPartitions(!hiveTable.getPartitionColumns().isEmpty() && isIgnoreAbsentPartitions(session))
                 .setOptimizeSymlinkListing(isOptimizeSymlinkListing(session))
                 .setValidWriteIds(metastore.getValidWriteIds(session, hiveTable)

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -802,7 +802,6 @@ public abstract class AbstractTestHive
                 hiveConfig.getMaxInitialSplits(),
                 hiveConfig.getSplitLoaderConcurrency(),
                 hiveConfig.getMaxSplitsPerSecond(),
-                false,
                 TYPE_MANAGER);
         pageSinkProvider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(hiveConfig, hdfsEnvironment),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -227,7 +227,6 @@ public abstract class AbstractTestHiveFileSystem
                 config.getMaxInitialSplits(),
                 config.getSplitLoaderConcurrency(),
                 config.getMaxSplitsPerSecond(),
-                config.getRecursiveDirWalkerEnabled(),
                 TYPE_MANAGER);
         TypeOperators typeOperators = new TypeOperators();
         BlockTypeOperators blockTypeOperators = new BlockTypeOperators(typeOperators);

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -36,6 +36,7 @@ import io.prestosql.spi.connector.DynamicFilter;
 import io.prestosql.spi.connector.SchemaTableName;
 import io.prestosql.spi.predicate.Domain;
 import io.prestosql.spi.predicate.TupleDomain;
+import io.prestosql.testing.TestingConnectorSession;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -103,6 +104,7 @@ import static io.prestosql.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.prestosql.plugin.hive.HiveTestUtils.SESSION;
 import static io.prestosql.plugin.hive.HiveTestUtils.TYPE_MANAGER;
 import static io.prestosql.plugin.hive.HiveTestUtils.getHiveSession;
+import static io.prestosql.plugin.hive.HiveTestUtils.getHiveSessionProperties;
 import static io.prestosql.plugin.hive.HiveTimestampPrecision.DEFAULT_PRECISION;
 import static io.prestosql.plugin.hive.HiveType.HIVE_INT;
 import static io.prestosql.plugin.hive.HiveType.HIVE_STRING;
@@ -846,9 +848,12 @@ public class TestBackgroundHiveSplitLoader
         List<String> splits = drain(hiveSplitSource);
         assertEquals(splits.size(), 0);
 
+        ConnectorSession session = TestingConnectorSession.builder()
+                .setPropertyMetadata(getHiveSessionProperties(new HiveConfig().setRecursiveDirWalkerEnabled(true)).getSessionProperties())
+                .build();
         backgroundHiveSplitLoader = testBackgroundHiveSplitLoaderBuilder()
                 .setTable(table)
-                .setRecursiveDirWalkerEnabled(true)
+                .setConnectorSession(session)
                 .build();
         hiveSplitSource = hiveSplitSource(backgroundHiveSplitLoader);
         backgroundHiveSplitLoader.start(hiveSplitSource);


### PR DESCRIPTION

Hive supports reading data from sub directories using below session properties -
```
SET hive.mapred.supports.subdirectories=TRUE;
SET mapred.input.dir.recursive=TRUE;
SELECT ...
```

Presto today supports recursive directory walking only as a global configuration property by setting `hive.recursive-directories` in hive.properties. This PR provides a way for Presto users to read data in sub directories using the new session property `hive.recursive_directories`.

```
SET hive.recursive_directories=TRUE;
SELECT ...
```