### PR TITLE
Filter sys schema on MySQL

### DIFF
--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -194,7 +194,8 @@ public class MySqlClient
     @Override
     protected boolean filterSchema(String schemaName)
     {
-        if (schemaName.equalsIgnoreCase("mysql")) {
+        if (schemaName.equalsIgnoreCase("mysql")
+                || schemaName.equalsIgnoreCase("sys")) {
             return false;
         }
         return super.filterSchema(schemaName);


### PR DESCRIPTION
On MySQL 8 has a new sys schema that's used in conjunction with the performance schema, we should hide this as well. See this for details https://dev.mysql.com/doc/refman/8.0/en/sys-schema.html