### PR TITLE
Fallback to an available alter table and alter partitions API in Hive Metastore 3.x

### DIFF
--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
@@ -34,7 +34,6 @@ import org.apache.thrift.TException;
 
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalLong;
 
 import static java.util.Objects.requireNonNull;
 
@@ -144,6 +143,13 @@ public class FailureAwareThriftMetastoreClient
             throws TException
     {
         runWithHandle(() -> delegate.alterTableWithEnvironmentContext(databaseName, tableName, newTable, context));
+    }
+
+    @Override
+    public void alterPartitionsWithEnvironmentContext(String dbName, String tableName, List<Partition> partitions, EnvironmentContext context)
+            throws TException
+    {
+        runWithHandle(() -> delegate.alterPartitionsWithEnvironmentContext(dbName, tableName, partitions, context));
     }
 
     @Override
@@ -410,13 +416,6 @@ public class FailureAwareThriftMetastoreClient
             throws TException
     {
         return runWithHandle(() -> delegate.allocateTableWriteIds(database, tableName, transactionIds));
-    }
-
-    @Override
-    public void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId, OptionalLong rowCountChange)
-            throws TException
-    {
-        runWithHandle(() -> delegate.updateTableWriteId(dbName, tableName, transactionId, writeId, rowCountChange));
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -129,6 +129,7 @@ import static io.prestosql.plugin.hive.HiveErrorCode.HIVE_TABLE_LOCK_NOT_ACQUIRE
 import static io.prestosql.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
 import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import static io.prestosql.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
+import static io.prestosql.plugin.hive.metastore.MetastoreUtil.adjustRowCount;
 import static io.prestosql.plugin.hive.metastore.MetastoreUtil.partitionKeyFilterToStringList;
 import static io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreUtil.createMetastoreColumnStatistics;
 import static io.prestosql.plugin.hive.metastore.thrift.ThriftMetastoreUtil.fromMetastoreApiPrincipalType;
@@ -184,6 +185,8 @@ public class ThriftHiveMetastore
     private final AtomicInteger chosenGetTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosenTableParamAlternative = new AtomicInteger(Integer.MAX_VALUE);
     private final AtomicInteger chosesGetAllViewsAlternative = new AtomicInteger(Integer.MAX_VALUE);
+    private final AtomicInteger chosenAlterTableAlternative = new AtomicInteger(Integer.MAX_VALUE);
+    private final AtomicInteger chosenAlterPartitionsAlternative = new AtomicInteger(Integer.MAX_VALUE);
 
     private final AtomicReference<Optional<Boolean>> metastoreSupportsDateStatistics = new AtomicReference<>(Optional.empty());
     private final CoalescingCounter metastoreSetDateStatisticsFailures = new CoalescingCounter(new Duration(1, SECONDS));
@@ -1168,9 +1171,18 @@ public class ThriftHiveMetastore
                     .stopOn(InvalidOperationException.class, MetaException.class)
                     .stopOnIllegalExceptions()
                     .run("alterTransactionalTable", stats.getAlterTransactionalTable().wrap(() -> {
-                        try (ThriftMetastoreClient client = createMetastoreClient(identity)) {
-                            client.alterTransactionalTable(table, transactionId, writeId, context);
-                        }
+                        alternativeCall(
+                                () -> createMetastoreClient(identity),
+                                exception -> !isUnknownMethodExceptionalResponse(exception),
+                                chosenAlterTableAlternative,
+                                client -> {
+                                    client.alterTransactionalTable(table, transactionId, writeId, context);
+                                    return null;
+                                },
+                                client -> {
+                                    client.alterTableWithEnvironmentContext(table.getDbName(), table.getTableName(), table, context);
+                                    return null;
+                                });
                         return null;
                     }));
         }
@@ -1805,12 +1817,14 @@ public class ThriftHiveMetastore
         requireNonNull(tableName, "tableName is null");
         checkArgument(writeId > 0, "writeId should be a positive integer, but was %s", writeId);
         try {
+            Table table = getTable(identity, dbName, tableName)
+                    .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(dbName, tableName)));
+            rowCountChange.ifPresent(rowCount ->
+                    table.setParameters(adjustRowCount(table.getParameters(), tableName, rowCount)));
             retry()
                     .stopOnIllegalExceptions()
                     .run("updateTableWriteId", stats.getUpdateTableWriteId().wrap(() -> {
-                        try (ThriftMetastoreClient metastoreClient = createMetastoreClient(identity)) {
-                            metastoreClient.updateTableWriteId(dbName, tableName, transactionId, writeId, rowCountChange);
-                        }
+                        alterTransactionalTable(identity, table, transactionId, writeId, new EnvironmentContext());
                         return null;
                     }));
         }
@@ -1830,9 +1844,18 @@ public class ThriftHiveMetastore
             retry()
                     .stopOnIllegalExceptions()
                     .run("alterPartitions", stats.getAlterPartitions().wrap(() -> {
-                        try (ThriftMetastoreClient metastoreClient = createMetastoreClient(identity)) {
-                            metastoreClient.alterPartitions(dbName, tableName, partitions, writeId);
-                        }
+                        alternativeCall(
+                                () -> createMetastoreClient(identity),
+                                exception -> !isUnknownMethodExceptionalResponse(exception),
+                                chosenAlterPartitionsAlternative,
+                                client -> {
+                                    client.alterPartitions(dbName, tableName, partitions, writeId);
+                                    return null;
+                                },
+                                client -> {
+                                    client.alterPartitionsWithEnvironmentContext(dbName, tableName, partitions, new EnvironmentContext());
+                                    return null;
+                                });
                         return null;
                     }));
         }

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -70,11 +70,9 @@ import org.apache.thrift.transport.TTransport;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalLong;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.reflect.Reflection.newProxy;
-import static io.prestosql.plugin.hive.metastore.MetastoreUtil.adjustRowCount;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.hive.metastore.txn.TxnUtils.createValidTxnWriteIdList;
@@ -184,6 +182,13 @@ public class ThriftHiveMetastoreClient
             throws TException
     {
         client.alter_table_with_environment_context(databaseName, tableName, newTable, context);
+    }
+
+    @Override
+    public void alterPartitionsWithEnvironmentContext(String dbName, String tableName, List<Partition> partitions, EnvironmentContext context)
+            throws TException
+    {
+        client.alter_partitions_with_environment_context(dbName, tableName, partitions, context);
     }
 
     @Override
@@ -540,16 +545,6 @@ public class ThriftHiveMetastoreClient
         request.setTxnIds(transactionIds);
         AllocateTableWriteIdsResponse response = client.allocate_table_write_ids(request);
         return response.getTxnToWriteIds();
-    }
-
-    @Override
-    public void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId, OptionalLong rowCountChange)
-            throws TException
-    {
-        Table table = getTableWithCapabilities(dbName, tableName);
-        rowCountChange.ifPresent(rowCount ->
-                table.setParameters(adjustRowCount(table.getParameters(), tableName, rowCount)));
-        alterTransactionalTable(table, transactionId, writeId, new EnvironmentContext());
     }
 
     @Override

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
@@ -34,7 +34,6 @@ import org.apache.thrift.TException;
 import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalLong;
 
 public interface ThriftMetastoreClient
         extends Closeable
@@ -73,6 +72,9 @@ public interface ThriftMetastoreClient
             throws TException;
 
     void alterTableWithEnvironmentContext(String databaseName, String tableName, Table newTable, EnvironmentContext context)
+            throws TException;
+
+    void alterPartitionsWithEnvironmentContext(String dbName, String tableName, List<Partition> partitions, EnvironmentContext context)
             throws TException;
 
     Table getTable(String databaseName, String tableName)
@@ -194,9 +196,6 @@ public interface ThriftMetastoreClient
     {
         throw new UnsupportedOperationException();
     }
-
-    void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId, OptionalLong rowCountChange)
-            throws TException;
 
     void alterPartitions(String dbName, String tableName, List<Partition> partitions, long writeId)
             throws TException;

--- a/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/presto-hive/src/test/java/io/prestosql/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -44,7 +44,6 @@ import org.apache.thrift.TException;
 
 import java.util.List;
 import java.util.Map;
-import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.hadoop.hive.metastore.api.PrincipalType.ROLE;
@@ -343,6 +342,13 @@ public class MockThriftMetastoreClient
     }
 
     @Override
+    public void alterPartitionsWithEnvironmentContext(String dbName, String tableName, List<Partition> partitions, EnvironmentContext context)
+    {
+        accessCount.incrementAndGet();
+        // No-op
+    }
+
+    @Override
     public int addPartitions(List<Partition> newPartitions)
     {
         throw new UnsupportedOperationException();
@@ -486,13 +492,6 @@ public class MockThriftMetastoreClient
 
     @Override
     public String get_config_value(String name, String defaultValue)
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void updateTableWriteId(String dbName, String tableName, long transactionId, long writeId, OptionalLong rowCountChange)
-            throws TException
     {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
HiveMetaStore 3.1.2 doesn't have the new alter_table_req and alter_partitions_req API. This commit
adds the ability to fallback to alter_table_with_environment_context and
alter_partitions_with_environment_context in case the new APIs are not available.

Testing:
Ran hive queries with Hive 3.1.2 and used tcp dump to figure out alternative HMS alter_table[alter_partitions]_with_environment_context calls being used.
Ran all the product tests in the hive_transactional test group by choosing the with_environment_context alternative calls with the singlenode-hdp3 env.
Manually tested with HMS 3.1.2 on EMR

fixes https://github.com/trinodb/trino/issues/7310