### PR TITLE
Make ViewFS temp staging directory configurable

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -316,6 +316,9 @@ Property Name                                      Description                  
 ``hive.legacy-hive-view-translation``              Use the legacy algorithm to translate Hive views. You can    ``false``
                                                    alternatively set the ``legacy_hive_view_translation``
                                                    session property to ``true``.
+
+``hive.viewfs-temporary-staging-directory-path``   Controls the location of temporary staging directory that    ``../.hive-staging``
+                                                   is used for write operations to ViewFS.
 ================================================== ============================================================ ============
 
 Metastore Configuration Properties

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveConfig.java
@@ -145,6 +145,8 @@ public class HiveConfig
 
     private boolean legacyHiveViewTranslation;
 
+    private String viewFsTemporaryStagingDirectoryPath = "../.hive-staging";
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1038,5 +1040,19 @@ public class HiveConfig
     public boolean isLegacyHiveViewTranslation()
     {
         return this.legacyHiveViewTranslation;
+    }
+
+    @Config("hive.viewfs-temporary-staging-directory-path")
+    @ConfigDescription("Location of ViewFS temporary staging directory for write operations")
+    public HiveConfig setViewFsTemporaryStagingDirectoryPath(String viewFsTemporaryStagingDirectoryPath)
+    {
+        this.viewFsTemporaryStagingDirectoryPath = viewFsTemporaryStagingDirectoryPath;
+        return this;
+    }
+
+    @NotNull
+    public String getViewFsTemporaryStagingDirectoryPath()
+    {
+        return viewFsTemporaryStagingDirectoryPath;
     }
 }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/HiveLocationService.java
@@ -45,11 +45,13 @@ public class HiveLocationService
         implements LocationService
 {
     private final HdfsEnvironment hdfsEnvironment;
+    private final String viewFsTemporaryStagingDirectoryPath;
 
     @Inject
-    public HiveLocationService(HdfsEnvironment hdfsEnvironment)
+    public HiveLocationService(HdfsEnvironment hdfsEnvironment, HiveConfig hiveConfig)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.viewFsTemporaryStagingDirectoryPath = requireNonNull(hiveConfig, "hiveConfig is null").getViewFsTemporaryStagingDirectoryPath();
     }
 
     @Override
@@ -65,7 +67,7 @@ public class HiveLocationService
 
         // TODO detect when existing table's location is a on a different file system than the temporary directory
         if (shouldUseTemporaryDirectory(session, context, targetPath, externalLocation)) {
-            Path writePath = createTemporaryPath(session, context, hdfsEnvironment, targetPath);
+            Path writePath = createTemporaryPath(session, context, hdfsEnvironment, targetPath, viewFsTemporaryStagingDirectoryPath);
             return new LocationHandle(targetPath, writePath, false, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
         else {
@@ -80,7 +82,7 @@ public class HiveLocationService
         Path targetPath = new Path(table.getStorage().getLocation());
 
         if (shouldUseTemporaryDirectory(session, context, targetPath, Optional.empty()) && !isTransactionalTable(table.getParameters())) {
-            Path writePath = createTemporaryPath(session, context, hdfsEnvironment, targetPath);
+            Path writePath = createTemporaryPath(session, context, hdfsEnvironment, targetPath, viewFsTemporaryStagingDirectoryPath);
             return new LocationHandle(targetPath, writePath, true, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
         else {

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/util/HiveWriteUtils.java
@@ -516,7 +516,7 @@ public final class HiveWriteUtils
         }
     }
 
-    public static Path createTemporaryPath(ConnectorSession session, HdfsContext context, HdfsEnvironment hdfsEnvironment, Path targetPath)
+    public static Path createTemporaryPath(ConnectorSession session, HdfsContext context, HdfsEnvironment hdfsEnvironment, Path targetPath, String viewFsStagingDirectoryPath)
     {
         // use a per-user temporary directory to avoid permission problems
         String temporaryPrefix = getTemporaryStagingDirectoryPath(session)
@@ -524,7 +524,7 @@ public final class HiveWriteUtils
 
         // use relative temporary directory on ViewFS
         if (isViewFileSystem(context, hdfsEnvironment, targetPath)) {
-            temporaryPrefix = ".hive-staging";
+            temporaryPrefix = viewFsStagingDirectoryPath;
         }
 
         // create a temporary directory on the same filesystem

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHive.java
@@ -761,7 +761,7 @@ public abstract class AbstractTestHive
         metastoreClient = hiveMetastore;
         hdfsEnvironment = hdfsConfiguration;
         HivePartitionManager partitionManager = new HivePartitionManager(hiveConfig);
-        locationService = new HiveLocationService(hdfsEnvironment);
+        locationService = new HiveLocationService(hdfsEnvironment, hiveConfig);
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);
         metadataFactory = new HiveMetadataFactory(
                 new CatalogName("hive"),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/AbstractTestHiveFileSystem.java
@@ -195,7 +195,7 @@ public abstract class AbstractTestHiveFileSystem
                 executor,
                 getBasePath(),
                 hdfsEnvironment);
-        locationService = new HiveLocationService(hdfsEnvironment);
+        locationService = new HiveLocationService(hdfsEnvironment, config);
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);
         metadataFactory = new HiveMetadataFactory(
                 new CatalogName("hive"),

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveConfig.java
@@ -101,7 +101,8 @@ public class TestHiveConfig
                 .setDynamicFilteringProbeBlockingTimeout(new Duration(0, TimeUnit.MINUTES))
                 .setTimestampPrecision(HiveTimestampPrecision.DEFAULT_PRECISION)
                 .setOptimizeSymlinkListing(true)
-                .setLegacyHiveViewTranslation(false));
+                .setLegacyHiveViewTranslation(false)
+                .setViewFsTemporaryStagingDirectoryPath("../.hive-staging"));
     }
 
     @Test
@@ -174,6 +175,7 @@ public class TestHiveConfig
                 .put("hive.timestamp-precision", "NANOSECONDS")
                 .put("hive.optimize-symlink-listing", "false")
                 .put("hive.legacy-hive-view-translation", "true")
+                .put("hive.viewfs-temporary-staging-directory-path", "updated")
                 .build();
 
         HiveConfig expected = new HiveConfig()
@@ -242,7 +244,8 @@ public class TestHiveConfig
                 .setDynamicFilteringProbeBlockingTimeout(new Duration(10, TimeUnit.SECONDS))
                 .setTimestampPrecision(HiveTimestampPrecision.NANOSECONDS)
                 .setOptimizeSymlinkListing(false)
-                .setLegacyHiveViewTranslation(true);
+                .setLegacyHiveViewTranslation(true)
+                .setViewFsTemporaryStagingDirectoryPath("updated");
 
         assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveLocationService.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHiveLocationService.java
@@ -83,7 +83,7 @@ public class TestHiveLocationService
         public Assertion(LocationHandle locationHandle, boolean overwrite)
         {
             HdfsEnvironment hdfsEnvironment = new TestingHdfsEnvironment(ImmutableList.of());
-            LocationService service = new HiveLocationService(hdfsEnvironment);
+            LocationService service = new HiveLocationService(hdfsEnvironment, new HiveConfig());
             this.actual = service.getTableWriteInfo(locationHandle, overwrite);
         }
 

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/TestHivePageSink.java
@@ -284,7 +284,7 @@ public class TestHivePageSink
                 new GroupByHashPageIndexerFactory(new JoinCompiler(typeOperators), blockTypeOperators),
                 TYPE_MANAGER,
                 config,
-                new HiveLocationService(HDFS_ENVIRONMENT),
+                new HiveLocationService(HDFS_ENVIRONMENT, config),
                 partitionUpdateCodec,
                 new TestingNodeManager("fake-environment"),
                 new HiveEventClient(),


### PR DESCRIPTION
1. Add a new session property VIEWFS_TEMPORARY_STAGING_DIRECTORY_PATH to make it configurable for ViewFS users.
2. Change the default value to "../.hive-staging" so it does not generate too many staging directories. Putting the staging at same level as targetPath will generate one directory under each table, put staging at parent level should generate one directory for one database. 