### PR TITLE
Decompress Kinesis message if needed

### DIFF
--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisCompressionCodec.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisCompressionCodec.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kinesis;
+
+public enum KinesisCompressionCodec
+{
+    UNCOMPRESSED,
+    GZIP,
+    AUTOMATIC;
+
+    public static boolean canUseGzip(KinesisCompressionCodec compressionCodec)
+    {
+        return compressionCodec == GZIP || compressionCodec == AUTOMATIC;
+    }
+}

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisMetadata.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisMetadata.java
@@ -76,7 +76,8 @@ public class KinesisMetadata
                 schemaTableName.getSchemaName(),
                 schemaTableName.getTableName(),
                 table.getStreamName(),
-                getDataFormat(table.getMessage()));
+                getDataFormat(table.getMessage()),
+                table.getMessage().getCompressionCodec());
     }
 
     @Override

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplit.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplit.java
@@ -33,6 +33,7 @@ public class KinesisSplit
 {
     private final String streamName;
     private final String messageDataFormat;
+    private final KinesisCompressionCodec compressionCodec;
     private final String shardId;
     private final String start;
     private final String end;
@@ -41,12 +42,14 @@ public class KinesisSplit
     public KinesisSplit(
             @JsonProperty("streamName") String streamName,
             @JsonProperty("messageDataFormat") String messageDataFormat,
+            @JsonProperty("compressionCodec") KinesisCompressionCodec compressionCodec,
             @JsonProperty("shardId") String shardId,
             @JsonProperty("start") String start,
             @JsonProperty("end") String end)
     {
         this.streamName = requireNonNull(streamName, "streamName is null");
         this.messageDataFormat = requireNonNull(messageDataFormat, "messageDataFormat is null");
+        this.compressionCodec = requireNonNull(compressionCodec, "compressionCodec is null");
         this.shardId = shardId;
         this.start = start;
         this.end = end;
@@ -74,6 +77,12 @@ public class KinesisSplit
     public String getMessageDataFormat()
     {
         return messageDataFormat;
+    }
+
+    @JsonProperty
+    public KinesisCompressionCodec getCompressionCodec()
+    {
+        return compressionCodec;
     }
 
     @JsonProperty
@@ -106,6 +115,7 @@ public class KinesisSplit
         return toStringHelper(this)
                 .add("streamName", streamName)
                 .add("messageDataFormat", messageDataFormat)
+                .add("compressionCodec", compressionCodec)
                 .add("shardId", shardId)
                 .add("start", start)
                 .add("end", end)

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplitManager.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisSplitManager.java
@@ -111,6 +111,7 @@ public class KinesisSplitManager
             KinesisSplit split = new KinesisSplit(
                     kinesisTableHandle.getStreamName(),
                     kinesisTableHandle.getMessageDataFormat(),
+                    kinesisTableHandle.getCompressionCodec(),
                     shard.getShardId(),
                     shard.getSequenceNumberRange().getStartingSequenceNumber(),
                     shard.getSequenceNumberRange().getEndingSequenceNumber());

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisStreamFieldGroup.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisStreamFieldGroup.java
@@ -18,21 +18,26 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.trino.plugin.kinesis.KinesisCompressionCodec.UNCOMPRESSED;
 import static java.util.Objects.requireNonNull;
 
 public class KinesisStreamFieldGroup
 {
     private final String dataFormat;
+    private final Optional<KinesisCompressionCodec> compressionCodec;
     private final List<KinesisStreamFieldDescription> fields;
 
     @JsonCreator
     public KinesisStreamFieldGroup(
             @JsonProperty("dataFormat") String dataFormat,
+            @JsonProperty("compressionCodec") Optional<KinesisCompressionCodec> compressionCodec,
             @JsonProperty("fields") List<KinesisStreamFieldDescription> fields)
     {
         this.dataFormat = requireNonNull(dataFormat, "dataFormat is null");
+        this.compressionCodec = requireNonNull(compressionCodec, "compressionCodec is null");
         this.fields = ImmutableList.copyOf(requireNonNull(fields, "fields is null"));
     }
 
@@ -40,6 +45,11 @@ public class KinesisStreamFieldGroup
     public String getDataFormat()
     {
         return dataFormat;
+    }
+
+    public KinesisCompressionCodec getCompressionCodec()
+    {
+        return compressionCodec.orElse(UNCOMPRESSED);
     }
 
     @JsonProperty
@@ -53,6 +63,7 @@ public class KinesisStreamFieldGroup
     {
         return toStringHelper(this)
                 .add("dataFormat", dataFormat)
+                .add("compressionCodec", compressionCodec)
                 .add("fields", fields)
                 .toString();
     }

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableHandle.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableHandle.java
@@ -47,17 +47,21 @@ public class KinesisTableHandle
 
     private final String messageDataFormat;
 
+    private final KinesisCompressionCodec compressionCodec;
+
     @JsonCreator
     public KinesisTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("streamName") String streamName,
-            @JsonProperty("messageDataFormat") String messageDataFormat)
+            @JsonProperty("messageDataFormat") String messageDataFormat,
+            @JsonProperty("compressionCodec") KinesisCompressionCodec compressionCodec)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.streamName = requireNonNull(streamName, "topicName is null");
         this.messageDataFormat = requireNonNull(messageDataFormat, "messageDataFormat is null");
+        this.compressionCodec = requireNonNull(compressionCodec, "compressionCodec is null");
     }
 
     @JsonProperty
@@ -84,6 +88,12 @@ public class KinesisTableHandle
         return messageDataFormat;
     }
 
+    @JsonProperty
+    public KinesisCompressionCodec getCompressionCodec()
+    {
+        return compressionCodec;
+    }
+
     public SchemaTableName toSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -92,7 +102,7 @@ public class KinesisTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(schemaName, tableName, streamName, messageDataFormat);
+        return Objects.hash(schemaName, tableName, streamName, messageDataFormat, compressionCodec);
     }
 
     @Override
@@ -109,7 +119,8 @@ public class KinesisTableHandle
         return Objects.equals(this.schemaName, other.schemaName)
                 && Objects.equals(this.tableName, other.tableName)
                 && Objects.equals(this.streamName, other.streamName)
-                && Objects.equals(this.messageDataFormat, other.messageDataFormat);
+                && Objects.equals(this.messageDataFormat, other.messageDataFormat)
+                && Objects.equals(this.compressionCodec, other.compressionCodec);
     }
 
     @Override
@@ -120,6 +131,7 @@ public class KinesisTableHandle
                 .add("tableName", tableName)
                 .add("streamName", streamName)
                 .add("messageDataFormat", messageDataFormat)
+                .add("compressionCodec", compressionCodec)
                 .toString();
     }
 }

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/util/TestUtils.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/util/TestUtils.java
@@ -54,6 +54,8 @@ public final class TestUtils
         MockKinesisClient mockClient = (MockKinesisClient) kinesisTestClientManager.getClient();
         mockClient.createStream("test123", 2);
         mockClient.createStream("sampleTable", 2);
+        mockClient.createStream("sampleGzipCompressTable", 2);
+        mockClient.createStream("sampleAutomaticCompressTable", 2);
         KinesisConnectorFactory kinesisConnectorFactory = new TestingKinesisConnectorFactory(kinesisTestClientManager);
 
         KinesisPlugin kinesisPlugin = new KinesisPlugin(kinesisConnectorFactory);

--- a/plugin/trino-kinesis/src/test/resources/tableDescriptions/SampleAutomaticCompressTable.json
+++ b/plugin/trino-kinesis/src/test/resources/tableDescriptions/SampleAutomaticCompressTable.json
@@ -1,9 +1,10 @@
 {
-  "tableName": "sampleTable",
+  "tableName": "sampleAutomaticCompressTable",
   "schemaName": "default",
-  "streamName": "sampleTable",
+  "streamName": "sampleAutomaticCompressTable",
   "message": {
     "dataFormat": "json",
+    "compressionCodec": "AUTOMATIC",
     "fields": [{
       "name": "id",
       "type": "BIGINT",

--- a/plugin/trino-kinesis/src/test/resources/tableDescriptions/SampleGzipCompressTable.json
+++ b/plugin/trino-kinesis/src/test/resources/tableDescriptions/SampleGzipCompressTable.json
@@ -1,9 +1,10 @@
 {
-  "tableName": "sampleTable",
+  "tableName": "sampleGzipCompressTable",
   "schemaName": "default",
-  "streamName": "sampleTable",
+  "streamName": "sampleGzipCompressTable",
   "message": {
     "dataFormat": "json",
+    "compressionCodec": "GZIP",
     "fields": [{
       "name": "id",
       "type": "BIGINT",


### PR DESCRIPTION
Producer might push compressed messages to save network bandwidth and consumers should transparently uncompress the message before decoding it