### PR TITLE
Remove BeginTableWrite.rewriteDeleteTableScan()

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -18,6 +18,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.HashMultiset;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multiset;
@@ -94,6 +95,8 @@ import static java.util.Objects.requireNonNull;
 
 public class Analysis
 {
+    private static final Set<String> MODIFY_TYPES = ImmutableSet.of("DELETE");
+
     @Nullable
     private final Statement root;
     private final Map<NodeRef<Parameter>, Expression> parameters;
@@ -222,11 +225,11 @@ public class Analysis
         this.target = Optional.empty();
     }
 
-    public boolean isDeleteTarget(Table table)
+    public boolean isModifyTarget(Table table)
     {
-        return "DELETE".equals(updateType) &&
-                target.orElseThrow(() -> new IllegalStateException("Update target not set"))
-                        .getTable().orElseThrow(() -> new IllegalStateException("Table reference not set in update target")) == table; // intentional comparison by reference
+        return MODIFY_TYPES.contains(updateType) &&
+                target.orElseThrow(() -> new IllegalStateException("Modify target not set"))
+                        .getTable().orElseThrow(() -> new IllegalStateException("Table reference not set in modify target")) == table; // intentional comparison by reference
     }
 
     public boolean isSkipMaterializedViewRefresh()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanCopier.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanCopier.java
@@ -120,7 +120,7 @@ public final class PlanCopier
         @Override
         public PlanNode visitTableScan(TableScanNode node, RewriteContext<Void> context)
         {
-            return new TableScanNode(idAllocator.getNextId(), node.getTable(), node.getOutputSymbols(), node.getAssignments(), node.getEnforcedConstraint(), node.isForDelete());
+            return new TableScanNode(idAllocator.getNextId(), node.getTable(), node.getOutputSymbols(), node.getAssignments(), node.getEnforcedConstraint(), node.isForModify());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
@@ -787,7 +787,7 @@ public class PlanFragmenter
                     node.getOutputSymbols(),
                     node.getAssignments(),
                     node.getEnforcedConstraint(),
-                    node.isForDelete());
+                    node.isForModify());
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -202,8 +202,8 @@ class RelationPlanner
             }
 
             List<Symbol> outputSymbols = outputSymbolsBuilder.build();
-            boolean isDeleteTarget = analysis.isDeleteTarget(node);
-            PlanNode root = TableScanNode.newInstance(idAllocator.getNextId(), handle, outputSymbols, columns.build(), isDeleteTarget);
+            boolean isModifyTarget = analysis.isModifyTarget(node);
+            PlanNode root = TableScanNode.newInstance(idAllocator.getNextId(), handle, outputSymbols, columns.build(), isModifyTarget);
 
             plan = new RelationPlan(root, scope, outputSymbols, outerContext);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyTableScanRedirection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyTableScanRedirection.java
@@ -124,7 +124,7 @@ public class ApplyTableScanRedirection
                             scanNode.getOutputSymbols(),
                             newAssignments,
                             TupleDomain.all(),
-                            scanNode.isForDelete()));
+                            scanNode.isForModify()));
         }
 
         ImmutableMap.Builder<Symbol, ColumnHandle> newAssignmentsBuilder = ImmutableMap.<Symbol, ColumnHandle>builder()
@@ -175,7 +175,7 @@ public class ApplyTableScanRedirection
                 newOutputSymbols,
                 newAssignmentsBuilder.build(),
                 TupleDomain.all(),
-                scanNode.isForDelete());
+                scanNode.isForModify());
 
         FilterNode filterNode = new FilterNode(
                 context.getIdAllocator().getNextId(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableScanColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneTableScanColumns.java
@@ -110,6 +110,6 @@ public class PruneTableScanColumns
                 newOutputs,
                 newAssignments,
                 node.getEnforcedConstraint(),
-                node.isForDelete()));
+                node.isForModify()));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
@@ -204,7 +204,7 @@ public class PushAggregationIntoTableScan
                                 result.getHandle(),
                                 newScanOutputs.build(),
                                 scanAssignments,
-                                tableScan.isForDelete()),
+                                tableScan.isForModify()),
                         assignmentBuilder.build()));
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushLimitIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushLimitIntoTableScan.java
@@ -70,7 +70,7 @@ public class PushLimitIntoTableScan
                             tableScan.getOutputSymbols(),
                             tableScan.getAssignments(),
                             tableScan.getEnforcedConstraint(),
-                            tableScan.isForDelete());
+                            tableScan.isForModify());
 
                     if (!result.isLimitGuaranteed()) {
                         node = new LimitNode(limit.getId(), node, limit.getCount(), limit.isPartial());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -260,7 +260,7 @@ public class PushPredicateIntoTableScan
                 node.getOutputSymbols(),
                 node.getAssignments(),
                 computeEnforced(newDomain, remainingFilter),
-                node.isForDelete());
+                node.isForModify());
 
         Expression resultingPredicate = createResultingPredicate(
                 metadata,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushProjectionIntoTableScan.java
@@ -162,7 +162,7 @@ public class PushProjectionIntoTableScan
                                 result.get().getHandle(),
                                 newScanOutputs,
                                 newScanAssignments,
-                                tableScan.isForDelete()),
+                                tableScan.isForModify()),
                         newProjectionAssignments.build()));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushSampleIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushSampleIntoTableScan.java
@@ -70,7 +70,7 @@ public class PushSampleIntoTableScan
                         tableScan.getOutputSymbols(),
                         tableScan.getAssignments(),
                         tableScan.getEnforcedConstraint(),
-                        tableScan.isForDelete())))
+                        tableScan.isForModify())))
                 .orElseGet(Result::empty);
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushTopNIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushTopNIntoTableScan.java
@@ -73,7 +73,7 @@ public class PushTopNIntoTableScan
                             result.getHandle(),
                             tableScan.getOutputSymbols(),
                             tableScan.getAssignments(),
-                            tableScan.isForDelete());
+                            tableScan.isForModify());
 
                     if (!result.isTopNGuaranteed()) {
                         node = new TopNNode(topNNode.getId(), node, topNNode.getCount(), topNNode.getOrderingScheme(), TopNNode.Step.FINAL);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformFilteringSemiJoinToInnerJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/TransformFilteringSemiJoinToInnerJoin.java
@@ -99,7 +99,7 @@ public class TransformFilteringSemiJoinToInnerJoin
 
         // Do not transform semi-join in context of DELETE
         if (PlanNodeSearcher.searchFrom(semiJoin.getSource(), context.getLookup())
-                .where(node -> node instanceof TableScanNode && ((TableScanNode) node).isForDelete())
+                .where(node -> node instanceof TableScanNode && ((TableScanNode) node).isForModify())
                 .matches()) {
             return Result.empty();
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -285,7 +285,7 @@ public class UnaliasSymbolReferences
             });
 
             return new PlanAndMappings(
-                    new TableScanNode(node.getId(), node.getTable(), newOutputs, newAssignments, node.getEnforcedConstraint(), node.isForDelete()),
+                    new TableScanNode(node.getId(), node.getTable(), newOutputs, newAssignments, node.getEnforcedConstraint(), node.isForModify()),
                     mapping);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableScanNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableScanNode.java
@@ -41,7 +41,7 @@ public class TableScanNode
     private final Map<Symbol, ColumnHandle> assignments; // symbol -> column
 
     private final TupleDomain<ColumnHandle> enforcedConstraint;
-    private final boolean forDelete;
+    private final boolean forModify;
 
     // We need this factory method to disambiguate with the constructor used for deserializing
     // from a json object. The deserializer sets some fields which are never transported
@@ -51,9 +51,9 @@ public class TableScanNode
             TableHandle table,
             List<Symbol> outputs,
             Map<Symbol, ColumnHandle> assignments,
-            boolean forDelete)
+            boolean forModify)
     {
-        return new TableScanNode(id, table, outputs, assignments, TupleDomain.all(), forDelete);
+        return new TableScanNode(id, table, outputs, assignments, TupleDomain.all(), forModify);
     }
 
     @JsonCreator
@@ -62,7 +62,7 @@ public class TableScanNode
             @JsonProperty("table") TableHandle table,
             @JsonProperty("outputSymbols") List<Symbol> outputs,
             @JsonProperty("assignments") Map<Symbol, ColumnHandle> assignments,
-            @JsonProperty("forDelete") boolean forDelete)
+            @JsonProperty("forModify") boolean forModify)
     {
         // This constructor is for JSON deserialization only. Do not use.
         super(id);
@@ -71,7 +71,7 @@ public class TableScanNode
         this.assignments = ImmutableMap.copyOf(requireNonNull(assignments, "assignments is null"));
         checkArgument(assignments.keySet().containsAll(outputs), "assignments does not cover all of outputs");
         this.enforcedConstraint = null;
-        this.forDelete = forDelete;
+        this.forModify = forModify;
     }
 
     public TableScanNode(
@@ -80,7 +80,7 @@ public class TableScanNode
             List<Symbol> outputs,
             Map<Symbol, ColumnHandle> assignments,
             TupleDomain<ColumnHandle> enforcedConstraint,
-            boolean forDelete)
+            boolean forModify)
     {
         super(id);
         this.table = requireNonNull(table, "table is null");
@@ -88,7 +88,7 @@ public class TableScanNode
         this.assignments = ImmutableMap.copyOf(requireNonNull(assignments, "assignments is null"));
         checkArgument(assignments.keySet().containsAll(outputs), "assignments does not cover all of outputs");
         this.enforcedConstraint = requireNonNull(enforcedConstraint, "enforcedConstraint is null");
-        this.forDelete = forDelete;
+        this.forModify = forModify;
     }
 
     @JsonProperty("table")
@@ -125,10 +125,10 @@ public class TableScanNode
         return enforcedConstraint;
     }
 
-    @JsonProperty("forDelete")
-    public boolean isForDelete()
+    @JsonProperty("forModify")
+    public boolean isForModify()
     {
-        return forDelete;
+        return forModify;
     }
 
     @Override
@@ -151,7 +151,7 @@ public class TableScanNode
                 .add("outputSymbols", outputSymbols)
                 .add("assignments", assignments)
                 .add("enforcedConstraint", enforcedConstraint)
-                .add("forDelete", forDelete)
+                .add("forModify", forModify)
                 .toString();
     }
 


### PR DESCRIPTION
Before this change, BeginTableWrite contained a hit-and-miss
tree crawler, rewriteDeleteTableScan(), finding the first TableScanNode
it encountered.  But in general optimizations can change the shape of
the tree.  Instead, use the existing TableScanNode.forDelete()
mechanism to find the DELETE TableScanNode to update, and replace
rewriteDeleteTableScan() with a method that finds the marked
table scan.

Since the same mechanism will be used for SQL UPDATE and MERGE, rename
TableScanNode and BeginTableWrite uses of forDelete to be forModify.