### PR TITLE
Fix realtype conversion in KafkaRecordCursor

### DIFF
--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
@@ -166,7 +166,7 @@ public class AvroColumnDecoder
         @Override
         public double getDouble()
         {
-            if (value instanceof Double || value instanceof Float) {
+            if (value instanceof Double) {
                 return ((Number) value).doubleValue();
             }
             throw new TrinoException(DECODER_CONVERSION_NOT_SUPPORTED, format("cannot decode object of '%s' as '%s' for column '%s'", value.getClass(), columnType, columnName));
@@ -186,6 +186,9 @@ public class AvroColumnDecoder
         {
             if (value instanceof Long || value instanceof Integer) {
                 return ((Number) value).longValue();
+            }
+            else if (value instanceof Float) {
+                return floatToIntBits((Float) value);
             }
             throw new TrinoException(DECODER_CONVERSION_NOT_SUPPORTED, format("cannot decode object of '%s' as '%s' for column '%s'", value.getClass(), columnType, columnName));
         }

--- a/lib/trino-record-decoder/src/test/java/io/trino/decoder/avro/TestAvroDecoder.java
+++ b/lib/trino-record-decoder/src/test/java/io/trino/decoder/avro/TestAvroDecoder.java
@@ -417,21 +417,12 @@ public class TestAvroDecoder
     }
 
     @Test
-    public void testFloatDecodedAsDouble()
-    {
-        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", DOUBLE, "float_field", null, null, false, false, false);
-        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "float_field", "\"float\"", 10.2f);
-
-        checkValue(decodedRow, row, 10.2);
-    }
-
-    @Test
     public void testFloatDecodedAsReal()
     {
         DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", REAL, "float_field", null, null, false, false, false);
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "float_field", "\"float\"", 10.2f);
 
-        checkValue(decodedRow, row, 10.2);
+        checkValue(decodedRow, row, 10.2f);
     }
 
     @Test

--- a/lib/trino-record-decoder/src/test/java/io/trino/decoder/util/DecoderTestUtil.java
+++ b/lib/trino-record-decoder/src/test/java/io/trino/decoder/util/DecoderTestUtil.java
@@ -19,6 +19,8 @@ import io.trino.decoder.FieldValueProvider;
 
 import java.util.Map;
 
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -53,6 +55,13 @@ public final class DecoderTestUtil
         FieldValueProvider provider = decodedRow.get(handle);
         assertNotNull(provider);
         assertEquals(provider.getDouble(), value, 0.0001);
+    }
+
+    public static void checkValue(Map<DecoderColumnHandle, FieldValueProvider> decodedRow, DecoderColumnHandle handle, float value)
+    {
+        FieldValueProvider provider = decodedRow.get(handle);
+        assertNotNull(provider);
+        assertEquals(intBitsToFloat(toIntExact(provider.getLong())), value, 0.0001);
     }
 
     public static void checkValue(Map<DecoderColumnHandle, FieldValueProvider> decodedRow, DecoderColumnHandle handle, boolean value)


### PR DESCRIPTION
Since RealType has javaType of long, float types should
be handled in getLong()