### PR TITLE
Use dedicated modules for Kafka Schema Registry

### DIFF
--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/DecoderModule.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/DecoderModule.java
@@ -27,7 +27,6 @@ import io.trino.decoder.raw.RawRowDecoder;
 import io.trino.decoder.raw.RawRowDecoderFactory;
 
 import static com.google.inject.Scopes.SINGLETON;
-import static java.util.Objects.requireNonNull;
 
 /**
  * Default decoder module. Installs the registry and all known decoder submodules.
@@ -35,18 +34,6 @@ import static java.util.Objects.requireNonNull;
 public class DecoderModule
         implements Module
 {
-    private final Module extension;
-
-    public DecoderModule()
-    {
-        this(new AvroDecoderModule());
-    }
-
-    public DecoderModule(Module extension)
-    {
-        this.extension = requireNonNull(extension, "extension is null");
-    }
-
     @Override
     public void configure(Binder binder)
     {
@@ -55,7 +42,7 @@ public class DecoderModule
         decoderFactoriesByName.addBinding(CsvRowDecoder.NAME).to(CsvRowDecoderFactory.class).in(SINGLETON);
         decoderFactoriesByName.addBinding(JsonRowDecoder.NAME).to(JsonRowDecoderFactory.class).in(SINGLETON);
         decoderFactoriesByName.addBinding(RawRowDecoder.NAME).to(RawRowDecoderFactory.class).in(SINGLETON);
-        binder.install(extension);
+        binder.install(new AvroDecoderModule());
         binder.bind(DispatchingRowDecoderFactory.class).in(SINGLETON);
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/EncoderModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/EncoderModule.java
@@ -26,23 +26,10 @@ import io.trino.plugin.kafka.encoder.raw.RawRowEncoderFactory;
 
 import static com.google.inject.Scopes.SINGLETON;
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
-import static java.util.Objects.requireNonNull;
 
 public class EncoderModule
         implements Module
 {
-    private final Module extension;
-
-    public EncoderModule()
-    {
-        this(new AvroEncoderModule());
-    }
-
-    public EncoderModule(Module extension)
-    {
-        this.extension = requireNonNull(extension, "extension is null");
-    }
-
     @Override
     public void configure(Binder binder)
     {
@@ -51,10 +38,9 @@ public class EncoderModule
         encoderFactoriesByName.addBinding(CsvRowEncoder.NAME).to(CsvRowEncoderFactory.class).in(SINGLETON);
         encoderFactoriesByName.addBinding(RawRowEncoder.NAME).to(RawRowEncoderFactory.class).in(SINGLETON);
         encoderFactoriesByName.addBinding(JsonRowEncoder.NAME).to(JsonRowEncoderFactory.class).in(SINGLETON);
+        binder.install(new AvroEncoderModule());
 
         binder.bind(DispatchingRowEncoderFactory.class).in(SINGLETON);
-
-        binder.install(extension);
     }
 
     public static MapBinder<String, RowEncoderFactory> encoderFactory(Binder binder)


### PR DESCRIPTION
Use dedicated modules for Kafka Schema Registry

Reusing generic encoder and decoder module with extensions points make
it more complex that it is needed. Also it is very likely that for JSON
or RAW formats we will need dedicated binding hence that would be even
more complex.

Also current code structure gave a false impression that JSON and RAW is
already supported as it was already bound in the guice context of that
Kafka connector.
