### PR TITLE
Add new parametric datatype called TSRange representing an interval o…

### DIFF
--- a/presto-client/src/main/java/io/prestosql/client/ClientStandardTypes.java
+++ b/presto-client/src/main/java/io/prestosql/client/ClientStandardTypes.java
@@ -44,6 +44,7 @@ public final class ClientStandardTypes
     public static final String UUID = "uuid";
     public static final String GEOMETRY = "Geometry";
     public static final String BING_TILE = "BingTile";
+    public static final String TSRANGE = "tsrange";
 
     private ClientStandardTypes() {}
 }

--- a/presto-client/src/main/java/io/prestosql/client/FixJsonDataUtils.java
+++ b/presto-client/src/main/java/io/prestosql/client/FixJsonDataUtils.java
@@ -47,6 +47,7 @@ import static io.prestosql.client.ClientStandardTypes.TIMESTAMP;
 import static io.prestosql.client.ClientStandardTypes.TIMESTAMP_WITH_TIME_ZONE;
 import static io.prestosql.client.ClientStandardTypes.TIME_WITH_TIME_ZONE;
 import static io.prestosql.client.ClientStandardTypes.TINYINT;
+import static io.prestosql.client.ClientStandardTypes.TSRANGE;
 import static io.prestosql.client.ClientStandardTypes.UUID;
 import static io.prestosql.client.ClientStandardTypes.VARCHAR;
 import static java.util.Collections.unmodifiableList;
@@ -169,6 +170,7 @@ final class FixJsonDataUtils
             case DECIMAL:
             case CHAR:
             case GEOMETRY:
+            case TSRANGE: // maintain postgres standard tsrange '[a,b)' -> ["a","b")
                 return String.class.cast(value);
             case BING_TILE:
                 // Bing tiles are serialized as strings when used as map keys,

--- a/presto-client/src/test/java/io/prestosql/client/TestFixJsonDataUtils.java
+++ b/presto-client/src/test/java/io/prestosql/client/TestFixJsonDataUtils.java
@@ -41,6 +41,7 @@ import static io.prestosql.spi.type.StandardTypes.INTERVAL_YEAR_TO_MONTH;
 import static io.prestosql.spi.type.StandardTypes.IPADDRESS;
 import static io.prestosql.spi.type.StandardTypes.JSON;
 import static io.prestosql.spi.type.StandardTypes.UUID;
+import static io.prestosql.spi.type.TSRangeType.TSRANGE_MILLIS;
 import static io.prestosql.spi.type.TimeType.TIME;
 import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.prestosql.spi.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
@@ -90,6 +91,8 @@ public class TestFixJsonDataUtils
                 mapType(new TypeSignature("BingTile"), BIGINT.getTypeSignature()),
                 ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1),
                 ImmutableMap.of("BingTile{x=1, y=2, zoom_level=10}", 1L));
+        assertQueryResult(TSRANGE_MILLIS.getTypeSignature(), "[2020-10-31 04,2020-10-31 06)", "[2020-10-31 04,2020-10-31 06)");
+        assertQueryResult(TSRANGE_MILLIS.getTypeSignature(), "[2020-10-31 04:34:00.000,2020-10-31 06:00:00.000)", "[2020-10-31 04:34:00.000,2020-10-31 06:00:00.000)");
     }
 
     private void assertQueryResult(TypeSignature type, Object data, Object expected)

--- a/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/FunctionRegistry.java
@@ -145,6 +145,8 @@ import io.prestosql.operator.scalar.SplitToMapFunction;
 import io.prestosql.operator.scalar.SplitToMultimapFunction;
 import io.prestosql.operator.scalar.StringFunctions;
 import io.prestosql.operator.scalar.TDigestFunctions;
+import io.prestosql.operator.scalar.TSRangeFunctions;
+import io.prestosql.operator.scalar.TSRangeOperators;
 import io.prestosql.operator.scalar.TryFunction;
 import io.prestosql.operator.scalar.TypeOfFunction;
 import io.prestosql.operator.scalar.UrlFunctions;
@@ -723,6 +725,11 @@ public class FunctionRegistry
                 .scalar(io.prestosql.operator.scalar.timetz.AtTimeZone.class)
                 .scalar(io.prestosql.operator.scalar.timetz.AtTimeZoneWithOffset.class)
                 .scalar(CurrentTime.class);
+
+        // tsrange operators and functions
+        builder
+                .scalars(TSRangeOperators.class)
+                .scalars(TSRangeFunctions.class);
 
         switch (featuresConfig.getRegexLibrary()) {
             case JONI:

--- a/presto-main/src/main/java/io/prestosql/metadata/TypeRegistry.java
+++ b/presto-main/src/main/java/io/prestosql/metadata/TypeRegistry.java
@@ -55,6 +55,7 @@ import static io.prestosql.spi.type.P4HyperLogLogType.P4_HYPER_LOG_LOG;
 import static io.prestosql.spi.type.QuantileDigestParametricType.QDIGEST;
 import static io.prestosql.spi.type.RealType.REAL;
 import static io.prestosql.spi.type.SmallintType.SMALLINT;
+import static io.prestosql.spi.type.TSRangeParametricType.TSRANGE;
 import static io.prestosql.spi.type.TimeParametricType.TIME;
 import static io.prestosql.spi.type.TimeWithTimeZoneParametricType.TIME_WITH_TIME_ZONE;
 import static io.prestosql.spi.type.TimestampParametricType.TIMESTAMP;
@@ -134,6 +135,7 @@ final class TypeRegistry
         addParametricType(TIMESTAMP_WITH_TIME_ZONE);
         addParametricType(TIME);
         addParametricType(TIME_WITH_TIME_ZONE);
+        addParametricType(TSRANGE);
 
         parametricTypeCache = CacheBuilder.newBuilder()
                 .maximumSize(1000)

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/TSRangeFunctions.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/TSRangeFunctions.java
@@ -1,0 +1,299 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.scalar;
+
+import io.airlift.slice.Slice;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.function.Description;
+import io.prestosql.spi.function.LiteralParameter;
+import io.prestosql.spi.function.LiteralParameters;
+import io.prestosql.spi.function.ScalarFunction;
+import io.prestosql.spi.function.SqlType;
+import io.prestosql.spi.type.StandardTypes;
+import io.prestosql.spi.type.TSRange;
+import io.prestosql.spi.type.TSRangeType;
+import io.prestosql.type.DateTimes;
+
+import static io.prestosql.spi.StandardErrorCode.CONSTRAINT_VIOLATION;
+import static io.prestosql.spi.type.TSRangeType.combine;
+import static io.prestosql.spi.type.TSRangeType.createTSRangeSlice;
+import static io.prestosql.spi.type.TSRangeType.sliceToTSRange;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MICROS;
+
+public class TSRangeFunctions
+{
+    private TSRangeFunctions()
+    {
+    }
+
+    @Description("Create half-open tsrange [lower,upper)")
+    @ScalarFunction(value = "tsrange")
+    @LiteralParameters("p")
+    @SqlType("tsrange(p)")
+    public static Slice tsrangeHalfOpenFromTimestamp(@SqlType("timestamp(p)") long lower, @SqlType("timestamp(p)") long upper)
+    { // postgres default is [lower,upper)
+        return createTSRangeSlice(lower, upper, true, false);
+    }
+
+    @Description("Create half-open tsrange [lower,upper) from epochMillis")
+    @ScalarFunction(value = "tsrange")
+    @SqlType("tsrange(3)") // assume milliseconds precision if created with bigint
+    public static Slice tsrangeHalfOpenFromEpoch(@SqlType(StandardTypes.BIGINT) long lower, @SqlType(StandardTypes.BIGINT) long upper)
+    {
+        return createTSRangeSlice(lower, upper, true, false);
+    }
+
+    @Description("Utility constructor")
+    @ScalarFunction(value = "tsrange")
+    @LiteralParameters("p")
+    @SqlType("tsrange(p)")
+    public static Slice tsrangeFromTimestamp(@SqlType("timestamp(p)") long lower, @SqlType("timestamp(p)") long upper,
+            @SqlType(StandardTypes.BOOLEAN) boolean lowerClosed, @SqlType(StandardTypes.BOOLEAN) boolean upperClosed)
+    {
+        return createTSRangeSlice(lower, upper, lowerClosed, upperClosed);
+    }
+
+    @Description("Utility constructor from epochMillis")
+    @ScalarFunction(value = "tsrange")
+    @SqlType("tsrange(3)")
+    public static Slice tsrangeFromEpoch(@SqlType(StandardTypes.BIGINT) long lower,
+            @SqlType(StandardTypes.BIGINT) long upper, @SqlType(StandardTypes.BOOLEAN) boolean lowerClosed, @SqlType(StandardTypes.BOOLEAN) boolean upperClosed)
+    {
+        return createTSRangeSlice(lower, upper, lowerClosed, upperClosed);
+    }
+
+    @Description("Creates the smallest interval containing both intervals")
+    @ScalarFunction(value = "combine")
+    @LiteralParameters("p")
+    @SqlType("tsrange(p)")
+    public static Slice combineTSRanges(@SqlType("tsrange(p)") Slice left, @SqlType("tsrange(p)") Slice right)
+    {
+        return combine(left, right);
+    }
+
+    @Description("Returns true if lower bound is closed")
+    @ScalarFunction(value = "lower_inc")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean leftClosed(@SqlType("tsrange(p)") Slice slice)
+    {
+        final TSRange tsRange = sliceToTSRange(slice);
+        if (tsRange.isEmpty()) {
+            throw new PrestoException(CONSTRAINT_VIOLATION, "Empty range has no bounds");
+        }
+        return tsRange.isLowerClosed();
+    }
+
+    @Description("Returns true if upper bound is closed")
+    @ScalarFunction(value = "upper_inc")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean rightClosed(@SqlType("tsrange(p)") Slice slice)
+    {
+        final TSRange tsRange = sliceToTSRange(slice);
+        if (tsRange.isEmpty()) {
+            throw new PrestoException(CONSTRAINT_VIOLATION, "Empty range has no bounds");
+        }
+        return tsRange.isUpperClosed();
+    }
+
+    @Description("Returns lower timestamp from tsrange")
+    @ScalarFunction(value = "lower")
+    @LiteralParameters("p")
+    @SqlType("timestamp(p)")
+    public static long lower(@LiteralParameter("p") long precision, @SqlType("tsrange(p)") Slice slice)
+    {
+        final TSRange tsRange = sliceToTSRange(slice);
+        if (tsRange.isEmpty()) {
+            throw new PrestoException(CONSTRAINT_VIOLATION, "Cannot obtain element of empty tsrange");
+        }
+        return DateTimes.rescale(tsRange.getLower(), (int) precision, TIMESTAMP_MICROS.getPrecision());
+    }
+
+    @Description("Returns upper timestamp from tsrange")
+    @ScalarFunction(value = "upper")
+    @LiteralParameters("p")
+    @SqlType("timestamp(p)")
+    public static long upper(@LiteralParameter("p") long precision, @SqlType("tsrange(p)") Slice slice)
+    {
+        final TSRange tsRange = sliceToTSRange(slice);
+        if (tsRange.isEmpty()) {
+            throw new PrestoException(CONSTRAINT_VIOLATION, "Cannot obtain element of empty tsrange");
+        }
+        return DateTimes.rescale(tsRange.getUpper(), (int) precision, TIMESTAMP_MICROS.getPrecision());
+    }
+
+    @Description("Returns lower epoch from tsrange")
+    @ScalarFunction(value = "lowerEpoch")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BIGINT)
+    public static long lowerEpoch(@LiteralParameter("p") long precision, @SqlType("tsrange(p)") Slice slice)
+    {
+        final TSRange tsRange = sliceToTSRange(slice);
+        if (tsRange.isEmpty()) {
+            throw new PrestoException(CONSTRAINT_VIOLATION, "Cannot obtain element of empty tsrange");
+        }
+        return DateTimes.rescale(tsRange.getLower(), (int) precision, 3);
+    }
+
+    @Description("Returns upper epoch from tsrange")
+    @ScalarFunction(value = "upperEpoch")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BIGINT)
+    public static long upperEpoch(@LiteralParameter("p") long precision, @SqlType("tsrange(p)") Slice slice)
+    {
+        final TSRange tsRange = sliceToTSRange(slice);
+        if (tsRange.isEmpty()) {
+            throw new PrestoException(CONSTRAINT_VIOLATION, "Cannot obtain element of empty tsrange");
+        }
+        return DateTimes.rescale(tsRange.getUpper(), (int) precision, 3);
+    }
+
+    @Description("Returns true if left tsrange is strictly left from right tsrange")
+    @ScalarFunction(value = "strictlyLeft")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean strictlyLeft(@SqlType("tsrange(p)") Slice left, @SqlType("tsrange(p)") Slice right)
+    {
+        return TSRangeType.strictlyLeft(left, right);
+    }
+
+    @Description("Returns true if left is strictly right from right")
+    @ScalarFunction(value = "strictlyRight")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean strictlyRight(@SqlType("tsrange(p)") Slice left, @SqlType("tsrange(p)") Slice right)
+    {
+        return TSRangeType.strictlyLeft(right, left);
+    }
+
+    @Description("Returns true if left is adjacent to other tsrange")
+    @ScalarFunction(value = "adjacent")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean adjacent(@SqlType("tsrange(p)") Slice left, @SqlType("tsrange(p)") Slice right)
+    {
+        return TSRangeType.adjacent(left, right);
+    }
+
+    @Description("Returns true if tsrange is empty")
+    @ScalarFunction(value = "isEmpty")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean isEmpty(@SqlType("tsrange(p)") Slice slice)
+    {
+        final TSRange tsRange = sliceToTSRange(slice);
+        return tsRange.isEmpty();
+    }
+
+    @Description("Returns true if left contains right")
+    @ScalarFunction(value = "containsTSRange")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean containsTSRange(@SqlType("tsrange(p)") Slice left, @SqlType("tsrange(p)") Slice right)
+    {
+        return TSRangeType.contains(left, right);
+    }
+
+    @Description("Returns true if tsrange contains timestamp")
+    @ScalarFunction(value = "containsTimestamp")
+    @LiteralParameters({"p1", "p2"})
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean containsTimestamp(@LiteralParameter("p1") long tsrangePrecision, @LiteralParameter("p2") long tsPrecision,
+            @SqlType("tsrange(p1)") Slice slice, @SqlType("timestamp(p2)") long ts)
+    {
+        final TSRange tsRange = sliceToTSRange(slice);
+        if (tsRange.isEmpty()) {
+            return false;
+        }
+        else { // somehow timestamp(3) returns microseconds
+            final long element = DateTimes.rescale(ts, (int) tsPrecision, (int) tsrangePrecision - 3);
+            final long lower = tsRange.getLower();
+            final long upper = tsRange.getUpper();
+            return (element > lower || (element == lower && tsRange.isLowerClosed())) && (element < upper || (element == upper && tsRange.isUpperClosed()));
+        }
+    }
+
+    @Description("Returns true if tsrange contains epochMillis")
+    @ScalarFunction(value = "containsElement")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean containsEpochMillis(@LiteralParameter("p") long scale, @SqlType("tsrange(p)") Slice slice, @SqlType(StandardTypes.BIGINT) long element)
+    {
+        final TSRange tsRange = sliceToTSRange(slice);
+        if (tsRange.isEmpty()) {
+            return false;
+        }
+        else {
+            final long lower = DateTimes.rescale(tsRange.getLower(), (int) scale, 3);
+            final long upper = DateTimes.rescale(tsRange.getUpper(), (int) scale, 3);
+            return (element > lower || (element == lower && tsRange.isLowerClosed())) && (element < upper || (element == upper && tsRange.isUpperClosed()));
+        }
+    }
+
+    @Description("Returns true if left and right have points in common")
+    @ScalarFunction(value = "overlap")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean overlap(@SqlType("tsrange(p)") Slice leftSlice, @SqlType("tsrange(p)") Slice rightSlice)
+    {
+        final TSRange left = sliceToTSRange(leftSlice);
+        final TSRange right = sliceToTSRange(rightSlice);
+
+        if (left.isEmpty()) {
+            return false;
+        }
+
+        if (right.isEmpty()) {
+            return false;
+        }
+
+        if (left.getUpper() == right.getLower()) {
+            return left.isUpperClosed() && right.isLowerClosed();
+        }
+
+        if (left.getLower() == right.getUpper()) {
+            return left.isLowerClosed() && right.isUpperClosed();
+        }
+
+        if (left.getUpper() < right.getLower()) {
+            return false;
+        }
+        return left.getLower() <= right.getUpper();
+    }
+
+    @Description("Returns true if right contains an upper bound for left")
+    @ScalarFunction(value = "doesNotExtendToTheRightOf")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean doesNotExtendToTheRight(@SqlType("tsrange(p)") Slice left, @SqlType("tsrange(p)") Slice right)
+    {
+        if (sliceToTSRange(left).isEmpty() || sliceToTSRange(right).isEmpty()) {
+            return false;
+        }
+        return TSRangeType.compareUpper(left, right) <= 0;
+    }
+
+    @Description("Returns true if right tsrange contains a lower bound for left")
+    @ScalarFunction(value = "doesNotExtendToTheLeftOf")
+    @LiteralParameters("p")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean doesNotExtendToTheLeft(@SqlType("tsrange(p)") Slice left, @SqlType("tsrange(p)") Slice right)
+    {
+        if (sliceToTSRange(left).isEmpty() || sliceToTSRange(right).isEmpty()) {
+            return false;
+        }
+        return TSRangeType.compareLower(left, right) >= 0;
+    }
+}

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/TSRangeOperators.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/TSRangeOperators.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.operator.scalar;
+
+import io.airlift.slice.Slice;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.function.LiteralParameters;
+import io.prestosql.spi.function.ScalarOperator;
+import io.prestosql.spi.function.SqlType;
+import io.prestosql.spi.type.TSRange;
+import io.prestosql.spi.type.TSRangeType;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.prestosql.spi.StandardErrorCode.CONSTRAINT_VIOLATION;
+import static io.prestosql.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static io.prestosql.spi.function.OperatorType.ADD;
+import static io.prestosql.spi.function.OperatorType.CAST;
+import static io.prestosql.spi.function.OperatorType.MULTIPLY;
+import static io.prestosql.spi.function.OperatorType.SUBTRACT;
+
+public class TSRangeOperators
+{
+    private TSRangeOperators()
+    {
+    }
+
+    @ScalarOperator(ADD)
+    @LiteralParameters("p")
+    @SqlType("tsrange(p)")
+    public static Slice union(@SqlType("tsrange(p)") Slice slice, @SqlType("tsrange(p)") Slice other)
+    {
+        if (TSRangeType.sliceToTSRange(other).isEmpty()) {
+            return slice;
+        }
+        else if (!TSRangeType.adjacent(slice, other) && TSRangeType.sliceToTSRange(intersection(slice, other)).isEmpty()) {
+            throw new PrestoException(CONSTRAINT_VIOLATION, "Result of tsrange union would not be contiguous");
+        }
+        return TSRangeType.combine(slice, other);
+    }
+
+    @ScalarOperator(SUBTRACT)
+    @LiteralParameters("p")
+    @SqlType("tsrange(p)")
+    public static Slice difference(@SqlType("tsrange(p)") Slice slice, @SqlType("tsrange(p)") Slice other)
+    {
+        if (TSRangeType.compareLower(slice, other) < 0 && TSRangeType.compareUpper(slice, other) > 0 && TSRangeType.contains(slice, other)) {
+            throw new PrestoException(CONSTRAINT_VIOLATION, "Result of tsrange union would not be contiguous");
+        }
+        else if (TSRangeType.contains(other, slice)) {
+            return TSRangeType.empty();
+        }
+        Slice intersection = intersection(slice, other);
+        if (TSRangeType.sliceToTSRange(intersection).isEmpty()) {
+            return slice;
+        }
+        // cut off intersection from tsrange; 2 cases intersection is on the left or the right
+        if (TSRangeType.compareLower(slice, intersection) < 0) {
+            return TSRangeType.createTSRangeSlice(TSRangeType.getLower(slice), -TSRangeType.getLower(intersection));
+        }
+        else {
+            return TSRangeType.createTSRangeSlice(-TSRangeType.getUpper(intersection), TSRangeType.getUpper(slice));
+        }
+    }
+
+    @ScalarOperator(MULTIPLY)
+    @LiteralParameters("p")
+    @SqlType("tsrange(p)")
+    public static Slice intersection(@SqlType("tsrange(p)") Slice slice, @SqlType("tsrange(p)") Slice other)
+    {
+        final TSRange left = TSRangeType.sliceToTSRange(slice);
+        if (left.isEmpty()) {
+            return TSRangeType.empty();
+        }
+
+        final TSRange right = TSRangeType.sliceToTSRange(other);
+        if (right.isEmpty()) {
+            return TSRangeType.empty();
+        }
+
+        if (left.getLower() > right.getUpper() || left.getUpper() < right.getLower()) {
+            return TSRangeType.empty();
+        }
+
+        // special case: adjacent in numbers but not in boundaries
+        if ((left.getLower() == right.getUpper() && !(left.isLowerClosed() && right.isUpperClosed())) || (left.getUpper() == right.getLower() && !(left.isUpperClosed() && right.isLowerClosed()))) {
+            return TSRangeType.empty();
+        }
+
+        final boolean lb;
+        final long lv;
+        if (left.getLower() < right.getLower()) {
+            lv = right.getLower();
+            lb = right.isLowerClosed();
+        }
+        else if (left.getLower() == right.getLower()) {
+            lv = left.getLower();
+            lb = left.isLowerClosed() && right.isLowerClosed();
+        }
+        else {
+            lv = left.getLower();
+            lb = left.isLowerClosed();
+        }
+        final boolean rb;
+        final long rv;
+        if (left.getUpper() < right.getUpper()) {
+            rv = left.getUpper();
+            rb = left.isUpperClosed();
+        }
+        else if (left.getUpper() == right.getUpper()) {
+            rv = left.getUpper();
+            rb = left.isUpperClosed() && right.isUpperClosed();
+        }
+        else {
+            rv = right.getUpper();
+            rb = right.isUpperClosed();
+        }
+
+        return TSRangeType.createTSRangeSlice(lv, rv, lb, rb);
+    }
+
+    @ScalarOperator(CAST)
+    @LiteralParameters({"p", "x"})
+    @SqlType("tsrange(p)")
+    public static Slice castFromVarcharToTSRange(@SqlType("varchar(x)") Slice slice)
+    {
+        TSRange tsRange;
+        try {
+            tsRange = TSRange.fromString(slice.toStringUtf8());
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_CAST_ARGUMENT, "Cannot cast value to tsrange: " + slice.toStringUtf8());
+        }
+        return TSRangeType.tsrangeLongToSlice(tsRange);
+    }
+
+    @ScalarOperator(CAST)
+    @LiteralParameters({"p", "x"})
+    @SqlType("varchar(x)")
+    public static Slice castTSRangeToVarchar(@SqlType("tsrange(p)") Slice slice)
+    {
+        return utf8Slice(TSRangeType.sliceToTSRange(slice).toString());
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/type/TestTSRangeFunctions.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTSRangeFunctions.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.type;
+
+import io.prestosql.operator.scalar.AbstractTestFunctions;
+import io.prestosql.spi.type.TSRange;
+import org.testng.annotations.Test;
+
+import java.time.LocalDateTime;
+
+import static io.prestosql.spi.StandardErrorCode.CONSTRAINT_VIOLATION;
+import static io.prestosql.spi.type.BigintType.BIGINT;
+import static io.prestosql.spi.type.BooleanType.BOOLEAN;
+import static io.prestosql.spi.type.TSRangeType.TSRANGE_MILLIS;
+import static io.prestosql.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.prestosql.testing.DateTimeTestingUtils.sqlTimestampOf;
+
+public class TestTSRangeFunctions
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testTSRangeConstructor()
+    {
+        assertFunction("tsrange (20,30,false,false)", TSRANGE_MILLIS, TSRange.fromString("(20,30)"));
+        assertFunction("tsrange (20,30,false,true)", TSRANGE_MILLIS, TSRange.fromString("(20,30]"));
+        assertFunction("tsrange (20,30,true,false)", TSRANGE_MILLIS, TSRange.fromString("[20,30)"));
+        assertFunction("tsrange (20,30,true,true)", TSRANGE_MILLIS, TSRange.fromString("[20,30]"));
+        // no bounds -> [a,b)
+        assertFunction("tsrange (10,20)", TSRANGE_MILLIS, TSRange.fromString("[10,20)"));
+    }
+
+    @Test
+    public void testTSRangeFromTimestampsConstructor()
+    {
+        assertFunction("tsrange '(2020-08-18 20:00:00,2020-08-18 21:00:00)'", TSRANGE_MILLIS, TSRange.fromString("(2020-08-18 20:00:00,2020-08-18 21:00:00)"));
+        // postgres standard
+        assertFunction("tsrange '(\"2020-08-18 20:00:00\",\"2020-08-18 21:00:00\")'", TSRANGE_MILLIS, TSRange.fromString("(2020-08-18 20:00:00,2020-08-18 21:00:00)"));
+    }
+
+    @Test
+    public void testLower()
+    {
+        // there seems to be a bug in the projection of AbstractTestFunctions
+        assertFunction("lower(tsrange '[2020-11-03 18:51:00.123,2020-11-03 21:54:00.456)')", TIMESTAMP_MILLIS,
+                sqlTimestampOf(3, LocalDateTime.of(2020, 11, 3, 18, 51, 0, 123_000_000)));
+        assertInvalidFunction("lower(tsrange 'empty')", CONSTRAINT_VIOLATION);
+    }
+
+    @Test
+    public void testUpper()
+    {
+        // there seems to be a bug in the projection of AbstractTestFunctions
+        assertFunction("upper(tsrange '[2020-11-03 18:51:00.123,2020-11-03 21:54:02.456)')", TIMESTAMP_MILLIS,
+                sqlTimestampOf(3, LocalDateTime.of(2020, 11, 3, 21, 54, 2, 456_000_000)));
+        assertInvalidFunction("upper(tsrange 'empty')", CONSTRAINT_VIOLATION);
+    }
+
+    @Test
+    public void testLowerEpoch()
+    {
+        assertFunction("lowerEpoch(tsrange '(1,3)')", BIGINT, 1L);
+        assertInvalidFunction("lowerEpoch(tsrange 'empty')", CONSTRAINT_VIOLATION);
+    }
+
+    @Test
+    public void testUpperEpoch()
+    {
+        assertFunction("upperEpoch(tsrange '(1,3)')", BIGINT, 3L);
+        assertInvalidFunction("upperEpoch(tsrange 'empty')", CONSTRAINT_VIOLATION);
+    }
+
+    @Test
+    public void testLeftClosed()
+    {
+        assertFunction("lower_inc(tsrange '[1,3)')", BOOLEAN, true);
+        assertFunction("lower_inc(tsrange '(1,3)')", BOOLEAN, false);
+        assertInvalidFunction("lower_inc(tsrange 'empty')", CONSTRAINT_VIOLATION, "Empty range has no bounds");
+    }
+
+    @Test
+    public void testStrictlyLeft()
+    {
+        assertFunction("strictlyLeft(tsrange '(1,3)', tsrange '(3,4)')", BOOLEAN, true);
+        // show asymmetry a << b -> !(b << a)
+        assertFunction("strictlyLeft(tsrange '(3,4)', tsrange '(1,3)')", BOOLEAN, false);
+        assertFunction("strictlyLeft(tsrange '(1,3]', tsrange '(3,4)')", BOOLEAN, true);
+        assertFunction("strictlyLeft(tsrange '(1,3)', tsrange '[3,4)')", BOOLEAN, true);
+        assertFunction("strictlyLeft(tsrange '(1,3]', tsrange '[3,4)')", BOOLEAN, false);
+        assertFunction("strictlyLeft(tsrange '(1,3)', tsrange '(2,4)')", BOOLEAN, false);
+    }
+
+    @Test
+    public void testAdjacent()
+    {
+        assertFunction("adjacent(tsrange '(1,3]', tsrange '(3,4)')", BOOLEAN, true);
+        assertFunction("adjacent(tsrange '(1,3)', tsrange '[3,4)')", BOOLEAN, true);
+        // symmetric
+        assertFunction("adjacent(tsrange '[3,4)', tsrange '(1,3)')", BOOLEAN, true);
+        assertFunction("adjacent(tsrange '(1,3)', tsrange '(3,4)')", BOOLEAN, false);
+        assertFunction("adjacent(tsrange '(1,3]', tsrange '[3,4)')", BOOLEAN, false);
+        assertFunction("adjacent(tsrange '(1,4]', tsrange '[3,4]')", BOOLEAN, false);
+    }
+
+    @Test
+    public void testIsEmpty()
+    {
+        assertFunction("isempty(tsrange '(1,3]')", BOOLEAN, false);
+        assertFunction("isempty(tsrange 'empty')", BOOLEAN, true);
+    }
+
+    @Test
+    public void testContainsTSRange()
+    {
+        assertFunction("containsTSRange(tsrange '(1,10]', tsrange '(1,10]')", BOOLEAN, true);
+        assertFunction("containsTSRange(tsrange '(1,10]', tsrange '[2,9)')", BOOLEAN, true);
+        assertFunction("containsTSRange(tsrange '(1,10]', tsrange 'empty')", BOOLEAN, true);
+        assertFunction("containsTSRange(tsrange 'empty', tsrange 'empty')", BOOLEAN, true);
+        assertFunction("containsTSRange(tsrange '(1,10]', tsrange '[1,10)')", BOOLEAN, false);
+        assertFunction("containsTSRange(tsrange '[1,10)', tsrange '(1,10]')", BOOLEAN, false);
+    }
+
+    @Test
+    public void testContainsElement()
+    {
+        assertFunction("containsElement(tsrange '(1,10]', 10)", BOOLEAN, true);
+        assertFunction("containsElement(tsrange '(1,10]', 1)", BOOLEAN, false);
+        assertFunction("containsElement(tsrange 'empty', 1)", BOOLEAN, false);
+    }
+
+    @Test
+    public void testContainsTimestamp()
+    {
+        assertFunction("containsTimestamp(tsrange '[2020-11-03 20:00:00,2020-11-03 23:00:00]', timestamp '2020-11-03 21:00:00.123')", BOOLEAN, true);
+        assertFunction("containsTimestamp(tsrange '[2020-11-03 20:00:00,2020-11-03 21:00:00.123]', timestamp '2020-11-03 21:00:00.123')", BOOLEAN, true);
+        // upper is exclusive
+        assertFunction("containsTimestamp(tsrange '[2020-11-03 20:00:00,2020-11-03 21:00:00.123)', timestamp '2020-11-03 21:00:00.123')", BOOLEAN, false);
+        // empty never contains elements
+        assertFunction("containsTimestamp(tsrange 'empty', timestamp '2020-11-03 21:00:00.123')", BOOLEAN, false);
+    }
+
+    @Test
+    public void testOverlap()
+    {
+        assertFunction("overlap(tsrange '(2,4]', tsrange '(3,5]')", BOOLEAN, true);
+        // symmetry
+        assertFunction("overlap(tsrange '(3,5]', tsrange '(2,4]')", BOOLEAN, true);
+        assertFunction("overlap(tsrange '[5,7]', tsrange '(3,5]')", BOOLEAN, true);
+        assertFunction("overlap(tsrange '(3,5]', tsrange '[5,7]')", BOOLEAN, true);
+        assertFunction("overlap(tsrange '(2,4]', tsrange '[4,5]')", BOOLEAN, true);
+        // (2,4) * (3,5] = (3,4)
+        assertFunction("overlap(tsrange '(2,4)', tsrange '(3,5]')", BOOLEAN, true);
+        assertFunction("overlap(tsrange '(3,5)', tsrange '[5,7]')", BOOLEAN, false);
+        assertFunction("overlap(tsrange '(4,5)', tsrange '(2,4)')", BOOLEAN, false);
+        assertFunction("overlap(tsrange '(2,4)', tsrange '[4,5]')", BOOLEAN, false);
+        assertFunction("overlap(tsrange '[20,30]', tsrange '[0,9]')", BOOLEAN, false);
+        assertFunction("overlap(tsrange 'empty', tsrange '[0,9]')", BOOLEAN, false);
+    }
+
+    @Test
+    public void testDoesNotExtendToTheRightOf()
+    {
+        assertFunction("doesNotExtendToTheRightOf(tsrange '(2,4]', tsrange '(3,5]')", BOOLEAN, true);
+        assertFunction("doesNotExtendToTheRightOf(tsrange '(2,4]', tsrange '(4,5]')", BOOLEAN, true);
+        assertFunction("doesNotExtendToTheRightOf(tsrange '(2,4)', tsrange '(3,4)')", BOOLEAN, true);
+        assertFunction("doesNotExtendToTheRightOf(tsrange '(2,4]', tsrange '(3,4)')", BOOLEAN, false);
+        assertFunction("doesNotExtendToTheRightOf(tsrange 'empty', tsrange '(3,5]')", BOOLEAN, false);
+        assertFunction("doesNotExtendToTheRightOf(tsrange '[4,4]', tsrange 'empty')", BOOLEAN, false);
+        assertFunction("doesNotExtendToTheRightOf(tsrange 'empty', tsrange 'empty')", BOOLEAN, false);
+    }
+
+    @Test
+    public void testDoesNotExtendToTheLeftOf()
+    {
+        assertFunction("doesNotExtendToTheLeftOf(tsrange '(2,4]', tsrange '(2,5]')", BOOLEAN, true);
+        assertFunction("doesNotExtendToTheLeftOf(tsrange '[2,4]', tsrange '[2,5]')", BOOLEAN, true);
+        assertFunction("doesNotExtendToTheLeftOf(tsrange '(5,8)', tsrange '(3,4)')", BOOLEAN, true);
+        assertFunction("doesNotExtendToTheLeftOf(tsrange '[3,4]', tsrange '(3,4)')", BOOLEAN, false);
+        assertFunction("doesNotExtendToTheLeftOf(tsrange 'empty', tsrange '(2,5]')", BOOLEAN, false);
+        assertFunction("doesNotExtendToTheLeftOf(tsrange '[4,4]', tsrange 'empty')", BOOLEAN, false);
+        assertFunction("doesNotExtendToTheLeftOf(tsrange 'empty', tsrange 'empty')", BOOLEAN, false);
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/type/TestTSRangeOperators.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTSRangeOperators.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.type;
+
+import io.prestosql.operator.scalar.AbstractTestFunctions;
+import io.prestosql.spi.type.TSRangeType;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static io.prestosql.spi.StandardErrorCode.CONSTRAINT_VIOLATION;
+import static io.prestosql.spi.type.BooleanType.BOOLEAN;
+import static io.prestosql.spi.type.TSRange.fromString;
+import static io.prestosql.spi.type.TSRangeType.TSRANGE_MICROS;
+import static io.prestosql.spi.type.TSRangeType.TSRANGE_MILLIS;
+import static io.prestosql.spi.type.TSRangeType.TSRANGE_NANOS;
+import static io.prestosql.spi.type.TSRangeType.TSRANGE_SECONDS;
+import static io.prestosql.spi.type.VarcharType.VARCHAR;
+import static java.lang.String.format;
+
+public class TestTSRangeOperators
+        extends AbstractTestFunctions
+{
+    // test tsrange with long-slice format
+    @DataProvider(name = "tsrangeTypes")
+    public Object[][] tsrangeTypes()
+    {
+        return new Object[][] {
+                {TSRANGE_SECONDS}, {TSRANGE_MILLIS}, {TSRANGE_MICROS}, {TSRANGE_NANOS}
+        };
+    }
+
+    @Test(dataProvider = "tsrangeTypes")
+    public void testVarcharToTSRangeLongCast(TSRangeType type)
+    {
+        final int precision = type.getPrecision();
+        assertFunction(format("CAST('[1,2)' AS TSRANGE(%s))", precision), type, fromString("[1,2)"));
+        assertFunction(format("CAST('[2,3]' AS TSRANGE(%s))", precision), type, fromString("[2,3]"));
+        assertFunction(format("CAST('(2,3]' AS TSRANGE(%s))", precision), type, fromString("(2,3]"));
+        assertFunction(format("CAST('[2,2]' AS TSRANGE(%s))", precision), type, fromString("[2,2]"));
+        assertFunction(format("CAST('(2,2]' AS TSRANGE(%s))", precision), type, fromString("empty"));
+        assertFunction(format("CAST('[2,2)' AS TSRANGE(%s))", precision), type, fromString("empty"));
+        assertFunction(format("CAST('(2,2)' AS TSRANGE(%s))", precision), type, fromString("empty"));
+        assertFunction(format("CAST('(0,0)' AS TSRANGE(%s))", precision), type, fromString("empty"));
+        assertFunction(format("CAST('(0,0)' AS TSRANGE(%s))", precision), type, fromString("empty"));
+        assertInvalidCast(format("CAST('[3,2]' AS TSRANGE(%s))", precision), "Cannot cast value to tsrange: [3,2]");
+        assertInvalidCast(format("CAST('[-1,3]' AS TSRANGE(%s))", precision), "Cannot cast value to tsrange: [-1,3]");
+        assertInvalidCast(format("CAST('-$?a' AS TSRANGE(%s))", precision), "Cannot cast value to tsrange: -$?a");
+        // timestamp format
+        assertFunction(format("CAST('[2020-01-01 00:00:00,2020-01-01 05:00:00)' AS TSRANGE(%s))", precision), type,
+                fromString("[2020-01-01 00:00:00,2020-01-01 05:00:00)"));
+    }
+
+    @Test
+    public void testTSRangeToVarcharCast()
+    {
+        assertFunction("CAST(TSRANGE '[2,3)' AS VARCHAR)", VARCHAR, fromString("[2,3)").toString());
+        assertFunction("CAST(TSRANGE '[2,3]' AS VARCHAR)", VARCHAR, fromString("[2,3]").toString());
+        assertFunction("CAST(TSRANGE '(1,1]' AS VARCHAR)", VARCHAR, "empty");
+        assertFunction("CAST(TSRANGE '[2,2)' AS VARCHAR)", VARCHAR, "empty");
+        assertFunction("CAST(TSRANGE '(3,3)' AS VARCHAR)", VARCHAR, "empty");
+        assertInvalidCast("CAST(TSRANGE '(3,2]' AS VARCHAR)", "Cannot cast value to tsrange: (3,2]");
+    }
+
+    @Test
+    public void testEquals()
+    {
+        assertFunction("TSRANGE '[1,2)' = TSRANGE '[1,2)'", BOOLEAN, true);
+        assertFunction("TSRANGE '[1,2)' = TSRANGE '[2,3)'", BOOLEAN, false);
+        assertFunction("TSRANGE '[1,2)' = TSRANGE '[1,2]'", BOOLEAN, false);
+    }
+
+    // verify same behaviour for "+","*","-" as for postgres
+    @Test
+    public void testUnion()
+    {
+        assertFunction("TSRANGE '(1,3)' + TSRANGE '(2,4)'", TSRANGE_MILLIS, fromString("(1,4)"));
+        // commutative (a,b)+(c,d) = (c,d)+(a,b)
+        assertFunction("TSRANGE '(2,4)' + TSRANGE '(1,3)'", TSRANGE_MILLIS, fromString("(1,4)"));
+        assertFunction("TSRANGE '(2,4)' + TSRANGE 'empty'", TSRANGE_MILLIS, fromString("(2,4)"));
+        assertFunction("TSRANGE '(1,2)' + TSRANGE '[2,5]'", TSRANGE_MILLIS, fromString("(1,5]"));
+        assertFunction("TSRANGE '(1,2]' + TSRANGE '(2,5]'", TSRANGE_MILLIS, fromString("(1,5]"));
+        assertInvalidFunction("TSRANGE '(1,2)' + TSRANGE '(2,5)'",
+                CONSTRAINT_VIOLATION, "Result of tsrange union would not be contiguous");
+    }
+
+    @Test
+    public void testIntersection()
+    {
+        //identity
+        assertFunction("TSRANGE '(1,3)' * TSRANGE '(1,3)'", TSRANGE_MILLIS, fromString("(1,3)"));
+        assertFunction("TSRANGE '(1,3)' * TSRANGE '(2,4)'", TSRANGE_MILLIS, fromString("(2,3)"));
+        // commutative (a,b)*(c,d) = (c,d)*(a,b)
+        assertFunction("TSRANGE '(2,4)' * TSRANGE '(1,3)'", TSRANGE_MILLIS, fromString("(2,3)"));
+        assertFunction("TSRANGE '(1,3]' * TSRANGE '[3,4)'", TSRANGE_MILLIS, fromString("[3,3]"));
+        assertFunction("TSRANGE '(1,3)' * TSRANGE '[1,3]'", TSRANGE_MILLIS, fromString("(1,3)"));
+        assertFunction("TSRANGE '(2,4)' * TSRANGE '(3,5]'", TSRANGE_MILLIS, fromString("(3,4)"));
+        assertFunction("TSRANGE '(3,5)' * TSRANGE '(2,4)'", TSRANGE_MILLIS, fromString("(3,4)"));
+        assertFunction("TSRANGE '(1,3)' * TSRANGE '[3,4)'", TSRANGE_MILLIS, fromString("empty"));
+        assertFunction("TSRANGE '(1,3]' * TSRANGE '(3,4)'", TSRANGE_MILLIS, fromString("empty"));
+        assertFunction("TSRANGE '(1,3]' * TSRANGE '(5,6)'", TSRANGE_MILLIS, fromString("empty"));
+    }
+
+    @Test
+    public void testDifference()
+    {
+        assertFunction("TSRANGE '(5,15)' - TSRANGE '(10,20)'", TSRANGE_MILLIS, fromString("(5,10]"));
+        assertFunction("TSRANGE '(5,15)' - TSRANGE '[10,20)'", TSRANGE_MILLIS, fromString("(5,10)"));
+        assertFunction("TSRANGE '(5,15)' - TSRANGE '[0,10)'", TSRANGE_MILLIS, fromString("[10,15)"));
+        assertFunction("TSRANGE '[5,20]' - TSRANGE '[5,20)'", TSRANGE_MILLIS, fromString("[20,20]"));
+        assertInvalidFunction("TSRANGE '[5,20]' - TSRANGE '(5,20)'",
+                CONSTRAINT_VIOLATION, "Result of tsrange union would not be contiguous");
+        assertFunction("TSRANGE '(10,15)' - TSRANGE '(5,20)'", TSRANGE_MILLIS, fromString("empty"));
+        assertFunction("TSRANGE '(10,15)' - TSRANGE 'empty'", TSRANGE_MILLIS, fromString("(10,15)"));
+        assertFunction("TSRANGE '(10,15)' - TSRANGE '(10,15)'", TSRANGE_MILLIS, fromString("empty"));
+        assertFunction("TSRANGE '(10,15)' - TSRANGE '(10,14)'", TSRANGE_MILLIS, fromString("[14,15)"));
+    }
+}

--- a/presto-main/src/test/java/io/prestosql/type/TestTSRangeType.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTSRangeType.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.type;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.type.TSRange;
+import org.testng.annotations.Test;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.prestosql.spi.type.TSRangeType.TSRANGE_MILLIS;
+import static java.lang.Math.abs;
+import static org.testng.Assert.assertEquals;
+
+public class TestTSRangeType
+        extends AbstractTestType
+{
+    private static final int RANGE_ENTRIES = 2;
+    private static final int RANGE_LENGTH = 2 * SIZE_OF_LONG;
+
+    public TestTSRangeType()
+    {
+        super(TSRANGE_MILLIS, TSRange.class, createTestBlock());
+    }
+
+    public static Block createTestBlock()
+    {
+        BlockBuilder blockBuilder = TSRANGE_MILLIS.createBlockBuilder(null, RANGE_ENTRIES);
+        TSRANGE_MILLIS.writeSlice(blockBuilder, getSliceForRange("[5,6)"));
+        TSRANGE_MILLIS.writeSlice(blockBuilder, getSliceForRange("[5,7)"));
+        TSRANGE_MILLIS.writeSlice(blockBuilder, getSliceForRange("[5,8)"));
+        TSRANGE_MILLIS.writeSlice(blockBuilder, getSliceForRange("[5,9)"));
+        return blockBuilder.build();
+    }
+
+    private static Slice getSliceForRange(String rangeString)
+    {
+        return tSRangeToSlice(TSRange.fromString(rangeString));
+    }
+
+    public static Slice tSRangeToSlice(TSRange tsRange)
+    {
+        Slice slice = Slices.allocate(RANGE_LENGTH);
+        slice.setLong(0, tsRange.isLowerClosed() ? tsRange.getLower() : -tsRange.getLower());
+        slice.setLong(SIZE_OF_LONG, tsRange.isUpperClosed() ? tsRange.getUpper() : -tsRange.getUpper());
+        return slice;
+    }
+
+    @Override
+    protected Object getGreaterValue(Object value)
+    {
+        Slice slice = (Slice) value;
+        final long lower = slice.getLong(0);
+        final long upper = slice.getLong(SIZE_OF_LONG);
+        return tSRangeToSlice(TSRange.createTSRange(abs(lower) + 1, abs(upper) + 1, lower >= 0, upper >= 0));
+    }
+
+    @Test
+    public void testDisplayName()
+    {
+        assertEquals(TSRANGE_MILLIS.getDisplayName(), "tsrange(3)");
+    }
+
+    @Override
+    protected Object getNonNullValue()
+    {
+        return getSliceForRange("[1,2)");
+    }
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/type/StandardTypes.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/StandardTypes.java
@@ -45,6 +45,7 @@ public final class StandardTypes
     public static final String GEOMETRY = "Geometry";
     public static final String BING_TILE = "BingTile";
     public static final String UUID = "uuid";
+    public static final String TSRANGE = "tsrange";
 
     private StandardTypes() {}
 }

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TSRange.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TSRange.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi.type;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Objects;
+
+import static java.time.ZoneOffset.UTC;
+
+public final class TSRange
+{
+    public static final DateTimeFormatter JSON_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd HH[:mm][:ss][.SSS]");
+
+    private final long lower;
+    private final long upper;
+    private final boolean lowerClosed;
+    private final boolean upperClosed;
+    private final boolean empty;
+
+    protected static final TSRange EMPTY_RANGE = new TSRange(TSRangeType.EMPTY_VALUE, TSRangeType.EMPTY_VALUE, false, false);
+
+    protected static TSRange empty()
+    {
+        return TSRangeType.sliceToTSRange(TSRangeType.EMPTY_RANGE_SLICE);
+    }
+
+    public static TSRange createTSRange(long lower, long upper, boolean lowerClosed, boolean upperClosed)
+    {
+        if (lower < 0 || upper < 0) {
+            throw new IllegalArgumentException("left and right must not be negative");
+        }
+        if (lower > upper) {
+            throw new IllegalArgumentException("left must not be larger than right");
+        }
+
+        if (lower == upper && !(lowerClosed && upperClosed)) {
+            return empty();
+        }
+
+        return new TSRange(lower, upper, lowerClosed, upperClosed);
+    }
+
+    private TSRange(long lower, long upper, boolean lowerClosed, boolean upperClosed)
+    {
+        this.empty = lower == upper && !(lowerClosed && upperClosed);
+        this.lowerClosed = lowerClosed;
+        this.lower = empty ? TSRangeType.EMPTY_VALUE : lower;
+        this.upper = empty ? TSRangeType.EMPTY_VALUE : upper;
+        this.upperClosed = upperClosed;
+    }
+
+    public static TSRange fromString(String s)
+    {
+        if (s == null) {
+            throw new IllegalArgumentException("rangeString must not be null");
+        }
+        else if (s.equals("empty")) {
+            return empty();
+        }
+        final char firstChar = s.charAt(0);
+        final char lastChar = s.charAt(s.length() - 1);
+        if ((firstChar != '(' && firstChar != '[') || (lastChar != ')' && lastChar != ']')) {
+            throw new IllegalArgumentException("Provided string has to start with ( or [ and to end with ) or ]");
+        }
+        String[] parts = s.substring(1, s.length() - 1).replaceAll("\"", "").split(",");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("Lower and Upper Bound of Range String must be separated by ,");
+        }
+        if (isJsonTimestampFormat(parts[0]) && isJsonTimestampFormat(parts[1])) {
+            return fromJson(s);
+        }
+        try {
+            final long lowerEndpoint = Long.parseLong(parts[0]);
+            final long upperEndpoint = Long.parseLong(parts[1]);
+            final boolean lowerClosed = firstChar == '[';
+            final boolean upperClosed = lastChar == ']';
+            return createTSRange(lowerEndpoint, upperEndpoint, lowerClosed, upperClosed);
+        }
+        catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Lower and Upper Bound of Range String must be given as long values");
+        }
+    }
+
+    @JsonCreator
+    public static TSRange fromJson(@JsonProperty(value = "value") String value)
+    {
+        if (value.equals("empty")) {
+            return empty();
+        }
+        String[] parts = value.replaceAll("\"", "").split(",");
+        final boolean leftClosed = parts[0].charAt(0) == '[';
+        final boolean rightClosed = parts[1].charAt(parts[1].length() - 1) == ']';
+        final long left = LocalDateTime.parse(parts[0].substring(1), JSON_FORMATTER).toInstant(UTC).toEpochMilli();
+        final long right = LocalDateTime.parse(parts[1].substring(0, parts[1].length() - 1), JSON_FORMATTER).toInstant(UTC).toEpochMilli();
+        return createTSRange(left, right, leftClosed, rightClosed);
+    }
+
+    private static boolean isJsonTimestampFormat(String timestampString)
+    {
+        try {
+            JSON_FORMATTER.parse(timestampString);
+        }
+        catch (DateTimeParseException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        if (isEmpty()) {
+            return "empty";
+        } // use postgres standard ["lower","upper")
+        return String.format("%s\"%s\",\"%s\"%s", lowerClosed ? '[' : '(',
+                Instant.ofEpochMilli(lower).atZone(UTC).format(JSON_FORMATTER),
+                Instant.ofEpochMilli(upper).atZone(UTC).format(JSON_FORMATTER),
+                upperClosed ? ']' : ')');
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(lower, lowerClosed, upper, upperClosed);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final TSRange other = (TSRange) o;
+        if (this.isEmpty() && other.isEmpty()) {
+            return true;
+        }
+        return this.lower == other.lower &&
+                this.upper == other.upper &&
+                this.lowerClosed == other.lowerClosed &&
+                this.upperClosed == other.upperClosed;
+    }
+
+    public long getLower()
+    {
+        return lower;
+    }
+
+    public long getUpper()
+    {
+        return upper;
+    }
+
+    public boolean isLowerClosed()
+    {
+        return lowerClosed;
+    }
+
+    public boolean isUpperClosed()
+    {
+        return upperClosed;
+    }
+
+    public boolean isEmpty()
+    {
+        return empty;
+    }
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TSRangeParametricType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TSRangeParametricType.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi.type;
+
+import java.util.List;
+
+public final class TSRangeParametricType
+        implements ParametricType
+{
+    public static final TSRangeParametricType TSRANGE = new TSRangeParametricType();
+
+    @Override
+    public String getName()
+    {
+        return StandardTypes.TSRANGE;
+    }
+
+    @Override
+    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    {
+        if (parameters.isEmpty()) {
+            return TSRangeType.createTSRangeType(TSRangeType.DEFAULT_PRECISION);
+        }
+        if (parameters.size() != 1) {
+            throw new IllegalArgumentException("Expected exactly one parameter for tsrange");
+        }
+
+        TypeParameter parameter = parameters.get(0);
+
+        if (!parameter.isLongLiteral()) {
+            throw new IllegalArgumentException("tsrange precision must be a number");
+        }
+
+        long precision = parameter.getLongLiteral();
+
+        if (precision < 0 || precision > TSRangeType.MAX_PRECISION || precision % 3 != 0) {
+            throw new IllegalArgumentException("Invalid tsrange precision " + precision);
+        }
+
+        return TSRangeType.createTSRangeType((int) precision);
+    }
+}

--- a/presto-spi/src/main/java/io/prestosql/spi/type/TSRangeType.java
+++ b/presto-spi/src/main/java/io/prestosql/spi/type/TSRangeType.java
@@ -1,0 +1,463 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.spi.type;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.airlift.slice.XxHash64;
+import io.prestosql.spi.PrestoException;
+import io.prestosql.spi.block.Block;
+import io.prestosql.spi.block.BlockBuilder;
+import io.prestosql.spi.block.BlockBuilderStatus;
+import io.prestosql.spi.block.VariableWidthBlockBuilder;
+import io.prestosql.spi.connector.ConnectorSession;
+import io.prestosql.spi.function.BlockIndex;
+import io.prestosql.spi.function.BlockPosition;
+import io.prestosql.spi.function.ScalarOperator;
+import io.prestosql.spi.function.SqlType;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.prestosql.spi.StandardErrorCode.CONSTRAINT_VIOLATION;
+import static io.prestosql.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
+import static io.prestosql.spi.function.OperatorType.COMPARISON;
+import static io.prestosql.spi.function.OperatorType.EQUAL;
+import static io.prestosql.spi.function.OperatorType.HASH_CODE;
+import static io.prestosql.spi.function.OperatorType.LESS_THAN;
+import static io.prestosql.spi.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static io.prestosql.spi.function.OperatorType.XX_HASH_64;
+import static io.prestosql.spi.type.TypeOperatorDeclaration.extractOperatorDeclaration;
+import static java.lang.Math.abs;
+import static java.lang.Math.signum;
+import static java.lang.String.format;
+import static java.lang.invoke.MethodHandles.lookup;
+
+/**
+ * TSRangeType is an interval between two timestamps and additionally encodes whether first/last timestamp is inclusive or exclusive.
+ */
+public class TSRangeType
+        extends AbstractType
+        implements FixedWidthType
+{
+    public static final String TSRANGE_SIGNATURE = "tsrange";
+    private static final TypeOperatorDeclaration TYPE_OPERATOR_DECLARATION = extractOperatorDeclaration(TSRangeType.class, lookup(), Slice.class);
+
+    public static final int MAX_PRECISION = 9;
+    public static final int DEFAULT_PRECISION = TimestampType.DEFAULT_PRECISION;
+
+    private static final TSRangeType[] TYPES = new TSRangeType[MAX_PRECISION + 1];
+
+    static {
+        for (int precision = 0; precision <= MAX_PRECISION; precision++) {
+            TYPES[precision] = new TSRangeType(precision);
+        }
+    }
+
+    public static final TSRangeType TSRANGE_SECONDS = createTSRangeType(0);
+    public static final TSRangeType TSRANGE_MILLIS = createTSRangeType(3);
+    public static final TSRangeType TSRANGE_MICROS = createTSRangeType(6);
+    public static final TSRangeType TSRANGE_NANOS = createTSRangeType(9);
+
+    private final int precision;
+
+    private TSRangeType(int precision)
+    {
+        super(new TypeSignature(TSRANGE_SIGNATURE, TypeSignatureParameter.numericParameter(precision)), Slice.class);
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new IllegalArgumentException(format("Precision must be in the range [0, %s]", MAX_PRECISION));
+        }
+        this.precision = precision;
+    }
+
+    public static TSRangeType createTSRangeType(int precision)
+    {
+        if (precision < 0 || precision > MAX_PRECISION) {
+            throw new PrestoException(NUMERIC_VALUE_OUT_OF_RANGE,
+                    format("tsrange precision must be in range [0, %s] but got: %s", MAX_PRECISION, precision));
+        }
+        return TYPES[precision];
+    }
+
+    public int getPrecision()
+    {
+        return precision;
+    }
+
+    @Override
+    public boolean isComparable()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return true;
+    }
+
+    // internal structure of the tsrangeType - encoded as a slice of 2 longs
+
+    public static final int RANGE_LENGTH = 2 * SIZE_OF_LONG;
+    public static final int RANGE_ENTRIES = 2;
+    public static final int LOWER_OFFSET = 0;
+    public static final int UPPER_OFFSET = SIZE_OF_LONG;
+
+    static final long EMPTY_VALUE = Long.MAX_VALUE - 1;
+
+    public static final Slice EMPTY_RANGE_SLICE;
+
+    static {
+        Slice slice = Slices.allocate(RANGE_LENGTH);
+        slice.setLong(0, -abs(TSRange.EMPTY_RANGE.getLower()));
+        slice.setLong(SIZE_OF_LONG, -abs(TSRange.EMPTY_RANGE.getUpper()));
+
+        EMPTY_RANGE_SLICE = slice;
+
+        if (!TSRange.EMPTY_RANGE.isEmpty() || TSRange.EMPTY_RANGE.getLower() != EMPTY_VALUE) {
+            throw new IllegalStateException("inconsistent slice <> tsrange state");
+        }
+    }
+
+    @Override
+    public TypeOperatorDeclaration getTypeOperatorDeclaration(TypeOperators typeOperators)
+    {
+        return TYPE_OPERATOR_DECLARATION;
+    }
+
+    @Override
+    public int getFixedSize()
+    {
+        return RANGE_LENGTH;
+    }
+
+    @Override
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        return new VariableWidthBlockBuilder(null, RANGE_ENTRIES, RANGE_LENGTH);
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        return createFixedSizeBlockBuilder(0);
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return createFixedSizeBlockBuilder(0);
+    }
+
+    @Override
+    public void writeObject(BlockBuilder out, Object value)
+    {
+        if (!(value instanceof TSRange)) {
+            throw new IllegalArgumentException("value must be an instance of tsrange");
+        }
+        final TSRange range = (TSRange) value;
+        out.writeLong(range.isLowerClosed() ? range.getLower() : -range.getLower());
+        out.writeLong(range.isUpperClosed() ? range.getUpper() : -range.getUpper());
+        out.closeEntry();
+    }
+
+    @Override
+    public Object getObjectValue(ConnectorSession session, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+        final long lower = block.getLong(position, LOWER_OFFSET);
+        final long upper = block.getLong(position, UPPER_OFFSET);
+        return TSRange.createTSRange(abs(lower), abs(upper), lower >= 0, upper >= 0);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else {
+            blockBuilder.writeLong(block.getLong(position, LOWER_OFFSET));
+            blockBuilder.writeLong(block.getLong(position, UPPER_OFFSET));
+            blockBuilder.closeEntry();
+        }
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
+    {
+        if (length != RANGE_LENGTH) {
+            throw new IllegalStateException("Expected entry size to be exactly " + RANGE_LENGTH + " but was " + length);
+        }
+        blockBuilder.writeLong(value.getLong(offset));
+        blockBuilder.writeLong(value.getLong(offset + UPPER_OFFSET));
+        blockBuilder.closeEntry();
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value)
+    {
+        writeSlice(blockBuilder, value, 0, value.length());
+    }
+
+    @Override
+    public final Slice getSlice(Block block, int position)
+    {
+        return createTSRangeSlice(block.getLong(position, LOWER_OFFSET), block.getLong(position, UPPER_OFFSET));
+    }
+
+    @ScalarOperator(HASH_CODE)
+    @SqlType(StandardTypes.BIGINT)
+    private static long hashCodeOperator(Slice value)
+    {
+        return XxHash64.hash(value);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    private static long xxHash64Operator(Slice value)
+    {
+        return XxHash64.hash(value);
+    }
+
+    @ScalarOperator(XX_HASH_64)
+    private static long xxHash64Operator(@BlockPosition Block block, @BlockIndex int position)
+    {
+        return XxHash64.hash(createTSRangeSlice(block.getLong(position, LOWER_OFFSET), block.getLong(position, UPPER_OFFSET)));
+    }
+
+    @ScalarOperator(COMPARISON)
+    private static long comparisonOperator(Slice slice, Slice other)
+    {
+        return TSRangeType.compare(slice, other);
+    }
+
+    @ScalarOperator(COMPARISON)
+    private static long comparisonOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition,
+            @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
+    {
+        final long leftLower = leftBlock.getLong(leftPosition, LOWER_OFFSET);
+        final long leftUpper = leftBlock.getLong(leftPosition, UPPER_OFFSET);
+        final long rightLower = rightBlock.getLong(rightPosition, LOWER_OFFSET);
+        final long rightUpper = rightBlock.getLong(rightPosition, UPPER_OFFSET);
+        return comparisonOperator(createTSRangeSlice(leftLower, leftUpper), createTSRangeSlice(rightLower, rightUpper));
+    }
+
+    @ScalarOperator(EQUAL)
+    public static boolean equalOperator(Slice left, Slice right)
+    {
+        return left.equals(right);
+    }
+
+    @ScalarOperator(EQUAL)
+    public static boolean equalOperator(@BlockPosition Block leftBlock, @BlockIndex int leftPosition,
+            @BlockPosition Block rightBlock, @BlockIndex int rightPosition)
+    {
+        return leftBlock.getLong(leftPosition, LOWER_OFFSET) == rightBlock.getLong(rightPosition, LOWER_OFFSET) &&
+                leftBlock.getLong(leftPosition, UPPER_OFFSET) == rightBlock.getLong(rightPosition, UPPER_OFFSET);
+    }
+
+    @ScalarOperator(LESS_THAN)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThanOperator(Slice left, Slice right)
+    {
+        return TSRangeType.compare(left, right) < 0;
+    }
+
+    @ScalarOperator(LESS_THAN_OR_EQUAL)
+    @SqlType(StandardTypes.BOOLEAN)
+    public static boolean lessThanOrEqualOperator(Slice left, Slice right)
+    {
+        return TSRangeType.compare(left, right) <= 0;
+    }
+
+    public static Slice empty()
+    {
+        return EMPTY_RANGE_SLICE;
+    }
+
+    public static Slice createTSRangeSlice(long lower, long right)
+    {
+        return createTSRangeSlice(abs(lower), abs(right), lower >= 0, right >= 0);
+    }
+
+    public static Slice createTSRangeSlice(long lower, long upper, boolean lowerClosed, boolean upperClosed)
+    {
+        if (lower > upper) {
+            throw new PrestoException(CONSTRAINT_VIOLATION, "invalid values for slice creation:, " + lower + "," + upper + " bounds=" + lowerClosed + "," + upperClosed);
+        }
+
+        if (lower < 0 || upper < 0) {
+            throw new PrestoException(CONSTRAINT_VIOLATION, "invalid values, negative timestamps: " + lower + "," + upper + " bounds=" + lowerClosed + "," + upperClosed);
+        }
+
+        if (lower == upper && !(lowerClosed && upperClosed)) {
+            return empty();
+        }
+
+        final Slice slice = Slices.allocate(RANGE_LENGTH);
+        slice.setLong(0, lowerClosed ? lower : -lower);
+        slice.setLong(SIZE_OF_LONG, upperClosed ? upper : -upper);
+        return slice;
+    }
+
+    public static Slice tsrangeLongToSlice(TSRange tsrange)
+    {
+        if (tsrange.isEmpty()) {
+            return EMPTY_RANGE_SLICE;
+        }
+
+        return createTSRangeSlice(tsrange.getLower(), tsrange.getUpper(), tsrange.isLowerClosed(), tsrange.isUpperClosed());
+    }
+
+    public static TSRange sliceToTSRange(Slice slice)
+    {
+        if (EMPTY_RANGE_SLICE.equals(slice)) {
+            return TSRange.EMPTY_RANGE;
+        }
+
+        final long lowerValue = getLower(slice);
+        final long upperValue = getUpper(slice);
+
+        return TSRange.createTSRange(abs(lowerValue), abs(upperValue), lowerValue >= 0, upperValue >= 0);
+    }
+
+    public static long getLower(Slice slice)
+    {
+        return slice.getLong(0);
+    }
+
+    public static long getUpper(Slice slice)
+    {
+        return slice.getLong(SIZE_OF_LONG);
+    }
+
+    public static long getFirstInclusive(Slice slice)
+    {
+        final long lower = getLower(slice);
+        if (lower >= 0) {
+            return lower;
+        }
+        else {
+            return -lower + 1;
+        }
+    }
+
+    public static long getLastInclusive(Slice slice)
+    {
+        final long right = getUpper(slice);
+        if (right >= 0) {
+            return right;
+        }
+        else {
+            return -right - 1;
+        }
+    }
+
+    public static int compare(Slice slice, Slice other)
+    {
+        final int lowerBoundsCompared = compareLower(slice, other);
+        if (lowerBoundsCompared != 0) {
+            return lowerBoundsCompared;
+        }
+        else {
+            return compareUpper(slice, other);
+        }
+    }
+
+    public static int compareLower(Slice slice, Slice other)
+    {
+        return compareSliceBounds(slice, other, LOWER_OFFSET);
+    }
+
+    public static int compareUpper(Slice slice, Slice other)
+    {
+        return compareSliceBounds(slice, other, UPPER_OFFSET);
+    }
+
+    private static int compareSliceBounds(Slice leftSlice, Slice rightSlice, int offsetValue)
+    {
+        final long leftValue = leftSlice.getLong(offsetValue);
+        final long rightValue = rightSlice.getLong(offsetValue);
+        final int compareAbsoluteValues = Long.compare(abs(leftValue), abs(rightValue));
+        if (compareAbsoluteValues != 0) {
+            return compareAbsoluteValues;
+        }
+        final int boundTypeCompare = Boolean.compare(leftValue >= 0, rightValue >= 0);
+        if (offsetValue == LOWER_OFFSET) {
+            return -boundTypeCompare;
+        }
+        else {
+            return boundTypeCompare;
+        }
+    }
+
+    public static boolean adjacent(Slice left, Slice right)
+    {
+        final long leftUpper = getUpper(left);
+        final long rightLower = getLower(right);
+        if (abs(leftUpper) == abs(rightLower)) {
+            return signum(leftUpper) != signum(rightLower);
+        }
+        final long leftLower = getLower(left);
+        final long rightUpper = getUpper(right);
+        if (abs(rightUpper) == abs(leftLower)) {
+            return signum(rightUpper) != signum(leftLower);
+        }
+        return false;
+    }
+
+    public static boolean strictlyLeft(Slice left, Slice right)
+    {
+        final long leftUpper = getUpper(left);
+        final long rightLower = getLower(right);
+        if (abs(leftUpper) > abs(rightLower)) {
+            return false;
+        }
+        else if (abs(leftUpper) < abs(rightLower)) {
+            return true;
+        }
+        else {
+            return leftUpper < 0 || rightLower < 0;
+        }
+    }
+
+    public static Slice combine(Slice left, Slice right)
+    {
+        final long lower;
+        if (compareLower(left, right) <= 0) {
+            lower = getLower(left);
+        }
+        else {
+            lower = getLower(right);
+        }
+        final long upper;
+        if (compareUpper(left, right) >= 0) {
+            upper = getUpper(left);
+        }
+        else {
+            upper = getUpper(right);
+        }
+        return createTSRangeSlice(lower, upper);
+    }
+
+    public static boolean contains(Slice left, Slice right)
+    {
+        if (right.equals(empty())) {
+            return true;
+        }
+        final int lowerCompare = compareLower(left, right);
+        final int upperCompare = compareUpper(left, right);
+        return lowerCompare <= 0 && upperCompare >= 0;
+    }
+}


### PR DESCRIPTION
Adds new datatype called `tsrange` inspired by Postgres.

A tsrange is an interval can be of the form `[lower,upper), [lower,upper], (lower,upper], (lower,upper)` or  `empty`
It is internally stored as a slice of two longs (signed epochs) and the sign of the long determines whether the interval is closed. 

Additionally, this datatype has some convenience operators such as an intersection `*`, union `+` and some more, which should behave analogously to postgres operators. Also this datatype comes with some utility scalar functions such as `containsTimestamp(tsrange,timestamp)` which returns true if and only if `timestamp` is contained by the interval.

Even though this type is natively part of postgres, I did not yet add a Postgres Serde to read/write tsranges, however one can easily transform a postgres tsrange to this new tsrange type via `cast(pg_tsrange as tsrange)`