### PR TITLE
Use the Redshift JDBC driver in the Redshift connector

### DIFF
--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -19,7 +19,7 @@ connection properties as appropriate for your setup:
 .. code-block:: text
 
     connector.name=redshift
-    connection-url=jdbc:postgresql://example.net:5439/database
+    connection-url=jdbc:redshift://example.net:5439/database
     connection-user=root
     connection-password=secret
 

--- a/plugin/trino-redshift/pom.xml
+++ b/plugin/trino-redshift/pom.xml
@@ -17,10 +17,26 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
     </properties>
 
+    <repositories>
+        <repository>
+            <id>redshift</id>
+            <url>http://redshift-maven-repository.s3-website-us-east-1.amazonaws.com/release</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-base-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazon.redshift</groupId>
+            <artifactId>redshift-jdbc42</artifactId>
+            <version>2.0.0.1</version>
         </dependency>
 
         <dependency>
@@ -36,13 +52,6 @@
         <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
-        </dependency>
-
-        <!-- old version of the PostgreSQL driver known to work with Redshift -->
-        <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>9.3-1102-jdbc41</version>
         </dependency>
 
         <!-- Trino SPI -->

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClientModule.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClientModule.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.redshift;
 
+import com.amazon.redshift.Driver;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -24,7 +25,6 @@ import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
-import org.postgresql.Driver;
 
 public class RedshiftClientModule
         implements Module


### PR DESCRIPTION
The Redshift 2.0 driver is Apache licensed.

Fixes #2094