### PR TITLE
add missing jars when `hive.s3-file-system-type=HADOOP_DEFAULT`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1167,6 +1167,12 @@
 
             <dependency>
                 <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.8</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.commons</groupId>
                 <artifactId>commons-math3</artifactId>
                 <version>3.6.1</version>
             </dependency>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -188,7 +188,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
         </dependency>
 
         <dependency>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -124,6 +124,11 @@
 
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-dynamodb</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sts</artifactId>
         </dependency>
 

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -344,7 +344,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
I use Hadoop default S3A implementation because of [per-bucket configuration feature](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html#Configuring_different_S3_buckets_with_Per-Bucket_Configuration).
But Presto don't find `org.apache.hadoop.fs.s3a.S3AFileSystem` class because of some missing jars.

![Screenshot from 2020-10-31 23-58-00](https://user-images.githubusercontent.com/6848311/97785670-1b9c1880-1bd9-11eb-8119-4d1aaa3c95ba.png)

Here is my `hive.properties`
```properties
connector.name=hive-hadoop2

### Metastore configs
# Options: file | glue | thrift
# See: https://github.com/prestosql/presto/tree/master/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore
hive.metastore=thrift
hive.metastore.uri=thrift://hive-metastore.hive:9083
hive.metastore-timeout=1m

### Security configs
# See: https://prestosql.io/docs/current/connector/hive-security.html
hive.security=legacy
hive.allow-drop-table=true

### Storage configs
hive.config.resources=/etc/presto/core-site.xml
hive.s3-file-system-type=HADOOP_DEFAULT
hive.s3select-pushdown.enabled=true
hive.parquet.use-column-names=true
hive.orc.use-column-names=true
```

Signed-off-by: Đặng Minh Dũng <dungdm93@live.com>