### PR TITLE
Add hero text for rename

### DIFF
--- a/presto-docs/src/main/sphinx/conf.py
+++ b/presto-docs/src/main/sphinx/conf.py
@@ -112,6 +112,7 @@ html_theme_options = {
     'repo_url': 'https://github.com/prestosql/presto',
     'repo_name': 'Presto',
     'version_json': '../versions.json',
+    'heroes': {'index': 'Presto SQL is now Trino &nbsp;&nbsp;&nbsp;<a href="https://trino.io/blog/2020/12/27/announcing-trino.html" target="_blank">Read why &gt;</a>'},
 }
 
 html_css_files = [


### PR DESCRIPTION
This is also only a theme config.. it adds the text as a hero. We can not use the color styling for this as on the trino.io site because of that... 

I can do some styling for the link if desired.. 

But wanted to get feedback first if we want to go with this approach or #6469

<img width="1281" alt="Screen Shot 2020-12-29 at 15 37 30" src="https://user-images.githubusercontent.com/145658/103320839-cc614100-49eb-11eb-8578-7d96508d8825.png">

This is using the built in hero stuff and it collapses away... 

Also this is currently only on the index page... 