### PR TITLE
Fix memory revoking accounting

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/MemoryRevokingScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/MemoryRevokingScheduler.java
@@ -24,6 +24,7 @@ import io.trino.memory.QueryContext;
 import io.trino.memory.TraversingQueryContextVisitor;
 import io.trino.memory.VoidTraversingQueryContextVisitor;
 import io.trino.operator.OperatorContext;
+import io.trino.spi.memory.MemoryPoolId;
 import io.trino.sql.analyzer.FeaturesConfig;
 
 import javax.annotation.Nullable;
@@ -40,6 +41,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -187,26 +189,29 @@ public class MemoryRevokingScheduler
     private synchronized void runMemoryRevoking()
     {
         if (checkPending.getAndSet(false)) {
-            Collection<SqlTask> sqlTasks = null;
+            Collection<SqlTask> allTasks = null;
             for (MemoryPool memoryPool : memoryPools) {
                 if (!memoryRevokingNeeded(memoryPool)) {
                     continue;
                 }
 
-                if (sqlTasks == null) {
-                    sqlTasks = requireNonNull(currentTasksSupplier.get());
+                if (allTasks == null) {
+                    allTasks = requireNonNull(currentTasksSupplier.get());
                 }
 
-                requestMemoryRevoking(memoryPool, sqlTasks);
+                requestMemoryRevoking(memoryPool, allTasks);
             }
         }
     }
 
-    private void requestMemoryRevoking(MemoryPool memoryPool, Collection<SqlTask> sqlTasks)
+    private void requestMemoryRevoking(MemoryPool memoryPool, Collection<SqlTask> allTasks)
     {
         long remainingBytesToRevoke = (long) (-memoryPool.getFreeBytes() + (memoryPool.getMaxBytes() * (1.0 - memoryRevokingTarget)));
-        remainingBytesToRevoke -= getMemoryAlreadyBeingRevoked(sqlTasks, memoryPool);
-        requestRevoking(memoryPool, sqlTasks, remainingBytesToRevoke);
+        List<SqlTask> runningTasksInPool = findRunningTasksInMemoryPool(allTasks, memoryPool);
+        remainingBytesToRevoke -= getMemoryAlreadyBeingRevoked(runningTasksInPool, remainingBytesToRevoke);
+        if (remainingBytesToRevoke > 0) {
+            requestRevoking(memoryPool.getId(), runningTasksInPool, remainingBytesToRevoke);
+        }
     }
 
     private boolean memoryRevokingNeeded(MemoryPool memoryPool)
@@ -215,63 +220,81 @@ public class MemoryRevokingScheduler
                 && memoryPool.getFreeBytes() <= memoryPool.getMaxBytes() * (1.0 - memoryRevokingThreshold);
     }
 
-    private long getMemoryAlreadyBeingRevoked(Collection<SqlTask> sqlTasks, MemoryPool memoryPool)
+    private long getMemoryAlreadyBeingRevoked(List<SqlTask> sqlTasks, long targetRevokingLimit)
     {
-        return sqlTasks.stream()
-                .filter(task -> task.getTaskState() == TaskState.RUNNING)
-                .filter(task -> task.getQueryContext().getMemoryPool() == memoryPool)
-                .mapToLong(task -> task.getQueryContext().accept(new TraversingQueryContextVisitor<Void, Long>()
-                {
-                    @Override
-                    public Long visitOperatorContext(OperatorContext operatorContext, Void context)
-                    {
-                        if (operatorContext.isMemoryRevokingRequested()) {
-                            return operatorContext.getReservedRevocableBytes();
-                        }
-                        return 0L;
-                    }
+        TraversingQueryContextVisitor<Void, Long> visitor = new TraversingQueryContextVisitor<>()
+        {
+            @Override
+            public Long visitOperatorContext(OperatorContext operatorContext, Void context)
+            {
+                if (operatorContext.isMemoryRevokingRequested()) {
+                    return operatorContext.getReservedRevocableBytes();
+                }
+                return 0L;
+            }
 
-                    @Override
-                    public Long mergeResults(List<Long> childrenResults)
-                    {
-                        return childrenResults.stream()
-                                .mapToLong(i -> i).sum();
-                    }
-                }, null))
-                .sum();
+            @Override
+            public Long mergeResults(List<Long> childrenResults)
+            {
+                return childrenResults.stream()
+                        .mapToLong(i -> i).sum();
+            }
+        };
+
+        long currentRevoking = 0;
+        for (SqlTask task : sqlTasks) {
+            currentRevoking += task.getQueryContext().accept(visitor, null);
+            if (currentRevoking >= targetRevokingLimit) {
+                // Return early, target value exceeded and revoking will not occur
+                return currentRevoking;
+            }
+        }
+        return currentRevoking;
     }
 
-    private void requestRevoking(MemoryPool memoryPool, Collection<SqlTask> sqlTasks, long remainingBytesToRevoke)
+    private void requestRevoking(MemoryPoolId memoryPoolId, List<SqlTask> sqlTasks, long remainingBytesToRevoke)
     {
-        AtomicLong remainingBytesToRevokeAtomic = new AtomicLong(remainingBytesToRevoke);
-        sqlTasks.stream()
-                .filter(task -> task.getTaskState() == TaskState.RUNNING)
-                .filter(task -> task.getQueryContext().getMemoryPool() == memoryPool)
-                .sorted(ORDER_BY_CREATE_TIME)
-                .forEach(task -> task.getQueryContext().accept(new VoidTraversingQueryContextVisitor<>()
-                {
-                    @Override
-                    public Void visitQueryContext(QueryContext queryContext, AtomicLong remainingBytesToRevoke)
-                    {
-                        if (remainingBytesToRevoke.get() < 0) {
-                            // exit immediately if no work needs to be done
-                            return null;
-                        }
-                        return super.visitQueryContext(queryContext, remainingBytesToRevoke);
-                    }
+        VoidTraversingQueryContextVisitor<AtomicLong> visitor = new VoidTraversingQueryContextVisitor<>()
+        {
+            @Override
+            public Void visitQueryContext(QueryContext queryContext, AtomicLong remainingBytesToRevoke)
+            {
+                if (remainingBytesToRevoke.get() < 0) {
+                    // exit immediately if no work needs to be done
+                    return null;
+                }
+                return super.visitQueryContext(queryContext, remainingBytesToRevoke);
+            }
 
-                    @Override
-                    public Void visitOperatorContext(OperatorContext operatorContext, AtomicLong remainingBytesToRevoke)
-                    {
-                        if (remainingBytesToRevoke.get() > 0) {
-                            long revokedBytes = operatorContext.requestMemoryRevoking();
-                            if (revokedBytes > 0) {
-                                remainingBytesToRevoke.addAndGet(-revokedBytes);
-                                log.debug("memoryPool=%s: requested revoking %s; remaining %s", memoryPool.getId(), revokedBytes, remainingBytesToRevoke.get());
-                            }
-                        }
-                        return null;
+            @Override
+            public Void visitOperatorContext(OperatorContext operatorContext, AtomicLong remainingBytesToRevoke)
+            {
+                if (remainingBytesToRevoke.get() > 0) {
+                    long revokedBytes = operatorContext.requestMemoryRevoking();
+                    if (revokedBytes > 0) {
+                        remainingBytesToRevoke.addAndGet(-revokedBytes);
+                        log.debug("memoryPool=%s: requested revoking %s; remaining %s", memoryPoolId, revokedBytes, remainingBytesToRevoke.get());
                     }
-                }, remainingBytesToRevokeAtomic));
+                }
+                return null;
+            }
+        };
+
+        AtomicLong remainingBytesToRevokeAtomic = new AtomicLong(remainingBytesToRevoke);
+        for (SqlTask task : sqlTasks) {
+            task.getQueryContext().accept(visitor, remainingBytesToRevokeAtomic);
+            if (remainingBytesToRevokeAtomic.get() <= 0) {
+                // No further revoking required
+                return;
+            }
+        }
+    }
+
+    private static List<SqlTask> findRunningTasksInMemoryPool(Collection<SqlTask> allCurrentTasks, MemoryPool memoryPool)
+    {
+        return allCurrentTasks.stream()
+                .filter(task -> task.getTaskState() == TaskState.RUNNING && task.getQueryContext().getMemoryPool() == memoryPool)
+                .sorted(ORDER_BY_CREATE_TIME)
+                .collect(toImmutableList());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -203,6 +203,16 @@ public class SqlTask
         return taskHolderReference.get().getIoStats();
     }
 
+    public TaskState getTaskState()
+    {
+        return taskStateMachine.getState();
+    }
+
+    public DateTime getTaskCreatedTime()
+    {
+        return taskStateMachine.getCreatedTime();
+    }
+
     public TaskId getTaskId()
     {
         return taskStateMachine.getTaskId();

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -578,4 +578,13 @@ public class SqlTask
     {
         return queryContext;
     }
+
+    public Optional<TaskContext> getTaskContext()
+    {
+        SqlTaskExecution taskExecution = taskHolderReference.get().getTaskExecution();
+        if (taskExecution == null) {
+            return Optional.empty();
+        }
+        return Optional.of(taskExecution.getTaskContext());
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -255,7 +255,7 @@ public class SqlTaskManager
     {
         boolean taskCanceled = false;
         for (SqlTask task : tasks.asMap().values()) {
-            if (task.getTaskStatus().getState().isDone()) {
+            if (task.getTaskState().isDone()) {
                 continue;
             }
             task.failed(new TrinoException(SERVER_SHUTTING_DOWN, format("Server is shutting down. Task %s has been canceled", task.getTaskId())));
@@ -492,7 +492,7 @@ public class SqlTaskManager
         // already merged the final stats, we could miss the stats from this task
         // which would result in an under-count, but we will not get an over-count.
         tasks.asMap().values().stream()
-                .filter(task -> !task.getTaskStatus().getState().isDone())
+                .filter(task -> !task.getTaskState().isDone())
                 .forEach(task -> tempIoStats.merge(task.getIoStats()));
 
         cachedStats.resetTo(tempIoStats);

--- a/core/trino-main/src/main/java/io/trino/memory/QueryContext.java
+++ b/core/trino-main/src/main/java/io/trino/memory/QueryContext.java
@@ -156,6 +156,11 @@ public class QueryContext
         return maxTotalMemory;
     }
 
+    public QueryId getQueryId()
+    {
+        return queryId;
+    }
+
     /**
      * Deadlock is possible for concurrent user and system allocations when updateSystemMemory()/updateUserMemory
      * calls queryMemoryContext.getUserMemory()/queryMemoryContext.getSystemMemory(), respectively.


### PR DESCRIPTION
Extracted relevant changes from https://github.com/prestodb/presto/pull/15569

Previously, `MemoryRevokingScheduler` would find running tasks and operate on them by traversing through their QueryContext. This led to two significant problems:
- `MemoryRevokingScheduler` would over-count the amount of memory that was already being revoked since it would traverse each task for a given query through all other tasks in that query.
- `MemoryRevokingScheduler` would repeatedly traverse the same tasks and attempt to revoke memory from the same operators if the number of tasks in a given query was > 1 on the current node

This PR also contains some cleanup commits that refactor related methods to avoid redundant work and to use cheaper methods than `SqlTask#getTaskStatus()` when possible.