### PR TITLE
Add option to allow authentication over HTTP

### DIFF
--- a/presto-main/src/main/java/io/prestosql/server/security/AuthenticationFilter.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/AuthenticationFilter.java
@@ -40,7 +40,7 @@ public class AuthenticationFilter
 {
     private final List<Authenticator> authenticators;
     private final InternalAuthenticationManager internalAuthenticationManager;
-    private final boolean insecureAuthenticationOverHttpAllowed;
+    private final SecurityConfig securityConfig;
     private final InsecureAuthenticator insecureAuthenticator;
 
     @Inject
@@ -53,7 +53,7 @@ public class AuthenticationFilter
         this.authenticators = ImmutableList.copyOf(requireNonNull(authenticators, "authenticators is null"));
         checkArgument(!authenticators.isEmpty(), "authenticators is empty");
         this.internalAuthenticationManager = requireNonNull(internalAuthenticationManager, "internalAuthenticationManager is null");
-        insecureAuthenticationOverHttpAllowed = requireNonNull(securityConfig, "securityConfig is null").isInsecureAuthenticationOverHttpAllowed();
+        this.securityConfig = requireNonNull(securityConfig, "securityConfig is null");
         this.insecureAuthenticator = requireNonNull(insecureAuthenticator, "insecureAuthenticator is null");
     }
 
@@ -66,10 +66,10 @@ public class AuthenticationFilter
         }
 
         List<Authenticator> authenticators;
-        if (request.getSecurityContext().isSecure()) {
+        if (request.getSecurityContext().isSecure() || securityConfig.isAuthenticationOverHttpAllowed()) {
             authenticators = this.authenticators;
         }
-        else if (insecureAuthenticationOverHttpAllowed) {
+        else if (securityConfig.isInsecureAuthenticationOverHttpAllowed()) {
             authenticators = ImmutableList.of(insecureAuthenticator);
         }
         else {

--- a/presto-main/src/main/java/io/prestosql/server/security/SecurityConfig.java
+++ b/presto-main/src/main/java/io/prestosql/server/security/SecurityConfig.java
@@ -33,10 +33,24 @@ public class SecurityConfig
 {
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
+    private boolean authenticationOverHttpAllowed;
     private boolean insecureAuthenticationOverHttpAllowed = true;
     private List<String> authenticationTypes = ImmutableList.of("insecure");
     private Optional<String> fixedManagementUser = Optional.empty();
     private boolean fixedManagementUserForHttps;
+
+    public boolean isAuthenticationOverHttpAllowed()
+    {
+        return authenticationOverHttpAllowed;
+    }
+
+    @Config("http-server.authentication.allow-over-http")
+    @ConfigDescription("Authentication over HTTP (non-secure) enabled")
+    public SecurityConfig setAuthenticationOverHttpAllowed(boolean authenticationOverHttpAllowed)
+    {
+        this.authenticationOverHttpAllowed = authenticationOverHttpAllowed;
+        return this;
+    }
 
     public boolean isInsecureAuthenticationOverHttpAllowed()
     {

--- a/presto-main/src/test/java/io/prestosql/server/security/TestSecurityConfig.java
+++ b/presto-main/src/test/java/io/prestosql/server/security/TestSecurityConfig.java
@@ -30,6 +30,7 @@ public class TestSecurityConfig
     {
         assertRecordedDefaults(recordDefaults(SecurityConfig.class)
                 .setAuthenticationTypes("insecure")
+                .setAuthenticationOverHttpAllowed(false)
                 .setInsecureAuthenticationOverHttpAllowed(true)
                 .setFixedManagementUser(null)
                 .setFixedManagementUserForHttps(false));
@@ -40,6 +41,7 @@ public class TestSecurityConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("http-server.authentication.type", "KERBEROS,PASSWORD")
+                .put("http-server.authentication.allow-over-http", "true")
                 .put("http-server.authentication.allow-insecure-over-http", "false")
                 .put("management.user", "management-user")
                 .put("management.user.https-enabled", "true")
@@ -47,6 +49,7 @@ public class TestSecurityConfig
 
         SecurityConfig expected = new SecurityConfig()
                 .setAuthenticationTypes(ImmutableList.of("KERBEROS", "PASSWORD"))
+                .setAuthenticationOverHttpAllowed(true)
                 .setInsecureAuthenticationOverHttpAllowed(false)
                 .setFixedManagementUser("management-user")
                 .setFixedManagementUserForHttps(true);


### PR DESCRIPTION
This is useful for automated integration tests that aren't run over HTTPS. 

We would use a customized authenticator that sets a special principal to the authenticated identity and this principal is required for access control. Though authenticator is enabled only over HTTPS, setup HTTPS on CI environment is annoying.

There is an option (`http-server.authentication.allow-insecure-over-http`) to enable InsecureAuthenticator over HTTP, but replacing InsecureAuthenticator for testing is not easy, though overriding InsecureAuthenticator binding is not impossible.

I believe that this option will make it much easier to run automated integration tests on CI environment even with a special authenticator.