### PR TITLE
Fix JdbcRecordCursor.isNull for types mapped to slice

### DIFF
--- a/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/SliceReadFunction.java
+++ b/presto-base-jdbc/src/main/java/io/prestosql/plugin/jdbc/SliceReadFunction.java
@@ -30,4 +30,15 @@ public interface SliceReadFunction
 
     Slice readSlice(ResultSet resultSet, int columnIndex)
             throws SQLException;
+
+    @Override
+    default boolean isNull(ResultSet resultSet, int columnIndex)
+            throws SQLException
+    {
+        // JDBC is kind of dumb: we need to read the field and then ask
+        // if it was null, which means we are wasting effort here.
+        // We could save the result of the field access if it matters.
+        resultSet.getString(columnIndex);
+        return resultSet.wasNull();
+    }
 }


### PR DESCRIPTION
This fixes an issue when the postgresql plugin is
used to connect to cockroachdb: https://go.crdb.dev/issue-v/40195/v20.1