### PR TITLE
Improve audience support in OAuth2 authenticator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
@@ -33,6 +33,7 @@ public class OAuth2Config
     private String jwksUrl;
     private String clientId;
     private String clientSecret;
+    private Optional<String> audience = Optional.empty();
     private Duration challengeTimeout = new Duration(15, TimeUnit.MINUTES);
     private Optional<String> userMappingPattern = Optional.empty();
     private Optional<File> userMappingFile = Optional.empty();
@@ -117,6 +118,19 @@ public class OAuth2Config
     public OAuth2Config setClientSecret(String clientSecret)
     {
         this.clientSecret = clientSecret;
+        return this;
+    }
+
+    public Optional<String> getAudience()
+    {
+        return audience;
+    }
+
+    @Config("http-server.authentication.oauth2.audience")
+    @ConfigDescription("The required audience of a token")
+    public OAuth2Config setAudience(String audience)
+    {
+        this.audience = Optional.ofNullable(audience);
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/ScribeJavaOAuth2Client.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/ScribeJavaOAuth2Client.java
@@ -27,26 +27,32 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.Optional;
 
+import static com.github.scribejava.core.model.OAuthConstants.REDIRECT_URI;
+import static com.github.scribejava.core.model.OAuthConstants.STATE;
 import static java.util.Objects.requireNonNull;
 
 public class ScribeJavaOAuth2Client
         implements OAuth2Client
 {
     private final DynamicCallbackOAuth2Service service;
+    private final Optional<String> audience;
 
     @Inject
     public ScribeJavaOAuth2Client(OAuth2Config config)
     {
+        requireNonNull(config, "config is null");
         service = new DynamicCallbackOAuth2Service(config);
+        audience = config.getAudience();
     }
 
     @Override
     public URI getAuthorizationUri(String state, URI callbackUri)
     {
-        return URI.create(service.getAuthorizationUrl(ImmutableMap.<String, String>builder()
-                .put(OAuthConstants.REDIRECT_URI, callbackUri.toString())
-                .put(OAuthConstants.STATE, state)
-                .build()));
+        ImmutableMap.Builder<String, String> parameters = ImmutableMap.builder();
+        parameters.put(REDIRECT_URI, callbackUri.toString());
+        parameters.put(STATE, state);
+        audience.ifPresent(audience -> parameters.put("audience", audience));
+        return URI.create(service.getAuthorizationUrl(parameters.build()));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
@@ -30,9 +30,11 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.jsonwebtoken.Claims.AUDIENCE;
 import static io.trino.server.ServletSecurityUtils.sendErrorMessage;
 import static io.trino.server.ServletSecurityUtils.sendWwwAuthenticate;
 import static io.trino.server.ServletSecurityUtils.setAuthenticatedIdentity;
@@ -50,6 +52,7 @@ public class OAuth2WebUiAuthenticationFilter
 
     private final OAuth2Service service;
     private final UserMapping userMapping;
+    private final Optional<String> validAudience;
 
     @Inject
     public OAuth2WebUiAuthenticationFilter(OAuth2Service service, OAuth2Config oauth2Config)
@@ -57,6 +60,7 @@ public class OAuth2WebUiAuthenticationFilter
         this.service = requireNonNull(service, "service is null");
         requireNonNull(oauth2Config, "oauth2Config is null");
         this.userMapping = UserMapping.createUserMapping(oauth2Config.getUserMappingPattern(), oauth2Config.getUserMappingFile());
+        this.validAudience = oauth2Config.getAudience();
     }
 
     @Override
@@ -78,15 +82,21 @@ public class OAuth2WebUiAuthenticationFilter
             request.abortWith(Response.seeOther(DISABLED_LOCATION_URI).build());
             return;
         }
-
-        Optional<String> subject = getAccessToken(request).map(token -> token.getBody().getSubject());
-        if (subject.isEmpty()) {
+        Optional<Claims> claims = getAccessToken(request).map(Jws::getBody);
+        if (claims.isEmpty()) {
             needAuthentication(request);
             return;
         }
+        Object audience = claims.get().get(AUDIENCE);
+        if (!hasValidAudience(audience)) {
+            LOG.debug("Invalid audience: %s. Expected audience to be equal to or contain: %s", audience, validAudience);
+            sendErrorMessage(request, UNAUTHORIZED, "Unauthorized");
+            return;
+        }
         try {
-            setAuthenticatedIdentity(request, Identity.forUser(userMapping.mapUser(subject.get()))
-                    .withPrincipal(new BasicPrincipal(subject.get()))
+            String subject = claims.get().getSubject();
+            setAuthenticatedIdentity(request, Identity.forUser(userMapping.mapUser(subject))
+                    .withPrincipal(new BasicPrincipal(subject))
                     .build());
         }
         catch (UserMappingException e) {
@@ -112,5 +122,22 @@ public class OAuth2WebUiAuthenticationFilter
     {
         URI redirectLocation = service.startChallenge(request.getUriInfo().getBaseUri().resolve(CALLBACK_ENDPOINT));
         request.abortWith(Response.seeOther(redirectLocation).build());
+    }
+
+    private boolean hasValidAudience(Object audience)
+    {
+        if (validAudience.isEmpty()) {
+            return true;
+        }
+        if (audience == null) {
+            return false;
+        }
+        if (audience instanceof String) {
+            return audience.equals(validAudience.get());
+        }
+        if (audience instanceof List) {
+            return ((List<?>) audience).contains(validAudience.get());
+        }
+        return false;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
@@ -38,6 +38,7 @@ public class TestOAuth2Config
                 .setJwksUrl(null)
                 .setClientId(null)
                 .setClientSecret(null)
+                .setAudience(null)
                 .setChallengeTimeout(Duration.valueOf("15m"))
                 .setUserMappingPattern(null)
                 .setUserMappingFile(null));
@@ -55,6 +56,7 @@ public class TestOAuth2Config
                 .put("http-server.authentication.oauth2.jwks-url", "http://127.0.0.1:9000/.well-known/jwks.json")
                 .put("http-server.authentication.oauth2.client-id", "another-consumer")
                 .put("http-server.authentication.oauth2.client-secret", "consumer-secret")
+                .put("http-server.authentication.oauth2.audience", "https://127.0.0.1:8443")
                 .put("http-server.authentication.oauth2.challenge-timeout", "90s")
                 .put("http-server.authentication.oauth2.user-mapping.pattern", "(.*)@something")
                 .put("http-server.authentication.oauth2.user-mapping.file", userMappingFile.toString())
@@ -67,6 +69,7 @@ public class TestOAuth2Config
                 .setJwksUrl("http://127.0.0.1:9000/.well-known/jwks.json")
                 .setClientId("another-consumer")
                 .setClientSecret("consumer-secret")
+                .setAudience("https://127.0.0.1:8443")
                 .setChallengeTimeout(Duration.valueOf("90s"))
                 .setUserMappingPattern("(.*)@something")
                 .setUserMappingFile(userMappingFile.toFile());

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilter.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilter.java
@@ -57,6 +57,7 @@ import java.net.URL;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -159,6 +160,7 @@ public class TestOAuth2WebUiAuthenticationFilter
         KeyPairGenerator keyGenerator = KeyPairGenerator.getInstance("RSA");
         SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.RS256;
         keyGenerator.initialize(4096);
+        long now = Instant.now().getEpochSecond();
         String token = Jwts.builder()
                 .setHeaderParam("alg", "RS256")
                 .setHeaderParam("kid", "public:f467aa08-1c1b-4cde-ba45-84b0ef5d2ba8")
@@ -168,11 +170,11 @@ public class TestOAuth2WebUiAuthenticationFilter
                                 ImmutableMap.<String, Object>builder()
                                         .put("aud", ImmutableList.of())
                                         .put("client_id", "another-consumer")
-                                        .put("exp", System.currentTimeMillis() / 1000L + 60L)
-                                        .put("iat", System.currentTimeMillis())
+                                        .put("exp", now + 60L)
+                                        .put("iat", now)
                                         .put("iss", "http://hydra:4444/")
                                         .put("jti", UUID.randomUUID())
-                                        .put("nbf", System.currentTimeMillis() - 60L)
+                                        .put("nbf", now)
                                         .put("scp", ImmutableList.of("openid"))
                                         .put("sub", "foo@bar.com")
                                         .build()))

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilter.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilter.java
@@ -188,6 +188,7 @@ public class TestOAuth2WebUiAuthenticationFilter
     }
 
     @Test
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/6223", match = OAUTH2_COOKIE + " is missing")
     public void testSuccessfulFlow()
             throws Exception
     {

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraService.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraService.java
@@ -49,7 +49,7 @@ public class TestingHydraService
             .withDatabaseName("hydra");
 
     private final GenericContainer<?> migrationContainer = createHydraContainer()
-            .withCommand("migrate sql --yes " + DSN)
+            .withCommand("migrate", "sql", "--yes", DSN)
             .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(ofMinutes(5)));
 
     private final FixedHostPortGenericContainer<?> consentContainer = new FixedHostPortGenericContainer<>("oryd/hydra-login-consent-node:v1.4.2")
@@ -100,14 +100,14 @@ public class TestingHydraService
     public void createConsumer(String callback)
     {
         createHydraContainer()
-                .withCommand("clients create " +
-                        "--endpoint http://hydra:4445 " +
-                        "--id another-consumer " +
-                        "--secret consumer-secret " +
-                        "-g authorization_code,refresh_token " +
-                        "-r token,code,id_token " +
-                        "--scope openid,offline " +
-                        "--callbacks " + callback)
+                .withCommand("clients", "create",
+                        "--endpoint", "http://hydra:4445",
+                        "--id", "another-consumer",
+                        "--secret", "consumer-secret",
+                        "-g", "authorization_code,refresh_token",
+                        "-r", "token,code,id_token",
+                        "--scope", "openid,offline",
+                        "--callbacks", callback)
                 .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(30)))
                 .start();
     }

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraService.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraService.java
@@ -35,7 +35,7 @@ public class TestingHydraService
         implements AutoCloseable
 {
     static final int TTL_ACCESS_TOKEN_IN_SECONDS = 5;
-    private static final String HYDRA_IMAGE = "oryd/hydra:v1.4.2";
+    private static final String HYDRA_IMAGE = "oryd/hydra:v1.9.0";
     private static final String DSN = "postgres://hydra:mysecretpassword@database:5432/hydra?sslmode=disable";
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
@@ -68,7 +68,7 @@ public class TestingHydraService
             .withEnv("URLS_SELF_ISSUER", "http://hydra:4444/")
             .withEnv("URLS_CONSENT", "http://consent:3000/consent")
             .withEnv("URLS_LOGIN", "http://consent:3000/login")
-            .withEnv("OAUTH2_ACCESS_TOKEN_STRATEGY", "jwt")
+            .withEnv("STRATEGIES_ACCESS_TOKEN", "jwt")
             .withEnv("TTL_ACCESS_TOKEN", TTL_ACCESS_TOKEN_IN_SECONDS + "s")
             .withCommand("serve all --dangerous-force-http")
             .waitingFor(Wait.forHttp("/health/ready").forPort(4444).forStatusCode(200));

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraService.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestingHydraService.java
@@ -22,6 +22,7 @@ import org.testcontainers.containers.FixedHostPortGenericContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 
@@ -29,6 +30,7 @@ import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Base64;
 
+import static io.trino.server.security.oauth2.TokenEndpointAuthMethod.CLIENT_SECRET_BASIC;
 import static java.time.Duration.ofMinutes;
 
 public class TestingHydraService
@@ -97,19 +99,39 @@ public class TestingHydraService
         return new FixedHostPortGenericContainer<>(HYDRA_IMAGE).withNetwork(network);
     }
 
-    public void createConsumer(String callback)
+    public void createClient(
+            String clientId,
+            String clientSecret,
+            TokenEndpointAuthMethod tokenEndpointAuthMethod,
+            String audience,
+            String callbackUrl)
     {
         createHydraContainer()
                 .withCommand("clients", "create",
                         "--endpoint", "http://hydra:4445",
-                        "--id", "another-consumer",
-                        "--secret", "consumer-secret",
-                        "-g", "authorization_code,refresh_token",
+                        "--id", clientId,
+                        "--secret", clientSecret,
+                        "--audience", audience,
+                        "-g", "authorization_code,refresh_token,client_credentials",
                         "-r", "token,code,id_token",
                         "--scope", "openid,offline",
-                        "--callbacks", callback)
+                        "--token-endpoint-auth-method", tokenEndpointAuthMethod.getValue(),
+                        "--callbacks", callbackUrl)
                 .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(30)))
                 .start();
+    }
+
+    public String getToken(String clientId, String clientSecret, String audience)
+    {
+        FixedHostPortGenericContainer<?> container = createHydraContainer()
+                .withCommand("token client " +
+                        "--endpoint http://hydra:4444 " +
+                        "--client-id " + clientId + " " +
+                        "--client-secret " + clientSecret + " " +
+                        "--audience " + audience)
+                .withStartupCheckStrategy(new OneShotStartupCheckStrategy().withTimeout(Duration.ofSeconds(30)));
+        container.start();
+        return container.getLogs(OutputFrame.OutputType.STDOUT).replaceAll("\\s+", "");
     }
 
     public Network getNetwork()
@@ -151,7 +173,12 @@ public class TestingHydraService
                     .withEnv("URLS_LOGIN", "http://localhost:9020/login")
                     .withEnv("TTL_ACCESS_TOKEN", "30m");
             service.start();
-            service.createConsumer("https://localhost:8443/oauth2/callback");
+            service.createClient(
+                    "trino-client",
+                    "trino-secret",
+                    CLIENT_SECRET_BASIC,
+                    "https://localhost:8443/ui",
+                    "https://localhost:8443/oauth2/callback");
             try (TestingTrinoServer ignored = TestingTrinoServer.builder()
                     .setCoordinator(true)
                     .setAdditionalModule(new WebUiModule())
@@ -166,8 +193,9 @@ public class TestingHydraService
                                     .put("http-server.authentication.oauth2.auth-url", "http://localhost:9001/oauth2/auth")
                                     .put("http-server.authentication.oauth2.token-url", "http://localhost:9001/oauth2/token")
                                     .put("http-server.authentication.oauth2.jwks-url", "http://localhost:9001/.well-known/jwks.json")
-                                    .put("http-server.authentication.oauth2.client-id", "another-consumer")
-                                    .put("http-server.authentication.oauth2.client-secret", "consumer-secret")
+                                    .put("http-server.authentication.oauth2.client-id", "trino-client")
+                                    .put("http-server.authentication.oauth2.client-secret", "trino-secret")
+                                    .put("http-server.authentication.oauth2.audience", "https://localhost:8443/ui")
                                     .put("http-server.authentication.oauth2.user-mapping.pattern", "(.*)@.*")
                                     .build())
                     .build()) {

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TokenEndpointAuthMethod.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TokenEndpointAuthMethod.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import static java.util.Objects.requireNonNull;
+
+public enum TokenEndpointAuthMethod
+{
+    CLIENT_SECRET_POST("client_secret_post"),
+    CLIENT_SECRET_BASIC("client_secret_basic"),
+    PRIVATE_KEY_JWT("private_key_jwt"),
+    NONE("none");
+
+    private final String value;
+
+    TokenEndpointAuthMethod(String value)
+    {
+        this.value = requireNonNull(value, "value is null");
+    }
+
+    public String getValue()
+    {
+        return value;
+    }
+}


### PR DESCRIPTION
* Add validation of JWT's audience (`aud`) field
* Add support for multiple-valued audience field
* Send audience in the authentication request
   Some IdPs (ex. Auth0) require including audience in the authorization
   request in order to obtain an access token in JWT format