### PR TITLE
Redirect to HTTPS when HTTP ui is disabled

### DIFF
--- a/core/trino-main/src/main/resources/webapp/forward_disabled.html
+++ b/core/trino-main/src/main/resources/webapp/forward_disabled.html
@@ -1,0 +1,62 @@
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta name="description" content="Web Interface - Presto">
+    <title>Cluster Overview - Presto</title>
+
+    <link rel="icon" href="assets/favicon.ico">
+
+    <!-- Bootstrap core -->
+    <link href="vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+    <!-- jQuery -->
+    <script type="text/javascript" src="vendor/jquery/jquery-3.5.1.min.js"></script>
+
+    <!-- Bootstrap JS -->
+    <script type="text/javascript" src="vendor/bootstrap/js/bootstrap.js"></script>
+
+    <!-- Sparkline -->
+    <script type="text/javascript" src="vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
+
+    <!-- CSS loader -->
+    <link href="vendor/css-loaders/loader.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link href="assets/presto.css" rel="stylesheet">
+</head>
+
+<body>
+
+<h2 class="text-center">Web Interface is not via HTTP</h2>
+<h4 class="text-center">
+    It appears that the Presto server is being accessed through a proxy, but processing of the forwarding headers has not been enabled.
+    Processing of forwarded headers can be enabled by setting the "http-server.process-forwarded" property.
+</h4>
+
+<!-- Fonts -->
+<link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
+
+</body>
+</html>


### PR DESCRIPTION
If the HTTP authentication is disabled in the UI attempt to redirect to HTTPS.
This is only for request that have not been forwarded, since the forwarded
HTTPS address is not know.  To avoid confusion, if the request contains
unprocessed forwarded headers, the client is redirected to a custom error page
that can explain how to enable processing of the forwarded headers.