### PR TITLE
Do not create temp staging directory for CREATE TABLE without data

### DIFF
--- a/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveAlluxioMetastore.java
+++ b/presto-hive-hadoop2/src/test/java/io/prestosql/plugin/hive/TestHiveAlluxioMetastore.java
@@ -309,4 +309,10 @@ public class TestHiveAlluxioMetastore
     {
         // Alluxio metastore does not support create operations
     }
+
+    @Override
+    public void testCreateEmptyTableStaging()
+    {
+        // Alluxio metastore does not support create operations
+    }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
@@ -53,7 +53,7 @@ public class HiveLocationService
     }
 
     @Override
-    public LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, Optional<Path> externalLocation)
+    public LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, Optional<Path> externalLocation, boolean withData)
     {
         HdfsContext context = new HdfsContext(session, schemaName, tableName);
         Path targetPath = externalLocation.orElseGet(() -> getTableDefaultLocation(context, metastore, hdfsEnvironment, schemaName, tableName));
@@ -64,7 +64,7 @@ public class HiveLocationService
         }
 
         // TODO detect when existing table's location is a on a different file system than the temporary directory
-        if (shouldUseTemporaryDirectory(session, context, targetPath, externalLocation)) {
+        if (withData && shouldUseTemporaryDirectory(session, context, targetPath, externalLocation)) {
             Path writePath = createTemporaryPath(session, context, hdfsEnvironment, targetPath);
             return new LocationHandle(targetPath, writePath, false, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveMetadata.java
@@ -877,7 +877,7 @@ public class HiveMetadata
         }
         else {
             external = false;
-            LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, Optional.empty());
+            LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, Optional.empty(), false);
             targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
         }
 
@@ -1325,7 +1325,7 @@ public class HiveMetadata
                 .collect(toList());
         checkPartitionTypesSupported(partitionColumns);
 
-        LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, externalLocation);
+        LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, externalLocation, true);
 
         boolean transactional = isTransactional(tableMetadata.getProperties()).orElse(false);
         AcidTransaction transaction = transactional ? forCreateTable() : NO_ACID_TRANSACTION;

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/LocationService.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/LocationService.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 public interface LocationService
 {
-    LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, Optional<Path> externalLocation);
+    LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, Optional<Path> externalLocation, boolean withData);
 
     LocationHandle forExistingTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, Table table);
 


### PR DESCRIPTION
In case of CREATE TABLE (managed), empty staging directory was not cleaned up at commit time, but relying on /tmp periodic delete. 