### PR TITLE
Fix DateTimeException error classification in varchar casts.

### DIFF
--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/VarcharToTimestampCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/VarcharToTimestampCast.java
@@ -57,7 +57,7 @@ public final class VarcharToTimestampCast
         catch (DateTimeException e) {
             //Leverage highly specific error message from the source exception.
             throw new PrestoException(INVALID_CAST_ARGUMENT,
-                    String.format("Value cannot be cast to timestamp; %s.", e.getMessage()), e);
+                    String.format("Value cannot be cast to timestamp: '%s'. %s.", value.toStringUtf8(), e.getMessage()), e);
         }
     }
 
@@ -74,7 +74,7 @@ public final class VarcharToTimestampCast
         catch (DateTimeException e) {
             //Leverage highly specific error message from the source exception.
             throw new PrestoException(INVALID_CAST_ARGUMENT,
-                    String.format("Value cannot be cast to timestamp; %s. ", e.getMessage()), e);
+                    String.format("Value cannot be cast to timestamp: '%s'. %s.", value.toStringUtf8(), e.getMessage()), e);
         }
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/VarcharToTimestampCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/VarcharToTimestampCast.java
@@ -57,7 +57,7 @@ public final class VarcharToTimestampCast
         catch (DateTimeException e) {
             //Leverage highly specific error message from the source exception.
             throw new PrestoException(INVALID_CAST_ARGUMENT,
-                    String.format("Value cannot be cast to timestamp; %s. ", e.getMessage()), e);
+                    String.format("Value cannot be cast to timestamp; %s.", e.getMessage()), e);
         }
     }
 

--- a/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/VarcharToTimestampCast.java
+++ b/presto-main/src/main/java/io/prestosql/operator/scalar/timestamp/VarcharToTimestampCast.java
@@ -23,6 +23,7 @@ import io.prestosql.spi.function.SqlType;
 import io.prestosql.spi.type.LongTimestamp;
 import io.prestosql.type.DateTimes;
 
+import java.time.DateTimeException;
 import java.time.ZonedDateTime;
 import java.util.regex.Matcher;
 
@@ -53,6 +54,11 @@ public final class VarcharToTimestampCast
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
         }
+        catch (DateTimeException e) {
+            //Leverage highly specific error message from the source exception.
+            throw new PrestoException(INVALID_CAST_ARGUMENT,
+                    String.format("Value cannot be cast to timestamp; %s. ", e.getMessage()), e);
+        }
     }
 
     @LiteralParameters({"x", "p"})
@@ -64,6 +70,11 @@ public final class VarcharToTimestampCast
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_CAST_ARGUMENT, "Value cannot be cast to timestamp: " + value.toStringUtf8(), e);
+        }
+        catch (DateTimeException e) {
+            //Leverage highly specific error message from the source exception.
+            throw new PrestoException(INVALID_CAST_ARGUMENT,
+                    String.format("Value cannot be cast to timestamp; %s. ", e.getMessage()), e);
         }
     }
 

--- a/presto-main/src/test/java/io/prestosql/type/TestTimestamp.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTimestamp.java
@@ -235,6 +235,15 @@ public class TestTimestamp
     }
 
     @Test
+    public void testCastInvalidVarcharToTimestamp()
+    {
+        assertInvalidCast("cast('2020-13-01 23:59:01' as timestamp)",
+                "Value cannot be cast to timestamp; Invalid value for MonthOfYear (valid values 1 - 12): 13.");
+        assertInvalidCast("cast('2020-12-01 24:00:00' as timestamp)",
+                "Value cannot be cast to timestamp; Invalid value for HourOfDay (valid values 0 - 23): 24.");
+    }
+
+    @Test
     public void testCastToSlice()
     {
         assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321' as varchar)", VARCHAR, "2001-01-22 03:04:05.321");

--- a/presto-main/src/test/java/io/prestosql/type/TestTimestamp.java
+++ b/presto-main/src/test/java/io/prestosql/type/TestTimestamp.java
@@ -238,9 +238,9 @@ public class TestTimestamp
     public void testCastInvalidVarcharToTimestamp()
     {
         assertInvalidCast("cast('2020-13-01 23:59:01' as timestamp)",
-                "Value cannot be cast to timestamp; Invalid value for MonthOfYear (valid values 1 - 12): 13.");
+                "Value cannot be cast to timestamp: '2020-13-01 23:59:01'. Invalid value for MonthOfYear (valid values 1 - 12): 13.");
         assertInvalidCast("cast('2020-12-01 24:00:00' as timestamp)",
-                "Value cannot be cast to timestamp; Invalid value for HourOfDay (valid values 0 - 23): 24.");
+                "Value cannot be cast to timestamp: '2020-12-01 24:00:00'. Invalid value for HourOfDay (valid values 0 - 23): 24.");
     }
 
     @Test


### PR DESCRIPTION
Fixes #5924 - Ensures that varchar casts to timestamps yield user error exceptions with detailed messages when they have improper field values.

