### PR TITLE
Rename JdbcClient.toTrinoType to toColumnMapping

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -364,7 +364,7 @@ public abstract class BaseJdbcClient
     }
 
     @Override
-    public List<ColumnMapping> getColumnMappings(ConnectorSession session, List<JdbcTypeHandle> typeHandles)
+    public List<ColumnMapping> toColumnMappings(ConnectorSession session, List<JdbcTypeHandle> typeHandles)
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
             return typeHandles.stream()

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -286,7 +286,7 @@ public abstract class BaseJdbcClient
                         getInteger(resultSet, "DECIMAL_DIGITS"),
                         Optional.empty(),
                         Optional.empty());
-                Optional<ColumnMapping> columnMapping = toTrinoType(session, connection, typeHandle);
+                Optional<ColumnMapping> columnMapping = toColumnMapping(session, connection, typeHandle);
                 log.debug("Mapping data type of '%s' column '%s': %s mapped to %s", tableHandle.getSchemaTableName(), columnName, typeHandle, columnMapping);
                 // skip unsupported column types
                 boolean nullable = (resultSet.getInt("NULLABLE") != columnNoNulls);
@@ -368,7 +368,7 @@ public abstract class BaseJdbcClient
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
             return typeHandles.stream()
-                    .map(typeHandle -> toTrinoType(session, connection, typeHandle)
+                    .map(typeHandle -> toColumnMapping(session, connection, typeHandle)
                             .orElseThrow(() -> new VerifyException(format("Unsupported type handle %s", typeHandle))))
                     .collect(toImmutableList());
         }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -141,9 +141,9 @@ public class CachingJdbcClient
     }
 
     @Override
-    public List<ColumnMapping> getColumnMappings(ConnectorSession session, List<JdbcTypeHandle> typeHandles)
+    public List<ColumnMapping> toColumnMappings(ConnectorSession session, List<JdbcTypeHandle> typeHandles)
     {
-        return delegate.getColumnMappings(session, typeHandles);
+        return delegate.toColumnMappings(session, typeHandles);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -135,9 +135,9 @@ public class CachingJdbcClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
-        return delegate.toTrinoType(session, connection, typeHandle);
+        return delegate.toColumnMapping(session, connection, typeHandle);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -92,9 +92,9 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public List<ColumnMapping> getColumnMappings(ConnectorSession session, List<JdbcTypeHandle> typeHandles)
+    public List<ColumnMapping> toColumnMappings(ConnectorSession session, List<JdbcTypeHandle> typeHandles)
     {
-        return delegate().getColumnMappings(session, typeHandles);
+        return delegate().toColumnMappings(session, typeHandles);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -86,9 +86,9 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
-        return delegate().toTrinoType(session, connection, typeHandle);
+        return delegate().toColumnMapping(session, connection, typeHandle);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -52,10 +52,10 @@ public interface JdbcClient
 
     List<JdbcColumnHandle> getColumns(ConnectorSession session, JdbcTableHandle tableHandle);
 
-    Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle);
+    Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle);
 
     /**
-     * Bulk variant of {@link #toTrinoType(ConnectorSession, Connection, JdbcTypeHandle)}.
+     * Bulk variant of {@link #toColumnMapping(ConnectorSession, Connection, JdbcTypeHandle)}.
      */
     List<ColumnMapping> getColumnMappings(ConnectorSession session, List<JdbcTypeHandle> typeHandles);
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -57,7 +57,7 @@ public interface JdbcClient
     /**
      * Bulk variant of {@link #toColumnMapping(ConnectorSession, Connection, JdbcTypeHandle)}.
      */
-    List<ColumnMapping> getColumnMappings(ConnectorSession session, List<JdbcTypeHandle> typeHandles);
+    List<ColumnMapping> toColumnMappings(ConnectorSession session, List<JdbcTypeHandle> typeHandles);
 
     WriteMapping toWriteMapping(ConnectorSession session, Type type);
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
@@ -141,7 +141,7 @@ public class JdbcMetadata
             List<JdbcColumnHandle> columnHandles = domains.keySet().stream()
                     .map(JdbcColumnHandle.class::cast)
                     .collect(toImmutableList());
-            List<ColumnMapping> columnMappings = jdbcClient.getColumnMappings(
+            List<ColumnMapping> columnMappings = jdbcClient.toColumnMappings(
                     session,
                     columnHandles.stream()
                             .map(JdbcColumnHandle::getJdbcTypeHandle)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPageSink.java
@@ -85,7 +85,7 @@ public class JdbcPageSink
         }
         else {
             columnWriters = handle.getJdbcColumnTypes().get().stream()
-                    .map(typeHandle -> jdbcClient.toTrinoType(session, connection, typeHandle)
+                    .map(typeHandle -> jdbcClient.toColumnMapping(session, connection, typeHandle)
                             .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, "Underlying type is not supported for INSERT: " + typeHandle)))
                     .map(ColumnMapping::getWriteFunction)
                     .collect(toImmutableList());

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
@@ -71,7 +71,7 @@ public class JdbcRecordCursor
 
             for (int i = 0; i < this.columnHandles.length; i++) {
                 JdbcColumnHandle columnHandle = columnHandles.get(i);
-                ColumnMapping columnMapping = jdbcClient.toTrinoType(session, connection, columnHandle.getJdbcTypeHandle())
+                ColumnMapping columnMapping = jdbcClient.toColumnMapping(session, connection, columnHandle.getJdbcTypeHandle())
                         .orElseThrow(() -> new VerifyException("Unsupported column type"));
                 verify(
                         columnHandle.getColumnType().equals(columnMapping.getType()),

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
@@ -156,7 +156,7 @@ public class QueryBuilder
 
     private static Domain pushDownDomain(JdbcClient client, ConnectorSession session, Connection connection, JdbcColumnHandle column, Domain domain)
     {
-        return client.toTrinoType(session, connection, column.getJdbcTypeHandle())
+        return client.toColumnMapping(session, connection, column.getJdbcTypeHandle())
                 .orElseThrow(() -> new IllegalStateException(format("Unsupported type %s with handle %s", column.getColumnType(), column.getJdbcTypeHandle())))
                 .getPredicatePushdownController().apply(session, domain).getPushedDown();
     }
@@ -285,7 +285,7 @@ public class QueryBuilder
 
     private WriteFunction getWriteFunction(ConnectorSession session, Connection connection, JdbcColumnHandle column)
     {
-        WriteFunction writeFunction = client.toTrinoType(session, connection, column.getJdbcTypeHandle())
+        WriteFunction writeFunction = client.toColumnMapping(session, connection, column.getJdbcTypeHandle())
                 .orElseThrow(() -> new VerifyException(format("Unsupported type %s with handle %s for %s", column.getColumnType(), column.getJdbcTypeHandle(), column)))
                 .getWriteFunction();
         verify(writeFunction.getJavaType() == column.getColumnType().getJavaType(), "Java type mismatch for %s: %s, %s", column, writeFunction, column.getColumnType());

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCount.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCount.java
@@ -47,7 +47,7 @@ public class ImplementCount
     private final JdbcTypeHandle bigintTypeHandle;
 
     /**
-     * @param bigintTypeHandle A {@link JdbcTypeHandle} that will be mapped to {@link BigintType} by {@link JdbcClient#toTrinoType}.
+     * @param bigintTypeHandle A {@link JdbcTypeHandle} that will be mapped to {@link BigintType} by {@link JdbcClient#toColumnMapping}.
      */
     public ImplementCount(JdbcTypeHandle bigintTypeHandle)
     {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCountAll.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCountAll.java
@@ -40,7 +40,7 @@ public class ImplementCountAll
     private final JdbcTypeHandle bigintTypeHandle;
 
     /**
-     * @param bigintTypeHandle A {@link JdbcTypeHandle} that will be mapped to {@link BigintType} by {@link JdbcClient#toTrinoType}.
+     * @param bigintTypeHandle A {@link JdbcTypeHandle} that will be mapped to {@link BigintType} by {@link JdbcClient#toColumnMapping}.
      */
     public ImplementCountAll(JdbcTypeHandle bigintTypeHandle)
     {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -109,9 +109,9 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public List<ColumnMapping> getColumnMappings(ConnectorSession session, List<JdbcTypeHandle> typeHandles)
+    public List<ColumnMapping> toColumnMappings(ConnectorSession session, List<JdbcTypeHandle> typeHandles)
     {
-        return stats.getGetColumnMappings().wrap(() -> delegate.getColumnMappings(session, typeHandles));
+        return stats.getGetColumnMappings().wrap(() -> delegate.toColumnMappings(session, typeHandles));
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -103,9 +103,9 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
-        return stats.getToPrestoType().wrap(() -> delegate().toTrinoType(session, connection, typeHandle));
+        return stats.getToPrestoType().wrap(() -> delegate().toColumnMapping(session, connection, typeHandle));
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
@@ -85,7 +85,7 @@ class TestingH2JdbcClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
         Optional<ColumnMapping> mapping = getForcedMappingToVarchar(typeHandle);
         if (mapping.isPresent()) {

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -135,7 +135,7 @@ public class DruidJdbcClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
         switch (typeHandle.getJdbcType()) {
             case Types.VARCHAR:

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
@@ -124,7 +124,7 @@ public class MemSqlClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
         String jdbcTypeName = typeHandle.getJdbcTypeName()
                 .orElseThrow(() -> new TrinoException(JDBC_ERROR, "Type name is missing: " + typeHandle));

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -230,7 +230,7 @@ public class MySqlClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
         String jdbcTypeName = typeHandle.getJdbcTypeName()
                 .orElseThrow(() -> new TrinoException(JDBC_ERROR, "Type name is missing: " + typeHandle));

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClient.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClient.java
@@ -153,7 +153,7 @@ public class TestMySqlClient
         else {
             assertThat(result).isPresent();
             assertEquals(result.get().getExpression(), expectedExpression.get());
-            Optional<ColumnMapping> columnMapping = JDBC_CLIENT.toTrinoType(SESSION, null, result.get().getJdbcTypeHandle());
+            Optional<ColumnMapping> columnMapping = JDBC_CLIENT.toColumnMapping(SESSION, null, result.get().getJdbcTypeHandle());
             assertTrue(columnMapping.isPresent(), "No mapping for: " + result.get().getJdbcTypeHandle());
             assertEquals(columnMapping.get().getType(), aggregateFunction.getOutputType());
         }

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -238,7 +238,7 @@ public class OracleClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
         Optional<ColumnMapping> mappingToVarchar = getForcedMappingToVarchar(typeHandle);
         if (mappingToVarchar.isPresent()) {

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -309,7 +309,7 @@ public class PhoenixClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
         switch (typeHandle.getJdbcType()) {
             case Types.BOOLEAN:
@@ -375,7 +375,7 @@ public class PhoenixClient
                 if (elementTypeHandle.getJdbcType() == Types.VARBINARY) {
                     return Optional.empty();
                 }
-                return toTrinoType(session, connection, elementTypeHandle)
+                return toColumnMapping(session, connection, elementTypeHandle)
                         .map(elementMapping -> {
                             ArrayType prestoArrayType = new ArrayType(elementMapping.getType());
                             String jdbcTypeName = elementTypeHandle.getJdbcTypeName()

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -311,7 +311,7 @@ public class PostgreSqlClient
                             getInteger(resultSet, "DECIMAL_DIGITS"),
                             Optional.ofNullable(arrayColumnDimensions.get(columnName)),
                             Optional.empty());
-                    Optional<ColumnMapping> columnMapping = toTrinoType(session, connection, typeHandle);
+                    Optional<ColumnMapping> columnMapping = toColumnMapping(session, connection, typeHandle);
                     log.debug("Mapping data type of '%s' column '%s': %s mapped to %s", tableHandle.getSchemaTableName(), columnName, typeHandle, columnMapping);
                     // skip unsupported column types
                     if (columnMapping.isPresent()) {
@@ -373,7 +373,7 @@ public class PostgreSqlClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
         String jdbcTypeName = typeHandle.getJdbcTypeName()
                 .orElseThrow(() -> new TrinoException(JDBC_ERROR, "Type name is missing: " + typeHandle));
@@ -498,7 +498,7 @@ public class PostgreSqlClient
             // https://github.com/pgjdbc/pgjdbc/pull/1184
             return Optional.empty();
         }
-        Optional<ColumnMapping> baseElementMapping = toTrinoType(session, connection, baseElementTypeHandle);
+        Optional<ColumnMapping> baseElementMapping = toColumnMapping(session, connection, baseElementTypeHandle);
 
         if (arrayMapping == AS_ARRAY) {
             if (typeHandle.getArrayDimensions().isEmpty()) {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -152,7 +152,7 @@ public class TestPostgreSqlClient
         else {
             assertThat(result).isPresent();
             assertEquals(result.get().getExpression(), expectedExpression.get());
-            Optional<ColumnMapping> columnMapping = JDBC_CLIENT.toTrinoType(SESSION, null, result.get().getJdbcTypeHandle());
+            Optional<ColumnMapping> columnMapping = JDBC_CLIENT.toColumnMapping(SESSION, null, result.get().getJdbcTypeHandle());
             assertTrue(columnMapping.isPresent(), "No mapping for: " + result.get().getJdbcTypeHandle());
             assertEquals(columnMapping.get().getType(), aggregateFunction.getOutputType());
         }

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
@@ -71,7 +71,7 @@ public class RedshiftClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
         // TODO implement proper type mapping
         return legacyToPrestoType(session, connection, typeHandle);

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -181,7 +181,7 @@ public class SqlServerClient
     }
 
     @Override
-    public Optional<ColumnMapping> toTrinoType(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
         Optional<ColumnMapping> mapping = getForcedMappingToVarchar(typeHandle);
         if (mapping.isPresent()) {

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
@@ -146,7 +146,7 @@ public class TestSqlServerClient
         else {
             assertThat(result).isPresent();
             assertEquals(result.get().getExpression(), expectedExpression.get());
-            Optional<ColumnMapping> columnMapping = JDBC_CLIENT.toTrinoType(SESSION, null, result.get().getJdbcTypeHandle());
+            Optional<ColumnMapping> columnMapping = JDBC_CLIENT.toColumnMapping(SESSION, null, result.get().getJdbcTypeHandle());
             assertTrue(columnMapping.isPresent(), "No mapping for: " + result.get().getJdbcTypeHandle());
             assertEquals(columnMapping.get().getType(), aggregateFunction.getOutputType());
         }


### PR DESCRIPTION
The old name (`toPrestoType`) was a left-over since the times when the
method was returning `Type`. It was kept unchanged to ease migration.
Now that we change the method name anyway, we can fix it too.