### PR TITLE
Fix operators that should be using IS NOT DISTINCT FROM rather than EQUALS

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankAccumulator.java
@@ -577,11 +577,11 @@ public class GroupedTopNRankAccumulator
         verify(actualPeerGroupCount == peerGroupCount, "Recorded peer group count does not match actual");
 
         if (leftChildHeapIndex != UNKNOWN_INDEX) {
-            verify(rowComparisonStrategy.compare(rowId, peerGroupBuffer.getRowId(heapNodeBuffer.getPeerGroupIndex(leftChildHeapIndex))) >= 0, "Max heap invariant violated");
+            verify(rowComparisonStrategy.compare(rowId, peerGroupBuffer.getRowId(heapNodeBuffer.getPeerGroupIndex(leftChildHeapIndex))) > 0, "Max heap invariant violated");
         }
         if (rightChildHeapIndex != UNKNOWN_INDEX) {
             verify(leftChildHeapIndex != UNKNOWN_INDEX, "Left should always be inserted before right");
-            verify(rowComparisonStrategy.compare(rowId, peerGroupBuffer.getRowId(heapNodeBuffer.getPeerGroupIndex(rightChildHeapIndex))) >= 0, "Max heap invariant violated");
+            verify(rowComparisonStrategy.compare(rowId, peerGroupBuffer.getRowId(heapNodeBuffer.getPeerGroupIndex(rightChildHeapIndex))) > 0, "Max heap invariant violated");
         }
 
         IntegrityStats leftIntegrityStats = verifyHeapIntegrity(groupId, leftChildHeapIndex);

--- a/core/trino-main/src/main/java/io/trino/operator/PagesHashStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesHashStrategy.java
@@ -52,12 +52,28 @@ public interface PagesHashStrategy
     boolean rowEqualsRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage);
 
     /**
+     * Compares the values in the specified pages. The values are compared positionally, so {@code leftPage}
+     * and {@code rightPage} must have the same number of entries as the hashed columns and each entry
+     * is expected to be the same type. The values are compared under "not distinct from" semantics.
+     */
+    boolean rowNotDistinctFromRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage);
+
+    /**
      * Compares the hashed columns in this PagesHashStrategy to the values in the specified page. The
      * values are compared positionally, so {@code rightPage} must have the same number of entries as
      * the hashed columns and each entry is expected to be the same type.
      * {@code rightPage} is used if join uses filter function and must contain all columns from probe side of join.
      */
     boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Page rightPage);
+
+    /**
+     * Compares the hashed columns in this PagesHashStrategy to the values in the specified page. The
+     * values are compared positionally, so {@code rightPage} must have the same number of entries as
+     * the hashed columns and each entry is expected to be the same type.
+     * {@code rightPage} is used if join uses filter function and must contain all columns from probe side of join.
+     * The values are compared under "not distinct from" semantics.
+     */
+    boolean positionNotDistinctFromRow(int leftBlockIndex, int leftPosition, int rightPosition, Page rightPage);
 
     /**
      * Compares the hashed columns in this PagesHashStrategy to the values in the specified page. The
@@ -81,6 +97,12 @@ public interface PagesHashStrategy
      * Compares the hashed columns in this PagesHashStrategy at the specified positions.
      */
     boolean positionEqualsPosition(int leftBlockIndex, int leftPosition, int rightBlockIndex, int rightPosition);
+
+    /**
+     * Compares the hashed columns in this PagesHashStrategy at the specified positions.
+     * The values are compared under "not distinct from" semantics.
+     */
+    boolean positionNotDistinctFromPosition(int leftBlockIndex, int leftPosition, int rightBlockIndex, int rightPosition);
 
     /**
      * Compares the hashed columns in this PagesHashStrategy at the specified positions.

--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
@@ -393,7 +393,7 @@ public class PagesIndex
         createPagesIndexComparator(sortChannels, sortOrders).sort(this, startPosition, endPosition);
     }
 
-    public boolean positionEqualsPosition(PagesHashStrategy partitionHashStrategy, int leftPosition, int rightPosition)
+    public boolean positionNotDistinctFromPosition(PagesHashStrategy partitionHashStrategy, int leftPosition, int rightPosition)
     {
         long leftAddress = valueAddresses.getLong(leftPosition);
         int leftPageIndex = decodeSliceIndex(leftAddress);
@@ -403,16 +403,16 @@ public class PagesIndex
         int rightPageIndex = decodeSliceIndex(rightAddress);
         int rightPagePosition = decodePosition(rightAddress);
 
-        return partitionHashStrategy.positionEqualsPosition(leftPageIndex, leftPagePosition, rightPageIndex, rightPagePosition);
+        return partitionHashStrategy.positionNotDistinctFromPosition(leftPageIndex, leftPagePosition, rightPageIndex, rightPagePosition);
     }
 
-    public boolean positionEqualsRow(PagesHashStrategy pagesHashStrategy, int indexPosition, int rightPosition, Page rightPage)
+    public boolean positionNotDistinctFromRow(PagesHashStrategy pagesHashStrategy, int indexPosition, int rightPosition, Page rightPage)
     {
         long pageAddress = valueAddresses.getLong(indexPosition);
         int pageIndex = decodeSliceIndex(pageAddress);
         int pagePosition = decodePosition(pageAddress);
 
-        return pagesHashStrategy.positionEqualsRow(pageIndex, pagePosition, rightPosition, rightPage);
+        return pagesHashStrategy.positionNotDistinctFromRow(pageIndex, pagePosition, rightPosition, rightPage);
     }
 
     private PagesIndexOrdering createPagesIndexComparator(List<Integer> sortChannels, List<SortOrder> sortOrders)

--- a/core/trino-main/src/main/java/io/trino/operator/SimplePagesHashStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SimplePagesHashStrategy.java
@@ -155,12 +155,38 @@ public class SimplePagesHashStrategy
     }
 
     @Override
+    public boolean rowNotDistinctFromRow(int leftPosition, Page leftPage, int rightPosition, Page rightPage)
+    {
+        for (int i = 0; i < hashChannels.size(); i++) {
+            Block leftBlock = leftPage.getBlock(i);
+            Block rightBlock = rightPage.getBlock(i);
+            if (isDistinctFromOperators.get(i).isDistinctFrom(leftBlock, leftPosition, rightBlock, rightPosition)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
     public boolean positionEqualsRow(int leftBlockIndex, int leftPosition, int rightPosition, Page rightPage)
     {
         for (int i = 0; i < hashChannels.size(); i++) {
             Block leftBlock = channels.get(hashChannels.get(i)).get(leftBlockIndex);
             Block rightBlock = rightPage.getBlock(i);
             if (!equalOperators.get(i).equalNullSafe(leftBlock, leftPosition, rightBlock, rightPosition)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean positionNotDistinctFromRow(int leftBlockIndex, int leftPosition, int rightPosition, Page rightPage)
+    {
+        for (int i = 0; i < hashChannels.size(); i++) {
+            Block leftBlock = channels.get(hashChannels.get(i)).get(leftBlockIndex);
+            Block rightBlock = rightPage.getBlock(i);
+            if (isDistinctFromOperators.get(i).isDistinctFrom(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
         }
@@ -204,6 +230,20 @@ public class SimplePagesHashStrategy
             Block leftBlock = channel.get(leftBlockIndex);
             Block rightBlock = channel.get(rightBlockIndex);
             if (!equalOperators.get(i).equalNullSafe(leftBlock, leftPosition, rightBlock, rightPosition)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean positionNotDistinctFromPosition(int leftBlockIndex, int leftPosition, int rightBlockIndex, int rightPosition)
+    {
+        for (int i = 0; i < hashChannels.size(); i++) {
+            List<Block> channel = channels.get(hashChannels.get(i));
+            Block leftBlock = channel.get(leftBlockIndex);
+            Block rightBlock = channel.get(rightBlockIndex);
+            if (isDistinctFromOperators.get(i).isDistinctFrom(leftBlock, leftPosition, rightBlock, rightPosition)) {
                 return false;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/operator/StreamingAggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/StreamingAggregationOperator.java
@@ -280,7 +280,7 @@ public class StreamingAggregationOperator
 
             Page groupByPage = page.getColumns(groupByChannels);
             if (currentGroup != null) {
-                if (!pagesHashStrategy.rowEqualsRow(0, currentGroup.getColumns(groupByChannels), 0, groupByPage)) {
+                if (!pagesHashStrategy.rowNotDistinctFromRow(0, currentGroup.getColumns(groupByChannels), 0, groupByPage)) {
                     // page starts with new group, so flush it
                     evaluateAndFlushGroup(currentGroup, 0);
                 }
@@ -338,7 +338,7 @@ public class StreamingAggregationOperator
         private int findNextGroupStart(int startPosition, Page page)
         {
             for (int i = startPosition + 1; i < page.getPositionCount(); i++) {
-                if (!pagesHashStrategy.rowEqualsRow(startPosition, page, i, page)) {
+                if (!pagesHashStrategy.rowNotDistinctFromRow(startPosition, page, i, page)) {
                     return i;
                 }
             }

--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -818,12 +818,12 @@ public class WindowOperator
         PagesIndex pagesIndex = pagesIndexWithHashStrategies.pagesIndex;
         PagesHashStrategy preGroupedPartitionHashStrategy = pagesIndexWithHashStrategies.preGroupedPartitionHashStrategy;
         if (currentSpillGroupRowPage.isPresent()) {
-            if (!preGroupedPartitionHashStrategy.rowEqualsRow(0, currentSpillGroupRowPage.get().getColumns(pagesIndexWithHashStrategies.preGroupedPartitionChannels), startPosition, preGroupedPage)) {
+            if (!preGroupedPartitionHashStrategy.rowNotDistinctFromRow(0, currentSpillGroupRowPage.get().getColumns(pagesIndexWithHashStrategies.preGroupedPartitionChannels), startPosition, preGroupedPage)) {
                 return startPosition;
             }
         }
 
-        if (pagesIndex.getPositionCount() == 0 || pagesIndex.positionEqualsRow(preGroupedPartitionHashStrategy, 0, startPosition, preGroupedPage)) {
+        if (pagesIndex.getPositionCount() == 0 || pagesIndex.positionNotDistinctFromRow(preGroupedPartitionHashStrategy, 0, startPosition, preGroupedPage)) {
             // Find the position where the pre-grouped columns change
             int groupEnd = findGroupEnd(preGroupedPage, preGroupedPartitionHashStrategy, startPosition);
 
@@ -859,7 +859,7 @@ public class WindowOperator
         checkArgument(page.getPositionCount() > 0, "Must have at least one position");
         checkPositionIndex(startPosition, page.getPositionCount(), "startPosition out of bounds");
 
-        return findEndPosition(startPosition, page.getPositionCount(), (firstPosition, secondPosition) -> pagesHashStrategy.rowEqualsRow(firstPosition, page, secondPosition, page));
+        return findEndPosition(startPosition, page.getPositionCount(), (firstPosition, secondPosition) -> pagesHashStrategy.rowNotDistinctFromRow(firstPosition, page, secondPosition, page));
     }
 
     // Assumes input grouped on relevant pagesHashStrategy columns
@@ -868,7 +868,7 @@ public class WindowOperator
         checkArgument(pagesIndex.getPositionCount() > 0, "Must have at least one position");
         checkPositionIndex(startPosition, pagesIndex.getPositionCount(), "startPosition out of bounds");
 
-        return findEndPosition(startPosition, pagesIndex.getPositionCount(), (firstPosition, secondPosition) -> pagesIndex.positionEqualsPosition(pagesHashStrategy, firstPosition, secondPosition));
+        return findEndPosition(startPosition, pagesIndex.getPositionCount(), (firstPosition, secondPosition) -> pagesIndex.positionNotDistinctFromPosition(pagesHashStrategy, firstPosition, secondPosition));
     }
 
     /**

--- a/core/trino-main/src/main/java/io/trino/operator/window/WindowPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/WindowPartition.java
@@ -117,7 +117,7 @@ public final class WindowPartition
 
         seekGroupStart = position -> {
             requireNonNull(position, "position is null");
-            while (position > 0 && pagesIndex.positionEqualsPosition(peerGroupHashStrategy, partitionStart + position, partitionStart + position - 1)) {
+            while (position > 0 && pagesIndex.positionNotDistinctFromPosition(peerGroupHashStrategy, partitionStart + position, partitionStart + position - 1)) {
                 position--;
             }
             return position;
@@ -125,7 +125,7 @@ public final class WindowPartition
 
         seekGroupEnd = position -> {
             requireNonNull(position, "position is null");
-            while (position < partitionEnd - 1 - partitionStart && pagesIndex.positionEqualsPosition(peerGroupHashStrategy, partitionStart + position, partitionStart + position + 1)) {
+            while (position < partitionEnd - 1 - partitionStart && pagesIndex.positionNotDistinctFromPosition(peerGroupHashStrategy, partitionStart + position, partitionStart + position + 1)) {
                 position++;
             }
             return position;
@@ -241,7 +241,7 @@ public final class WindowPartition
         peerGroupStart = currentPosition;
         // find end of peer group
         peerGroupEnd = peerGroupStart + 1;
-        while ((peerGroupEnd < partitionEnd) && pagesIndex.positionEqualsPosition(peerGroupHashStrategy, peerGroupStart, peerGroupEnd)) {
+        while ((peerGroupEnd < partitionEnd) && pagesIndex.positionNotDistinctFromPosition(peerGroupHashStrategy, peerGroupStart, peerGroupEnd)) {
             peerGroupEnd++;
         }
     }
@@ -334,7 +334,7 @@ public final class WindowPartition
                 frameInfo.getStartType() == CURRENT_ROW && frameInfo.getEndType() == UNBOUNDED_FOLLOWING ||
                 frameInfo.getStartType() == UNBOUNDED_PRECEDING && frameInfo.getEndType() == CURRENT_ROW) {
             // same peer group as recent row
-            if (currentPosition == partitionStart || pagesIndex.positionEqualsPosition(peerGroupHashStrategy, currentPosition - 1, currentPosition)) {
+            if (currentPosition == partitionStart || pagesIndex.positionNotDistinctFromPosition(peerGroupHashStrategy, currentPosition - 1, currentPosition)) {
                 return recentRange;
             }
             // next peer group

--- a/core/trino-main/src/test/java/io/trino/operator/TestTopNRankingOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTopNRankingOperator.java
@@ -292,6 +292,7 @@ public class TestTopNRankingOperator
                 .row(0.2, "b", 1L)
                 .row(0.7, "b", 2L)
                 .row(Double.NaN, "b", 3L)
+                .row(Double.NaN, "b", 3L)
                 .row(0.1, "c", 1L)
                 .row(0.91, "c", 2L)
                 .build();


### PR DESCRIPTION
We have a few operators that should be using IS NOT DISTINCT FROM rather than EQUALS to provide the proper grouping semantics. This results in queries incorrectly grouping values that are NaN, as well as structural types that contain null elements.