### PR TITLE
fix session property casing typo

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -255,7 +255,7 @@ public final class HiveSessionProperties
                         false),
                 booleanProperty(
                         ORC_USE_COLUMN_NAME,
-                        "Orc: Access ORC columns using names from the file",
+                        "ORC: Access ORC columns using names from the file",
                         orcReaderConfig.isUseColumnNames(),
                         false),
                 enumProperty(


### PR DESCRIPTION
All other ORC descriptions use upper case:
![orctypo](https://user-images.githubusercontent.com/33283496/103036967-cc33f200-4562-11eb-885d-9917061143ef.png)
