### PR TITLE
Support SQL UPDATE in the Presto Engine and Hive ACID Tables

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -289,9 +289,14 @@ public interface Metadata
             List<TableHandle> sourceTableHandles);
 
     /**
-     * Get the row ID column handle used with UpdatablePageSource.
+     * Get the row ID column handle used with UpdatablePageSource#deleteRows.
      */
-    ColumnHandle getUpdateRowIdColumnHandle(Session session, TableHandle tableHandle);
+    ColumnHandle getDeleteRowIdColumnHandle(Session session, TableHandle tableHandle);
+
+    /**
+     * Get the row ID column handle used with UpdatablePageSource#updateRows.
+     */
+    ColumnHandle getUpdateRowIdColumnHandle(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns);
 
     /**
      * @return whether delete without table scan is supported
@@ -317,6 +322,16 @@ public interface Metadata
      * Finish delete query
      */
     void finishDelete(Session session, TableHandle tableHandle, Collection<Slice> fragments);
+
+    /**
+     * Begin update query
+     */
+    TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns);
+
+    /**
+     * Finish update query
+     */
+    void finishUpdate(Session session, TableHandle tableHandle, Collection<Slice> fragments);
 
     /**
      * Returns a connector id for the specified catalog name.

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -906,11 +906,19 @@ public final class MetadataManager
     }
 
     @Override
-    public ColumnHandle getUpdateRowIdColumnHandle(Session session, TableHandle tableHandle)
+    public ColumnHandle getDeleteRowIdColumnHandle(Session session, TableHandle tableHandle)
     {
         CatalogName catalogName = tableHandle.getCatalogName();
         ConnectorMetadata metadata = getMetadata(session, catalogName);
-        return metadata.getUpdateRowIdColumnHandle(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle());
+        return metadata.getDeleteRowIdColumnHandle(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle());
+    }
+
+    @Override
+    public ColumnHandle getUpdateRowIdColumnHandle(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    {
+        CatalogName catalogName = tableHandle.getCatalogName();
+        ConnectorMetadata metadata = getMetadata(session, catalogName);
+        return metadata.getUpdateRowIdColumnHandle(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle(), updatedColumns);
     }
 
     @Override
@@ -975,6 +983,23 @@ public final class MetadataManager
         CatalogName catalogName = tableHandle.getCatalogName();
         ConnectorMetadata metadata = getMetadata(session, catalogName);
         metadata.finishDelete(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle(), fragments);
+    }
+
+    @Override
+    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    {
+        CatalogName catalogName = tableHandle.getCatalogName();
+        ConnectorMetadata metadata = getMetadataForWrite(session, catalogName);
+        ConnectorTableHandle newHandle = metadata.beginUpdate(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle(), updatedColumns);
+        return new TableHandle(tableHandle.getCatalogName(), newHandle, tableHandle.getTransaction(), tableHandle.getLayout());
+    }
+
+    @Override
+    public void finishUpdate(Session session, TableHandle tableHandle, Collection<Slice> fragments)
+    {
+        CatalogName catalogName = tableHandle.getCatalogName();
+        ConnectorMetadata metadata = getMetadata(session, catalogName);
+        metadata.finishUpdate(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle(), fragments);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/AbstractRowChangeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/AbstractRowChangeOperator.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.slice.Slice;
+import io.trino.spi.Page;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.connector.UpdatablePageSource;
+import io.trino.spi.type.Type;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.airlift.concurrent.MoreFutures.toListenableFuture;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static java.util.Objects.requireNonNull;
+
+public abstract class AbstractRowChangeOperator
+        implements Operator
+{
+    private static final List<Type> TYPES = ImmutableList.of(BIGINT, VARBINARY);
+
+    protected enum State
+    {
+        RUNNING, FINISHING, FINISHED
+    }
+
+    private final OperatorContext operatorContext;
+
+    protected State state = State.RUNNING;
+    protected long rowCount;
+    private boolean closed;
+    private ListenableFuture<Collection<Slice>> finishFuture;
+    private Supplier<Optional<UpdatablePageSource>> pageSource = Optional::empty;
+
+    public AbstractRowChangeOperator(OperatorContext operatorContext)
+    {
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public void finish()
+    {
+        if (state == State.RUNNING) {
+            state = State.FINISHING;
+            finishFuture = toListenableFuture(pageSource().finish());
+        }
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return state == State.FINISHED;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return state == State.RUNNING;
+    }
+
+    @Override
+    public abstract void addInput(Page page);
+
+    @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        if (finishFuture == null) {
+            return NOT_BLOCKED;
+        }
+        return finishFuture;
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if ((state != State.FINISHING) || !finishFuture.isDone()) {
+            return null;
+        }
+        state = State.FINISHED;
+
+        Collection<Slice> fragments = getFutureValue(finishFuture);
+
+        // output page will only be constructed once,
+        // so a new PageBuilder is constructed (instead of using PageBuilder.reset)
+        PageBuilder page = new PageBuilder(fragments.size() + 1, TYPES);
+        BlockBuilder rowsBuilder = page.getBlockBuilder(0);
+        BlockBuilder fragmentBuilder = page.getBlockBuilder(1);
+
+        // write row count
+        page.declarePosition();
+        BIGINT.writeLong(rowsBuilder, rowCount);
+        fragmentBuilder.appendNull();
+
+        // write fragments
+        for (Slice fragment : fragments) {
+            page.declarePosition();
+            rowsBuilder.appendNull();
+            VARBINARY.writeSlice(fragmentBuilder, fragment);
+        }
+
+        return page.build();
+    }
+
+    @Override
+    public void close()
+    {
+        if (!closed) {
+            closed = true;
+            if (finishFuture != null) {
+                finishFuture.cancel(true);
+            }
+            else {
+                pageSource.get().ifPresent(UpdatablePageSource::abort);
+            }
+        }
+    }
+
+    public void setPageSource(Supplier<Optional<UpdatablePageSource>> pageSource)
+    {
+        this.pageSource = requireNonNull(pageSource, "pageSource is null");
+    }
+
+    protected UpdatablePageSource pageSource()
+    {
+        Optional<UpdatablePageSource> source = pageSource.get();
+        checkState(source.isPresent(), "UpdatablePageSource not set");
+        return source.get();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/security/AccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControl.java
@@ -268,6 +268,13 @@ public interface AccessControl
     void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName);
 
     /**
+     * Check if identity is allowed to update the specified table.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> updatedColumnNames);
+
+    /**
      * Check if identity is allowed to create the specified view.
      *
      * @throws AccessDeniedException if not allowed

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -615,6 +615,19 @@ public class AccessControlManager
     }
 
     @Override
+    public void checkCanUpdateTableColumns(SecurityContext securityContext, QualifiedObjectName tableName, Set<String> updatedColumnNames)
+    {
+        requireNonNull(securityContext, "securityContext is null");
+        requireNonNull(tableName, "tableName is null");
+
+        checkCanAccessCatalog(securityContext, tableName.getCatalogName());
+
+        systemAuthorizationCheck(control -> control.checkCanUpdateTableColumns(securityContext.toSystemSecurityContext(), tableName.asCatalogSchemaTableName(), updatedColumnNames));
+
+        catalogAuthorizationCheck(tableName.getCatalogName(), securityContext, (control, context) -> control.checkCanUpdateTableColumns(context, tableName.asSchemaTableName(), updatedColumnNames));
+    }
+
+    @Override
     public void checkCanCreateView(SecurityContext securityContext, QualifiedObjectName viewName)
     {
         requireNonNull(securityContext, "securityContext is null");

--- a/core/trino-main/src/main/java/io/trino/security/AllowAllAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AllowAllAccessControl.java
@@ -194,6 +194,11 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> updatedColumnNames)
+    {
+    }
+
+    @Override
     public void checkCanCreateView(SecurityContext context, QualifiedObjectName viewName)
     {
     }

--- a/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
@@ -75,6 +75,7 @@ import static io.trino.spi.security.AccessDeniedException.denyShowRoleGrants;
 import static io.trino.spi.security.AccessDeniedException.denyShowRoles;
 import static io.trino.spi.security.AccessDeniedException.denyShowSchemas;
 import static io.trino.spi.security.AccessDeniedException.denyShowTables;
+import static io.trino.spi.security.AccessDeniedException.denyUpdateTableColumns;
 import static io.trino.spi.security.AccessDeniedException.denyViewQuery;
 import static io.trino.spi.security.AccessDeniedException.denyWriteSystemInformationAccess;
 
@@ -271,6 +272,12 @@ public class DenyAllAccessControl
     public void checkCanDeleteFromTable(SecurityContext context, QualifiedObjectName tableName)
     {
         denyDeleteTable(tableName.toString());
+    }
+
+    @Override
+    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> updatedColumnNames)
+    {
+        denyUpdateTableColumns(tableName.toString(), updatedColumnNames);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
@@ -243,6 +243,12 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
+    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> updatedColumnNames)
+    {
+        delegate().checkCanUpdateTableColumns(context, tableName, updatedColumnNames);
+    }
+
+    @Override
     public void checkCanCreateView(SecurityContext context, QualifiedObjectName viewName)
     {
         delegate().checkCanCreateView(context, viewName);

--- a/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
@@ -216,6 +216,13 @@ public class InjectedConnectorAccessControl
     }
 
     @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    {
+        checkArgument(context == null, "context must be null");
+        accessControl.checkCanUpdateTableColumns(securityContext, getQualifiedObjectName(tableName), updatedColumns);
+    }
+
+    @Override
     public void checkCanCreateView(ConnectorSecurityContext context, SchemaTableName viewName)
     {
         checkArgument(context == null, "context must be null");

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -30,6 +30,7 @@ import io.trino.security.AccessControl;
 import io.trino.security.SecurityContext;
 import io.trino.spi.QueryId;
 import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.eventlistener.ColumnInfo;
 import io.trino.spi.eventlistener.RoutineInfo;
@@ -183,6 +184,7 @@ public class Analysis
     private Optional<Insert> insert = Optional.empty();
     private Optional<RefreshMaterializedViewAnalysis> refreshMaterializedView = Optional.empty();
     private Optional<TableHandle> analyzeTarget = Optional.empty();
+    private Optional<List<ColumnMetadata>> updatedColumns = Optional.empty();
 
     // for describe input and describe output
     private final boolean isDescribe;
@@ -691,6 +693,16 @@ public class Analysis
     public Optional<Insert> getInsert()
     {
         return insert;
+    }
+
+    public void setUpdatedColumns(List<ColumnMetadata> updatedColumns)
+    {
+        this.updatedColumns = Optional.of(updatedColumns);
+    }
+
+    public Optional<List<ColumnMetadata>> getUpdatedColumns()
+    {
+        return updatedColumns;
     }
 
     public void setRefreshMaterializedView(RefreshMaterializedViewAnalysis refreshMaterializedView)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DistributedExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DistributedExecutionPlanner.java
@@ -61,6 +61,7 @@ import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
 import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.UnnestNode;
+import io.trino.sql.planner.plan.UpdateNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.planner.plan.WindowNode;
 
@@ -407,6 +408,12 @@ public class DistributedExecutionPlanner
 
         @Override
         public Map<PlanNodeId, SplitSource> visitDelete(DeleteNode node, Void context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Map<PlanNodeId, SplitSource> visitUpdate(UpdateNode node, Void context)
         {
             return node.getSource().accept(this, context);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -96,6 +96,7 @@ import io.trino.operator.TaskContext;
 import io.trino.operator.TaskOutputOperator.TaskOutputFactory;
 import io.trino.operator.TopNOperator;
 import io.trino.operator.TopNRankingOperator;
+import io.trino.operator.UpdateOperator.UpdateOperatorFactory;
 import io.trino.operator.ValuesOperator.ValuesOperatorFactory;
 import io.trino.operator.WindowFunctionDefinition;
 import io.trino.operator.WindowOperator.WindowOperatorFactory;
@@ -183,10 +184,12 @@ import io.trino.sql.planner.plan.TableFinishNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TableWriterNode;
 import io.trino.sql.planner.plan.TableWriterNode.DeleteTarget;
+import io.trino.sql.planner.plan.TableWriterNode.UpdateTarget;
 import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
 import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.UnnestNode;
+import io.trino.sql.planner.plan.UpdateNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.planner.plan.WindowNode.Frame;
@@ -2651,6 +2654,38 @@ public class LocalExecutionPlanner
         }
 
         @Override
+        public PhysicalOperation visitUpdate(UpdateNode node, LocalExecutionPlanContext context)
+        {
+            PhysicalOperation source = node.getSource().accept(this, context);
+            List<Integer> channelNumbers = createColumnValueAndRowIdChannels(node.getSource().getOutputSymbols(), node.getColumnValueAndRowIdSymbols());
+            OperatorFactory operatorFactory = new UpdateOperatorFactory(context.getNextOperatorId(), node.getId(), channelNumbers);
+
+            Map<Symbol, Integer> layout = ImmutableMap.<Symbol, Integer>builder()
+                    .put(node.getOutputSymbols().get(0), 0)
+                    .put(node.getOutputSymbols().get(1), 1)
+                    .build();
+
+            return new PhysicalOperation(operatorFactory, layout, context, source);
+        }
+
+        private List<Integer> createColumnValueAndRowIdChannels(List<Symbol> outputSymbols, List<Symbol> columnValueAndRowIdSymbols)
+        {
+            Integer[] columnValueAndRowIdChannels = new Integer[columnValueAndRowIdSymbols.size()];
+            int symbolCounter = 0;
+            // This depends on the outputSymbols being ordered as the blocks of the
+            // resulting page are ordered.
+            for (Symbol symbol : outputSymbols) {
+                int index = columnValueAndRowIdSymbols.indexOf(symbol);
+                if (index >= 0) {
+                    columnValueAndRowIdChannels[index] = symbolCounter;
+                }
+                symbolCounter++;
+            }
+            checkArgument(symbolCounter == columnValueAndRowIdSymbols.size(), "symbolCounter %s should be columnValueAndRowIdChannels.size() %s", symbolCounter);
+            return Arrays.asList(columnValueAndRowIdChannels);
+        }
+
+        @Override
         public PhysicalOperation visitTableDelete(TableDeleteNode node, LocalExecutionPlanContext context)
         {
             OperatorFactory operatorFactory = new TableDeleteOperatorFactory(context.getNextOperatorId(), node.getId(), metadata, session, node.getTarget());
@@ -3180,6 +3215,10 @@ public class LocalExecutionPlanner
             }
             else if (target instanceof DeleteTarget) {
                 metadata.finishDelete(session, ((DeleteTarget) target).getHandle(), fragments);
+                return Optional.empty();
+            }
+            else if (target instanceof UpdateTarget) {
+                metadata.finishUpdate(session, ((UpdateTarget) target).getHandle(), fragments);
                 return Optional.empty();
             }
             else {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -114,6 +114,7 @@ import io.trino.sql.planner.iterative.rule.PruneUnionColumns;
 import io.trino.sql.planner.iterative.rule.PruneUnionSourceColumns;
 import io.trino.sql.planner.iterative.rule.PruneUnnestColumns;
 import io.trino.sql.planner.iterative.rule.PruneUnnestSourceColumns;
+import io.trino.sql.planner.iterative.rule.PruneUpdateSourceColumns;
 import io.trino.sql.planner.iterative.rule.PruneValuesColumns;
 import io.trino.sql.planner.iterative.rule.PruneWindowColumns;
 import io.trino.sql.planner.iterative.rule.PushAggregationIntoTableScan;
@@ -311,6 +312,7 @@ public class PlanOptimizers
                 new PruneCorrelatedJoinColumns(),
                 new PruneCorrelatedJoinCorrelation(),
                 new PruneDeleteSourceColumns(),
+                new PruneUpdateSourceColumns(),
                 new PruneDistinctLimitSourceColumns(),
                 new PruneEnforceSingleRowColumns(),
                 new PruneExceptSourceColumns(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneUpdateSourceColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneUpdateSourceColumns.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.UpdateNode;
+
+import static io.trino.sql.planner.iterative.rule.Util.restrictChildOutputs;
+import static io.trino.sql.planner.plan.Patterns.update;
+
+public class PruneUpdateSourceColumns
+        implements Rule<UpdateNode>
+{
+    private static final Pattern<UpdateNode> PATTERN = update();
+
+    @Override
+    public Pattern<UpdateNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(UpdateNode updateNode, Captures captures, Context context)
+    {
+        return restrictChildOutputs(context.getIdAllocator(), updateNode, ImmutableSet.copyOf(updateNode.getColumnValueAndRowIdSymbols()))
+                .map(Result::ofPlanNode)
+                .orElse(Result.empty());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
@@ -14,7 +14,6 @@
 package io.trino.sql.planner.optimizations;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
@@ -39,13 +38,16 @@ import io.trino.sql.planner.plan.TableWriterNode.CreateTarget;
 import io.trino.sql.planner.plan.TableWriterNode.DeleteTarget;
 import io.trino.sql.planner.plan.TableWriterNode.InsertReference;
 import io.trino.sql.planner.plan.TableWriterNode.InsertTarget;
+import io.trino.sql.planner.plan.TableWriterNode.UpdateTarget;
 import io.trino.sql.planner.plan.TableWriterNode.WriterTarget;
 import io.trino.sql.planner.plan.UnionNode;
+import io.trino.sql.planner.plan.UpdateNode;
 
 import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.sql.planner.optimizations.QueryCardinalityUtil.isAtMostScalar;
 import static io.trino.sql.planner.plan.ChildReplacer.replaceChildren;
 import static java.util.stream.Collectors.toSet;
@@ -110,9 +112,22 @@ public class BeginTableWrite
             DeleteTarget deleteTarget = (DeleteTarget) context.get().getMaterializedHandle(node.getTarget()).get();
             return new DeleteNode(
                     node.getId(),
-                    rewriteDeleteTableScan(node.getSource(), deleteTarget.getHandle()),
+                    rewriteModifyTableScan(node.getSource(), deleteTarget.getHandle()),
                     deleteTarget,
                     node.getRowId(),
+                    node.getOutputSymbols());
+        }
+
+        @Override
+        public PlanNode visitUpdate(UpdateNode node, RewriteContext<Context> context)
+        {
+            UpdateTarget updateTarget = (UpdateTarget) context.get().getMaterializedHandle(node.getTarget()).get();
+            return new UpdateNode(
+                    node.getId(),
+                    rewriteModifyTableScan(node.getSource(), updateTarget.getHandle()),
+                    updateTarget,
+                    node.getRowId(),
+                    node.getColumnValueAndRowIdSymbols(),
                     node.getOutputSymbols());
         }
 
@@ -162,11 +177,14 @@ public class BeginTableWrite
             if (node instanceof DeleteNode) {
                 return ((DeleteNode) node).getTarget();
             }
+            if (node instanceof UpdateNode) {
+                return ((UpdateNode) node).getTarget();
+            }
             if (node instanceof ExchangeNode || node instanceof UnionNode) {
                 Set<WriterTarget> writerTargets = node.getSources().stream()
                         .map(this::getTarget)
                         .collect(toSet());
-                return Iterables.getOnlyElement(writerTargets);
+                return getOnlyElement(writerTargets);
             }
             throw new IllegalArgumentException("Invalid child for TableCommitNode: " + node.getClass().getSimpleName());
         }
@@ -187,6 +205,14 @@ public class BeginTableWrite
                 DeleteTarget delete = (DeleteTarget) target;
                 return new DeleteTarget(metadata.beginDelete(session, delete.getHandle()), delete.getSchemaTableName());
             }
+            if (target instanceof UpdateTarget) {
+                UpdateTarget update = (UpdateTarget) target;
+                return new UpdateTarget(
+                        metadata.beginUpdate(session, update.getHandle(), ImmutableList.copyOf(update.getUpdatedColumnHandles())),
+                        update.getSchemaTableName(),
+                        update.getUpdatedColumns(),
+                        update.getUpdatedColumnHandles());
+            }
             if (target instanceof TableWriterNode.RefreshMaterializedViewReference) {
                 TableWriterNode.RefreshMaterializedViewReference refreshMV = (TableWriterNode.RefreshMaterializedViewReference) target;
                 return new TableWriterNode.RefreshMaterializedViewTarget(
@@ -198,7 +224,7 @@ public class BeginTableWrite
             throw new IllegalArgumentException("Unhandled target type: " + target.getClass().getSimpleName());
         }
 
-        private PlanNode rewriteDeleteTableScan(PlanNode node, TableHandle handle)
+        private PlanNode rewriteModifyTableScan(PlanNode node, TableHandle handle)
         {
             if (node instanceof TableScanNode) {
                 TableScanNode scan = (TableScanNode) node;
@@ -212,25 +238,25 @@ public class BeginTableWrite
             }
 
             if (node instanceof FilterNode) {
-                PlanNode source = rewriteDeleteTableScan(((FilterNode) node).getSource(), handle);
+                PlanNode source = rewriteModifyTableScan(((FilterNode) node).getSource(), handle);
                 return replaceChildren(node, ImmutableList.of(source));
             }
             if (node instanceof ProjectNode) {
-                PlanNode source = rewriteDeleteTableScan(((ProjectNode) node).getSource(), handle);
+                PlanNode source = rewriteModifyTableScan(((ProjectNode) node).getSource(), handle);
                 return replaceChildren(node, ImmutableList.of(source));
             }
             if (node instanceof SemiJoinNode) {
-                PlanNode source = rewriteDeleteTableScan(((SemiJoinNode) node).getSource(), handle);
+                PlanNode source = rewriteModifyTableScan(((SemiJoinNode) node).getSource(), handle);
                 return replaceChildren(node, ImmutableList.of(source, ((SemiJoinNode) node).getFilteringSource()));
             }
             if (node instanceof JoinNode) {
                 JoinNode joinNode = (JoinNode) node;
                 if (joinNode.getType() == JoinNode.Type.INNER && isAtMostScalar(joinNode.getRight())) {
-                    PlanNode source = rewriteDeleteTableScan(joinNode.getLeft(), handle);
+                    PlanNode source = rewriteModifyTableScan(joinNode.getLeft(), handle);
                     return replaceChildren(node, ImmutableList.of(source, joinNode.getRight()));
                 }
             }
-            throw new IllegalArgumentException("Invalid descendant for DeleteNode: " + node.getClass().getName());
+            throw new IllegalArgumentException("Invalid descendant for DeleteNode or UpdateNode: " + node.getClass().getName());
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -73,6 +73,7 @@ import io.trino.sql.planner.plan.TableWriterNode;
 import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
 import io.trino.sql.planner.plan.UnnestNode;
+import io.trino.sql.planner.plan.UpdateNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.CoalesceExpression;
@@ -415,6 +416,12 @@ public final class PropertyDerivations
         public ActualProperties visitDelete(DeleteNode node, List<ActualProperties> inputProperties)
         {
             // drop all symbols in property because delete doesn't pass on any of the columns
+            return Iterables.getOnlyElement(inputProperties).translate(symbol -> Optional.empty());
+        }
+
+        @Override
+        public ActualProperties visitUpdate(UpdateNode node, List<ActualProperties> inputProperties)
+        {
             return Iterables.getOnlyElement(inputProperties).translate(symbol -> Optional.empty());
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -70,6 +70,7 @@ import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
 import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.UnnestNode;
+import io.trino.sql.planner.plan.UpdateNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.Expression;
@@ -715,6 +716,13 @@ public class PruneUnreferencedOutputs
         {
             PlanNode source = context.rewrite(node.getSource(), ImmutableSet.of(node.getRowId()));
             return new DeleteNode(node.getId(), source, node.getTarget(), node.getRowId(), node.getOutputSymbols());
+        }
+
+        @Override
+        public PlanNode visitUpdate(UpdateNode node, RewriteContext<Set<Symbol>> context)
+        {
+            PlanNode source = context.rewrite(node.getSource(), ImmutableSet.copyOf(node.getColumnValueAndRowIdSymbols()));
+            return new UpdateNode(node.getId(), source, node.getTarget(), node.getRowId(), node.getColumnValueAndRowIdSymbols(), node.getOutputSymbols());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -62,6 +62,7 @@ import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
 import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.UnnestNode;
+import io.trino.sql.planner.plan.UpdateNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.Expression;
@@ -434,6 +435,13 @@ public final class StreamPropertyDerivations
         {
             StreamProperties properties = Iterables.getOnlyElement(inputProperties);
             // delete only outputs the row count
+            return properties.withUnspecifiedPartitioning();
+        }
+
+        @Override
+        public StreamProperties visitUpdate(UpdateNode node, List<StreamProperties> inputProperties)
+        {
+            StreamProperties properties = Iterables.getOnlyElement(inputProperties);
             return properties.withUnspecifiedPartitioning();
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/Patterns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/Patterns.java
@@ -58,6 +58,11 @@ public final class Patterns
         return typeOf(DeleteNode.class);
     }
 
+    public static Pattern<UpdateNode> update()
+    {
+        return typeOf(UpdateNode.class);
+    }
+
     public static Pattern<ExchangeNode> exchange()
     {
         return typeOf(ExchangeNode.class);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanNode.java
@@ -49,6 +49,7 @@ import static java.util.Objects.requireNonNull;
         @JsonSubTypes.Type(value = IndexSourceNode.class, name = "indexsource"),
         @JsonSubTypes.Type(value = TableWriterNode.class, name = "tablewriter"),
         @JsonSubTypes.Type(value = DeleteNode.class, name = "delete"),
+        @JsonSubTypes.Type(value = UpdateNode.class, name = "update"),
         @JsonSubTypes.Type(value = TableDeleteNode.class, name = "tableDelete"),
         @JsonSubTypes.Type(value = TableFinishNode.class, name = "tablecommit"),
         @JsonSubTypes.Type(value = UnnestNode.class, name = "unnest"),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanVisitor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/PlanVisitor.java
@@ -129,6 +129,11 @@ public abstract class PlanVisitor<R, C>
         return visitPlan(node, context);
     }
 
+    public R visitUpdate(UpdateNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
     public R visitTableDelete(TableDeleteNode node, C context)
     {
         return visitPlan(node, context);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
@@ -187,6 +187,7 @@ public class TableWriterNode
             @JsonSubTypes.Type(value = CreateTarget.class, name = "CreateTarget"),
             @JsonSubTypes.Type(value = InsertTarget.class, name = "InsertTarget"),
             @JsonSubTypes.Type(value = DeleteTarget.class, name = "DeleteTarget"),
+            @JsonSubTypes.Type(value = UpdateTarget.class, name = "UpdateTarget"),
             @JsonSubTypes.Type(value = RefreshMaterializedViewTarget.class, name = "RefreshMaterializedViewTarget")})
     @SuppressWarnings({"EmptyClass", "ClassMayBeInterface"})
     public abstract static class WriterTarget
@@ -443,6 +444,59 @@ public class TableWriterNode
         public SchemaTableName getSchemaTableName()
         {
             return schemaTableName;
+        }
+
+        @Override
+        public String toString()
+        {
+            return handle.toString();
+        }
+    }
+
+    public static class UpdateTarget
+            extends WriterTarget
+    {
+        private final TableHandle handle;
+        private final SchemaTableName schemaTableName;
+        private final List<String> updatedColumns;
+        private final List<ColumnHandle> updatedColumnHandles;
+
+        @JsonCreator
+        public UpdateTarget(
+                @JsonProperty("handle") TableHandle handle,
+                @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
+                @JsonProperty("updatedColumns") List<String> updatedColumns,
+                @JsonProperty("updatedColumnHandles") List<ColumnHandle> updatedColumnHandles)
+        {
+            this.handle = requireNonNull(handle, "handle is null");
+            this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+            checkArgument(updatedColumns.size() == updatedColumnHandles.size(), "updatedColumns size %s must equal updatedColumnHandles size %s", updatedColumns.size(), updatedColumnHandles.size());
+            this.updatedColumns = requireNonNull(updatedColumns, "updatedColumns is null");
+            this.updatedColumnHandles = requireNonNull(updatedColumnHandles, "updatedColumnHandles is null");
+        }
+
+        @JsonProperty
+        public TableHandle getHandle()
+        {
+            return handle;
+        }
+
+        @JsonProperty
+        public SchemaTableName getSchemaTableName()
+        {
+            return schemaTableName;
+        }
+
+        @JsonProperty
+        public List<String> getUpdatedColumns()
+        {
+            return updatedColumns;
+        }
+
+        @JsonProperty
+        public List<ColumnHandle> getUpdatedColumnHandles()
+        {
+            return updatedColumnHandles;
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/UpdateNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/UpdateNode.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.plan;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.plan.TableWriterNode.UpdateTarget;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class UpdateNode
+        extends PlanNode
+{
+    private final PlanNode source;
+    private final UpdateTarget target;
+    private final Symbol rowId;
+    private final List<Symbol> columnValueAndRowIdSymbols;
+    private final List<Symbol> outputs;
+
+    @JsonCreator
+    public UpdateNode(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("source") PlanNode source,
+            @JsonProperty("target") UpdateTarget target,
+            @JsonProperty("rowId") Symbol rowId,
+            @JsonProperty("columnValueAndRowIdSymbols") List<Symbol> columnValueAndRowIdSymbols,
+            @JsonProperty("outputs") List<Symbol> outputs)
+    {
+        super(id);
+
+        this.source = requireNonNull(source, "source is null");
+        this.target = requireNonNull(target, "target is null");
+        this.rowId = requireNonNull(rowId, "rowId is null");
+        this.columnValueAndRowIdSymbols = ImmutableList.copyOf(requireNonNull(columnValueAndRowIdSymbols, "columnValueAndRowIdSymbols is null"));
+        this.outputs = ImmutableList.copyOf(requireNonNull(outputs, "outputs is null"));
+        int symbolsSize = columnValueAndRowIdSymbols.size();
+        int columnsSize = target.getUpdatedColumns().size();
+        checkArgument(symbolsSize == columnsSize + 1, "The symbol count %s must be one greater than updated columns count %s", symbolsSize, columnsSize);
+    }
+
+    @JsonProperty
+    public PlanNode getSource()
+    {
+        return source;
+    }
+
+    @JsonProperty
+    public UpdateTarget getTarget()
+    {
+        return target;
+    }
+
+    @JsonProperty
+    public Symbol getRowId()
+    {
+        return rowId;
+    }
+
+    @JsonProperty
+    public List<Symbol> getColumnValueAndRowIdSymbols()
+    {
+        return columnValueAndRowIdSymbols;
+    }
+
+    /**
+     * Aggregate information about updated data
+     */
+    @JsonProperty("outputs")
+    @Override
+    public List<Symbol> getOutputSymbols()
+    {
+        return outputs;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return ImmutableList.of(source);
+    }
+
+    @Override
+    public <R, C> R accept(PlanVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitUpdate(this, context);
+    }
+
+    @Override
+    public PlanNode replaceChildren(List<PlanNode> newChildren)
+    {
+        return new UpdateNode(getId(), Iterables.getOnlyElement(newChildren), target, rowId, columnValueAndRowIdSymbols, outputs);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
@@ -45,6 +45,7 @@ import io.trino.sql.planner.plan.TableWriterNode.CreateTarget;
 import io.trino.sql.planner.plan.TableWriterNode.DeleteTarget;
 import io.trino.sql.planner.plan.TableWriterNode.InsertReference;
 import io.trino.sql.planner.plan.TableWriterNode.InsertTarget;
+import io.trino.sql.planner.plan.TableWriterNode.UpdateTarget;
 import io.trino.sql.planner.plan.TableWriterNode.WriterTarget;
 import io.trino.sql.planner.planprinter.IoPlanPrinter.IoPlan.IoPlanBuilder;
 
@@ -653,6 +654,13 @@ public class IoPlanPrinter
             }
             else if (writerTarget instanceof DeleteTarget) {
                 DeleteTarget target = (DeleteTarget) writerTarget;
+                context.setOutputTable(new CatalogSchemaTableName(
+                        target.getHandle().getCatalogName().getCatalogName(),
+                        target.getSchemaTableName().getSchemaName(),
+                        target.getSchemaTableName().getTableName()));
+            }
+            else if (writerTarget instanceof UpdateTarget) {
+                UpdateTarget target = (UpdateTarget) writerTarget;
                 context.setOutputTable(new CatalogSchemaTableName(
                         target.getHandle().getCatalogName().getCatalogName(),
                         target.getSchemaTableName().getSchemaName(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -94,6 +94,7 @@ import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
 import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.UnnestNode;
+import io.trino.sql.planner.plan.UpdateNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.planner.planprinter.NodeRepresentation.TypedSymbol;
@@ -1106,6 +1107,18 @@ public class PlanPrinter
         {
             addNode(node, "Delete", format("[%s]", node.getTarget()));
 
+            return processChildren(node, context);
+        }
+
+        @Override
+        public Void visitUpdate(UpdateNode node, Void context)
+        {
+            NodeRepresentation nodeOutput = addNode(node, format("Update[%s]", node.getTarget()));
+            int index = 0;
+            for (String columnName : node.getTarget().getUpdatedColumns()) {
+                nodeOutput.appendDetailsLine("%s := %s", columnName, node.getColumnValueAndRowIdSymbols().get(index).getName());
+                index++;
+            }
             return processChildren(node, context);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -65,6 +65,7 @@ import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
 import io.trino.sql.planner.plan.UnionNode;
 import io.trino.sql.planner.plan.UnnestNode;
+import io.trino.sql.planner.plan.UpdateNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.Expression;
@@ -569,6 +570,18 @@ public final class ValidateDependenciesChecker
             source.accept(this, boundSymbols); // visit child
 
             checkArgument(source.getOutputSymbols().contains(node.getRowId()), "Invalid node. Row ID symbol (%s) is not in source plan output (%s)", node.getRowId(), node.getSource().getOutputSymbols());
+
+            return null;
+        }
+
+        @Override
+        public Void visitUpdate(UpdateNode node, Set<Symbol> boundSymbols)
+        {
+            PlanNode source = node.getSource();
+            source.accept(this, boundSymbols); // visit child
+
+            checkArgument(source.getOutputSymbols().contains(node.getRowId()), "Invalid node. Row ID symbol (%s) is not in source plan output (%s)", node.getRowId(), node.getSource().getOutputSymbols());
+            checkArgument(source.getOutputSymbols().containsAll(node.getColumnValueAndRowIdSymbols()), "Invalid node. Some UPDATE SET expression symbols (%s) are not contained in the outputSymbols (%s)", node.getColumnValueAndRowIdSymbols(), source.getOutputSymbols());
 
             return null;
         }

--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -72,6 +72,7 @@ import static io.trino.spi.security.AccessDeniedException.denySetSystemSessionPr
 import static io.trino.spi.security.AccessDeniedException.denySetUser;
 import static io.trino.spi.security.AccessDeniedException.denyShowColumns;
 import static io.trino.spi.security.AccessDeniedException.denyShowCreateTable;
+import static io.trino.spi.security.AccessDeniedException.denyUpdateTableColumns;
 import static io.trino.spi.security.AccessDeniedException.denyViewQuery;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.ADD_COLUMN;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.COMMENT_COLUMN;
@@ -100,6 +101,7 @@ import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SET_USER;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SHOW_COLUMNS;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SHOW_CREATE_TABLE;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.UPDATE_TABLE;
 import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.VIEW_QUERY;
 import static java.util.Objects.requireNonNull;
 
@@ -416,6 +418,17 @@ public class TestingAccessControlManager
     }
 
     @Override
+    public void checkCanUpdateTableColumns(SecurityContext context, QualifiedObjectName tableName, Set<String> updatedColumnNames)
+    {
+        if (shouldDenyPrivilege(context.getIdentity().getUser(), tableName.getObjectName(), UPDATE_TABLE)) {
+            denyUpdateTableColumns(tableName.toString(), updatedColumnNames);
+        }
+        if (denyPrivileges.isEmpty()) {
+            super.checkCanUpdateTableColumns(context, tableName, updatedColumnNames);
+        }
+    }
+
+    @Override
     public void checkCanCreateView(SecurityContext context, QualifiedObjectName viewName)
     {
         if (shouldDenyPrivilege(context.getIdentity().getUser(), viewName.getObjectName(), CREATE_VIEW)) {
@@ -589,7 +602,7 @@ public class TestingAccessControlManager
         EXECUTE_QUERY, VIEW_QUERY, KILL_QUERY,
         EXECUTE_FUNCTION,
         CREATE_SCHEMA, DROP_SCHEMA, RENAME_SCHEMA,
-        SHOW_CREATE_TABLE, CREATE_TABLE, DROP_TABLE, RENAME_TABLE, COMMENT_TABLE, COMMENT_COLUMN, INSERT_TABLE, DELETE_TABLE, SHOW_COLUMNS,
+        SHOW_CREATE_TABLE, CREATE_TABLE, DROP_TABLE, RENAME_TABLE, COMMENT_TABLE, COMMENT_COLUMN, INSERT_TABLE, DELETE_TABLE, UPDATE_TABLE, SHOW_COLUMNS,
         ADD_COLUMN, DROP_COLUMN, RENAME_COLUMN, SELECT_COLUMN,
         CREATE_VIEW, RENAME_VIEW, DROP_VIEW, CREATE_VIEW_WITH_SELECT_COLUMNS,
         GRANT_EXECUTE_FUNCTION,

--- a/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
@@ -70,6 +70,7 @@ import io.trino.sql.tree.ShowStats;
 import io.trino.sql.tree.ShowTables;
 import io.trino.sql.tree.StartTransaction;
 import io.trino.sql.tree.Statement;
+import io.trino.sql.tree.Update;
 import io.trino.sql.tree.Use;
 
 import java.util.Map;
@@ -92,6 +93,8 @@ public final class StatementUtils
         builder.put(Insert.class, QueryType.INSERT);
 
         builder.put(Delete.class, QueryType.DELETE);
+
+        builder.put(Update.class, QueryType.UPDATE);
 
         builder.put(ShowCatalogs.class, QueryType.DESCRIBE);
         builder.put(ShowCreate.class, QueryType.DESCRIBE);

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -364,7 +364,13 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public ColumnHandle getUpdateRowIdColumnHandle(Session session, TableHandle tableHandle)
+    public ColumnHandle getDeleteRowIdColumnHandle(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ColumnHandle getUpdateRowIdColumnHandle(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
     {
         throw new UnsupportedOperationException();
     }
@@ -395,6 +401,18 @@ public abstract class AbstractMockMetadata
 
     @Override
     public void finishDelete(Session session, TableHandle tableHandle, Collection<Slice> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TableHandle beginUpdate(Session session, TableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void finishUpdate(Session session, TableHandle tableHandle, Collection<Slice> fragments)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -141,6 +141,9 @@ statement
     | DESCRIBE INPUT identifier                                        #describeInput
     | DESCRIBE OUTPUT identifier                                       #describeOutput
     | SET PATH pathSpecification                                       #setPath
+    | UPDATE qualifiedName
+        SET updateAssignment (',' updateAssignment)*
+        (WHERE where=booleanExpression)?                               #update
     ;
 
 query
@@ -469,6 +472,9 @@ frameBound
     | expression boundType=(PRECEDING | FOLLOWING)  #boundedFrame
     ;
 
+updateAssignment
+    : identifier '=' expression
+    ;
 
 explainOption
     : FORMAT value=(TEXT | GRAPHVIZ | JSON)                 #explainFormat
@@ -560,7 +566,7 @@ nonReserved
     | SCHEMA | SCHEMAS | SECOND | SECURITY | SERIALIZABLE | SESSION | SET | SETS
     | SHOW | SOME | START | STATS | SUBSTRING | SYSTEM
     | TABLES | TABLESAMPLE | TEXT | TIES | TIME | TIMESTAMP | TO | TRANSACTION | TRY_CAST | TYPE
-    | UNBOUNDED | UNCOMMITTED | USE | USER
+    | UNBOUNDED | UNCOMMITTED | UPDATE | USE | USER
     | VALIDATE | VERBOSE | VIEW
     | WINDOW | WITHOUT | WORK | WRITE
     | YEAR
@@ -755,6 +761,7 @@ UNBOUNDED: 'UNBOUNDED';
 UNCOMMITTED: 'UNCOMMITTED';
 UNION: 'UNION';
 UNNEST: 'UNNEST';
+UPDATE: 'UPDATE';
 USE: 'USE';
 USER: 'USER';
 USING: 'USING';

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -112,6 +112,8 @@ import io.trino.sql.tree.TransactionAccessMode;
 import io.trino.sql.tree.TransactionMode;
 import io.trino.sql.tree.Union;
 import io.trino.sql.tree.Unnest;
+import io.trino.sql.tree.Update;
+import io.trino.sql.tree.UpdateAssignment;
 import io.trino.sql.tree.Values;
 import io.trino.sql.tree.WindowDefinition;
 import io.trino.sql.tree.With;
@@ -1254,6 +1256,32 @@ public final class SqlFormatter
 
             process(node.getQuery(), indent);
 
+            return null;
+        }
+
+        @Override
+        protected Void visitUpdate(Update node, Integer indent)
+        {
+            builder.append("UPDATE ")
+                    .append(node.getTable().getName())
+                    .append(" SET");
+            int setCounter = node.getAssignments().size() - 1;
+            for (UpdateAssignment assignment : node.getAssignments()) {
+                builder.append("\n")
+                        .append(indentString(indent + 1))
+                        .append(assignment.getName().getValue())
+                        .append(" = ")
+                        .append(formatExpression(assignment.getValue()));
+                if (setCounter > 0) {
+                    builder.append(",");
+                }
+                setCounter--;
+            }
+            if (node.getWhere().isPresent()) {
+                builder.append("\n")
+                        .append(indentString(indent))
+                        .append("WHERE ").append(formatExpression(node.getWhere().get()));
+            }
             return null;
         }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -186,6 +186,8 @@ import io.trino.sql.tree.TryExpression;
 import io.trino.sql.tree.TypeParameter;
 import io.trino.sql.tree.Union;
 import io.trino.sql.tree.Unnest;
+import io.trino.sql.tree.Update;
+import io.trino.sql.tree.UpdateAssignment;
 import io.trino.sql.tree.Use;
 import io.trino.sql.tree.Values;
 import io.trino.sql.tree.WhenClause;
@@ -435,6 +437,22 @@ class AstBuilder
                 getLocation(context),
                 new Table(getLocation(context), getQualifiedName(context.qualifiedName())),
                 visitIfPresent(context.booleanExpression(), Expression.class));
+    }
+
+    @Override
+    public Node visitUpdate(SqlBaseParser.UpdateContext context)
+    {
+        return new Update(
+                getLocation(context),
+                new Table(getLocation(context), getQualifiedName(context.qualifiedName())),
+                visit(context.updateAssignment(), UpdateAssignment.class),
+                visitIfPresent(context.booleanExpression(), Expression.class));
+    }
+
+    @Override
+    public Node visitUpdateAssignment(SqlBaseParser.UpdateAssignmentContext context)
+    {
+        return new UpdateAssignment((Identifier) visit(context.identifier()), (Expression) visit(context.expression()));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -657,6 +657,16 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitUpdate(Update node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
+    protected R visitUpdateAssignment(UpdateAssignment node, C context)
+    {
+        return visitNode(node, context);
+    }
+
     protected R visitStartTransaction(StartTransaction node, C context)
     {
         return visitStatement(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -619,6 +619,24 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitUpdate(Update node, C context)
+    {
+        process(node.getTable(), context);
+        node.getAssignments().forEach(value -> process(value, context));
+        node.getWhere().ifPresent(where -> process(where, context));
+
+        return null;
+    }
+
+    @Override
+    protected Void visitUpdateAssignment(UpdateAssignment node, C context)
+    {
+        process(node.getName(), context);
+        process(node.getValue(), context);
+        return null;
+    }
+
+    @Override
     protected Void visitCreateTableAsSelect(CreateTableAsSelect node, C context)
     {
         process(node.getQuery(), context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Update.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Update.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class Update
+        extends Statement
+{
+    private final Table table;
+    private final List<UpdateAssignment> assignments;
+    private final Optional<Expression> where;
+
+    public Update(Table table, List<UpdateAssignment> assignments, Optional<Expression> where)
+    {
+        this(Optional.empty(), table, assignments, where);
+    }
+
+    public Update(NodeLocation location, Table table, List<UpdateAssignment> assignments, Optional<Expression> where)
+    {
+        this(Optional.of(location), table, assignments, where);
+    }
+
+    private Update(Optional<NodeLocation> location, Table table, List<UpdateAssignment> assignments, Optional<Expression> where)
+    {
+        super(location);
+        this.table = requireNonNull(table, "table is null");
+        this.assignments = requireNonNull(assignments, "targets is null");
+        this.where = requireNonNull(where, "where is null");
+    }
+
+    public Table getTable()
+    {
+        return table;
+    }
+
+    public List<UpdateAssignment> getAssignments()
+    {
+        return assignments;
+    }
+
+    public Optional<Expression> getWhere()
+    {
+        return where;
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
+        nodes.addAll(assignments);
+        where.ifPresent(nodes::add);
+        return nodes.build();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitUpdate(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Update update = (Update) o;
+        return table.equals(update.table) &&
+                assignments.equals(update.assignments) &&
+                where.equals(update.where);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(table, assignments, where);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("table", table)
+                .add("assignments", assignments)
+                .add("where", where.orElse(null))
+                .omitNullValues()
+                .toString();
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/UpdateAssignment.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/UpdateAssignment.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class UpdateAssignment
+        extends Node
+{
+    private final Identifier name;
+    private final Expression value;
+
+    public UpdateAssignment(Identifier name, Expression value)
+    {
+        this(Optional.empty(), name, value);
+    }
+
+    public UpdateAssignment(NodeLocation location, Identifier name, Expression value)
+    {
+        this(Optional.of(location), name, value);
+    }
+
+    private UpdateAssignment(Optional<NodeLocation> location, Identifier name, Expression value)
+    {
+        super(location);
+        this.name = requireNonNull(name, "name is null");
+        this.value = requireNonNull(value, "value is null");
+    }
+
+    public Identifier getName()
+    {
+        return name;
+    }
+
+    public Expression getValue()
+    {
+        return value;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitUpdateAssignment(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.of(name, value);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        UpdateAssignment other = (UpdateAssignment) obj;
+        return Objects.equals(name, other.name) &&
+                Objects.equals(value, other.value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, value);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("%s = %s", name, value);
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -157,6 +157,8 @@ import io.trino.sql.tree.TimestampLiteral;
 import io.trino.sql.tree.TransactionAccessMode;
 import io.trino.sql.tree.Union;
 import io.trino.sql.tree.Unnest;
+import io.trino.sql.tree.Update;
+import io.trino.sql.tree.UpdateAssignment;
 import io.trino.sql.tree.Values;
 import io.trino.sql.tree.WhenClause;
 import io.trino.sql.tree.WindowDefinition;
@@ -2804,6 +2806,36 @@ public class TestSqlParser
                                                 Optional.empty()))),
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty()));
+    }
+
+    public void testUpdate()
+    {
+        assertStatement("" +
+                        "UPDATE foo_table\n" +
+                        "    SET bar = 23, baz = 3.1415E0, bletch = 'barf'\n" +
+                        "WHERE (nothing = 'fun')",
+                new Update(
+                        new NodeLocation(1, 1),
+                        table(QualifiedName.of("foo_table")),
+                        ImmutableList.of(
+                                new UpdateAssignment(new Identifier("bar"), new LongLiteral("23")),
+                                new UpdateAssignment(new Identifier("baz"), new DoubleLiteral("3.1415")),
+                                new UpdateAssignment(new Identifier("bletch"), new StringLiteral("barf"))),
+                        Optional.of(new ComparisonExpression(ComparisonExpression.Operator.EQUAL, new Identifier("nothing"), new StringLiteral("fun")))));
+    }
+
+    @Test
+    public void testWherelessUpdate()
+    {
+        assertStatement("" +
+                        "UPDATE foo_table\n" +
+                        "    SET bar = 23",
+                new Update(
+                        new NodeLocation(1, 1),
+                        table(QualifiedName.of("foo_table")),
+                        ImmutableList.of(
+                                new UpdateAssignment(new Identifier("bar"), new LongLiteral("23"))),
                         Optional.empty()));
     }
 

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -41,10 +41,10 @@ public class TestSqlParserErrorHandling
         return new Object[][] {
                 {"",
                         "line 1:1: mismatched input '<EOF>'. Expecting: 'ALTER', 'ANALYZE', 'CALL', 'COMMENT', 'COMMIT', 'CREATE', 'DEALLOCATE', 'DELETE', 'DESC', 'DESCRIBE', 'DROP', 'EXECUTE', 'EXPLAIN', 'GRANT', " +
-                                "'INSERT', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'USE', <query>"},
+                                "'INSERT', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'UPDATE', 'USE', <query>"},
                 {"@select",
                         "line 1:1: mismatched input '@'. Expecting: 'ALTER', 'ANALYZE', 'CALL', 'COMMENT', 'COMMIT', 'CREATE', 'DEALLOCATE', 'DELETE', 'DESC', 'DESCRIBE', 'DROP', 'EXECUTE', 'EXPLAIN', 'GRANT', " +
-                                "'INSERT', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'USE', <query>"},
+                                "'INSERT', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'UPDATE', 'USE', <query>"},
                 {"select * from foo where @what",
                         "line 1:25: mismatched input '@'. Expecting: <expression>"},
                 {"select * from 'oops",

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
@@ -62,6 +62,7 @@ import static io.trino.spi.security.AccessDeniedException.denyShowRoleGrants;
 import static io.trino.spi.security.AccessDeniedException.denyShowRoles;
 import static io.trino.spi.security.AccessDeniedException.denyShowSchemas;
 import static io.trino.spi.security.AccessDeniedException.denyShowTables;
+import static io.trino.spi.security.AccessDeniedException.denyUpdateTableColumns;
 import static java.util.Collections.emptySet;
 
 public interface ConnectorAccessControl
@@ -310,6 +311,16 @@ public interface ConnectorAccessControl
     default void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         denyDeleteTable(tableName.toString());
+    }
+
+    /**
+     * Check if identity is allowed to update the supplied columns in the specified table in this catalog.
+     *
+     * @throws io.trino.spi.security.AccessDeniedException if not allowed
+     */
+    default void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    {
+        denyUpdateTableColumns(tableName.toString(), updatedColumns);
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -486,9 +486,19 @@ public interface ConnectorMetadata
      * These IDs will be passed to the {@code deleteRows()} method of the
      * {@link io.trino.spi.connector.UpdatablePageSource} that created them.
      */
-    default ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    default ColumnHandle getDeleteRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        throw new TrinoException(NOT_SUPPORTED, "This connector does not support updates or deletes");
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support deletes");
+    }
+
+    /**
+     * Get the column handle that will generate row IDs for the update operation.
+     * These IDs will be passed to the {@code updateRows() method of the
+     * {@link io.trino.spi.connector.UpdatablePageSource} that created them.
+     */
+    default ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support updates");
     }
 
     /**
@@ -507,6 +517,31 @@ public interface ConnectorMetadata
     default void finishDelete(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<Slice> fragments)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support deletes");
+    }
+
+    /**
+     * Do whatever is necessary to start an UPDATE query, returning the {@link ConnectorTableHandle}
+     * instance that will be passed to split generation, and to the {@link #finishUpdate} method.
+     * @param session The session in which to start the update operation.
+     * @param tableHandle A ConnectorTableHandle for the table to be updated.
+     * @param updatedColumns A list of the ColumnHandles of columns that will be updated by this UPDATE
+     * operation, in table column order.
+     * @return a ConnectorTableHandle that will be passed to split generation, and to the
+     * {@link #finishUpdate} method.
+     */
+    default ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support updates");
+    }
+
+    /**
+     * Finish an update query
+     *
+     * @param fragments all fragments returned by {@link io.trino.spi.connector.UpdatablePageSource#finish()}
+     */
+    default void finishUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support updates");
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/EmptyPageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/EmptyPageSource.java
@@ -19,6 +19,7 @@ import io.trino.spi.block.Block;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -30,6 +31,12 @@ public class EmptyPageSource
     public void deleteRows(Block rowIds)
     {
         throw new UnsupportedOperationException("deleteRows called on EmptyPageSource");
+    }
+
+    @Override
+    public void updateRows(Page page, List<Integer> columnValueAndRowIdChannels)
+    {
+        throw new UnsupportedOperationException("updateRows called on EmptyPageSource");
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/UpdatablePageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/UpdatablePageSource.java
@@ -14,15 +14,25 @@
 package io.trino.spi.connector;
 
 import io.airlift.slice.Slice;
+import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 public interface UpdatablePageSource
         extends ConnectorPageSource
 {
-    void deleteRows(Block rowIds);
+    default void deleteRows(Block rowIds)
+    {
+        throw new UnsupportedOperationException("This connector does not support row-level delete");
+    }
+
+    default void updateRows(Page page, List<Integer> columnValueAndRowIdChannels)
+    {
+        throw new UnsupportedOperationException("This connector does not support row update");
+    }
 
     CompletableFuture<Collection<Slice>> finish();
 

--- a/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/QueryType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/QueryType.java
@@ -21,5 +21,6 @@ public enum QueryType
     EXPLAIN,
     ANALYZE,
     INSERT,
+    UPDATE,
     SELECT
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
@@ -308,6 +308,16 @@ public class AccessDeniedException
         throw new AccessDeniedException(format("Cannot delete from table %s%s", tableName, formatExtraInfo(extraInfo)));
     }
 
+    public static void denyUpdateTableColumns(String tableName, Set<String> updatedColumnNames)
+    {
+        denyUpdateTableColumns(tableName, updatedColumnNames, null);
+    }
+
+    public static void denyUpdateTableColumns(String tableName, Set<String> updatedColumnNames, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot update columns [%s] in table %s%s", updatedColumnNames, tableName, formatExtraInfo(extraInfo)));
+    }
+
     public static void denyCreateView(String viewName)
     {
         denyCreateView(viewName, null);

--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
@@ -65,6 +65,7 @@ import static io.trino.spi.security.AccessDeniedException.denyShowCreateTable;
 import static io.trino.spi.security.AccessDeniedException.denyShowRoles;
 import static io.trino.spi.security.AccessDeniedException.denyShowSchemas;
 import static io.trino.spi.security.AccessDeniedException.denyShowTables;
+import static io.trino.spi.security.AccessDeniedException.denyUpdateTableColumns;
 import static io.trino.spi.security.AccessDeniedException.denyViewQuery;
 import static java.lang.String.format;
 import static java.util.Collections.emptySet;
@@ -429,6 +430,16 @@ public interface SystemAccessControl
     default void checkCanDeleteFromTable(SystemSecurityContext context, CatalogSchemaTableName table)
     {
         denyDeleteTable(table.toString());
+    }
+
+    /**
+     * Check if identity is allowed to update the supplied columns in the specified table in a catalog.
+     *
+     * @throws AccessDeniedException if not allowed
+     */
+    default void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Set<String> updatedColumnNames)
+    {
+        denyUpdateTableColumns(table.toString(), updatedColumnNames);
     }
 
     /**

--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -88,7 +88,9 @@ Transactional and ACID tables
 
 When connecting to a Hive metastore version 3.x, the Hive connector supports
 reading from and writing to insert-only and ACID tables, with full support for
-partitioning and bucketing. Row-level deletes are supported for ACID tables.
+partitioning and bucketing. Row-level DELETE is supported for ACID tables,
+as well as SQL UPDATE.  UPDATE of partition key columns and bucket columns is
+not supported.
 
 ACID tables created with `Hive Streaming Ingest <https://cwiki.apache.org/confluence/display/Hive/Streaming+Data+Ingest>`_
 are not supported.
@@ -873,6 +875,11 @@ Hive connector limitations
 --------------------------
 
 * :doc:`/sql/alter-schema` usage fails, since the Hive metastore does not support renaming schemas.
+* :doc:`/sql/delete` applied to non-transactional tables is only supported if the ``WHERE`` clause matches entire partitions.
+  Transactional Hive tables with format ORC support "row-by-row" deletion, in which the ``WHERE`` clause may match arbitrary
+  sets of rows.
+* :doc:`/sql/update` is only supported for transactional Hive tables with format ORC.  ``UPDATE`` of partition or bucket
+  columns is not supported.
 
 
 Hive 3 related limitations

--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -872,8 +872,8 @@ Drop a schema::
 Hive connector limitations
 --------------------------
 
-* :doc:`/sql/delete` is only supported if the ``WHERE`` clause matches entire partitions.
 * :doc:`/sql/alter-schema` usage fails, since the Hive metastore does not support renaming schemas.
+
 
 Hive 3 related limitations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/src/main/sphinx/develop.rst
+++ b/docs/src/main/sphinx/develop.rst
@@ -10,6 +10,7 @@ This guide is intended for Trino contributors and plugin developers.
     develop/spi-overview
     develop/connectors
     develop/example-http
+    develop/delete-and-update
     develop/types
     develop/functions
     develop/system-access-control

--- a/docs/src/main/sphinx/develop/delete-and-update.rst
+++ b/docs/src/main/sphinx/develop/delete-and-update.rst
@@ -1,0 +1,196 @@
+====================================
+Supporting ``DELETE`` and ``UPDATE``
+====================================
+
+The Trino engine provides APIs to support row-level SQL ``DELETE`` and ``UPDATE``.
+To implement ``DELETE`` or ``UPDATE``, a connector must layer an ``UpdatablePageSource``
+on top of the connector's usual ``ConnectorPageSource``, and define ``ConnectorMetadata``
+methods to get a "rowId" column handle; to start the operation; and to finish the operation.
+
+``DELETE`` and ``UPDATE`` Data Flow
+===================================
+
+``DELETE`` and ``UPDATE`` have a similar flow:
+
+* For each split, the connector will create an ``UpdatablePageSource`` instance, layered over the
+  connector's ``ConnectorPageSource``, to read pages on behalf of the Trino engine, and to
+  write deletions and/or updates to the underlying data store.
+* The connector's ``UpdatablePageSource.getNextPage()`` implementation fetches the next page
+  from the underlying ``ConnectorPageSource``, optionally reformats the page, and returns it
+  to the Trino engine.
+* The Trino engine performs filtering and projection on the page read, producing a page of filtered,
+  projected results.
+* The Trino engine passes that filtered, projected page of results to the connector's
+  ``UpdatablePageSource`` ``deleteRows()`` or ``updateRows()`` method.  Those methods persist
+  the deletions or updates in the underlying data store.
+* When all the pages for a specific split have been processed, the Trino engine calls
+  ``UpdatablePageSource.finish()``, which returns a ``Collection<Slice>`` of "fragments"
+  representing connector-specific information about the rows processed by the calls to
+  ``deleteRows`` or ``updateRows``.
+* When all pages for all splits have been processed, the Trino engine calls ``ConnectorMetadata.finishDelete()`` or
+  ``finishUpdate``, passing a collection containing all the "fragments" from all the splits.  The connector
+  does what is required to finalize the operation, for example, committing the transaction.
+
+The rowId Column Abstraction
+============================
+
+The Trino engine and connectors use a "rowId" column handle abstraction to agree on the identities of rows
+to be updated or deleted.  The rowId column handle is opaque to the Trino engine.  Depending on the connector,
+the rowId column handle abstraction could represent several physical columns.  For the JDBC connector, the rowId
+column handle points might be the primary key for the table.  For deletion in Hive ACID tables, the rowId consists
+of the three ACID columns that uniquely identify rows.
+
+The rowId Column for ``DELETE``
+-------------------------------
+
+The Trino engine identifies the rows to be deleted using a connector-specific
+rowId column handle, returned by the connector's ``ConnectorMetadata.getDeleteRowIdColumnHandle()``
+method, whose full signature is::
+
+    ColumnHandle getDeleteRowIdColumnHandle(
+        ConnectorSession session,
+        ConnectorTableHandle tableHandle)
+
+The rowId Column for ``UPDATE``
+-------------------------------
+
+The Trino engine identifies rows to be updated using a connector-specific rowId column handle,
+returned by the connector's ``ConnectorMetadata.getUpdateRowIdColumnHandle()``
+method.  In addition to the columns that identify the row, for ``UPDATE`` the rowId column will contain
+any columns that the connector requires in order to perform the ``UPDATE`` operation.  In Hive ACID, for example,
+the rowId column contains the values of all columns *not* updated by the ``UPDATE`` operation, since Hive ACID
+implements ``UPDATE`` as a ``DELETE`` paired with an INSERT.
+
+UpdatablePageSource API
+=======================
+
+As mentioned above, to support ``DELETE`` or ``UPDATE``, the connector must define a subclass of
+``UpdatablePageSource``, layered over the connector's usual ``ConnectorPageSource``.  The interesting methods are:
+
+* ``Page getNextPage()``.  When the Trino engine calls ``getNextPage()``, the ``UpdatablePageSource`` calls
+  its underlying ``ConnectorPageSource.getNextPage()`` method to get a page.  Some connectors will reformat
+  the page before returning it to the Trino engine.
+
+* ``void deleteRows(Block rowIds)``.  The Trino engine calls the ``deleteRows()`` method of the same ``UpdatablePageSource``
+  instance that supplied the original page,  passing a block of "rowIds", created by the Trino engine based on the column
+  handle returned by ``ConnectorMetadata.getDeleteRowIdColumnHandle()``
+
+* ``void updateRows(Page page, List<Integer> columnValueAndRowIdChannels)``.  The Trino engine calls the ``updateRows()``
+  method of the same ``UpdatablePageSource`` instance that supplied the original page, passing a page of projected columns,
+  one for each updated column and the last one for the rowId column.  The order of projected columns is defined by the Trino engine,
+  and that order is reflected in the ``columnValueAndRowIdChannels`` argument.  The job of ``updateRows()`` is to:
+
+  * Extract the updated column blocks and the rowId block from the projected page.
+  * Assemble them in whatever order is required by the connector for storage.
+  * Store the update result in the underlying file store.
+
+  In the case of Hive ACID, ``updateRows()`` stores a file of records that delete the
+  previous contents of the updated rows, and a separate file that inserts completely
+  new rows containing the updated and non-updated column values.
+
+* ``CompletableFuture<Collection<Slice>> finish()``.  The Trino engine calls ``finish()`` when all the pages
+  of a split have been processed.  The connector returns a future containing a collection of ``Slice``, representing
+  connector-specific information about the rows processed.  Usually this will include the row count, and might
+  include information like the files or partitions created or changed.
+
+``ConnectorMetadata`` ``DELETE`` API
+====================================
+
+A connector implementing ``DELETE`` must specify three ``ConnectorMetadata`` methods.
+
+* ``getDeleteRowIdColumnHandle()``::
+
+   ColumnHandle getDeleteRowIdColumnHandle(
+        ConnectorSession session,
+        ConnectorTableHandle tableHandle)
+
+  The ColumnHandle returned by this method provides the "rowId" used by the connector to identify rows to be deleted, as
+  well as any other fields of the row that the connector will need to complete the ``DELETE`` operation.
+  For a JDBC connector, that rowId is usually the primary key for the table and no other fields are required.
+  For other connectors, the information needed to identify a row usually consists of multiple physical columns.
+  With the Hive connector and a Hive ACID table, for example, the ``DELETE`` rowId consists of the three ORC ACID columns
+  that identify the row.
+
+* ``beginDelete()``::
+
+    ConnectorTableHandle beginDelete(
+         ConnectorSession session,
+         ConnectorTableHandle tableHandle)
+
+  As the last step in creating the ``DELETE`` execution plan, the connector's ``beginDelete()`` method is called,
+  passing the ``session`` and ``tableHandle``.
+
+  ``beginDelete()`` performs any orchestration needed in the connector to start processing the ``DELETE``.
+  This orchestration varies from connector to connector.  In the Hive ACID connector, for example, ``beginDelete()``
+  checks that the table is transactional and starts a Hive Metastore transaction.
+
+  ``beginDelete()`` returns a ``ConnectorTableHandle`` with any added information the connector needs when the handle
+  is passed back to ``finishDelete()`` and the split generation machinery.  For most connectors, the returned table
+  handle contains a flag identifying the table handle as a table handle for a ``DELETE`` operation.
+
+* ``finishDelete()``::
+
+      void finishDelete(
+          ConnectorSession session,
+          ConnectorTableHandle tableHandle,
+          Collection<Slice> fragments)
+
+  During ``DELETE`` processing, the Trino engine accumulates the ``Slice`` collections returned by ``UpdatablePageSource.finish()``.
+  After all splits have been processed, the engine calls ``finishDelete()``, passing the table handle and that
+  collection of ``Slice`` fragments.  In response, the connector takes appropriate actions to complete the ``Delete`` operation.
+  Those actions might include committing the transaction, assuming the connector supports a transaction paradigm.
+
+``ConnectorMetadata`` ``UPDATE`` API
+====================================
+
+A connector implementing ``UPDATE`` must specify three ``ConnectorMetadata`` methods.
+
+* ``getUpdateRowIdColumnHandle``::
+
+   ColumnHandle getUpdateRowIdColumnHandle(
+        ConnectorSession session,
+        ConnectorTableHandle tableHandle,
+        List<ColumnHandle> updatedColumns)
+
+  The ``updatedColumns`` list contains column handles for all columns updated by the ``UPDATE`` operation in table column order.
+
+  The ColumnHandle returned by this method provides the "rowId" used by the connector to identify rows to be updated, as
+  well as any other fields of the row that the connector will need to complete the ``UPDATE`` operation.
+  For a JDBC connector, that rowId is usually the primary key for the table and no other fields are required.
+  For other connectors, the information needed to identify a row usually consists of multiple physical columns.
+  Moreover, some connectors may need the values of columns that are not updated to complete the ``UPDATE`` operation.
+  With the Hive connector and a Hive ACID table, for example, the ``UPDATE`` rowId consists of the three ORC ACID columns
+  that identify the row, plus the values of all the data columns not updated.
+
+* ``beginUpdate``::
+
+    ConnectorTableHandle beginUpdate(
+         ConnectorSession session,
+         ConnectorTableHandle tableHandle,
+         List<ColumnHandle> updatedColumns)
+
+  As the last step in creating the ``UPDATE`` execution plan, the connector's ``beginUpdate()`` method is called,
+  passing arguments that define the ``UPDATE`` to the connector.  In addition to the ``session``
+  and ``tableHandle``, the arguments includes the list of the updated columns handles, in table column order.
+
+  ``beginUpdate()`` performs any orchestration needed in the connector to start processing the ``UPDATE``.
+  This orchestration varies from connector to connector.  In the Hive ACID connector, for example, ``beginUpdate()``
+  starts the Hive Metastore transaction; checks that the updated table is transactional and that neither
+  parition columns nor bucket columns are updated.
+
+  ``beginUpdate`` returns a ``ConnectorTableHandle`` with any added information the connector needs when the handle
+  is passed back to ``finishUpdate()`` and the split generation machinery.  For most connectors, the returned table
+  handle contains a flag identifying the table handle as a table handle for a ``UPDATE`` operation.  For some connectors
+  that support partitioning, the table handle will reflect that partitioning.
+
+* ``finishUpdate``::
+
+      void finishUpdate(
+          ConnectorSession session,
+          ConnectorTableHandle tableHandle,
+          Collection<Slice> fragments)
+
+  During ``UPDATE`` processing, the Trino engine accumulates the ``Slice`` collections returned by ``UpdatablePageSource.finish()``.
+  After all splits have been processed, the engine calls ``finishUpdate()``, passing the table handle and that
+  collection of ``Slice`` fragments.  In response, the connector takes appropriate actions to complete the ``UPDATE`` operation.
+  Those actions might include committing the transaction, assuming the connector supports a transaction paradigm.

--- a/docs/src/main/sphinx/sql.rst
+++ b/docs/src/main/sphinx/sql.rst
@@ -60,5 +60,6 @@ Trino also provides :doc:`numerous SQL functions and operators<functions>`.
     sql/show-stats
     sql/show-tables
     sql/start-transaction
+    sql/update
     sql/use
     sql/values

--- a/docs/src/main/sphinx/sql/update.rst
+++ b/docs/src/main/sphinx/sql/update.rst
@@ -1,0 +1,41 @@
+======
+UPDATE
+======
+
+Synopsis
+--------
+
+.. code-block:: text
+
+    UPDATE table_name SET [ ( column = expression [, ... ] ) ] [ WHERE condition ]
+
+Description
+-----------
+
+Update selected columns values in existing rows in a table.
+
+The columns named in the ``column = expression`` assignments will be updated
+for all rows that match the ``WHERE`` condition.  The values of all column update
+expressions for a matching row are evaluated before any column value is changed.
+When the type of the expression and the type of the column differ, the usual implicit
+CASTs, such as widening numeric fields, are applied to the ``UPDATE`` expression values.
+
+
+Examples
+--------
+
+Update the status of all purchases that haven't been assigned a ship date::
+
+    UPDATE purchases SET status = 'OVERDUE' WHERE ship_date IS NULL;
+
+Update the account manager and account assign date for all customers::
+
+    UPDATE customers SET
+      account_manager = 'John Henry',
+      assign_date = DATE '2007-01-01';
+
+Limitations
+-----------
+
+Some connectors have limited or no support for ``UPDATE``.
+See connector documentation for more details.

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
@@ -236,6 +236,14 @@ public class ClassLoaderSafeConnectorAccessControl
     }
 
     @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumnNames)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.checkCanUpdateTableColumns(context, tableName, updatedColumnNames);
+        }
+    }
+
+    @Override
     public void checkCanCreateView(ConnectorSecurityContext context, SchemaTableName viewName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -469,6 +469,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public ColumnHandle getDeleteRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getDeleteRowIdColumnHandle(session, tableHandle);
+        }
+    }
+
+    @Override
     public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
@@ -541,10 +549,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getUpdateRowIdColumnHandle(session, tableHandle);
+            return delegate.getUpdateRowIdColumnHandle(session, tableHandle, updatedColumns);
         }
     }
 
@@ -835,6 +843,22 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.applyTableScanRedirect(session, tableHandle);
+        }
+    }
+
+    @Override
+    public ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.beginUpdate(session, tableHandle, updatedColumns);
+        }
+    }
+
+    @Override
+    public void finishUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<Slice> fragments)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.finishUpdate(session, tableHandle, fragments);
         }
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
@@ -152,6 +152,11 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumnNames)
+    {
+    }
+
+    @Override
     public void checkCanCreateView(ConnectorSecurityContext context, SchemaTableName viewName)
     {
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
@@ -241,6 +241,11 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
+    public void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Set<String> updatedColumnNames)
+    {
+    }
+
+    @Override
     public void checkCanCreateView(SystemSecurityContext context, CatalogSchemaTableName view)
     {
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -38,6 +38,7 @@ import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivileg
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.INSERT;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.OWNERSHIP;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.SELECT;
+import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.UPDATE;
 import static io.trino.plugin.base.util.JsonUtils.parseJson;
 import static io.trino.spi.security.AccessDeniedException.denyAddColumn;
 import static io.trino.spi.security.AccessDeniedException.denyCommentColumn;
@@ -74,6 +75,7 @@ import static io.trino.spi.security.AccessDeniedException.denyShowColumns;
 import static io.trino.spi.security.AccessDeniedException.denyShowCreateSchema;
 import static io.trino.spi.security.AccessDeniedException.denyShowCreateTable;
 import static io.trino.spi.security.AccessDeniedException.denyShowTables;
+import static io.trino.spi.security.AccessDeniedException.denyUpdateTableColumns;
 import static java.util.Objects.requireNonNull;
 
 public class FileBasedAccessControl
@@ -327,6 +329,14 @@ public class FileBasedAccessControl
     {
         if (!checkTablePermission(context, tableName, DELETE)) {
             denyDeleteTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    {
+        if (!checkTablePermission(context, tableName, UPDATE)) {
+            denyUpdateTableColumns(tableName.toString(), updatedColumns);
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -57,6 +57,7 @@ import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivileg
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.INSERT;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.OWNERSHIP;
 import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.SELECT;
+import static io.trino.plugin.base.security.TableAccessControlRule.TablePrivilege.UPDATE;
 import static io.trino.plugin.base.util.JsonUtils.parseJson;
 import static io.trino.spi.StandardErrorCode.CONFIGURATION_INVALID;
 import static io.trino.spi.security.AccessDeniedException.denyAddColumn;
@@ -95,6 +96,7 @@ import static io.trino.spi.security.AccessDeniedException.denyShowCreateSchema;
 import static io.trino.spi.security.AccessDeniedException.denyShowCreateTable;
 import static io.trino.spi.security.AccessDeniedException.denyShowSchemas;
 import static io.trino.spi.security.AccessDeniedException.denyShowTables;
+import static io.trino.spi.security.AccessDeniedException.denyUpdateTableColumns;
 import static io.trino.spi.security.AccessDeniedException.denyViewQuery;
 import static io.trino.spi.security.AccessDeniedException.denyWriteSystemInformationAccess;
 import static java.lang.String.format;
@@ -656,6 +658,14 @@ public class FileBasedSystemAccessControl
     {
         if (!checkTablePermission(context, table, DELETE)) {
             denyDeleteTable(table.toString());
+        }
+    }
+
+    @Override
+    public void checkCanUpdateTableColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> updatedColumnNames)
+    {
+        if (!checkTablePermission(context, table, UPDATE)) {
+            denyUpdateTableColumns(table.toString(), updatedColumnNames);
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
@@ -191,6 +191,12 @@ public abstract class ForwardingConnectorAccessControl
     }
 
     @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    {
+        delegate().checkCanUpdateTableColumns(context, tableName, updatedColumns);
+    }
+
+    @Override
     public void checkCanCreateView(ConnectorSecurityContext context, SchemaTableName viewName)
     {
         delegate().checkCanCreateView(context, viewName);

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
@@ -261,6 +261,12 @@ public abstract class ForwardingSystemAccessControl
     }
 
     @Override
+    public void checkCanUpdateTableColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> updatedColumnNames)
+    {
+        delegate().checkCanUpdateTableColumns(context, table, updatedColumnNames);
+    }
+
+    @Override
     public void checkCanCreateView(SystemSecurityContext context, CatalogSchemaTableName view)
     {
         delegate().checkCanCreateView(context, view);

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlyAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlyAccessControl.java
@@ -36,6 +36,7 @@ import static io.trino.spi.security.AccessDeniedException.denyRenameColumn;
 import static io.trino.spi.security.AccessDeniedException.denyRenameTable;
 import static io.trino.spi.security.AccessDeniedException.denyRenameView;
 import static io.trino.spi.security.AccessDeniedException.denyRevokeTablePrivilege;
+import static io.trino.spi.security.AccessDeniedException.denyUpdateTableColumns;
 
 public class ReadOnlyAccessControl
         implements ConnectorAccessControl
@@ -148,6 +149,12 @@ public class ReadOnlyAccessControl
     public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         denyDeleteTable(tableName.toString());
+    }
+
+    @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    {
+        denyUpdateTableColumns(tableName.toString(), updatedColumns);
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableAccessControlRule.java
@@ -146,6 +146,6 @@ public class TableAccessControlRule
 
     public enum TablePrivilege
     {
-        SELECT, INSERT, DELETE, OWNERSHIP, GRANT_SELECT
+        SELECT, INSERT, DELETE, UPDATE, OWNERSHIP, GRANT_SELECT
     }
 }

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleMetadata.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleMetadata.java
@@ -311,7 +311,7 @@ public class BlackHoleMetadata
     }
 
     @Override
-    public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ColumnHandle getDeleteRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         return new BlackHoleColumnHandle("row_id", BIGINT);
     }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
@@ -373,7 +373,7 @@ public class CassandraMetadata
     }
 
     @Override
-    public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ColumnHandle getDeleteRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         return new CassandraColumnHandle("$update_row_id", 0, CassandraType.TEXT, false, false, false, true);
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/AbstractHiveAcidWriters.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/AbstractHiveAcidWriters.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.plugin.hive.acid.AcidOperation;
+import io.trino.plugin.hive.acid.AcidTransaction;
+import io.trino.plugin.hive.orc.OrcFileWriterFactory;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorSession;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.orc.OrcWriter.OrcOperation.DELETE;
+import static io.trino.orc.OrcWriter.OrcOperation.INSERT;
+import static io.trino.plugin.hive.HiveStorageFormat.ORC;
+import static io.trino.plugin.hive.acid.AcidSchema.ACID_COLUMN_NAMES;
+import static io.trino.plugin.hive.acid.AcidSchema.createAcidSchema;
+import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static io.trino.plugin.hive.util.ConfigurationUtils.toJobConf;
+import static io.trino.spi.predicate.Utils.nativeValueToBlock;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.hive.ql.io.AcidUtils.deleteDeltaSubdir;
+import static org.apache.hadoop.hive.ql.io.AcidUtils.deltaSubdir;
+
+public abstract class AbstractHiveAcidWriters
+{
+    public static final Block DELETE_OPERATION_BLOCK = nativeValueToBlock(INTEGER, Long.valueOf(DELETE.getOperationNumber()));
+    public static final Block INSERT_OPERATION_BLOCK = nativeValueToBlock(INTEGER, Long.valueOf(INSERT.getOperationNumber()));
+
+    // The bucketPath looks like .../delta_nnnnnnn_mmmmmmm_ssss/bucket_bbbbb(_aaaa)?
+    public static final Pattern BUCKET_PATH_MATCHER = Pattern.compile("(?s)(?<rootDir>.*)/(?<dirStart>delta_[\\d]+_[\\d]+)_(?<statementId>[\\d]+)/(?<filenameBase>bucket_(?<bucketNumber>[\\d]+))(?<attemptId>_[\\d]+)?$");
+    // The original file path looks like .../nnnnnnn_m(_copy_ccc)?
+    public static final Pattern ORIGINAL_FILE_PATH_MATCHER = Pattern.compile("(?s)(?<rootDir>.*)/(?<filename>(?<bucketNumber>[\\d]+)_(?<rest>.*)?)$");
+    // After compaction, the bucketPath looks like .../base_nnnnnnn(_vmmmmmmm)?/bucket_bbbbb(_aaaa)?
+    public static final Pattern BASE_PATH_MATCHER = Pattern.compile("(?s)(?<rootDir>.*)/(?<dirStart>base_[\\d]+(_v[\\d]+)?)/(?<filenameBase>bucket_(?<bucketNumber>[\\d]+))(?<attemptId>_[\\d]+)?$");
+
+    protected final AcidTransaction transaction;
+    protected final OptionalInt bucketNumber;
+    protected final int statementId;
+    private final OrcFileWriterFactory orcFileWriterFactory;
+    private final Configuration configuration;
+    protected final ConnectorSession session;
+    protected final HiveType hiveRowType;
+    private final Properties hiveAcidSchema;
+    protected final Path deleteDeltaDirectory;
+    private final String bucketFilename;
+    protected Optional<Path> deltaDirectory;
+
+    protected Optional<FileWriter> deleteFileWriter = Optional.empty();
+    protected Optional<FileWriter> insertFileWriter = Optional.empty();
+
+    public AbstractHiveAcidWriters(
+            AcidTransaction transaction,
+            int statementId,
+            OptionalInt bucketNumber,
+            Path bucketPath,
+            boolean originalFile,
+            OrcFileWriterFactory orcFileWriterFactory,
+            Configuration configuration,
+            ConnectorSession session,
+            HiveType hiveRowType,
+            AcidOperation updateKind)
+    {
+        this.transaction = requireNonNull(transaction, "transaction is null");
+        this.statementId = statementId;
+        this.bucketNumber = requireNonNull(bucketNumber, "bucketNumber is null");
+        this.orcFileWriterFactory = requireNonNull(orcFileWriterFactory, "orcFileWriterFactory is null");
+        this.configuration = requireNonNull(configuration, "configuration is null");
+        this.session = requireNonNull(session, "session is null");
+        checkArgument(transaction.isTransactional(), "Not in a transaction: %s", transaction);
+        this.hiveRowType = requireNonNull(hiveRowType, "hiveRowType is null");
+        this.hiveAcidSchema = createAcidSchema(hiveRowType);
+        requireNonNull(bucketPath, "bucketPath is null");
+        Matcher matcher;
+        if (originalFile) {
+            matcher = ORIGINAL_FILE_PATH_MATCHER.matcher(bucketPath.toString());
+            checkArgument(matcher.matches(), "Original file bucketPath doesn't have the required format: %s", bucketPath);
+            this.bucketFilename = format("bucket_%05d", bucketNumber.isEmpty() ? 0 : bucketNumber.getAsInt());
+        }
+        else {
+            matcher = BASE_PATH_MATCHER.matcher(bucketPath.toString());
+            if (matcher.matches()) {
+                this.bucketFilename = matcher.group("filenameBase");
+            }
+            else {
+                matcher = BUCKET_PATH_MATCHER.matcher(bucketPath.toString());
+                checkArgument(matcher.matches(), "bucketPath doesn't have the required format: %s", bucketPath);
+                this.bucketFilename = matcher.group("filenameBase");
+            }
+        }
+        long writeId = transaction.getWriteId();
+        this.deleteDeltaDirectory = new Path(format("%s/%s", matcher.group("rootDir"), deleteDeltaSubdir(writeId, writeId, statementId)));
+        if (updateKind == AcidOperation.UPDATE) {
+            this.deltaDirectory = Optional.of(new Path(format("%s/%s", matcher.group("rootDir"), deltaSubdir(writeId, writeId, statementId))));
+        }
+        else {
+            this.deltaDirectory = Optional.empty();
+        }
+    }
+
+    protected void lazyInitializeDeleteFileWriter()
+    {
+        if (deleteFileWriter.isEmpty()) {
+            Properties schemaCopy = new Properties();
+            schemaCopy.putAll(hiveAcidSchema);
+            deleteFileWriter = orcFileWriterFactory.createFileWriter(
+                    new Path(format("%s/%s", deleteDeltaDirectory, bucketFilename)),
+                    ACID_COLUMN_NAMES,
+                    fromHiveStorageFormat(ORC),
+                    schemaCopy,
+                    toJobConf(configuration),
+                    session,
+                    bucketNumber,
+                    transaction,
+                    true,
+                    WriterKind.DELETE);
+        }
+    }
+
+    protected void lazyInitializeInsertFileWriter()
+    {
+        if (insertFileWriter.isEmpty()) {
+            Properties schemaCopy = new Properties();
+            schemaCopy.putAll(hiveAcidSchema);
+            Path deltaDir = deltaDirectory.orElseThrow(() -> new IllegalArgumentException("deltaDirectory not present"));
+            insertFileWriter = orcFileWriterFactory.createFileWriter(
+                    new Path(format("%s/%s", deltaDir, bucketFilename)),
+                    ACID_COLUMN_NAMES,
+                    fromHiveStorageFormat(ORC),
+                    schemaCopy,
+                    toJobConf(configuration),
+                    session,
+                    bucketNumber,
+                    transaction,
+                    true,
+                    WriterKind.INSERT);
+        }
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveColumnHandle.java
@@ -15,22 +15,25 @@ package io.trino.plugin.hive;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.trino.plugin.hive.acid.AcidSchema;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.type.Type;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
 import static io.trino.plugin.hive.HiveType.HIVE_INT;
 import static io.trino.plugin.hive.HiveType.HIVE_LONG;
 import static io.trino.plugin.hive.HiveType.HIVE_STRING;
 import static io.trino.plugin.hive.HiveType.toHiveType;
+import static io.trino.plugin.hive.HiveUpdateProcessor.getUpdateRowIdColumnHandle;
+import static io.trino.plugin.hive.acid.AcidSchema.ACID_ROW_ID_ROW_TYPE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
@@ -251,9 +254,18 @@ public class HiveColumnHandle
         return new Column(name, getHiveType(), comment);
     }
 
-    public static HiveColumnHandle updateRowIdColumnHandle()
+    public static HiveColumnHandle getDeleteRowIdColumnHandle()
     {
-        return createBaseColumn(UPDATE_ROW_ID_COLUMN_NAME, UPDATE_ROW_ID_COLUMN_INDEX, toHiveType(AcidSchema.ACID_ROW_ID_ROW_TYPE), AcidSchema.ACID_ROW_ID_ROW_TYPE, SYNTHESIZED, Optional.empty());
+        return createBaseColumn(UPDATE_ROW_ID_COLUMN_NAME, UPDATE_ROW_ID_COLUMN_INDEX, toHiveType(ACID_ROW_ID_ROW_TYPE), ACID_ROW_ID_ROW_TYPE, SYNTHESIZED, Optional.empty());
+    }
+
+    public static HiveColumnHandle updateRowIdColumnHandle(List<HiveColumnHandle> columnHandles, List<ColumnHandle> updatedColumns)
+    {
+        requireNonNull(updatedColumns, "updatedColumns is null");
+        List<HiveColumnHandle> nonUpdatedColumnHandles = columnHandles.stream()
+                .filter(column -> !column.isPartitionKey() && !column.isHidden() && !updatedColumns.contains(column))
+                .collect(toImmutableList());
+        return getUpdateRowIdColumnHandle(nonUpdatedColumnHandles);
     }
 
     public static HiveColumnHandle pathColumnHandle()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveFileWriterFactory.java
@@ -35,5 +35,6 @@ public interface HiveFileWriterFactory
             ConnectorSession session,
             OptionalInt bucketNumber,
             AcidTransaction transaction,
-            boolean useAcidSchema);
+            boolean useAcidSchema,
+            WriterKind writerKind);
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2022,7 +2022,7 @@ public class HiveMetadata
     }
 
     @Override
-    public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ColumnHandle getDeleteRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         return updateRowIdColumnHandle();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
@@ -199,6 +199,26 @@ public class HiveTableHandle
                 transaction);
     }
 
+    public HiveTableHandle withUpdateProcessor(AcidTransaction transaction, HiveUpdateProcessor updateProcessor)
+    {
+        requireNonNull(updateProcessor, "updatedColumns is null");
+        return new HiveTableHandle(
+                schemaName,
+                tableName,
+                tableParameters,
+                partitionColumns,
+                dataColumns,
+                partitions,
+                compactEffectivePredicate,
+                enforcedConstraint,
+                bucketHandle,
+                bucketFilter,
+                analyzePartitionValues,
+                analyzeColumnNames,
+                constraintColumns,
+                transaction);
+    }
+
     @JsonProperty
     public String getSchemaName()
     {
@@ -295,6 +315,18 @@ public class HiveTableHandle
     public boolean isAcidDelete()
     {
         return transaction.isDelete();
+    }
+
+    @JsonIgnore
+    public boolean isAcidUpdate()
+    {
+        return transaction.isUpdate();
+    }
+
+    @JsonIgnore
+    public Optional<HiveUpdateProcessor> getUpdateProcessor()
+    {
+        return transaction.getUpdateProcessor();
     }
 
     @JsonIgnore

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
@@ -16,11 +16,14 @@ package io.trino.plugin.hive;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import io.trino.plugin.hive.acid.AcidOperation;
 import io.trino.plugin.hive.orc.OrcFileWriter;
 import io.trino.plugin.hive.orc.OrcFileWriterFactory;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.LongArrayBlock;
+import io.trino.spi.block.RowBlock;
 import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
@@ -33,60 +36,39 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.trino.orc.OrcWriter.OrcOperation.DELETE;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
-import static io.trino.plugin.hive.HiveStorageFormat.ORC;
 import static io.trino.plugin.hive.PartitionAndStatementId.CODEC;
-import static io.trino.plugin.hive.acid.AcidSchema.ACID_COLUMN_NAMES;
-import static io.trino.plugin.hive.acid.AcidSchema.createAcidSchema;
-import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
-import static io.trino.plugin.hive.util.ConfigurationUtils.toJobConf;
 import static io.trino.spi.predicate.Utils.nativeValueToBlock;
 import static io.trino.spi.type.BigintType.BIGINT;
-import static io.trino.spi.type.IntegerType.INTEGER;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static org.apache.hadoop.hive.ql.io.AcidUtils.deleteDeltaSubdir;
 
 public class HiveUpdatablePageSource
+        extends AbstractHiveAcidWriters
         implements UpdatablePageSource
 {
     // The channel numbers of the child blocks in the RowBlock passed to deleteRows()
     public static final int ORIGINAL_TRANSACTION_CHANNEL = 0;
     public static final int ROW_ID_CHANNEL = 1;
     public static final int BUCKET_CHANNEL = 2;
+    // Used for UPDATE operations
+    public static final int ROW_CHANNEL = 3;
     public static final int ACID_ROW_STRUCT_COLUMN_ID = 6;
-    public static final Block DELETE_OPERATION_BLOCK = nativeValueToBlock(INTEGER, Long.valueOf(DELETE.getOperationNumber()));
 
-    // The bucketPath looks like .../delta_nnnnnnn_mmmmmmm_ssss/bucket_bbbbb(_aaaa)?
-    public static final Pattern BUCKET_PATH_MATCHER = Pattern.compile("(?s)(?<rootDir>.*)/(?<dirStart>delta_[\\d]+_[\\d]+)_(?<statementId>[\\d]+)/(?<filenameBase>bucket_(?<bucketNumber>[\\d]+))(?<attemptId>_[\\d]+)?$");
-    // The orignal file path looks like .../nnnnnnn_m(_copy_ccc)?
-    public static final Pattern ORIGINAL_FILE_PATH_MATCHER = Pattern.compile("(?s)(?<rootDir>.*)/(?<filename>(?<bucketNumber>[\\d]+)_(?<rest>.*)?)$");
-
-    private final HiveTableHandle hiveTable;
     private final String partitionName;
-    private final int statementId;
     private final ConnectorPageSource hivePageSource;
-    private final OptionalInt bucketNumber;
-    private final OrcFileWriterFactory orcFileWriterFactory;
-    private final Configuration configuration;
-    private final ConnectorSession session;
+    private final AcidOperation updateKind;
     private final Block hiveRowTypeNullsBlock;
     private final long writeId;
-    private final Properties hiveAcidSchema;
-    private final Path deleteDeltaDirectory;
-    private final String bucketFilename;
+    private final Optional<List<Integer>> dependencyChannels;
+
     private long maxWriteId;
     private long rowCount;
+    private long insertRowCounter;
 
-    private Optional<FileWriter> writer = Optional.empty();
     private boolean closed;
 
     public HiveUpdatablePageSource(
@@ -101,49 +83,46 @@ public class HiveUpdatablePageSource
             OrcFileWriterFactory orcFileWriterFactory,
             Configuration configuration,
             ConnectorSession session,
-            HiveType hiveRowType)
+            HiveType hiveRowType,
+            List<HiveColumnHandle> dependencyColumns,
+            AcidOperation updateKind)
     {
-        this.hiveTable = requireNonNull(hiveTableHandle, "hiveTable is null");
+        super(hiveTableHandle.getTransaction(), statementId, bucketNumber, bucketPath, originalFile, orcFileWriterFactory, configuration, session, hiveRowType, updateKind);
         this.partitionName = requireNonNull(partitionName, "partitionName is null");
-        this.statementId = statementId;
         this.hivePageSource = requireNonNull(hivePageSource, "hivePageSource is null");
-        this.bucketNumber = requireNonNull(bucketNumber, "bucketNumber is null");
-        this.orcFileWriterFactory = requireNonNull(orcFileWriterFactory, "orcFileWriterFactory is null");
-        this.configuration = requireNonNull(configuration, "configuration is null");
-        this.session = requireNonNull(session, "session is null");
+        this.updateKind = requireNonNull(updateKind, "updateKind is null");
         this.hiveRowTypeNullsBlock = nativeValueToBlock(hiveRowType.getType(typeManager), null);
         checkArgument(hiveTableHandle.isInAcidTransaction(), "Not in a transaction; hiveTableHandle: %s", hiveTableHandle);
         this.writeId = hiveTableHandle.getWriteId();
-        this.hiveAcidSchema = createAcidSchema(hiveRowType);
-        requireNonNull(bucketPath, "bucketPath is null");
-        if (originalFile) {
-            Matcher matcher = ORIGINAL_FILE_PATH_MATCHER.matcher(bucketPath.toString());
-            checkArgument(matcher.matches(), "Original file bucketPath doesn't have the required format: %s", bucketPath);
-            this.bucketFilename = format("bucket_%05d", bucketNumber.isEmpty() ? 0 : bucketNumber.getAsInt());
-            this.deleteDeltaDirectory = new Path(format("%s/%s", matcher.group("rootDir"), deleteDeltaSubdir(writeId, writeId, statementId)));
+        if (updateKind == AcidOperation.UPDATE) {
+            this.dependencyChannels = Optional.of(hiveTableHandle.getUpdateProcessor()
+                    .orElseThrow(() -> new IllegalArgumentException("updateProcessor not present"))
+                    .makeDependencyChannelNumbers(dependencyColumns));
         }
         else {
-            Matcher matcher = BUCKET_PATH_MATCHER.matcher(bucketPath.toString());
-            checkArgument(matcher.matches(), "bucketPath doesn't have the required format: %s", bucketPath);
-            // delete_delta bucket files should not have attemptId suffix
-            this.bucketFilename = matcher.group("filenameBase");
-            this.deleteDeltaDirectory = new Path(format("%s/%s", matcher.group("rootDir"), deleteDeltaSubdir(writeId, writeId, statementId)));
+            this.dependencyChannels = Optional.empty();
         }
     }
 
     @Override
     public void deleteRows(Block rowIds)
     {
+        List<Block> blocks = rowIds.getChildren();
+        checkArgument(blocks.size() == 3, "The rowId block for DELETE should have 3 children, but has %s", blocks.size());
+        deleteRowsInternal(rowIds);
+    }
+
+    private void deleteRowsInternal(Block rowIds)
+    {
         int positionCount = rowIds.getPositionCount();
         List<Block> blocks = rowIds.getChildren();
-        checkArgument(blocks.size() == 3, "The rowId block should have 3 children, but has " + blocks.size());
-        Block[] blockArray = new Block[] {
+        Block[] blockArray = {
                 new RunLengthEncodedBlock(DELETE_OPERATION_BLOCK, positionCount),
                 blocks.get(ORIGINAL_TRANSACTION_CHANNEL),
                 blocks.get(BUCKET_CHANNEL),
                 blocks.get(ROW_ID_CHANNEL),
                 RunLengthEncodedBlock.create(BIGINT, writeId, positionCount),
-                new RunLengthEncodedBlock(hiveRowTypeNullsBlock, positionCount)
+                new RunLengthEncodedBlock(hiveRowTypeNullsBlock, positionCount),
         };
         Page deletePage = new Page(blockArray);
 
@@ -152,41 +131,86 @@ public class HiveUpdatablePageSource
             maxWriteId = Math.max(maxWriteId, block.getLong(index, 0));
         }
 
-        lazyInitializeFileWriter();
-        checkArgument(writer.isPresent(), "writer not present");
-        writer.get().appendRows(deletePage);
+        lazyInitializeDeleteFileWriter();
+        deleteFileWriter.orElseThrow(() -> new IllegalArgumentException("deleteFileWriter not present")).appendRows(deletePage);
         rowCount += positionCount;
     }
 
-    private void lazyInitializeFileWriter()
+    @Override
+    public void updateRows(Page page, List<Integer> columnValueAndRowIdChannels)
     {
-        if (writer.isEmpty()) {
-            Properties schemaCopy = new Properties();
-            schemaCopy.putAll(hiveAcidSchema);
-            writer = orcFileWriterFactory.createFileWriter(
-                    new Path(format("%s/%s", deleteDeltaDirectory, bucketFilename)),
-                    ACID_COLUMN_NAMES,
-                    fromHiveStorageFormat(ORC),
-                    schemaCopy,
-                    toJobConf(configuration),
-                    session,
-                    bucketNumber,
-                    hiveTable.getTransaction(),
-                    true);
+        int positionCount = page.getPositionCount();
+        if (positionCount == 0) {
+            return;
         }
+
+        HiveUpdateProcessor updateProcessor = transaction.getUpdateProcessor().orElseThrow(() -> new IllegalArgumentException("updateProcessor not present"));
+        RowBlock acidRowBlock = updateProcessor.getAcidRowBlock(page, columnValueAndRowIdChannels);
+
+        List<Block> blocks = acidRowBlock.getChildren();
+        checkArgument(blocks.size() == 3 || blocks.size() == 4, "The rowId block for UPDATE should have 3 or 4 children, but has %s", blocks.size());
+        deleteRowsInternal(acidRowBlock);
+
+        Block mergedColumnsBlock = updateProcessor.createMergedColumnsBlock(page, columnValueAndRowIdChannels);
+
+        Block currentTransactionBlock = RunLengthEncodedBlock.create(BIGINT, writeId, positionCount);
+        Block[] blockArray = {
+                new RunLengthEncodedBlock(INSERT_OPERATION_BLOCK, positionCount),
+                currentTransactionBlock,
+                blocks.get(BUCKET_CHANNEL),
+                createRowIdBlock(positionCount),
+                currentTransactionBlock,
+                mergedColumnsBlock,
+        };
+
+        Page insertPage = new Page(blockArray);
+        lazyInitializeInsertFileWriter();
+        insertFileWriter.orElseThrow(() -> new IllegalArgumentException("insertFileWriter not present")).appendRows(insertPage);
+    }
+
+    Block createRowIdBlock(int positionCount)
+    {
+        long[] rowIds = new long[positionCount];
+        for (int index = 0; index < positionCount; index++) {
+            rowIds[index] = insertRowCounter++;
+        }
+        return new LongArrayBlock(positionCount, Optional.empty(), rowIds);
     }
 
     @Override
     public CompletableFuture<Collection<Slice>> finish()
     {
-        if (writer.isPresent()) {
-            OrcFileWriter orcFileWriter = (OrcFileWriter) writer.get();
-            orcFileWriter.setMaxWriteId(maxWriteId);
-            orcFileWriter.commit();
-            Slice fragment = Slices.wrappedBuffer(CODEC.toJsonBytes(new PartitionAndStatementId(partitionName, statementId, rowCount, deleteDeltaDirectory.toString())));
-            return completedFuture(ImmutableList.of(fragment));
+        if (deleteFileWriter.isEmpty()) {
+            return completedFuture(ImmutableList.of());
         }
-        return completedFuture(ImmutableList.of());
+        OrcFileWriter deleteWriter = (OrcFileWriter) deleteFileWriter.get();
+        deleteWriter.setMaxWriteId(maxWriteId);
+        deleteWriter.commit();
+
+        Optional<String> deltaDirectoryString;
+        switch (updateKind) {
+            case DELETE:
+                deltaDirectoryString = Optional.empty();
+                break;
+
+            case UPDATE:
+                OrcFileWriter insertWriter = (OrcFileWriter) insertFileWriter.get();
+                insertWriter.setMaxWriteId(maxWriteId);
+                insertWriter.commit();
+                checkArgument(deltaDirectory.isPresent(), "deltaDirectory not present");
+                deltaDirectoryString = Optional.of(deltaDirectory.get().toString());
+                break;
+
+            default:
+                throw new IllegalArgumentException("Unknown UpdateKind " + updateKind);
+        }
+        Slice fragment = Slices.wrappedBuffer(CODEC.toJsonBytes(new PartitionAndStatementId(
+                partitionName,
+                statementId,
+                rowCount,
+                deleteDeltaDirectory.toString(),
+                deltaDirectoryString)));
+        return completedFuture(ImmutableList.of(fragment));
     }
 
     @Override
@@ -215,7 +239,14 @@ public class HiveUpdatablePageSource
             close();
             return null;
         }
-        return page;
+        if (transaction.isUpdate()) {
+            HiveUpdateProcessor updateProcessor = transaction.getUpdateProcessor().orElseThrow(() -> new IllegalArgumentException("updateProcessor not present"));
+            List<Integer> channels = dependencyChannels.orElseThrow(() -> new IllegalArgumentException("dependencyChannels not present"));
+            return updateProcessor.removeNonDependencyColumns(page, channels);
+        }
+        else {
+            return page;
+        }
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateProcessor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateProcessor.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.orc.OrcDeletedRows.MaskDeletedRowsFunction;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.type.RowType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.SYNTHESIZED;
+import static io.trino.plugin.hive.HiveColumnHandle.UPDATE_ROW_ID_COLUMN_INDEX;
+import static io.trino.plugin.hive.HiveColumnHandle.UPDATE_ROW_ID_COLUMN_NAME;
+import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
+import static io.trino.plugin.hive.HiveType.toHiveType;
+import static io.trino.plugin.hive.HiveUpdatablePageSource.BUCKET_CHANNEL;
+import static io.trino.plugin.hive.HiveUpdatablePageSource.ORIGINAL_TRANSACTION_CHANNEL;
+import static io.trino.plugin.hive.HiveUpdatablePageSource.ROW_CHANNEL;
+import static io.trino.plugin.hive.HiveUpdatablePageSource.ROW_ID_CHANNEL;
+import static io.trino.plugin.hive.acid.AcidSchema.ACID_COLUMN_ROW_STRUCT;
+import static io.trino.plugin.hive.acid.AcidSchema.ACID_READ_FIELDS;
+import static io.trino.spi.block.RowBlock.fromFieldBlocks;
+import static io.trino.spi.type.RowType.Field;
+import static io.trino.spi.type.RowType.field;
+import static io.trino.spi.type.RowType.from;
+import static java.util.Objects.requireNonNull;
+
+public class HiveUpdateProcessor
+{
+    private final List<HiveColumnHandle> allDataColumns;
+    private final List<HiveColumnHandle> updatedColumns;
+    private final Set<String> updatedColumnNames;
+    private final List<HiveColumnHandle> nonUpdatedColumns;
+    private final Set<String> nonUpdatedColumnNames;
+
+    @JsonCreator
+    public HiveUpdateProcessor(
+            @JsonProperty("allColumns") List<HiveColumnHandle> allDataColumns,
+            @JsonProperty("updatedColumns") List<HiveColumnHandle> updatedColumns)
+    {
+        this.allDataColumns = requireNonNull(allDataColumns, "allColumns is null");
+        this.updatedColumns = requireNonNull(updatedColumns, "updatedColumns is null");
+        this.updatedColumnNames = updatedColumns.stream().map(HiveColumnHandle::getName).collect(toImmutableSet());
+        Set<String> allDataColumnNames = allDataColumns.stream().map(HiveColumnHandle::getName).collect(toImmutableSet());
+        checkArgument(allDataColumnNames.containsAll(updatedColumnNames), "allColumns does not contain all updatedColumns");
+        this.nonUpdatedColumns = allDataColumns.stream()
+                .filter(column -> !updatedColumnNames.contains(column.getName()))
+                .collect(toImmutableList());
+        this.nonUpdatedColumnNames = nonUpdatedColumns.stream().map(HiveColumnHandle::getName).collect(toImmutableSet());
+    }
+
+    @JsonProperty
+    public List<HiveColumnHandle> getAllDataColumns()
+    {
+        return allDataColumns;
+    }
+
+    @JsonProperty
+    public List<HiveColumnHandle> getUpdatedColumns()
+    {
+        return updatedColumns;
+    }
+
+    @JsonIgnore
+    public List<HiveColumnHandle> getNonUpdatedColumns()
+    {
+        return nonUpdatedColumns;
+    }
+
+    /**
+     * Merge the non-updated columns with the update dependencies, in allDataColumns order,
+     * and finally add the rowId column as the last dependency.
+     */
+    public List<HiveColumnHandle> mergeWithNonUpdatedColumns(List<HiveColumnHandle> updateDependencies)
+    {
+        ImmutableList.Builder<HiveColumnHandle> builder = ImmutableList.builder();
+        Set<String> updateDependencyNames = updateDependencies.stream().map(HiveColumnHandle::getName).collect(toImmutableSet());
+        for (HiveColumnHandle handle : allDataColumns) {
+            if (nonUpdatedColumnNames.contains(handle.getName()) || updateDependencyNames.contains(handle.getName())) {
+                builder.add(handle);
+            }
+        }
+        // The last updateDependency is the rowId column
+        builder.add(updateDependencies.get(updateDependencies.size() - 1));
+        return builder.build();
+    }
+
+    /**
+     * Create a RowBlock containing four children: the three ACID columns - - originalTransaction,
+     * rowId, bucket - - and a RowBlock containing all the data columns not changed
+     * by the UPDATE statement.
+     */
+    public Block createUpdateRowBlock(Page page, List<Integer> nonUpdatedChannelNumbers, MaskDeletedRowsFunction maskDeletedRowsFunction)
+    {
+        requireNonNull(page, "page is null");
+        requireNonNull(nonUpdatedChannelNumbers, "nonUpdatedChannelNumbers is null");
+        int acidBlocks = 3;
+        checkArgument(page.getChannelCount() >= acidBlocks + nonUpdatedColumns.size(), "page doesn't have enough columns");
+
+        Block[] blocks = new Block[acidBlocks + (nonUpdatedColumns.isEmpty() ? 0 : 1)];
+        blocks[ORIGINAL_TRANSACTION_CHANNEL] = page.getBlock(ORIGINAL_TRANSACTION_CHANNEL);
+        blocks[ROW_ID_CHANNEL] = page.getBlock(ROW_ID_CHANNEL);
+        blocks[BUCKET_CHANNEL] = page.getBlock(BUCKET_CHANNEL);
+
+        if (!nonUpdatedColumns.isEmpty()) {
+            Block[] nonUpdatedColumnBlocks = new Block[getNonUpdatedColumns().size()];
+            int offset = 0;
+            for (int sourceChannel : nonUpdatedChannelNumbers) {
+                nonUpdatedColumnBlocks[offset] = page.getBlock(acidBlocks + sourceChannel);
+                offset++;
+            }
+            blocks[ROW_CHANNEL] = RowBlock.fromFieldBlocks(page.getPositionCount(), Optional.empty(), nonUpdatedColumnBlocks);
+        }
+        return maskDeletedRowsFunction.apply(fromFieldBlocks(
+                page.getPositionCount(),
+                Optional.empty(),
+                blocks));
+    }
+
+    /**
+     * Project expects the page to begin with the update dependencies, followed by
+     * the "rowId" column.  Remove columns from the page if they are not
+     * update dependencies.
+     */
+    public Page removeNonDependencyColumns(Page page, List<Integer> dependencyChannels)
+    {
+        int dependencyCount = dependencyChannels.size();
+        Block[] blocks = new Block[dependencyCount + 1];
+        int index = 0;
+        for (Integer channel : dependencyChannels) {
+            blocks[index] = page.getBlock(channel);
+            index++;
+        }
+        // Copy the rowId block
+        blocks[dependencyCount] = page.getBlock(page.getChannelCount() - 1);
+        return new Page(blocks);
+    }
+
+    /**
+     * Return the column UPDATE column handle, which depends on the 3 ACID columns as well as the non-updated columns.
+     */
+    public static HiveColumnHandle getUpdateRowIdColumnHandle(List<HiveColumnHandle> nonUpdatedColumnHandles)
+    {
+        List<Field> allAcidFields = new ArrayList<>(ACID_READ_FIELDS);
+        if (!nonUpdatedColumnHandles.isEmpty()) {
+            RowType userColumnRowType = from(nonUpdatedColumnHandles.stream()
+                    .map(column -> field(column.getName(), column.getType()))
+                    .collect(toImmutableList()));
+
+            allAcidFields.add(field(ACID_COLUMN_ROW_STRUCT, userColumnRowType));
+        }
+        RowType acidRowType = from(allAcidFields);
+        return createBaseColumn(UPDATE_ROW_ID_COLUMN_NAME, UPDATE_ROW_ID_COLUMN_INDEX, toHiveType(acidRowType), acidRowType, SYNTHESIZED, Optional.empty());
+    }
+
+    public RowBlock getAcidRowBlock(Page page, List<Integer> columnValueAndRowIdChannels)
+    {
+        Block acidBlock = page.getBlock(columnValueAndRowIdChannels.get(columnValueAndRowIdChannels.size() - 1));
+        checkArgument(acidBlock instanceof RowBlock, "The acid block in the page must be a RowBlock, but instead was %s", acidBlock);
+        return (RowBlock) acidBlock;
+    }
+
+    /**
+     * @param page The first block in the page is a RowBlock, containing the three ACID
+     * columns - - originalTransaction, bucket and rowId - - plus a RowBlock containing
+     * the values of non-updated columns. The remaining blocks are the values of the updated
+     * columns, whose offsets given by columnValueAndRowIdChannels
+     * @return The RowBlock for updated and non-updated columns
+     */
+    public Block createMergedColumnsBlock(Page page, List<Integer> columnValueAndRowIdChannels)
+    {
+        requireNonNull(page, "originalPage is null");
+        RowBlock acidBlock = getAcidRowBlock(page, columnValueAndRowIdChannels);
+        List<Block> acidBlocks = acidBlock.getChildren();
+        List<Block> nonUpdatedColumnRowBlocks;
+        if (nonUpdatedColumns.isEmpty()) {
+            checkArgument(acidBlocks.size() == 3, "The ACID RowBlock must contain 3 children, but instead had %s children", acidBlocks.size());
+            nonUpdatedColumnRowBlocks = ImmutableList.of();
+        }
+        else {
+            checkArgument(acidBlocks.size() == 4, "The first RowBlock must contain 4 children, but instead had %s children", acidBlocks.size());
+            Block lastAcidBlock = acidBlocks.get(3);
+            checkArgument(lastAcidBlock instanceof RowBlock, "The last block in the acidBlock must be a RowBlock, but instead was %s", lastAcidBlock);
+            nonUpdatedColumnRowBlocks = lastAcidBlock.getChildren();
+        }
+
+        // Merge the non-updated and updated column blocks
+        Block[] dataColumnBlocks = new Block[allDataColumns.size()];
+        int targetColumnChannel = 0;
+        int nonUpdatedColumnChannel = 0;
+        int updatedColumnNumber = 0;
+        for (HiveColumnHandle column : allDataColumns) {
+            Block block;
+            if (nonUpdatedColumnNames.contains(column.getName())) {
+                block = nonUpdatedColumnRowBlocks.get(nonUpdatedColumnChannel);
+                nonUpdatedColumnChannel++;
+            }
+            else {
+                int index = columnValueAndRowIdChannels.get(updatedColumnNumber);
+                block = page.getBlock(index);
+                updatedColumnNumber++;
+            }
+            dataColumnBlocks[targetColumnChannel] = block;
+            targetColumnChannel++;
+        }
+        return RowBlock.fromFieldBlocks(page.getPositionCount(), Optional.empty(), dataColumnBlocks);
+    }
+
+    public List<Integer> makeDependencyChannelNumbers(List<HiveColumnHandle> dependencyColumns)
+    {
+        ImmutableList.Builder<Integer> dependencyIndexBuilder = ImmutableList.builder();
+        Set<String> dependencyColumnNames = dependencyColumns.stream().map(HiveColumnHandle::getName).collect(toImmutableSet());
+        int dependencyIndex = 0;
+        for (HiveColumnHandle handle : allDataColumns) {
+            if (dependencyColumnNames.contains(handle.getName())) {
+                dependencyIndexBuilder.add(dependencyIndex);
+                dependencyIndex++;
+            }
+            else if (nonUpdatedColumnNames.contains(handle.getName())) {
+                dependencyIndex++;
+            }
+        }
+        return dependencyIndexBuilder.build();
+    }
+
+    public List<Integer> makeNonUpdatedSourceChannels(List<HiveColumnHandle> dependencyColumns)
+    {
+        ImmutableMap.Builder<HiveColumnHandle, Integer> nonUpdatedNumbersBuilder = ImmutableMap.builder();
+        Set<String> dependencyColumnNames = dependencyColumns.stream().map(HiveColumnHandle::getName).collect(toImmutableSet());
+        int nonUpdatedIndex = 0;
+        for (HiveColumnHandle handle : allDataColumns) {
+            if (nonUpdatedColumnNames.contains(handle.getName())) {
+                nonUpdatedNumbersBuilder.put(handle, nonUpdatedIndex);
+                nonUpdatedIndex++;
+            }
+            else if (dependencyColumnNames.contains(handle.getName())) {
+                nonUpdatedIndex++;
+            }
+        }
+        Map<HiveColumnHandle, Integer> nonUpdatedMap = nonUpdatedNumbersBuilder.build();
+        return nonUpdatedColumns.stream().map(nonUpdatedMap::get).collect(toImmutableList());
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWritableTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWritableTableHandle.java
@@ -56,7 +56,7 @@ public class HiveWritableTableHandle
         this.bucketProperty = requireNonNull(bucketProperty, "bucketProperty is null");
         this.tableStorageFormat = requireNonNull(tableStorageFormat, "tableStorageFormat is null");
         this.partitionStorageFormat = requireNonNull(partitionStorageFormat, "partitionStorageFormat is null");
-        this.transaction = requireNonNull(transaction);
+        this.transaction = requireNonNull(transaction, "transaction is null");
     }
 
     @JsonProperty

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
@@ -470,7 +470,8 @@ public class HiveWriterFactory
                     session,
                     bucketNumber,
                     transaction,
-                    useAcidSchema);
+                    useAcidSchema,
+                    WriterKind.INSERT);
 
             if (fileWriter.isPresent()) {
                 hiveFileWriter = fileWriter.get();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionAndStatementId.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionAndStatementId.java
@@ -14,10 +14,14 @@
 package io.trino.plugin.hive;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import io.airlift.json.JsonCodec;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -29,18 +33,21 @@ public class PartitionAndStatementId
     private final int statementId;
     private final long rowCount;
     private final String deleteDeltaDirectory;
+    private final Optional<String> deltaDirectory;
 
     @JsonCreator
     public PartitionAndStatementId(
             @JsonProperty("partitionName") String partitionName,
             @JsonProperty("statementId") int statementId,
             @JsonProperty("rowCount") long rowCount,
-            @JsonProperty("deleteDeltaDirectory") String deleteDeltaDirectory)
+            @JsonProperty("deleteDeltaDirectory") String deleteDeltaDirectory,
+            @JsonProperty("deltaDirectory") Optional<String> deltaDirectory)
     {
         this.partitionName = requireNonNull(partitionName, "partitionName is null");
         this.statementId = statementId;
         this.rowCount = rowCount;
         this.deleteDeltaDirectory = requireNonNull(deleteDeltaDirectory, "deleteDeltaDirectory is null");
+        this.deltaDirectory = requireNonNull(deltaDirectory, "deltaDirectory is null");
     }
 
     @JsonProperty
@@ -67,6 +74,20 @@ public class PartitionAndStatementId
         return deleteDeltaDirectory;
     }
 
+    @JsonProperty
+    public Optional<String> getDeltaDirectory()
+    {
+        return deltaDirectory;
+    }
+
+    @JsonIgnore
+    public List<String> getAllDirectories()
+    {
+        return deltaDirectory
+                .map(directory -> ImmutableList.of(deleteDeltaDirectory, directory))
+                .orElseGet(() -> ImmutableList.of(deleteDeltaDirectory));
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -80,12 +101,13 @@ public class PartitionAndStatementId
         return statementId == that.statementId &&
                 rowCount == that.rowCount &&
                 partitionName.equals(that.partitionName) &&
-                deleteDeltaDirectory.equals(that.deleteDeltaDirectory);
+                deleteDeltaDirectory.equals(that.deleteDeltaDirectory) &&
+                deltaDirectory.equals(that.deltaDirectory);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(partitionName, statementId, rowCount, deleteDeltaDirectory);
+        return Objects.hash(partitionName, statementId, rowCount, deleteDeltaDirectory, deltaDirectory);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriterFactory.java
@@ -100,7 +100,8 @@ public class RcFileFileWriterFactory
             ConnectorSession session,
             OptionalInt bucketNumber,
             AcidTransaction transaction,
-            boolean useAcidSchema)
+            boolean useAcidSchema,
+            WriterKind writerKind)
     {
         if (!RCFileOutputFormat.class.getName().equals(storageFormat.getOutputFormat())) {
             return Optional.empty();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/WriterKind.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/WriterKind.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+public enum WriterKind
+{
+    DELETE,
+    INSERT;
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/acid/AcidOperation.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/acid/AcidOperation.java
@@ -13,33 +13,37 @@
  */
 package io.trino.plugin.hive.acid;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.orc.OrcWriter.OrcOperation;
 import org.apache.hadoop.hive.metastore.api.DataOperationType;
+
+import java.util.Map;
+import java.util.Optional;
 
 public enum AcidOperation
 {
     // UPDATE and MERGE will be added when they are implemented
-    NONE(DataOperationType.NO_TXN, OrcOperation.NONE),
-    CREATE_TABLE(DataOperationType.NO_TXN, OrcOperation.NONE),
-    DELETE(DataOperationType.DELETE, OrcOperation.DELETE),
-    INSERT(DataOperationType.INSERT, OrcOperation.INSERT);
+    NONE,
+    CREATE_TABLE,
+    DELETE,
+    INSERT,
+    UPDATE;
 
-    private final DataOperationType metastoreOperationType;
-    private final OrcOperation orcOperation;
+    private static final Map<AcidOperation, DataOperationType> DATA_OPERATION_TYPES = ImmutableMap.of(
+            DELETE, DataOperationType.DELETE,
+            INSERT, DataOperationType.INSERT);
 
-    AcidOperation(DataOperationType metastoreOperationType, OrcOperation orcOperation)
+    private static final Map<AcidOperation, OrcOperation> ORC_OPERATIONS = ImmutableMap.of(
+            DELETE, OrcOperation.DELETE,
+            INSERT, OrcOperation.INSERT);
+
+    public Optional<DataOperationType> getMetastoreOperationType()
     {
-        this.metastoreOperationType = metastoreOperationType;
-        this.orcOperation = orcOperation;
+        return Optional.ofNullable(DATA_OPERATION_TYPES.get(this));
     }
 
-    public DataOperationType getMetastoreOperationType()
+    public Optional<OrcOperation> getOrcOperation()
     {
-        return metastoreOperationType;
-    }
-
-    public OrcOperation getOrcOperation()
-    {
-        return orcOperation;
+        return Optional.ofNullable(ORC_OPERATIONS.get(this));
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/acid/AcidSchema.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/acid/AcidSchema.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.HiveTypeName;
 import io.trino.spi.type.RowType;
+import io.trino.spi.type.RowType.Field;
 import io.trino.spi.type.Type;
 import org.apache.hadoop.hive.ql.io.IOConstants;
 
@@ -50,11 +51,12 @@ public final class AcidSchema
             ACID_COLUMN_ROW_ID,
             ACID_COLUMN_CURRENT_TRANSACTION,
             ACID_COLUMN_ROW_STRUCT);
-
-    public static final RowType ACID_ROW_ID_ROW_TYPE = RowType.from(ImmutableList.of(
+    public static final List<Field> ACID_READ_FIELDS = ImmutableList.of(
             field(ACID_COLUMN_ORIGINAL_TRANSACTION, BIGINT),
             field(ACID_COLUMN_ROW_ID, BIGINT),
-            field(ACID_COLUMN_BUCKET, INTEGER)));
+            field(ACID_COLUMN_BUCKET, INTEGER));
+
+    public static final RowType ACID_ROW_ID_ROW_TYPE = RowType.from(ACID_READ_FIELDS);
 
     private AcidSchema() {}
 
@@ -76,9 +78,9 @@ public final class AcidSchema
         requireNonNull(names, "names is null");
         requireNonNull(types, "types is null");
         checkArgument(names.size() == types.size(), "names size %s differs from types size %s", names.size(), types.size());
-        ImmutableList.Builder<RowType.Field> builder = ImmutableList.builder();
+        ImmutableList.Builder<Field> builder = ImmutableList.builder();
         for (int i = 0; i < names.size(); i++) {
-            builder.add(new RowType.Field(Optional.of(names.get(i)), types.get(i)));
+            builder.add(new Field(Optional.of(names.get(i)), types.get(i)));
         }
         return RowType.from(builder.build());
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -566,7 +566,7 @@ public class ThriftHiveMetastoreClient
             throws TException
     {
         AddDynamicPartitions request = new AddDynamicPartitions(transactionId, writeId, dbName, tableName, partitionNames);
-        request.setOperationType(operation.getMetastoreOperationType());
+        request.setOperationType(operation.getMetastoreOperationType().get());
         client.add_dynamic_partitions(request);
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriterFactory.java
@@ -27,7 +27,7 @@ import io.trino.plugin.hive.FileWriter;
 import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.plugin.hive.HiveFileWriterFactory;
 import io.trino.plugin.hive.NodeVersion;
-import io.trino.plugin.hive.acid.AcidSchema;
+import io.trino.plugin.hive.WriterKind;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.StorageFormat;
 import io.trino.spi.TrinoException;
@@ -68,6 +68,7 @@ import static io.trino.plugin.hive.HiveSessionProperties.getTimestampPrecision;
 import static io.trino.plugin.hive.HiveSessionProperties.isOrcOptimizedWriterValidate;
 import static io.trino.plugin.hive.acid.AcidSchema.ACID_COLUMN_NAMES;
 import static io.trino.plugin.hive.acid.AcidSchema.createAcidColumnPrestoTypes;
+import static io.trino.plugin.hive.acid.AcidSchema.createRowType;
 import static io.trino.plugin.hive.util.HiveUtil.getColumnNames;
 import static io.trino.plugin.hive.util.HiveUtil.getColumnTypes;
 import static io.trino.plugin.hive.util.HiveUtil.getOrcWriterOptions;
@@ -137,7 +138,8 @@ public class OrcFileWriterFactory
             ConnectorSession session,
             OptionalInt bucketNumber,
             AcidTransaction transaction,
-            boolean useAcidSchema)
+            boolean useAcidSchema,
+            WriterKind writerKind)
     {
         if (!OrcOutputFormat.class.getName().equals(storageFormat.getOutputFormat())) {
             return Optional.empty();
@@ -155,7 +157,7 @@ public class OrcFileWriterFactory
         int[] fileInputColumnIndexes = fileColumnNames.stream()
                 .mapToInt(inputColumnNames::indexOf)
                 .toArray();
-        if (transaction.isDelete()) {
+        if (transaction.isAcidDeleteOperation(writerKind)) {
             // For delete, set the "row" column to -1
             fileInputColumnIndexes[fileInputColumnIndexes.length - 1] = -1;
         }
@@ -187,17 +189,18 @@ public class OrcFileWriterFactory
             };
 
             if (transaction.isInsert() && useAcidSchema) {
-                // Only add the ACID columns if the request is for INSERT -- for DELETE, the columns are
-                // added by the caller.  This is because the ACID columns for DELETE depend on the rows
-                // being deleted, whereas the ACID columns for INSERT are completely determined by bucket
-                // and writeId.
-                Type rowType = AcidSchema.createRowType(fileColumnNames, fileColumnTypes);
+                // Only add the ACID columns if the request is for insert-type operations - - for delete operations,
+                // the columns are added by the caller.  This is because the ACID columns for delete operations
+                // depend on the rows being deleted, whereas the ACID columns for INSERT are completely determined
+                // by bucket and writeId.
+                Type rowType = createRowType(fileColumnNames, fileColumnTypes);
                 fileColumnNames = ACID_COLUMN_NAMES;
                 fileColumnTypes = createAcidColumnPrestoTypes(rowType);
             }
 
             return Optional.of(new OrcFileWriter(
                     orcDataSink,
+                    writerKind,
                     transaction,
                     useAcidSchema,
                     bucketNumber,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -19,6 +19,7 @@ import io.trino.plugin.hive.FileWriter;
 import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.plugin.hive.HiveFileWriterFactory;
 import io.trino.plugin.hive.HiveSessionProperties;
+import io.trino.plugin.hive.WriterKind;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.StorageFormat;
 import io.trino.spi.TrinoException;
@@ -73,7 +74,8 @@ public class ParquetFileWriterFactory
             ConnectorSession session,
             OptionalInt bucketNumber,
             AcidTransaction transaction,
-            boolean useAcidSchema)
+            boolean useAcidSchema,
+            WriterKind writerKind)
     {
         if (!HiveSessionProperties.isParquetOptimizedWriterEnabled(session)) {
             return Optional.empty();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
@@ -223,6 +223,11 @@ public class LegacyAccessControl
     }
 
     @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    {
+    }
+
+    @Override
     public void checkCanCreateView(ConnectorSecurityContext context, SchemaTableName viewName)
     {
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -45,6 +45,7 @@ import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.DEL
 import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.INSERT;
 import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
 import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.SELECT;
+import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.UPDATE;
 import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.toHivePrivilege;
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.isRoleApplicable;
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.isRoleEnabled;
@@ -85,6 +86,7 @@ import static io.trino.spi.security.AccessDeniedException.denyShowCreateSchema;
 import static io.trino.spi.security.AccessDeniedException.denyShowCreateTable;
 import static io.trino.spi.security.AccessDeniedException.denyShowRoleAuthorizationDescriptors;
 import static io.trino.spi.security.AccessDeniedException.denyShowRoles;
+import static io.trino.spi.security.AccessDeniedException.denyUpdateTableColumns;
 import static io.trino.spi.security.PrincipalType.ROLE;
 import static io.trino.spi.security.PrincipalType.USER;
 import static java.util.Objects.requireNonNull;
@@ -292,6 +294,14 @@ public class SqlStandardAccessControl
     {
         if (!checkTablePermission(context, tableName, DELETE, false)) {
             denyDeleteTable(tableName.toString());
+        }
+    }
+
+    @Override
+    public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumns)
+    {
+        if (!checkTablePermission(context, tableName, UPDATE, false)) {
+            denyUpdateTableColumns(tableName.toString(), updatedColumns);
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileFormats.java
@@ -589,7 +589,8 @@ public abstract class AbstractTestHiveFileFormats
                 session,
                 OptionalInt.empty(),
                 NO_ACID_TRANSACTION,
-                false);
+                false,
+                WriterKind.INSERT);
 
         FileWriter hiveFileWriter = fileWriter.orElseThrow(() -> new IllegalArgumentException("fileWriterFactory"));
         hiveFileWriter.appendRows(page);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -590,7 +590,7 @@ public class IcebergMetadata
     }
 
     @Override
-    public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ColumnHandle getDeleteRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         return new IcebergColumnHandle(0, "$row_id", BIGINT, Optional.empty());
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergOrcFileWriter.java
@@ -31,6 +31,7 @@ import io.trino.orc.metadata.statistics.DecimalStatistics;
 import io.trino.orc.metadata.statistics.DoubleStatistics;
 import io.trino.orc.metadata.statistics.IntegerStatistics;
 import io.trino.orc.metadata.statistics.StringStatistics;
+import io.trino.plugin.hive.WriterKind;
 import io.trino.plugin.hive.orc.OrcFileWriter;
 import io.trino.spi.type.Type;
 import org.apache.iceberg.Metrics;
@@ -78,7 +79,7 @@ public class IcebergOrcFileWriter
             OrcWriteValidation.OrcWriteValidationMode validationMode,
             OrcWriterStats stats)
     {
-        super(orcDataSink, NO_ACID_TRANSACTION, false, OptionalInt.empty(), rollbackAction, columnNames, fileColumnTypes, fileColumnOrcTypes, compression, options, writeLegacyVersion, fileInputColumnIndexes, metadata, validationInputFactory, validationMode, stats);
+        super(orcDataSink, WriterKind.INSERT, NO_ACID_TRANSACTION, false, OptionalInt.empty(), rollbackAction, columnNames, fileColumnTypes, fileColumnOrcTypes, compression, options, writeLegacyVersion, fileInputColumnIndexes, metadata, validationInputFactory, validationMode, stats);
         this.icebergSchema = requireNonNull(icebergSchema, "icebergSchema is null");
         orcColumns = fileColumnOrcTypes;
     }

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
@@ -409,7 +409,7 @@ public class KuduMetadata
     }
 
     @Override
-    public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ColumnHandle getDeleteRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         return KuduColumnHandle.ROW_ID_HANDLE;
     }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorMetadata.java
@@ -776,7 +776,7 @@ public class RaptorMetadata
     }
 
     @Override
-    public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public ColumnHandle getDeleteRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         return shardRowIdHandle();
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveTransactionalTable.java
@@ -713,6 +713,23 @@ public class TestHiveTransactionalTable
         });
     }
 
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testDeleteAllRowsInPartition()
+    {
+        withTemporaryTable("bucketed_partitioned_delete", true, true, NONE, tableName -> {
+            onHive().executeQuery(format("CREATE TABLE %s (purchase STRING) PARTITIONED BY (customer STRING) STORED AS ORC TBLPROPERTIES ('transactional' = 'true')", tableName));
+
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (customer, purchase) VALUES ('Fred', 'cards'), ('Fred', 'cereal'), ('Ann', 'lemons'), ('Ann', 'chips')", tableName));
+
+            log.info("About to delete");
+            onPresto().executeQuery(format("DELETE FROM %s WHERE customer = 'Fred'", tableName));
+
+            log.info("About to verify");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "TRUE", row("lemons", "Ann"), row("chips", "Ann"));
+        });
+    }
+
     @Test(groups = HIVE_TRANSACTIONAL, dataProvider = "inserterAndDeleterProvider", timeOut = TEST_TIMEOUT)
     public void testBucketedUnpartitionedDelete(HiveOrPresto inserter, HiveOrPresto deleter)
     {
@@ -940,6 +957,306 @@ public class TestHiveTransactionalTable
                 {true},
                 {false},
         };
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateFailNonTransactional()
+    {
+        withTemporaryTable("update_fail_nontransactional", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (customer VARCHAR, purchase VARCHAR)", tableName));
+
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (customer, purchase) VALUES ('Fred', 'cards')", tableName));
+
+            log.info("About to fail update");
+            assertThat(() -> onPresto().executeQuery(format("UPDATE %s SET purchase = 'bread' WHERE customer = 'Fred'", tableName)))
+                    .failsWithMessage("Hive update is only supported for transactional tables");
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateFailUpdatePartitionKey()
+    {
+        withTemporaryTable("fail_update_partition_key", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 INT, col2 VARCHAR, col3 BIGINT) WITH (transactional = true, partitioned_by = ARRAY['col3'])", tableName));
+
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3) VALUES (17, 'S1', 7)", tableName));
+
+            log.info("About to fail update");
+            assertThat(() -> onPresto().executeQuery(format("UPDATE %s SET col3 = 17 WHERE col3 = 7", tableName)))
+                    .failsWithMessage("Updating Hive table partition columns is not supported");
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateFailUpdateBucketColumn()
+    {
+        withTemporaryTable("fail_update_bucket_column", true, true, NONE, tableName -> {
+            onHive().executeQuery(format("CREATE TABLE %s (customer STRING, purchase STRING) CLUSTERED BY (purchase) INTO 3 BUCKETS STORED AS ORC TBLPROPERTIES ('transactional' = 'true')", tableName));
+
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (customer, purchase) VALUES ('Fred', 'cards')", tableName));
+
+            log.info("About to fail update");
+            assertThat(() -> onPresto().executeQuery(format("UPDATE %s SET purchase = 'bread' WHERE customer = 'Fred'", tableName)))
+                    .failsWithMessage("Updating Hive table bucket columns is not supported");
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateFailOnIllegalCast()
+    {
+        withTemporaryTable("fail_update_on_illegal_cast", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 INT, col2 VARCHAR, col3 BIGINT) WITH (transactional = true)", tableName));
+
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3) VALUES (17, 'S1', 7)", tableName));
+
+            log.info("About to fail update");
+            assertThat(() -> onPresto().executeQuery(format("UPDATE %s SET col1 = col2 WHERE col3 = 7", tableName)))
+                    .failsWithMessage("UPDATE table column types don't match SET expressions: Table: [integer], Expressions: [varchar]");
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateSimple()
+    {
+        withTemporaryTable("acid_update_simple", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 TINYINT, col2 VARCHAR, col3 BIGINT, col4 BOOLEAN, col5 INT) WITH (transactional = true)", tableName));
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (7, 'ONE', 1000, true, 101), (13, 'TWO', 2000, false, 202)", tableName));
+            log.info("About to update");
+            onPresto().executeQuery(format("UPDATE %s SET col2 = 'DEUX', col3 = col3 + 20 + col1 + col5 WHERE col1 = 13", tableName));
+            log.info("Finished update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(7, "ONE", 1000, true, 101), row(13, "DEUX", 2235, false, 202));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateSelectedValues()
+    {
+        withTemporaryTable("acid_update_simple", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 TINYINT, col2 VARCHAR, col3 BIGINT, col4 BOOLEAN, col5 INT) WITH (transactional = true)", tableName));
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (7, 'ONE', 1000, true, 101), (13, 'TWO', 2000, false, 202)", tableName));
+            log.info("About to update %s", tableName);
+            onPresto().executeQuery(format("UPDATE %s SET col2 = 'DEUX', col3 = col3 + 20 + col1 + col5 WHERE col1 = 13", tableName));
+            log.info("Finished update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(7, "ONE", 1000, true, 101), row(13, "DEUX", 2235, false, 202));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateCopyColumn()
+    {
+        withTemporaryTable("acid_update_copy_column", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 int, col2 int, col3 VARCHAR) WITH (transactional = true)", tableName));
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3) VALUES (7, 15, 'ONE'), (13, 17, 'DEUX')", tableName));
+            log.info("About to update");
+            onPresto().executeQuery(format("UPDATE %s SET col1 = col2 WHERE col1 = 13", tableName));
+            log.info("Finished update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(7, 15, "ONE"), row(17, 17, "DEUX"));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateSomeLiteralNullColumnValues()
+    {
+        withTemporaryTable("update_some_literal_null_columns", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 TINYINT, col2 VARCHAR, col3 BIGINT, col4 BOOLEAN, col5 INT) WITH (transactional = true)", tableName));
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (1, 'ONE', 1000, true, 101), (2, 'TWO', 2000, false, 202)", tableName));
+            log.info("About to run first update");
+            onPresto().executeQuery(format("UPDATE %s SET col2 = NULL, col3 = NULL WHERE col1 = 2", tableName));
+            log.info("Finished first update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(1, "ONE", 1000, true, 101), row(2, null, null, false, 202));
+            log.info("About to run second update");
+            onPresto().executeQuery(format("UPDATE %s SET col1 = NULL, col2 = NULL, col3 = NULL, col4 = NULL WHERE col1 = 1", tableName));
+            log.info("Finished first update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(null, null, null, null, 101), row(2, null, null, false, 202));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateSomeComputedNullColumnValues()
+    {
+        withTemporaryTable("update_some_computed_null_columns", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 TINYINT, col2 VARCHAR, col3 BIGINT, col4 BOOLEAN, col5 INT) WITH (transactional = true)", tableName));
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (1, 'ONE', 1000, true, 101), (2, 'TWO', 2000, false, 202)", tableName));
+            log.info("About to run first update");
+            // Use IF(RAND()<0, NULL) as a way to compute null
+            onPresto().executeQuery(format("UPDATE %s SET col2 = IF(RAND()<0, NULL), col3 = IF(RAND()<0, NULL) WHERE col1 = 2", tableName));
+            log.info("Finished first update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(1, "ONE", 1000, true, 101), row(2, null, null, false, 202));
+            log.info("About to run second update");
+            onPresto().executeQuery(format("UPDATE %s SET col1 = IF(RAND()<0, NULL), col2 = IF(RAND()<0, NULL), col3 = IF(RAND()<0, NULL), col4 = IF(RAND()<0, NULL) WHERE col1 = 1", tableName));
+            log.info("Finished first update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(null, null, null, null, 101), row(2, null, null, false, 202));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateAllLiteralNullColumnValues()
+    {
+        withTemporaryTable("update_all_literal_null_columns", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 TINYINT, col2 VARCHAR, col3 BIGINT, col4 BOOLEAN, col5 INT) WITH (transactional = true)", tableName));
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (1, 'ONE', 1000, true, 101), (2, 'TWO', 2000, false, 202)", tableName));
+            log.info("About to update");
+            onPresto().executeQuery(format("UPDATE %s SET col1 = NULL, col2 = NULL, col3 = NULL, col4 = NULL, col5 = null WHERE col1 = 1", tableName));
+            log.info("Finished first update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(null, null, null, null, null), row(2, "TWO", 2000, false, 202));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateAllComputedNullColumnValues()
+    {
+        withTemporaryTable("update_all_computed_null_columns", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 TINYINT, col2 VARCHAR, col3 BIGINT, col4 BOOLEAN, col5 INT) WITH (transactional = true)", tableName));
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (1, 'ONE', 1000, true, 101), (2, 'TWO', 2000, false, 202)", tableName));
+            log.info("About to update");
+            // Use IF(RAND()<0, NULL) as a way to compute null
+            onPresto().executeQuery(format("UPDATE %s SET col1 = IF(RAND()<0, NULL), col2 = IF(RAND()<0, NULL), col3 = IF(RAND()<0, NULL), col4 = IF(RAND()<0, NULL), col5 = IF(RAND()<0, NULL) WHERE col1 = 1", tableName));
+            log.info("Finished first update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(null, null, null, null, null), row(2, "TWO", 2000, false, 202));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateReversed()
+    {
+        withTemporaryTable("update_reversed", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 TINYINT, col2 VARCHAR, col3 BIGINT, col4 BOOLEAN, col5 INT) WITH (transactional = true)", tableName));
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (1, 'ONE', 1000, true, 101), (2, 'TWO', 2000, false, 202)", tableName));
+            log.info("About to update");
+            onPresto().executeQuery(format("UPDATE %s SET col3 = col3 + 20 + col1 + col5, col1 = 3, col2 = 'DEUX' WHERE col1 = 2", tableName));
+            log.info("Finished update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(1, "ONE", 1000, true, 101), row(3, "DEUX", 2224, false, 202));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdatePermuted()
+    {
+        withTemporaryTable("update_permuted", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 TINYINT, col2 VARCHAR, col3 BIGINT, col4 BOOLEAN, col5 INT) WITH (transactional = true)", tableName));
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (1, 'ONE', 1000, true, 101), (2, 'TWO', 2000, false, 202)", tableName));
+            log.info("About to update");
+            onPresto().executeQuery(format("UPDATE %s SET col5 = 303, col1 = 3, col3 = col3 + 20 + col1 + col5, col4 = true, col2 = 'DUO' WHERE col1 = 2", tableName));
+            log.info("Finished update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(1, "ONE", 1000, true, 101), row(3, "DUO", 2224, true, 303));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateAllColumnsSetAndDependencies()
+    {
+        withTemporaryTable("update_all_columns_set", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 TINYINT, col2 INT, col3 BIGINT, col4 INT, col5 TINYINT) WITH (transactional = true)", tableName));
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (1, 2, 3, 4, 5), (21, 22, 23, 24, 25)", tableName));
+            log.info("About to update");
+            onPresto().executeQuery(format("UPDATE %s SET col5 = col4, col1 = col3, col3 = col2, col4 = col5, col2 = col1 WHERE col1 = 21", tableName));
+            log.info("Finished update");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(1, 2, 3, 4, 5), row(23, 21, 22, 25, 24));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdatePartitioned()
+    {
+        withTemporaryTable("update_partitioned", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 INT, col2 VARCHAR, col3 BIGINT) WITH (transactional = true, partitioned_by = ARRAY['col3'])", tableName));
+
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3) VALUES (13, 'T1', 3), (23, 'T2', 3), (17, 'S1', 7)", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "TRUE", row(13, "T1", 3), row(23, "T2", 3), row(17, "S1", 7));
+
+            log.info("About to update");
+            onPresto().executeQuery(format("UPDATE %s SET col1 = col1 + 1 WHERE col3 = 3 AND col1 > 15", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "TRUE", row(13, "T1", 3), row(24, "T2", 3), row(18, "S1", 7));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateBucketed()
+    {
+        withTemporaryTable("update_bucketed", true, true, NONE, tableName -> {
+            onHive().executeQuery(format("CREATE TABLE %s (customer STRING, purchase STRING) CLUSTERED BY (customer) INTO 3 BUCKETS STORED AS ORC TBLPROPERTIES ('transactional' = 'true')", tableName));
+
+            log.info("About to insert");
+            onPresto().executeQuery(format("INSERT INTO %s (customer, purchase) VALUES ('Fred', 'cards'), ('Fred', 'limes'), ('Ann', 'lemons')", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "TRUE", row("Fred", "cards"), row("Fred", "limes"), row("Ann", "lemons"));
+
+            log.info("About to update");
+            onPresto().executeQuery(format("UPDATE %s SET purchase = 'bread' WHERE customer = 'Ann'", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "TRUE", row("Fred", "cards"), row("Fred", "limes"), row("Ann", "bread"));
+        });
+    }
+
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testAcidUpdateMajorCompaction()
+    {
+        withTemporaryTable("schema_evolution_column_addition", true, false, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (column1 INT, column2 BIGINT) WITH (transactional = true)", tableName));
+            onPresto().executeQuery(format("INSERT INTO %s VALUES (11, 100)", tableName));
+            onPresto().executeQuery(format("INSERT INTO %s VALUES (22, 200)", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(11, 100L), row(22, 200L));
+            log.info("About to compact");
+            compactTableAndWait(MAJOR, tableName, "", Duration.valueOf("6m"));
+            log.info("About to update");
+            onPresto().executeQuery(format("UPDATE %s SET column1 = 33 WHERE column2 = 200", tableName));
+            log.info("About to select");
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(11, 100L), row(33, 200L));
+            onPresto().executeQuery(format("INSERT INTO %s VALUES (44, 400), (55, 500)", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(11, 100L), row(33, 200L), row(44, 400L), row(55, 500L));
+            onPresto().executeQuery(format("DELETE FROM %s WHERE column2 IN (100, 500)", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(33, 200L), row(44, 400L));
+        });
+    }
+
+    @Flaky(issue = ERROR_COMMITTING_WRITE_TO_HIVE_ISSUE, match = ERROR_COMMITTING_WRITE_TO_HIVE_MATCH)
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testInsertDeletUpdateWithPrestoAndHive()
+    {
+        withTemporaryTable("update_insert_delete_presto_hive", true, true, NONE, tableName -> {
+            onPresto().executeQuery(format("CREATE TABLE %s (col1 TINYINT, col2 INT, col3 BIGINT, col4 INT, col5 TINYINT) WITH (transactional = true)", tableName));
+
+            log.info("Performing first insert on Presto");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (1, 2, 3, 4, 5), (21, 22, 23, 24, 25)", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "TRUE", row(1, 2, 3, 4, 5), row(21, 22, 23, 24, 25));
+
+            log.info("Performing first update on Presto");
+            onPresto().executeQuery(format("UPDATE %s SET col5 = col4, col1 = col3, col3 = col2, col4 = col5, col2 = col1 WHERE col1 = 21", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(1, 2, 3, 4, 5), row(23, 21, 22, 25, 24));
+
+            log.info("Performing second insert on Hive");
+            onHive().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (31, 32, 33, 34, 35)", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(1, 2, 3, 4, 5), row(23, 21, 22, 25, 24), row(31, 32, 33, 34, 35));
+
+            log.info("Performing first delete on Presto");
+            onPresto().executeQuery(format("DELETE FROM %s WHERE col1 = 23", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(1, 2, 3, 4, 5), row(31, 32, 33, 34, 35));
+
+            log.info("Performing second update on Hive");
+            onHive().executeQuery(format("UPDATE %s SET col5 = col4, col1 = col3, col3 = col2, col4 = col5, col2 = col1 WHERE col1 = 31", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "true", row(1, 2, 3, 4, 5), row(33, 31, 32, 35, 34));
+
+            log.info("Performing more inserts on Presto");
+            onPresto().executeQuery(format("INSERT INTO %s (col1, col2, col3, col4, col5) VALUES (41, 42, 43, 44, 45), (51, 52, 53, 54, 55)", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "TRUE", row(1, 2, 3, 4, 5), row(33, 31, 32, 35, 34), row(41, 42, 43, 44, 45), row(51, 52, 53, 54, 55));
+
+            log.info("Performing second delete on Hive");
+            onHive().executeQuery(format("DELETE FROM %s WHERE col5 = 5", tableName));
+            verifySelectForPrestoAndHive("SELECT * FROM " + tableName, "TRUE", row(33, 31, 32, 35, 34), row(41, 42, 43, 44, 45), row(51, 52, 53, 54, 55));
+        });
     }
 
     @DataProvider

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
@@ -609,7 +609,7 @@ public abstract class AbstractTestDistributedQueries
 
         if (!supportsDelete()) {
             assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM orders WITH NO DATA", 0);
-            assertQueryFails("DELETE FROM " + tableName, "This connector does not support updates or deletes");
+            assertQueryFails("DELETE FROM " + tableName, "This connector does not support deletes");
             assertUpdate("DROP TABLE " + tableName);
             return;
         }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -135,7 +135,7 @@ public class TestEventListenerBasic
     public void testParseError()
             throws Exception
     {
-        assertFailedQuery("You shall not parse!", "line 1:1: mismatched input 'You'. Expecting: 'ALTER', 'ANALYZE', 'CALL', 'COMMENT', 'COMMIT', 'CREATE', 'DEALLOCATE', 'DELETE', 'DESC', 'DESCRIBE', 'DROP', 'EXECUTE', 'EXPLAIN', 'GRANT', 'INSERT', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'USE', <query>");
+        assertFailedQuery("You shall not parse!", "line 1:1: mismatched input 'You'. Expecting: 'ALTER', 'ANALYZE', 'CALL', 'COMMENT', 'COMMIT', 'CREATE', 'DEALLOCATE', 'DELETE', 'DESC', 'DESCRIBE', 'DROP', 'EXECUTE', 'EXPLAIN', 'GRANT', 'INSERT', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'UPDATE', 'USE', <query>");
     }
 
     @Test


### PR DESCRIPTION
This PR consists of two commits.  The first commit adds support for SQL UPDATE in the Presto engine.  That commit also includes a new connector developer doc delete-and-update.rst that explains in details how both DELETE and UPDATE work, and documents the APIs that the connector developer must implement.

@martint, please take a close look at the QueryPlanner changes to support UPDATE.  I think I got it right, but you are the expert.
