### PR TITLE
Fix generated connector JMX metrics names

### DIFF
--- a/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/jmx/ConnectorObjectNameGeneratorModule.java
+++ b/presto-plugin-toolkit/src/main/java/io/prestosql/plugin/base/jmx/ConnectorObjectNameGeneratorModule.java
@@ -79,12 +79,23 @@ public class ConnectorObjectNameGeneratorModule
         }
 
         @Override
+        public String generatedNameOf(Class<?> type, String name)
+        {
+            return new ObjectNameBuilder(toDomain(type))
+                    .withProperties(ImmutableMap.<String, String>builder()
+                            .put("type", type.getSimpleName())
+                            .put("name", name)
+                            .build())
+                    .build();
+        }
+
+        @Override
         public String generatedNameOf(Class<?> type, Map<String, String> properties)
         {
             return new ObjectNameBuilder(toDomain(type))
                     .withProperties(ImmutableMap.<String, String>builder()
                             .putAll(properties)
-                            .put("catalog", catalogName)
+                            .put("name", catalogName)
                             .build())
                     .build();
         }


### PR DESCRIPTION
According to convention, JMX metrics
should have "name" property instead of
"catalog" property.