### PR TITLE
Allow specific testcontainers on product test.

### DIFF
--- a/presto-product-tests-launcher/pom.xml
+++ b/presto-product-tests-launcher/pom.xml
@@ -93,6 +93,11 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
         </dependency>
 

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/DelegateContainers.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/DelegateContainers.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.env;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.testcontainers.containers.FixedHostPortGenericContainer;
+import org.testcontainers.containers.GenericContainer;
+
+public class DelegateContainers
+{
+    private DelegateContainers()
+    {
+    }
+
+    public static DelegateContainerFactory<FixedHostPortGenericContainer> fixedHostPort(String dockerImageName)
+    {
+        return (listener, portsAdapter) -> {
+            FixedHostPortGenericContainer container = new FixedHostPortGenericContainer(dockerImageName)
+            {
+                @Override
+                protected void containerIsStarting(InspectContainerResponse containerInfo)
+                {
+                    listener.containerIsStarting(containerInfo, info -> super.containerIsStarting(info));
+                }
+
+                @Override
+                protected void containerIsStarted(InspectContainerResponse containerInfo)
+                {
+                    listener.containerIsStarted(containerInfo, info -> super.containerIsStarted(info));
+                }
+
+                @Override
+                protected void containerIsStopping(InspectContainerResponse containerInfo)
+                {
+                    listener.containerIsStopping(containerInfo, info -> super.containerIsStopping(info));
+                }
+
+                @Override
+                protected void containerIsStopped(InspectContainerResponse containerInfo)
+                {
+                    listener.containerIsStopped(containerInfo, info -> super.containerIsStopped(info));
+                }
+            };
+            portsAdapter.attachPortController(container::withFixedExposedPort);
+            return container;
+        };
+    }
+
+    public interface DelegateContainerFactory<T extends GenericContainer>
+    {
+        T create(EnvironmentListenerAdapter listener, FixedPortsAdapter portsAdapter);
+    }
+}

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentListener.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentListener.java
@@ -41,6 +41,8 @@ public interface EnvironmentListener
 {
     Logger log = Logger.get(EnvironmentListener.class);
 
+    EnvironmentListener NO_OP = new EnvironmentListener() {};
+
     default void environmentStarting(Environment environment)
     {
     }

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentListenerAdapter.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/EnvironmentListenerAdapter.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.env;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.google.common.base.Stopwatch;
+
+import java.util.function.Consumer;
+
+import static java.util.Objects.requireNonNull;
+
+public class EnvironmentListenerAdapter
+{
+    private final Stopwatch startupTime = Stopwatch.createUnstarted();
+    private final DockerContainer container;
+    private EnvironmentListener delegate = EnvironmentListener.NO_OP;
+
+    EnvironmentListenerAdapter(DockerContainer container)
+    {
+        this.container = requireNonNull(container, "container is null");
+    }
+
+    public void set(EnvironmentListener listener)
+    {
+        requireNonNull(listener, "listener is null");
+
+        delegate = listener;
+    }
+
+    public Stopwatch getStartupTime()
+    {
+        return startupTime;
+    }
+
+    public void containerIsStarting(InspectContainerResponse containerInfo, Consumer<InspectContainerResponse> additionalAction)
+    {
+        this.startupTime.start();
+        additionalAction.accept(containerInfo);
+        delegate.containerStarting(container, containerInfo);
+    }
+
+    public void containerIsStarted(InspectContainerResponse containerInfo, Consumer<InspectContainerResponse> additionalAction)
+    {
+        this.startupTime.stop();
+        additionalAction.accept(containerInfo);
+        delegate.containerStarted(container, containerInfo);
+    }
+
+    public void containerIsStopping(InspectContainerResponse containerInfo, Consumer<InspectContainerResponse> additionalAction)
+    {
+        additionalAction.accept(containerInfo);
+        delegate.containerStopping(container, containerInfo);
+    }
+
+    public void containerIsStopped(InspectContainerResponse containerInfo, Consumer<InspectContainerResponse> additionalAction)
+    {
+        additionalAction.accept(containerInfo);
+        delegate.containerStopped(container, containerInfo);
+    }
+}

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/FixedPortsAdapter.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/FixedPortsAdapter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tests.product.launcher.env;
+
+import org.testcontainers.containers.InternetProtocol;
+
+import static java.util.Objects.requireNonNull;
+
+public class FixedPortsAdapter
+{
+    private PortController portController = (hostPort, containerPort, protocol) -> {};
+
+    void attachPortController(PortController portController)
+    {
+        this.portController = requireNonNull(portController, "portController is null");
+    }
+
+    public void addFixedExposedPort(int hostPort, int containerPort)
+    {
+        this.addFixedExposedPort(hostPort, containerPort, InternetProtocol.TCP);
+    }
+
+    public void addFixedExposedPort(int hostPort, int containerPort, InternetProtocol protocol)
+    {
+        portController.addFixedExposedPort(hostPort, containerPort, protocol);
+    }
+
+    interface PortController
+    {
+        void addFixedExposedPort(int hostPort, int containerPort, InternetProtocol protocol);
+    }
+}

--- a/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodePostgresql.java
+++ b/presto-product-tests-launcher/src/main/java/io/prestosql/tests/product/launcher/env/environment/SinglenodePostgresql.java
@@ -27,6 +27,7 @@ import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 import javax.inject.Inject;
 
 import static io.prestosql.tests.product.launcher.docker.ContainerUtil.forSelectedPorts;
+import static io.prestosql.tests.product.launcher.env.DelegateContainers.postgreSQLContainer;
 import static io.prestosql.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.prestosql.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
@@ -65,13 +66,13 @@ public final class SinglenodePostgresql
     private DockerContainer createPostgreSql()
     {
         // Use the oldest supported PostgreSQL version
-        DockerContainer container = new DockerContainer("postgres:9.5", "postgresql")
-                .withEnv("POSTGRES_PASSWORD", "test")
-                .withEnv("POSTGRES_USER", "test")
-                .withEnv("POSTGRES_DB", "test")
-                .withEnv("PGPORT", Integer.toString(POSTGRESQL_PORT))
-                .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
-                .waitingFor(forSelectedPorts(POSTGRESQL_PORT));
+        DockerContainer container = new DockerContainer("postgresql", postgreSQLContainer("postgres:9.5"), postgres ->
+                postgres.withPassword("test")
+                        .withUsername("test")
+                        .withDatabaseName("test")
+                        .withEnv("PGPORT", Integer.toString(POSTGRESQL_PORT))
+                        .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                        .waitingFor(forSelectedPorts(POSTGRESQL_PORT)));
 
         portBinder.exposePort(container, POSTGRESQL_PORT);
 


### PR DESCRIPTION
This pr allows usage of different subclasses of GenericContainer, rather than limiting us to only single implementation, that does not allow to use existing predefined testcontainers.