### PR TITLE
Add banner for rename

### DIFF
--- a/presto-docs/src/main/sphinx/templates/layout.html
+++ b/presto-docs/src/main/sphinx/templates/layout.html
@@ -1,0 +1,9 @@
+{# Import the theme's layout. #}
+{% extends '!layout.html' %}
+
+{%- block header %}
+{{ super() }}
+<div style="background-color: #dd00a1; border: 1px; color: white; text-align: center; font-size: 1rem; position: fixed; top: 48px; width: 100%; padding: 0.3rem; ">
+Presto SQL is now Trino &nbsp;&nbsp;&nbsp;&nbsp;<a href="https://trino.io/blog/2020/12/27/announcing-trino.html" target="_blank" style="text-decoration: underline">Read why &gt;</a>
+</div>
+{% endblock %}


### PR DESCRIPTION
Alternative to #6468 
<img width="1273" alt="Screen Shot 2020-12-29 at 15 31 54" src="https://user-images.githubusercontent.com/145658/103320647-09790380-49eb-11eb-99b1-32fa80ad2327.png">

@electrum already changed the other colors..  this just adds the banner on all pages

The sphinx material theme is a bit of a pain and this is as good as I could get it for now.

If we want to do that via a script that inserts this snippet on all pages we can replace the setup here with a placeholder and then use sed or whatever for replacement

Keep in mind that this is a theme configuration and as such does not affect the src rst files and such and also still completely allows reuse of those for other rendered doc sets of downstream consumers.

This is visible on all pages ... 