### PR TITLE
Fix return type of array subscript

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySubscriptOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySubscriptOperator.java
@@ -77,7 +77,8 @@ public class ArraySubscriptOperator
             methodHandle = METHOD_HANDLE_SLICE;
         }
         else {
-            methodHandle = METHOD_HANDLE_OBJECT;
+            methodHandle = METHOD_HANDLE_OBJECT.asType(
+                    METHOD_HANDLE_OBJECT.type().changeReturnType(elementType.getJavaType()));
         }
         methodHandle = methodHandle.bindTo(elementType);
         requireNonNull(methodHandle, "methodHandle is null");

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -750,6 +750,24 @@ public class TestArrayOperators
     }
 
     @Test
+    public void testSubscriptReturnType()
+    {
+        // Test return type of array subscript by passing it to another operation
+        // One test for each specialization of the operator, as well as a Block-based type
+        assertSubscriptToJson("true", "true"); // boolean
+        assertSubscriptToJson("1234", "1234"); // long
+        assertSubscriptToJson("1.23", "1.23"); // double
+        assertSubscriptToJson("'vc'", "\"vc\""); // Slice
+        assertSubscriptToJson("TIMESTAMP '1970-01-01 00:00:00.000000001'", "\"1970-01-01 00:00:00.000000001\""); // Object (LongTimestamp)
+        assertSubscriptToJson("ARRAY [1]", "[1]"); // Block
+    }
+
+    private void assertSubscriptToJson(String literal, String expected)
+    {
+        assertFunction(format("CAST((ARRAY [%s])[1] AS JSON)", literal), JSON, expected);
+    }
+
+    @Test
     public void testElementAt()
     {
         assertInvalidFunction("ELEMENT_AT(ARRAY [], 0)", "SQL array indices start at 1");


### PR DESCRIPTION
This addresses #6350.

The second and fourth commits are reverted in the third and fifth (I'll squash
them before merging).

The second commit presents an alternative solution that potentially requires
fewer changes to operators, at a marginally-increased runtime cost (a checked
cast for every time a SQL function is called on an object-based type). It also
loses its benefit when combined with the fix for `verifyMethodHandleSignature`.

The test added in the fourth commit becomes redundant with the fix for
`verifyMethodHandleSignature`, because the error is not caught in
`testSubscript`.
