### PR TITLE
Add OpenGraph to documentation

### DIFF
--- a/presto-docs/requirements.txt
+++ b/presto-docs/requirements.txt
@@ -32,6 +32,7 @@ sphinxcontrib-htmlhelp==1.0.3
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.4
+sphinxext-opengraph==0.3.1
 text-unidecode==1.3
 Unidecode==1.1.1
 urllib3==1.25.8

--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -62,7 +62,7 @@ def get_version():
 
 needs_sphinx = '2.0'
 
-extensions = ['myst_parser', 'backquote', 'download', 'issue']
+extensions = ['myst_parser', 'backquote', 'download', 'issue', 'sphinxext.opengraph']
 
 templates_path = ['templates']
 
@@ -113,6 +113,16 @@ html_theme_options = {
     'repo_name': 'Presto',
     'version_json': '../versions.json',
 }
+
+base_url='https://prestosql.io'
+ogp_site_url='%s/docs/current/' % (base_url)
+ogp_site_name='%s %s Documentation' % (project, release)
+ogp_image='https://raw.githubusercontent.com/prestosql/presto/master/presto-docs/src/main/resources/logo/web/main/black/Presto_Logo_BlackBG-01.svg'
+
+ogp_custom_meta_tags=[
+    '<meta name="twitter:card" content="summary_large_image">',
+    '<meta name="twitter:site" content="prestosql">'
+]
 
 html_css_files = [
     'presto.css',


### PR DESCRIPTION
This PR adds OpenGraph tags to the documentation so it will render nice in social media (i.e. twitter, facebook, Linkedin).

Here are the screenshots from debugging tools:

![Screenshot 2020-11-06 at 13 20 39](https://user-images.githubusercontent.com/66972/98365823-43eda200-2033-11eb-8d0e-fd2a3fbe05a4.png)
![Screenshot 2020-11-06 at 13 20 48](https://user-images.githubusercontent.com/66972/98365826-451ecf00-2033-11eb-8142-5391c7958ecd.png)
![Screenshot 2020-11-06 at 13 21 51](https://user-images.githubusercontent.com/66972/98365827-451ecf00-2033-11eb-81ec-fdd979dd5381.png)
