### PR TITLE
Allow returning custom metrics from ConnectorPageSource

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/ExchangeClientStatus.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExchangeClientStatus.java
@@ -16,7 +16,7 @@ package io.trino.operator;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
-import io.trino.util.Mergeable;
+import io.trino.spi.Mergeable;
 
 import java.util.List;
 

--- a/core/trino-main/src/main/java/io/trino/operator/HashCollisionsInfo.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashCollisionsInfo.java
@@ -15,7 +15,7 @@ package io.trino.operator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.trino.util.Mergeable;
+import io.trino.spi.Mergeable;
 
 public class HashCollisionsInfo
         implements Mergeable<HashCollisionsInfo>, OperatorInfo

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.spi.Mergeable;
+import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import javax.annotation.Nullable;
@@ -63,6 +64,7 @@ public class OperatorStats
     private final long outputPositions;
 
     private final long dynamicFilterSplitsProcessed;
+    private final Metrics metrics;
 
     private final DataSize physicalWrittenDataSize;
 
@@ -115,6 +117,7 @@ public class OperatorStats
             @JsonProperty("outputPositions") long outputPositions,
 
             @JsonProperty("dynamicFilterSplitsProcessed") long dynamicFilterSplitsProcessed,
+            @JsonProperty("metrics") Metrics metrics,
 
             @JsonProperty("physicalWrittenDataSize") DataSize physicalWrittenDataSize,
 
@@ -169,6 +172,7 @@ public class OperatorStats
         this.outputPositions = outputPositions;
 
         this.dynamicFilterSplitsProcessed = dynamicFilterSplitsProcessed;
+        this.metrics = requireNonNull(metrics);
 
         this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "physicalWrittenDataSize is null");
 
@@ -333,6 +337,12 @@ public class OperatorStats
     }
 
     @JsonProperty
+    public Metrics getMetrics()
+    {
+        return metrics;
+    }
+
+    @JsonProperty
     public DataSize getPhysicalWrittenDataSize()
     {
         return physicalWrittenDataSize;
@@ -451,6 +461,7 @@ public class OperatorStats
         long outputPositions = this.outputPositions;
 
         long dynamicFilterSplitsProcessed = this.dynamicFilterSplitsProcessed;
+        Metrics.Accumulator metricsAccumulator = Metrics.accumulator().add(this.getMetrics());
 
         long physicalWrittenDataSize = this.physicalWrittenDataSize.toBytes();
 
@@ -498,6 +509,7 @@ public class OperatorStats
             outputPositions += operator.getOutputPositions();
 
             dynamicFilterSplitsProcessed += operator.getDynamicFilterSplitsProcessed();
+            metricsAccumulator.add(operator.getMetrics());
 
             physicalWrittenDataSize += operator.getPhysicalWrittenDataSize().toBytes();
 
@@ -557,6 +569,7 @@ public class OperatorStats
                 outputPositions,
 
                 dynamicFilterSplitsProcessed,
+                metricsAccumulator.get(),
 
                 succinctBytes(physicalWrittenDataSize),
 
@@ -623,6 +636,7 @@ public class OperatorStats
                 outputDataSize,
                 outputPositions,
                 dynamicFilterSplitsProcessed,
+                metrics,
                 physicalWrittenDataSize,
                 blockedWall,
                 finishCalls,

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
@@ -18,8 +18,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.spi.Mergeable;
 import io.trino.sql.planner.plan.PlanNodeId;
-import io.trino.util.Mergeable;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;

--- a/core/trino-main/src/main/java/io/trino/operator/PartitionedOutputOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PartitionedOutputOperator.java
@@ -24,6 +24,7 @@ import io.trino.execution.buffer.PagesSerde;
 import io.trino.execution.buffer.PagesSerdeFactory;
 import io.trino.execution.buffer.SerializedPage;
 import io.trino.memory.context.LocalMemoryContext;
+import io.trino.spi.Mergeable;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.Block;
@@ -31,7 +32,6 @@ import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.PlanNodeId;
-import io.trino.util.Mergeable;
 
 import javax.annotation.Nullable;
 

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -247,6 +247,7 @@ public class TableScanOperator
                 throw new UncheckedIOException(e);
             }
             systemMemoryContext.setBytes(source.getSystemMemoryUsage());
+            operatorContext.setLatestMetrics(source.getMetrics());
         }
     }
 
@@ -322,7 +323,7 @@ public class TableScanOperator
 
         // updating system memory usage should happen after page is loaded.
         systemMemoryContext.setBytes(source.getSystemMemoryUsage());
-
+        operatorContext.setLatestMetrics(source.getMetrics());
         return page;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanWorkProcessorOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanWorkProcessorOperator.java
@@ -32,6 +32,7 @@ import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.DynamicFilter;
 import io.trino.spi.connector.EmptyPageSource;
 import io.trino.spi.connector.UpdatablePageSource;
+import io.trino.spi.metrics.Metrics;
 import io.trino.split.EmptySplit;
 import io.trino.split.PageSourceProvider;
 
@@ -115,6 +116,12 @@ public class TableScanWorkProcessorOperator
     public long getDynamicFilterSplitsProcessed()
     {
         return splitToPages.getDynamicFilterSplitsProcessed();
+    }
+
+    @Override
+    public Metrics getConnectorMetrics()
+    {
+        return splitToPages.source.getMetrics();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
@@ -24,6 +24,7 @@ import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.OperationTimer.OperationTiming;
+import io.trino.spi.Mergeable;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
@@ -37,7 +38,6 @@ import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.TableWriterNode;
 import io.trino.sql.planner.plan.TableWriterNode.WriterTarget;
 import io.trino.util.AutoCloseableCloser;
-import io.trino.util.Mergeable;
 
 import java.util.Collection;
 import java.util.List;

--- a/core/trino-main/src/main/java/io/trino/operator/WindowInfo.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowInfo.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.operator.window.WindowPartition;
-import io.trino.util.Mergeable;
+import io.trino.spi.Mergeable;
 
 import javax.annotation.concurrent.Immutable;
 

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperator.java
@@ -16,6 +16,7 @@ package io.trino.operator;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.spi.connector.UpdatablePageSource;
+import io.trino.spi.metrics.Metrics;
 
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -67,4 +68,6 @@ public interface WorkProcessorSourceOperator
     {
         return 0;
     }
+
+    Metrics getConnectorMetrics();
 }

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
@@ -21,6 +21,7 @@ import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.metadata.Split;
 import io.trino.spi.Page;
 import io.trino.spi.connector.UpdatablePageSource;
+import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import java.util.ArrayList;
@@ -175,6 +176,7 @@ public class WorkProcessorSourceOperatorAdapter
     public void close()
             throws Exception
     {
+        operatorContext.setLatestMetrics(sourceOperator.getConnectorMetrics());
         sourceOperator.close();
     }
 
@@ -191,6 +193,7 @@ public class WorkProcessorSourceOperatorAdapter
         long currentInputPositions = sourceOperator.getInputPositions();
 
         long currentDynamicFilterSplitsProcessed = sourceOperator.getDynamicFilterSplitsProcessed();
+        Metrics currentMetrics = sourceOperator.getConnectorMetrics();
 
         if (currentPhysicalInputBytes != previousPhysicalInputBytes
                 || currentPhysicalInputPositions != previousPhysicalInputPositions
@@ -229,6 +232,8 @@ public class WorkProcessorSourceOperatorAdapter
             operatorContext.recordDynamicFilterSplitProcessed(currentDynamicFilterSplitsProcessed - previousDynamicFilterSplitsProcessed);
             previousDynamicFilterSplitsProcessed = currentDynamicFilterSplitsProcessed;
         }
+
+        operatorContext.setLatestMetrics(currentMetrics);
     }
 
     private static class SplitBuffer

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeBufferInfo.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeBufferInfo.java
@@ -16,7 +16,7 @@ package io.trino.operator.exchange;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.operator.OperatorInfo;
-import io.trino.util.Mergeable;
+import io.trino.spi.Mergeable;
 
 public class LocalExchangeBufferInfo
         implements Mergeable<LocalExchangeBufferInfo>, OperatorInfo

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinOperatorInfo.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinOperatorInfo.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.operator.OperatorInfo;
 import io.trino.operator.join.LookupJoinOperatorFactory.JoinType;
-import io.trino.util.Mergeable;
+import io.trino.spi.Mergeable;
 
 import java.util.Optional;
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
@@ -15,8 +15,8 @@ package io.trino.sql.planner.planprinter;
 
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.spi.Mergeable;
 import io.trino.sql.planner.plan.PlanNodeId;
-import io.trino.util.Mergeable;
 
 import java.util.Map;
 import java.util.Set;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/WindowOperatorStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/WindowOperatorStats.java
@@ -15,7 +15,7 @@ package io.trino.sql.planner.planprinter;
 
 import io.trino.operator.WindowInfo;
 import io.trino.operator.WindowInfo.DriverWindowInfo;
-import io.trino.util.Mergeable;
+import io.trino.spi.Mergeable;
 
 class WindowOperatorStats
         implements Mergeable<WindowOperatorStats>

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
@@ -22,6 +22,7 @@ import io.trino.operator.FilterAndProjectOperator;
 import io.trino.operator.OperatorStats;
 import io.trino.operator.TableWriterOperator;
 import io.trino.spi.eventlistener.StageGcStatistics;
+import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
 import org.joda.time.DateTime;
 import org.testng.annotations.Test;
@@ -62,6 +63,7 @@ public class TestQueryStats
                     succinctBytes(116L),
                     117L,
                     1833,
+                    Metrics.EMPTY,
                     succinctBytes(118L),
                     new Duration(119, NANOSECONDS),
                     120L,
@@ -101,6 +103,7 @@ public class TestQueryStats
                     succinctBytes(216L),
                     217L,
                     2833,
+                    Metrics.EMPTY,
                     succinctBytes(218L),
                     new Duration(219, NANOSECONDS),
                     220L,
@@ -140,6 +143,7 @@ public class TestQueryStats
                     succinctBytes(316L),
                     317L,
                     3833,
+                    Metrics.EMPTY,
                     succinctBytes(318L),
                     new Duration(319, NANOSECONDS),
                     320L,

--- a/core/trino-main/src/test/java/io/trino/operator/TestOperatorStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestOperatorStats.java
@@ -13,11 +13,13 @@
  */
 package io.trino.operator;
 
+import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.connector.CatalogName;
 import io.trino.operator.PartitionedOutputOperator.PartitionedOutputInfo;
+import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
 import org.testng.annotations.Test;
 
@@ -59,6 +61,7 @@ public class TestOperatorStats
             DataSize.ofBytes(12),
             13,
             533,
+            Metrics.EMPTY,
 
             DataSize.ofBytes(14),
 
@@ -106,6 +109,7 @@ public class TestOperatorStats
             DataSize.ofBytes(12),
             13,
             533,
+            Metrics.EMPTY,
 
             DataSize.ofBytes(14),
 
@@ -163,6 +167,7 @@ public class TestOperatorStats
         assertEquals(actual.getOutputPositions(), 13);
 
         assertEquals(actual.getDynamicFilterSplitsProcessed(), 533);
+        assertEquals(actual.getMetrics().getMetrics(), ImmutableMap.of());
 
         assertEquals(actual.getPhysicalWrittenDataSize(), DataSize.ofBytes(14));
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -26,6 +26,7 @@ import io.trino.operator.WorkProcessor.TransformationState;
 import io.trino.operator.WorkProcessorAssertion.Transform;
 import io.trino.spi.Page;
 import io.trino.spi.connector.UpdatablePageSource;
+import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.LocalExecutionPlanner.OperatorFactoryWithTypes;
 import io.trino.sql.planner.plan.PlanNodeId;
 import org.testng.annotations.AfterClass;
@@ -390,6 +391,12 @@ public class TestWorkProcessorPipelineSourceOperator
         public Duration getReadTime()
         {
             return new Duration(7, NANOSECONDS);
+        }
+
+        @Override
+        public Metrics getConnectorMetrics()
+        {
+            return Metrics.EMPTY;
         }
 
         @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/Mergeable.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Mergeable.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.util;
+package io.trino.spi;
 
 public interface Mergeable<T>
 {

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSource.java
@@ -14,6 +14,7 @@
 package io.trino.spi.connector;
 
 import io.trino.spi.Page;
+import io.trino.spi.metrics.Metrics;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -69,5 +70,15 @@ public interface ConnectorPageSource
     default CompletableFuture<?> isBlocked()
     {
         return NOT_BLOCKED;
+    }
+
+    /**
+     * Returns the connector's metrics, mapping a metric ID to its latest value.
+     * Each call must return an immutable snapshot of available metrics.
+     * Same ID metrics are merged across all tasks and exposed via OperatorStats.
+     */
+    default Metrics getMetrics()
+    {
+        return Metrics.EMPTY;
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/metrics/Count.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/metrics/Count.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.metrics;
+
+public interface Count<T>
+        extends Metric<T>
+{
+    long getTotal();
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/metrics/Distribution.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/metrics/Distribution.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.metrics;
+
+public interface Distribution<T>
+        extends Metric<T>
+{
+    long getTotal();
+
+    double getPercentile(double percentile);
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/metrics/Metric.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/metrics/Metric.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.metrics;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.trino.spi.Mergeable;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+public interface Metric<T>
+        extends Mergeable<T>
+{
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/metrics/Metrics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/metrics/Metrics.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.metrics;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.trino.spi.Mergeable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class Metrics
+        implements Mergeable<Metrics>
+{
+    public static final Metrics EMPTY = new Metrics(Map.of());
+
+    private final Map<String, Metric> metrics;
+
+    @JsonCreator
+    public Metrics(Map<String, Metric> metrics)
+    {
+        this.metrics = Map.copyOf(requireNonNull(metrics, "metrics is null"));
+    }
+
+    @JsonValue
+    public Map<String, Metric> getMetrics()
+    {
+        return metrics;
+    }
+
+    @Override
+    public Metrics mergeWith(Metrics other)
+    {
+        return accumulator().add(this).add(other).get();
+    }
+
+    public static Accumulator accumulator()
+    {
+        return new Accumulator();
+    }
+
+    public static class Accumulator
+    {
+        private final Map<String, Metric> merged = new HashMap<>();
+
+        private Accumulator()
+        {
+        }
+
+        public Accumulator add(Metrics metrics)
+        {
+            metrics.getMetrics().forEach((key, value) ->
+                    merged.merge(key, value, (left, right) -> (Metric) left.mergeWith(right)));
+            return this;
+        }
+
+        public Metrics get()
+        {
+            return new Metrics(merged);
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -50,6 +50,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>stats</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/LongCount.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/LongCount.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.metrics;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.spi.metrics.Count;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class LongCount
+        implements Count<LongCount>
+{
+    private final long total;
+
+    @JsonCreator
+    public LongCount(long total)
+    {
+        this.total = total;
+    }
+
+    @JsonProperty("total")
+    @Override
+    public long getTotal()
+    {
+        return total;
+    }
+
+    @Override
+    public LongCount mergeWith(LongCount other)
+    {
+        return new LongCount(total + other.getTotal());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LongCount count = (LongCount) o;
+        return total == count.total;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(total);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("total", total)
+                .toString();
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.base.metrics;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.util.StdConverter;
+import io.airlift.slice.Slice;
+import io.airlift.stats.TDigest;
+import io.trino.spi.metrics.Distribution;
+
+import java.util.Base64;
+
+import static io.airlift.slice.Slices.wrappedBuffer;
+
+public class TDigestHistogram
+        implements Distribution<TDigestHistogram>
+{
+    @JsonSerialize(converter = TDigestToBase64Converter.class)
+    @JsonDeserialize(converter = Base64ToTDigestConverter.class)
+    private final TDigest digest;
+
+    @JsonCreator
+    public TDigestHistogram(TDigest digest)
+    {
+        this.digest = digest;
+    }
+
+    @JsonProperty
+    public TDigest getDigest()
+    {
+        return digest;
+    }
+
+    @Override
+    public TDigestHistogram mergeWith(TDigestHistogram other)
+    {
+        TDigest result = TDigest.copyOf(digest);
+        result.mergeWith(other.getDigest());
+        return new TDigestHistogram(result);
+    }
+
+    @Override
+    public long getTotal()
+    {
+        return (long) digest.getCount();
+    }
+
+    @Override
+    public double getPercentile(double percentile)
+    {
+        return digest.valueAt(percentile / 100.0);
+    }
+
+    public static class TDigestToBase64Converter
+            extends StdConverter<TDigest, String>
+    {
+        public TDigestToBase64Converter()
+        {
+        }
+
+        @Override
+        public String convert(TDigest value)
+        {
+            Slice slice = value.serialize();
+            return Base64.getEncoder().encodeToString(slice.getBytes());
+        }
+    }
+
+    public static class Base64ToTDigestConverter
+            extends StdConverter<String, TDigest>
+    {
+        public Base64ToTDigestConverter()
+        {
+        }
+
+        @Override
+        public TDigest convert(String value)
+        {
+            Slice slice = wrappedBuffer(Base64.getDecoder().decode(value));
+            return TDigest.deserialize(slice);
+        }
+    }
+}

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/metrics/TestMetrics.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/metrics/TestMetrics.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.base.metrics;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.json.JsonCodec;
+import io.airlift.stats.TDigest;
+import io.trino.spi.metrics.Metric;
+import io.trino.spi.metrics.Metrics;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestMetrics
+{
+    @Test
+    public void testMergeCount()
+    {
+        Metrics m1 = new Metrics(ImmutableMap.of(
+                "a", new LongCount(1),
+                "b", new LongCount(2)));
+        Metrics m2 = new Metrics(ImmutableMap.of(
+                "b", new LongCount(3),
+                "c", new LongCount(4)));
+        Metrics merged = merge(m1, m2);
+        Map<String, Metric> expectedMap = ImmutableMap.of(
+                "a", new LongCount(1),
+                "b", new LongCount(5),
+                "c", new LongCount(4));
+        assertThat(merged.getMetrics()).isEqualTo(expectedMap);
+    }
+
+    @Test
+    public void testMergeHistogram()
+    {
+        TDigest d1 = new TDigest();
+        d1.add(10.0, 1);
+
+        TDigest d2 = new TDigest();
+        d2.add(5.0, 2);
+
+        Metrics m1 = new Metrics(ImmutableMap.of("a", new TDigestHistogram(d1)));
+        Metrics m2 = new Metrics(ImmutableMap.of("a", new TDigestHistogram(d2)));
+        TDigestHistogram merged = (TDigestHistogram) merge(m1, m2).getMetrics().get("a");
+
+        assertThat(merged.getTotal()).isEqualTo(3L);
+        assertThat(merged.getPercentile(0)).isEqualTo(5.0);
+        assertThat(merged.getPercentile(100)).isEqualTo(10.0);
+    }
+
+    @Test
+    public void testHistogramJson()
+    {
+        JsonCodec<TDigestHistogram> codec = JsonCodec.jsonCodec(TDigestHistogram.class);
+
+        TDigest digest = new TDigest();
+        digest.add(123);
+
+        String json = codec.toJson(new TDigestHistogram(digest));
+        TDigestHistogram result = codec.fromJson(json);
+        assertThat(result.getDigest().getCount()).isEqualTo(digest.getCount());
+    }
+
+    @Test(expectedExceptions = ClassCastException.class)
+    public void testFailIncompatibleTypes()
+    {
+        Metrics m1 = new Metrics(ImmutableMap.of("a", new TDigestHistogram(new TDigest())));
+        Metrics m2 = new Metrics(ImmutableMap.of("a", new LongCount(0)));
+        merge(m1, m2);
+    }
+
+    private static Metrics merge(Metrics... metrics)
+    {
+        return Arrays.stream(metrics).reduce(Metrics.EMPTY, Metrics::mergeWith);
+    }
+}

--- a/plugin/trino-memory/pom.xml
+++ b/plugin/trino-memory/pom.xml
@@ -19,6 +19,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>


### PR DESCRIPTION
We suggest the following simple mechanism for returning and aggregating custom per-query metrics from each page source:
https://github.com/prestosql/presto/compare/master...rzeyde-varada:custom-metrics?expand=1#diff-1b3e5d066c2bad4b806846b761b9d68526c7abb942df89f1b6b92a8e76fe2948

For simplicity, each ConnectorPageSource returns a single mapping from strings to longs, and the engine aggregates them across all splits. This allows the connectors to expose various "low-level" counters without changing modifying the engine code (to return them via `OperatorStats`).

I would be happy to hear your opinion about this feature - any comments/questions/suggestions are welcome :)