### PR TITLE
Allow JDBC connectors to control aggregation pushdown for individual tables

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -159,6 +159,12 @@ public class CachingJdbcClient
     }
 
     @Override
+    public boolean supportsAggregationPushdown(ConnectorSession session, JdbcTableHandle table, List<List<ColumnHandle>> groupingSets)
+    {
+        return delegate.supportsAggregationPushdown(session, table, groupingSets);
+    }
+
+    @Override
     public Optional<JdbcExpression> implementAggregation(ConnectorSession session, AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
     {
         return delegate.implementAggregation(session, aggregate, assignments);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -110,6 +110,12 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
+    public boolean supportsAggregationPushdown(ConnectorSession session, JdbcTableHandle table, List<List<ColumnHandle>> groupingSets)
+    {
+        return delegate().supportsAggregationPushdown(session, table, groupingSets);
+    }
+
+    @Override
     public Optional<JdbcExpression> implementAggregation(ConnectorSession session, AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
     {
         return delegate().implementAggregation(session, aggregate, assignments);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -66,6 +66,11 @@ public interface JdbcClient
         return true;
     }
 
+    default boolean supportsAggregationPushdown(ConnectorSession session, JdbcTableHandle table, List<List<ColumnHandle>> groupingSets)
+    {
+        return true;
+    }
+
     default Optional<JdbcExpression> implementAggregation(ConnectorSession session, AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
     {
         return Optional.empty();

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
@@ -234,6 +234,11 @@ public class JdbcMetadata
             return Optional.empty();
         }
 
+        if (!jdbcClient.supportsAggregationPushdown(session, handle, groupingSets)) {
+            // JDBC client implementation prevents pushdown for the given table
+            return Optional.empty();
+        }
+
         // Global aggregation is represented by [[]]
         verify(!groupingSets.isEmpty(), "No grouping sets provided");
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -127,6 +127,12 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
+    public boolean supportsAggregationPushdown(ConnectorSession session, JdbcTableHandle table, List<List<ColumnHandle>> groupingSets)
+    {
+        return delegate().supportsAggregationPushdown(session, table, groupingSets);
+    }
+
+    @Override
     public Optional<JdbcExpression> implementAggregation(ConnectorSession session, AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
     {
         return stats.getImplementAggregation().wrap(() -> delegate().implementAggregation(session, aggregate, assignments));


### PR DESCRIPTION
This change allows implementations of JdbcClient to control aggregation pushdown per-table.