### PR TITLE
More contention reductions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/memory/MemoryPool.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryPool.java
@@ -273,7 +273,7 @@ public class MemoryPool
     }
 
     @Managed
-    public synchronized long getMaxBytes()
+    public long getMaxBytes()
     {
         return maxBytes;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/ExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExchangeClient.java
@@ -14,7 +14,6 @@
 package io.trino.operator;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.http.client.HttpClient;
@@ -49,6 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.slice.Slices.EMPTY_SLICE;
 import static java.util.Objects.requireNonNull;
 
@@ -57,6 +57,7 @@ public class ExchangeClient
         implements Closeable
 {
     private static final SerializedPage NO_MORE_PAGES = new SerializedPage(EMPTY_SLICE, PageCodecMarker.MarkerSet.empty(), 0, 0);
+    private static final ListenableFuture<?> NOT_BLOCKED = immediateFuture(null);
 
     private final String selfAddress;
     private final DataIntegrityVerification dataIntegrityVerification;
@@ -322,52 +323,75 @@ public class ExchangeClient
         }
     }
 
-    public synchronized ListenableFuture<?> isBlocked()
+    public ListenableFuture<?> isBlocked()
     {
+        // Fast path pre-check
         if (isClosed() || isFailed() || pageBuffer.peek() != null) {
-            return Futures.immediateFuture(true);
+            return NOT_BLOCKED;
         }
-        SettableFuture<?> future = SettableFuture.create();
-        blockedCallers.add(future);
-        return future;
+        synchronized (this) {
+            // Recheck after acquiring the lock
+            if (isClosed() || isFailed() || pageBuffer.peek() != null) {
+                return NOT_BLOCKED;
+            }
+            SettableFuture<?> future = SettableFuture.create();
+            blockedCallers.add(future);
+            return future;
+        }
     }
 
-    private synchronized boolean addPages(List<SerializedPage> pages)
+    private boolean addPages(List<SerializedPage> pages)
     {
-        if (isClosed() || isFailed()) {
-            return false;
+        // Compute stats before acquiring the lock
+        long pagesRetainedSizeInBytes = 0;
+        long responseSize = 0;
+        for (SerializedPage page : pages) {
+            pagesRetainedSizeInBytes += page.getRetainedSizeInBytes();
+            responseSize += page.getSizeInBytes();
         }
 
-        pageBuffer.addAll(pages);
+        List<SettableFuture<?>> notify = ImmutableList.of();
+        synchronized (this) {
+            if (isClosed() || isFailed()) {
+                return false;
+            }
 
-        if (!pages.isEmpty()) {
-            // notify all blocked callers
-            notifyBlockedCallers();
+            if (!pages.isEmpty()) {
+                pageBuffer.addAll(pages);
+
+                bufferRetainedSizeInBytes += pagesRetainedSizeInBytes;
+                maxBufferRetainedSizeInBytes = Math.max(maxBufferRetainedSizeInBytes, bufferRetainedSizeInBytes);
+                systemMemoryContext.setBytes(bufferRetainedSizeInBytes);
+
+                // Notify pending listeners that a page has been added
+                notify = ImmutableList.copyOf(blockedCallers);
+                blockedCallers.clear();
+            }
+
+            successfulRequests++;
+            // AVG_n = AVG_(n-1) * (n-1)/n + VALUE_n / n
+            averageBytesPerRequest = (long) (1.0 * averageBytesPerRequest * (successfulRequests - 1) / successfulRequests + responseSize / successfulRequests);
         }
 
-        long pagesRetainedSizeInBytes = pages.stream()
-                .mapToLong(SerializedPage::getRetainedSizeInBytes)
-                .sum();
-
-        bufferRetainedSizeInBytes += pagesRetainedSizeInBytes;
-        maxBufferRetainedSizeInBytes = Math.max(maxBufferRetainedSizeInBytes, bufferRetainedSizeInBytes);
-        systemMemoryContext.setBytes(bufferRetainedSizeInBytes);
-        successfulRequests++;
-
-        long responseSize = pages.stream()
-                .mapToLong(SerializedPage::getSizeInBytes)
-                .sum();
-        // AVG_n = AVG_(n-1) * (n-1)/n + VALUE_n / n
-        averageBytesPerRequest = (long) (1.0 * averageBytesPerRequest * (successfulRequests - 1) / successfulRequests + responseSize / successfulRequests);
+        // Trigger notifications after releasing the lock
+        notifyListeners(notify);
 
         return true;
     }
 
-    private synchronized void notifyBlockedCallers()
+    private void notifyBlockedCallers()
     {
-        List<SettableFuture<?>> callers = ImmutableList.copyOf(blockedCallers);
-        blockedCallers.clear();
-        for (SettableFuture<?> blockedCaller : callers) {
+        List<SettableFuture<?>> callers;
+        synchronized (this) {
+            callers = ImmutableList.copyOf(blockedCallers);
+            blockedCallers.clear();
+        }
+        notifyListeners(callers);
+    }
+
+    private void notifyListeners(List<SettableFuture<?>> blockedCallers)
+    {
+        for (SettableFuture<?> blockedCaller : blockedCallers) {
             // Notify callers in a separate thread to avoid callbacks while holding a lock
             scheduler.execute(() -> blockedCaller.set(null));
         }

--- a/core/trino-main/src/main/java/io/trino/operator/ExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExchangeClient.java
@@ -219,12 +219,6 @@ public class ExchangeClient
         }
 
         SerializedPage page = pageBuffer.poll();
-        return postProcessPage(page);
-    }
-
-    private SerializedPage postProcessPage(SerializedPage page)
-    {
-        checkState(!Thread.holdsLock(this), "Cannot get next page while holding a lock on this");
 
         if (page == null) {
             return null;
@@ -244,12 +238,10 @@ public class ExchangeClient
             if (!closed.get()) {
                 bufferRetainedSizeInBytes -= page.getRetainedSizeInBytes();
                 systemMemoryContext.setBytes(bufferRetainedSizeInBytes);
-                if (pageBuffer.peek() == NO_MORE_PAGES) {
-                    close();
-                }
             }
+            scheduleRequestIfNecessary();
         }
-        scheduleRequestIfNecessary();
+
         return page;
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/TaskOutputOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskOutputOperator.java
@@ -91,6 +91,7 @@ public class TaskOutputOperator
     private final OutputBuffer outputBuffer;
     private final Function<Page, Page> pagePreprocessor;
     private final PagesSerde serde;
+    private ListenableFuture<?> isBlocked = NOT_BLOCKED;
     private boolean finished;
 
     public TaskOutputOperator(OperatorContext operatorContext, OutputBuffer outputBuffer, Function<Page, Page> pagePreprocessor, PagesSerdeFactory serdeFactory)
@@ -122,8 +123,14 @@ public class TaskOutputOperator
     @Override
     public ListenableFuture<?> isBlocked()
     {
-        ListenableFuture<?> blocked = outputBuffer.isFull();
-        return blocked.isDone() ? NOT_BLOCKED : blocked;
+        // Avoid re-synchronizing on the output buffer when operator is already blocked
+        if (isBlocked.isDone()) {
+            isBlocked = outputBuffer.isFull();
+            if (isBlocked.isDone()) {
+                isBlocked = NOT_BLOCKED;
+            }
+        }
+        return isBlocked;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/BroadcastExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/BroadcastExchanger.java
@@ -15,6 +15,7 @@ package io.trino.operator.exchange;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.operator.exchange.PageReference.PageReleasedListener;
 import io.trino.spi.Page;
 
 import java.util.List;
@@ -27,11 +28,13 @@ class BroadcastExchanger
 {
     private final List<Consumer<PageReference>> buffers;
     private final LocalExchangeMemoryManager memoryManager;
+    private final PageReleasedListener onPageReleased;
 
     public BroadcastExchanger(List<Consumer<PageReference>> buffers, LocalExchangeMemoryManager memoryManager)
     {
         this.buffers = ImmutableList.copyOf(requireNonNull(buffers, "buffers is null"));
         this.memoryManager = requireNonNull(memoryManager, "memoryManager is null");
+        this.onPageReleased = PageReleasedListener.forLocalExchangeMemoryManager(memoryManager);
     }
 
     @Override
@@ -39,7 +42,7 @@ class BroadcastExchanger
     {
         memoryManager.updateMemoryUsage(page.getRetainedSizeInBytes());
 
-        PageReference pageReference = new PageReference(page, buffers.size(), () -> memoryManager.updateMemoryUsage(-page.getRetainedSizeInBytes()));
+        PageReference pageReference = new PageReference(page, buffers.size(), onPageReleased);
 
         for (Consumer<PageReference> buffer : buffers) {
             buffer.accept(pageReference);

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeMemoryManager.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeMemoryManager.java
@@ -16,28 +16,26 @@ package io.trino.operator.exchange;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 
 @ThreadSafe
 public class LocalExchangeMemoryManager
 {
-    private static final SettableFuture<?> NOT_FULL;
-
-    static {
-        NOT_FULL = SettableFuture.create();
-        NOT_FULL.set(null);
-    }
+    private static final ListenableFuture<?> NOT_BLOCKED = immediateFuture(null);
 
     private final long maxBufferedBytes;
     private final AtomicLong bufferedBytes = new AtomicLong();
 
+    @Nullable
     @GuardedBy("this")
-    private SettableFuture<?> notFullFuture = NOT_FULL;
+    private SettableFuture<?> notFullFuture; // null represents "no callback registered"
 
     public LocalExchangeMemoryManager(long maxBufferedBytes)
     {
@@ -47,31 +45,39 @@ public class LocalExchangeMemoryManager
 
     public void updateMemoryUsage(long bytesAdded)
     {
-        SettableFuture<?> future;
-        synchronized (this) {
-            bufferedBytes.addAndGet(bytesAdded);
-
-            // if we are full, then breakout
-            if (bufferedBytes.get() > maxBufferedBytes || notFullFuture.isDone()) {
-                return;
+        long bufferedBytes = this.bufferedBytes.addAndGet(bytesAdded);
+        // detect the transition from above to below the full boundary
+        if (bufferedBytes <= maxBufferedBytes && (bufferedBytes - bytesAdded) > maxBufferedBytes) {
+            SettableFuture<?> future;
+            synchronized (this) {
+                // if we have no callback waiting, return early
+                if (notFullFuture == null) {
+                    return;
+                }
+                future = notFullFuture;
+                notFullFuture = null;
             }
-
-            // otherwise, we are not full, so complete the future
-            future = notFullFuture;
-            notFullFuture = NOT_FULL;
+            // complete future outside of lock since this can invoke callbacks
+            future.set(null);
         }
-
-        // complete future outside of lock since this can invoke callbacks
-        future.set(null);
     }
 
-    public synchronized ListenableFuture<?> getNotFullFuture()
+    public ListenableFuture<?> getNotFullFuture()
     {
-        // if we are full and the current not full future is already complete, create a new one
-        if (bufferedBytes.get() > maxBufferedBytes && notFullFuture.isDone()) {
-            notFullFuture = SettableFuture.create();
+        if (bufferedBytes.get() <= maxBufferedBytes) {
+            return NOT_BLOCKED;
         }
-        return notFullFuture;
+        synchronized (this) {
+            // Recheck after synchronizing but before creating a real listener
+            if (bufferedBytes.get() <= maxBufferedBytes) {
+                return NOT_BLOCKED;
+            }
+            // if we are full and no current listener is registered, create one
+            if (notFullFuture == null) {
+                notFullFuture = SettableFuture.create();
+            }
+            return notFullFuture;
+        }
     }
 
     public long getBufferedBytes()

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSource.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSource.java
@@ -19,6 +19,7 @@ import io.trino.operator.WorkProcessor;
 import io.trino.operator.WorkProcessor.ProcessState;
 import io.trino.spi.Page;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -30,30 +31,24 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
 public class LocalExchangeSource
 {
-    private static final SettableFuture<?> NOT_EMPTY;
-
-    static {
-        NOT_EMPTY = SettableFuture.create();
-        NOT_EMPTY.set(null);
-    }
+    private static final ListenableFuture<?> NOT_BLOCKED = immediateFuture(null);
 
     private final Consumer<LocalExchangeSource> onFinish;
 
     private final BlockingQueue<PageReference> buffer = new LinkedBlockingDeque<>();
     private final AtomicLong bufferedBytes = new AtomicLong();
 
-    private final Object lock = new Object();
+    @Nullable
+    @GuardedBy("this")
+    private SettableFuture<?> notEmptyFuture; // null indicates no callback has been registered
 
-    @GuardedBy("lock")
-    private SettableFuture<?> notEmptyFuture = NOT_EMPTY;
-
-    @GuardedBy("lock")
-    private boolean finishing;
+    private volatile boolean finishing;
 
     public LocalExchangeSource(Consumer<LocalExchangeSource> onFinish)
     {
@@ -72,20 +67,23 @@ public class LocalExchangeSource
         checkNotHoldsLock();
 
         boolean added = false;
-        SettableFuture<?> notEmptyFuture;
-        synchronized (lock) {
+        SettableFuture<?> notEmptyFuture = null;
+        long retainedSizeInBytes = pageReference.getRetainedSizeInBytes();
+        synchronized (this) {
             // ignore pages after finish
             if (!finishing) {
                 // buffered bytes must be updated before adding to the buffer to assure
                 // the count does not go negative
-                bufferedBytes.addAndGet(pageReference.getRetainedSizeInBytes());
+                bufferedBytes.addAndGet(retainedSizeInBytes);
                 buffer.add(pageReference);
                 added = true;
             }
 
             // we just added a page (or we are finishing) so we are not empty
-            notEmptyFuture = this.notEmptyFuture;
-            this.notEmptyFuture = NOT_EMPTY;
+            if (this.notEmptyFuture != null) {
+                notEmptyFuture = this.notEmptyFuture;
+                this.notEmptyFuture = null;
+            }
         }
 
         if (!added) {
@@ -94,7 +92,9 @@ public class LocalExchangeSource
         }
 
         // notify readers outside of lock since this may result in a callback
-        notEmptyFuture.set(null);
+        if (notEmptyFuture != null) {
+            notEmptyFuture.set(null);
+        }
     }
 
     public WorkProcessor<Page> pages()
@@ -142,10 +142,18 @@ public class LocalExchangeSource
     public ListenableFuture<?> waitForReading()
     {
         checkNotHoldsLock();
+        // Fast path, definitely not blocked
+        if (finishing || !buffer.isEmpty()) {
+            return NOT_BLOCKED;
+        }
 
-        synchronized (lock) {
+        synchronized (this) {
+            // re-check after synchronizing
+            if (finishing || !buffer.isEmpty()) {
+                return NOT_BLOCKED;
+            }
             // if we need to block readers, and the current future is complete, create a new one
-            if (!finishing && buffer.isEmpty() && notEmptyFuture.isDone()) {
+            if (notEmptyFuture == null) {
                 notEmptyFuture = SettableFuture.create();
             }
             return notEmptyFuture;
@@ -154,7 +162,12 @@ public class LocalExchangeSource
 
     public boolean isFinished()
     {
-        synchronized (lock) {
+        // Common case fast-path without synchronizing
+        if (!finishing) {
+            return false;
+        }
+        synchronized (this) {
+            // Synchronize to ensure effects of an in-flight close() or finish() are observed
             return finishing && buffer.isEmpty();
         }
     }
@@ -164,18 +177,21 @@ public class LocalExchangeSource
         checkNotHoldsLock();
 
         SettableFuture<?> notEmptyFuture;
-        synchronized (lock) {
+        synchronized (this) {
             if (finishing) {
                 return;
             }
             finishing = true;
 
+            // Unblock any waiters
             notEmptyFuture = this.notEmptyFuture;
-            this.notEmptyFuture = NOT_EMPTY;
+            this.notEmptyFuture = null;
         }
 
         // notify readers outside of lock since this may result in a callback
-        notEmptyFuture.set(null);
+        if (notEmptyFuture != null) {
+            notEmptyFuture.set(null);
+        }
 
         checkFinished();
     }
@@ -186,21 +202,23 @@ public class LocalExchangeSource
 
         List<PageReference> remainingPages = new ArrayList<>();
         SettableFuture<?> notEmptyFuture;
-        synchronized (lock) {
+        synchronized (this) {
             finishing = true;
 
             buffer.drainTo(remainingPages);
             bufferedBytes.addAndGet(-remainingPages.stream().mapToLong(PageReference::getRetainedSizeInBytes).sum());
 
             notEmptyFuture = this.notEmptyFuture;
-            this.notEmptyFuture = NOT_EMPTY;
+            this.notEmptyFuture = null;
         }
 
         // free all the remaining pages
         remainingPages.forEach(PageReference::removePage);
 
         // notify readers outside of lock since this may result in a callback
-        notEmptyFuture.set(null);
+        if (notEmptyFuture != null) {
+            notEmptyFuture.set(null);
+        }
 
         // this will always fire the finished event
         checkState(isFinished(), "Expected buffer to be finished");
@@ -222,6 +240,6 @@ public class LocalExchangeSource
 
     private void checkNotHoldsLock()
     {
-        checkState(!Thread.holdsLock(lock), "Cannot execute this method while holding the lock");
+        checkState(!Thread.holdsLock(this), "Cannot execute this method while holding the lock");
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSourceOperator.java
@@ -74,6 +74,7 @@ public class LocalExchangeSourceOperator
 
     private final OperatorContext operatorContext;
     private final LocalExchangeSource source;
+    private ListenableFuture<?> isBlocked = NOT_BLOCKED;
 
     public LocalExchangeSourceOperator(OperatorContext operatorContext, LocalExchangeSource source)
     {
@@ -103,7 +104,13 @@ public class LocalExchangeSourceOperator
     @Override
     public ListenableFuture<?> isBlocked()
     {
-        return source.waitForReading();
+        if (isBlocked.isDone()) {
+            isBlocked = source.waitForReading();
+            if (isBlocked.isDone()) {
+                isBlocked = NOT_BLOCKED;
+            }
+        }
+        return isBlocked;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PageReference.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PageReference.java
@@ -17,24 +17,27 @@ import io.trino.spi.Page;
 
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
-class PageReference
+final class PageReference
 {
-    private final Page page;
-    private final Runnable onFree;
-    private final AtomicInteger referenceCount;
+    private static final AtomicIntegerFieldUpdater<PageReference> REFERENCE_COUNT_UPDATER = AtomicIntegerFieldUpdater.newUpdater(PageReference.class, "referenceCount");
 
-    public PageReference(Page page, int referenceCount, Runnable onFree)
+    private volatile int referenceCount;
+    private final Page page;
+    private final PageReleasedListener onPageReleased;
+
+    public PageReference(Page page, int referenceCount, PageReleasedListener onPageReleased)
     {
         this.page = requireNonNull(page, "page is null");
-        this.onFree = requireNonNull(onFree, "onFree is null");
+        this.onPageReleased = requireNonNull(onPageReleased, "onPageReleased is null");
         checkArgument(referenceCount >= 1, "referenceCount must be at least 1");
-        this.referenceCount = new AtomicInteger(referenceCount);
+        this.referenceCount = referenceCount;
     }
 
     public long getRetainedSizeInBytes()
@@ -44,11 +47,31 @@ class PageReference
 
     public Page removePage()
     {
-        int referenceCount = this.referenceCount.decrementAndGet();
+        int referenceCount = REFERENCE_COUNT_UPDATER.decrementAndGet(this);
         checkArgument(referenceCount >= 0, "Page reference count is negative");
         if (referenceCount == 0) {
-            onFree.run();
+            onPageReleased.onPageReleased(page.getRetainedSizeInBytes());
         }
         return page;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("size", getRetainedSizeInBytes())
+                .add("referenceCount", referenceCount)
+                .toString();
+    }
+
+    interface PageReleasedListener
+    {
+        void onPageReleased(long releasedSizeInBytes);
+
+        static PageReleasedListener forLocalExchangeMemoryManager(LocalExchangeMemoryManager memoryManager)
+        {
+            requireNonNull(memoryManager, "memoryManager is null");
+            return (releasedSizeInBytes) -> memoryManager.updateMemoryUsage(-releasedSizeInBytes);
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PassthroughExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PassthroughExchanger.java
@@ -14,6 +14,7 @@
 package io.trino.operator.exchange;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.operator.exchange.PageReference.PageReleasedListener;
 import io.trino.spi.Page;
 
 import java.util.function.LongConsumer;
@@ -26,12 +27,17 @@ public class PassthroughExchanger
     private final LocalExchangeSource localExchangeSource;
     private final LocalExchangeMemoryManager bufferMemoryManager;
     private final LongConsumer memoryTracker;
+    private final PageReleasedListener onPageReleased;
 
     public PassthroughExchanger(LocalExchangeSource localExchangeSource, long bufferMaxMemory, LongConsumer memoryTracker)
     {
         this.localExchangeSource = requireNonNull(localExchangeSource, "localExchangeSource is null");
-        this.bufferMemoryManager = new LocalExchangeMemoryManager(bufferMaxMemory);
         this.memoryTracker = requireNonNull(memoryTracker, "memoryTracker is null");
+        bufferMemoryManager = new LocalExchangeMemoryManager(bufferMaxMemory);
+        onPageReleased = (releasedSizeInBytes) -> {
+            this.bufferMemoryManager.updateMemoryUsage(-releasedSizeInBytes);
+            this.memoryTracker.accept(-releasedSizeInBytes);
+        };
     }
 
     @Override
@@ -41,12 +47,7 @@ public class PassthroughExchanger
         bufferMemoryManager.updateMemoryUsage(retainedSizeInBytes);
         memoryTracker.accept(retainedSizeInBytes);
 
-        PageReference pageReference = new PageReference(page, 1, () -> {
-            bufferMemoryManager.updateMemoryUsage(-retainedSizeInBytes);
-            memoryTracker.accept(-retainedSizeInBytes);
-        });
-
-        localExchangeSource.addPage(pageReference);
+        localExchangeSource.addPage(new PageReference(page, 1, onPageReleased));
     }
 
     @Override


### PR DESCRIPTION
Continuation of contention reducing changes in https://github.com/prestosql/presto/pull/6097 extracted from https://github.com/prestodb/presto/pull/15509

Seven commits:
- Cache `ListenableFuture<?> isBlocked` in various operators to avoid repeatedly contending for locks and potentially registering new callbacks once those operators are blocked
- Add unsynchronized fast-paths in ExchangeClient to avoid unnecessary contention
- Refactor `ExchangeClient#pollPage` to avoid redundant checks and synchronizations
- Use `AtomicIntegerFieldUpdater` for local exchange `PageReference`
- Reduce synchronization in `LocalExchangeMemoryManager` by making unblocking an edge-triggered event that only a single caller initiates.
- Add unsynchronized common-case fast paths in `LocalExchangeSource`
- Remove synchronized for final field read in `MemoryPool#getMaxBytes()`
