### PR TITLE
Document assume canonical hive partition key

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -370,6 +370,10 @@ Property Name                                                   Description     
                                                                 Possible values are ``NONE`` or ``KERBEROS``
                                                                 (defaults to ``NONE``).
 
+``hive.metastore.thrift.assume-canonical-partition-keys``       Allow conversion of non-char types (eg BIGINT, timestamp)    ``false``
+                                                                to canonical string formats. If false, non-char types will
+                                                                be replaced with the wildcard.
+
 ``hive.metastore.thrift.impersonation.enabled``                 Enable Hive metastore end user impersonation.
 
 ``hive.metastore.thrift.delegation-token.cache-ttl``            Time to live delegation token cache for metastore.           ``1h``

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -370,9 +370,22 @@ Property Name                                                   Description     
                                                                 Possible values are ``NONE`` or ``KERBEROS``
                                                                 (defaults to ``NONE``).
 
-``hive.metastore.thrift.assume-canonical-partition-keys``       Allow conversion of non-char types (eg BIGINT, timestamp)    ``false``
-                                                                to canonical string formats. If false, non-char types will
-                                                                be replaced with the wildcard.
+``hive.metastore.thrift.assume-canonical-partition-keys``       Assume that partition keys for non-string types are          ``false``
+                                                                represented in their canonical form in the metastore.
+                                                                Without this assumption, filters on such columns cannot be
+                                                                pushed into the metastore. However, if the assumption is
+                                                                violated, the query may incorrectly skip data that should
+                                                                be present, or it may fail entirely. Thus, you should only
+                                                                set this value to true if you are certain that your partition
+                                                                keys are always stored in canonical form.
+                                                                As background, the Hive metastore uses strings for partition
+                                                                keys for all data types, but does not enforce a canonical
+                                                                representation of values. For example, a partition column
+                                                                of type int can have the value 42, but be stored as '0042'
+                                                                in the metastore. If a query has a filter on value 42, then
+                                                                the Hive connector will ask the metastore for partitions
+                                                                matching the string '42', which will fail to match the actual
+                                                                partition value of '0042'.
 
 ``hive.metastore.thrift.impersonation.enabled``                 Enable Hive metastore end user impersonation.
 

--- a/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
+++ b/presto-hive/src/main/java/io/prestosql/plugin/hive/metastore/thrift/ThriftMetastoreConfig.java
@@ -292,6 +292,7 @@ public class ThriftMetastoreConfig
     }
 
     @Config("hive.metastore.thrift.assume-canonical-partition-keys")
+    @ConfigDescription("Assume canonical partition key type")
     public ThriftMetastoreConfig setAssumeCanonicalPartitionKeys(boolean assumeCanonicalPartitionKeys)
     {
         this.assumeCanonicalPartitionKeys = assumeCanonicalPartitionKeys;


### PR DESCRIPTION
When the partition key of the partition table is an integer type, no data can be found and an exception is thrown like follow：
PrestoException：Table ‘aa.bb' was dropped by another transaction
But in fact the table exists, and the partition also exists.
By reading the code, it is found that there is a parameter in the configuration of thrift metastore.
In order to remove this obstacle for future users, we hereby use documents to record.

Fixes #6437