### PR TITLE
Migrate WindowFilterPushdown to rule framework

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -128,6 +128,7 @@ public final class SystemSessionProperties
     public static final String REQUIRED_WORKERS_MAX_WAIT_TIME = "required_workers_max_wait_time";
     public static final String COST_ESTIMATION_WORKER_COUNT = "cost_estimation_worker_count";
     public static final String OMIT_DATETIME_TYPE_PRECISION = "omit_datetime_type_precision";
+    public static final String USE_LEGACY_WINDOW_FILTER_PUSHDOWN = "use_legacy_window_filter_pushdown";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -573,6 +574,11 @@ public final class SystemSessionProperties
                         OMIT_DATETIME_TYPE_PRECISION,
                         "Omit precision when rendering datetime type names with default precision",
                         featuresConfig.isOmitDateTimeTypePrecision(),
+                        false),
+                booleanProperty(
+                        USE_LEGACY_WINDOW_FILTER_PUSHDOWN,
+                        "Use legacy window filter pushdown optimizer",
+                        featuresConfig.isUseLegacyWindowFilterPushdown(),
                         false));
     }
 
@@ -1029,5 +1035,10 @@ public final class SystemSessionProperties
     public static boolean isOmitDateTimeTypePrecision(Session session)
     {
         return session.getSystemProperty(OMIT_DATETIME_TYPE_PRECISION, Boolean.class);
+    }
+
+    public static boolean useLegacyWindowFilterPushdown(Session session)
+    {
+        return session.getSystemProperty(USE_LEGACY_WINDOW_FILTER_PUSHDOWN, Boolean.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/FeaturesConfig.java
@@ -128,6 +128,7 @@ public class FeaturesConfig
     private boolean iterativeRuleBasedColumnPruning = true;
     private boolean rewriteFilteringSemiJoinToInnerJoin = true;
     private boolean optimizeDuplicateInsensitiveJoins = true;
+    private boolean useLegacyWindowFilterPushdown;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
     private DataSize filterAndProjectMinOutputPageSize = DataSize.of(500, KILOBYTE);
@@ -988,6 +989,18 @@ public class FeaturesConfig
     public FeaturesConfig setOptimizeDuplicateInsensitiveJoins(boolean optimizeDuplicateInsensitiveJoins)
     {
         this.optimizeDuplicateInsensitiveJoins = optimizeDuplicateInsensitiveJoins;
+        return this;
+    }
+
+    public boolean isUseLegacyWindowFilterPushdown()
+    {
+        return useLegacyWindowFilterPushdown;
+    }
+
+    @Config("optimizer.use-legacy-window-filter-pushdown")
+    public FeaturesConfig setUseLegacyWindowFilterPushdown(boolean useLegacyWindowFilterPushdown)
+    {
+        this.useLegacyWindowFilterPushdown = useLegacyWindowFilterPushdown;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import io.trino.SystemSessionProperties;
 import io.trino.cost.CostCalculator;
 import io.trino.cost.CostCalculator.EstimatedExchanges;
 import io.trino.cost.CostComparator;
@@ -154,6 +155,10 @@ import io.trino.sql.planner.iterative.rule.PushTopNIntoTableScan;
 import io.trino.sql.planner.iterative.rule.PushTopNThroughOuterJoin;
 import io.trino.sql.planner.iterative.rule.PushTopNThroughProject;
 import io.trino.sql.planner.iterative.rule.PushTopNThroughUnion;
+import io.trino.sql.planner.iterative.rule.PushdownFilterIntoRowNumber;
+import io.trino.sql.planner.iterative.rule.PushdownFilterIntoWindow;
+import io.trino.sql.planner.iterative.rule.PushdownLimitIntoRowNumber;
+import io.trino.sql.planner.iterative.rule.PushdownLimitIntoWindow;
 import io.trino.sql.planner.iterative.rule.RemoveAggregationInSemiJoin;
 import io.trino.sql.planner.iterative.rule.RemoveDuplicateConditions;
 import io.trino.sql.planner.iterative.rule.RemoveEmptyDelete;
@@ -174,6 +179,7 @@ import io.trino.sql.planner.iterative.rule.RemoveUnreferencedScalarApplyNodes;
 import io.trino.sql.planner.iterative.rule.RemoveUnreferencedScalarSubqueries;
 import io.trino.sql.planner.iterative.rule.RemoveUnsupportedDynamicFilters;
 import io.trino.sql.planner.iterative.rule.ReorderJoins;
+import io.trino.sql.planner.iterative.rule.ReplaceWindowWithRowNumber;
 import io.trino.sql.planner.iterative.rule.RewriteSpatialPartitioningAggregation;
 import io.trino.sql.planner.iterative.rule.SimplifyCountOverConstant;
 import io.trino.sql.planner.iterative.rule.SimplifyExpressions;
@@ -580,7 +586,6 @@ public class PlanOptimizers
         builder.add(pushIntoTableScanOptimizer);
         builder.add(new UnaliasSymbolReferences(metadata));
         builder.add(pushIntoTableScanOptimizer); // TODO (https://github.com/trinodb/trino/issues/811) merge with the above after migrating UnaliasSymbolReferences to rules
-
         builder.add(
                 new IterativeOptimizer(
                         ruleStats,
@@ -615,7 +620,18 @@ public class PlanOptimizers
                 columnPruningOptimizer, // Make sure to run this before index join. Filtered projections may not have all the columns.
                 new IndexJoinOptimizer(metadata, typeOperators), // Run this after projections and filters have been fully simplified and pushed down
                 new LimitPushDown(), // Run LimitPushDown before WindowFilterPushDown
-                new WindowFilterPushDown(metadata, typeOperators), // This must run after PredicatePushDown and LimitPushDown so that it squashes any successive filter nodes and limits
+                new IterativeOptimizer(
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        SystemSessionProperties::useLegacyWindowFilterPushdown,
+                        ImmutableList.of(new WindowFilterPushDown(metadata, typeOperators)),
+                        ImmutableSet.of(
+                                new PushdownLimitIntoRowNumber(),
+                                new PushdownLimitIntoWindow(metadata),
+                                new PushdownFilterIntoRowNumber(metadata, typeOperators),
+                                new PushdownFilterIntoWindow(metadata, typeOperators),
+                                new ReplaceWindowWithRowNumber(metadata))),
                 new IterativeOptimizer(
                         ruleStats,
                         statsCalculator,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownFilterIntoRowNumber.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownFilterIntoRowNumber.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.metadata.Metadata;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.TypeOperators;
+import io.trino.sql.ExpressionUtils;
+import io.trino.sql.planner.DomainTranslator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.RowNumberNode;
+import io.trino.sql.planner.plan.ValuesNode;
+import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.Expression;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.spi.predicate.Marker.Bound.BELOW;
+import static io.trino.spi.predicate.Range.range;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.DomainTranslator.fromPredicate;
+import static io.trino.sql.planner.plan.Patterns.filter;
+import static io.trino.sql.planner.plan.Patterns.rowNumber;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static java.lang.Math.toIntExact;
+
+public class PushdownFilterIntoRowNumber
+        implements Rule<FilterNode>
+{
+    private static final Capture<RowNumberNode> CHILD = newCapture();
+    private static final Pattern<FilterNode> PATTERN = filter().with(source().matching(rowNumber().capturedAs(CHILD)));
+
+    private final Metadata metadata;
+    private final DomainTranslator domainTranslator;
+    private final TypeOperators typeOperators;
+
+    public PushdownFilterIntoRowNumber(Metadata metadata, TypeOperators typeOperators)
+    {
+        this.metadata = metadata;
+        this.domainTranslator = new DomainTranslator(metadata);
+        this.typeOperators = typeOperators;
+    }
+
+    @Override
+    public Pattern<FilterNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(FilterNode node, Captures captures, Context context)
+    {
+        Session session = context.getSession();
+        TypeProvider types = context.getSymbolAllocator().getTypes();
+
+        DomainTranslator.ExtractionResult extractionResult = fromPredicate(metadata, typeOperators, session, node.getPredicate(), types);
+        TupleDomain<Symbol> tupleDomain = extractionResult.getTupleDomain();
+
+        RowNumberNode source = captures.get(CHILD);
+        Symbol rowNumberSymbol = source.getRowNumberSymbol();
+        OptionalInt upperBound = extractUpperBound(tupleDomain, rowNumberSymbol);
+
+        if (upperBound.isEmpty()) {
+            return Result.empty();
+        }
+
+        if (upperBound.getAsInt() <= 0) {
+            return Result.ofPlanNode(new ValuesNode(node.getId(), node.getOutputSymbols(), ImmutableList.of()));
+        }
+
+        RowNumberNode merged = mergeLimit(source, upperBound.getAsInt());
+        boolean needRewriteSource = !merged.getMaxRowCountPerPartition().equals(source.getMaxRowCountPerPartition());
+        if (needRewriteSource) {
+            source = merged;
+        }
+
+        if (!allRowNumberValuesInDomain(tupleDomain, rowNumberSymbol, source.getMaxRowCountPerPartition().get())) {
+            if (needRewriteSource) {
+                return Result.ofPlanNode(new FilterNode(node.getId(), source, node.getPredicate()));
+            }
+            else {
+                return Result.empty();
+            }
+        }
+
+        TupleDomain<Symbol> newTupleDomain = tupleDomain.filter((symbol, domain) -> !symbol.equals(rowNumberSymbol));
+        Expression newPredicate = ExpressionUtils.combineConjuncts(
+                metadata,
+                extractionResult.getRemainingExpression(),
+                domainTranslator.toPredicate(newTupleDomain));
+
+        if (newPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
+            return Result.ofPlanNode(source);
+        }
+
+        if (!newPredicate.equals(node.getPredicate())) {
+            return Result.ofPlanNode(new FilterNode(node.getId(), source, newPredicate));
+        }
+
+        return Result.empty();
+    }
+
+    private static boolean allRowNumberValuesInDomain(TupleDomain<Symbol> tupleDomain, Symbol symbol, long upperBound)
+    {
+        if (tupleDomain.isNone()) {
+            return false;
+        }
+        Domain domain = tupleDomain.getDomains().get().get(symbol);
+        if (domain == null) {
+            return true;
+        }
+        return domain.getValues().contains(ValueSet.ofRanges(range(domain.getType(), 1L, true, upperBound, true)));
+    }
+
+    private static OptionalInt extractUpperBound(TupleDomain<Symbol> tupleDomain, Symbol symbol)
+    {
+        if (tupleDomain.isNone()) {
+            return OptionalInt.empty();
+        }
+
+        Domain rowNumberDomain = tupleDomain.getDomains().get().get(symbol);
+        if (rowNumberDomain == null) {
+            return OptionalInt.empty();
+        }
+        ValueSet values = rowNumberDomain.getValues();
+        if (values.isAll() || values.isNone() || values.getRanges().getRangeCount() <= 0) {
+            return OptionalInt.empty();
+        }
+
+        Range span = values.getRanges().getSpan();
+
+        if (span.getHigh().isUpperUnbounded()) {
+            return OptionalInt.empty();
+        }
+
+        verify(rowNumberDomain.getType().equals(BIGINT));
+        long upperBound = (Long) span.getHigh().getValue();
+        if (span.getHigh().getBound() == BELOW) {
+            upperBound--;
+        }
+
+        if (upperBound >= Integer.MIN_VALUE && upperBound <= Integer.MAX_VALUE) {
+            return OptionalInt.of(toIntExact(upperBound));
+        }
+        return OptionalInt.empty();
+    }
+
+    private static RowNumberNode mergeLimit(RowNumberNode node, int newRowCountPerPartition)
+    {
+        if (node.getMaxRowCountPerPartition().isPresent()) {
+            newRowCountPerPartition = Math.min(node.getMaxRowCountPerPartition().get(), newRowCountPerPartition);
+        }
+        return new RowNumberNode(
+                node.getId(),
+                node.getSource(),
+                node.getPartitionBy(),
+                node.isOrderSensitive(),
+                node.getRowNumberSymbol(),
+                Optional.of(newRowCountPerPartition),
+                node.getHashSymbol());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownFilterIntoWindow.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownFilterIntoWindow.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.metadata.FunctionId;
+import io.trino.metadata.Metadata;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.TypeOperators;
+import io.trino.sql.ExpressionUtils;
+import io.trino.sql.planner.DomainTranslator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.FilterNode;
+import io.trino.sql.planner.plan.TopNRankingNode;
+import io.trino.sql.planner.plan.TopNRankingNode.RankingType;
+import io.trino.sql.planner.plan.ValuesNode;
+import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.tree.BooleanLiteral;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.QualifiedName;
+
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.SystemSessionProperties.isOptimizeTopNRanking;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.spi.predicate.Marker.Bound.BELOW;
+import static io.trino.spi.predicate.Range.range;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.planner.DomainTranslator.fromPredicate;
+import static io.trino.sql.planner.plan.Patterns.filter;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static io.trino.sql.planner.plan.Patterns.window;
+import static io.trino.sql.planner.plan.TopNRankingNode.RankingType.RANK;
+import static io.trino.sql.planner.plan.TopNRankingNode.RankingType.ROW_NUMBER;
+import static java.lang.Math.toIntExact;
+
+public class PushdownFilterIntoWindow
+        implements Rule<FilterNode>
+{
+    private static final Capture<WindowNode> childCapture = newCapture();
+
+    private final Pattern<FilterNode> pattern;
+    private final Metadata metadata;
+    private final DomainTranslator domainTranslator;
+    private final FunctionId rowNumberFunctionId;
+    private final FunctionId rankFunctionId;
+    private final TypeOperators typeOperators;
+
+    public PushdownFilterIntoWindow(Metadata metadata, TypeOperators typeOperators)
+    {
+        this.metadata = metadata;
+        this.domainTranslator = new DomainTranslator(metadata);
+        this.rowNumberFunctionId = metadata.resolveFunction(QualifiedName.of("row_number"), ImmutableList.of()).getFunctionId();
+        this.rankFunctionId = metadata.resolveFunction(QualifiedName.of("rank"), ImmutableList.of()).getFunctionId();
+        this.pattern = filter()
+                .with(source().matching(window()
+                        .matching(window -> window.getOrderingScheme().isPresent())
+                        .matching(window -> toTopNRankingType(window).isPresent())
+                        .capturedAs(childCapture)));
+        this.typeOperators = typeOperators;
+    }
+
+    @Override
+    public Pattern<FilterNode> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isOptimizeTopNRanking(session);
+    }
+
+    @Override
+    public Result apply(FilterNode node, Captures captures, Context context)
+    {
+        Session session = context.getSession();
+        TypeProvider types = context.getSymbolAllocator().getTypes();
+
+        WindowNode windowNode = captures.get(childCapture);
+
+        DomainTranslator.ExtractionResult extractionResult = fromPredicate(metadata, typeOperators, session, node.getPredicate(), types);
+        TupleDomain<Symbol> tupleDomain = extractionResult.getTupleDomain();
+
+        Optional<RankingType> rankingType = toTopNRankingType(windowNode);
+
+        Symbol rankingSymbol = getOnlyElement(windowNode.getWindowFunctions().keySet());
+        OptionalInt upperBound = extractUpperBound(tupleDomain, rankingSymbol);
+
+        if (upperBound.isEmpty()) {
+            return Result.empty();
+        }
+
+        if (upperBound.getAsInt() <= 0) {
+            return Result.ofPlanNode(new ValuesNode(node.getId(), node.getOutputSymbols(), ImmutableList.of()));
+        }
+        TopNRankingNode newSource = new TopNRankingNode(
+                windowNode.getId(),
+                windowNode.getSource(),
+                windowNode.getSpecification(),
+                rankingType.get(),
+                rankingSymbol,
+                upperBound.getAsInt(),
+                false,
+                Optional.empty());
+
+        if (!allRowNumberValuesInDomain(tupleDomain, rankingSymbol, upperBound.getAsInt())) {
+            return Result.ofPlanNode(new FilterNode(node.getId(), newSource, node.getPredicate()));
+        }
+
+        // Remove the row number domain because it is absorbed into the node
+        TupleDomain<Symbol> newTupleDomain = tupleDomain.filter((symbol, domain) -> !symbol.equals(rankingSymbol));
+        Expression newPredicate = ExpressionUtils.combineConjuncts(
+                metadata,
+                extractionResult.getRemainingExpression(),
+                domainTranslator.toPredicate(newTupleDomain));
+
+        if (newPredicate.equals(BooleanLiteral.TRUE_LITERAL)) {
+            return Result.ofPlanNode(newSource);
+        }
+        return Result.ofPlanNode(new FilterNode(node.getId(), newSource, newPredicate));
+    }
+
+    private static boolean allRowNumberValuesInDomain(TupleDomain<Symbol> tupleDomain, Symbol symbol, long upperBound)
+    {
+        if (tupleDomain.isNone()) {
+            return false;
+        }
+        Domain domain = tupleDomain.getDomains().get().get(symbol);
+        if (domain == null) {
+            return true;
+        }
+        return domain.getValues().contains(ValueSet.ofRanges(range(domain.getType(), 1L, true, upperBound, true)));
+    }
+
+    private static OptionalInt extractUpperBound(TupleDomain<Symbol> tupleDomain, Symbol symbol)
+    {
+        if (tupleDomain.isNone()) {
+            return OptionalInt.empty();
+        }
+
+        Domain rowNumberDomain = tupleDomain.getDomains().get().get(symbol);
+        if (rowNumberDomain == null) {
+            return OptionalInt.empty();
+        }
+        ValueSet values = rowNumberDomain.getValues();
+        if (values.isAll() || values.isNone() || values.getRanges().getRangeCount() <= 0) {
+            return OptionalInt.empty();
+        }
+
+        Range span = values.getRanges().getSpan();
+
+        if (span.getHigh().isUpperUnbounded()) {
+            return OptionalInt.empty();
+        }
+
+        verify(rowNumberDomain.getType().equals(BIGINT));
+        long upperBound = (Long) span.getHigh().getValue();
+        if (span.getHigh().getBound() == BELOW) {
+            upperBound--;
+        }
+
+        if (upperBound >= Integer.MIN_VALUE && upperBound <= Integer.MAX_VALUE) {
+            return OptionalInt.of(toIntExact(upperBound));
+        }
+        return OptionalInt.empty();
+    }
+
+    private Optional<RankingType> toTopNRankingType(WindowNode node)
+    {
+        if (node.getWindowFunctions().size() != 1 || node.getOrderingScheme().isEmpty()) {
+            return Optional.empty();
+        }
+        Symbol rankingSymbol = getOnlyElement(node.getWindowFunctions().entrySet()).getKey();
+        FunctionId functionId = node.getWindowFunctions().get(rankingSymbol).getResolvedFunction().getFunctionId();
+        if (functionId.equals(rowNumberFunctionId)) {
+            return Optional.of(ROW_NUMBER);
+        }
+        if (functionId.equals(rankFunctionId)) {
+            return Optional.of(RANK);
+        }
+        return Optional.empty();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownLimitIntoRowNumber.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownLimitIntoRowNumber.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.LimitNode;
+import io.trino.sql.planner.plan.RowNumberNode;
+
+import java.util.Optional;
+
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.sql.planner.plan.ChildReplacer.replaceChildren;
+import static io.trino.sql.planner.plan.Patterns.limit;
+import static io.trino.sql.planner.plan.Patterns.rowNumber;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static java.lang.Math.toIntExact;
+
+public class PushdownLimitIntoRowNumber
+        implements Rule<LimitNode>
+{
+    private static final Capture<RowNumberNode> CHILD = newCapture();
+    private static final Pattern<LimitNode> PATTERN = limit()
+            .matching(limit -> !limit.isWithTies() && limit.getCount() != 0 && limit.getCount() <= Integer.MAX_VALUE)
+            .with(source().matching(rowNumber().capturedAs(CHILD)));
+
+    @Override
+    public Pattern<LimitNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(LimitNode node, Captures captures, Context context)
+    {
+        RowNumberNode source = captures.get(CHILD);
+        int limit = toIntExact(node.getCount());
+        RowNumberNode rowNumberNode = mergeLimit(source, limit);
+        if (rowNumberNode.getPartitionBy().isEmpty()) {
+            return Result.ofPlanNode(rowNumberNode);
+        }
+        if (source.getMaxRowCountPerPartition().isPresent()) {
+            if (rowNumberNode.getMaxRowCountPerPartition().equals(source.getMaxRowCountPerPartition())) {
+                // Source node unchanged
+                return Result.empty();
+            }
+        }
+        return Result.ofPlanNode(replaceChildren(node, ImmutableList.of(rowNumberNode)));
+    }
+
+    private static RowNumberNode mergeLimit(RowNumberNode node, int newRowCountPerPartition)
+    {
+        if (node.getMaxRowCountPerPartition().isPresent()) {
+            newRowCountPerPartition = Math.min(node.getMaxRowCountPerPartition().get(), newRowCountPerPartition);
+        }
+        return new RowNumberNode(
+                node.getId(),
+                node.getSource(),
+                node.getPartitionBy(),
+                node.isOrderSensitive(),
+                node.getRowNumberSymbol(),
+                Optional.of(newRowCountPerPartition),
+                node.getHashSymbol());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownLimitIntoWindow.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushdownLimitIntoWindow.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.Session;
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.metadata.FunctionId;
+import io.trino.metadata.Metadata;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.LimitNode;
+import io.trino.sql.planner.plan.TopNRankingNode;
+import io.trino.sql.planner.plan.TopNRankingNode.RankingType;
+import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.tree.QualifiedName;
+
+import java.util.Optional;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.SystemSessionProperties.isOptimizeTopNRanking;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.sql.planner.plan.ChildReplacer.replaceChildren;
+import static io.trino.sql.planner.plan.Patterns.limit;
+import static io.trino.sql.planner.plan.Patterns.source;
+import static io.trino.sql.planner.plan.Patterns.window;
+import static io.trino.sql.planner.plan.TopNRankingNode.RankingType.RANK;
+import static io.trino.sql.planner.plan.TopNRankingNode.RankingType.ROW_NUMBER;
+import static java.lang.Math.toIntExact;
+
+public class PushdownLimitIntoWindow
+        implements Rule<LimitNode>
+{
+    private static final Capture<WindowNode> childCapture = newCapture();
+    private final Pattern<LimitNode> pattern;
+
+    private final FunctionId rowNumberFunctionId;
+    private final FunctionId rankFunctionId;
+
+    public PushdownLimitIntoWindow(Metadata metadata)
+    {
+        this.rowNumberFunctionId = metadata.resolveFunction(QualifiedName.of("row_number"), ImmutableList.of()).getFunctionId();
+        this.rankFunctionId = metadata.resolveFunction(QualifiedName.of("rank"), ImmutableList.of()).getFunctionId();
+        this.pattern = limit()
+                .matching(limit -> !limit.isWithTies() && limit.getCount() != 0 && limit.getCount() <= Integer.MAX_VALUE)
+                .with(source().matching(window()
+                        .matching(window -> window.getOrderingScheme().isPresent())
+                        .matching(window -> toTopNRankingType(window).isPresent())
+                        .capturedAs(childCapture)));
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isOptimizeTopNRanking(session);
+    }
+
+    @Override
+    public Pattern<LimitNode> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Result apply(LimitNode node, Captures captures, Context context)
+    {
+        WindowNode source = captures.get(childCapture);
+
+        Optional<RankingType> rankingType = toTopNRankingType(source);
+
+        int limit = toIntExact(node.getCount());
+        TopNRankingNode topNRowNumberNode = new TopNRankingNode(
+                source.getId(),
+                source.getSource(),
+                source.getSpecification(),
+                rankingType.get(),
+                getOnlyElement(source.getWindowFunctions().keySet()),
+                limit,
+                false,
+                Optional.empty());
+        if (rankingType.get() == ROW_NUMBER && source.getPartitionBy().isEmpty()) {
+            return Result.ofPlanNode(topNRowNumberNode);
+        }
+        return Result.ofPlanNode(replaceChildren(node, ImmutableList.of(topNRowNumberNode)));
+    }
+
+    private Optional<RankingType> toTopNRankingType(WindowNode node)
+    {
+        if (node.getWindowFunctions().size() != 1 || node.getOrderingScheme().isEmpty()) {
+            return Optional.empty();
+        }
+        Symbol rankingSymbol = getOnlyElement(node.getWindowFunctions().entrySet()).getKey();
+        FunctionId functionId = node.getWindowFunctions().get(rankingSymbol).getResolvedFunction().getFunctionId();
+        if (functionId.equals(rowNumberFunctionId)) {
+            return Optional.of(ROW_NUMBER);
+        }
+        if (functionId.equals(rankFunctionId)) {
+            return Optional.of(RANK);
+        }
+        return Optional.empty();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceWindowWithRowNumber.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReplaceWindowWithRowNumber.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.metadata.FunctionId;
+import io.trino.metadata.Metadata;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.RowNumberNode;
+import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.tree.QualifiedName;
+
+import java.util.Optional;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.sql.planner.plan.Patterns.window;
+
+public class ReplaceWindowWithRowNumber
+        implements Rule<WindowNode>
+{
+    private final Pattern<WindowNode> pattern;
+
+    public ReplaceWindowWithRowNumber(Metadata metadata)
+    {
+        FunctionId rowNumber = metadata.resolveFunction(QualifiedName.of("row_number"), ImmutableList.of()).getFunctionId();
+        this.pattern = window()
+                .matching(window -> window.getWindowFunctions().size() == 1 && getOnlyElement(window.getWindowFunctions().values()).getResolvedFunction().getFunctionId().equals(rowNumber))
+                .matching(window -> window.getOrderingScheme().isEmpty());
+    }
+
+    @Override
+    public Pattern<WindowNode> getPattern()
+    {
+        return pattern;
+    }
+
+    @Override
+    public Result apply(WindowNode node, Captures captures, Context context)
+    {
+        return Result.ofPlanNode(new RowNumberNode(
+                node.getId(),
+                node.getSource(),
+                node.getPartitionBy(),
+                false,
+                getOnlyElement(node.getWindowFunctions().keySet()),
+                Optional.empty(),
+                Optional.empty()));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
@@ -106,7 +106,8 @@ public class TestFeaturesConfig
                 .setOmitDateTimeTypePrecision(false)
                 .setIterativeRuleBasedColumnPruning(true)
                 .setRewriteFilteringSemiJoinToInnerJoin(true)
-                .setOptimizeDuplicateInsensitiveJoins(true));
+                .setOptimizeDuplicateInsensitiveJoins(true)
+                .setUseLegacyWindowFilterPushdown(false));
     }
 
     @Test
@@ -178,6 +179,7 @@ public class TestFeaturesConfig
                 .put("optimizer.iterative-rule-based-column-pruning", "false")
                 .put("optimizer.rewrite-filtering-semi-join-to-inner-join", "false")
                 .put("optimizer.optimize-duplicate-insensitive-joins", "false")
+                .put("optimizer.use-legacy-window-filter-pushdown", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -245,7 +247,8 @@ public class TestFeaturesConfig
                 .setOmitDateTimeTypePrecision(true)
                 .setIterativeRuleBasedColumnPruning(false)
                 .setRewriteFilteringSemiJoinToInnerJoin(false)
-                .setOptimizeDuplicateInsensitiveJoins(false);
+                .setOptimizeDuplicateInsensitiveJoins(false)
+                .setUseLegacyWindowFilterPushdown(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoRowNumber.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoRowNumber.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.type.TypeOperators;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.assertions.RowNumberSymbolMatcher;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.rowNumber;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
+
+public class TestPushdownFilterIntoRowNumber
+        extends BaseRuleTest
+{
+    @Test
+    public void testSourceRowNumber()
+    {
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(
+                            expression("row_number_1 < cast(100 as bigint)"),
+                            p.rowNumber(
+                                    ImmutableList.of(a),
+                                    Optional.empty(),
+                                    rowNumberSymbol,
+                                    p.values(a)));
+                })
+                .matches(
+                        rowNumber(rowNumber -> rowNumber
+                                        .maxRowCountPerPartition(Optional.of(99))
+                                        .partitionBy(ImmutableList.of("a")),
+                        values("a")));
+
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(
+                            expression("row_number_1 < cast(100 as bigint)"),
+                            p.rowNumber(
+                                    ImmutableList.of(a),
+                                    Optional.of(10),
+                                    rowNumberSymbol,
+                                    p.values(a)));
+                })
+                .matches(
+                        rowNumber(rowNumber -> rowNumber
+                                        .maxRowCountPerPartition(Optional.of(10))
+                                        .partitionBy(ImmutableList.of("a")),
+                        values("a")));
+
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(
+                            expression("cast(3 as bigint) < row_number_1 and row_number_1 < cast(5 as bigint)"),
+                            p.rowNumber(
+                                    ImmutableList.of(a),
+                                    Optional.of(10),
+                                    rowNumberSymbol,
+                                    p.values(a)));
+                })
+                .matches(
+                        filter(
+                                "cast(3 as bigint) < row_number_1 and row_number_1 < cast(5 as bigint)",
+                                rowNumber(rowNumber -> rowNumber
+                                                .maxRowCountPerPartition(Optional.of(4))
+                                                .partitionBy(ImmutableList.of("a")),
+                                        values("a"))
+                                        .withAlias("row_number_1", new RowNumberSymbolMatcher())));
+
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(
+                            expression("row_number_1 < cast(5 as bigint) and a = 1"),
+                            p.rowNumber(
+                                    ImmutableList.of(a),
+                                    Optional.of(10),
+                                    rowNumberSymbol,
+                                    p.values(a)));
+                })
+                .matches(
+                        filter(
+                                "a = 1",
+                                rowNumber(rowNumber -> rowNumber
+                                                .maxRowCountPerPartition(Optional.of(4))
+                                                .partitionBy(ImmutableList.of("a")),
+                                        values("a"))
+                                        .withAlias("row_number_1", new RowNumberSymbolMatcher())));
+    }
+
+    @Test
+    public void testNoOutputsThroughRowNumber()
+    {
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(expression("row_number_1 < cast(-100 as bigint)"),
+                            p.rowNumber(ImmutableList.of(p.symbol("a")), Optional.empty(), rowNumberSymbol,
+                                    p.values(p.symbol("a"))));
+                })
+                .matches(values("a", "row_number_1"));
+    }
+
+    @Test
+    public void testDoNotFire()
+    {
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(expression("not_row_number < cast(100 as bigint)"),
+                            p.rowNumber(ImmutableList.of(p.symbol("a")), Optional.empty(), rowNumberSymbol,
+                                    p.values(p.symbol("a"), p.symbol("not_row_number"))));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(expression("row_number_1 > cast(100 as bigint)"),
+                            p.rowNumber(ImmutableList.of(p.symbol("a")), Optional.empty(), rowNumberSymbol,
+                                    p.values(p.symbol("a"))));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new PushdownFilterIntoRowNumber(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.filter(
+                            expression("cast(3 as bigint) < row_number_1 and row_number_1 < cast(5 as bigint)"),
+                            p.rowNumber(
+                                    ImmutableList.of(a),
+                                    Optional.of(4),
+                                    rowNumberSymbol,
+                                    p.values(a)));
+                })
+                .doesNotFire();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownFilterIntoWindow.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.connector.SortOrder;
+import io.trino.spi.type.TypeOperators;
+import io.trino.sql.planner.OrderingScheme;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.assertions.TopNRankingSymbolMatcher;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.WindowFrame;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.topNRanking;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static io.trino.sql.tree.FrameBound.Type.CURRENT_ROW;
+import static io.trino.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
+
+public class TestPushdownFilterIntoWindow
+        extends BaseRuleTest
+{
+    @Test
+    public void testEliminateFilter()
+    {
+        ResolvedFunction rowNumber = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownFilterIntoWindow(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    Symbol a = p.symbol("a", BIGINT);
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.filter(expression("row_number_1 < cast(100 as bigint)"), p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumber, a)),
+                            p.values(p.symbol("a"))));
+                })
+                .matches(topNRanking(pattern -> pattern
+                                .maxRankingPerPartition(99)
+                                .partial(false),
+                        values("a")));
+    }
+
+    @Test
+    public void testKeepFilter()
+    {
+        ResolvedFunction rowNumber = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownFilterIntoWindow(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    Symbol a = p.symbol("a", BIGINT);
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.filter(expression("cast(3 as bigint) < row_number_1 and row_number_1 < cast(100 as bigint)"), p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumber, a)),
+                            p.values(p.symbol("a"))));
+                })
+                .matches(filter(
+                        "cast(3 as bigint) < row_number_1 and row_number_1 < cast(100 as bigint)",
+                        topNRanking(pattern -> pattern
+                                .partial(false)
+                                .maxRankingPerPartition(99)
+                                .specification(
+                                        ImmutableList.of("a"),
+                                        ImmutableList.of("a"),
+                                        ImmutableMap.of("a", SortOrder.ASC_NULLS_FIRST)),
+                                values("a")).withAlias("row_number_1", new TopNRankingSymbolMatcher())));
+
+        tester().assertThat(new PushdownFilterIntoWindow(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    Symbol a = p.symbol("a", BIGINT);
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.filter(expression("row_number_1 < cast(100 as bigint) and a = 1"), p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumber, a)),
+                            p.values(p.symbol("a"))));
+                })
+                .matches(filter(
+                        "a = 1",
+                        topNRanking(pattern -> pattern
+                                        .partial(false)
+                                        .maxRankingPerPartition(99)
+                                        .specification(
+                                                ImmutableList.of("a"),
+                                                ImmutableList.of("a"),
+                                                ImmutableMap.of("a", SortOrder.ASC_NULLS_FIRST)),
+                                values("a")).withAlias("row_number_1", new TopNRankingSymbolMatcher())));
+    }
+
+    @Test
+    public void testNoUpperBound()
+    {
+        ResolvedFunction rowNumber = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownFilterIntoWindow(tester().getMetadata(), new TypeOperators()))
+                .on(p -> {
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    Symbol a = p.symbol("a");
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.filter(
+                            expression("cast(3 as bigint) < row_number_1"),
+                            p.window(
+                                    new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                                    ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumber, a)),
+                                    p.values(a)));
+                })
+                .doesNotFire();
+    }
+
+    private static WindowNode.Function newWindowNodeFunction(ResolvedFunction resolvedFunction, Symbol symbol)
+    {
+        return new WindowNode.Function(
+                resolvedFunction,
+                ImmutableList.of(symbol.toSymbolReference()),
+                new WindowNode.Frame(
+                        WindowFrame.Type.RANGE,
+                        UNBOUNDED_PRECEDING,
+                        Optional.empty(),
+                        Optional.empty(),
+                        CURRENT_ROW,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                false);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownLimitIntoRowNumber.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownLimitIntoRowNumber.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.sql.planner.assertions.PlanMatchPattern.limit;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.rowNumber;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestPushdownLimitIntoRowNumber
+        extends BaseRuleTest
+{
+    @Test
+    public void testLimitAboveRowNumber()
+    {
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p ->
+                        p.limit(
+                                3,
+                                p.rowNumber(
+                                ImmutableList.of(),
+                                Optional.of(5),
+                                p.symbol("row_number"),
+                                p.values(p.symbol("a")))))
+                .matches(
+                        rowNumber(rowNumber -> rowNumber
+                                        .partitionBy(ImmutableList.of())
+                                        .maxRowCountPerPartition(Optional.of(3)),
+                        values("a")));
+
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    return p.limit(
+                            3,
+                            p.rowNumber(
+                            ImmutableList.of(a),
+                            Optional.of(5),
+                            p.symbol("row_number"), p.values(a)));
+                })
+                .matches(
+                        limit(
+                                3,
+                                rowNumber(rowNumber -> rowNumber
+                                                .partitionBy(ImmutableList.of("a"))
+                                                .maxRowCountPerPartition(Optional.of(3)),
+                        values("a"))));
+
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    return p.limit(
+                            3,
+                            p.rowNumber(
+                            ImmutableList.of(a),
+                            Optional.empty(),
+                            p.symbol("row_number"), p.values(a)));
+                })
+                .matches(
+                        limit(
+                                3,
+                                rowNumber(rowNumber -> rowNumber
+                                                .partitionBy(ImmutableList.of("a"))
+                                                .maxRowCountPerPartition(Optional.of(3)),
+                        values("a"))));
+
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    return p.limit(
+                            5,
+                            p.rowNumber(
+                            ImmutableList.of(),
+                            Optional.of(3),
+                            p.symbol("row_number"), p.values(a)));
+                })
+                .matches(
+                        rowNumber(rowNumber -> rowNumber
+                                        .partitionBy(ImmutableList.of())
+                                        .maxRowCountPerPartition(Optional.of(3)),
+                        values("a")));
+    }
+
+    @Test
+    public void testZeroLimit()
+    {
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p ->
+                        p.limit(
+                                0,
+                                p.rowNumber(ImmutableList.of(), Optional.of(5),
+                                p.symbol("row_number"), p.values(p.symbol("a")))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testTiesLimit()
+    {
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p ->
+                        p.limit(
+                                0,
+                                ImmutableList.of(p.symbol("a")),
+                                p.rowNumber(
+                                        ImmutableList.of(),
+                                        Optional.of(5),
+                                        p.symbol("row_number"),
+                                        p.values(p.symbol("a")))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testIdenticalLimit()
+    {
+        tester().assertThat(new PushdownLimitIntoRowNumber())
+                .on(p ->
+                        p.limit(
+                                5,
+                                ImmutableList.of(p.symbol("a")),
+                                p.rowNumber(
+                                        ImmutableList.of(),
+                                        Optional.of(5),
+                                        p.symbol("row_number"),
+                                        p.values(p.symbol("a")))))
+                .doesNotFire();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownLimitIntoWindow.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushdownLimitIntoWindow.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.connector.SortOrder;
+import io.trino.sql.planner.OrderingScheme;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.WindowFrame;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.limit;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.topNRanking;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.tree.FrameBound.Type.CURRENT_ROW;
+import static io.trino.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
+
+public class TestPushdownLimitIntoWindow
+        extends BaseRuleTest
+{
+    @Test
+    public void testLimitAboveWindow()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownLimitIntoWindow(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.limit(
+                            3,
+                            p.window(
+                                    new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                                    ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction, a)),
+                                    p.values(a)));
+                })
+                .matches(
+                        limit(3, topNRanking(
+                                pattern -> pattern
+                                        .specification(
+                                                ImmutableList.of("a"),
+                                                ImmutableList.of("a"),
+                                                ImmutableMap.of("a", SortOrder.ASC_NULLS_FIRST))
+                                        .maxRankingPerPartition(3)
+                                        .partial(false), values("a"))));
+    }
+
+    @Test
+    public void testConvertToTopNRowNumber()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownLimitIntoWindow(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.limit(3, p.window(
+                            new WindowNode.Specification(ImmutableList.of(), Optional.of(orderingScheme)),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction, a)),
+                            p.values(a)));
+                })
+                .matches(
+                        topNRanking(pattern -> pattern
+                                .specification(
+                                        ImmutableList.of(),
+                                        ImmutableList.of("a"),
+                                        ImmutableMap.of("a", SortOrder.ASC_NULLS_FIRST))
+                        .maxRankingPerPartition(3)
+                        .partial(false), values("a")));
+    }
+
+    @Test
+    public void testZeroLimit()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownLimitIntoWindow(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    OrderingScheme orderingScheme = new OrderingScheme(
+                            ImmutableList.of(a),
+                            ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    return p.limit(
+                            0,
+                            p.window(
+                                    new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                                    ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction, a)),
+                                    p.values(a)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testWindowNotOrdered()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new PushdownLimitIntoWindow(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.limit(
+                            3,
+                            p.window(
+                                    new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                                    ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction, a)),
+                                    p.values(a)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testMultipleWindowFunctions()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        ResolvedFunction rankFunction = tester().getMetadata().resolveFunction(QualifiedName.of("rank"), fromTypes());
+        tester().assertThat(new PushdownLimitIntoWindow(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    Symbol rankSymbol = p.symbol("rank_1");
+                    return p.limit(
+                            3,
+                            p.window(
+                                    new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                                    ImmutableMap.of(
+                                            rowNumberSymbol,
+                                            newWindowNodeFunction(rowNumberFunction, a),
+                                            rankSymbol,
+                                            newWindowNodeFunction(rankFunction, a)),
+                                    p.values(a)));
+                })
+                .doesNotFire();
+    }
+
+    private static WindowNode.Function newWindowNodeFunction(ResolvedFunction resolvedFunction, Symbol symbol)
+    {
+        return new WindowNode.Function(
+                resolvedFunction,
+                ImmutableList.of(symbol.toSymbolReference()),
+                new WindowNode.Frame(
+                        WindowFrame.Type.RANGE,
+                        UNBOUNDED_PRECEDING,
+                        Optional.empty(),
+                        Optional.empty(),
+                        CURRENT_ROW,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                false);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceWindowWithRowNumber.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestReplaceWindowWithRowNumber.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.connector.SortOrder;
+import io.trino.sql.planner.OrderingScheme;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.WindowNode;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.WindowFrame;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.rowNumber;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.tree.FrameBound.Type.CURRENT_ROW;
+import static io.trino.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
+
+public class TestReplaceWindowWithRowNumber
+        extends BaseRuleTest
+{
+    @Test
+    public void test()
+    {
+        ResolvedFunction rowNumberFunction = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new ReplaceWindowWithRowNumber(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction)),
+                            p.values(a));
+                })
+                .matches(rowNumber(
+                        pattern -> pattern
+                                .maxRowCountPerPartition(Optional.empty())
+                                .partitionBy(ImmutableList.of("a")),
+                        values("a")));
+
+        tester().assertThat(new ReplaceWindowWithRowNumber(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumberSymbol = p.symbol("row_number_1");
+                    return p.window(
+                            new WindowNode.Specification(ImmutableList.of(), Optional.empty()),
+                            ImmutableMap.of(rowNumberSymbol, newWindowNodeFunction(rowNumberFunction)),
+                            p.values(a));
+                })
+                .matches(rowNumber(
+                        pattern -> pattern
+                                .maxRowCountPerPartition(Optional.empty())
+                                .partitionBy(ImmutableList.of()),
+                        values("a")));
+    }
+
+    @Test
+    public void testDoNotFire()
+    {
+        ResolvedFunction rank = tester().getMetadata().resolveFunction(QualifiedName.of("rank"), fromTypes());
+        tester().assertThat(new ReplaceWindowWithRowNumber(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rank1 = p.symbol("rank_1");
+                    return p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                                ImmutableMap.of(rank1, newWindowNodeFunction(rank)),
+                                p.values(a));
+                })
+                .doesNotFire();
+
+        ResolvedFunction rowNumber = tester().getMetadata().resolveFunction(QualifiedName.of("row_number"), fromTypes());
+        tester().assertThat(new ReplaceWindowWithRowNumber(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    Symbol rowNumber1 = p.symbol("row_number_1");
+                    Symbol rank1 = p.symbol("rank_1");
+                    return p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.empty()),
+                            ImmutableMap.of(rowNumber1, newWindowNodeFunction(rowNumber), rank1, newWindowNodeFunction(rank)),
+                            p.values(a));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new ReplaceWindowWithRowNumber(tester().getMetadata()))
+                .on(p -> {
+                    Symbol a = p.symbol("a");
+                    OrderingScheme orderingScheme = new OrderingScheme(ImmutableList.of(a), ImmutableMap.of(a, SortOrder.ASC_NULLS_FIRST));
+                    Symbol rowNumber1 = p.symbol("row_number_1");
+                    return p.window(
+                            new WindowNode.Specification(ImmutableList.of(a), Optional.of(orderingScheme)),
+                            ImmutableMap.of(rowNumber1, newWindowNodeFunction(rowNumber)),
+                            p.values(a));
+                })
+                .doesNotFire();
+    }
+
+    private static WindowNode.Function newWindowNodeFunction(ResolvedFunction resolvedFunction)
+    {
+        return new WindowNode.Function(
+                resolvedFunction,
+                ImmutableList.of(),
+                new WindowNode.Frame(
+                        WindowFrame.Type.RANGE,
+                        UNBOUNDED_PRECEDING,
+                        Optional.empty(),
+                        Optional.empty(),
+                        CURRENT_ROW,
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.empty()),
+                false);
+    }
+}


### PR DESCRIPTION
Migrate WindowFilterPushdown rule to new iterative rule framework keeping the optimization behavior as it is. WindowFilterPushdown is decomposed into

- PushdownFilterThroughRowNumber
- PushdownFilterThroughWindow
- PushdownLimitThroughRowNumber
- PushdownLimitThroughWindow
- ReplaceWindowWithRowNumber

See: https://github.com/prestosql/presto/issues/811

This PR is a rebased version of https://github.com/trinodb/trino/pull/4242 alongside the Trino migration. 