### PR TITLE
Revert exposing data compression in SHOW CREATE for SQLServer tables

### DIFF
--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -58,11 +58,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-core</artifactId>
-        </dependency>
-
-        <dependency>
             <!-- transitive compile, but used in tests -->
             <groupId>net.jodah</groupId>
             <artifactId>failsafe</artifactId>


### PR DESCRIPTION
Fixes #6464
Overrides #6471 

Table properties are being populated when we are planning (`StatementAnalyzer#visitTable`) which might cause an overhead during planning.