### PR TITLE
Use eventual assertion with query stats

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/assertions/Assert.java
+++ b/core/trino-main/src/main/java/io/trino/testing/assertions/Assert.java
@@ -15,6 +15,8 @@ package io.trino.testing.assertions;
 
 import io.airlift.units.Duration;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 /**
  * This class provides replacements for TestNG's faulty assertion methods.
  * <p>
@@ -48,6 +50,11 @@ public class Assert
             //if we're here, the Iterables differ on their fields. Use the original error message.
             throw error;
         }
+    }
+
+    public static void assertEventually(Runnable assertion)
+    {
+        assertEventually(new Duration(30, SECONDS), assertion);
     }
 
     public static void assertEventually(Duration timeout, Runnable assertion)


### PR DESCRIPTION
Use eventual assertion with query stats

It is possible that retrieved query stats might not collect all
information, so running eventual assertion to make tests more reliable.
