### PR TITLE
Added ability to have unique table location for each iceberg table

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -30,6 +30,7 @@ public class IcebergConfig
     private HiveCompressionCodec compressionCodec = GZIP;
     private boolean useFileSizeFromMetadata = true;
     private int maxPartitionsPerWriter = 100;
+    private boolean uniqueTableLocation;
 
     @NotNull
     public FileFormat getFileFormat()
@@ -89,6 +90,19 @@ public class IcebergConfig
     public IcebergConfig setMaxPartitionsPerWriter(int maxPartitionsPerWriter)
     {
         this.maxPartitionsPerWriter = maxPartitionsPerWriter;
+        return this;
+    }
+
+    public boolean isUniqueTableLocation()
+    {
+        return uniqueTableLocation;
+    }
+
+    @Config("iceberg.unique-table-location")
+    @ConfigDescription("Use randomized, unique table locations")
+    public IcebergConfig setUniqueTableLocation(boolean uniqueTableLocation)
+    {
+        this.uniqueTableLocation = uniqueTableLocation;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
@@ -33,6 +33,7 @@ public class IcebergMetadataFactory
     private final JsonCodec<CommitTaskData> commitTaskCodec;
     private final HiveTableOperationsProvider tableOperationsProvider;
     private final String trinoVersion;
+    private final boolean useUniqueTableLocation;
 
     @Inject
     public IcebergMetadataFactory(
@@ -45,7 +46,7 @@ public class IcebergMetadataFactory
             HiveTableOperationsProvider tableOperationsProvider,
             NodeVersion nodeVersion)
     {
-        this(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskDataJsonCodec, tableOperationsProvider, nodeVersion);
+        this(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskDataJsonCodec, tableOperationsProvider, nodeVersion, config.isUniqueTableLocation());
     }
 
     public IcebergMetadataFactory(
@@ -55,7 +56,8 @@ public class IcebergMetadataFactory
             TypeManager typeManager,
             JsonCodec<CommitTaskData> commitTaskCodec,
             HiveTableOperationsProvider tableOperationsProvider,
-            NodeVersion nodeVersion)
+            NodeVersion nodeVersion,
+            boolean useUniqueTableLocation)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
@@ -64,10 +66,11 @@ public class IcebergMetadataFactory
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
         this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
         this.trinoVersion = requireNonNull(nodeVersion, "nodeVersion is null").toString();
+        this.useUniqueTableLocation = useUniqueTableLocation;
     }
 
     public IcebergMetadata create()
     {
-        return new IcebergMetadata(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskCodec, tableOperationsProvider, trinoVersion);
+        return new IcebergMetadata(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskCodec, tableOperationsProvider, trinoVersion, useUniqueTableLocation);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/IcebergQueryRunner.java
@@ -72,6 +72,17 @@ public final class IcebergQueryRunner
             List<TpchTable<?>> tables,
             Optional<File> metastoreDirectory)
             throws Exception
+    {
+        return createIcebergQueryRunner(extraProperties, ImmutableMap.of(), format, tables, metastoreDirectory);
+    }
+
+    public static DistributedQueryRunner createIcebergQueryRunner(
+            Map<String, String> extraProperties,
+            Map<String, String> connectorProperties,
+            FileFormat format,
+            List<TpchTable<?>> tables,
+            Optional<File> metastoreDirectory)
+            throws Exception
 
     {
         Session session = testSessionBuilder()
@@ -93,6 +104,7 @@ public final class IcebergQueryRunner
                 .put("hive.metastore", "file")
                 .put("hive.metastore.catalog.dir", dataDir.toString())
                 .put("iceberg.file-format", format.name())
+                .putAll(connectorProperties)
                 .build();
 
         queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -35,7 +35,8 @@ public class TestIcebergConfig
                 .setFileFormat(ORC)
                 .setCompressionCodec(GZIP)
                 .setUseFileSizeFromMetadata(true)
-                .setMaxPartitionsPerWriter(100));
+                .setMaxPartitionsPerWriter(100)
+                .setUniqueTableLocation(false));
     }
 
     @Test
@@ -46,13 +47,15 @@ public class TestIcebergConfig
                 .put("iceberg.compression-codec", "NONE")
                 .put("iceberg.use-file-size-from-metadata", "false")
                 .put("iceberg.max-partitions-per-writer", "222")
+                .put("iceberg.unique-table-location", "true")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
                 .setFileFormat(PARQUET)
                 .setCompressionCodec(HiveCompressionCodec.NONE)
                 .setUseFileSizeFromMetadata(false)
-                .setMaxPartitionsPerWriter(222);
+                .setMaxPartitionsPerWriter(222)
+                .setUniqueTableLocation(true);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithCustomLocation.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergTableWithCustomLocation.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.metastore.Table;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastore;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
+import static io.trino.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static io.trino.tpch.TpchTable.NATION;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestIcebergTableWithCustomLocation
+        extends AbstractTestQueryFramework
+{
+    private FileHiveMetastore metastore;
+    private File metastoreDir;
+
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        metastoreDir = Files.createTempDirectory("test_iceberg").toFile();
+        metastore = createTestingFileHiveMetastore(metastoreDir);
+
+        return createIcebergQueryRunner(
+                ImmutableMap.of(),
+                ImmutableMap.of("iceberg.unique-table-location", "true"),
+                new IcebergConfig().getFileFormat(),
+                ImmutableList.of(NATION),
+                Optional.of(metastoreDir));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws IOException
+    {
+        deleteRecursively(metastoreDir.toPath(), ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testTableHasUuidSuffixInLocation()
+    {
+        String tableName = "table_with_uuid";
+        assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
+        Optional<Table> table = metastore.getTable(null, "tpch", tableName);
+        assertTrue(table.isPresent(), "Table should exists");
+        String location = table.get().getStorage().getLocation();
+        assertThat(location).matches(format(".*%s-[0-9a-f]{32}", tableName));
+    }
+
+    @Test
+    public void testCreateAndDrop()
+    {
+        String tableName = "test_create_and_drop";
+        assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
+        Optional<Table> table = metastore.getTable(null, "tpch", tableName);
+        assertTrue(table.isPresent(), "Table should exist");
+
+        assertQuerySucceeds(format("DROP TABLE %s", tableName));
+        assertFalse(metastore.getTable(null, "tpch", tableName).isPresent(), "Table should be dropped");
+    }
+
+    @Test
+    public void testCreateRenameDrop()
+    {
+        String tableName = "test_create_rename_drop";
+        String renamedName = "test_create_rename_drop_renamed";
+        assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
+        Optional<Table> table = metastore.getTable(null, "tpch", tableName);
+        assertTrue(table.isPresent(), "Table should exist");
+        String tableInitialLocation = table.get().getStorage().getLocation();
+
+        assertQuerySucceeds(format("ALTER TABLE %s RENAME TO %s", tableName, renamedName));
+        Optional<Table> renamedTable = metastore.getTable(null, "tpch", renamedName);
+        assertTrue(renamedTable.isPresent(), "Table should exist");
+        String renamedTableLocation = renamedTable.get().getStorage().getLocation();
+        assertEquals(renamedTableLocation, tableInitialLocation, "Location should not be changed");
+
+        assertQuerySucceeds(format("DROP TABLE %s", renamedName));
+        assertFalse(metastore.getTable(null, "tpch", tableName).isPresent(), "Initial table should not exists");
+        assertFalse(metastore.getTable(null, "tpch", renamedName).isPresent(), "Renamed table should be dropped");
+    }
+
+    @Test
+    public void testCreateRenameCreate()
+    {
+        String tableName = "test_create_rename_create";
+        String renamedName = "test_create_rename_create_renamed";
+        assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
+        Optional<Table> table = metastore.getTable(null, "tpch", tableName);
+        assertTrue(table.isPresent(), "Table should exist");
+        String tableInitialLocation = table.get().getStorage().getLocation();
+
+        assertQuerySucceeds(format("ALTER TABLE %s RENAME TO %s", tableName, renamedName));
+        Optional<Table> renamedTable = metastore.getTable(null, "tpch", renamedName);
+        assertTrue(renamedTable.isPresent(), "Table should exist");
+        String renamedTableLocation = renamedTable.get().getStorage().getLocation();
+        assertEquals(renamedTableLocation, tableInitialLocation, "Location should not be changed");
+
+        assertQuerySucceeds(format("CREATE TABLE %s as select 1 as val", tableName));
+        Optional<Table> recreatedTableWithInitialName = metastore.getTable(null, "tpch", tableName);
+        assertTrue(recreatedTableWithInitialName.isPresent(), "Table should exist");
+        String recreatedTableLocation = recreatedTableWithInitialName.get().getStorage().getLocation();
+        assertNotEquals(tableInitialLocation, recreatedTableLocation, "Location should be different");
+    }
+}


### PR DESCRIPTION
https://github.com/prestosql/presto/issues/5632

Added new iceberg configuration property `iceberg.unique-table-location` 

By default this `property = false`, so table directory will have the same name as table.
In case `iceberg.unique-table-location = true` unique UUID will be added to the  table directory name, so each table will have unique location