### PR TITLE
Tighten allowed characters for non-delimited identifiers

### DIFF
--- a/presto-parser/src/main/java/io/prestosql/sql/tree/Identifier.java
+++ b/presto-parser/src/main/java/io/prestosql/sql/tree/Identifier.java
@@ -26,7 +26,7 @@ import static java.util.Objects.requireNonNull;
 public class Identifier
         extends Expression
 {
-    private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z_]([a-zA-Z0-9_:@])*");
+    private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z_]([a-zA-Z0-9_])*");
 
     private final String value;
     private final boolean delimited;


### PR DESCRIPTION
Identifiers with characters such as @ or : are not being treated as
delimited identifiers, which causes issues when the planner creates
synthetic identifiers as part of the plan IR expressions. When
the IR expressions are serialized, they are not being properly
quoted, which causes failures when parsing the plan on the work side.

For example, for a query such as:

    SELECT try("a@b") FROM t

The planner creates an expression of the form:

    "$internal$try"("$INTERNAL$BIND"("a@b", (a@b_0) -> "a@b_0"))

The argument to the lambda expression is not properly quoted.

Fixes https://github.com/prestosql/presto/issues/6375