### PR TITLE
Use sentence case in titles consistently

### DIFF
--- a/docs/src/main/sphinx/admin/dist-sort.rst
+++ b/docs/src/main/sphinx/admin/dist-sort.rst
@@ -1,5 +1,5 @@
 ================
-Distributed Sort
+Distributed sort
 ================
 
 Distributed sort allows to sort data, which exceeds ``query.max-memory-per-node``.

--- a/docs/src/main/sphinx/admin/dynamic-filtering.rst
+++ b/docs/src/main/sphinx/admin/dynamic-filtering.rst
@@ -1,5 +1,5 @@
 =================
-Dynamic Filtering
+Dynamic filtering
 =================
 
 Dynamic filtering optimizations significantly improve the performance of queries

--- a/docs/src/main/sphinx/admin/graceful-shutdown.rst
+++ b/docs/src/main/sphinx/admin/graceful-shutdown.rst
@@ -1,5 +1,5 @@
 =================
-Graceful Shutdown
+Graceful shutdown
 =================
 
 Trino has a graceful shutdown API that can be used exclusively on workers in
@@ -27,7 +27,7 @@ Keep the following aspects in mind:
   then the user in the HTTP request must have read and write permissions in
   the system information rules.
 
-Shutdown Behavior
+Shutdown behavior
 -----------------
 
 Once the API is called, the worker performs the following steps:

--- a/docs/src/main/sphinx/admin/jmx.rst
+++ b/docs/src/main/sphinx/admin/jmx.rst
@@ -36,7 +36,7 @@ JVM
 * Heap size: ``java.lang:type=Memory:HeapMemoryUsage.used``
 * Thread count: ``java.lang:type=Threading:ThreadCount``
 
-Trino Cluster and Nodes
+Trino cluster and nodes
 ------------------------
 
 * Active nodes:
@@ -48,7 +48,7 @@ Trino Cluster and Nodes
 * Cumulative count (since Trino started) of queries that ran out of memory and were killed:
   ``trino.memory:name=ClusterMemoryManager:QueriesKilledDueToOutOfMemory``
 
-Trino Queries
+Trino queries
 --------------
 
 * Active queries currently executing or queued: ``trino.execution:name=QueryManager:RunningQueries``
@@ -63,7 +63,7 @@ Trino Queries
 * Execution latency (P50): ``trino.execution:name=QueryManager:ExecutionTime.FiveMinutes.P50``
 * Input data rate (P90): ``trino.execution:name=QueryManager:WallInputBytesRate.FiveMinutes.P90``
 
-Trino Tasks
+Trino tasks
 ------------
 
 * Input data bytes: ``trino.execution:name=TaskManager:InputDataSize.FiveMinute.Count``

--- a/docs/src/main/sphinx/admin/properties-exchange.rst
+++ b/docs/src/main/sphinx/admin/properties-exchange.rst
@@ -1,5 +1,5 @@
 ===================
-Exchange Properties
+Exchange properties
 ===================
 
 Exchanges transfer data between Trino nodes for different stages of

--- a/docs/src/main/sphinx/admin/properties-general.rst
+++ b/docs/src/main/sphinx/admin/properties-general.rst
@@ -1,5 +1,5 @@
 ==================
-General Properties
+General properties
 ==================
 
 ``join-distribution-type``

--- a/docs/src/main/sphinx/admin/properties-logging.rst
+++ b/docs/src/main/sphinx/admin/properties-logging.rst
@@ -1,5 +1,5 @@
 ==================
-Logging Properties
+Logging properties
 ==================
 
 ``log.path``

--- a/docs/src/main/sphinx/admin/properties-memory-management.rst
+++ b/docs/src/main/sphinx/admin/properties-memory-management.rst
@@ -1,5 +1,5 @@
 ============================
-Memory Management Properties
+Memory management properties
 ============================
 
 ``query.max-memory-per-node``

--- a/docs/src/main/sphinx/admin/properties-node-scheduler.rst
+++ b/docs/src/main/sphinx/admin/properties-node-scheduler.rst
@@ -1,5 +1,5 @@
 =========================
-Node Scheduler Properties
+Node scheduler properties
 =========================
 
 Splits
@@ -66,7 +66,7 @@ distribution across all hosts. ``topology`` tries to schedule splits according t
 the topology distance between nodes and splits. It is recommended to use ``uniform``
 for clusters where distributed storage runs on the same nodes as Trino workers.
 
-Network Topology
+Network topology
 ----------------
 
 ``node-scheduler.network-topology.segments``
@@ -98,7 +98,7 @@ must be set to ``topology``.
   and ``node-scheduler.network-topology.subnet.ip-address-protocol`` described
   in the following sections.
 
-File Based Network Topology
+File based network topology
 ---------------------------
 
 ``node-scheduler.network-topology.file``
@@ -127,7 +127,7 @@ network location, separated by whitespace. Network location must begin with a le
 Controls how often the network topology file is reloaded.  To use this option,
 ``node-scheduler.network-topology.type`` must be set to ``file``.
 
-Subnet Based Network Topology
+Subnet based network topology
 -----------------------------
 
 ``node-scheduler.network-topology.subnet.ip-address-protocol``

--- a/docs/src/main/sphinx/admin/properties-optimizer.rst
+++ b/docs/src/main/sphinx/admin/properties-optimizer.rst
@@ -1,5 +1,5 @@
 ====================
-Optimizer Properties
+Optimizer properties
 ====================
 
 ``optimizer.dictionary-aggregation``

--- a/docs/src/main/sphinx/admin/properties-query-management.rst
+++ b/docs/src/main/sphinx/admin/properties-query-management.rst
@@ -1,5 +1,5 @@
 ===========================
-Query Management Properties
+Query management properties
 ===========================
 
 ``query.max-execution-time``

--- a/docs/src/main/sphinx/admin/properties-regexp-function.rst
+++ b/docs/src/main/sphinx/admin/properties-regexp-function.rst
@@ -1,5 +1,5 @@
 ======================================
-Regular Expression Function Properties
+Regular expression function properties
 ======================================
 
 These properties allow tuning the :doc:`/functions/regexp`.

--- a/docs/src/main/sphinx/admin/properties-spilling.rst
+++ b/docs/src/main/sphinx/admin/properties-spilling.rst
@@ -1,5 +1,5 @@
 ===================
-Spilling Properties
+Spilling properties
 ===================
 
 These properties control :doc:`spill`.

--- a/docs/src/main/sphinx/admin/properties-task.rst
+++ b/docs/src/main/sphinx/admin/properties-task.rst
@@ -1,5 +1,5 @@
 ===============
-Task Properties
+Task properties
 ===============
 
 ``task.concurrency``

--- a/docs/src/main/sphinx/admin/properties-web-interface.rst
+++ b/docs/src/main/sphinx/admin/properties-web-interface.rst
@@ -1,4 +1,4 @@
-Web UI Properties
+Web UI properties
 -----------------
 
 The following properties can be used to configure the :doc:`web-interface`.

--- a/docs/src/main/sphinx/admin/properties-writer-scaling.rst
+++ b/docs/src/main/sphinx/admin/properties-writer-scaling.rst
@@ -1,5 +1,5 @@
 =========================
-Writer Scaling Properties
+Writer scaling properties
 =========================
 
 By default, the number of writer tasks is static. Enabling writer scaling allows

--- a/docs/src/main/sphinx/admin/properties.rst
+++ b/docs/src/main/sphinx/admin/properties.rst
@@ -1,5 +1,5 @@
 ====================
-Properties Reference
+Properties reference
 ====================
 
 This section describes the most important config properties, that
@@ -9,14 +9,14 @@ may be used to tune Trino or alter its behavior when required.
     :titlesonly:
 
     General <properties-general>
-    Memory Management <properties-memory-management>
-    Query Management <properties-query-management>
+    Memory management <properties-memory-management>
+    Query management <properties-query-management>
     Spilling <properties-spilling>
     Exchange <properties-exchange>
     Task <properties-task>
-    Writer Scaling <properties-writer-scaling>
-    Node Scheduler <properties-node-scheduler>
+    Writer scaling <properties-writer-scaling>
+    Node scheduler <properties-node-scheduler>
     Optimizer <properties-optimizer>
     Logging <properties-logging>
     Web UI <properties-web-interface>
-    Regular Expression Function <properties-regexp-function>
+    Regular expression function <properties-regexp-function>

--- a/docs/src/main/sphinx/admin/resource-groups.rst
+++ b/docs/src/main/sphinx/admin/resource-groups.rst
@@ -1,5 +1,5 @@
 ===============
-Resource Groups
+Resource groups
 ===============
 
 Resource groups place limits on resource usage, and can enforce queueing policies on
@@ -21,7 +21,7 @@ the built-in manager that reads a JSON config file:
 Change the value of ``resource-groups.config-file`` to point to a JSON config file,
 which can be an absolute path, or a path relative to the Trino data directory.
 
-Resource Group Properties
+Resource group properties
 -------------------------
 
 * ``name`` (required): name of the group. May be a template (see below).
@@ -72,7 +72,7 @@ Resource Group Properties
 
 * ``subGroups`` (optional): list of sub-groups.
 
-Selector Rules
+Selector rules
 --------------
 
 * ``user`` (optional): regex to match against user name.
@@ -98,12 +98,12 @@ Selector Rules
 
 Selectors are processed sequentially and the first one that matches will be used.
 
-Global Properties
+Global properties
 -----------------
 
 * ``cpuQuotaPeriod`` (optional): the period in which cpu quotas are enforced.
 
-Providing Selector Properties
+Providing selector properties
 -----------------------------
 
 The source name can be set as follows:

--- a/docs/src/main/sphinx/admin/session-property-managers.rst
+++ b/docs/src/main/sphinx/admin/session-property-managers.rst
@@ -1,5 +1,5 @@
 =========================
-Session Property Managers
+Session property managers
 =========================
 
 Administrators can add session properties to control the behavior for subsets of their workload.
@@ -24,7 +24,7 @@ by default. All matching rules contribute to constructing a list of session prop
 are applied in the order they are specified. Rules specified later in the file override values
 for properties that have been previously encountered.
 
-Match Rules
+Match rules
 -----------
 
 * ``user`` (optional): regex to match against user name.

--- a/docs/src/main/sphinx/admin/spill.rst
+++ b/docs/src/main/sphinx/admin/spill.rst
@@ -1,5 +1,5 @@
 =============
-Spill to Disk
+Spill to disk
 =============
 
 Overview
@@ -15,7 +15,7 @@ implemented on the application level to address specific needs of Trino.
 
 Properties related to spilling are described in :doc:`properties-spilling`.
 
-Memory Management and Spill
+Memory management and spill
 ---------------------------
 
 By default, Trino kills queries, if the memory requested by the query execution
@@ -43,7 +43,7 @@ memory intensive queries. It is still possible that the query runner fails
 to divide intermediate data into chunks small enough so that every chunk fits into
 memory, leading to ``Out of memory`` errors while loading the data from disk.
 
-Spill Disk Space
+Spill disk space
 ----------------
 
 Spilling intermediate results to disk, and retrieving them back, is expensive
@@ -60,7 +60,7 @@ Trino treats spill paths as independent disks (see `JBOD
 <https://en.wikipedia.org/wiki/Non-RAID_drive_architectures#JBOD>`_), so
 there is no need to use RAID for spill.
 
-Spill Compression
+Spill compression
 -----------------
 
 When spill compression is enabled (``spill-compression-enabled`` property in
@@ -68,7 +68,7 @@ When spill compression is enabled (``spill-compression-enabled`` property in
 written to disk. Enabling this feature can reduce disk IO at the cost
 of extra CPU load to compress and decompress spilled pages.
 
-Spill Encryption
+Spill encryption
 ----------------
 
 When spill encryption is enabled (``spill-encryption-enabled`` property in
@@ -78,7 +78,7 @@ of spilling to disk, but can protect spilled data from being recovered from spil
 Consider reducing the value of ``memory-revoking-threshold`` when spill
 encryption is enabled, to account for the increase in latency of spilling.
 
-Supported Operations
+Supported operations
 --------------------
 
 Not all operations support spilling to disk, and each handles spilling
@@ -119,7 +119,7 @@ amount of memory may be needed. When spill-to-disk is enabled, if there is not
 enough memory, intermediate cumulated aggregation results are written to disk.
 They are loaded back and merged with a lower memory footprint.
 
-Order By
+Order by
 ^^^^^^^^
 
 If your trying to sort a larger amount of data, a significant amount of memory
@@ -127,7 +127,7 @@ may be needed. When spill to disk for ``order by`` is enabled, if there is not e
 memory, intermediate sorted results are written to disk. They are loaded back and
 merged with a lower memory footprint.
 
-Window Functions
+Window functions
 ^^^^^^^^^^^^^^^^
 
 Window functions perform an operator over a window of rows, and return one value

--- a/docs/src/main/sphinx/admin/tuning.rst
+++ b/docs/src/main/sphinx/admin/tuning.rst
@@ -5,12 +5,12 @@ Tuning Trino
 The default Trino settings should work well for most workloads. The following
 information may help you, if your cluster is facing a specific performance problem.
 
-Config Properties
+Config properties
 -----------------
 
 See :doc:`/admin/properties`.
 
-JVM Settings
+JVM settings
 ------------
 
 The following can be helpful for diagnosing garbage collection (GC) issues:

--- a/docs/src/main/sphinx/admin/web-interface.rst
+++ b/docs/src/main/sphinx/admin/web-interface.rst
@@ -28,7 +28,7 @@ any query. This can be restricted by using :ref:`query rules <query_rules>` with
 :doc:`/security/built-in-system-access-control`. Users always have permission to view
 or kill their own queries.
 
-Password Authentication
+Password authentication
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Typically, a :doc:`password authenticator </develop/password-authenticator>`
@@ -38,7 +38,7 @@ is configured to use a password authenticator, the Web UI authentication type
 is automatically set to ``form``. The Web UI will display a login form that accepts
 a username and password.
 
-Fixed User Authentication
+Fixed user authentication
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you require the Web UI to be accessible without authentication, you can set a fixed
@@ -47,7 +47,7 @@ username that will be used for all Web UI access by setting the authentication t
 If there is a system access control installed, this user must have permission to view
 (and possibly to kill) queries.
 
-Other Authentication Types
+Other authentication types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following Web UI authentication types are also supported:
@@ -60,7 +60,7 @@ For these authentication types, the username is defined by :doc:`/security/user-
 
 .. _web-ui-overview:
 
-User Interface Overview
+User interface overview
 -----------------------
 
 The main page has a list of queries along with information like unique query ID, query text,

--- a/docs/src/main/sphinx/connector/accumulo.rst
+++ b/docs/src/main/sphinx/connector/accumulo.rst
@@ -1,4 +1,4 @@
-Accumulo Connector
+Accumulo connector
 ==================
 
 Overview
@@ -8,7 +8,7 @@ The Accumulo connector supports reading and writing data from
 `Apache Accumulo <https://accumulo.apache.org/>`_.
 Please read this page thoroughly to understand the capabilities and features of the connector.
 
-Installing the Iterator Dependency
+Installing the iterator dependency
 ----------------------------------
 
 The Accumulo connector uses custom Accumulo iterators in
@@ -24,7 +24,7 @@ JAR file to Accumulo's ``lib/ext`` directory on each TabletServer node.
 
     # TabletServer should pick up new JAR files in ext directory, but may require restart
 
-Connector Configuration
+Connector configuration
 -----------------------
 
 Create ``etc/catalog/accumulo.properties``
@@ -39,7 +39,7 @@ replacing the ``accumulo.xxx`` properties as required:
     accumulo.username=username
     accumulo.password=password
 
-Configuration Variables
+Configuration variables
 -----------------------
 
 ================================================ ====================== ========== =====================================================================================
@@ -54,7 +54,7 @@ Property Name                                    Default Value          Required
 ``accumulo.cardinality.cache.expire.duration``   ``5m``                 No         Sets the expiration duration of the cardinality cache.
 ================================================ ====================== ========== =====================================================================================
 
-Unsupported Features
+Unsupported features
 --------------------
 
 The following features are not supported:
@@ -206,7 +206,7 @@ tables.
 
     DROP TABLE myschema.scientists;
 
-Indexing Columns
+Indexing columns
 ----------------
 
 Internally, the connector creates an Accumulo ``Range`` and packs it in
@@ -298,7 +298,7 @@ scans the data table.
      row1      | Grace Hopper | 109 | 1906-12-09
     (1 row)
 
-Loading Data
+Loading data
 ------------
 
 The Accumulo connector supports loading data via INSERT statements, however
@@ -312,7 +312,7 @@ leverages the Trino/Accumulo metadata to write Mutations to the main data table.
 In particular, it handles indexing the given mutations on any indexed columns.
 Usage of the tool is provided in the README in the `repository <https://github.com/bloomberg/presto-accumulo>`_.
 
-External Tables
+External tables
 ---------------
 
 By default, the tables created using SQL statements via Trino are
@@ -427,7 +427,7 @@ tables, setting the locality groups and iterator configuration.
      2 | 2 | 2015-03-07 | NULL
     (2 rows)
 
-Table Properties
+Table properties
 ----------------
 
 Table property usage example:
@@ -463,7 +463,7 @@ Property Name        Default Value    Description
 ``scan_auths``       (user auths)     Scan-time authorizations set on the batch scanner.
 ==================== ================ ======================================================================================================
 
-Session Properties
+Session properties
 ------------------
 
 You can change the default value of a session property by using :doc:`/sql/set-session`.
@@ -488,7 +488,7 @@ Property Name                                 Default Value Description
 ``index_cardinality_cache_polling_duration``  ``10ms``      Sets the cardinality cache polling duration for short circuit retrieval of index metrics
 ============================================= ============= =======================================================================================================
 
-Adding Columns
+Adding columns
 --------------
 
 Adding a new column to an existing table cannot be done today via
@@ -599,7 +599,7 @@ specifying the fully-qualified Java class name in the connector configuration.
       serializer = 'my.serializer.package.MySerializer'
     );
 
-Metadata Management
+Metadata management
 -------------------
 
 Metadata for the Trino/Accumulo tables is stored in ZooKeeper. You can,
@@ -630,7 +630,7 @@ for Accumulo, take a look at
 ``io.trino.plugin.accumulo.metadata.ZooKeeperMetadataManager`` for some
 Java code to simplify the process.
 
-Converting Table from Internal to External
+Converting table from internal to external
 ------------------------------------------
 
 If your table is *internal*, you can convert it to an external table by deleting

--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -1,5 +1,5 @@
 ==================
-BigQuery Connector
+BigQuery connector
 ==================
 
 The BigQuery connector allows querying the data stored in `BigQuery
@@ -8,7 +8,7 @@ different systems like BigQuery and Hive. The connector uses the `BigQuery
 Storage API <https://cloud.google.com/bigquery/docs/reference/storage/>`_ to
 read the data from the tables.
 
-Beta Disclaimer
+Beta disclaimer
 ---------------
 
 The BigQuery Storage API and this connector are in Beta and are subject to change.
@@ -78,7 +78,7 @@ your setup:
     connector.name=bigquery
     bigquery.project-id=<your Google Cloud Platform project id>
 
-Multiple GCP Projects
+Multiple GCP projects
 ^^^^^^^^^^^^^^^^^^^^^
 
 The BigQuery connector can only access a single GCP project.Thus, if you have
@@ -89,7 +89,7 @@ one for the sales and one for analytics, you can create two properties files in
 having ``connector.name=bigquery`` but with different ``project-id``. This will
 create the two catalogs, ``sales`` and ``analytics`` respectively.
 
-Configuring Partitioning
+Configuring partitioning
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default the connector creates one partition per 400MB in the table being
@@ -98,7 +98,7 @@ of readers supported by the BigQuery Storage API. This can be configured
 explicitly with the ``bigquery.parallelism`` property. BigQuery may limit the
 number of partitions based on server constraints.
 
-Reading From Views
+Reading from views
 ^^^^^^^^^^^^^^^^^^
 
 The connector has a preliminary support for reading from `BigQuery views
@@ -117,7 +117,7 @@ a few caveats:
 * Reading from views is disabled by default. In order to enable it, set the
   ``bigquery.views-enabled`` configuration property to ``true``.
 
-Configuration Properties
+Configuration properties
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 All configuration properties are optional.
@@ -138,7 +138,7 @@ Property                                  Description                           
 ``bigquery.credentials-file``             The path to the JSON credentials file                          None. See `authentication <#authentication>`_
 ========================================= ============================================================== ==============================================
 
-Data Types
+Data types
 ----------
 
 With a few exceptions, all BigQuery types are mapped directly to their Trino

--- a/docs/src/main/sphinx/connector/blackhole.rst
+++ b/docs/src/main/sphinx/connector/blackhole.rst
@@ -1,5 +1,5 @@
 ====================
-Black Hole Connector
+Black Hole connector
 ====================
 
 Primarily Black Hole connector is designed for high performance testing of

--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -1,5 +1,5 @@
 ===================
-Cassandra Connector
+Cassandra connector
 ===================
 
 The Cassandra connector allows querying data stored in
@@ -26,7 +26,7 @@ nodes, used to discovery the cluster topology:
 You also need to set ``cassandra.native-protocol-port``, if your
 Cassandra nodes are not using the default port 9042.
 
-Multiple Cassandra Clusters
+Multiple Cassandra clusters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can have as many catalogs as you need, so if you have additional
@@ -35,7 +35,7 @@ with a different name, making sure it ends in ``.properties``. For
 example, if you name the property file ``sales.properties``, Trino
 creates a catalog named ``sales`` using the configured connector.
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 The following configuration properties are available:
@@ -158,7 +158,7 @@ Property Name                                                 Description
 ``cassandra.tls.truststore-password``                         Password for the trust store.
 ============================================================= ======================================================================
 
-Querying Cassandra Tables
+Querying Cassandra tables
 -------------------------
 
 The ``users`` table is an example Cassandra table from the Cassandra

--- a/docs/src/main/sphinx/connector/druid.rst
+++ b/docs/src/main/sphinx/connector/druid.rst
@@ -1,5 +1,5 @@
 ===============
-Druid Connector
+Druid connector
 ===============
 
 The Druid connector allows querying an `Apache Druid <https://druid.apache.org/>`_

--- a/docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/docs/src/main/sphinx/connector/elasticsearch.rst
@@ -1,5 +1,5 @@
 =======================
-Elasticsearch Connector
+Elasticsearch connector
 =======================
 
 Overview
@@ -26,7 +26,7 @@ replacing the properties as appropriate:
     elasticsearch.port=9200
     elasticsearch.default-schema-name=default
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 The following configuration properties are available:
@@ -119,7 +119,7 @@ User name to use to authenticate to Elasticsearch nodes.
 
 Password to use to authenticate to Elasticsearch nodes.
 
-TLS Security
+TLS security
 ------------
 
 The Elasticsearch connector provides additional security options to support Elasticsearch clusters that have been configured to use TLS.
@@ -154,7 +154,7 @@ The key password for the trust store specified by ``elasticsearch.tls.truststore
 
 This property is optional.
 
-Data Types
+Data types
 ----------
 
 The data type mappings are as follows:
@@ -179,7 +179,7 @@ Elasticsearch Trino
 
 .. _elasticsearch-array-types:
 
-Array Types
+Array types
 ^^^^^^^^^^^
 
 Fields in Elasticsearch can contain `zero or more values <https://www.elastic.co/guide/en/elasticsearch/reference/current/array.html>`_
@@ -225,7 +225,7 @@ property definition to the ``_meta.presto`` property of the target index mapping
         }
     }'
 
-Special Columns
+Special columns
 ---------------
 
 The following hidden columns are available:
@@ -240,7 +240,7 @@ _source The source of the original document
 
 .. _elasticsearch-full-text-queries:
 
-Full Text Queries
+Full text queries
 -----------------
 
 Trino SQL queries can be combined with Elasticsearch queries by providing the `full text query`_
@@ -253,7 +253,7 @@ as part of the table name, separated by a colon. For example:
 .. _full text query: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax
 
 
-Pass-through Queries
+Pass-through queries
 --------------------
 
 The Elasticsearch connector allows you to embed any valid Elasticsearch query,
@@ -275,7 +275,7 @@ column named ``result`` of type VARCHAR. It contains the JSON payload returned
 by Elasticsearch, and can be processed with the :doc:`built-in JSON functions
 </functions/json>`.
 
-AWS Authorization
+AWS authorization
 -----------------
 
 To enable AWS authorization using IAM policies, the ``elasticsearch.security`` option needs to be set to ``AWS``.

--- a/docs/src/main/sphinx/connector/googlesheets.rst
+++ b/docs/src/main/sphinx/connector/googlesheets.rst
@@ -1,5 +1,5 @@
 =======================
-Google Sheets Connector
+Google Sheets connector
 =======================
 
 The Google Sheets connector allows reading `Google Sheets <https://www.google.com/sheets/about/>`_ spreadsheets as tables in Trino.
@@ -17,7 +17,7 @@ replacing the properties as appropriate:
     credentials-path=/path/to/google-sheets-credentials.json
     metadata-sheet-id=exampleId
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 The following configuration properties are available:
@@ -51,7 +51,7 @@ The key file needs to be available on the Trino coordinator and workers.
 Set the ``credentials-path`` configuration property to point to this file.
 The exact name of the file does not matter -- it can be named anything.
 
-Metadata Sheet
+Metadata sheet
 --------------
 
 The metadata sheet is used to map table names to sheet IDs.
@@ -72,7 +72,7 @@ button to share the sheet with the email address of the service account.
 
 Set the ``metadata-sheet-id`` configuration property to the ID of this sheet.
 
-Querying Sheets
+Querying sheets
 ---------------
 
 The service account user must have access to the sheet in order for Trino
@@ -85,7 +85,7 @@ to a specific tab in the sheet, add the tab name after the sheet ID, separated
 with ``#``. If tab name is not provided, connector loads only 10,000 rows by default from
 the first tab in the sheet.
 
-API Usage Limits
+API usage limits
 ----------------
 
 The Google Sheets API has `usage limits <https://developers.google.com/sheets/api/limits>`_,

--- a/docs/src/main/sphinx/connector/hive-alluxio.rst
+++ b/docs/src/main/sphinx/connector/hive-alluxio.rst
@@ -1,5 +1,5 @@
 ===========================
-Hive Connector with Alluxio
+Hive connector with Alluxio
 ===========================
 
 The :doc:`hive` can read and write tables stored in the `Alluxio Data Orchestration
@@ -46,7 +46,7 @@ for more details.
 
 .. _alluxio_catalog_service:
 
-Alluxio Catalog Service
+Alluxio catalog service
 -----------------------
 
 An alternative way for Trino to interact with Alluxio is via the

--- a/docs/src/main/sphinx/connector/hive-azure.rst
+++ b/docs/src/main/sphinx/connector/hive-azure.rst
@@ -1,5 +1,5 @@
 =================================
-Hive Connector with Azure Storage
+Hive connector with Azure Storage
 =================================
 
 The :doc:`hive` can be configured to query
@@ -12,7 +12,7 @@ Trino supports both ADLS Gen1 and Gen2. With ADLS Gen2 now generally available,
 we recommend using ADLS Gen2. Learn more from `the official documentation
 <https://docs.microsoft.com/en-us/azure/data-lake-store/data-lake-store-overview>`_.
 
-Hive Connector Configuration
+Hive connector configuration
 ----------------------------
 
 All configuration for the Azure storage driver is stored in the Hadoop
@@ -36,7 +36,7 @@ accounts involved, we recommend configuring Trino using a ``core-site.xml``
 containing the appropriate credentials for each account, as described in the
 preceding section.
 
-WASB Storage
+WASB storage
 ^^^^^^^^^^^^
 
 .. list-table:: WASB properties
@@ -50,7 +50,7 @@ WASB Storage
   * - ``hive.azure.wasb-access-key``
     - The decrypted access key for the Azure Blob Storage
 
-ADLS Gen2 / ABFS Storage
+ADLS Gen2 / ABFS storage
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 To connect to ABFS storage, you may either use the storage account's access

--- a/docs/src/main/sphinx/connector/hive-caching.rst
+++ b/docs/src/main/sphinx/connector/hive-caching.rst
@@ -1,5 +1,5 @@
 ==============================
-Hive Connector Storage Caching
+Hive connector storage caching
 ==============================
 
 Querying object storage with the :doc:`/connector/hive` is a

--- a/docs/src/main/sphinx/connector/hive-gcs-tutorial.rst
+++ b/docs/src/main/sphinx/connector/hive-gcs-tutorial.rst
@@ -1,10 +1,10 @@
-Hive Connector GCS Tutorial
+Hive connector GCS tutorial
 ===========================
 
-Preliminary Steps
+Preliminary steps
 -----------------
 
-Ensure Access to GCS
+Ensure access to GCS
 ^^^^^^^^^^^^^^^^^^^^
 
 The :doc:`hive` can access
@@ -18,7 +18,7 @@ You can do this on the
 `service accounts page in GCP <https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts>`_.
 Once you create a service account, create a key for it and download the key in JSON format.
 
-Hive Connector configuration
+Hive connector configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Another requirement is that you have enabled and configured a Hive connector in Trino.
@@ -82,17 +82,17 @@ There are two possible solutions to this problem:
 * Make sure Hive GCS configuration includes a ``fs.gs.reported.permissions`` property
   with a value of ``777``.
 
-Accessing GCS Data From Trino for the First Time
+Accessing GCS data from Trino for the first time
 -------------------------------------------------
 
-Accessing Data Already Mapped in the Hive metastore
+Accessing data already mapped in the Hive metastore
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you migrate to Trino from Hive, chances are that your GCS data is already mapped to
 SQL tables in the metastore.
 In that case, you should be able to query it.
 
-Accessing Data Not Yet Mapped in the Hive metastore
+Accessing data not yet mapped in the Hive metastore
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To access GCS data that is not yet mapped in the Hive metastore you need to provide the
@@ -122,7 +122,7 @@ Now you should be able to query the newly mapped table::
 
     SELECT * FROM orders;
 
-Writing GCS Data with Trino
+Writing GCS data with Trino
 ----------------------------
 
 Prerequisites
@@ -131,7 +131,7 @@ Prerequisites
 Before you attempt to write data to GCS, make sure you have configured everything
 necessary to read data from GCS.
 
-Create Export Schema
+Create export schema
 ^^^^^^^^^^^^^^^^^^^^
 
 If Hive metastore contains schema(s) mapped to GCS locations, you can use them to
@@ -141,7 +141,7 @@ the Hive metastore, you need to create a new one::
 
     CREATE SCHEMA hive.gcs_export WITH (location = 'gs://my_bucket/some/path');
 
-Export Data to GCS
+Export data to GCS
 ^^^^^^^^^^^^^^^^^^
 
 Once you have a schema pointing to a location, where you want to export the data, you can issue

--- a/docs/src/main/sphinx/connector/hive-s3.rst
+++ b/docs/src/main/sphinx/connector/hive-s3.rst
@@ -1,5 +1,5 @@
 =============================
-Hive Connector with Amazon S3
+Hive connector with Amazon S3
 =============================
 
 The :doc:`hive` can read and write tables that are stored in
@@ -10,7 +10,7 @@ uses an S3 prefix, rather than an HDFS prefix.
 Trino uses its own S3 filesystem for the URI prefixes
 ``s3://``, ``s3n://`` and  ``s3a://``.
 
-S3 Configuration Properties
+S3 configuration properties
 ---------------------------
 
 ============================================ =================================================================
@@ -90,7 +90,7 @@ Property Name                                Description
 
 .. _hive-s3-credentials:
 
-S3 Credentials
+S3 credentials
 --------------
 
 If you are running Trino on Amazon EC2, using EMR or another facility,
@@ -103,7 +103,7 @@ setting AWS access and secret keys in the ``hive.s3.aws-access-key``
 and ``hive.s3.aws-secret-key`` settings, and also allows EC2 to automatically
 rotate credentials on a regular basis without any additional work on your part.
 
-Custom S3 Credentials Provider
+Custom S3 credentials provider
 ------------------------------
 
 You can configure a custom S3 credentials provider by setting the Hadoop
@@ -122,7 +122,7 @@ files referenced by the ``hive.config.resources`` Hive connector property.
 
 .. _hive-s3-security-mapping:
 
-S3 Security Mapping
+S3 security mapping
 -------------------
 
 Trino supports flexible security mapping for S3, allowing for separate
@@ -232,7 +232,7 @@ Property Name                                           Description
                                                         value that is not used in any of your IAM ARNs.
 ======================================================= =================================================================
 
-Tuning Properties
+Tuning properties
 -----------------
 
 The following tuning properties affect the behavior of the client
@@ -263,7 +263,7 @@ Property Name                         Description                               
 ``hive.s3.multipart.min-part-size``   Minimum multi-part upload part size.                        ``5 MB``
 ===================================== =========================================================== ===============
 
-S3 Data Encryption
+S3 data encryption
 ------------------
 
 
@@ -294,10 +294,10 @@ encryption keys.
 
 .. _s3selectpushdown:
 
-S3 Select Pushdown
+S3 Select pushdown
 ------------------
 
-S3 Select Pushdown enables pushing down projection (SELECT) and predicate (WHERE)
+S3 Select pushdown enables pushing down projection (SELECT) and predicate (WHERE)
 processing to `S3 Select <https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectSELECTContent.html>`_.
 With S3 Select Pushdown, Trino only retrieves the required data from S3 instead
 of entire S3 objects, reducing both latency and network usage.
@@ -305,7 +305,7 @@ of entire S3 objects, reducing both latency and network usage.
 Is S3 Select a good fit for my workload?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Performance of S3 Select Pushdown depends on the amount of data filtered by the
+Performance of S3 Select pushdown depends on the amount of data filtered by the
 query. Filtering a large number of rows should result in better performance. If
 the query doesn't filter any data, then pushdown may not add any additional value
 and the user is charged for S3 Select requests. Thus, we recommend that you
@@ -329,7 +329,7 @@ workload:
   transfer speed and available bandwidth. Amazon S3 Select does not compress
   HTTP responses, so the response size may increase for compressed input files.
 
-Considerations and Limitations
+Considerations and limitations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Only objects stored in CSV format are supported. Objects can be uncompressed,
@@ -341,7 +341,7 @@ Considerations and Limitations
 * S3 Select Pushdown is not a substitute for using columnar or compressed file
   formats such as ORC and Parquet.
 
-Enabling S3 Select Pushdown
+Enabling S3 Select pushdown
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can enable S3 Select Pushdown using the ``s3_select_pushdown_enabled``
@@ -349,7 +349,7 @@ Hive session property, or using the ``hive.s3select-pushdown.enabled``
 configuration property. The session property overrides the config
 property, allowing you enable or disable on a per-query basis.
 
-Understanding and Tuning the Maximum Connections
+Understanding and tuning the maximum connections
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Trino can use its native S3 file system or EMRFS. When using the native FS, the

--- a/docs/src/main/sphinx/connector/hive-security.rst
+++ b/docs/src/main/sphinx/connector/hive-security.rst
@@ -1,5 +1,5 @@
 =====================================
-Hive Connector Security Configuration
+Hive connector security configuration
 =====================================
 
 Authorization
@@ -40,7 +40,7 @@ Property Value                                     Description
 
 .. _hive-sql-standard-based-authorization:
 
-SQL Standard Based Authorization
+SQL standard based authorization
 --------------------------------
 
 When ``sql-standard`` security is enabled, Trino enforces the same SQL
@@ -90,7 +90,7 @@ Lists)` to provide additional security for data.
   See :doc:`/security/server` and :doc:`/security/cli`
   for information on setting up Kerberos authentication.
 
-Kerberos Support
+Kerberos support
 ================
 
 In order to use the Hive connector with a Hadoop cluster that uses ``kerberos``
@@ -111,7 +111,7 @@ file that contains the general Hive connector configuration.
 
     Example: ``-Djava.security.krb5.conf=/example/path/krb5.conf``.
 
-Hive Metastore Thrift Service Authentication
+Hive metastore Thrift service authentication
 --------------------------------------------
 
 In a Kerberized Hadoop cluster, Trino connects to the Hive metastore Thrift
@@ -240,7 +240,7 @@ Keytab files must be distributed to every node in the cluster that runs Trino.
 
 :ref:`Additional Information About Keytab Files.<hive-security-additional-keytab>`
 
-HDFS Authentication
+HDFS authentication
 -------------------
 
 In a Kerberized Hadoop cluster, Trino authenticates to HDFS using Kerberos.
@@ -351,10 +351,10 @@ Keytab files must be distributed to every node in the cluster that runs Trino.
 
 .. _hive-security-impersonation:
 
-End User Impersonation
+End user impersonation
 ======================
 
-Impersonation Accessing HDFS
+Impersonation accessing HDFS
 ----------------------------
 
 Trino can impersonate the end user who is running a query. In the case of a
@@ -383,7 +383,7 @@ section :ref:`configuring-hadoop-impersonation`. Kerberos is not used.
 
 .. _hive-security-kerberos-impersonation:
 
-``KERBEROS`` Authentication With HDFS Impersonation
+``KERBEROS`` authentication with HDFS impersonation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: text
@@ -407,7 +407,7 @@ Keytab files must be distributed to every node in the cluster that runs Trino.
 
 .. _hive-security-metastore-impersonation:
 
-Impersonation Accessing the Hive Metastore
+Impersonation accessing the Hive metastore
 ------------------------------------------
 
 Trino supports impersonating the end user when accessing the Hive metastore.
@@ -450,7 +450,7 @@ configuration options can be found in the `Hadoop documentation
 
 .. _hive-security-additional-keytab:
 
-Additional Information About Keytab Files
+Additional information about Keytab files
 =========================================
 
 Keytab files contain encryption keys that are used to authenticate principals
@@ -473,7 +473,7 @@ node after distributing them.
 
 .. _hive-file-based-authorization:
 
-File Based Authorization
+File based authorization
 ========================
 
 The config file is specified using JSON and is composed of three sections,
@@ -485,7 +485,7 @@ matching rule. All regexes default to ``.*`` if not specified.
 
     These rules do not apply to system defined table in the ``information_schema`` schema.
 
-Schema Rules
+Schema rules
 ------------
 
 These rules govern who is considered an owner of a schema.
@@ -498,7 +498,7 @@ These rules govern who is considered an owner of a schema.
 
 * ``owner`` (required): boolean indicating ownership.
 
-Table Rules
+Table rules
 -----------
 
 These rules govern the privileges granted on specific tables.
@@ -520,7 +520,7 @@ These rules govern the privileges granted on specific tables.
 
 * ``filter_environment`` (optional): environment use during filter evaluation.
 
-Column Constraint
+Column constraint
 ^^^^^^^^^^^^^^^^^
 
 These constraints can be used to restrict access to column data.
@@ -530,12 +530,12 @@ These constraints can be used to restrict access to column data.
 * ``mask`` (optional): mask expression applied to column.
 * ``mask_environment`` (optional): environment use during mask evaluation.
 
-Filter and Mask Environment
+Filter and mask environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * ``user`` (optional): username for checking permission of subqueries in mask.
 
-Session Property Rules
+Session property rules
 ----------------------
 
 These rules govern who may set session properties.

--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -1,5 +1,5 @@
 ==============
-Hive Connector
+Hive connector
 ==============
 
 .. toctree::
@@ -50,7 +50,7 @@ and :doc:`Azure Storage <hive-azure>`.
 The coordinator and all workers must have network access to the Hive metastore
 and the storage system.
 
-Supported File Types
+Supported file types
 --------------------
 
 The following file types are supported for the Hive connector:
@@ -65,7 +65,7 @@ The following file types are supported for the Hive connector:
 * CSV (using ``org.apache.hadoop.hive.serde2.OpenCSVSerde``)
 * TextFile
 
-Metastore Configuration for Avro
+Metastore configuration for Avro
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In order to enable first-class support for Avro tables when using
@@ -80,10 +80,10 @@ configuration file ``hive-site.xml`` (and restart the metastore service):
         <value>org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader</value>
     </property>
 
-Supported Table Types
+Supported table types
 ---------------------
 
-Transactional and ACID Tables
+Transactional and ACID tables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When connecting to a Hive metastore version 3.x, the Hive connector supports
@@ -93,7 +93,7 @@ partitioning and bucketing. Row-level deletes are supported for ACID tables.
 ACID tables created with `Hive Streaming Ingest <https://cwiki.apache.org/confluence/display/Hive/Streaming+Data+Ingest>`_
 are not supported.
 
-Materialized Views
+Materialized views
 ------------------
 
 The Hive connector supports reading from Hive materialized views.
@@ -112,7 +112,7 @@ for your Hive metastore Thrift service:
     connector.name=hive-hadoop2
     hive.metastore.uri=thrift://example.net:9083
 
-Multiple Hive Clusters
+Multiple Hive clusters
 ^^^^^^^^^^^^^^^^^^^^^^
 
 You can have as many catalogs as you need, so if you have additional
@@ -121,7 +121,7 @@ with a different name, making sure it ends in ``.properties``. For
 example, if you name the property file ``sales.properties``, Trino
 creates a catalog named ``sales`` using the configured connector.
 
-HDFS Configuration
+HDFS configuration
 ^^^^^^^^^^^^^^^^^^
 
 For basic setups, Trino configures the HDFS client automatically and
@@ -142,7 +142,7 @@ The configuration files must exist on all Trino nodes. If you are
 referencing existing Hadoop config files, make sure to copy them to
 any Trino nodes that are not running Hadoop.
 
-HDFS Username and Permissions
+HDFS username and permissions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Before running any ``CREATE TABLE`` or ``CREATE TABLE AS`` statements
@@ -183,7 +183,7 @@ security options in the Hive connector.
 
 .. _hive_configuration_properties:
 
-Hive Configuration Properties
+Hive configuration properties
 -----------------------------
 
 ================================================== ============================================================ ============
@@ -318,7 +318,7 @@ Property Name                                      Description                  
                                                    session property to ``true``.
 ================================================== ============================================================ ============
 
-Metastore Configuration Properties
+Metastore configuration properties
 ----------------------------------
 
 The required Hive metastore can be configured with a number of properties.
@@ -351,7 +351,7 @@ Property Name                                      Description                  
                                         metastore.
 ======================================= ============================================================ ============
 
-Thrift Metastore Configuration Properties
+Thrift metastore configuration properties
 -----------------------------------------
 
 =============================================================== ============================================================ ============
@@ -396,7 +396,7 @@ Property Name                                                   Description     
 
 =============================================================== ============================================================ ============
 
-AWS Glue Catalog Configuration Properties
+AWS Glue catalog configuration properties
 -----------------------------------------
 
 In order to use a Glue catalog, ensure to configure the metastore with
@@ -455,13 +455,13 @@ Property Name                                        Description
                                                      defaults to ``20``.
 ==================================================== ============================================================
 
-Google Cloud Storage Configuration
+Google Cloud Storage configuration
 ----------------------------------
 
 The Hive connector can access data stored in GCS, using the ``gs://`` URI prefix.
 Please refer to the :doc:`hive-gcs-tutorial` for step-by-step instructions.
 
-GCS Configuration properties
+GCS configuration properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ============================================ =================================================================
@@ -473,7 +473,7 @@ Property Name                                Description
                                              This is mutually exclusive with a global JSON key file.
 ============================================ =================================================================
 
-Table Statistics
+Table statistics
 ----------------
 
 The Hive connector supports collecting and managing :doc:`table statistics
@@ -543,7 +543,7 @@ You can also drop statistics for selected partitions only::
 
     CALL system.drop_stats(schema_name, table_name, ARRAY[ARRAY['p2_value1', 'p2_value2']])
 
-Dynamic Filtering
+Dynamic filtering
 -----------------
 
 The Hive connector supports the :doc:`dynamic filtering </admin/dynamic-filtering>` optimization.
@@ -573,7 +573,7 @@ time until the collection of dynamic filters by using the configuration property
 ``hive.dynamic-filtering-probe-blocking-timeout`` in the catalog file or the catalog
 session property ``<hive-catalog>.dynamic_filtering_probe_blocking_timeout``.
 
-Schema Evolution
+Schema evolution
 ----------------
 
 Hive allows the partitions in a table to have a different schema than the
@@ -590,7 +590,7 @@ as Hive. For example, converting the string ``'foo'`` to a number,
 or converting the string ``'1234'`` to a ``tinyint`` (which has a
 maximum value of ``127``).
 
-Avro Schema Evolution
+Avro schema evolution
 ---------------------
 
 Trino supports querying and manipulating Hive tables with the Avro storage
@@ -698,7 +698,7 @@ Procedures
   Unregisters given, existing partition in the metastore for the specified table.
   The partition data is not deleted.
 
-Special Columns
+Special columns
 ---------------
 
 In addition to the defined columns, the Hive connector automatically exposes
@@ -716,10 +716,10 @@ directly or used in conditional statements.
 
 * ``$partition``: Partition name for this row
 
-Special Tables
+Special tables
 ----------------
 
-Table Properties
+Table properties
 ^^^^^^^^^^^^^^^^
 
 The raw Hive table properties are available as a hidden table, containing a
@@ -824,13 +824,13 @@ Drop a schema::
 
     DROP SCHEMA hive.web
 
-Hive Connector Limitations
+Hive connector limitations
 --------------------------
 
 * :doc:`/sql/delete` is only supported if the ``WHERE`` clause matches entire partitions.
 * :doc:`/sql/alter-schema` usage fails, since the Hive metastore does not support renaming schemas.
 
-Hive 3 Related Limitations
+Hive 3 related limitations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * For security reasons, the ``sys`` system catalog is not accessible.

--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -1,5 +1,5 @@
 =================
-Iceberg Connector
+Iceberg connector
 =================
 
 Overview
@@ -40,7 +40,7 @@ At a minimum, ``hive.metastore.uri`` must be configured:
     connector.name=iceberg
     hive.metastore.uri=thrift://localhost:9083
 
-Partitioned Tables
+Partitioned tables
 ------------------
 
 Iceberg supports partitioning by specifying transforms over the table columns.
@@ -79,7 +79,7 @@ In this example, the table is partitioned by month and further divided into 10 b
         customer VARCHAR)
     WITH (partitioning = ARRAY['month(order_date)', 'bucket(account_number, 10)'])
 
-Deletion by Partition
+Deletion by partition
 ---------------------
 
 For partitioned tables, the Iceberg connector supports the deletion of entire
@@ -97,7 +97,7 @@ in the partition::
     DELETE FROM iceberg.testdb.sample_partitioned
     WHERE date_trunc(month, order_date) = date_trunc(month, DATE '2018-06-01') AND customer = 'Freds Foods'
 
-Rolling Back to a Previous Snapshot
+Rolling back to a previous snapshot
 -----------------------------------
 
 Iceberg supports a "snapshot" model of data, where table snapshots are
@@ -114,7 +114,7 @@ the state of the table to a previous snapshot id::
 
     CALL system.rollback_to_snapshot(schema_name, table_name, snapshot_id)
 
-Schema Evolution
+Schema evolution
 ----------------
 
 Iceberg and the Iceberg connector support schema evolution, with safe
@@ -122,21 +122,21 @@ column add, drop, reorder and rename operations, including in nested structures.
 Table partitioning can also be changed and the connector can still
 query data created before the partitioning change.
 
-Migrating Existing Tables
+Migrating existing tables
 -------------------------
 
 The connector can read from or write to Hive tables that have been migrated to Iceberg.
 Currently, there is no Trino support to migrate Hive tables to Trino, so you will
 need to use either the Iceberg API or Spark.
 
-System Tables and Columns
+System tables and columns
 -------------------------
 
 The connector supports queries of the table partitions.  Given a table ``customer_accounts``,
 ``SELECT * customer_acccounts$partitions`` shows the table partitions, including the minimum
 and maximum values for the partition columns.
 
-Iceberg Table Properties
+Iceberg table properties
 ------------------------
 
 ================================================== ================================================================

--- a/docs/src/main/sphinx/connector/jmx.rst
+++ b/docs/src/main/sphinx/connector/jmx.rst
@@ -1,5 +1,5 @@
 =============
-JMX Connector
+JMX connector
 =============
 
 The JMX connector provides the ability to query Java Management Extensions (JMX)

--- a/docs/src/main/sphinx/connector/kafka-tutorial.rst
+++ b/docs/src/main/sphinx/connector/kafka-tutorial.rst
@@ -1,5 +1,5 @@
 ========================
-Kafka Connector Tutorial
+Kafka connector tutorial
 ========================
 
 Introduction

--- a/docs/src/main/sphinx/connector/kafka.rst
+++ b/docs/src/main/sphinx/connector/kafka.rst
@@ -1,5 +1,5 @@
 ===============
-Kafka Connector
+Kafka connector
 ===============
 
 .. toctree::
@@ -44,7 +44,7 @@ replacing the properties as appropriate:
     kafka.table-names=table1,table2
     kafka.nodes=host1:port,host2:port
 
-Multiple Kafka Clusters
+Multiple Kafka clusters
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 You can have as many catalogs as you need, so if you have additional
@@ -53,7 +53,7 @@ with a different name (making sure it ends in ``.properties``). For
 example, if you name the property file ``sales.properties``, Trino
 creates a catalog named ``sales`` using the configured connector.
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 The following configuration properties are available:
@@ -146,7 +146,7 @@ show up in ``DESCRIBE <table-name>`` or ``SELECT *``.
 
 This property is optional; the default is ``true``.
 
-Internal Columns
+Internal columns
 ----------------
 
 For each defined table, the connector maintains the following columns:
@@ -172,7 +172,7 @@ Column name             Type                            Description
 For tables without a table definition file, the ``_key_corrupt`` and
 ``_message_corrupt`` columns will always be ``false``.
 
-Table Definition Files
+Table definition files
 ----------------------
 
 Kafka maintains topics only as byte messages and leaves it to producers
@@ -223,7 +223,7 @@ Field           Required  Type           Description
 ``message``     optional  JSON object    Field definitions for data columns mapped to the message itself.
 =============== ========= ============== =============================
 
-Key and Message in Kafka
+Key and message in Kafka
 ------------------------
 
 Starting with Kafka 0.8, each message in a topic can have an optional key.
@@ -269,7 +269,7 @@ Field           Required  Type      Description
 
 There is no limit on field descriptions for either key or message.
 
-Kafka Inserts
+Kafka inserts
 -------------
 
 The Kafka connector supports the use of :doc:`/sql/insert` statements to write
@@ -296,7 +296,7 @@ used as the target for a message. If a message includes a key, the producer will
 use a hash algorithm to choose the target partition for the message. The same
 key will always be assigned the same partition.
 
-Row Encoding
+Row encoding
 ------------
 
 Encoding is required to allow writing data and defines how table columns in
@@ -318,7 +318,7 @@ The Kafka connector contains the following encoders:
     A `table definition file <#table-definition-files>`__ must be defined
     for the encoder to work.
 
-Raw Encoder
+Raw encoder
 ^^^^^^^^^^^
 
 The raw encoder formats the table columns as raw bytes using the mapping
@@ -449,7 +449,7 @@ decoder will not be able to properly read the value because there is no defined
 padding character. Due to these constraints the encoder fails if the width of
 the inserted value is not equal to the mapping width.
 
-CSV Encoder
+CSV encoder
 ^^^^^^^^^^^
 
 The CSV encoder formats the values for each row as a line of
@@ -514,7 +514,7 @@ Example insert query for the above table definition::
     INSERT INTO example_csv_table (field1, field2, field3)
       VALUES (123456789, 'example text', TRUE);
 
-JSON Encoder
+JSON encoder
 ^^^^^^^^^^^^
 
 The JSON encoder maps table columns to JSON fields defined in the
@@ -633,7 +633,7 @@ Example insert query for the above table definition::
     INSERT INTO example_json_table (field1, field2, field3)
       VALUES (123456789, 'example text', TIMESTAMP '2020-07-15 01:02:03.456');
 
-Avro Encoder
+Avro encoder
 ^^^^^^^^^^^^
 
 The Avro encoder serializes rows to Avro records as defined by the
@@ -747,7 +747,7 @@ Example insert query for the above table definition::
     INSERT INTO example_avro_table (field1, field2, field3)
       VALUES (123456789, 'example text', FALSE);
 
-Row Decoding
+Row decoding
 ------------
 
 For key and message, a decoder is used to map message and key data onto table columns.
@@ -764,7 +764,7 @@ The Kafka connector contains the following decoders:
     If no table definition file exists for a table, the ``dummy`` decoder is used,
     which does not expose any columns.
 
-``raw`` Decoder
+``raw`` decoder
 ^^^^^^^^^^^^^^^
 
 The raw decoder supports reading of raw (byte-based) values from Kafka message
@@ -829,7 +829,7 @@ Length of decoded byte sequence is implied by the ``dataFormat``.
 
 For ``VARCHAR`` data type a sequence of bytes is interpreted according to UTF-8 encoding.
 
-``csv`` Decoder
+``csv`` decoder
 ^^^^^^^^^^^^^^^
 
 The CSV decoder converts the bytes representing a message or key into a
@@ -862,7 +862,7 @@ Table below lists supported Trino types, which can be used in ``type`` and decod
 +-------------------------------------+--------------------------------------------------------------------------------+
 
 
-``json`` Decoder
+``json`` decoder
 ^^^^^^^^^^^^^^^^
 
 The JSON decoder converts the bytes representing a message or key into a
@@ -910,15 +910,15 @@ which can be specified via ``dataFormat`` attribute.
 +-------------------------------------+--------------------------------------------------------------------------------+
 
 
-Default Field decoder
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Default field decoder
+^^^^^^^^^^^^^^^^^^^^^
 
 This is the standard field decoder, supporting all the Trino physical data
 types. A field value is transformed under JSON conversion rules into
 boolean, long, double or string values. For non-date/time based columns,
 this decoder should be used.
 
-Date and Time Decoders
+Date and time decoders
 ^^^^^^^^^^^^^^^^^^^^^^
 
 To convert values from JSON objects into Trino ``DATE``, ``TIME``, ``TIME WITH TIME ZONE``,
@@ -936,7 +936,7 @@ To convert values from JSON objects into Trino ``DATE``, ``TIME``, ``TIME WITH T
 For ``TIMESTAMP WITH TIME ZONE`` and ``TIME WITH TIME ZONE`` data types, if timezone information is present in decoded value, it will
 be used in Trino value. Otherwise result time zone will be set to ``UTC``.
 
-``avro`` Decoder
+``avro`` decoder
 ^^^^^^^^^^^^^^^^
 
 The Avro decoder converts the bytes representing a message or key in

--- a/docs/src/main/sphinx/connector/kinesis.rst
+++ b/docs/src/main/sphinx/connector/kinesis.rst
@@ -1,5 +1,5 @@
 =================
-Kinesis Connector
+Kinesis connector
 =================
 
 `Kinesis <https://aws.amazon.com/kinesis/>`_ is Amazon's fully managed cloud-based service for real-time processing of large, distributed data streams.
@@ -28,7 +28,7 @@ with the following contents, replacing the properties as appropriate:
     kinesis.access-key=XXXXXX
     kinesis.secret-key=XXXXXX
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 The following configuration properties are available:
@@ -147,7 +147,7 @@ If these columns are hidden, they can still be used in queries, but they do not 
 
 This property is optional; the default is true.
 
-Internal Columns
+Internal columns
 ----------------
 For each defined table, the connector maintains the following columns:
 
@@ -174,7 +174,7 @@ Column name               Type          Description
 
 For tables without a table definition file, the ``_message_valid`` column is always ``true``.
 
-Table Definition
+Table definition
 ----------------
 
 A table definition file consists of a JSON definition for a table, which corresponds to one stream in Kinesis.

--- a/docs/src/main/sphinx/connector/kudu.rst
+++ b/docs/src/main/sphinx/connector/kudu.rst
@@ -1,5 +1,5 @@
 ==============
-Kudu Connector
+Kudu connector
 ==============
 
 The Kudu connector allows querying, inserting and deleting data in `Apache Kudu`_.
@@ -59,7 +59,7 @@ replacing the properties as appropriate:
    #kudu.client.disable-statistics = false
 
 
-Querying Data
+Querying data
 -------------
 
 Apache Kudu does not support schemas, i.e. namespaces for tables.
@@ -119,7 +119,7 @@ Example
 
     SELECT * FROM kudu.default.users;
 
-Behaviour With Schema Emulation
+Behaviour with schema emulation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If schema emulation has been enabled in the connector properties, i.e. ``etc/catalog/kudu.properties``,
@@ -162,7 +162,7 @@ tables are mapped to schemas depending on some conventions.
   As schemas are not directly supported by Kudu, a special table named
   ``presto::$schemas`` is created for managing the schemas.
 
-Data Type Mapping
+Data type mapping
 -----------------
 
 The data types of Trino and Kudu are mapped as far as possible:
@@ -288,7 +288,7 @@ Supported Trino SQL statements
 ``ALTER SCHEMA ... RENAME TO ...`` is not supported.
 
 
-Create Table
+Create table
 ------------
 
 On creating a Kudu table, you need to provide the columns and their types, of
@@ -330,7 +330,7 @@ but multiple hash partitioning 'levels'.
 For more details see `Partitioning Design`_.
 
 
-Column Properties
+Column properties
 ~~~~~~~~~~~~~~~~~
 
 Besides column name and type, you can specify some more properties of a column.
@@ -383,7 +383,7 @@ Example
        ...
     ) WITH (...);
 
-Partitioning Design
+Partitioning design
 ~~~~~~~~~~~~~~~~~~~
 
 A table must have at least one partitioning (either hash or range).
@@ -573,7 +573,7 @@ Use the SQL statement ``SHOW CREATE TABLE`` to query the existing
 range partitions (they are shown in the table property
 ``range_partitions``).
 
-Add Column
+Add column
 ----------
 
 Adding a column to an existing table uses the SQL statement ``ALTER TABLE ... ADD COLUMN ...``.

--- a/docs/src/main/sphinx/connector/localfile.rst
+++ b/docs/src/main/sphinx/connector/localfile.rst
@@ -1,5 +1,5 @@
 ====================
-Local File Connector
+Local file connector
 ====================
 
 The local file connector allows querying data stored on the local
@@ -15,7 +15,7 @@ under ``etc/catalog`` named, for example, ``localfile.properties`` with the foll
 
     connector.name=localfile
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 =========================================   ==============================================================
@@ -26,7 +26,7 @@ Property Name                               Description
                                             to match file names in the directory
 =========================================   ==============================================================
 
-Local File Connector Schemas and Tables
+Local file connector schemas and tables
 ---------------------------------------
 
 The local file connector provides a single schema named ``logs``.

--- a/docs/src/main/sphinx/connector/memory.rst
+++ b/docs/src/main/sphinx/connector/memory.rst
@@ -1,5 +1,5 @@
 ================
-Memory Connector
+Memory connector
 ================
 
 The Memory connector stores all data and metadata in RAM on workers
@@ -41,7 +41,7 @@ Drop table::
 
     DROP TABLE memory.default.nation;
 
-Dynamic Filtering
+Dynamic filtering
 -----------------
 
 The Memory connector supports the :doc:`dynamic filtering </admin/dynamic-filtering>` optimization.

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -1,5 +1,5 @@
 ================
-MemSQL Connector
+MemSQL connector
 ================
 
 The MemSQL connector allows querying and creating tables in an external
@@ -22,7 +22,7 @@ connection properties as appropriate for your setup:
     connection-user=root
     connection-password=secret
 
-Multiple MemSQL Servers
+Multiple MemSQL servers
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 You can have as many catalogs as you need, so if you have additional

--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -1,5 +1,5 @@
 =================
-MongoDB Connector
+MongoDB connector
 =================
 
 The ``mongodb`` connector allows the use of `MongoDB <https://www.mongodb.com/>`_ collections as tables in Trino.
@@ -20,7 +20,7 @@ replacing the properties as appropriate:
     connector.name=mongodb
     mongodb.seeds=host1,host:port
 
-Multiple MongoDB Clusters
+Multiple MongoDB clusters
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can have as many catalogs as you need, so if you have additional
@@ -29,7 +29,7 @@ with a different name, making sure it ends in ``.properties``). For
 example, if you name the property file ``sales.properties``, Trino
 will create a catalog named ``sales`` using the configured connector.
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 The following configuration properties are available:
@@ -185,7 +185,7 @@ This property is optional; the default is ``0``.
 
 .. _table-definition-label:
 
-Table Definition
+Table definition
 ----------------
 
 MongoDB maintains table definitions on the special collection where ``mongodb.schema-collection`` configuration value specifies.

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -1,5 +1,5 @@
 ===============
-MySQL Connector
+MySQL connector
 ===============
 
 The MySQL connector allows querying and creating tables in an external
@@ -22,7 +22,7 @@ connection properties as appropriate for your setup:
     connection-user=root
     connection-password=secret
 
-Multiple MySQL Servers
+Multiple MySQL servers
 ^^^^^^^^^^^^^^^^^^^^^^
 
 You can have as many catalogs as you need, so if you have additional
@@ -31,7 +31,7 @@ with a different name, making sure it ends in ``.properties``. For
 example, if you name the property file ``sales.properties``, Trino
 creates a catalog named ``sales`` using the configured connector.
 
-Decimal Type Handling
+Decimal type handling
 ---------------------
 
 ``DECIMAL`` types with precision larger than 38 can be mapped to a Trino ``DECIMAL``

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -1,5 +1,5 @@
 ================
-Oracle Connector
+Oracle connector
 ================
 
 The Oracle connector allows querying and creating tables in an external Oracle

--- a/docs/src/main/sphinx/connector/phoenix.rst
+++ b/docs/src/main/sphinx/connector/phoenix.rst
@@ -1,5 +1,5 @@
 =================
-Phoenix Connector
+Phoenix connector
 =================
 
 The Phoenix connector allows querying data stored in
@@ -28,7 +28,7 @@ nodes used for discovery of the HBase cluster:
 The optional paths to Hadoop resource files, such as ``hbase-site.xml`` are used
 to load custom Phoenix client connection properties.
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 The following configuration properties are available:
@@ -45,7 +45,7 @@ Property Name                                      Required   Description
                                                               connection properties.  These files must exist on the machines running Trino.
 ================================================== ========== ===================================================================================
 
-Querying Phoenix Tables
+Querying Phoenix tables
 -------------------------
 
 The default empty schema in Phoenix maps to a schema named ``default`` in Trino.
@@ -101,7 +101,7 @@ Phoenix table in Trino that uses the ``BINARY`` data type, as Trino
 does not have an equivalent type.
 
 
-Table Properties - Phoenix
+Table properties - Phoenix
 --------------------------
 
 Table property usage example::
@@ -142,7 +142,7 @@ This is a comma-separated list of columns to be used as the table's primary key.
 , as well as a sequence with the same name as the table suffixed with ``_seq`` (i.e. ``<schema>.<table>_seq``)
 , which is used to automatically populate the ``ROWKEY`` for each row during insertion.
 
-Table Properties - HBase
+Table properties - HBase
 ------------------------
 The following are the supported HBase table properties that are passed through by Phoenix during table creation.
 Use them in the the same way as above: in the ``WITH`` clause of the ``CREATE TABLE`` statement.

--- a/docs/src/main/sphinx/connector/pinot.rst
+++ b/docs/src/main/sphinx/connector/pinot.rst
@@ -1,5 +1,5 @@
 ===============
-Pinot Connector
+Pinot connector
 ===============
 
 The Pinot connector allows Trino to query data stored in
@@ -24,7 +24,7 @@ e.g. ``etc/catalog/pinot.properties`` with at least the following contents:
 Replace ``host1:9000,host2:9000`` with a comma-separated list of Pinot Controller nodes.
 This can be the ip or the FDQN, the url scheme (``http://``) is optional.
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 The following configuration properties are available:
@@ -42,8 +42,8 @@ Property Name                  Required   Description
                                           resolution is slow.
 ============================== ========== ==============================================================================
 
-Querying Pinot Tables
--------------------------
+Querying Pinot tables
+---------------------
 
 The Pinot connector automatically exposes all tables in the default schema of the catalog.
 You can list all tables in the pinot catalog with the following query::
@@ -62,7 +62,7 @@ Queries written with SQL are fully supported and can include filters and limits:
     WHERE bar = 3 AND baz IN ('ONE', 'TWO', 'THREE')
     LIMIT 25000;
 
-Dynamic Tables
+Dynamic tables
 --------------
 
 To leverage Pinot's fast aggregation, a Pinot query written in PQL can be used as the table name.

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -1,5 +1,5 @@
 ====================
-PostgreSQL Connector
+PostgreSQL connector
 ====================
 
 The PostgreSQL connector allows querying and creating tables in an
@@ -23,7 +23,7 @@ connection properties as appropriate for your setup:
     connection-user=root
     connection-password=secret
 
-Multiple PostgreSQL Databases or Servers
+Multiple PostgreSQL databases or servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The PostgreSQL connector can only access a single database within
@@ -36,7 +36,7 @@ with a different name, making sure it ends in ``.properties``. For example,
 if you name the property file ``sales.properties``, Trino creates a
 catalog named ``sales`` using the configured connector.
 
-Decimal Type Handling
+Decimal type handling
 ---------------------
 
 ``DECIMAL`` types with precision larger than 38 can be mapped to a Trino ``DECIMAL``
@@ -50,7 +50,7 @@ property, which can be set to ``UNNECESSARY`` (the default),
 ``UP``, ``DOWN``, ``CEILING``, ``FLOOR``, ``HALF_UP``, ``HALF_DOWN``, or ``HALF_EVEN``
 (see `RoundingMode <https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/math/RoundingMode.html#enum.constant.summary>`_).
 
-Array Type Handling
+Array type handling
 -------------------
 
 The PostgreSQL array implementation does not support fixed dimensions whereas Trino

--- a/docs/src/main/sphinx/connector/prometheus.rst
+++ b/docs/src/main/sphinx/connector/prometheus.rst
@@ -1,5 +1,5 @@
 ====================
-Prometheus Connector
+Prometheus connector
 ====================
 
 The Prometheus connector allows reading
@@ -28,7 +28,7 @@ replacing the properties as appropriate:
     prometheus.cache.ttl=30s
     prometheus.bearer.token.file=/path/to/bearer/token/file
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 The following configuration properties are available:
@@ -43,7 +43,7 @@ Property Name                                   Description
 ``prometheus.bearer.token.file``         File holding bearer token if needed for access to Prometheus
 ======================================== ============================================================================================
 
-Not Exhausting Your Trino Available Heap
+Not exhausting your Trino available heap
 -----------------------------------------
 
 The ``prometheus.query.chunk.size.duration`` and ``prometheus.max.query.range.duration`` are values to protect Trino from
@@ -67,7 +67,7 @@ If the query does not include a WHERE clause limit, these config
 settings are meant to protect against an unlimited query.
 
 
-Bearer Token Authentication
+Bearer token authentication
 ---------------------------
 
 Prometheus can be setup to require a Authorization header with every query. The value in

--- a/docs/src/main/sphinx/connector/redis.rst
+++ b/docs/src/main/sphinx/connector/redis.rst
@@ -1,5 +1,5 @@
 ===============
-Redis Connector
+Redis connector
 ===============
 
 The Redis connector allows querying of live data stored in `Redis <https://redis.io/>`_. This can be
@@ -26,14 +26,14 @@ replacing the properties as appropriate:
     redis.table-names=schema1.table1,schema1.table2
     redis.nodes=host:port
 
-Multiple Redis Servers
+Multiple Redis servers
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 You can have as many catalogs as you need. If you have additional
 Redis servers, simply add another properties file to ``etc/catalog``
 with a different name, making sure it ends in ``.properties``.
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 The following configuration properties are available:
@@ -143,7 +143,7 @@ The password for password-protected Redis server.
 This property is optional; the default is ``null``.
 
 
-Internal Columns
+Internal columns
 ----------------
 
 For each defined table, the connector maintains the following columns:
@@ -162,7 +162,7 @@ Column name             Type      Description
 For tables without a table definition file, the ``_key_corrupt`` and
 ``_value_corrupt`` columns are ``false``.
 
-Table Definition Files
+Table definition files
 ----------------------
 
 With the Redis connector it's possible to further reduce Redis key/value pairs into

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -1,5 +1,5 @@
 ==================
-Redshift Connector
+Redshift connector
 ==================
 
 The Redshift connector allows querying and creating tables in an
@@ -23,7 +23,7 @@ connection properties as appropriate for your setup:
     connection-user=root
     connection-password=secret
 
-Multiple Redshift Databases or Clusters
+Multiple Redshift databases or clusters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Redshift connector can only access a single database within

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -1,5 +1,5 @@
 ====================
-SQL Server Connector
+SQL Server connector
 ====================
 
 The SQL Server connector allows querying and creating tables in an
@@ -25,7 +25,7 @@ appropriate for your setup:
     connection-user=root
     connection-password=secret
 
-Multiple SQL Server Databases or Servers
+Multiple SQL Server databases or servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The SQL Server connector can't access more than one database using a single

--- a/docs/src/main/sphinx/connector/system.rst
+++ b/docs/src/main/sphinx/connector/system.rst
@@ -1,5 +1,5 @@
 ================
-System Connector
+System connector
 ================
 
 The System connector provides information and metrics about the currently
@@ -11,7 +11,7 @@ Configuration
 The System connector doesn't need to be configured: it is automatically
 available via a catalog named ``system``.
 
-Using the System Connector
+Using the System connector
 --------------------------
 
 List the available system schemas::
@@ -30,7 +30,7 @@ Kill a running query::
 
     CALL system.runtime.kill_query(query_id => '20151207_215727_00146_tx3nr', message => 'Using too many resources');
 
-System Connector Tables
+System connector tables
 -----------------------
 
 ``metadata.catalogs``
@@ -97,7 +97,7 @@ The transactions table contains the list of currently open transactions
 and related metadata. This includes information such as the create time,
 idle time, initialization parameters, and accessed catalogs.
 
-System Connector Procedures
+System connector procedures
 ---------------------------
 
 .. function:: runtime.kill_query(query_id, message)

--- a/docs/src/main/sphinx/connector/thrift.rst
+++ b/docs/src/main/sphinx/connector/thrift.rst
@@ -1,5 +1,5 @@
 ================
-Thrift Connector
+Thrift connector
 ================
 
 The Thrift connector makes it possible to integrate with external storage systems
@@ -26,14 +26,14 @@ replacing the properties as appropriate:
     connector.name=trino-thrift
     trino.thrift.client.addresses=host:port,host:port
 
-Multiple Thrift Systems
+Multiple Thrift systems
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 You can have as many catalogs as you need, so if you have additional
 Thrift systems to connect to, simply add another properties file to ``etc/catalog``
 with a different name, making sure it ends in ``.properties``.
 
-Configuration Properties
+Configuration properties
 ------------------------
 
 The following configuration properties are available:
@@ -84,7 +84,7 @@ Number of refresh threads for metadata cache.
 
 This property is optional; the default is ``1``.
 
-Thrift IDL File
+Thrift IDL file
 ---------------
 
 The following IDL describes the ``TrinoThriftService`` that must be implemented:

--- a/docs/src/main/sphinx/connector/tpcds.rst
+++ b/docs/src/main/sphinx/connector/tpcds.rst
@@ -1,5 +1,5 @@
 ===============
-TPCDS Connector
+TPCDS connector
 ===============
 
 The TPCDS connector provides a set of schemas to support the
@@ -21,7 +21,7 @@ To configure the TPCDS connector, create a catalog properties file
 
     connector.name=tpcds
 
-TPCDS Schemas
+TPCDS schemas
 -------------
 
 The TPCDS connector supplies several schemas::

--- a/docs/src/main/sphinx/connector/tpch.rst
+++ b/docs/src/main/sphinx/connector/tpch.rst
@@ -1,5 +1,5 @@
 ==============
-TPCH Connector
+TPCH connector
 ==============
 
 The TPCH connector provides a set of schemas to support the
@@ -21,7 +21,7 @@ To configure the TPCH connector, create a catalog properties file
 
     connector.name=tpch
 
-TPCH Schemas
+TPCH schemas
 ------------
 
 The TPCH connector supplies several schemas::

--- a/docs/src/main/sphinx/develop.rst
+++ b/docs/src/main/sphinx/develop.rst
@@ -1,5 +1,5 @@
 ***************
-Developer Guide
+Developer guide
 ***************
 
 This guide is intended for Trino contributors and plugin developers.

--- a/docs/src/main/sphinx/develop/certificate-authenticator.rst
+++ b/docs/src/main/sphinx/develop/certificate-authenticator.rst
@@ -1,5 +1,5 @@
 =========================
-Certificate Authenticator
+Certificate authenticator
 =========================
 
 Trino supports TLS-based authentication with X509 certificates via a custom

--- a/docs/src/main/sphinx/develop/event-listener.rst
+++ b/docs/src/main/sphinx/develop/event-listener.rst
@@ -1,5 +1,5 @@
 ==============
-Event Listener
+Event listener
 ==============
 
 Trino supports custom event listeners that are invoked for the following
@@ -47,7 +47,7 @@ Example configuration file:
     custom-property1=custom-value1
     custom-property2=custom-value2
 
-Multiple Event Listeners
+Multiple event listeners
 ------------------------
 
 Multiple instances of the same, or different event listeners can be

--- a/docs/src/main/sphinx/develop/example-http.rst
+++ b/docs/src/main/sphinx/develop/example-http.rst
@@ -1,5 +1,5 @@
 ======================
-Example HTTP Connector
+Example HTTP connector
 ======================
 
 The Example HTTP connector has a simple goal: it reads comma-separated
@@ -13,7 +13,7 @@ Code
 The Example HTTP connector can be found in the ``trino-example-http``
 directory in the root of the Trino source tree.
 
-Plugin Implementation
+Plugin implementation
 ---------------------
 
 The plugin implementation in the Example HTTP connector looks very
@@ -34,7 +34,7 @@ Note that the ``ImmutableList`` class is a utility class from Guava.
 As with all connectors, this plugin overrides the ``getConnectorFactories()`` method
 and returns an ``ExampleConnectorFactory``.
 
-ConnectorFactory Implementation
+ConnectorFactory implementation
 -------------------------------
 
 In Trino, the primary object that handles the connection between
@@ -94,7 +94,7 @@ The ``ExampleMetadata`` implementation delegates many of these calls to
 ``ExampleClient``, a class that implements much of the core functionality
 of the connector.
 
-Split Manager: ExampleSplitManager
+Split manager: ExampleSplitManager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The split manager partitions the data for a table into the individual
@@ -102,7 +102,7 @@ chunks that Trino will distribute to workers for processing.
 In the case of the Example HTTP connector, each table contains one or
 more URIs pointing at the actual data. One split is created per URI.
 
-Record Set Provider: ExampleRecordSetProvider
+Record set provider: ExampleRecordSetProvider
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The record set provider creates a record set which in turn creates a

--- a/docs/src/main/sphinx/develop/functions.rst
+++ b/docs/src/main/sphinx/develop/functions.rst
@@ -2,7 +2,7 @@
 Functions
 =========
 
-Plugin Implementation
+Plugin implementation
 ---------------------
 
 The function framework is used to implement SQL functions. Trino includes a
@@ -35,7 +35,7 @@ For a full example in the codebase, see either the ``trino-ml`` module for machi
 learning functions or the ``trino-teradata-functions`` module for Teradata-compatible
 functions, both in the root of the Trino source.
 
-Scalar Function Implementation
+Scalar function implementation
 ------------------------------
 
 The function framework uses annotations to indicate relevant information
@@ -91,7 +91,7 @@ to avoid unexpected results.
   native container type when using ``@SqlNullable``. The method must be annotated with
   ``@SqlNullable`` if it can return ``NULL`` when the arguments are non-null.
 
-Parametric Scalar Functions
+Parametric scalar functions
 ---------------------------
 
 Scalar functions that have type parameters have some additional complexity.
@@ -165,7 +165,7 @@ To make our previous example work with any type we need the following:
         // ...and so on for each native container type
     }
 
-Another Scalar Function Example
+Another scalar function example
 -------------------------------
 
 The ``lowercaser`` function takes a single ``VARCHAR`` argument and returns a
@@ -191,7 +191,7 @@ on the underlying ``byte[]``, which have much better performance. This function
 has no ``@SqlNullable`` annotations, meaning that if the argument is ``NULL``,
 the result will automatically be ``NULL`` (the function will not be called).
 
-Aggregation Function Implementation
+Aggregation function implementation
 -----------------------------------
 
 Aggregation functions use a similar framework to scalar functions, but are
@@ -305,7 +305,7 @@ function follows:
   will be automatically generated for you, if you don't specify a
   ``AccumulatorStateFactory``
 
-Deprecated Function
+Deprecated function
 -------------------
 
 The ``@Deprecated`` annotation has to be used on any function that should no longer be

--- a/docs/src/main/sphinx/develop/group-provider.rst
+++ b/docs/src/main/sphinx/develop/group-provider.rst
@@ -1,5 +1,5 @@
 ==============
-Group Provider
+Group provider
 ==============
 
 Trino can map user names onto groups for easier access control management.

--- a/docs/src/main/sphinx/develop/password-authenticator.rst
+++ b/docs/src/main/sphinx/develop/password-authenticator.rst
@@ -1,5 +1,5 @@
 ======================
-Password Authenticator
+Password authenticator
 ======================
 
 Trino supports authentication with a username and password via a custom

--- a/docs/src/main/sphinx/develop/spi-overview.rst
+++ b/docs/src/main/sphinx/develop/spi-overview.rst
@@ -1,5 +1,5 @@
 ============
-SPI Overview
+SPI overview
 ============
 
 When you implement a new Trino plugin, you implement interfaces and
@@ -16,7 +16,7 @@ Code
 The SPI source can be found in the ``trino-spi`` directory in the
 root of the Trino source tree.
 
-Plugin Metadata
+Plugin metadata
 ---------------
 
 Each plugin identifies an entry point: an implementation of the
@@ -49,7 +49,7 @@ is ready to create an instance of a connector to back a catalog. There are simil
 methods for ``Type``, ``ParametricType``, ``Function``, ``SystemAccessControl``, and
 ``EventListenerFactory`` objects.
 
-Building Plugins via Maven
+Building plugins via Maven
 --------------------------
 
 Plugins depend on the SPI from Trino:
@@ -79,7 +79,7 @@ of a library that Trino uses internally.
 For an example ``pom.xml`` file, see the example HTTP connector in the
 ``trino-example-http`` directory in the root of the Trino source tree.
 
-Deploying a Custom Plugin
+Deploying a custom plugin
 -------------------------
 
 In order to add a custom plugin to a Trino installation, create a directory

--- a/docs/src/main/sphinx/develop/system-access-control.rst
+++ b/docs/src/main/sphinx/develop/system-access-control.rst
@@ -1,5 +1,5 @@
 =====================
-System Access Control
+System access control
 =====================
 
 Trino separates the concept of the principal who authenticates to the

--- a/docs/src/main/sphinx/functions.rst
+++ b/docs/src/main/sphinx/functions.rst
@@ -1,5 +1,5 @@
 ***********************
-Functions and Operators
+Functions and operators
 ***********************
 
 This chapter describes the SQL functions and operators supported by Trino. They
@@ -24,10 +24,10 @@ and the :doc:`SQL statement and syntax reference</sql>`.
     Bitwise             <functions/bitwise>
     Decimal             <functions/decimal>
     String              <functions/string>
-    Regular Expression  <functions/regexp>
+    Regular expression  <functions/regexp>
     Binary              <functions/binary>
     JSON                <functions/json>
-    Date and Time       <functions/datetime>
+    Date and time       <functions/datetime>
     Aggregate           <functions/aggregate>
     Window              <functions/window>
     Array               <functions/array>
@@ -35,11 +35,11 @@ and the :doc:`SQL statement and syntax reference</sql>`.
     URL                 <functions/url>
     Geospatial          <functions/geospatial>
     HyperLogLog         <functions/hyperloglog>
-    Quantile Digest     <functions/qdigest>
+    Quantile digest     <functions/qdigest>
     T-Digest            <functions/tdigest>
     UUID                <functions/uuid>
     Color               <functions/color>
     Session             <functions/session>
     Teradata            <functions/teradata>
-    Machine Learning    <functions/ml>
+    Machine learning    <functions/ml>
     functions/list

--- a/docs/src/main/sphinx/functions/aggregate.rst
+++ b/docs/src/main/sphinx/functions/aggregate.rst
@@ -1,5 +1,5 @@
 ===================
-Aggregate Functions
+Aggregate functions
 ===================
 
 Aggregate functions operate on a set of values to compute a single result.
@@ -13,7 +13,7 @@ zero.
 
 .. _aggregate-function-ordering-during-aggregation:
 
-Ordering During Aggregation
+Ordering during aggregation
 ----------------------------
 
 Some aggregate functions such as :func:`array_agg` produce different results
@@ -25,7 +25,7 @@ an :ref:`order-by-clause` within the aggregate function::
 
 .. _aggregate-function-filtering-during-aggregation:
 
-Filtering During Aggregation
+Filtering during aggregation
 ----------------------------
 
 The ``FILTER`` keyword can be used to remove rows from aggregation processing
@@ -90,7 +90,7 @@ Using a filter you retain all information::
     versicolor |   34
 
 
-General Aggregate Functions
+General aggregate functions
 ---------------------------
 
 .. function:: arbitrary(x) -> [same as input]
@@ -186,7 +186,7 @@ General Aggregate Functions
 
     Returns the sum of all input values.
 
-Bitwise Aggregate Functions
+Bitwise aggregate functions
 ---------------------------
 
 .. function:: bitwise_and_agg(x) -> bigint
@@ -197,7 +197,7 @@ Bitwise Aggregate Functions
 
     Returns the bitwise OR of all input values in 2's complement representation.
 
-Map Aggregate Functions
+Map aggregate functions
 -----------------------
 
 .. function:: histogram(x) -> map(K,bigint)
@@ -218,7 +218,7 @@ Map Aggregate Functions
     Returns a multimap created from the input ``key`` / ``value`` pairs.
     Each key can be associated with multiple values.
 
-Approximate Aggregate Functions
+Approximate aggregate functions
 -------------------------------
 
 .. function:: approx_distinct(x) -> bigint
@@ -363,7 +363,7 @@ Approximate Aggregate Functions
 
     See :doc:`tdigest`.
 
-Statistical Aggregate Functions
+Statistical aggregate functions
 -------------------------------
 
 .. function:: corr(y, x) -> double
@@ -425,7 +425,7 @@ Statistical Aggregate Functions
 
     Returns the sample variance of all input values.
 
-Lambda Aggregate Functions
+Lambda aggregate functions
 --------------------------
 
 .. function:: reduce_agg(inputValue T, initialState S, inputFunction(S, T, S), combineFunction(S, S, S)) -> S

--- a/docs/src/main/sphinx/functions/array.rst
+++ b/docs/src/main/sphinx/functions/array.rst
@@ -1,10 +1,10 @@
 =============================
-Array Functions and Operators
+Array functions and operators
 =============================
 
 .. _subscript_operator:
 
-Subscript Operator: []
+Subscript operator: []
 ----------------------
 
 The ``[]`` operator is used to access an element of an array and is indexed starting from one::
@@ -13,7 +13,7 @@ The ``[]`` operator is used to access an element of an array and is indexed star
 
 .. _concatenation_operator:
 
-Concatenation Operator: ||
+Concatenation operator: ||
 --------------------------
 
 The ``||`` operator is used to concatenate an array with an array or an element of the same type::
@@ -27,7 +27,7 @@ The ``||`` operator is used to concatenate an array with an array or an element 
     SELECT 2 || ARRAY[1];
     -- [2, 1]
 
-Array Functions
+Array functions
 ---------------
 
 .. function:: all_match(array(T), function(T,boolean)) -> boolean

--- a/docs/src/main/sphinx/functions/binary.rst
+++ b/docs/src/main/sphinx/functions/binary.rst
@@ -1,13 +1,13 @@
 ==============================
-Binary Functions and Operators
+Binary functions and operators
 ==============================
 
-Binary Operators
+Binary operators
 ----------------
 
 The ``||`` operator performs concatenation.
 
-Binary Functions
+Binary functions
 ----------------
 
 .. function:: concat(binary1, ..., binaryN) -> varbinary
@@ -60,7 +60,7 @@ Binary Functions
 
     Returns ``binary`` with the bytes in reverse order.
 
-Base64 Encoding Functions
+Base64 encoding functions
 -------------------------
 
 The Base64 functions implement the encoding specified in :rfc:`4648`.
@@ -81,7 +81,7 @@ The Base64 functions implement the encoding specified in :rfc:`4648`.
 
     Encodes ``binary`` into a base64 string representation using the URL safe alphabet.
 
-Hex Encoding Functions
+Hex encoding functions
 ----------------------
 
 .. function:: from_hex(string) -> varbinary
@@ -92,7 +92,7 @@ Hex Encoding Functions
 
     Encodes ``binary`` into a hex string representation.
 
-Integer Encoding Functions
+Integer encoding functions
 --------------------------
 
 .. function:: from_big_endian_32(binary) -> integer
@@ -113,7 +113,7 @@ Integer Encoding Functions
 
     Encodes ``bigint`` into a 64-bit two's complement big-endian format.
 
-Floating-Point Encoding Functions
+Floating-point encoding functions
 ---------------------------------
 
 .. function:: from_ieee754_32(binary) -> real
@@ -134,7 +134,7 @@ Floating-Point Encoding Functions
 
     Encodes ``double`` into a 64-bit big-endian binary according to IEEE 754 double-precision floating-point format.
 
-Hashing Functions
+Hashing functions
 -----------------
 
 .. function:: crc32(binary) -> bigint
@@ -174,7 +174,7 @@ Hashing Functions
 
     Computes the 128-bit murmur3 hash of ``binary``.
 
-HMAC Functions
+HMAC functions
 --------------
 
 .. function:: hmac_md5(binary, key) -> varbinary

--- a/docs/src/main/sphinx/functions/bitwise.rst
+++ b/docs/src/main/sphinx/functions/bitwise.rst
@@ -1,5 +1,5 @@
 =================
-Bitwise Functions
+Bitwise functions
 =================
 
 .. function:: bit_count(x, bits) -> bigint

--- a/docs/src/main/sphinx/functions/color.rst
+++ b/docs/src/main/sphinx/functions/color.rst
@@ -1,5 +1,5 @@
 ===============
-Color Functions
+Color functions
 ===============
 
 .. function:: bar(x, width) -> varchar

--- a/docs/src/main/sphinx/functions/comparison.rst
+++ b/docs/src/main/sphinx/functions/comparison.rst
@@ -1,10 +1,10 @@
 ==================================
-Comparison Functions and Operators
+Comparison functions and operators
 ==================================
 
 .. _comparison_operators:
 
-Comparison Operators
+Comparison operators
 --------------------
 
 ======== ===========
@@ -21,7 +21,7 @@ Operator Description
 
 .. _range_operator:
 
-Range Operator: BETWEEN
+Range operator: BETWEEN
 -----------------------
 
 The ``BETWEEN`` operator tests if a value is within a specified range.
@@ -136,7 +136,7 @@ The following types are supported:
 
 .. _quantified_comparison_predicates:
 
-Quantified Comparison Predicates: ALL, ANY and SOME
+Quantified comparison predicates: ALL, ANY and SOME
 ---------------------------------------------------
 
 The ``ALL``, ``ANY`` and ``SOME`` quantifiers can be used together with comparison operators in the
@@ -171,7 +171,7 @@ Expression              Meaning
 
 .. _like_operator:
 
-Pattern Comparison: LIKE
+Pattern comparison: LIKE
 ------------------------
 
 The ``LIKE`` operator can be used to compare values with a pattern::

--- a/docs/src/main/sphinx/functions/conditional.rst
+++ b/docs/src/main/sphinx/functions/conditional.rst
@@ -1,5 +1,5 @@
 =======================
-Conditional Expressions
+Conditional expressions
 =======================
 
 .. _case_expression:

--- a/docs/src/main/sphinx/functions/conversion.rst
+++ b/docs/src/main/sphinx/functions/conversion.rst
@@ -1,5 +1,5 @@
 ====================
-Conversion Functions
+Conversion functions
 ====================
 
 Trino will implicitly convert numeric and character values to the
@@ -10,7 +10,7 @@ equivalent varchar.
 
 When necessary, values can be explicitly cast to a particular type.
 
-Conversion Functions
+Conversion functions
 --------------------
 
 .. function:: cast(value AS type) -> type
@@ -52,7 +52,7 @@ Formatting
         SELECT format('%1$tA, %1$tB %1$te, %1$tY', date '2006-07-04');
         -- 'Tuesday, July 4, 2006'
 
-Data Size
+Data size
 ---------
 
 The ``parse_presto_data_size`` function supports the following units:

--- a/docs/src/main/sphinx/functions/datetime.rst
+++ b/docs/src/main/sphinx/functions/datetime.rst
@@ -1,10 +1,10 @@
 =====================================
-Date and Time Functions and Operators
+Date and time functions and operators
 =====================================
 
 These functions and operators operate on :ref:`date and time data types <date-time-data-types>`.
 
-Date and Time Operators
+Date and time operators
 -----------------------
 
 ======== ===================================================== ===========================
@@ -26,7 +26,7 @@ Operator Example                                               Result
 
 .. _at_time_zone_operator:
 
-Time Zone Conversion
+Time zone conversion
 --------------------
 
 The ``AT TIME ZONE`` operator sets the time zone of a timestamp::
@@ -37,7 +37,7 @@ The ``AT TIME ZONE`` operator sets the time zone of a timestamp::
     SELECT timestamp '2012-10-31 01:00 UTC' AT TIME ZONE 'America/Los_Angeles';
     -- 2012-10-30 18:00:00.000 America/Los_Angeles
 
-Date and Time Functions
+Date and time functions
 -----------------------
 
 .. data:: current_date
@@ -198,7 +198,7 @@ Date and Time Functions
     - ``localtime``
     - ``localtimestamp``
 
-Truncation Function
+Truncation function
 -------------------
 
 The ``date_trunc`` function supports the following units:
@@ -224,7 +224,7 @@ The above examples use the timestamp ``2001-08-22 03:04:05.321`` as the input.
 
 .. _datetime-interval-functions:
 
-Interval Functions
+Interval functions
 ------------------
 
 The functions in this section support the following interval units:
@@ -276,7 +276,7 @@ Unit              Description
         SELECT date_diff('millisecond', TIMESTAMP '2020-06-01 12:30:45.000000000', TIMESTAMP '2020-06-02 12:30:45.123456789');
         -- 86400123
 
-Duration Function
+Duration function
 -----------------
 
 The ``parse_duration`` function supports the following units:
@@ -317,7 +317,7 @@ Unit    Description
         SELECT human_readable_seconds(61);
         -- 1 minute, 1 second
 
-MySQL Date Functions
+MySQL date functions
 --------------------
 
 The functions in this section use a format string that is compatible with
@@ -377,7 +377,7 @@ Specifier Description
 
     Parses ``string`` into a timestamp using ``format``.
 
-Java Date Functions
+Java date functions
 -------------------
 
 The functions in this section use a format string that is compatible with
@@ -393,7 +393,7 @@ JodaTime's `DateTimeFormat`_ pattern format.
 
     Parses ``string`` into a timestamp with time zone using ``format``.
 
-Extraction Function
+Extraction function
 -------------------
 
 The ``extract`` function supports the following fields:
@@ -429,7 +429,7 @@ field to be extracted. Most fields support all date and time types.
 
     .. note:: This SQL-standard function uses special syntax for specifying the arguments.
 
-Convenience Extraction Functions
+Convenience extraction functions
 --------------------------------
 
 .. function:: day(x) -> bigint

--- a/docs/src/main/sphinx/functions/decimal.rst
+++ b/docs/src/main/sphinx/functions/decimal.rst
@@ -1,10 +1,10 @@
 ===============================
-Decimal Functions and Operators
+Decimal functions and operators
 ===============================
 
 .. _decimal_literal:
 
-Decimal Literals
+Decimal literals
 ----------------
 
 Use the ``DECIMAL 'xxxxxxx.yyyyyyy'`` syntax to define a decimal literal.
@@ -21,7 +21,7 @@ Example literal                             Data type
 ``DECIMAL '0000012345.1234500000'``         ``DECIMAL(20, 10)``
 =========================================== =============================
 
-Binary Arithmetic Decimal Operators
+Binary arithmetic decimal operators
 -----------------------------------
 
 Standard mathematical operators are supported. The table below explains
@@ -65,12 +65,12 @@ in the common super type. For example, the common super type of decimal(38, 0) a
 decimal(38, 1) is decimal(38, 1), but certain values that fit in decimal(38, 0)
 cannot be represented as a decimal(38, 1).
 
-Comparison Operators
+Comparison operators
 --------------------
 
 All standard :doc:`comparison` work for the decimal type.
 
-Unary Decimal Operators
+Unary decimal operators
 -----------------------
 
 The ``-`` operator performs negation. The type of result is same as type of argument.

--- a/docs/src/main/sphinx/functions/geospatial.rst
+++ b/docs/src/main/sphinx/functions/geospatial.rst
@@ -1,5 +1,5 @@
 ====================
-Geospatial Functions
+Geospatial functions
 ====================
 
 Trino Geospatial functions that begin with the ``ST_`` prefix support the SQL/MM specification
@@ -111,7 +111,7 @@ Constructors
 
     Converts a SphericalGeography object to a Geometry object.
 
-Relationship Tests
+Relationship tests
 ------------------
 
 .. function:: ST_Contains(Geometry, Geometry) -> boolean
@@ -417,7 +417,7 @@ Aggregations
 
     Returns a geometry that represents the point set union of all input geometries.
 
-Bing Tiles
+Bing tiles
 ----------
 
 These functions convert between geometries and
@@ -471,7 +471,7 @@ These functions convert between geometries and
     Returns the minimum set of Bing tiles that fully covers a given geometry at
     a given zoom level. Zoom levels from 1 to 23 are supported.
 
-Encoded Polylines
+Encoded polylines
 -----------------
 
 These functions convert between geometries and

--- a/docs/src/main/sphinx/functions/hyperloglog.rst
+++ b/docs/src/main/sphinx/functions/hyperloglog.rst
@@ -1,11 +1,11 @@
 =====================
-HyperLogLog Functions
+HyperLogLog functions
 =====================
 
 Trino implements the :func:`approx_distinct` function using the
 `HyperLogLog <https://en.wikipedia.org/wiki/HyperLogLog>`_ data structure.
 
-Data Structures
+Data structures
 ---------------
 
 Trino implements HyperLogLog data sketches as a set of 32-bit buckets which

--- a/docs/src/main/sphinx/functions/json.rst
+++ b/docs/src/main/sphinx/functions/json.rst
@@ -1,5 +1,5 @@
 ============================
-JSON Functions and Operators
+JSON functions and operators
 ============================
 
 Cast to JSON
@@ -119,7 +119,7 @@ some cases. To address this, Trino supports partial casting of arrays and maps::
 
 When casting from ``JSON`` to ``ROW``, both JSON array and JSON object are supported.
 
-JSON Functions
+JSON functions
 --------------
 .. function:: is_json_scalar(json) -> boolean
 

--- a/docs/src/main/sphinx/functions/lambda.rst
+++ b/docs/src/main/sphinx/functions/lambda.rst
@@ -1,7 +1,7 @@
 .. _lambda_expressions:
 
 ==================
-Lambda Expressions
+Lambda expressions
 ==================
 
 Lambda expressions are written with ``->``::

--- a/docs/src/main/sphinx/functions/list.rst
+++ b/docs/src/main/sphinx/functions/list.rst
@@ -1,5 +1,5 @@
 ===============================
-List of Functions and Operators
+List of functions and operators
 ===============================
 
 #

--- a/docs/src/main/sphinx/functions/logical.rst
+++ b/docs/src/main/sphinx/functions/logical.rst
@@ -1,10 +1,10 @@
 .. _logical_operators:
 
 =================
-Logical Operators
+Logical operators
 =================
 
-Logical Operators
+Logical operators
 -----------------
 
 ======== ============================ =======
@@ -15,7 +15,7 @@ Operator Description                  Example
 ``NOT``  True if the value is false   NOT a
 ======== ============================ =======
 
-Effect of NULL on Logical Operators
+Effect of NULL on logical operators
 -----------------------------------
 
 The result of an ``AND`` comparison may be ``NULL`` if one or both

--- a/docs/src/main/sphinx/functions/map.rst
+++ b/docs/src/main/sphinx/functions/map.rst
@@ -1,15 +1,15 @@
 ===========================
-Map Functions and Operators
+Map functions and operators
 ===========================
 
-Subscript Operator: []
+Subscript operator: []
 ----------------------
 
 The ``[]`` operator is used to retrieve the value corresponding to a given key from a map::
 
     SELECT name_to_age_map['Bob'] AS bob_age;
 
-Map Functions
+Map functions
 -------------
 
 .. function:: cardinality(x) -> bigint

--- a/docs/src/main/sphinx/functions/math.rst
+++ b/docs/src/main/sphinx/functions/math.rst
@@ -1,10 +1,10 @@
 ====================================
-Mathematical Functions and Operators
+Mathematical functions and operators
 ====================================
 
 .. _mathematical_operators:
 
-Mathematical Operators
+Mathematical operators
 ----------------------
 
 ======== ===========
@@ -17,7 +17,7 @@ Operator Description
 ``%``    Modulus (remainder)
 ======== ===========
 
-Mathematical Functions
+Mathematical functions
 ----------------------
 
 .. function:: abs(x) -> [same as input]
@@ -131,7 +131,7 @@ Mathematical Functions
     array ``bins``. The ``bins`` parameter must be an array of doubles and is
     assumed to be in sorted ascending order.
 
-Random Functions
+Random functions
 ----------------
 
 .. function:: rand() -> double
@@ -152,7 +152,7 @@ Random Functions
 
     Returns a pseudo-random number between m and n (exclusive).
 
-Trigonometric Functions
+Trigonometric functions
 -----------------------
 
 All trigonometric function arguments are expressed in radians.
@@ -194,7 +194,7 @@ See unit conversion functions :func:`degrees` and :func:`radians`.
 
     Returns the hyperbolic tangent of ``x``.
 
-Floating Point Functions
+Floating point functions
 ------------------------
 
 .. function:: infinity() -> double
@@ -217,7 +217,7 @@ Floating Point Functions
 
     Returns the constant representing not-a-number.
 
-Base Conversion Functions
+Base conversion functions
 -------------------------
 
 .. function:: from_base(string, radix) -> bigint
@@ -228,7 +228,7 @@ Base Conversion Functions
 
     Returns the base-``radix`` representation of ``x``.
 
-Statistical Functions
+Statistical functions
 ---------------------
 
 .. function:: cosine_similarity(x, y) -> double
@@ -247,7 +247,7 @@ Statistical Functions
     Returns the upper bound of the Wilson score interval of a Bernoulli trial process
     at a confidence specified by the z-score ``z``.
 
-Cumulative Distribution Functions
+Cumulative distribution functions
 ---------------------------------
 
 .. function:: beta_cdf(a, b, v) -> double

--- a/docs/src/main/sphinx/functions/ml.rst
+++ b/docs/src/main/sphinx/functions/ml.rst
@@ -1,5 +1,5 @@
 ==========================
-Machine Learning Functions
+Machine learning functions
 ==========================
 
 The machine learning plugin provides machine learning functionality
@@ -12,7 +12,7 @@ based classifiers and regressors for the supervised learning problems.
   The capability to train large data sets is limited by this execution of the
   final training on a single instance.
 
-Feature Vector
+Feature vector
 --------------
 
 To solve a problem with the machine learning technique, especially as a
@@ -119,7 +119,7 @@ The way to use the model is similar to the classification case::
 Internally, the model is trained by `libsvm <https://www.csie.ntu.edu.tw/~cjlin/libsvm/>`_.
 :func:`learn_libsvm_regressor` provides you a way to control the training process.
 
-Machine Learning Functions
+Machine learning functions
 --------------------------
 
 .. function:: features(double, ...) -> map(bigint, double)

--- a/docs/src/main/sphinx/functions/qdigest.rst
+++ b/docs/src/main/sphinx/functions/qdigest.rst
@@ -1,8 +1,8 @@
 =========================
-Quantile Digest Functions
+Quantile digest functions
 =========================
 
-Data Structures
+Data structures
 ---------------
 
 A quantile digest is a data sketch which stores approximate percentile

--- a/docs/src/main/sphinx/functions/regexp.rst
+++ b/docs/src/main/sphinx/functions/regexp.rst
@@ -1,5 +1,5 @@
 ============================
-Regular Expression Functions
+Regular expression functions
 ============================
 
 All of the regular expression functions use the `Java pattern`_ syntax,

--- a/docs/src/main/sphinx/functions/session.rst
+++ b/docs/src/main/sphinx/functions/session.rst
@@ -1,5 +1,5 @@
 ===================
-Session Information
+Session information
 ===================
 
 Functions providing information about the query execution environment.

--- a/docs/src/main/sphinx/functions/string.rst
+++ b/docs/src/main/sphinx/functions/string.rst
@@ -1,8 +1,8 @@
 ==============================
-String Functions and Operators
+String functions and operators
 ==============================
 
-String Operators
+String operators
 ----------------
 
 The ``||`` operator performs concatenation.
@@ -10,7 +10,7 @@ The ``||`` operator performs concatenation.
 The ``LIKE`` statement can be used for pattern matching and is documented in
 :ref:`like_operator`.
 
-String Functions
+String functions
 ----------------
 
 .. note::
@@ -241,7 +241,7 @@ String Functions
 
     Returns the stem of ``word`` in the ``lang`` language.
 
-Unicode Functions
+Unicode functions
 -----------------
 
 .. function:: normalize(string) -> varchar

--- a/docs/src/main/sphinx/functions/tdigest.rst
+++ b/docs/src/main/sphinx/functions/tdigest.rst
@@ -1,8 +1,8 @@
 =========================
-T-Digest Functions
+T-Digest functions
 =========================
 
-Data Structures
+Data structures
 ---------------
 
 A T-digest is a data sketch which stores approximate percentile

--- a/docs/src/main/sphinx/functions/teradata.rst
+++ b/docs/src/main/sphinx/functions/teradata.rst
@@ -1,10 +1,10 @@
 ==================
-Teradata Functions
+Teradata functions
 ==================
 
 These functions provide compatibility with Teradata SQL.
 
-String Functions
+String functions
 ----------------
 
 .. function:: char2hexint(string) -> varchar
@@ -15,7 +15,7 @@ String Functions
 
     Alias for :func:`strpos` function.
 
-Date Functions
+Date functions
 --------------
 
 The functions in this section use a format string that is compatible with

--- a/docs/src/main/sphinx/functions/url.rst
+++ b/docs/src/main/sphinx/functions/url.rst
@@ -1,8 +1,8 @@
 =============
-URL Functions
+URL functions
 =============
 
-Extraction Functions
+Extraction functions
 --------------------
 
 The URL extraction functions extract components from HTTP URLs
@@ -46,7 +46,7 @@ such as ``:`` or ``?``.
 
     Returns the query string from ``url``.
 
-Encoding Functions
+Encoding functions
 ------------------
 
 .. function:: url_encode(value) -> varchar

--- a/docs/src/main/sphinx/functions/uuid.rst
+++ b/docs/src/main/sphinx/functions/uuid.rst
@@ -1,5 +1,5 @@
 ==============
-UUID Functions
+UUID functions
 ==============
 
 .. function:: uuid() -> uuid

--- a/docs/src/main/sphinx/functions/window.rst
+++ b/docs/src/main/sphinx/functions/window.rst
@@ -1,5 +1,5 @@
 ================
-Window Functions
+Window functions
 ================
 
 Window functions perform calculations across rows of the query result.
@@ -29,7 +29,7 @@ For example, the following query ranks orders for each clerk by price::
     FROM orders
     ORDER BY clerk, rnk
 
-Aggregate Functions
+Aggregate functions
 -------------------
 
 All :doc:`aggregate` can be used as window functions by adding the ``OVER``
@@ -45,7 +45,7 @@ by day for each clerk::
     FROM orders
     ORDER BY clerk, orderdate, orderkey
 
-Ranking Functions
+Ranking functions
 -----------------
 
 .. function:: cume_dist() -> bigint
@@ -90,7 +90,7 @@ Ranking Functions
     Returns a unique, sequential number for each row, starting with one,
     according to the ordering of rows within the window partition.
 
-Value Functions
+Value functions
 ---------------
 
 By default, null values are respected. If ``IGNORE NULLS`` is specified, all rows where

--- a/docs/src/main/sphinx/index.rst
+++ b/docs/src/main/sphinx/index.rst
@@ -1,5 +1,5 @@
 ####################
-Trino Documentation
+Trino documentation
 ####################
 
 .. toctree::

--- a/docs/src/main/sphinx/installation/cli.rst
+++ b/docs/src/main/sphinx/installation/cli.rst
@@ -1,5 +1,5 @@
 ======================
-Command Line Interface
+Command line interface
 ======================
 
 The Trino CLI provides a terminal-based, interactive shell for running

--- a/docs/src/main/sphinx/installation/deployment.rst
+++ b/docs/src/main/sphinx/installation/deployment.rst
@@ -5,7 +5,7 @@ Deploying Trino
 Requirements
 ------------
 
-Linux Operating System
+Linux operating system
 ^^^^^^^^^^^^^^^^^^^^^^
 
 * 64-bit required
@@ -24,7 +24,7 @@ Linux Operating System
 
 .. _requirements-java:
 
-Java Runtime Environment
+Java runtime environment
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Trino requires a 64-bit version of Java 11, with a minimum required version of 11.0.7.
@@ -65,7 +65,7 @@ This holds the following configuration:
 * Config Properties: configuration for the Trino server
 * Catalog Properties: configuration for :doc:`/connector` (data sources)
 
-Node Properties
+Node properties
 ^^^^^^^^^^^^^^^
 
 The node properties file, ``etc/node.properties``, contains configuration
@@ -101,7 +101,7 @@ The above properties are described below:
 
 .. _trino_jvm_config:
 
-JVM Config
+JVM config
 ^^^^^^^^^^
 
 The JVM config file, ``etc/jvm.config``, contains a list of command line
@@ -141,7 +141,7 @@ list of JVM options.
 
 .. _config_properties:
 
-Config Properties
+Config properties
 ^^^^^^^^^^^^^^^^^
 
 The config properties file, ``etc/config.properties``, contains the
@@ -236,7 +236,7 @@ In particular, see :doc:`/admin/resource-groups` for configuring queuing policie
 
 .. _log-levels:
 
-Log Levels
+Log levels
 ^^^^^^^^^^
 
 The optional log levels file, ``etc/log.properties``, allows setting the
@@ -255,7 +255,7 @@ The default minimum level is ``INFO``,
 thus the above example does not actually change anything.
 There are four levels: ``DEBUG``, ``INFO``, ``WARN`` and ``ERROR``.
 
-Catalog Properties
+Catalog properties
 ^^^^^^^^^^^^^^^^^^
 
 Trino accesses data via *connectors*, which are mounted in catalogs.

--- a/docs/src/main/sphinx/installation/jdbc.rst
+++ b/docs/src/main/sphinx/installation/jdbc.rst
@@ -1,5 +1,5 @@
 ===========
-JDBC Driver
+JDBC driver
 ===========
 
 The Trino `JDBC driver <https://en.wikipedia.org/wiki/JDBC_driver>`_ allows

--- a/docs/src/main/sphinx/language.rst
+++ b/docs/src/main/sphinx/language.rst
@@ -1,5 +1,5 @@
 ************
-SQL Language
+SQL language
 ************
 
 Trino is an ANSI SQL compliant query engine. This standard compliance allows

--- a/docs/src/main/sphinx/language/reserved.rst
+++ b/docs/src/main/sphinx/language/reserved.rst
@@ -1,5 +1,5 @@
 =================
-Reserved Keywords
+Reserved keywords
 =================
 
 The following table lists all of the keywords that are reserved in Trino,

--- a/docs/src/main/sphinx/language/types.rst
+++ b/docs/src/main/sphinx/language/types.rst
@@ -1,5 +1,5 @@
 ==========
-Data Types
+Data types
 ==========
 
 Trino has a set of built-in data types, described below.
@@ -46,7 +46,7 @@ also available for this type.
 A 64-bit signed two's complement integer with a minimum value of
 ``-2^63`` and a maximum value of ``2^63 - 1``.
 
-Floating-Point
+Floating-point
 --------------
 
 ``REAL``
@@ -65,7 +65,7 @@ IEEE Standard 754 for Binary Floating-Point Arithmetic.
 
 Example literals: ``DOUBLE '10.3'``, ``DOUBLE '1.03e1'``, ``10.3e0``, ``1.03e1``
 
-Fixed-Precision
+Fixed-precision
 ---------------
 
 ``DECIMAL``
@@ -138,7 +138,7 @@ JSON value type, which can be a JSON object, a JSON array, a JSON number, a JSON
 
 .. _date-time-data-types:
 
-Date and Time
+Date and time
 -------------
 
 See also :doc:`/functions/datetime`
@@ -286,7 +286,7 @@ operator (``[]``). The position starts at ``1`` and must be a constant.
 
 Example: ``ROW(1, 2.0)[1]``
 
-Network Address
+Network address
 ---------------
 
 .. _ipaddress_type:
@@ -339,7 +339,7 @@ sparse representation, switching to a dense representation when it becomes more 
 A P4HyperLogLog sketch is similar to :ref:`hyperloglog_type`, but it starts (and remains)
 in the dense representation.
 
-Quantile Digest
+Quantile digest
 ---------------
 
 .. _qdigest_type:
@@ -363,7 +363,7 @@ the past week of data with ``approx_percentile``, ``qdigest``\ s could be stored
 daily, and quickly merged to retrieve the 99th percentile value.
 
 T-Digest
----------------
+--------
 
 .. _tdigest_type:
 

--- a/docs/src/main/sphinx/migration/from-hive.rst
+++ b/docs/src/main/sphinx/migration/from-hive.rst
@@ -1,5 +1,5 @@
 ===================
-Migrating From Hive
+Migrating from Hive
 ===================
 
 Trino uses ANSI SQL syntax and semantics, whereas Hive uses a SQL-like language called HiveQL which is loosely modeled after MySQL (which itself has many differences from ANSI SQL).

--- a/docs/src/main/sphinx/optimizer.rst
+++ b/docs/src/main/sphinx/optimizer.rst
@@ -1,5 +1,5 @@
 ***************
-Query Optimizer
+Query optimizer
 ***************
 
 .. toctree::

--- a/docs/src/main/sphinx/optimizer/cost-based-optimizations.rst
+++ b/docs/src/main/sphinx/optimizer/cost-based-optimizations.rst
@@ -4,7 +4,7 @@ Cost based optimizations
 
 Trino supports several cost based optimizations, described below.
 
-Join Enumeration
+Join enumeration
 ----------------
 
 The order in which joins are executed in a query can have a significant impact
@@ -33,7 +33,7 @@ If using ``AUTOMATIC`` and statistics are not available, or if for any other
 reason a cost could not be computed, the ``ELIMINATE_CROSS_JOINS`` strategy is
 used instead.
 
-Join Distribution Selection
+Join distribution selection
 ---------------------------
 
 Trino uses a hash based join algorithm. That implies that for each join
@@ -82,7 +82,7 @@ This allows to improve cluster concurrency and to prevent bad plans when CBO mis
 
 By default replicated table size is capped to 100MB.
 
-Connector Implementations
+Connector implementations
 -------------------------
 
 In order for the Trino optimizer to use the cost based strategies,

--- a/docs/src/main/sphinx/optimizer/pushdown.rst
+++ b/docs/src/main/sphinx/optimizer/pushdown.rst
@@ -16,7 +16,7 @@ The results of this pushdown can include the following benefits:
 Support for pushdown is specific to each connector and the relevant underlying
 database or storage system.
 
-Aggregation Pushdown
+Aggregation pushdown
 --------------------
 
 Aggregation pushdown can take place provided the following conditions are satisfied:

--- a/docs/src/main/sphinx/optimizer/statistics.rst
+++ b/docs/src/main/sphinx/optimizer/statistics.rst
@@ -1,5 +1,5 @@
 ================
-Table Statistics
+Table statistics
 ================
 
 Trino supports statistics based optimizations for queries. For a query to take
@@ -8,7 +8,7 @@ the tables in that query.
 
 Table statistics are provided to the query planner by connectors.
 
-Available Statistics
+Available statistics
 --------------------
 
 The following statistics are available in Trino:

--- a/docs/src/main/sphinx/overview/concepts.rst
+++ b/docs/src/main/sphinx/overview/concepts.rst
@@ -1,6 +1,6 @@
-===============
-Trino Concepts
-===============
+==============
+Trino concepts
+==============
 
 Overview
 --------
@@ -27,7 +27,7 @@ general to most specific.
     provide further information about Trino and the concepts in use.
 
 
-Server Types
+Server types
 ------------
 
 There are two types of Trino servers: coordinators and workers. The
@@ -68,7 +68,7 @@ for task execution.
 Workers communicate with other workers and Trino coordinators
 using a REST API.
 
-Data Sources
+Data sources
 ------------
 
 Throughout this documentation, you'll read terms such as connector,
@@ -138,7 +138,7 @@ A table is a set of unordered rows, which are organized into named columns
 with types. This is the same as in any relational database. The mapping
 from source data to tables is defined by the connector.
 
-Query Execution Model
+Query execution model
 ---------------------
 
 Trino executes SQL statements and turns these statements into queries,

--- a/docs/src/main/sphinx/overview/use-cases.rst
+++ b/docs/src/main/sphinx/overview/use-cases.rst
@@ -1,13 +1,13 @@
 =========
-Use Cases
+Use cases
 =========
 
 This section puts Trino into perspective, so that prospective
 administrators and end users know what to expect from Trino.
 
-------------------
-What Trino Is Not
-------------------
+-----------------
+What Trino is not
+-----------------
 
 Since Trino is being called a *database* by many members of the community,
 it makes sense to begin with a definition of what Trino is not.
@@ -19,9 +19,9 @@ PostgreSQL or Oracle. Trino was not designed to handle Online
 Transaction Processing (OLTP). This is also true for many other
 databases designed and optimized for data warehousing or analytics.
 
---------------
-What Trino Is
---------------
+-------------
+What Trino is
+-------------
 
 Trino is a tool designed to efficiently query vast amounts of data
 using distributed queries. If you work with terabytes or petabytes of

--- a/docs/src/main/sphinx/release.rst
+++ b/docs/src/main/sphinx/release.rst
@@ -1,5 +1,5 @@
 *************
-Release Notes
+Release notes
 *************
 
 .. toctree::

--- a/docs/src/main/sphinx/release/release-0.100.rst
+++ b/docs/src/main/sphinx/release/release-0.100.rst
@@ -2,7 +2,7 @@
 Release 0.100
 =============
 
-System Connector
+System connector
 ----------------
 
 The :doc:`/connector/system` now works like other connectors: global system
@@ -11,7 +11,7 @@ schema that is available in every catalog. Additionally, connectors may now
 provide system tables that are available within that connector's catalog by
 implementing the ``getSystemTables()`` method on the ``Connector`` interface.
 
-General Changes
+General changes
 ---------------
 
 * Fix ``%f`` specifier in :func:`date_format` and :func:`date_parse`.

--- a/docs/src/main/sphinx/release/release-0.101.rst
+++ b/docs/src/main/sphinx/release/release-0.101.rst
@@ -2,7 +2,7 @@
 Release 0.101
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add support for :doc:`/sql/create-table` (in addition to :doc:`/sql/create-table-as`).
@@ -35,14 +35,14 @@ General Changes
 * Make ``UNION`` run partitioned, if underlying plan is partitioned.
 * Add ``hash_partition_count`` session property to control hash partitions.
 
-Web UI Changes
+Web UI changes
 --------------
 
 The main page of the web UI has been completely rewritten to use ReactJS. It also has
 a number of new features, such as the ability to pause auto-refresh via the "Z" key and
 also with a toggle in the UI.
 
-Hive Changes
+Hive changes
 ------------
 
 * Add support for connecting to S3 using EC2 instance credentials.
@@ -64,7 +64,7 @@ Hive Changes
 * Add ``hive.recursive-directories`` config option to recursively scan
   partition directories for data.
 
-SPI Changes
+SPI changes
 -----------
 
 * Add connector callback for rollback of ``INSERT`` and ``CREATE TABLE AS``.

--- a/docs/src/main/sphinx/release/release-0.102.rst
+++ b/docs/src/main/sphinx/release/release-0.102.rst
@@ -2,7 +2,7 @@
 Release 0.102
 =============
 
-Unicode Support
+Unicode support
 ---------------
 
 All string functions have been updated to support Unicode. The functions assume
@@ -15,7 +15,7 @@ Additionally, the functions operate on Unicode code points and not user visible
 into a single user-perceived *character*, the basic unit of a writing system for a
 language, but the functions will treat each code point as a separate unit.
 
-Regular Expression Functions
+Regular expression functions
 ----------------------------
 
 All :doc:`/functions/regexp` have been rewritten to improve performance.
@@ -24,7 +24,7 @@ orders of magnitude faster (due to removal of quadratic behavior).
 This change introduced some minor incompatibilities that are explained
 in the documentation for the functions.
 
-General Changes
+General changes
 ---------------
 
 * Add support for partitioned right outer joins, which allows for larger tables to
@@ -42,7 +42,7 @@ General Changes
 * Implement implicit coercions in ``VALUES`` expressions.
 * Fix potential deadlock in scheduler.
 
-Hive Changes
+Hive changes
 ------------
 
 * Collect more metrics from ``PrestoS3FileSystem``.

--- a/docs/src/main/sphinx/release/release-0.103.rst
+++ b/docs/src/main/sphinx/release/release-0.103.rst
@@ -2,7 +2,7 @@
 Release 0.103
 =============
 
-Cluster Resource Management
+Cluster resource management
 ---------------------------
 
 There is a new cluster resource manager, which can be enabled via the
@@ -16,7 +16,7 @@ of memory a query may use on any one node. On each worker, the
 ``resources.reserved-system-memory`` flags controls how much memory is reserved
 for internal Presto data structures and temporary allocations.
 
-Task Parallelism
+Task parallelism
 ----------------
 Queries involving a large number of aggregations or a large hash table for a
 join can be slow due to single threaded execution in the intermediate stages.
@@ -35,7 +35,7 @@ This is an experimental feature and will likely change in a future release.  It
 is also expected that this will eventually be handled automatically by the
 query planner and these options will be removed entirely.
 
-Hive Changes
+Hive changes
 ------------
 
 * Removed the ``hive.max-split-iterator-threads`` parameter and renamed
@@ -43,7 +43,7 @@ Hive Changes
 * Fix excessive object creation when querying tables with a large number of partitions.
 * Do not retry requests when an S3 path is not found.
 
-General Changes
+General changes
 ---------------
 
 * Add :func:`array_remove`.

--- a/docs/src/main/sphinx/release/release-0.104.rst
+++ b/docs/src/main/sphinx/release/release-0.104.rst
@@ -2,7 +2,7 @@
 Release 0.104
 =============
 
-General Changes
+General changes
 ---------------
 
 * Handle thread interruption in StatementClient.
@@ -22,7 +22,7 @@ General Changes
 * Support ``TIMESTAMP`` for :func:`first_value`, :func:`last_value`,
   :func:`nth_value`, :func:`lead` and :func:`lag`.
 
-Hive Changes
+Hive changes
 ------------
 
 * Upgrade to Parquet 1.6.0.

--- a/docs/src/main/sphinx/release/release-0.105.rst
+++ b/docs/src/main/sphinx/release/release-0.105.rst
@@ -2,7 +2,7 @@
 Release 0.105
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix issue which can cause queries to be blocked permanently.
@@ -10,7 +10,7 @@ General Changes
 * Add implicit coercions for values of equi-join criteria.
 * Fix detection of window function calls without an ``OVER`` clause.
 
-SPI Changes
+SPI changes
 -----------
 
 * Remove ``ordinalPosition`` from ``ColumnMetadata``.

--- a/docs/src/main/sphinx/release/release-0.106.rst
+++ b/docs/src/main/sphinx/release/release-0.106.rst
@@ -2,7 +2,7 @@
 Release 0.106
 =============
 
-General Changes
+General changes
 ---------------
 
 * Parallelize startup of table scan task splits.

--- a/docs/src/main/sphinx/release/release-0.107.rst
+++ b/docs/src/main/sphinx/release/release-0.107.rst
@@ -2,7 +2,7 @@
 Release 0.107
 =============
 
-General Changes
+General changes
 ---------------
 
 * Added ``query_max_memory`` session property. Note: this session property cannot

--- a/docs/src/main/sphinx/release/release-0.108.rst
+++ b/docs/src/main/sphinx/release/release-0.108.rst
@@ -2,7 +2,7 @@
 Release 0.108
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect query results when a window function follows a :func:`row_number`
@@ -31,7 +31,7 @@ General Changes
 * Fix printing of table layouts in :doc:`/sql/explain`.
 * Add :doc:`/connector/blackhole`.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Randomly select Cassandra node for split generation.

--- a/docs/src/main/sphinx/release/release-0.109.rst
+++ b/docs/src/main/sphinx/release/release-0.109.rst
@@ -2,7 +2,7 @@
 Release 0.109
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add :func:`slice`, :func:`md5`, :func:`array_min` and :func:`array_max` functions.
@@ -16,7 +16,7 @@ General Changes
   be disabled by setting the session property ``redistribute_writes``
   or the config property ``redistribute-writes`` to false.
 
-Remove "Big Query" Support
+Remove "Big Query" support
 --------------------------
 The experimental support for big queries has been removed in favor of
 the new resource manager which can be enabled via the

--- a/docs/src/main/sphinx/release/release-0.110.rst
+++ b/docs/src/main/sphinx/release/release-0.110.rst
@@ -2,7 +2,7 @@
 Release 0.110
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix result truncation bug in window function :func:`row_number` when performing a

--- a/docs/src/main/sphinx/release/release-0.111.rst
+++ b/docs/src/main/sphinx/release/release-0.111.rst
@@ -2,7 +2,7 @@
 Release 0.111
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add :func:`histogram` function.

--- a/docs/src/main/sphinx/release/release-0.112.rst
+++ b/docs/src/main/sphinx/release/release-0.112.rst
@@ -2,14 +2,14 @@
 Release 0.112
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect handling of filters and limits in :func:`row_number` optimizer.
   This caused certain query shapes to produce incorrect results.
 * Fix non-string object arrays in JMX connector.
 
-Hive Changes
+Hive changes
 ------------
 
 * Tables created using :doc:`/sql/create-table` (not :doc:`/sql/create-table-as`)

--- a/docs/src/main/sphinx/release/release-0.113.rst
+++ b/docs/src/main/sphinx/release/release-0.113.rst
@@ -6,7 +6,7 @@ Release 0.113
 
     The ORC reader in the Hive connector is broken in this release.
 
-Cluster Resource Management
+Cluster resource management
 ---------------------------
 
 The cluster resource manager announced in :doc:`/release/release-0.103` is now enabled by default.
@@ -17,7 +17,7 @@ of memory a query may use on any one node. On each worker, the
 ``resources.reserved-system-memory`` config property controls how much memory is reserved
 for internal Presto data structures and temporary allocations.
 
-Session Properties
+Session properties
 ------------------
 
 All session properties now have a SQL type, default value and description.  The
@@ -36,7 +36,7 @@ can be validated and converted to any Java type using
     implementation and callers of ``ConnectorSession.getProperty()`` will now
     need the expected Java type of the property.
 
-General Changes
+General changes
 ---------------
 
 * Allow using any type with value window functions :func:`first_value`,
@@ -48,7 +48,7 @@ General Changes
 * Fix handling of literal ``NULL`` in ``IS DISTINCT FROM``.
 * Fix an issue that caused some specific queries to fail in planning.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix the Hive metadata cache to properly handle negative responses.
@@ -58,7 +58,7 @@ Hive Changes
   Hive but Presto thinks it still exists.
 * Fix metastore socket leak when SOCKS connect fails.
 
-SPI Changes
+SPI changes
 -----------
 
 * Changed the internal representation of structural types.

--- a/docs/src/main/sphinx/release/release-0.114.rst
+++ b/docs/src/main/sphinx/release/release-0.114.rst
@@ -2,13 +2,13 @@
 Release 0.114
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix ``%k`` specifier for :func:`date_format` and :func:`date_parse`.
   It previously used ``24`` rather than ``0`` for the midnight hour.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix ORC reader for Hive connector.

--- a/docs/src/main/sphinx/release/release-0.115.rst
+++ b/docs/src/main/sphinx/release/release-0.115.rst
@@ -2,7 +2,7 @@
 Release 0.115
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix an issue with hierarchical queue rules where queries could be rejected after being accepted.
@@ -10,7 +10,7 @@ General Changes
 * Add :func:`power` as an alias for :func:`pow`.
 * Add support for ``LIMIT ALL`` syntax.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix a race condition which could cause queries to finish without reading all the data.

--- a/docs/src/main/sphinx/release/release-0.116.rst
+++ b/docs/src/main/sphinx/release/release-0.116.rst
@@ -19,7 +19,7 @@ will be different from the semantics in 0.115 and before. When that comes,
 cast between JSON and VARCHAR in old scripts and views will produce unexpected
 result.
 
-Cluster Memory Manager Improvements
+Cluster memory manager improvements
 -----------------------------------
 
 The cluster memory manager now has a low memory killer. If the cluster runs low
@@ -28,7 +28,7 @@ with the ``query.low-memory-killer.enabled`` config flag, and the delay between
 when the cluster runs low on memory and when the killer will be invoked can be
 configured with the ``query.low-memory-killer.delay`` option.
 
-General Changes
+General changes
 ---------------
 
 * Add :func:`multimap_agg` function.

--- a/docs/src/main/sphinx/release/release-0.117.rst
+++ b/docs/src/main/sphinx/release/release-0.117.rst
@@ -2,7 +2,7 @@
 Release 0.117
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add back casts between JSON and VARCHAR to provide an easier migration path

--- a/docs/src/main/sphinx/release/release-0.118.rst
+++ b/docs/src/main/sphinx/release/release-0.118.rst
@@ -2,7 +2,7 @@
 Release 0.118
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix planning error for ``UNION`` queries that require implicit coercions.

--- a/docs/src/main/sphinx/release/release-0.119.rst
+++ b/docs/src/main/sphinx/release/release-0.119.rst
@@ -2,7 +2,7 @@
 Release 0.119
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add :doc:`/connector/redis`.
@@ -25,7 +25,7 @@ General Changes
   the same side.
 * Support ``RENAME COLUMN`` in :doc:`/sql/alter-table`.
 
-SPI Changes
+SPI changes
 -----------
 
 * Add more system table distribution modes.
@@ -37,7 +37,7 @@ SPI Changes
     new APIs.
 
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix handling of full width characters.
@@ -47,19 +47,19 @@ CLI Changes
 * Fix handling of query abortion after result has been partially received.
 * Fix handling of ``ctrl-C`` when displaying results without a pager.
 
-Verifier Changes
+Verifier changes
 ----------------
 
 * Add ``expected-double-precision`` config to specify the expected level of
   precision when comparing double values.
 * Return non-zero exit code when there are failures.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Add support for Cassandra blob types.
 
-Hive Changes
+Hive changes
 ------------
 
 * Support adding and renaming columns using :doc:`/sql/alter-table`.
@@ -67,7 +67,7 @@ Hive Changes
 * Allow configuring multiple Hive metastores for high availability.
 * Add support for ``TIMESTAMP`` and ``VARBINARY`` in Parquet.
 
-MySQL and PostgreSQL Changes
+MySQL and PostgreSQL changes
 ----------------------------
 
 * Enable streaming results instead of buffering everything in memory.

--- a/docs/src/main/sphinx/release/release-0.121.rst
+++ b/docs/src/main/sphinx/release/release-0.121.rst
@@ -2,7 +2,7 @@
 Release 0.121
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix regression that causes task scheduler to not retry requests in some cases.

--- a/docs/src/main/sphinx/release/release-0.122.rst
+++ b/docs/src/main/sphinx/release/release-0.122.rst
@@ -7,7 +7,7 @@ Release 0.122
    There is a bug in this release that will cause queries to fail when the
    ``optimizer.optimize-hash-generation`` config is disabled.
 
-General Changes
+General changes
 ---------------
 
 * The deprecated casts between JSON and VARCHAR will now fail and provide the

--- a/docs/src/main/sphinx/release/release-0.123.rst
+++ b/docs/src/main/sphinx/release/release-0.123.rst
@@ -2,7 +2,7 @@
 Release 0.123
 =============
 
-General Changes
+General changes
 ---------------
 
 * Remove ``node-scheduler.location-aware-scheduling-enabled`` config.
@@ -18,7 +18,7 @@ General Changes
 * Optimize execution of cross join.
 * Run Presto server as ``presto`` user in RPM init scripts.
 
-Table Properties
+Table properties
 ----------------
 
 When creating tables with :doc:`/sql/create-table` or :doc:`/sql/create-table-as`,
@@ -28,7 +28,7 @@ properties, run the following query::
 
     SELECT * FROM system.metadata.table_properties
 
-Hive Changes
+Hive changes
 ------------
 
 We have implemented ``INSERT`` and ``DELETE`` for Hive.  Both ``INSERT`` and ``CREATE``

--- a/docs/src/main/sphinx/release/release-0.124.rst
+++ b/docs/src/main/sphinx/release/release-0.124.rst
@@ -2,7 +2,7 @@
 Release 0.124
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix race in memory tracking of ``JOIN`` which could cause the cluster to become over
@@ -29,7 +29,7 @@ General Changes
   ``optimizer.use-intermediate-aggregations`` config property or
   ``task_intermediate_aggregation`` session property.
 
-Hive Changes
+Hive changes
 ------------
 
 * Do not count expected exceptions as errors in the Hive metastore client stats.

--- a/docs/src/main/sphinx/release/release-0.125.rst
+++ b/docs/src/main/sphinx/release/release-0.125.rst
@@ -2,7 +2,7 @@
 Release 0.125
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix an issue where certain operations such as ``GROUP BY``, ``DISTINCT``, etc. on the

--- a/docs/src/main/sphinx/release/release-0.126.rst
+++ b/docs/src/main/sphinx/release/release-0.126.rst
@@ -2,7 +2,7 @@
 Release 0.126
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add error location information (line and column number) for semantic errors.
@@ -35,7 +35,7 @@ General Changes
 * Fix memory leak in coordinator.
 * Add validation for names of table properties.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix reading structural types containing nulls in Parquet.

--- a/docs/src/main/sphinx/release/release-0.127.rst
+++ b/docs/src/main/sphinx/release/release-0.127.rst
@@ -2,7 +2,7 @@
 Release 0.127
 =============
 
-General Changes
+General changes
 ---------------
 
 * Disable index join repartitioning when it disrupts streaming execution.

--- a/docs/src/main/sphinx/release/release-0.128.rst
+++ b/docs/src/main/sphinx/release/release-0.128.rst
@@ -2,7 +2,7 @@
 Release 0.128
 =============
 
-Graceful Shutdown
+Graceful shutdown
 -----------------
 
 Workers can now be instructed to shutdown. This is done by submiting a ``PUT``
@@ -10,7 +10,7 @@ request to ``/v1/info/state`` with the body ``"SHUTTING_DOWN"``. Once instructed
 to shutdown, the worker will no longer receive new tasks, and will exit once
 all existing tasks have completed.
 
-General Changes
+General changes
 ---------------
 
 * Fix cast from json to structural types when rows or maps have arrays,
@@ -23,7 +23,7 @@ General Changes
   ``GROUP BY``, ``DISTINCT``, etc. When this triggers, the join may fail to
   produce some of the output rows.
 
-MySQL Changes
+MySQL changes
 -------------
 
 * Fix handling of MySQL database names with underscores.

--- a/docs/src/main/sphinx/release/release-0.129.rst
+++ b/docs/src/main/sphinx/release/release-0.129.rst
@@ -8,7 +8,7 @@ Release 0.129
    queries when the length of the keys is between 16 and 31 bytes. This is fixed
    in :doc:`/release/release-0.130`.
 
-General Changes
+General changes
 ---------------
 
 * Fix a planner issue that could cause queries involving ``OUTER JOIN`` to
@@ -28,7 +28,7 @@ General Changes
   structure that trades off accuracy and memory requirements when handling small sets for an
   improvement in performance.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Throw exception when using :doc:`/sql/set-session` or :doc:`/sql/reset-session`
@@ -37,20 +37,20 @@ JDBC Driver Changes
   The ``Statement`` interface supports all variants of the ``execute`` methods.
   It also supports the ``getUpdateCount`` and ``getLargeUpdateCount`` methods.
 
-CLI Changes
+CLI changes
 -----------
 
 * Always clear screen when canceling query with ``ctrl-C``.
 * Make client request timeout configurable.
 
-Network Topology Aware Scheduling
+Network topology aware scheduling
 ---------------------------------
 
 The scheduler can now be configured to take network topology into account when
 scheduling splits. This is set using the ``node-scheduler.network-topology``
 config. See :doc:`/admin/tuning` for more information.
 
-Hive Changes
+Hive changes
 ------------
 
 * The S3 region is no longer automatically configured when running in EC2.

--- a/docs/src/main/sphinx/release/release-0.130.rst
+++ b/docs/src/main/sphinx/release/release-0.130.rst
@@ -2,7 +2,7 @@
 Release 0.130
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix a performance regression in ``GROUP BY`` and ``JOIN`` queries when the

--- a/docs/src/main/sphinx/release/release-0.131.rst
+++ b/docs/src/main/sphinx/release/release-0.131.rst
@@ -2,7 +2,7 @@
 Release 0.131
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix poor performance of transporting dictionary encoded data over the network.

--- a/docs/src/main/sphinx/release/release-0.132.rst
+++ b/docs/src/main/sphinx/release/release-0.132.rst
@@ -7,7 +7,7 @@ Release 0.132
    :func:`concat` on :ref:`array_type`, or enabling ``columnar_processing_dictionary``
    may cause queries to fail in this release. This is fixed in :doc:`/release/release-0.133`.
 
-General Changes
+General changes
 ---------------
 
 * Fix a correctness issue that can occur when any join depends on the output
@@ -31,12 +31,12 @@ General Changes
 * Various performance optimizations for functions operating on :ref:`array_type`.
 * Add server version to web UI.
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix sporadic *"Failed to disable interrupt character"* error after exiting pager.
 
-Hive Changes
+Hive changes
 ------------
 
 * Report metastore and namenode latency in milliseconds rather than seconds in

--- a/docs/src/main/sphinx/release/release-0.133.rst
+++ b/docs/src/main/sphinx/release/release-0.133.rst
@@ -2,7 +2,7 @@
 Release 0.133
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add support for calling connector-defined procedures using :doc:`/sql/call`.

--- a/docs/src/main/sphinx/release/release-0.134.rst
+++ b/docs/src/main/sphinx/release/release-0.134.rst
@@ -2,7 +2,7 @@
 Release 0.134
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add cumulative memory statistics tracking and expose the stat in the web interface.
@@ -11,12 +11,12 @@ General Changes
 * Fix performance regression in creation of ``DictionaryBlock``.
 * Fix rare memory accounting leak in queries with ``JOIN``.
 
-Hive Changes
+Hive changes
 ------------
 
 * The comment for partition keys is now prefixed with *"Partition Key"*.
 
-SPI Changes
+SPI changes
 -----------
 
 * Remove legacy partition API methods and classes.

--- a/docs/src/main/sphinx/release/release-0.135.rst
+++ b/docs/src/main/sphinx/release/release-0.135.rst
@@ -2,7 +2,7 @@
 Release 0.135
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add summary of change in CPU usage to verifier output.

--- a/docs/src/main/sphinx/release/release-0.136.rst
+++ b/docs/src/main/sphinx/release/release-0.136.rst
@@ -2,7 +2,7 @@
 Release 0.136
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add ``control.query-types`` and ``test.query-types`` to verifier, which can

--- a/docs/src/main/sphinx/release/release-0.137.rst
+++ b/docs/src/main/sphinx/release/release-0.137.rst
@@ -2,7 +2,7 @@
 Release 0.137
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix ``current_date`` to return correct results for all time zones.
@@ -19,7 +19,7 @@ General Changes
   percentiles.
 * Add API to JDBC driver to track query progress.
 
-Hive Changes
+Hive changes
 ------------
 
 * Do not allow inserting into tables when the Hive type does not match

--- a/docs/src/main/sphinx/release/release-0.138.rst
+++ b/docs/src/main/sphinx/release/release-0.138.rst
@@ -2,13 +2,13 @@
 Release 0.138
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix planning bug with ``NULL`` literal coercions.
 * Reduce query startup time by reducing lock contention in scheduler.
 
-New Hive Parquet Reader
+New Hive Parquet reader
 -----------------------
 
 We have added a new Parquet reader implementation. The new reader supports vectorized

--- a/docs/src/main/sphinx/release/release-0.139.rst
+++ b/docs/src/main/sphinx/release/release-0.139.rst
@@ -2,7 +2,7 @@
 Release 0.139
 =============
 
-Dynamic Split Concurrency
+Dynamic split concurrency
 -------------------------
 
 The number of running leaf splits per query is now dynamically adjusted to improve
@@ -12,7 +12,7 @@ can be used to change how frequently adjustments happen. The session properties
 ``initial_splits_per_node`` and ``split_concurrency_adjustment_interval`` can
 also be used.
 
-General Changes
+General changes
 ---------------
 
 * Fix planning bug that causes some joins to not be redistributed when
@@ -21,7 +21,7 @@ General Changes
 * Add experimental ``task.join-concurrency`` config which can be used to increase
   concurrency for the probe side of joins.
 
-Hive Changes
+Hive changes
 ------------
 
 * Remove cursor-based readers for ORC and DWRF file formats, as they have been

--- a/docs/src/main/sphinx/release/release-0.140.rst
+++ b/docs/src/main/sphinx/release/release-0.140.rst
@@ -2,7 +2,7 @@
 Release 0.140
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add the ``TRY`` function to handle specific data exceptions. See
@@ -22,14 +22,14 @@ General Changes
   duplicated columns.
 * Optimize ``NOT IN`` queries to produce more compact predicates.
 
-Hive Changes
+Hive changes
 ------------
 
 * Remove bogus "from deserializer" column comments.
 * Change categorization of Hive writer errors to be more specific.
 * Add date and timestamp support to new Parquet Reader
 
-SPI Changes
+SPI changes
 -----------
 
 * Remove partition key from ``ColumnMetadata``.

--- a/docs/src/main/sphinx/release/release-0.141.rst
+++ b/docs/src/main/sphinx/release/release-0.141.rst
@@ -2,7 +2,7 @@
 Release 0.141
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix server returning an HTTP 500 response for queries with parse errors.

--- a/docs/src/main/sphinx/release/release-0.142.rst
+++ b/docs/src/main/sphinx/release/release-0.142.rst
@@ -2,7 +2,7 @@
 Release 0.142
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix planning bug for ``JOIN`` criteria that optimizes to a ``FALSE`` expression.
@@ -20,7 +20,7 @@ General Changes
 * Add support for non-correlated subqueries in aggregation queries.
 * Improve performance of :func:`json_extract`.
 
-Hive Changes
+Hive changes
 ------------
 
 * Change ORC input format to report actual bytes read as opposed to estimated bytes.

--- a/docs/src/main/sphinx/release/release-0.143.rst
+++ b/docs/src/main/sphinx/release/release-0.143.rst
@@ -2,7 +2,7 @@
 Release 0.143
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix race condition in output buffer that can cause a page to be lost.
@@ -19,7 +19,7 @@ General Changes
 * Improve query startup time in large clusters.
 * Improve error messages for ``CAST`` and :func:`slice`.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix native memory leak when reading or writing gzip compressed data.

--- a/docs/src/main/sphinx/release/release-0.144.1.rst
+++ b/docs/src/main/sphinx/release/release-0.144.1.rst
@@ -2,7 +2,7 @@
 Release 0.144.1
 ===============
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix bug when grouping on a bucketed column which causes incorrect results.

--- a/docs/src/main/sphinx/release/release-0.144.2.rst
+++ b/docs/src/main/sphinx/release/release-0.144.2.rst
@@ -2,7 +2,7 @@
 Release 0.144.2
 ===============
 
-General Changes
+General changes
 ---------------
 
 * Fix potential memory leak in coordinator query history.

--- a/docs/src/main/sphinx/release/release-0.144.3.rst
+++ b/docs/src/main/sphinx/release/release-0.144.3.rst
@@ -2,7 +2,7 @@
 Release 0.144.3
 ===============
 
-General Changes
+General changes
 ---------------
 
 * Fix bugs in planner where coercions were not taken into account when computing
@@ -12,7 +12,7 @@ General Changes
 * Fix race condition that can cause queries that process data from non-columnar data
   sources to fail.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix reading symlinks when the target is in a different HDFS instance.

--- a/docs/src/main/sphinx/release/release-0.144.4.rst
+++ b/docs/src/main/sphinx/release/release-0.144.4.rst
@@ -2,7 +2,7 @@
 Release 0.144.4
 ===============
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect results for grouping sets for some queries with filters.

--- a/docs/src/main/sphinx/release/release-0.144.5.rst
+++ b/docs/src/main/sphinx/release/release-0.144.5.rst
@@ -2,7 +2,7 @@
 Release 0.144.5
 ===============
 
-General Changes
+General changes
 ---------------
 
 * Fix window functions to correctly handle empty frames between unbounded and

--- a/docs/src/main/sphinx/release/release-0.144.6.rst
+++ b/docs/src/main/sphinx/release/release-0.144.6.rst
@@ -2,7 +2,7 @@
 Release 0.144.6
 ===============
 
-General Changes
+General changes
 ---------------
 
 This release fixes several problems with large and negative intervals.

--- a/docs/src/main/sphinx/release/release-0.144.7.rst
+++ b/docs/src/main/sphinx/release/release-0.144.7.rst
@@ -2,7 +2,7 @@
 Release 0.144.7
 ===============
 
-General Changes
+General changes
 ---------------
 
 * Fail queries with non-equi conjuncts in ``OUTER JOIN``\s, instead of silently

--- a/docs/src/main/sphinx/release/release-0.144.rst
+++ b/docs/src/main/sphinx/release/release-0.144.rst
@@ -7,7 +7,7 @@ Release 0.144
    Querying bucketed tables in the Hive connector may produce incorrect results.
    This is fixed in :doc:`/release/release-0.144.1`, and :doc:`/release/release-0.145`.
 
-General Changes
+General changes
 ---------------
 
 * Fix already exists check when adding a column to be case-insensitive.
@@ -24,7 +24,7 @@ General Changes
 * Improve performance when processing results in CLI and JDBC driver.
 * Improve performance of ``GROUP BY`` queries.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix ORC reader to actually use ``hive.orc.stream-buffer-size`` configuration property.

--- a/docs/src/main/sphinx/release/release-0.145.rst
+++ b/docs/src/main/sphinx/release/release-0.145.rst
@@ -2,7 +2,7 @@
 Release 0.145
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix potential memory leak in coordinator query history.
@@ -22,20 +22,20 @@ General Changes
 * Improve reliability in highly congested networks by adjusting the default
   connection idle timeouts.
 
-Verifier Changes
+Verifier changes
 ----------------
 
 * Change verifier to only run read-only queries by default. This behavior can be
   changed with the ``control.query-types`` and ``test.query-types`` config flags.
 
-CLI Changes
+CLI changes
 -----------
 
 * Improve performance of output in batch mode.
 * Fix hex rendering in batch mode.
 * Abort running queries when CLI is terminated.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix bug when grouping on a bucketed column which causes incorrect results.

--- a/docs/src/main/sphinx/release/release-0.146.rst
+++ b/docs/src/main/sphinx/release/release-0.146.rst
@@ -2,7 +2,7 @@
 Release 0.146
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix error in :func:`map_concat` when the second map is empty.
@@ -10,7 +10,7 @@ General Changes
 * Support casting between map types.
 * Add :doc:`/connector/mongodb`.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix incorrect skipping of data in Parquet during predicate push-down.
@@ -22,12 +22,12 @@ Hive Changes
   security system. Specifically, the ``sql-standard`` authorization system
   does not enforce these settings.
 
-Black Hole Changes
+Black Hole changes
 ------------------
 
 * Add support for ``varchar(n)``.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Add support for Cassandra 3.0.

--- a/docs/src/main/sphinx/release/release-0.147.rst
+++ b/docs/src/main/sphinx/release/release-0.147.rst
@@ -2,7 +2,7 @@
 Release 0.147
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix race condition that can cause queries that process data from non-columnar
@@ -32,7 +32,7 @@ General Changes
   property replaces the ``task_join_concurrency``, ``task_hash_build_concurrency``, and
   ``task_aggregation_concurrency`` properties.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix reading symlinks when the target is in a different HDFS instance.
@@ -45,18 +45,18 @@ Hive Changes
 * Rename table property ``clustered_by`` to ``bucketed_by``.
 * Add support for ``varchar(n)``.
 
-Kafka Changes
+Kafka changes
 -------------
 
 * Fix ``error code 6`` when reading data from Kafka.
 * Add support for ``varchar(n)``.
 
-Redis Changes
+Redis changes
 -------------
 
 * Add support for ``varchar(n)``.
 
-MySQL and PostgreSQL Changes
+MySQL and PostgreSQL changes
 ----------------------------
 
 * Cleanup temporary data when a ``CREATE TABLE AS`` fails.

--- a/docs/src/main/sphinx/release/release-0.148.rst
+++ b/docs/src/main/sphinx/release/release-0.148.rst
@@ -2,7 +2,7 @@
 Release 0.148
 =============
 
-General Changes
+General changes
 ---------------
 * Fix issue where auto-commit transaction can be rolled back for a successfully
   completed query.
@@ -35,7 +35,7 @@ General Changes
 * Warn if Presto server is not using G1 garbage collector.
 * Move interval types out of SPI.
 
-Interval Fixes
+Interval fixes
 --------------
 
 This release fixes several problems with large and negative intervals.
@@ -59,7 +59,7 @@ This release fixes several problems with large and negative intervals.
     intervals from new servers. Make sure to update the JDBC driver
     along with the server.
 
-Functions and Language Features
+Functions and language features
 -------------------------------
 
 * Add :func:`element_at` function for map type.
@@ -71,14 +71,14 @@ Functions and Language Features
 * Add support for ``SMALLINT`` and ``TINYINT`` types.
 * Add support for non-equi outer joins.
 
-Verifier Changes
+Verifier changes
 ----------------
 
 * Add ``skip-cpu-check-regex`` config property which can be used to skip the CPU
   time comparison for queries that match the given regex.
 * Add ``check-cpu`` config property which can be used to disable CPU time comparison.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix ``NoClassDefFoundError`` for ``KMSClientProvider`` in HDFS client.
@@ -90,28 +90,28 @@ Hive Changes
 * Push down filters for columns of type ``DECIMAL``.
 * Improve CPU efficiency when reading ORC files.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Allow configuring load balancing policy and no host available retry.
 * Add support for ``varchar(n)``.
 
-Kafka Changes
+Kafka changes
 -------------
 
 * Update to Kafka client 0.8.2.2. This enables support for LZ4 data.
 
-JMX Changes
+JMX changes
 -----------
 
 * Add ``jmx.history`` schema with in-memory periodic samples of values from JMX MBeans.
 
-MySQL and PostgreSQL Changes
+MySQL and PostgreSQL changes
 ----------------------------
 
 * Push down predicates for ``VARCHAR``, ``DATE``, ``TIME`` and ``TIMESTAMP`` types.
 
-Other Connector Changes
+Other connector changes
 -----------------------
 
 * Add support for ``varchar(n)`` to the Redis, TPCH, MongoDB, Local File

--- a/docs/src/main/sphinx/release/release-0.149.rst
+++ b/docs/src/main/sphinx/release/release-0.149.rst
@@ -2,7 +2,7 @@
 Release 0.149
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix runtime failure for queries that use grouping sets over unions.
@@ -32,7 +32,7 @@ General Changes
 * Improve performance of subscript operator for the ``MAP`` type.
 * Improve performance of ``JOIN`` and ``GROUP BY`` queries.
 
-Hive Changes
+Hive changes
 ------------
 
 * Clean up empty staging directories after inserts.

--- a/docs/src/main/sphinx/release/release-0.150.rst
+++ b/docs/src/main/sphinx/release/release-0.150.rst
@@ -8,7 +8,7 @@ Release 0.150
     disable them by adding ``hive.bucket-execution=false`` to your
     Hive catalog properties.
 
-General Changes
+General changes
 ---------------
 
 * Fix web UI bug that caused rendering to fail when a stage has no tasks.
@@ -17,7 +17,7 @@ General Changes
 * Add support for parsing timestamps with nanosecond precision in :func:`date_parse`.
 * Add CPU quotas to resource groups.
 
-Hive Changes
+Hive changes
 ------------
 
 * Add support for writing to bucketed tables.

--- a/docs/src/main/sphinx/release/release-0.151.rst
+++ b/docs/src/main/sphinx/release/release-0.151.rst
@@ -2,7 +2,7 @@
 Release 0.151
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix issue where aggregations may produce the wrong result when ``task.concurrency`` is set to ``1``.
@@ -16,13 +16,13 @@ General Changes
 * Add :func:`cosine_similarity` function.
 * Allow Tableau web connector to use catalogs other than ``hive``.
 
-Verifier Changes
+Verifier changes
 ----------------
 
 * Add ``shadow-writes.enabled`` option which can be used to transform ``CREATE TABLE AS SELECT``
   queries to write to a temporary table (rather than the originally specified table).
 
-SPI Changes
+SPI changes
 -----------
 
 * Remove ``getDataSourceName`` from ``ConnectorSplitSource``.

--- a/docs/src/main/sphinx/release/release-0.152.1.rst
+++ b/docs/src/main/sphinx/release/release-0.152.1.rst
@@ -2,7 +2,7 @@
 Release 0.152.1
 ===============
 
-General Changes
+General changes
 ---------------
 
 * Fix race which could cause failed queries to have no error details.

--- a/docs/src/main/sphinx/release/release-0.152.2.rst
+++ b/docs/src/main/sphinx/release/release-0.152.2.rst
@@ -2,7 +2,7 @@
 Release 0.152.2
 ===============
 
-Hive Changes
+Hive changes
 ------------
 
 * Improve performance of ORC reader when decoding dictionary encoded :ref:`map_type`.

--- a/docs/src/main/sphinx/release/release-0.152.3.rst
+++ b/docs/src/main/sphinx/release/release-0.152.3.rst
@@ -2,7 +2,7 @@
 Release 0.152.3
 ===============
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect results for grouping sets when ``task.concurrency`` is greater than one.

--- a/docs/src/main/sphinx/release/release-0.152.rst
+++ b/docs/src/main/sphinx/release/release-0.152.rst
@@ -2,7 +2,7 @@
 Release 0.152
 =============
 
-General Changes
+General changes
 ---------------
 
 * Add :func:`array_union` function.
@@ -19,13 +19,13 @@ General Changes
 * Rename ``FLOAT`` type to ``REAL`` for better compatibility with the SQL standard.
 * Fix potential performance regression when transporting rows between nodes.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Fix sizes returned from ``DatabaseMetaData.getColumns()`` for
   ``COLUMN_SIZE``, ``DECIMAL_DIGITS``, ``NUM_PREC_RADIX`` and ``CHAR_OCTET_LENGTH``.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix resource leak in Parquet reader.
@@ -36,7 +36,7 @@ Hive Changes
 * Add support for custom S3 credentials providers using the
   ``presto.s3.credentials-provider`` Hadoop configuration property.
 
-MySQL Changes
+MySQL changes
 -------------
 
 * Fix reading MySQL ``tinyint(1)`` columns. Previously, these columns were
@@ -44,13 +44,13 @@ MySQL Changes
 * Add support for ``INSERT``.
 * Add support for reading data as ``tinyint`` and ``smallint`` types rather than ``integer``.
 
-PostgreSQL Changes
+PostgreSQL changes
 ------------------
 
 * Add support for ``INSERT``.
 * Add support for reading data as ``tinyint`` and ``smallint`` types rather than ``integer``.
 
-SPI Changes
+SPI changes
 -----------
 
 * Remove ``owner`` from ``ConnectorTableMetadata``.
@@ -72,12 +72,12 @@ SPI Changes
     If you have written a plugin, you will need to update your code
     before deploying this release.
 
-Verifier Changes
+Verifier changes
 ----------------
 
 * Fix handling of shadow write queries with a ``LIMIT``.
 
-Local File Changes
+Local file changes
 ------------------
 
 * Fix file descriptor leak.

--- a/docs/src/main/sphinx/release/release-0.153.rst
+++ b/docs/src/main/sphinx/release/release-0.153.rst
@@ -2,7 +2,7 @@
 Release 0.153
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect results for grouping sets when ``task.concurrency`` is greater than one.
@@ -36,7 +36,7 @@ General Changes
 * Allow running Presto with early-access Java versions.
 * Add :doc:`/connector/accumulo`.
 
-Functions and Language Features
+Functions and language features
 -------------------------------
 
 * Allow subqueries in non-equality outer join criteria.
@@ -50,7 +50,7 @@ Functions and Language Features
   :func:`truncate`, :func:`abs`, :func:`mod` and :func:`sign`.
 * Add :func:`shuffle` function for arrays.
 
-Pluggable Resource Groups
+Pluggable resource groups
 -------------------------
 
 Resource group management is now pluggable. A ``Plugin`` can
@@ -60,7 +60,7 @@ configuration file by setting the ``resource-groups.configuration-manager``
 property. See the ``presto-resource-group-managers`` plugin for an example
 and :doc:`/admin/resource-groups` for more details.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix rendering failures due to null nested data structures.
@@ -70,17 +70,17 @@ Web UI Changes
 * Add option to filter task lists by status on query details page.
 * Add copy button for query text, query ID, and user to query details page.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Add support for ``real`` data type, which corresponds to the Java ``float`` type.
 
-CLI Changes
+CLI changes
 -----------
 
 * Add support for configuring the HTTPS Truststore.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix permissions for new tables when using SQL-standard authorization.
@@ -117,30 +117,30 @@ Hive Changes
 * Allow configuring a custom S3 encryption materials provider using the
   ``hive.s3.encryption-materials-provider`` configuration property.
 
-JMX Changes
+JMX changes
 -----------
 
 * Make name configuration for history tables case-insensitive.
 
-MySQL Changes
+MySQL changes
 -------------
 
 * Optimize fetching column names when describing a single table.
 * Add support for ``char(x)`` and ``real`` data types.
 
-PostgreSQL Changes
+PostgreSQL changes
 ------------------
 
 * Optimize fetching column names when describing a single table.
 * Add support for ``char(x)`` and ``real`` data types.
 * Add support for querying materialized views.
 
-Blackhole Changes
+Blackhole changes
 -----------------
 
 * Add ``page_processing_delay`` table property.
 
-SPI Changes
+SPI changes
 -----------
 
 * Add ``schemaExists()`` method to ``ConnectorMetadata``.

--- a/docs/src/main/sphinx/release/release-0.154.rst
+++ b/docs/src/main/sphinx/release/release-0.154.rst
@@ -2,7 +2,7 @@
 Release 0.154
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix planning issue that could cause ``JOIN`` queries involving functions
@@ -22,7 +22,7 @@ General Changes
 * Add support for ``DESCRIBE INPUT`` to describe the requirements for
   the input parameters to a prepared statement.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix handling of metastore cache TTL. With the introduction of the

--- a/docs/src/main/sphinx/release/release-0.155.rst
+++ b/docs/src/main/sphinx/release/release-0.155.rst
@@ -2,7 +2,7 @@
 Release 0.155
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect results when queries contain multiple grouping sets that
@@ -20,7 +20,7 @@ General Changes
 * Properly account for time spent creating page source.
 * Various optimizations to reduce coordinator CPU usage.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix schema evolution support in new Parquet reader.
@@ -28,7 +28,7 @@ Hive Changes
 * Add support for Avro file format.
 * Always produce dictionary blocks for DWRF dictionary encoded streams.
 
-SPI Changes
+SPI changes
 -----------
 
 * Remove legacy connector API.

--- a/docs/src/main/sphinx/release/release-0.156.rst
+++ b/docs/src/main/sphinx/release/release-0.156.rst
@@ -8,7 +8,7 @@ Release 0.156
     if the ``optimize_mixed_distinct_aggregations`` session property or
     the ``optimizer.optimize-mixed-distinct-aggregations`` config option is enabled.
 
-General Changes
+General changes
 ---------------
 
 * Fix potential correctness issue in queries that contain correlated scalar aggregation subqueries.
@@ -24,17 +24,17 @@ General Changes
   via the ``optimize_mixed_distinct_aggregations`` session property.
 * Change default task concurrency to 16.
 
-Hive Changes
+Hive changes
 ------------
 
 * Add support for legacy RCFile header version in new RCFile reader.
 
-Redis Changes
+Redis changes
 -------------
 
 * Support ``iso8601`` data format for the ``hash`` row decoder.
 
-SPI Changes
+SPI changes
 -----------
 
 * Make ``ConnectorPageSink#finish()`` asynchronous.

--- a/docs/src/main/sphinx/release/release-0.157.1.rst
+++ b/docs/src/main/sphinx/release/release-0.157.1.rst
@@ -2,7 +2,7 @@
 Release 0.157.1
 ===============
 
-General Changes
+General changes
 ---------------
 
 * Fix regression that could cause high CPU and heap usage on coordinator,

--- a/docs/src/main/sphinx/release/release-0.157.rst
+++ b/docs/src/main/sphinx/release/release-0.157.rst
@@ -2,7 +2,7 @@
 Release 0.157
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix regression that could cause queries containing scalar subqueries to fail
@@ -18,7 +18,7 @@ General Changes
   ``node-scheduler.max-pending-splits-per-task``. The old name may still be used, but is
   deprecated and will be removed in a future version.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fail attempts to create tables that are bucketed on non-existent columns.

--- a/docs/src/main/sphinx/release/release-0.158.rst
+++ b/docs/src/main/sphinx/release/release-0.158.rst
@@ -2,7 +2,7 @@
 Release 0.158
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix regression that could cause high CPU and heap usage on coordinator
@@ -21,7 +21,7 @@ General Changes
   the ``experimental.spill-enabled`` configuration flag.
 * Push down predicates for ``DECIMAL``, ``TINYINT``, ``SMALLINT`` and ``REAL`` data types.
 
-Hive Changes
+Hive changes
 ------------
 
 * Add hidden ``$bucket`` column for bucketed tables that
@@ -30,7 +30,7 @@ Hive Changes
 * Add configurable size limit to Hive metastore cache to avoid using too much
   coordinator memory.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Allow starting the server even if a contact point hostname cannot be resolved.

--- a/docs/src/main/sphinx/release/release-0.159.rst
+++ b/docs/src/main/sphinx/release/release-0.159.rst
@@ -2,12 +2,12 @@
 Release 0.159
 =============
 
-General Changes
+General changes
 ---------------
 
 * Improve predicate performance for ``JOIN`` queries.
 
-Hive Changes
+Hive changes
 ------------
 
 * Optimize filtering of partition names to reduce object creation.

--- a/docs/src/main/sphinx/release/release-0.160.rst
+++ b/docs/src/main/sphinx/release/release-0.160.rst
@@ -2,7 +2,7 @@
 Release 0.160
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix planning failure when query has multiple unions with identical underlying columns.
@@ -11,7 +11,7 @@ General Changes
   comes back before coordinator times out the query.
 * Add :doc:`/functions/lambda`.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix planning failure when inserting into columns of struct types with uppercase field names.

--- a/docs/src/main/sphinx/release/release-0.161.rst
+++ b/docs/src/main/sphinx/release/release-0.161.rst
@@ -2,7 +2,7 @@
 Release 0.161
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix correctness issue for queries involving multiple nested EXCEPT clauses.
@@ -25,13 +25,13 @@ General Changes
   to show extra information from connectors.
 * Add :func:`map` to construct an empty :ref:`map_type`.
 
-Hive Connector
+Hive connector
 --------------
 
 * Remove ``"Partition Key: "`` prefix from column comments and
   replace it with the new extra information field described above.
 
-JMX Connector
+JMX connector
 -------------
 
 * Add support for escaped commas in ``jmx.dump-tables`` config property.

--- a/docs/src/main/sphinx/release/release-0.162.rst
+++ b/docs/src/main/sphinx/release/release-0.162.rst
@@ -7,7 +7,7 @@ Release 0.162
     The :func:`xxhash64` function introduced in this release will return a
     varbinary instead of a bigint in the next release.
 
-General Changes
+General changes
 ---------------
 
 * Fix correctness issue when the type of the value in the ``IN`` predicate does
@@ -26,12 +26,12 @@ General Changes
 * Add aggregated operator statistics to final query statistics.
 * Allow specifying column comments for :doc:`/sql/create-table`.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix performance regression when querying Hive tables with large numbers of partitions.
 
-SPI Changes
+SPI changes
 -----------
 
 * Connectors can now return optional output metadata for write operations.

--- a/docs/src/main/sphinx/release/release-0.163.rst
+++ b/docs/src/main/sphinx/release/release-0.163.rst
@@ -2,7 +2,7 @@
 Release 0.163
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix data corruption when transporting dictionary-encoded data.
@@ -20,22 +20,22 @@ General Changes
 * Improve tolerance to communication errors for long running queries. This can be adjusted
   with the ``query.remote-task.max-error-duration`` config option.
 
-Accumulo Changes
+Accumulo changes
 ----------------
 
 * Fix issue that could cause incorrect results for large rows.
 
-MongoDB Changes
+MongoDB changes
 ---------------
 
 * Fix NullPointerException when a field contains a null.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Add support for ``VARBINARY``, ``TIMESTAMP`` and ``REAL`` data types.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix issue that would prevent predicates from being pushed into Parquet reader.

--- a/docs/src/main/sphinx/release/release-0.164.rst
+++ b/docs/src/main/sphinx/release/release-0.164.rst
@@ -2,7 +2,7 @@
 Release 0.164
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix correctness issue for queries that perform ``DISTINCT`` and ``LIMIT`` on the results of a ``JOIN``.
@@ -19,12 +19,12 @@ General Changes
 * Improve client error message for invalid session.
 * Add ``VALIDATE`` mode for :doc:`/sql/explain`.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Add resource group to query detail page.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix handling of ORC files containing extremely large metadata.

--- a/docs/src/main/sphinx/release/release-0.165.rst
+++ b/docs/src/main/sphinx/release/release-0.165.rst
@@ -2,7 +2,7 @@
 Release 0.165
 =============
 
-General Changes
+General changes
 ---------------
 
 * Make ``AT`` a non-reserved keyword.
@@ -12,12 +12,12 @@ General Changes
   config option.
 * Add input and hash collision statistics to :doc:`/sql/explain-analyze` output.
 
-Hive Changes
+Hive changes
 ------------
 
 * Add support for MAP and ARRAY types in optimized Parquet reader.
 
-MySQL and PostgreSQL Changes
+MySQL and PostgreSQL changes
 ----------------------------
 
 * Fix connection leak on workers.

--- a/docs/src/main/sphinx/release/release-0.166.rst
+++ b/docs/src/main/sphinx/release/release-0.166.rst
@@ -2,7 +2,7 @@
 Release 0.166
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix failure due to implicit coercion issue in ``IN`` expressions for
@@ -11,18 +11,18 @@ General Changes
   The default maximum length is 1MB.
 * Improve performance of :func:`approx_percentile`.
 
-Hive Changes
+Hive changes
 ------------
 
 * Include original exception from metastore for ``AlreadyExistsException`` when adding partitions.
 * Add support for the Hive JSON file format (``org.apache.hive.hcatalog.data.JsonSerDe``).
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Add configuration properties for speculative execution.
 
-SPI Changes
+SPI changes
 -----------
 
 * Add peak memory reservation to ``SplitStatistics`` in split completion events.

--- a/docs/src/main/sphinx/release/release-0.167.rst
+++ b/docs/src/main/sphinx/release/release-0.167.rst
@@ -2,7 +2,7 @@
 Release 0.167
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix planning failure when a window function depends on the output of another window function.
@@ -21,7 +21,7 @@ General Changes
 * Add JMX stats for compiler caches.
 * Raise required Java version to 8u92.
 
-Security Changes
+Security changes
 ----------------
 
 * The ``http.server.authentication.enabled`` config option that previously enabled
@@ -31,19 +31,19 @@ Security Changes
 * Allow access controls to filter the results of listing catalogs, schemas and tables.
 * Add access control checks for :doc:`/sql/show-schemas` and :doc:`/sql/show-tables`.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Add operator-level performance analysis.
 * Improve visibility of blocked and reserved query states.
 * Lots of minor improvements.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Allow escaping in ``DatabaseMetaData`` patterns.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix write operations for ``ViewFileSystem`` by using a relative location.
@@ -53,7 +53,7 @@ Hive Changes
 * Remove support for the legacy S3 block-based file system.
 * Add support for KMS-managed keys for S3 server-side encryption.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Add support for Cassandra 3.x by removing the deprecated Thrift interface used to
@@ -61,7 +61,7 @@ Cassandra Changes
   ``cassandra.thrift-port``, ``cassandra.thrift-connection-factory-class``,
   ``cassandra.transport-factory-options`` and ``cassandra.partitioner``.
 
-SPI Changes
+SPI changes
 -----------
 
 * Add methods to ``SystemAccessControl`` and ``ConnectorAccessControl`` to

--- a/docs/src/main/sphinx/release/release-0.168.rst
+++ b/docs/src/main/sphinx/release/release-0.168.rst
@@ -2,7 +2,7 @@
 Release 0.168
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix correctness issues for certain ``JOIN`` queries that require implicit coercions
@@ -26,14 +26,14 @@ General Changes
   This allows using them in comparison expressions, ``ORDER BY`` and
   functions that require orderable types (e.g., :func:`max`).
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Update ``DatabaseMetaData`` to reflect features that are now supported.
 * Update advertised JDBC version to 4.2, which part of Java 8.
 * Return correct driver and server versions rather than ``1.0``.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix reading decimals for RCFile text format using non-optimized reader.
@@ -44,17 +44,17 @@ Hive Changes
   ``rcfile_optimized_writer_enabled`` session property or the ``hive.rcfile-optimized-writer.enabled``
   Hive catalog property.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Add predicate pushdown for clustering key.
 
-MongoDB Changes
+MongoDB changes
 ---------------
 
 * Allow SSL connections using the ``mongodb.ssl.enabled`` config flag.
 
-SPI Changes
+SPI changes
 -----------
 
 * ConnectorIndex now returns ``ConnectorPageSource`` instead of ``RecordSet``.  Existing connectors

--- a/docs/src/main/sphinx/release/release-0.169.rst
+++ b/docs/src/main/sphinx/release/release-0.169.rst
@@ -2,7 +2,7 @@
 Release 0.169
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix regression that could cause queries involving ``JOIN`` and certain language features
@@ -11,17 +11,17 @@ General Changes
 * Improve performance of :func:`map_agg` and :func:`multimap_agg`.
 * Improve memory accounting when grouping on a single ``BIGINT`` column.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Return correct class name for ``ARRAY`` type from ``ResultSetMetaData.getColumnClassName()``.
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix support for non-standard offset time zones (e.g., ``GMT+01:00``).
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Add custom error codes.

--- a/docs/src/main/sphinx/release/release-0.170.rst
+++ b/docs/src/main/sphinx/release/release-0.170.rst
@@ -2,7 +2,7 @@
 Release 0.170
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix race condition that could cause queries to fail with ``InterruptedException`` in rare cases.
@@ -10,24 +10,24 @@ General Changes
 * Fix a performance regression that occurs when a significant number of exchange
   sources produce no data during an exchange (e.g., in a skewed hash join).
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix broken rendering when catalog properties are set.
 * Fix rendering of live plan when query is queued.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Add support for ``DatabaseMetaData.getTypeInfo()``.
 
-Hive Changes
+Hive changes
 ------------
 
 * Improve decimal support for the Parquet reader.
 * Remove misleading "HDFS" string from error messages.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Fix an intermittent connection issue for Cassandra 2.1.
@@ -40,7 +40,7 @@ Cassandra Changes
   ``cassandra.no-host-available-retry-timeout`` config option, which has a default value of ``1m``.
   The ``cassandra.no-host-available-retry-count`` config option is no longer supported.
 
-Verifier Changes
+Verifier changes
 ----------------
 
 * Add support for ``INSERT`` queries.

--- a/docs/src/main/sphinx/release/release-0.171.rst
+++ b/docs/src/main/sphinx/release/release-0.171.rst
@@ -2,7 +2,7 @@
 Release 0.171
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix planning regression for queries that compute a mix of distinct and non-distinct aggregations.
@@ -16,12 +16,12 @@ General Changes
 * Improve validation of resource group configuration.
 * Fail queries when casting unsupported types to JSON; see :doc:`/functions/json` for supported types.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix the threads UI (``/ui/thread``).
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix issue where some files are not deleted on cancellation of ``INSERT`` or ``CREATE`` queries.

--- a/docs/src/main/sphinx/release/release-0.172.rst
+++ b/docs/src/main/sphinx/release/release-0.172.rst
@@ -2,7 +2,7 @@
 Release 0.172
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix correctness issue in ``ORDER BY`` queries due to improper implicit coercions.

--- a/docs/src/main/sphinx/release/release-0.173.rst
+++ b/docs/src/main/sphinx/release/release-0.173.rst
@@ -2,7 +2,7 @@
 Release 0.173
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix issue where ``FILTER`` was ignored for :func:`count` with a constant argument.

--- a/docs/src/main/sphinx/release/release-0.174.rst
+++ b/docs/src/main/sphinx/release/release-0.174.rst
@@ -2,7 +2,7 @@
 Release 0.174
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix correctness issue for correlated subqueries containing a ``LIMIT`` clause.
@@ -24,7 +24,7 @@ General Changes
 * Add support for escaped unicode sequences in string literals.
 * Add :doc:`/sql/show-grants` and ``information_schema.table_privileges`` table.
 
-Hive Changes
+Hive changes
 ------------
 
 * Change default value of ``hive.metastore-cache-ttl`` and ``hive.metastore-refresh-interval`` to 0

--- a/docs/src/main/sphinx/release/release-0.175.rst
+++ b/docs/src/main/sphinx/release/release-0.175.rst
@@ -2,7 +2,7 @@
 Release 0.175
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix *"position is not valid"* query execution failures.
@@ -24,13 +24,13 @@ General Changes
 * Add support for ``INT`` as an alias for the ``INTEGER`` data type.
 * Add resource group information to query events.
 
-Hive Changes
+Hive changes
 ------------
 
 * Make table creation metastore operations idempotent, which allows
   recovery when retrying timeouts or other errors.
 
-MongoDB Changes
+MongoDB changes
 ---------------
 
 * Rename ``mongodb.connection-per-host`` config option to ``mongodb.connections-per-host``.

--- a/docs/src/main/sphinx/release/release-0.176.rst
+++ b/docs/src/main/sphinx/release/release-0.176.rst
@@ -2,7 +2,7 @@
 Release 0.176
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix an issue where a query (and some of its tasks) continues to
@@ -13,17 +13,17 @@ General Changes
 * Add support for casting from ``JSON`` to ``REAL`` type.
 * Add :func:`parse_duration` function.
 
-MySQL Changes
+MySQL changes
 -------------
 
 * Disallow having a database in the ``connection-url`` config property.
 
-Accumulo Changes
+Accumulo changes
 ----------------
 
 * Decrease planning time by fetching index metrics in parallel.
 
-MongoDB Changes
+MongoDB changes
 ---------------
 
 * Allow predicate pushdown for ObjectID.

--- a/docs/src/main/sphinx/release/release-0.177.rst
+++ b/docs/src/main/sphinx/release/release-0.177.rst
@@ -9,7 +9,7 @@ Release 0.177
     the ``optimizer.optimize-mixed-distinct-aggregations`` config option is enabled.
     This optimization was introduced in Presto version 0.156.
 
-General Changes
+General changes
 ---------------
 
 * Fix correctness issue when performing range comparisons over columns of type ``CHAR``.
@@ -39,7 +39,7 @@ General Changes
 * Improve error message when a lambda expression has a different number of arguments than expected.
 * Improve error message when certain invalid ``GROUP BY`` expressions containing lambda expressions.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix handling of trailing spaces for the ``CHAR`` type when reading RCFile.
@@ -48,7 +48,7 @@ Hive Changes
   can be turned on via the ``statistics_enabled`` session property.
 * Ensure file name is always present for error messages about corrupt ORC files.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Remove caching of metadata in the Cassandra connector. Metadata caching makes Presto violate
@@ -58,7 +58,7 @@ Cassandra Changes
   been removed.
 * Fix intermittent issue in the connection retry mechanism.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Change cluster HUD realtime statistics to be aggregated across all running queries.
@@ -69,7 +69,7 @@ Web UI Changes
 * Change query details page refresh interval to three seconds.
 * Add uptime and connected status indicators to every page.
 
-CLI Changes
+CLI changes
 -----------
 
 * Add support for preprocessing commands.  When the ``PRESTO_PREPROCESSOR`` environment

--- a/docs/src/main/sphinx/release/release-0.178.rst
+++ b/docs/src/main/sphinx/release/release-0.178.rst
@@ -2,7 +2,7 @@
 Release 0.178
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix various memory accounting bugs, which reduces the likelihood of full GCs/OOMs.
@@ -13,18 +13,18 @@ General Changes
 * Add support for correlated subqueries in ``IN`` predicates.
 * Add :func:`to_ieee754_32` and :func:`to_ieee754_64` functions.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix high CPU usage due to schema caching when reading Avro files.
 * Preserve decompression error causes when decoding ORC files.
 
-Memory Connector Changes
+Memory connector changes
 ------------------------
 
 * Fix a bug that prevented creating empty tables.
 
-SPI Changes
+SPI changes
 -----------
 
 * Make environment available to resource group configuration managers.

--- a/docs/src/main/sphinx/release/release-0.179.rst
+++ b/docs/src/main/sphinx/release/release-0.179.rst
@@ -2,7 +2,7 @@
 Release 0.179
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix issue which could cause incorrect results when processing dictionary encoded data.
@@ -24,17 +24,17 @@ General Changes
   for more details.
 * Add support for configuring query runtime and queueing time limits to resource groups.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fail queries that access encrypted S3 objects that do not have their unencrypted content lengths set in their metadata.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Add support for setting query timeout through ``Statement.setQueryTimeout()``.
 
-SPI Changes
+SPI changes
 -----------
 
 * Add grantee and revokee to ``GRANT`` and ``REVOKE`` security checks.

--- a/docs/src/main/sphinx/release/release-0.180.rst
+++ b/docs/src/main/sphinx/release/release-0.180.rst
@@ -2,7 +2,7 @@
 Release 0.180
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix a rare bug where rows containing only ``null`` values are not returned
@@ -25,7 +25,7 @@ General Changes
   external systems without the need to implement a custom connector.
 * Add experimental ``/v1/resourceGroupState`` REST endpoint on coordinator.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix skipping short decimal values in the optimized Parquet reader
@@ -39,25 +39,25 @@ Hive Changes
   writing. Validation is disabled by default, but can be enabled with the
   ``hive.rcfile.writer.validate`` config option.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Add support for ``INSERT``.
 * Add support for pushdown of non-equality predicates on clustering keys.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Add support for authenticating using Kerberos.
 * Allow configuring SSL/TLS and Kerberos properties on a per-connection basis.
 * Add support for executing queries using a SOCKS or HTTP proxy.
 
-CLI Changes
+CLI changes
 -----------
 
 * Add support for executing queries using an HTTP proxy.
 
-SPI Changes
+SPI changes
 -----------
 
 * Add running time limit and queued time limit to ``ResourceGroupInfo``.

--- a/docs/src/main/sphinx/release/release-0.181.rst
+++ b/docs/src/main/sphinx/release/release-0.181.rst
@@ -2,7 +2,7 @@
 Release 0.181
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix query failure and memory usage tracking when query contains
@@ -36,7 +36,7 @@ General Changes
   has an effect when ``task.level-absolute-priority=true`` and
   ``task.legacy-scheduling-behavior=false``.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix potential native memory leak when writing tables using RCFile.
@@ -44,22 +44,22 @@ Hive Changes
 * Decrease the number of file system metadata calls when reading tables.
 * Add support for dropping columns.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Add support for query cancellation using ``Statement.cancel()``.
 
-PostgreSQL Changes
+PostgreSQL changes
 ------------------
 
 * Add support for operations on external tables.
 
-Accumulo Changes
+Accumulo changes
 ----------------
 
 * Improve query performance by scanning index ranges in parallel.
 
-SPI Changes
+SPI changes
 -----------
 
 * Fix regression that broke serialization for ``SchemaTableName``.

--- a/docs/src/main/sphinx/release/release-0.182.rst
+++ b/docs/src/main/sphinx/release/release-0.182.rst
@@ -2,7 +2,7 @@
 Release 0.182
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix correctness issue that causes :func:`corr` to return positive numbers for inverse correlations.
@@ -25,12 +25,12 @@ General Changes
 * Add :doc:`/connector/tpcds`. This connector provides a set of schemas to
   support the TPC Benchmark™ DS (TPC-DS).
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix an issue that would sometimes prevent queries from being cancelled when exiting from the pager.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix reading decimal values in the optimized Parquet reader when they are backed

--- a/docs/src/main/sphinx/release/release-0.183.rst
+++ b/docs/src/main/sphinx/release/release-0.183.rst
@@ -2,7 +2,7 @@
 Release 0.183
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix planning failure for queries that use ``GROUPING`` and contain aggregation expressions
@@ -25,12 +25,12 @@ General Changes
   from disk using the ``experimental.aggregation-operator-unspill-memory-limit`` config
   property or the ``aggregation_operator_unspill_memory_limit`` session property.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Add output rows, output size, written rows and written size to query detail page.
 
-Hive Changes
+Hive changes
 ------------
 
 * Work around `ORC-222 <https://issues.apache.org/jira/browse/ORC-222>`_ which results in
@@ -42,17 +42,17 @@ Hive Changes
 * Improve error message for small ORC files that are completely corrupt or not actually ORC.
 * Add predicate pushdown for the hidden column ``"$path"``.
 
-TPCH Changes
+TPCH changes
 ------------
 
 * Add column statistics for schemas ``tiny`` and ``sf1``.
 
-TPCDS Changes
+TPCDS changes
 -------------
 
 * Add column statistics for schemas ``tiny`` and ``sf1``.
 
-SPI Changes
+SPI changes
 -----------
 
 * Map columns or values represented with ``ArrayBlock`` and ``InterleavedBlock`` are

--- a/docs/src/main/sphinx/release/release-0.184.rst
+++ b/docs/src/main/sphinx/release/release-0.184.rst
@@ -2,7 +2,7 @@
 Release 0.184
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix query execution failure for ``split_to_map(...)[...]``.
@@ -17,31 +17,31 @@ General Changes
 * Require ``coalesce()`` to have at least two arguments, as mandated by the SQL standard.
 * Add :func:`hamming_distance` function.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Always invoke the progress callback with the final stats at query completion.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Add worker status page with information about currently running threads
   and resource utilization (CPU, heap, memory pools). This page is accessible
   by clicking a hostname on a query task list.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix partition filtering for keys of ``CHAR``, ``DECIMAL``, or ``DATE`` type.
 * Reduce system memory usage when reading table columns containing string values
   from ORC or DWRF files. This can prevent high GC overhead or out-of-memory crashes.
 
-TPCDS Changes
+TPCDS changes
 -------------
 
 * Fix display of table statistics when running ``SHOW STATS FOR ...``.
 
-SPI Changes
+SPI changes
 -----------
 
 * Row columns or values represented with ``ArrayBlock`` and ``InterleavedBlock`` are

--- a/docs/src/main/sphinx/release/release-0.185.rst
+++ b/docs/src/main/sphinx/release/release-0.185.rst
@@ -2,7 +2,7 @@
 Release 0.185
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect column names in ``QueryCompletedEvent``.
@@ -23,7 +23,7 @@ General Changes
 * Add cast from ``JSON`` to ``ROW``.
 * Allow usage of ``TRY`` within lambda expressions.
 
-Hive Changes
+Hive changes
 ------------
 
 * Improve ORC reader efficiency by only reading small ORC streams when accessed in the query.
@@ -31,7 +31,7 @@ Hive Changes
 * Fix native memory leak for optimized RCFile writer.
 * Fix potential native memory leak for optimized ORC writer.
 
-Memory Connector Changes
+Memory connector changes
 ------------------------
 
 * Add support for views.

--- a/docs/src/main/sphinx/release/release-0.186.rst
+++ b/docs/src/main/sphinx/release/release-0.186.rst
@@ -7,7 +7,7 @@ Release 0.186
     This release has a stability issue that may cause query failures in large deployments
     due to HTTP requests timing out.
 
-General Changes
+General changes
 ---------------
 
 * Fix excessive GC overhead caused by map to map cast.
@@ -31,7 +31,7 @@ General Changes
 * Add :doc:`/admin/spill` for joins.
 * Add :doc:`/connector/redshift`.
 
-Resource Groups Changes
+Resource groups changes
 -----------------------
 
 * Query Queues are deprecated in favor of :doc:`/admin/resource-groups`
@@ -40,20 +40,20 @@ Resource Groups Changes
   property name is deprecated and will be removed in a future release.
 * Fail on unknown property names when loading the JSON config file.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Allow specifying an empty password.
 * Add ``getQueuedTimeMillis()`` and ``getElapsedTimeMillis()`` to ``QueryStats``.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix ``FileSystem closed`` errors when using Kerberos authentication.
 * Add support for path style access to the S3 file system. This can be enabled
   by setting the ``hive.s3.path-style-access=true`` config property.
 
-SPI Changes
+SPI changes
 -----------
 
 * Add an ``ignoreExisting`` flag to ``ConnectorMetadata::createTable()``.

--- a/docs/src/main/sphinx/release/release-0.187.rst
+++ b/docs/src/main/sphinx/release/release-0.187.rst
@@ -2,7 +2,7 @@
 Release 0.187
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix a stability issue that may cause query failures due to a large number of HTTP requests timing out.

--- a/docs/src/main/sphinx/release/release-0.188.rst
+++ b/docs/src/main/sphinx/release/release-0.188.rst
@@ -2,7 +2,7 @@
 Release 0.188
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix handling of negative start indexes in array :func:`slice` function.
@@ -20,19 +20,19 @@ General Changes
 * Mitigate performance issue caused by JVM when generated code is used
   for multiple hours or days.
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix transaction support. Previously, after the first statement in the
   transaction, the transaction would be abandoned and the session would
   silently revert to auto-commit mode.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Support using ``Statement.cancel()`` for all types of statements.
 
-Resource Group Changes
+Resource group changes
 ----------------------
 
 * Add environment support to the ``db`` resource groups manager.
@@ -40,7 +40,7 @@ Resource Group Changes
   With this change, different cluster configurations can be stored in the same table and
   Presto will use the new ``environment`` column to differentiate them.
 
-SPI Changes
+SPI changes
 -----------
 
 * Add query plan to the query completed event.

--- a/docs/src/main/sphinx/release/release-0.189.rst
+++ b/docs/src/main/sphinx/release/release-0.189.rst
@@ -2,7 +2,7 @@
 Release 0.189
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix query failure while logging the query plan.
@@ -20,7 +20,7 @@ General Changes
   field in the ``ROW``.
 * Add support for dereferencing row fields in lambda expressions.
 
-Security Changes
+Security changes
 ----------------
 
 * Support configuring multiple authentication types, which allows supporting
@@ -37,7 +37,7 @@ Security Changes
   yet supported).
 * Skip sending final leg of SPNEGO authentication when using Kerberos.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Per the JDBC specification, close the ``ResultSet`` when ``Statement`` is closed.
@@ -49,35 +49,35 @@ JDBC Driver Changes
   to use ``setCatalog()`` and ``setSchema()`` on ``Connection`` is recommended.
 * Allow executing ``SET SESSION`` and ``RESET SESSION``.
 
-Resource Group Changes
+Resource group changes
 ----------------------
 
 * Add ``WEIGHTED_FAIR`` resource group scheduling policy.
 
-Hive Changes
+Hive changes
 ------------
 
 * Do not require setting ``hive.metastore.uri`` when using the file metastore.
 * Reduce memory usage when reading string columns from ORC or DWRF files.
 
 
-MySQL, PostgreSQL, Redshift, and SQL Server Changes
+MySQL, PostgreSQL, Redshift, and SQL Server shanges
 ---------------------------------------------------
 
 * Change mapping for columns with ``DECIMAL(p,s)`` data type from Presto ``DOUBLE``
   type to the corresponding Presto ``DECIMAL`` type.
 
-Kafka Changes
+Kafka changes
 -------------
 
 * Fix documentation for raw decoder.
 
-Thrift Connector Changes
+Thrift connector changes
 ------------------------
 
 * Add support for index joins.
 
-SPI Changes
+SPI changes
 -----------
 
 * Deprecate ``SliceArrayBlock``.

--- a/docs/src/main/sphinx/release/release-0.190.rst
+++ b/docs/src/main/sphinx/release/release-0.190.rst
@@ -2,7 +2,7 @@
 Release 0.190
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix correctness issue for :func:`array_min` and :func:`array_max` when arrays contain ``NaN``.
@@ -29,28 +29,28 @@ General Changes
   config property or the ``parse_decimal_literals_as_double`` session property to ``false``.
 * Add JMX counter to track the number of submitted queries.
 
-Resource Groups Changes
+Resource groups changes
 -----------------------
 
 * Add priority column to the DB resource group selectors.
 * Add exact match source selector to the DB resource group selectors.
 
-CLI Changes
+CLI changes
 -----------
 
 * Add support for setting client tags.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Add ``getPeakMemoryBytes()`` to ``QueryStats``.
 
-Accumulo Changes
+Accumulo changes
 ----------------
 
 * Improve table scan parallelism.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix query failures for the file-based metastore implementation when partition
@@ -62,13 +62,13 @@ Hive Changes
   the default value is substantially higher than the previous hard-coded limit,
   which can prevent certain queries from failing.
 
-Thrift Connector Changes
+Thrift connector changes
 ------------------------
 
 * Make Thrift retry configurable.
 * Add JMX counters for Thrift requests.
 
-SPI Changes
+SPI changes
 -----------
 
 * Remove the ``RecordSink`` interface, which was difficult to use

--- a/docs/src/main/sphinx/release/release-0.191.rst
+++ b/docs/src/main/sphinx/release/release-0.191.rst
@@ -2,7 +2,7 @@
 Release 0.191
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix regression that could cause high CPU usage for join queries when dictionary
@@ -30,17 +30,17 @@ General Changes
   The tradeoff for writer scaling is that write queries can take longer to run
   due to the decreased writer parallelism while the writer count ramps up.
 
-Resource Groups Changes
+Resource groups changes
 -----------------------
 
 *  Add query type to the exact match source selector in the DB resource group selectors.
 
-CLI Changes
+CLI changes
 -----------
 
 * Improve display of values of the Geometry type.
 
-Hive Changes
+Hive changes
 ------------
 
 * Add support for grouped join execution for Hive tables when both
@@ -51,7 +51,7 @@ Hive Changes
   This is especially important for tables that have many small partitions, as
   small files can take a disproportionately longer time to read.
 
-Thrift Connector Changes
+Thrift connector changes
 ------------------------
 
 * Add page size distribution metrics.

--- a/docs/src/main/sphinx/release/release-0.192.rst
+++ b/docs/src/main/sphinx/release/release-0.192.rst
@@ -2,7 +2,7 @@
 Release 0.192
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix performance regression in split scheduling introduced in 0.191. If a query
@@ -29,19 +29,19 @@ General Changes
 * Remove ``dictionary-processing-joins-enabled`` configuration option and ``dictionary_processing_join``
   session property.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix incorrect reporting of input size and positions in live plan view.
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix update of prompt after ``USE`` statement.
 * Fix correctness issue when rendering arrays of Bing tiles that causes
   the first entry to be repeated multiple times.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix reading partitioned table statistics from newer Hive metastores.
@@ -57,19 +57,19 @@ Hive Changes
 * Improve error reporting when the target table of an insert query is dropped.
 * Remove retry when creating Hive record reader. This can help queries fail faster.
 
-MySQL Changes
+MySQL changes
 -------------
 
 * Remove support for ``TIME WITH TIME ZONE`` and ``TIMESTAMP WITH TIME ZONE``
   types due to MySQL types not being able to store timezone information.
 * Add support for ``REAL`` type, which maps to MySQL's ``FLOAT`` type.
 
-PostgreSQL Changes
+PostgreSQL changes
 ------------------
 
 * Add support for ``VARBINARY`` type, which maps to PostgreSQL's ``BYTEA`` type.
 
-MongoDB Changes
+MongoDB changes
 ---------------
 
 * Fix support for pushing down inequality operators for string types.
@@ -77,12 +77,12 @@ MongoDB Changes
 * Add support for MongoDB's ``Decimal128`` type.
 * Treat document and array of documents as ``JSON`` instead of ``VARCHAR``.
 
-JMX Changes
+JMX changes
 -----------
 
 * Allow nulls in history table values.
 
-SPI Changes
+SPI changes
 -----------
 
 * Remove ``SliceArrayBlock`` class.

--- a/docs/src/main/sphinx/release/release-0.193.rst
+++ b/docs/src/main/sphinx/release/release-0.193.rst
@@ -2,7 +2,7 @@
 Release 0.193
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix an infinite loop during planning for queries containing non-trivial predicates.
@@ -20,24 +20,24 @@ General Changes
 * Turn on new local scheduling algorithm by default (see :doc:`release-0.181`).
 * Remove the ``information_schema.__internal_partitions__`` table.
 
-Security Changes
+Security changes
 ----------------
 
 * Apply the authentication methods in the order they are listed in the
   ``http-server.authentication.type`` configuration.
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix rendering of maps of Bing tiles.
 * Abort the query when the result pager exits.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Use SSL by default for port 443.
 
-Hive Changes
+Hive changes
 ------------
 
 * Allow dropping any column in a table. Previously, dropping columns other
@@ -52,19 +52,19 @@ Hive Changes
   that have more than ``hive.max-partitions-per-scan`` partitions as long as
   the specified ``<condition>`` reduces the number of partitions to below this limit.
 
-Blackhole Changes
+Blackhole changes
 -----------------
 
 * Do not allow creating tables in a nonexistent schema.
 * Add support for ``CREATE SCHEMA``.
 
-Memory Connector Changes
+Memory connector changes
 ------------------------
 
 * Allow renaming tables across schemas. Previously, the target schema was ignored.
 * Do not allow creating tables in a nonexistent schema.
 
-MongoDB Changes
+MongoDB changes
 ---------------
 
 * Add ``INSERT`` support. It was previously removed in 0.155.

--- a/docs/src/main/sphinx/release/release-0.194.rst
+++ b/docs/src/main/sphinx/release/release-0.194.rst
@@ -2,7 +2,7 @@
 Release 0.194
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix planning performance regression that can affect queries over Hive tables
@@ -16,12 +16,12 @@ General Changes
 * Improve coordinator CPU efficiency when discovering splits.
 * Include minimum and maximum values for columns in ``SHOW STATS``.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix previously empty peak memory display in the query details page.
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix regression in CLI that makes it always print "query aborted by user" when
@@ -30,14 +30,14 @@ CLI Changes
 * Add ``--client-info`` option for specifying client info.
 * Add ``--ignore-errors`` option to continue processing in batch mode when an error occurs.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Allow configuring connection network timeout with ``setNetworkTimeout()``.
 * Allow setting client tags via the ``ClientTags`` client info property.
 * Expose update type via ``getUpdateType()`` on ``PrestoStatement``.
 
-Hive Changes
+Hive changes
 ------------
 
 * Consistently fail queries that attempt to read partitions that are offline.
@@ -49,7 +49,7 @@ Hive Changes
 * Reduce ORC file reader memory consumption by allocating buffers lazily.
   Buffers are only allocated for columns that are actually accessed.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Fix failure when querying ``information_schema.columns`` when there is no equality predicate on ``table_name``.

--- a/docs/src/main/sphinx/release/release-0.195.rst
+++ b/docs/src/main/sphinx/release/release-0.195.rst
@@ -2,7 +2,7 @@
 Release 0.195
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix :func:`histogram` for map type when type coercion is required.
@@ -19,7 +19,7 @@ General Changes
   the system when workers are offline for long periods due to GC or network errors.
 * Remove the ``compiler.interpreter-enabled`` config property.
 
-Security Changes
+Security changes
 ----------------
 
 * Presto now supports generic password authentication using a pluggable :doc:`/develop/password-authenticator`.
@@ -28,17 +28,17 @@ Security Changes
 * :doc:`/security/ldap` is now implemented as a password authentication
   plugin. You will need to update your configuration if you are using it.
 
-CLI and JDBC Changes
+CLI and JDBC changes
 --------------------
 
 * Provide a better error message when TLS client certificates are expired or not yet valid.
 
-MySQL Changes
+MySQL changes
 -------------
 
 * Fix an error that can occur while listing tables if one of the listed tables is dropped.
 
-Hive Changes
+Hive changes
 ------------
 
 * Add support for LZ4 compressed ORC files.
@@ -46,7 +46,7 @@ Hive Changes
 * Validate ORC compression block size when reading ORC files.
 * Set timeout of Thrift metastore client. This was accidentally removed in 0.191.
 
-MySQL, Redis, Kafka, and MongoDB Changes
+MySQL, Redis, Kafka, and MongoDB changes
 ----------------------------------------
 
 * Fix failure when querying ``information_schema.columns`` when there is no equality predicate on ``table_name``.

--- a/docs/src/main/sphinx/release/release-0.196.rst
+++ b/docs/src/main/sphinx/release/release-0.196.rst
@@ -2,7 +2,7 @@
 Release 0.196
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix behavior of ``JOIN ... USING`` to conform to standard SQL semantics.
@@ -33,7 +33,7 @@ Security
   to enforce a specific matching between authentication credentials and a
   executing username.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix a correctness issue where non-null values can be treated as null values

--- a/docs/src/main/sphinx/release/release-0.197.rst
+++ b/docs/src/main/sphinx/release/release-0.197.rst
@@ -2,7 +2,7 @@
 Release 0.197
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix query scheduling hang when the ``concurrent_lifespans_per_task`` session property is set.
@@ -19,7 +19,7 @@ General Changes
 * Add :func:`ST_IsSimple` geospatial function.
 * Add support for broadcast spatial joins.
 
-Resource Groups Changes
+Resource groups changes
 -----------------------
 
 * Change configuration check for weights in resource group policy to validate that
@@ -28,7 +28,7 @@ Resource Groups Changes
   used to parameterize resource group names.
 * Add support for optional fields in DB resource group exact match selectors.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix reading of Hive partition statistics with unset fields. Previously, unset fields
@@ -46,12 +46,12 @@ Hive Changes
 * Use the view owner returned from the metastore at the time of the query rather than
   always using the user who created the view. This allows changing the owner of a view.
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix hang when CLI fails to communicate with Presto server.
 
-SPI Changes
+SPI changes
 -----------
 
 * Include connector session properties for the connector metadata calls made

--- a/docs/src/main/sphinx/release/release-0.198.rst
+++ b/docs/src/main/sphinx/release/release-0.198.rst
@@ -2,7 +2,7 @@
 Release 0.198
 =============
 
-General Changes
+General changes
 ---------------
 
 * Perform semantic analysis before enqueuing queries.
@@ -34,7 +34,7 @@ General Changes
 * Improve parallelism of queries that have an empty grouping set.
 * Improve performance of join queries involving the :func:`ST_Distance` function.
 
-Resource Groups Changes
+Resource groups changes
 -----------------------
 
 * Query Queues have been removed. Resource Groups are always enabled. The
@@ -42,14 +42,14 @@ Resource Groups Changes
 * Change ``WEIGHTED_FAIR`` scheduling policy to select oldest eligible sub group
   of groups where utilization and share are identical.
 
-CLI Changes
+CLI changes
 -----------
 
 * The ``--enable-authentication`` option has been removed. Kerberos authentication
   is automatically enabled when ``--krb5-remote-service-name`` is specified.
 * Kerberos authentication now requires HTTPS.
 
-Hive Changes
+Hive changes
 ------------
 
 * Add support for using `AWS Glue <https://aws.amazon.com/glue/>`_ as the metastore.
@@ -57,12 +57,12 @@ Hive Changes
 * Fix a bug in the ORC writer that will write incorrect data of type ``VARCHAR`` or ``VARBINARY``
   into files.
 
-JMX Changes
+JMX changes
 -----------
 
 * Add wildcard character ``*`` which allows querying several MBeans with a single query.
 
-SPI Changes
+SPI changes
 -----------
 
 * Add performance statistics to query plan in ``QueryCompletedEvent``.

--- a/docs/src/main/sphinx/release/release-0.199.rst
+++ b/docs/src/main/sphinx/release/release-0.199.rst
@@ -2,7 +2,7 @@
 Release 0.199
 =============
 
-General Changes
+General changes
 ---------------
 
 * Allow users to create views for their own use when they do not have permission
@@ -38,22 +38,22 @@ General Changes
 * Improve the performance of functions that return maps.
 * Improve the performance of joins and aggregations that include map columns.
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Add support for installing on machines with OpenJDK.
 
-Security Changes
+Security changes
 ----------------
 
 * Add support for authentication with JWT access token.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Make driver compatible with Java 9+. It previously failed with ``IncompatibleClassChangeError``.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix ORC writer failure when writing ``NULL`` values into columns of type ``ROW``, ``MAP``,  or ``ARRAY``.
@@ -70,14 +70,14 @@ Hive Changes
   ``hive.max-partitions-per-scan`` config option.
 * Allow marking partitions as offline via the ``presto_offline`` partition property.
 
-Thrift Connector Changes
+Thrift connector changes
 ------------------------
 
 * Most of the config property names are different due to replacing the
   underlying Thrift client implementation. Please see :doc:`/connector/thrift`
   for details on the new properties.
 
-SPI Changes
+SPI changes
 -----------
 
 * Allow connectors to provide system tables dynamically.

--- a/docs/src/main/sphinx/release/release-0.200.rst
+++ b/docs/src/main/sphinx/release/release-0.200.rst
@@ -2,7 +2,7 @@
 Release 0.200
 =============
 
-General Changes
+General changes
 ---------------
 
 * Disable early termination of inner or right joins when the right side
@@ -19,7 +19,7 @@ General Changes
 * Add :func:`from_ieee754_32` and :func:`from_ieee754_64` functions.
 * Add :func:`ST_GeometryType` geospatial function.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix reading min/max statistics for columns of ``REAL`` type in partitioned tables.
@@ -29,7 +29,7 @@ Hive Changes
 * Fix failure when reading ORC files that contain UTF-8 Bloom filter streams.
   Such Bloom filters are now ignored.
 
-MySQL Changes
+MySQL changes
 -------------
 
 * Avoid reading extra rows from MySQL at query completion.

--- a/docs/src/main/sphinx/release/release-0.201.rst
+++ b/docs/src/main/sphinx/release/release-0.201.rst
@@ -2,7 +2,7 @@
 Release 0.201
 =============
 
-General Changes
+General changes
 ---------------
 
 * Change grouped aggregations to use ``IS NOT DISTINCT FROM`` semantics rather than equality
@@ -21,14 +21,14 @@ General Changes
   aggregations for queries that do not benefit.
 * Add support for ``current_user`` (see :doc:`/functions/session`).
 
-Security Changes
+Security changes
 ----------------
 
 * Change rules in the :doc:`/security/built-in-system-access-control` for enforcing matches
   between authentication credentials and a chosen username to allow more fine-grained
   control and ability to define superuser-like credentials.
 
-Hive Changes
+Hive changes
 ------------
 
 * Replace ORC writer stripe minimum row configuration ``hive.orc.writer.stripe-min-rows``
@@ -41,7 +41,7 @@ Hive Changes
 * Fix impersonation for the simple HDFS authentication to use login user rather than current
   user.
 
-SPI Changes
+SPI changes
 -----------
 
 * Support resource group selection based on resource estimates.

--- a/docs/src/main/sphinx/release/release-0.202.rst
+++ b/docs/src/main/sphinx/release/release-0.202.rst
@@ -2,7 +2,7 @@
 Release 0.202
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix correctness issue for queries involving aggregations over the result of an outer join (:issue:`x10592`).
@@ -36,7 +36,7 @@ General Changes
 * Add :func:`wilson_interval_lower` and :func:`wilson_interval_upper` functions.
 * Add ``IS DISTINCT FROM`` for ``json`` and ``ipaddress`` type.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix optimized ORC writer encoding of ``TIMESTAMP`` before ``1970-01-01``.  Previously, the
@@ -57,12 +57,12 @@ Hive Changes
   read multiple consecutive stripes or entire fires at once. Previously, this feature
   piggybacks on other properties.
 
-CLI Changes
+CLI changes
 -----------
 
 * Add peak memory usage to ``--debug`` output.
 
-SPI Changes
+SPI changes
 -----------
 
 * Make ``PageSorter`` and ``PageIndexer`` supported interfaces.

--- a/docs/src/main/sphinx/release/release-0.203.rst
+++ b/docs/src/main/sphinx/release/release-0.203.rst
@@ -2,7 +2,7 @@
 Release 0.203
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix spurious duplicate key errors from :func:`map`.
@@ -21,7 +21,7 @@ General Changes
 * Remove support for legacy ``ORDER BY`` semantics.
 * Distinguish between inner and left spatial joins in explain plans.
 
-Security Changes
+Security changes
 ----------------
 
 * Fix sending authentication challenge when at least two of the
@@ -30,14 +30,14 @@ Security Changes
   and the HTTP client used for internal communication. This was already supported
   for the CLI and JDBC driver.
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Declare a dependency on ``uuidgen``. The ``uuidgen`` program is required during
   installation of the Presto server RPM package and lack of it resulted in an invalid
   config file being generated during installation.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix complex type handling in the optimized Parquet reader. Previously, null values,
@@ -45,13 +45,13 @@ Hive Connector Changes
 * Fix an issue that could cause the optimized ORC writer to fail with a ``LazyBlock`` error.
 * Improve error message for max open writers.
 
-Thrift Connector Changes
+Thrift connector changes
 ------------------------
 
 * Fix retry of requests when the remote Thrift server indicates that the
   error is retryable.
 
-Local File Connector Changes
+Local file connector changes
 ----------------------------
 
 * Fix parsing of timestamps when the JVM time zone is UTC (:issue:`x9601`).

--- a/docs/src/main/sphinx/release/release-0.204.rst
+++ b/docs/src/main/sphinx/release/release-0.204.rst
@@ -2,7 +2,7 @@
 Release 0.204
 =============
 
-General Changes
+General changes
 ---------------
 
 * Use distributed join if one side is naturally partitioned on join keys.
@@ -18,23 +18,23 @@ General Changes
   The missing positions are filled with ``NULL``.
 * Track execution statistics of ``AddExchanges`` and ``PredicatePushdown`` optimizer rules.
 
-Event Listener Changes
+Event listener changes
 ----------------------
 
 * Add resource estimates to query events.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix kill query button.
 * Display resource estimates in Web UI query details page.
 
-Resource Group Changes
+Resource group changes
 ----------------------
 
 * Fix unnecessary queuing in deployments where no resource group configuration was specified.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix over-estimation of memory usage for scan operators when reading ORC files.
@@ -46,7 +46,7 @@ Hive Connector Changes
   highly compressed, dictionary encoded columns.
 * Enable optimized Parquet reader and predicate pushdown by default.
 
-Cassandra Connector Changes
+Cassandra connector changes
 ---------------------------
 
 * Add support for reading from materialized views.

--- a/docs/src/main/sphinx/release/release-0.205.rst
+++ b/docs/src/main/sphinx/release/release-0.205.rst
@@ -2,7 +2,7 @@
 Release 0.205
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix parsing of row types where the field types contain spaces.
@@ -31,7 +31,7 @@ General Changes
 * Do not allow using the ``FILTER`` clause for the ``COALESCE``, ``IF``, or ``NULLIF`` functions.
   The syntax was previously allowed but was otherwise ignored.
 
-Security Changes
+Security changes
 ----------------
 
 * Remove unnecessary check for ``SELECT`` privileges for ``DELETE`` queries.
@@ -46,7 +46,7 @@ Security Changes
 * Improve the error message when access is denied when selecting from a view due to the
   view owner having insufficient permissions to create the view.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Add support for prepared statements.
@@ -54,7 +54,7 @@ JDBC Driver Changes
 * Use ``VARCHAR`` rather than ``LONGNVARCHAR`` for the Presto ``varchar`` type.
 * Use ``VARBINARY`` rather than ``LONGVARBINARY`` for the Presto ``varbinary`` type.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Improve the performance of ``INSERT`` queries when all partition column values are constants.
@@ -62,12 +62,12 @@ Hive Connector Changes
   This reduces the number of cases where tiny ORC stripes will be written.
 * Respect the ``skip.footer.line.count`` Hive table property.
 
-CLI Changes
+CLI changes
 -----------
 
 * Prevent the CLI from crashing when running on certain 256 color terminals.
 
-SPI Changes
+SPI changes
 -----------
 
 * Add a context parameter to the ``create()`` method in ``SessionPropertyConfigurationManagerFactory``.

--- a/docs/src/main/sphinx/release/release-0.206.rst
+++ b/docs/src/main/sphinx/release/release-0.206.rst
@@ -2,7 +2,7 @@
 Release 0.206
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix execution failure for certain queries containing a join followed by an aggregation
@@ -36,13 +36,13 @@ General Changes
   In addition, the new semantics are not yet stable as more breaking changes are planned,
   particularly around the ``TIME WITH TIME ZONE`` type.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Add ``applicationNamePrefix`` parameter, which is combined with
   the ``ApplicationName`` property to construct the client source name.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Reduce ORC reader memory usage by reducing unnecessarily large internal buffers.

--- a/docs/src/main/sphinx/release/release-0.207.rst
+++ b/docs/src/main/sphinx/release/release-0.207.rst
@@ -2,7 +2,7 @@
 Release 0.207
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix a planning issue for queries where correlated references were used in ``VALUES``.
@@ -32,18 +32,18 @@ General Changes
   can be reordered at once using cost-based join reordering.
 * Add support for ``char`` type to :func:`approx_distinct`.
 
-Security Changes
+Security changes
 ----------------
 
 * Fail on startup when configuration for file based system access control is invalid.
 * Add support for securing communication between cluster nodes with Kerberos authentication.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Add peak total (user + system) memory to query details UI.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix handling of ``VARCHAR(length)`` type in the optimized Parquet reader. Previously, predicate pushdown
@@ -55,12 +55,12 @@ Hive Connector Changes
 * Change collector for columns statistics to only consider a sample of partitions. The sample size can be
   changed by setting the ``hive.partition-statistics-sample-size`` property.
 
-Memory Connector Changes
+Memory connector changes
 ------------------------
 
 * Add support for dropping schemas.
 
-SPI Changes
+SPI changes
 -----------
 
 * Remove deprecated table/view-level access control methods.

--- a/docs/src/main/sphinx/release/release-0.208.rst
+++ b/docs/src/main/sphinx/release/release-0.208.rst
@@ -7,7 +7,7 @@ Release 0.208
     This release has the potential for data loss in the Hive connector
     when writing bucketed sorted tables.
 
-General Changes
+General changes
 ---------------
 
 * Fix an issue with memory accounting that would lead to garbage collection pauses
@@ -28,13 +28,13 @@ General Changes
 * Add support for correlated subqueries requiring coercions.
 * Add experimental support for running on Linux ppc64le.
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix creation of the history file when it does not exist.
 * Add ``PRESTO_HISTORY_FILE`` environment variable to override location of history file.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Remove size limit for writing bucketed sorted tables.
@@ -45,7 +45,7 @@ Hive Connector Changes
 * Collect column level statistics when writing tables. This is disabled by default,
   and can be enabled by setting the ``hive.collect-column-statistics-on-write`` property.
 
-Thrift Connector Changes
+Thrift connector changes
 ------------------------
 
 * Include error message from remote server in query failure message.

--- a/docs/src/main/sphinx/release/release-0.209.rst
+++ b/docs/src/main/sphinx/release/release-0.209.rst
@@ -2,7 +2,7 @@
 Release 0.209
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect predicate pushdown when grouping sets contain the empty grouping set (:issue:`x11296`).
@@ -32,22 +32,22 @@ General Changes
 * Raise required Java version to 8u151. This avoids correctness issues for
   map to map cast when running under some earlier JVM versions, including 8u92.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix the kill query button on the live plan and stage performance pages.
 
-CLI Changes
+CLI changes
 -----------
 
 * Prevent spurious *"No route to host"* errors on macOS when using IPv6.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Prevent spurious *"No route to host"* errors on macOS when using IPv6.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix data loss when writing bucketed sorted tables. Partitions would
@@ -64,13 +64,13 @@ Hive Connector Changes
   This correctly handles missing or extra struct fields in the ORC file.
 * Add procedure ``system.create_empty_partition()`` for creating empty partitions.
 
-Kafka Connector Changes
+Kafka connector changes
 -----------------------
 
 * Support Avro formatted Kafka messages.
 * Support backward compatible Avro schema evolution.
 
-SPI Changes
+SPI changes
 -----------
 
 * Allow using ``Object`` as a parameter type or return type for SQL

--- a/docs/src/main/sphinx/release/release-0.210.rst
+++ b/docs/src/main/sphinx/release/release-0.210.rst
@@ -2,7 +2,7 @@
 Release 0.210
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix planning failure when aliasing columns of tables containing hidden
@@ -14,7 +14,7 @@ General Changes
 * Remove user CPU time tracking as introduces non-trivial overhead.
 * Select join distribution type automatically for queries involving outer joins.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix a security bug introduced in 0.209 when using ``hive.security=file``,
@@ -26,14 +26,14 @@ Hive Connector Changes
 * Support backward compatible Avro schema evolution.
 * Support cross-realm Kerberos authentication for HDFS and Hive Metastore.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Deallocate prepared statement when ``PreparedStatement`` is closed. Previously,
   ``Connection`` became unusable after many prepared statements were created.
 * Remove ``getUserTimeMillis()`` from ``QueryStats`` and ``StageStats``.
 
-SPI Changes
+SPI changes
 -----------
 
 * ``SystemAccessControl.checkCanSetUser()`` now takes an ``Optional<Principal>``

--- a/docs/src/main/sphinx/release/release-0.211.rst
+++ b/docs/src/main/sphinx/release/release-0.211.rst
@@ -2,7 +2,7 @@
 Release 0.211
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix missing final query plan in ``QueryCompletedEvent``. Statistics and cost estimates
@@ -23,7 +23,7 @@ General Changes
   to automate the setting of session properties based on query characteristics.
 * Allow running on a JVM from any vendor that meets the functional requirements.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix regression in 0.210 that causes query failure when writing ORC or DWRF files
@@ -33,12 +33,12 @@ Hive Connector Changes
 * Fix coordinator OOM when a query scans many partitions of a Hive table (:issue:`x11322`).
 * Improve readability of columns, partitioning, and transactions in explain plains.
 
-Thrift Connector Changes
+Thrift connector changes
 ------------------------
 
 * Fix lack of retry for network errors while sending requests.
 
-Resource Group Changes
+Resource group changes
 ----------------------
 
 * Add documentation for new resource group scheduling policies.
@@ -47,7 +47,7 @@ Resource Group Changes
   :doc:`file based property manager </admin/session-property-managers>`
   to set session properties.
 
-SPI Changes
+SPI changes
 -----------
 
 * Clarify semantics of ``predicate`` in ``ConnectorTableLayout``.

--- a/docs/src/main/sphinx/release/release-0.212.rst
+++ b/docs/src/main/sphinx/release/release-0.212.rst
@@ -2,7 +2,7 @@
 Release 0.212
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix query failures when the :func:`ST_GeomFromBinary` function is run on multiple rows.
@@ -14,7 +14,7 @@ General Changes
 * Remove ``round(x, d)`` and ``truncate(x, d)`` functions where ``d`` is a ``BIGINT`` (:issue:`x11462`).
 * Add :func:`ST_LineString` function to form a ``LineString`` from an array of points.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Prevent ORC writer from writing stripes larger than the max configured size for some rare data
@@ -25,13 +25,13 @@ Hive Connector Changes
   statistics can be ignored by setting the ``hive.ignore-corrupted-statistics``
   configuration property or the ``ignore_corrupted_statistics`` session property.
 
-Thrift Connector Changes
+Thrift connector changes
 ------------------------
 
 * Fix retry for network errors that occur while sending a Thrift request.
 * Remove failed connections from connection pool.
 
-Verifier Changes
+Verifier changes
 ----------------
 
 * Record the query ID of the test query regardless of query outcome.

--- a/docs/src/main/sphinx/release/release-0.213.rst
+++ b/docs/src/main/sphinx/release/release-0.213.rst
@@ -2,7 +2,7 @@
 Release 0.213
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix split scheduling backpressure when plan contains colocated join. Previously, splits
@@ -39,7 +39,7 @@ General Changes
 * Add experimental config option ``experimental.reserved-pool-enabled`` to disable the reserved memory pool.
 * Add ``targetResultSize`` query parameter to ``/v1/statement`` endpoint to control response data size.
 
-Geospatial Changes
+Geospatial changes
 ------------------
 
 * Fix :func:`ST_Distance` function to return ``NULL`` if any of the inputs is an
@@ -48,12 +48,12 @@ Geospatial Changes
 * Add :func:`geometry_union` function to efficiently union arrays of geometries.
 * Add support for distributed spatial joins (:issue:`x11072`).
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Allow running on a JVM from any vendor.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Remove legacy plan UI.
@@ -61,7 +61,7 @@ Web UI Changes
 * Add dialog to show errors refreshing data from coordinator.
 * Change worker thread list to not show thread stacks by default to improve page peformance.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix LZO and LZOP decompression to work with certain data compressed by Hadoop.
@@ -88,18 +88,18 @@ Hive Connector Changes
   configuration properties and ``parquet_writer_block_size`` and
   ``parquet_writer_page_size`` session properties for tuning Parquet writer options.
 
-Memory Connector Changes
+Memory connector changes
 ------------------------
 
 * Improve table data size accounting.
 
-Thrift Connector Changes
+Thrift connector changes
 ------------------------
 
 * Include constraint in explain plan for index joins.
 * Improve readability of columns, tables, layouts, and indexes in explain plans.
 
-Verifier Changes
+Verifier changes
 ----------------
 
 * Rewrite queries in parallel when shadowing writes.

--- a/docs/src/main/sphinx/release/release-0.214.rst
+++ b/docs/src/main/sphinx/release/release-0.214.rst
@@ -2,7 +2,7 @@
 Release 0.214
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix history leak in coordinator for failed or canceled queries.
@@ -31,25 +31,25 @@ General Changes
 * Remove experimental pre-allocated memory system, and the related configuration
   property ``experimental.preallocate-memory-threshold``.
 
-Security Changes
+Security changes
 ----------------
 
 * Add functionality to refresh the configuration of file-based access controllers.
   The refresh interval can be set using the ``security.refresh-period``
   configuration property.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Clear update count after calling ``Statement.getMoreResults()``.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Show query warnings on the query detail page.
 * Allow selecting non-default sort orders in query list view.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Prevent ORC writer from writing stripes larger than the maximum configured size.
@@ -58,7 +58,7 @@ Hive Connector Changes
 * Add Hive metastore API recording tool for remote debugging purposes.
 * Add support for retrying on metastore connection errors.
 
-Verifier Changes
+Verifier changes
 ----------------
 
 * Handle SQL execution timeouts while rewriting queries.

--- a/docs/src/main/sphinx/release/release-0.215.rst
+++ b/docs/src/main/sphinx/release/release-0.215.rst
@@ -2,7 +2,7 @@
 Release 0.215
 =============
 
-General Changes
+General changes
 ---------------
 
 * Fix regression in 0.214 that could cause queries to produce incorrect results for queries
@@ -31,14 +31,14 @@ General Changes
   The default value for the filter factor can be configured with the ``default_filter_factor_enabled``
   session property or the ``optimizer.default-filter-factor-enabled``.
 
-Geospatial Changes
+Geospatial changes
 ------------------
 
 * Add input validation checks to :func:`ST_LineString` to conform with the specification.
 * Improve spatial join performance.
 * Enable spatial joins for join conditions expressed with the :func:`ST_Within` function.
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix *Capture Snapshot* button for showing current thread stacks.
@@ -47,13 +47,13 @@ Web UI Changes
 * Make the reporting of *Cumulative Memory* usage consistent on the query list and query details pages.
 * Remove legacy thread UI.
 
-Hive Changes
+Hive changes
 ------------
 
 * Add predicate pushdown support for the ``DATE`` type to the Parquet reader. This change also fixes
   a bug that may cause queries with predicates on ``DATE`` columns to fail with type mismatch errors.
 
-Redis Changes
+Redis changes
 -------------
 
 * Prevent printing the value of the ``redis.password`` configuration property to log files.

--- a/docs/src/main/sphinx/release/release-0.55.rst
+++ b/docs/src/main/sphinx/release/release-0.55.rst
@@ -2,7 +2,7 @@
 Release 0.55
 ============
 
-RC Binary 2-4x Gain in CPU Efficiency
+RC binary 2-4x gain in CPU efficiency
 -------------------------------------
 
 Presto uses custom fast-path decoding logic for specific Hive file
@@ -15,7 +15,7 @@ result in measurable gains for most queries over RC Binary encoded data.
 Note that this optimization may not result in a reduction in latency
 if your cluster is network or disk I/O bound.
 
-Hash Distributed Aggregations
+Hash distributed aggregations
 -----------------------------
 
 ``GROUP BY`` aggregations are now distributed across a fixed number of machines.
@@ -27,7 +27,7 @@ will use all available machines.  The default value is ``8``.
 The maximum memory size of an aggregation is now
 ``query.initial-hash-partitions`` times ``task.max-memory``.
 
-Simple Distinct Aggregations
+Simple distinct aggregations
 ----------------------------
 
 We have added support for the ``DISTINCT`` argument qualifier for aggregation
@@ -39,7 +39,7 @@ where all the aggregation functions have the same input expression. For example:
 
 Support for complete ``DISTINCT`` functionality is in our roadmap.
 
-Range Predicate Pushdown
+Range predicate pushdown
 ------------------------
 
 We've modified the connector API to support range predicates in addition to simple equality predicates.
@@ -65,20 +65,20 @@ query to further limit the data scanned.
     so if you have written a connector, you will need to update your code
     before deploying this release.
 
-json_array_get Function
+json_array_get function
 -----------------------
 
 The :func:`json_array_get` function makes it simple to fetch a single element from a
 scalar json array.
 
-Non-reserved Keywords
+Non-reserved keywords
 ---------------------
 
 The keywords ``DATE``, ``TIME``, ``TIMESTAMP``, and ``INTERVAL`` are no longer
 reserved keywords in the grammar.  This means that you can access a column
 named ``date`` without quoting the identifier.
 
-CLI source Option
+CLI source option
 -----------------
 
 The Presto CLI now has an option to set the query source.  The source
@@ -92,7 +92,7 @@ SHOW SCHEMAS FROM
 Although the documentation included the syntax ``SHOW SCHEMAS [FROM catalog]``,
 it was not implemented.  This release now implements this statement correctly.
 
-Hive Bucketed Table Fixes
+Hive bucketed table fixes
 -------------------------
 
 For queries over Hive bucketed tables, Presto will attempt to limit scans to

--- a/docs/src/main/sphinx/release/release-0.56.rst
+++ b/docs/src/main/sphinx/release/release-0.56.rst
@@ -2,7 +2,7 @@
 Release 0.56
 ============
 
-Table Creation
+Table creation
 --------------
 
 Tables can be created from the result of a query::
@@ -23,7 +23,7 @@ currently the best format for Presto.
     the new ``ReadOnlyConnectorMetadata`` abstract base class unless you want to
     support table creation.
 
-Cross Joins
+Cross joins
 -----------
 
 Cross joins are supported using the standard ANSI SQL syntax::

--- a/docs/src/main/sphinx/release/release-0.57.rst
+++ b/docs/src/main/sphinx/release/release-0.57.rst
@@ -2,7 +2,7 @@
 Release 0.57
 ============
 
-Distinct Aggregations
+Distinct aggregations
 ---------------------
 
 The ``DISTINCT`` argument qualifier for aggregation functions is now

--- a/docs/src/main/sphinx/release/release-0.60.rst
+++ b/docs/src/main/sphinx/release/release-0.60.rst
@@ -20,7 +20,7 @@ The :doc:`/installation/cli` now supports ``USE CATALOG`` and
 ``USE SCHEMA``.
 
 
-TPCH Connector
+TPCH connector
 --------------
 
 We have added a new connector that will generate synthetic data following the

--- a/docs/src/main/sphinx/release/release-0.61.rst
+++ b/docs/src/main/sphinx/release/release-0.61.rst
@@ -2,7 +2,7 @@
 Release 0.61
 ============
 
-Add support for Table Value Constructors
+Add support for table value constructors
 ----------------------------------------
 
 Presto now supports the SQL table value constructor syntax to create inline tables.

--- a/docs/src/main/sphinx/release/release-0.66.rst
+++ b/docs/src/main/sphinx/release/release-0.66.rst
@@ -2,7 +2,7 @@
 Release 0.66
 ============
 
-Type System
+Type system
 -----------
 
 In this release we have replaced the existing simple fixed type system
@@ -23,7 +23,7 @@ there is only one namespace for types, you should be careful to make names
 for custom types unique as we will add other common SQL types to Presto
 in the near future.
 
-Date/Time Types
+Date/time types
 ---------------
 
 Presto now supports all standard SQL date/time types:
@@ -44,7 +44,7 @@ can perform an aggregation by hour::
     FROM ...
     GROUP BY 1
 
-Time Zones
+Time zones
 ~~~~~~~~~~
 
 This release has full support for time zone rules, which are needed to
@@ -157,7 +157,7 @@ In this release we have made a number of backward incompatible changes to the SP
 * Added a ``ConnectorSession`` parameter to most ``ConnectorMetadata`` methods
 * Removed most ``canHandle`` methods
 
-General Bug Fixes
+General bug fixes
 -----------------
 
 * Fixed CLI hang after using ``USE CATALOG`` or ``USE SCHEMA``
@@ -168,13 +168,13 @@ General Bug Fixes
 * Fixed resource leak caused by abandoned queries
 * Fail queries immediately on unrecoverable data transport errors
 
-Hive Bug Fixes
+Hive bug fixes
 --------------
 
 * Fixed parsing of timestamps in the Hive RCFile Text SerDe (``ColumnarSerDe``)
   by adding configuration to set the time zone originally used when writing data
 
-Cassandra Bug Fixes
+Cassandra bug fixes
 -------------------
 
 * Auto-reconnect if Cassandra session dies

--- a/docs/src/main/sphinx/release/release-0.69.rst
+++ b/docs/src/main/sphinx/release/release-0.69.rst
@@ -13,7 +13,7 @@ Release 0.69
     Additionally, the ``datasources`` property is now deprecated
     and should also be removed (see `Datasource Configuration`_).
 
-Prevent Scheduling Work on Coordinator
+Prevent scheduling work on coordinator
 --------------------------------------
 
 We have a new config property, ``node-scheduler.include-coordinator``,
@@ -27,7 +27,7 @@ query execution.
 We recommend setting this property to ``false`` for the coordinator.
 See :ref:`config_properties` for an example.
 
-Datasource Configuration
+Datasource configuration
 ------------------------
 
 The ``datasources`` config property has been deprecated.
@@ -36,7 +36,7 @@ The datasources configuration is now automatically generated based
 on the ``node-scheduler.include-coordinator`` property
 (see `Prevent Scheduling Work on Coordinator`_).
 
-Raptor Connector
+Raptor connector
 ----------------
 
 Presto has an extremely experimental connector that was previously called
@@ -66,7 +66,7 @@ coordinator and workers that contains the following:
     metadata.db.type=h2
     metadata.db.filename=var/data/db/MetaStore
 
-Machine Learning Functions
+Machine learning functions
 --------------------------
 
 Presto now has functions to train and use machine learning models
@@ -85,14 +85,14 @@ In the above example, the column ``label`` is a ``bigint`` and the column
 identifiers must be integers (encoded as strings because JSON only supports
 strings for map keys) and the feature values are numbers (floating point).
 
-Variable Length Binary Type
+Variable length binary type
 ---------------------------
 
 Presto now supports the ``varbinary`` type for variable length binary data.
 Currently, the only supported function is :func:`length`.
 The Hive connector now maps the Hive ``BINARY`` type to ``varbinary``.
 
-General Changes
+General changes
 ---------------
 
 * Add missing operator: ``timestamp with time zone`` - ``interval year to month``

--- a/docs/src/main/sphinx/release/release-0.70.rst
+++ b/docs/src/main/sphinx/release/release-0.70.rst
@@ -20,7 +20,7 @@ be queried by Hive, nor can Hive views be queried by Presto.
 See :doc:`/sql/create-view` and :doc:`/sql/drop-view`
 for details and examples.
 
-DUAL Table
+DUAL table
 ----------
 
 The synthetic ``DUAL`` table is no longer supported. As an alternative, please
@@ -32,7 +32,7 @@ Presto Verifier
 There is a new project, Presto Verifier, which can be used to verify a set of
 queries against two different clusters.
 
-Connector Improvements
+Connector improvements
 ----------------------
 
 * Connectors can now add hidden columns to a table. Hidden columns are not
@@ -44,7 +44,7 @@ Connector Improvements
   suite has been extracted into the ``presto-test`` module for use during
   connector development. For an example, see ``TestRaptorDistributedQueries``.
 
-Machine Learning Functions
+Machine learning functions
 --------------------------
 
 We have added two new machine learning functions, which can be used
@@ -52,7 +52,7 @@ by advanced users familiar with LIBSVM. The functions are
 ``learn_libsvm_classifier`` and ``learn_libsvm_regressor``. Both take a
 parameters string which has the form ``key=value,key=value``
 
-General Changes
+General changes
 ---------------
 
 * New comparison functions: :func:`greatest` and :func:`least`
@@ -80,7 +80,7 @@ General Changes
 
 * Fix processing of empty or commented out statements in the CLI.
 
-Hive Changes
+Hive changes
 ------------
 
 * There are two new configuration options for the Hive connector,

--- a/docs/src/main/sphinx/release/release-0.73.rst
+++ b/docs/src/main/sphinx/release/release-0.73.rst
@@ -2,14 +2,14 @@
 Release 0.73
 ============
 
-Cassandra Plugin
+Cassandra plugin
 ----------------
 
 The Cassandra connector now supports CREATE TABLE and DROP TABLE. Additionally,
 the connector now takes into account Cassandra indexes when generating CQL.
 This release also includes several bug fixes and performance improvements.
 
-General Changes
+General changes
 ---------------
 
 * New window functions: :func:`lead`, and :func:`lag`

--- a/docs/src/main/sphinx/release/release-0.74.rst
+++ b/docs/src/main/sphinx/release/release-0.74.rst
@@ -2,7 +2,7 @@
 Release 0.74
 ============
 
-Bytecode Compiler
+Bytecode compiler
 -----------------
 
 This version includes new infrastructure for bytecode compilation, and lays the groundwork for future improvements.
@@ -10,14 +10,14 @@ There should be no impact in performance or correctness with the new code, but w
 old implementation in case of issues. To do so, add ``compiler.new-bytecode-generator-enabled=false`` to
 ``etc/config.properties`` in the coordinator and workers.
 
-Hive Storage Format
+Hive storage format
 -------------------
 
 The storage format to use when writing data to Hive can now be configured via the ``hive.storage-format`` option
 in your Hive catalog properties file. Valid options are ``RCBINARY``, ``RCTEXT``, ``SEQUENCEFILE`` and ``TEXTFILE``.
 The default format if the property is not set is ``RCBINARY``.
 
-General Changes
+General changes
 ---------------
 
 * Show column comments in ``DESCRIBE``

--- a/docs/src/main/sphinx/release/release-0.75.rst
+++ b/docs/src/main/sphinx/release/release-0.75.rst
@@ -2,7 +2,7 @@
 Release 0.75
 ============
 
-Hive Changes
+Hive changes
 ------------
 
 * The Hive S3 file system has a new configuration option,
@@ -13,7 +13,7 @@ Hive Changes
   is not enabled. To enable it, set ``hive.allow-rename-table=true`` in
   your Hive catalog properties file.
 
-General Changes
+General changes
 ---------------
 
 * Optimize :func:`count` with a constant to execute as the much faster ``count(*)``
@@ -31,7 +31,7 @@ General Changes
 * Add basic support for inserting data using the :doc:`/sql/insert` statement.
   This is currently only supported for the Raptor connector.
 
-JSON Function Changes
+JSON function changes
 ---------------------
 
 The :func:`json_extract` and :func:`json_extract_scalar` functions now support
@@ -46,7 +46,7 @@ Additionally, colons cannot be used in a un-quoted bracketed path segment.
 Use the new bracket syntax with quotes to match elements that contain
 special characters.
 
-Scheduler Changes
+Scheduler changes
 -----------------
 
 The scheduler now assigns splits to a node based on the current load on the node across all queries.
@@ -55,7 +55,7 @@ Previously, the scheduler load balanced splits across nodes on a per query level
 when the node already has the maximum allowable splits, every task can schedule at most
 ``node-scheduler.max-pending-splits-per-node-per-task`` splits on the node.
 
-Row Number Optimizations
+Row number optimizations
 ------------------------
 
 Queries that use the :func:`row_number` function are substantially faster
@@ -85,7 +85,7 @@ from ``orders`` for each ``orderstatus``::
 Use the :doc:`/sql/explain` statement to see if any of these optimizations
 have been applied to your query.
 
-SPI Changes
+SPI changes
 -----------
 
 The core Presto engine no longer automatically adds a column for ``count(*)``

--- a/docs/src/main/sphinx/release/release-0.76.rst
+++ b/docs/src/main/sphinx/release/release-0.76.rst
@@ -2,7 +2,7 @@
 Release 0.76
 ============
 
-Kafka Connector
+Kafka connector
 ---------------
 
 This release adds a connector that allows querying of `Apache Kafka`_ topic data
@@ -14,7 +14,7 @@ the connector and a :doc:`tutorial </connector/kafka-tutorial>` to get started.
 
 .. _Apache Kafka: https://kafka.apache.org/
 
-MySQL and PostgreSQL Connectors
+MySQL and PostgreSQL connectors
 -------------------------------
 
 This release adds the :doc:`/connector/mysql` and :doc:`/connector/postgresql`
@@ -22,7 +22,7 @@ for querying and creating tables in external relational databases. These can
 be used to join or copy data between different systems like MySQL and Hive,
 or between two different MySQL or PostgreSQL instances, or any combination.
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 The :doc:`/connector/cassandra` configuration properties
@@ -35,7 +35,7 @@ The retry policy for the Cassandra client is now configurable via the
 ``cassandra.retry-policy`` property. In particular, the custom ``BACKOFF``
 retry policy may be useful.
 
-Hive Changes
+Hive changes
 ------------
 
 The new :doc:`/connector/hive` configuration property ``hive.s3.socket-timeout``
@@ -57,7 +57,7 @@ The property ``hive.storage-format`` is broken and has been disabled. It
 sets the storage format on the metadata but always writes the table using
 ``RCBINARY``. This will be implemented in a future release.
 
-General Changes
+General changes
 ---------------
 
 * Fix hang in verifier when an exception occurs.

--- a/docs/src/main/sphinx/release/release-0.77.rst
+++ b/docs/src/main/sphinx/release/release-0.77.rst
@@ -2,37 +2,37 @@
 Release 0.77
 ============
 
-Parametric Types
+Parametric types
 ----------------
 Presto now has a framework for implementing parametric types and functions.
 Support for :ref:`array_type` and :ref:`map_type` types has been added, including the element accessor
 operator ``[]``, and new :doc:`/functions/array`.
 
-Streaming Index Joins
+Streaming index joins
 ---------------------
 Index joins will now switch to use a key-by-key streaming join if index
 results fail to fit in the allocated index memory space.
 
-Distributed Joins
+Distributed joins
 -----------------
 Joins where both tables are distributed are now supported. This allows larger tables to be joined,
 and can be enabled with the ``distributed-joins-enabled`` flag. It may perform worse than the existing
 broadcast join implementation because it requires redistributing both tables.
 This feature is still experimental, and should be used with caution.
 
-Hive Changes
+Hive changes
 ------------
 * Handle spurious ``AbortedException`` when closing S3 input streams
 * Add support for ORC, DWRF and Parquet in Hive
 * Add support for ``DATE`` type in Hive
 * Fix performance regression in Hive when reading ``VARCHAR`` columns
 
-Kafka Changes
+Kafka changes
 -------------
 * Fix Kafka handling of default port
 * Add support for Kafka messages with a null key
 
-General Changes
+General changes
 ---------------
 * Fix race condition in scheduler that could cause queries to hang
 * Add ConnectorPageSource which is a more efficient interface for column-oriented sources

--- a/docs/src/main/sphinx/release/release-0.78.rst
+++ b/docs/src/main/sphinx/release/release-0.78.rst
@@ -2,7 +2,7 @@
 Release 0.78
 ============
 
-ARRAY and MAP Types in Hive Connector
+ARRAY and MAP types in Hive connector
 -------------------------------------
 
 The Hive connector now returns arrays and maps instead of json encoded strings,
@@ -10,7 +10,7 @@ for columns whose underlying type is array or map. Please note that this is a ba
 incompatible change, and the :doc:`/functions/json` will no longer work on these columns,
 unless you :func:`cast` them to the ``json`` type.
 
-Session Properties
+Session properties
 ------------------
 
 The Presto session can now contain properties, which can be used by the Presto
@@ -40,7 +40,7 @@ For JDBC, the properties can be set by unwrapping the ``Connection`` as follows:
     property values. Additionally, the Presto grammar will be extended to
     allow setting properties via a query.
 
-Hive Changes
+Hive changes
 ------------
 
 * Add ``storage_format`` session property to override format used for creating tables.
@@ -49,7 +49,7 @@ Hive Changes
 * Add support for partition keys with null values (``__HIVE_DEFAULT_PARTITION__``).
 * Fix ``hive.storage-format`` option (see :doc:`release-0.76`).
 
-General Changes
+General changes
 ---------------
 
 * Fix expression optimizer, so that it runs in linear time instead of exponential time.

--- a/docs/src/main/sphinx/release/release-0.79.rst
+++ b/docs/src/main/sphinx/release/release-0.79.rst
@@ -2,7 +2,7 @@
 Release 0.79
 ============
 
-Hive Changes
+Hive changes
 ------------
 
 * Add configuration option ``hive.force-local-scheduling`` and session property
@@ -11,7 +11,7 @@ Hive Changes
   setting the configuration option ``hive.optimized-reader.enabled`` or session
   property ``optimized_reader_enabled``.
 
-General Changes
+General changes
 ---------------
 
 * Add support for :ref:`unnest`, which can be used as a replacement for the ``explode()`` function in Hive.

--- a/docs/src/main/sphinx/release/release-0.80.rst
+++ b/docs/src/main/sphinx/release/release-0.80.rst
@@ -2,7 +2,7 @@
 Release 0.80
 ============
 
-New Hive ORC Reader
+New Hive ORC reader
 -------------------
 
 We have added a new ORC reader implementation. The new reader supports vectorized
@@ -15,20 +15,20 @@ disable the new reader on a per-query basis by setting the
 the reader by default by setting the Hive catalog property
 ``hive.optimized-reader.enabled=false``.
 
-Hive Changes
+Hive changes
 ------------
 
 * The maximum retry time for the Hive S3 file system can be configured
   by setting ``hive.s3.max-retry-time``.
 * Fix Hive partition pruning for null keys (i.e. ``__HIVE_DEFAULT_PARTITION__``).
 
-Cassandra Changes
+Cassandra changes
 -----------------
 
 * Update Cassandra driver to 2.1.0.
 * Map Cassandra ``TIMESTAMP`` type to Presto ``TIMESTAMP`` type.
 
-"Big Query" Support
+"Big Query" support
 -------------------
 
 We've added experimental support for "big" queries. This provides a separate
@@ -45,7 +45,7 @@ the ``experimental_big_query`` session property:
 
 Queries submitted with this property will use hash distribution for all joins.
 
-Metadata-Only Query Optimization
+Metadata-only query optimization
 --------------------------------
 
 We now support an optimization that rewrites aggregation queries that are insensitive to the
@@ -77,7 +77,7 @@ to the coordinator config properties.
       Hive connector will produce incorrect results if your Hive warehouse
       contains partitions without data.
 
-General Changes
+General changes
 ---------------
 
 * Add support implicit joins. The following syntax is now allowed::

--- a/docs/src/main/sphinx/release/release-0.81.rst
+++ b/docs/src/main/sphinx/release/release-0.81.rst
@@ -2,13 +2,13 @@
 Release 0.81
 ============
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix ORC predicate pushdown.
 * Fix column selection in RCFile.
 
-General Changes
+General changes
 ---------------
 
 * Fix handling of null and out-of-range offsets for

--- a/docs/src/main/sphinx/release/release-0.83.rst
+++ b/docs/src/main/sphinx/release/release-0.83.rst
@@ -2,12 +2,12 @@
 Release 0.83
 ============
 
-Raptor Changes
+Raptor changes
 --------------
 * Raptor now enables specifying the backup storage location. This feature is highly experimental.
 * Fix the handling of shards not assigned to any node.
 
-General Changes
+General changes
 ---------------
 
 * Fix resource leak in query queues.

--- a/docs/src/main/sphinx/release/release-0.86.rst
+++ b/docs/src/main/sphinx/release/release-0.86.rst
@@ -2,7 +2,7 @@
 Release 0.86
 ============
 
-General Changes
+General changes
 ---------------
 
 * Add support for inequality ``INNER JOIN`` when each term of the condition refers to only one side of the join.

--- a/docs/src/main/sphinx/release/release-0.87.rst
+++ b/docs/src/main/sphinx/release/release-0.87.rst
@@ -2,7 +2,7 @@
 Release 0.87
 ============
 
-General Changes
+General changes
 ---------------
 
 * Fixed a bug where :ref:`row_type` types could have the wrong field names.

--- a/docs/src/main/sphinx/release/release-0.88.rst
+++ b/docs/src/main/sphinx/release/release-0.88.rst
@@ -2,7 +2,7 @@
 Release 0.88
 ============
 
-General Changes
+General changes
 ---------------
 
 * Added :func:`arbitrary` aggregation function.

--- a/docs/src/main/sphinx/release/release-0.89.rst
+++ b/docs/src/main/sphinx/release/release-0.89.rst
@@ -2,7 +2,7 @@
 Release 0.89
 ============
 
-DATE Type
+DATE type
 ---------
 The memory representation of dates is now the number of days since January 1, 1970
 using a 32-bit signed integer.
@@ -12,7 +12,7 @@ using a 32-bit signed integer.
     representation, so if you have written a connector, you will need to update
     your code before deploying this release.
 
-General Changes
+General changes
 ---------------
 
 * ``USE CATALOG`` and ``USE SCHEMA`` have been replaced with :doc:`/sql/use`.

--- a/docs/src/main/sphinx/release/release-0.90.rst
+++ b/docs/src/main/sphinx/release/release-0.90.rst
@@ -4,7 +4,7 @@ Release 0.90
 
 .. warning:: This release has a memory leak and should not be used.
 
-General Changes
+General changes
 ---------------
 
 * Initial support for partition and placement awareness in the query planner. This can
@@ -27,7 +27,7 @@ General Changes
 * Improve :doc:`/installation/jdbc` conformance. In particular, all unimplemented
   methods now throw ``SQLException`` rather than ``UnsupportedOperationException``.
 
-Functions and Language Features
+Functions and language features
 -------------------------------
 
 * Add :func:`bool_and` and :func:`bool_or` aggregation functions.
@@ -41,7 +41,7 @@ Functions and Language Features
 * Improve formatting of ``EXPLAIN (TYPE DISTRIBUTED)`` output and include additional
   information such as output layout, task placement policy and partitioning functions.
 
-Hive Changes
+Hive changes
 ------------
 * Disable optimized metastore partition fetching for non-string partition keys.
   This fixes an issue were Presto might silently ignore data with non-canonical
@@ -49,7 +49,7 @@ Hive Changes
   to the coordinator and worker config properties.
 * Don't retry operations against S3 that fail due to lack of permissions.
 
-SPI Changes
+SPI changes
 -----------
 * Add ``getColumnTypes`` to ``RecordSink``.
 * Use ``Slice`` for table writer fragments.

--- a/docs/src/main/sphinx/release/release-0.91.rst
+++ b/docs/src/main/sphinx/release/release-0.91.rst
@@ -4,7 +4,7 @@ Release 0.91
 
 .. warning:: This release has a memory leak and should not be used.
 
-General Changes
+General changes
 ---------------
 
 * Clear ``LazyBlockLoader`` reference after load to free memory earlier.

--- a/docs/src/main/sphinx/release/release-0.92.rst
+++ b/docs/src/main/sphinx/release/release-0.92.rst
@@ -2,7 +2,7 @@
 Release 0.92
 ============
 
-General Changes
+General changes
 ---------------
 
 * Fix buffer leak when a query fails.

--- a/docs/src/main/sphinx/release/release-0.93.rst
+++ b/docs/src/main/sphinx/release/release-0.93.rst
@@ -2,7 +2,7 @@
 Release 0.93
 ============
 
-ORC Memory Usage
+ORC memory usage
 ----------------
 
 This release changes the Presto ORC reader to favor small buffers when reading
@@ -29,7 +29,7 @@ If you're upgrading from 0.92, you need to alter your verifier_queries table
     ALTER TABLE verifier_queries add control_username VARCHAR(256) NOT NULL default 'verifier-test';
     ALTER TABLE verifier_queries add control_password VARCHAR(256);
 
-General Changes
+General changes
 ---------------
 
 * Add optimizer for ``LIMIT 0``

--- a/docs/src/main/sphinx/release/release-0.94.rst
+++ b/docs/src/main/sphinx/release/release-0.94.rst
@@ -2,7 +2,7 @@
 Release 0.94
 ============
 
-ORC Memory Usage
+ORC memory usage
 ----------------
 
 This release contains additional changes to the Presto ORC reader to favor
@@ -15,7 +15,7 @@ single ORC buffer, and for larger columns we instead stream the data. This
 reduces heap fragmentation and excessive buffers in ORC at the expense of
 HDFS IOPS. The default value is ``8MB``.
 
-General Changes
+General changes
 ---------------
 
 * Update Hive CDH 4 connector to CDH 4.7.1

--- a/docs/src/main/sphinx/release/release-0.95.rst
+++ b/docs/src/main/sphinx/release/release-0.95.rst
@@ -2,7 +2,7 @@
 Release 0.95
 ============
 
-General Changes
+General changes
 ---------------
 
 * Fix task and stage leak, caused when a stage finishes before its substages.

--- a/docs/src/main/sphinx/release/release-0.96.rst
+++ b/docs/src/main/sphinx/release/release-0.96.rst
@@ -2,7 +2,7 @@
 Release 0.96
 ============
 
-General Changes
+General changes
 ---------------
 
 * Fix :func:`try_cast` for ``TIMESTAMP`` and other types that
@@ -16,7 +16,7 @@ General Changes
 * Fixed "running queries" JMX stat.
 * Add ``distributed_join`` session property to enable/disable distributed joins.
 
-Hive Changes
+Hive changes
 ------------
 
 * Add support for tables partitioned by ``DATE``.

--- a/docs/src/main/sphinx/release/release-0.97.rst
+++ b/docs/src/main/sphinx/release/release-0.97.rst
@@ -2,7 +2,7 @@
 Release 0.97
 ============
 
-General Changes
+General changes
 ---------------
 
 * The queueing policy in Presto may now be injected.
@@ -13,7 +13,7 @@ General Changes
 * Fix a planning issue in queries that use ``SELECT *``, window functions and implicit coercions.
 * Fix scheduler deadlock for queries with a ``UNION`` between ``VALUES`` and ``SELECT``.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix decoding of ``STRUCT`` type from Parquet files.

--- a/docs/src/main/sphinx/release/release-0.98.rst
+++ b/docs/src/main/sphinx/release/release-0.98.rst
@@ -2,7 +2,7 @@
 Release 0.98
 ============
 
-Array, Map, and Row Types
+Array, map, and row types
 -------------------------
 
 The memory representation of these types is now ``VariableWidthBlockEncoding``
@@ -13,12 +13,12 @@ instead of ``JSON``.
     so if you have written a connector or function, you will need to update
     your code before deploying this release.
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix handling of ORC files with corrupt checkpoints.
 
-SPI Changes
+SPI changes
 -----------
 
 * Rename ``Index`` to ``ConnectorIndex``.
@@ -27,7 +27,7 @@ SPI Changes
     This is a backwards incompatible change, so if you have written a connector
     that uses ``Index``, you will need to update your code before deploying this release.
 
-General Changes
+General changes
 ---------------
 
 * Fix bug in ``UNNEST`` when output is unreferenced or partially referenced.

--- a/docs/src/main/sphinx/release/release-0.99.rst
+++ b/docs/src/main/sphinx/release/release-0.99.rst
@@ -2,7 +2,7 @@
 Release 0.99
 ============
 
-General Changes
+General changes
 ---------------
 * Reduce lock contention in ``TaskExecutor``.
 * Fix reading maps with null keys from ORC.

--- a/docs/src/main/sphinx/release/release-300.rst
+++ b/docs/src/main/sphinx/release/release-300.rst
@@ -2,7 +2,7 @@
 Release 300 (22 Jan 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix :func:`array_intersect` and :func:`array_distinct`
@@ -19,7 +19,7 @@ General Changes
   to filters that can be pushed down to connectors.
 * Return final results to clients immediately for failed queries.
 
-JMX MBean Naming Changes
+JMX MBean naming changes
 ------------------------
 
 * The base domain name for server MBeans is now ``presto``. The old names can be
@@ -34,17 +34,17 @@ Web UI
 
 * Fix rendering of live plan view for queries involving index joins.
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Change driver class name to ``io.prestosql.jdbc.PrestoDriver``.
 
-System Connector Changes
+System connector changes
 ------------------------
 
 * Remove ``node_id`` column from ``system.runtime.queries`` table.
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix accounting of time spent reading Parquet data.
@@ -57,49 +57,49 @@ Hive Connector Changes
 * Add support for :ref:`s3selectpushdown`, which enables pushing down
   column selection and range filters into S3 for text files.
 
-Kudu Connector Changes
+Kudu connector changes
 ----------------------
 
 * Add ``number_of_replicas`` table property to ``SHOW CREATE TABLE`` output.
 
-Cassandra Connector Changes
+Cassandra connector changes
 ---------------------------
 
 * Add ``cassandra.splits-per-node`` and ``cassandra.protocol-version`` configuration
   properties to allow connecting to Cassandra servers older than 2.1.5.
 
-MySQL Connector Changes
+MySQL connector changes
 -----------------------
 
 * Add support for predicate pushdown for columns of ``char(x)`` type.
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Add support for predicate pushdown for columns of ``char(x)`` type.
 
-Redshift Connector Changes
+Redshift connector changes
 ---------------------------
 
 * Add support for predicate pushdown for columns of ``char(x)`` type.
 
-SQL Server Connector Changes
+SQL Server connector changes
 ----------------------------
 
 * Add support for predicate pushdown for columns of ``char(x)`` type.
 
-Raptor Legacy Connector Changes
+Raptor Legacy connector changes
 -------------------------------
 
 * Change name of connector to ``raptor-legacy``.
 
-Verifier Changes
+Verifier changes
 ----------------
 
 * Add ``run-teardown-on-result-mismatch`` configuration property to facilitate debugging.
   When set to false, temporary tables will not be dropped after checksum failures.
 
-SPI Changes
+SPI changes
 -----------
 
 * Change base package to ``io.prestosql.spi``.

--- a/docs/src/main/sphinx/release/release-301.rst
+++ b/docs/src/main/sphinx/release/release-301.rst
@@ -2,7 +2,7 @@
 Release 301 (31 Jan 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix reporting of aggregate input data size stats. (:issue:`100`)
@@ -20,17 +20,17 @@ General Changes
 * Improve performance of queries involving ``SYSTEM`` table sampling and computations over the
   columns of the sampled table. (:issue:`29`)
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Do not allow uninstalling RPM while server is still running. (:issue:`67`)
 
-Security Changes
+Security changes
 ----------------
 
 * Support LDAP with anonymous bind disabled. (:issue:`97`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Add procedure for dumping metastore recording to a file. (:issue:`54`)
@@ -43,18 +43,18 @@ Hive Connector Changes
   staging directory that is used for write operations. The ``${USER}`` placeholder can be used to
   use a different location for each user (e.g., ``/tmp/${USER}``). (:issue:`70`)
 
-Kafka Connector Changes
+Kafka connector changes
 -----------------------
 
 * The minimum supported Kafka broker version is now 0.10.0. (:issue:`53`)
 
-Base-JDBC Connector Library Changes
+Base-JDBC connector library changes
 -----------------------------------
 
 * Add support for defining procedures. (:issue:`73`)
 * Add support for providing table statistics. (:issue:`72`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Include session trace token in ``QueryCreatedEvent`` and ``QueryCompletedEvent``. (:issue:`24`)

--- a/docs/src/main/sphinx/release/release-302.rst
+++ b/docs/src/main/sphinx/release/release-302.rst
@@ -2,7 +2,7 @@
 Release 302 (6 Feb 2019)
 ========================
 
-General Changes
+General changes
 ---------------
 
 * Fix cluster starvation when wait for minimum number of workers is enabled. (:issue:`155`)
@@ -17,25 +17,25 @@ General Changes
 * Remove deprecated system memory pool. (:issue:`168`)
 * Improve query performance for certain queries involving ``ROLLUP``. (:issue:`105`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Add ``--trace-token`` option to set the trace token. (:issue:`117`)
 * Display spilled data size as part of debug information. (:issue:`161`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Add spilled data size to query details page. (:issue:`161`)
 
-Security Changes
+Security changes
 ----------------
 
 * Add ``http.server.authentication.krb5.principal-hostname`` configuration option to set the hostname
   for the Kerberos service principal. (:issue:`146`, :issue:`153`)
 * Add support for client-provided extra credentials that can be utilized by connectors. (:issue:`124`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix Parquet predicate pushdown for ``smallint``, ``tinyint`` types. (:issue:`131`)
@@ -46,17 +46,17 @@ Hive Connector Changes
 * Reduce GC pressure from Parquet reader by constraining the maximum column read size. (:issue:`58`)
 * Reduce network utilization and latency for S3 when reading ORC or Parquet. (:issue:`142`)
 
-Kafka Connector Changes
+Kafka connector changes
 -----------------------
 
 * Fix query failure when reading ``information_schema.columns`` without an equality condition on ``table_name``. (:issue:`120`)
 
-Redis Connector Changes
+Redis connector changes
 -----------------------
 
 * Fix query failure when reading ``information_schema.columns`` without an equality condition on ``table_name``. (:issue:`120`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Include query peak task user memory in ``QueryCreatedEvent`` and ``QueryCompletedEvent``. (:issue:`163`)

--- a/docs/src/main/sphinx/release/release-303.rst
+++ b/docs/src/main/sphinx/release/release-303.rst
@@ -2,7 +2,7 @@
 Release 303 (13 Feb 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect padding for ``CHAR`` values containing Unicode supplementary characters.
@@ -16,35 +16,35 @@ General Changes
 * Expand grouped execution support to window functions, making it possible
   to execute them with less peak memory usage. (:issue:`169`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Add additional details to and improve rendering of live plan. (:issue:`182`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Add ``--progress`` option to show query progress in batch mode. (:issue:`34`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix query failure when reading Parquet data with no columns selected.
   This affects queries such as ``SELECT count(*)``. (:issue:`203`)
 
-Mongo Connector Changes
+Mongo connector changes
 -----------------------
 
 * Fix failure for queries involving joins or aggregations on ``ObjectId`` type. (:issue:`215`)
 
 
-Base-JDBC Connector Library Changes
+Base-JDBC connector library changes
 -----------------------------------
 
 * Allow customizing how query predicates are pushed down to the underlying database. (:issue:`109`)
 * Allow customizing how values are written to the underlying database. (:issue:`109`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Remove deprecated methods ``getSchemaName`` and ``getTableName`` from the ``SchemaTablePrefix``

--- a/docs/src/main/sphinx/release/release-304.rst
+++ b/docs/src/main/sphinx/release/release-304.rst
@@ -2,7 +2,7 @@
 Release 304 (27 Feb 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix wrong results for queries involving ``FULL OUTER JOIN`` and ``coalesce`` expressions
@@ -15,19 +15,19 @@ General Changes
 * Avoid opening an unnecessary HTTP listener on an arbitrary port. (:issue:`239`)
 * Add experimental support for spilling for queries involving ``ORDER BY`` or window functions. (:issue:`228`)
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Preserve modified configuration files when the RPM is uninstalled. (:issue:`267`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix broken timeline view. (:issue:`283`)
 * Show data size and position count reported by connectors and by worker-to-worker data transfers
   in detailed query view. (:issue:`271`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix authorization failure when using SQL Standard Based Authorization mode with user identifiers
@@ -50,12 +50,12 @@ Hive Connector Changes
   in the metastore with the partitions that are physically on the file system. (:issue:`223`)
 * Improve performance of ORC reader for columns that only contain nulls. (:issue:`229`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Map PostgreSQL ``json`` and ``jsonb`` types to Presto ``json`` type. (:issue:`81`)
 
-Cassandra Connector Changes
+Cassandra connector changes
 ---------------------------
 
 * Support queries over tables containing partitioning columns of any type. (:issue:`252`)

--- a/docs/src/main/sphinx/release/release-305.rst
+++ b/docs/src/main/sphinx/release/release-305.rst
@@ -2,7 +2,7 @@
 Release 305 (7 Mar 2019)
 ========================
 
-General Changes
+General changes
 ---------------
 
 * Fix failure of :doc:`/functions/regexp` for certain patterns and inputs
@@ -17,23 +17,23 @@ General Changes
 * Add a system table ``system.metadata.analyze_properties``
   to list all :doc:`/sql/analyze` properties. (:issue:`376`)
 
-Resource Groups Changes
+Resource groups changes
 -----------------------
 
 * Fix resource group selection when selector uses regular expression variables. (:issue:`373`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Display peak revocable memory, current total memory,
   and peak total memory in detailed query view. (:issue:`273`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Add option to output CSV without quotes. (:issue:`319`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix handling of updated credentials for Google Cloud Storage (GCS). (:issue:`398`)
@@ -48,7 +48,7 @@ Hive Connector Changes
 * Remove legacy writers for ORC and RCFile. (:issue:`353`)
 * Remove support for the DWRF file format. (:issue:`353`)
 
-Base-JDBC Connector Library Changes
+Base-JDBC connector library changes
 -----------------------------------
 
 * Allow access to extra credentials when opening a JDBC connection. (:issue:`281`)

--- a/docs/src/main/sphinx/release/release-306.rst
+++ b/docs/src/main/sphinx/release/release-306.rst
@@ -2,7 +2,7 @@
 Release 306 (16 Mar 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix planning failure for queries containing a ``LIMIT`` after a global
@@ -33,7 +33,7 @@ General Changes
 * Remove deprecated ``distributed_join`` system property. Use ``join_distribution_type``
   instead. (:issue:`452`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix calling procedures immediately after startup, before any other queries are run.
@@ -41,33 +41,33 @@ Hive Connector Changes
   to fail. (:issue:`414`)
 * Improve ORC reader performance for decoding ``REAL`` and ``DOUBLE`` types. (:issue:`465`)
 
-MySQL Connector Changes
+MySQL connector changes
 -----------------------
 
 * Allow creating or renaming tables, and adding, renaming, or dropping columns. (:issue:`418`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Fix predicate pushdown for PostgreSQL ``ENUM`` type. (:issue:`408`)
 * Allow creating or renaming tables, and adding, renaming, or dropping columns. (:issue:`418`)
 
-Redshift Connector Changes
+Redshift connector changes
 --------------------------
 
 * Allow creating or renaming tables, and adding, renaming, or dropping columns. (:issue:`418`)
 
-SQL Server Connector Changes
+SQL Server connector changes
 ----------------------------
 
 * Allow creating or renaming tables, and adding, renaming, or dropping columns. (:issue:`418`)
 
-Base-JDBC Connector Library Changes
+Base-JDBC connector library changes
 -----------------------------------
 
 * Allow mapping column type to Presto type based on ``Block``. (:issue:`454`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Deprecate Table Layout APIs. Connectors can opt out of the legacy behavior by implementing

--- a/docs/src/main/sphinx/release/release-307.rst
+++ b/docs/src/main/sphinx/release/release-307.rst
@@ -2,7 +2,7 @@
 Release 307 (3 Apr 2019)
 ========================
 
-General Changes
+General changes
 ---------------
 
 * Fix cleanup of spill files for queries using window functions or ``ORDER BY``. (:issue:`543`)
@@ -14,18 +14,18 @@ General Changes
 * Add support for outer joins involving lateral derived tables (i.e., ``LATERAL``). (:issue:`390`)
 * Add support for setting table comments via the :doc:`/sql/comment` syntax. (:issue:`200`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Allow UI to work when opened as ``/ui`` (no trailing slash). (:issue:`500`)
 
-Security Changes
+Security changes
 ----------------
 
 * Make query result and cancellation URIs secure. Previously, an authenticated
   user could potentially steal the result data of any running query. (:issue:`561`)
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Prevent JVM from allocating large amounts of native memory. The new configuration is applied
@@ -33,19 +33,19 @@ Server RPM Changes
   you provide your own ``jvm.config``, we recommend adding ``-Djdk.nio.maxCachedBufferSize=2000000``
   to your ``jvm.config``. See :doc:`/installation/deployment` for details. (:issue:`542`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Always abort query in batch mode when CLI is killed. (:issue:`508`, :issue:`580`)
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Abort query synchronously when the ``ResultSet`` is closed or when the
   ``Statement`` is cancelled. Previously, the abort was sent in the background,
   allowing the JVM to exit before the abort was received by the server. (:issue:`580`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Add safety checks for Hive bucketing version. Hive 3.0 introduced a new
@@ -53,27 +53,27 @@ Hive Connector Changes
   will treat such tables as not bucketed when reading and disallows writing. (:issue:`512`)
 * Add support for setting table comments via the :doc:`/sql/comment` syntax. (:issue:`200`)
 
-MySQL Connector Changes
+MySQL connector changes
 -----------------------
 
-See `Base-JDBC Connector Library Changes <#base-jdbc-connector-library-changes>`__.
+See `Base-JDBC connector library changes <#base-jdbc-connector-library-changes>`__.
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
-See `Base-JDBC Connector Library Changes <#base-jdbc-connector-library-changes>`__.
+See `Base-JDBC connector library changes <#base-jdbc-connector-library-changes>`__.
 
-Redshift Connector Changes
+Redshift connector changes
 --------------------------
 
-See `Base-JDBC Connector Library Changes <#base-jdbc-connector-library-changes>`__.
+See `Base-JDBC connector library changes <#base-jdbc-connector-library-changes>`__.
 
-SQL Server Connector Changes
+SQL Server connector changes
 ----------------------------
 
-See `Base-JDBC Connector Library Changes <#base-jdbc-connector-library-changes>`__.
+See `Base-JDBC connector library changes <#base-jdbc-connector-library-changes>`__.
 
-Base-JDBC Connector Library Changes
+Base-JDBC connector library changes
 -----------------------------------
 
 * Fix reading and writing of ``timestamp`` values. Previously, an incorrect value
@@ -82,7 +82,7 @@ Base-JDBC Connector Library Changes
   names can be configured using the ``user-credential-name`` and ``password-credential-name``
   configuration properties. (:issue:`482`)
 
-SPI Changes
+SPI changes
 -----------
 
 * ``LongDecimalType`` and ``IpAddressType`` now use ``Int128ArrayBlock`` instead

--- a/docs/src/main/sphinx/release/release-308.rst
+++ b/docs/src/main/sphinx/release/release-308.rst
@@ -2,30 +2,30 @@
 Release 308 (11 Apr 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix a regression that prevented the server from starting on Java 9+. (:issue:`610`)
 * Fix correctness issue for queries involving ``FULL OUTER JOIN`` and ``coalesce``. (:issue:`622`)
 
-Security Changes
+Security changes
 ----------------
 
 * Add authorization for listing table columns. (:issue:`507`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Add option for specifying Kerberos service principal pattern. (:issue:`597`)
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Correctly report precision and column display size in ``ResultSetMetaData``
   for ``char`` and ``varchar`` columns. (:issue:`615`)
 * Add option for specifying Kerberos service principal pattern. (:issue:`597`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix regression that could cause queries to fail with ``Query can potentially
@@ -36,23 +36,23 @@ Hive Connector Changes
 * Add directory listing cache for specific tables. The list of tables is specified
   using the  ``hive.file-status-cache-tables`` configuration property. (:issue:`343`)
 
-MySQL Connector Changes
+MySQL connector changes
 -----------------------
 
 * Fix ``ALTER TABLE ... RENAME TO ...`` statement. (:issue:`586`)
 * Push simple ``LIMIT`` queries into the external database. (:issue:`589`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Push simple ``LIMIT`` queries into the external database. (:issue:`589`)
 
-Redshift Connector Changes
+Redshift connector changes
 --------------------------
 
 * Push simple ``LIMIT`` queries into the external database. (:issue:`589`)
 
-SQL Server Connector Changes
+SQL Server connector changes
 ----------------------------
 
 * Fix writing ``varchar`` values with non-Latin characters in ``CREATE TABLE AS``. (:issue:`573`)
@@ -61,7 +61,7 @@ SQL Server Connector Changes
 * Support writing ``boolean`` values in ``CREATE TABLE AS``. (:issue:`573`)
 * Push simple ``LIMIT`` queries into the external database. (:issue:`589`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Add support for Search Guard in Elasticsearch connector. Please refer to :doc:`/connector/elasticsearch`

--- a/docs/src/main/sphinx/release/release-309.rst
+++ b/docs/src/main/sphinx/release/release-309.rst
@@ -2,7 +2,7 @@
 Release 309 (25 Apr 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect match result for :doc:`/functions/regexp` when pattern ends
@@ -11,18 +11,18 @@ General Changes
 * Fix failures for queries involving spatial joins. (:issue:`652`)
 * Add support for ``SphericalGeography`` to :func:`ST_Area()`. (:issue:`383`)
 
-Security Changes
+Security changes
 ----------------
 
 * Add option for specifying the Kerberos GSS name type. (:issue:`645`)
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Update default JVM configuration to recommended settings (see :doc:`/installation/deployment`).
   (:issue:`642`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix rare failure when reading ``DECIMAL`` values from ORC files. (:issue:`664`)
@@ -30,13 +30,13 @@ Hive Connector Changes
   properties. For example, a table named ``example`` will have an associated
   properties table named ``example$properties``. (:issue:`268`)
 
-MySQL Connector Changes
+MySQL connector changes
 -----------------------
 
 * Match schema and table names case insensitively. This behavior can be enabled by setting
   the ``case-insensitive-name-matching`` catalog configuration option to true. (:issue:`614`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Add support for ``ARRAY`` type. (:issue:`317`)
@@ -45,26 +45,26 @@ PostgreSQL Connector Changes
   the ``case-insensitive-name-matching`` catalog configuration option to true. (:issue:`614`)
 
 
-Redshift Connector Changes
+Redshift connector changes
 --------------------------
 
 * Match schema and table names case insensitively. This behavior can be enabled by setting
   the ``case-insensitive-name-matching`` catalog configuration option to true. (:issue:`614`)
 
 
-SQL Server Connector Changes
+SQL Server connector changes
 ----------------------------
 
 * Match schema and table names case insensitively. This behavior can be enabled by setting
   the ``case-insensitive-name-matching`` catalog configuration option to true. (:issue:`614`)
 
-Cassandra Connector Changes
+Cassandra connector changes
 ---------------------------
 
 * Allow reading from tables which have Cassandra column types that are not supported by Presto.
   These columns will not be visible in Presto. (:issue:`592`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Add session parameter to the ``applyFilter()`` and ``applyLimit()`` methods in

--- a/docs/src/main/sphinx/release/release-310.rst
+++ b/docs/src/main/sphinx/release/release-310.rst
@@ -2,7 +2,7 @@
 Release 310 (3 May 2019)
 ========================
 
-General Changes
+General changes
 ---------------
 
 * Reduce compilation failures for expressions over types containing an extremely
@@ -17,12 +17,12 @@ General Changes
   experience significant CPU and performance improvement. (:issue:`602`)
 * Add support for ``FETCH FIRST`` syntax. (:issue:`666`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Make the final query time consistent with query stats. (:issue:`692`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Ignore boolean column statistics when the count is ``-1``. (:issue:`241`)
@@ -33,12 +33,12 @@ Hive Connector Changes
   partition and table schema mismatch. (:issue:`352`)
 * Fix typo in Metastore recorder duration property name. (:issue:`711`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Support for the ``ARRAY`` type has been disabled by default.  (:issue:`687`)
 
-Blackhole Connector Changes
+Blackhole connector changes
 ---------------------------
 
 * Support having tables with same name in different Blackhole schemas. (:issue:`550`)

--- a/docs/src/main/sphinx/release/release-311.rst
+++ b/docs/src/main/sphinx/release/release-311.rst
@@ -2,7 +2,7 @@
 Release 311 (14 May 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect results for aggregation query that contains a ``HAVING`` clause but no
@@ -14,25 +14,25 @@ General Changes
 * Print cost metrics using appropriate units in the output of ``EXPLAIN``. (:issue:`68`)
 * Add :func:`combinations` function. (:issue:`714`)
 
-Hive Connector Changes
+Hive connector changes
 ------------------------
 
 * Add support for static AWS credentials for the Glue metastore. (:issue:`748`)
 
-Cassandra Connector Changes
+Cassandra connector changes
 ---------------------------
 
 * Support collections nested in other collections. (:issue:`657`)
 * Automatically discover the Cassandra protocol version when the previously required
   ``cassandra.protocol-version`` configuration property is not set. (:issue:`596`)
 
-Black Hole Connector Changes
+Black Hole connector changes
 ----------------------------
 
 * Fix rendering of tables and columns in plans. (:issue:`728`)
 * Add table and column statistics. (:issue:`728`)
 
-System Connector Changes
+System connector changes
 ------------------------
 
 * Add ``system.metadata.table_comments`` table that contains table comments. (:issue:`531`)

--- a/docs/src/main/sphinx/release/release-312.rst
+++ b/docs/src/main/sphinx/release/release-312.rst
@@ -2,7 +2,7 @@
 Release 312 (29 May 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect results for queries using ``IS [NOT] DISTINCT FROM``. (:issue:`795`)
@@ -28,7 +28,7 @@ General Changes
 * Report operator statistics when ``experimental.work-processor-pipelines``
   is enabled. (:issue:`788`)
 
-Server Changes
+Server changes
 --------------
 
 * Raise required Java version to 8u161. This version allows unlimited strength crypto. (:issue:`779`)
@@ -41,7 +41,7 @@ Server Changes
   ``query-manager.required-workers`` and ``query-manager.required-workers-max-wait`` configuration
   properties instead. (:issue:`95`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix ``SHOW GRANTS`` failure when metastore contains few tables. (:issue:`791`)
@@ -56,17 +56,17 @@ Hive Connector Changes
   but can be disabled using the ``hive.create-empty-bucket-files`` configuration property
   or the ``create_empty_bucket_files`` session property. (:issue:`822`)
 
-MySQL Connector Changes
+MySQL connector changes
 -----------------------
 
 * Map MySQL ``json`` type to Presto ``json`` type. (:issue:`824`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Add support for PostgreSQL's ``TIMESTAMP WITH TIME ZONE`` data type. (:issue:`640`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Add support for pushing ``TABLESAMPLE`` into connectors via the

--- a/docs/src/main/sphinx/release/release-313.rst
+++ b/docs/src/main/sphinx/release/release-313.rst
@@ -2,24 +2,24 @@
 Release 313 (31 May 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix leak in operator peak memory computations. (:issue:`843`)
 * Fix incorrect results for queries involving ``GROUPING SETS`` and ``LIMIT``. (:issue:`864`)
 * Add compression and encryption support for :doc:`/admin/spill`. (:issue:`778`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix failure when selecting a value of type :ref:`uuid_type`. (:issue:`854`)
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Fix failure when selecting a value of type :ref:`uuid_type`. (:issue:`854`)
 
-Phoenix Connector Changes
+Phoenix connector changes
 ---------------------------
 
 * Allow matching schema and table names case insensitively. This can be enabled by setting

--- a/docs/src/main/sphinx/release/release-314.rst
+++ b/docs/src/main/sphinx/release/release-314.rst
@@ -2,7 +2,7 @@
 Release 314 (7 Jun 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect results for ``BETWEEN`` involving ``NULL`` values. (:issue:`877`)
@@ -13,23 +13,23 @@ General Changes
 * Add support for positional access to ``ROW`` fields via the subscript
   operator. (:issue:`860`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Add JSON output format. (:issue:`878`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix queued queries counter in UI. (:issue:`894`)
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Change default location of the ``http-request.log`` to ``/var/log/presto``. Previously,
   the log would be located in ``/var/lib/presto/data/var/log`` by default. (:issue:`919`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix listing tables and views from Hive 2.3+ Metastore on certain databases,
@@ -49,23 +49,23 @@ Hive Connector Changes
   the split discovery rate, which can reduce load on the file system. (:issue:`534`)
 * Support overwriting unpartitioned tables for insert queries. (:issue:`924`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Support PostgreSQL arrays declared using internal type
   name, for example ``_int4`` (rather than ``int[]``). (:issue:`659`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Add support for mixed-case field names. (:issue:`887`)
 
-Base-JDBC Connector Library Changes
+Base-JDBC connector library changes
 -----------------------------------
 
 * Allow connectors to customize how they store ``NULL`` values. (:issue:`918`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Expose the SQL text of the executed prepared statement to ``EventListener``. (:issue:`908`)

--- a/docs/src/main/sphinx/release/release-315.rst
+++ b/docs/src/main/sphinx/release/release-315.rst
@@ -2,7 +2,7 @@
 Release 315 (14 Jun 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect results when dividing certain decimal numbers. (:issue:`958`)
@@ -10,17 +10,17 @@ General Changes
 * Add locality awareness to default split scheduler. (:issue:`680`)
 * Add :func:`format` function. (:issue:`548`)
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Require JDK version 8u161+ during installation, which is the version the server requires. (:issue:`983`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix alignment of nulls for numeric columns in aligned output format. (:issue:`871`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix regression in partition pruning for certain query shapes. (:issue:`984`)
@@ -33,13 +33,13 @@ Hive Connector Changes
   by turning on ``DEBUG`` logging for
   ``io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreClient``. (:issue:`946`)
 
-MongoDB Connector Changes
+MongoDB connector changes
 -------------------------
 
 * Fix query failure when ``ROW`` with an ``ObjectId`` field is used as a join key. (:issue:`933`)
 * Add cast from ``ObjectId`` to ``VARCHAR``. (:issue:`933`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Allow connectors to provide view definitions. ``ConnectorViewDefinition`` now contains

--- a/docs/src/main/sphinx/release/release-316.rst
+++ b/docs/src/main/sphinx/release/release-316.rst
@@ -2,7 +2,7 @@
 Release 316 (8 Jul 2019)
 ========================
 
-General Changes
+General changes
 ---------------
 
 * Fix ``date_format`` function failure when format string contains non-ASCII
@@ -10,13 +10,13 @@ General Changes
 * Improve performance of queries using ``UNNEST``.  (:issue:`901`)
 * Improve error message when statement parsing fails. (:issue:`1042`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix refresh of completion cache when catalog or schema is changed. (:issue:`1016`)
 * Allow reading password from console when stdout is a pipe. (:issue:`982`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Acquire S3 credentials from the default AWS locations if not configured explicitly. (:issue:`741`)
@@ -28,38 +28,38 @@ Hive Connector Changes
   ``collect_column_statistics_on_write`` session property. (:issue:`981`)
 * Eliminate unused idle threads when using the metastore cache. (:issue:`1061`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Add support for columns of type ``UUID``. (:issue:`1011`)
 * Export JMX statistics for various JDBC and connector operations. (:issue:`906`).
 
-MySQL Connector Changes
+MySQL connector changes
 -----------------------
 
 * Export JMX statistics for various JDBC and connector operations. (:issue:`906`).
 
-Redshift Connector Changes
+Redshift connector changes
 --------------------------
 
 * Export JMX statistics for various JDBC and connector operations. (:issue:`906`).
 
-SQL Server Connector Changes
+SQL Server connector changes
 ----------------------------
 
 * Export JMX statistics for various JDBC and connector operations. (:issue:`906`).
 
-TPC-H Connector Changes
+TPC-H connector changes
 -----------------------
 
 * Fix ``SHOW TABLES`` failure when used with a hidden schema. (:issue:`1005`)
 
-TPC-DS Connector Changes
+TPC-DS connector changes
 ------------------------
 
 * Fix ``SHOW TABLES`` failure when used with a hidden schema. (:issue:`1005`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Add support for pushing simple column and row field reference expressions into

--- a/docs/src/main/sphinx/release/release-317.rst
+++ b/docs/src/main/sphinx/release/release-317.rst
@@ -2,7 +2,7 @@
 Release 317 (1 Aug 2019)
 ========================
 
-General Changes
+General changes
 ---------------
 
 * Fix :func:`url_extract_parameter` when the query string contains an encoded ``&`` or ``=`` character.
@@ -14,13 +14,13 @@ General Changes
 * Allow overriding session time zone for clients via the
   ``sql.forced-session-time-zone`` configuration property. (:issue:`1164`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix tooltip visibility on stage performance details page. (:issue:`1113`)
 * Add planning time to query details page. (:issue:`1115`)
 
-Security Changes
+Security changes
 ----------------
 
 * Allow schema owner to create, drop, and rename schema when using file-based
@@ -32,17 +32,17 @@ Security Changes
   configuration property, as the header should only be used when the Presto
   coordinator is behind a proxy. (:issue:`1033`)
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Fix ``DatabaseMetaData.getURL()`` to include the ``jdbc:`` prefix. (:issue:`1211`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Add support for nested fields. (:issue:`1001`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix bucketing version safety check to correctly disallow writes
@@ -51,22 +51,22 @@ Hive Connector Changes
 * Improve performance of file listings in ``system.sync_partition_metadata`` procedure,
   especially for S3. (:issue:`1093`)
 
-Kudu Connector Changes
+Kudu connector changes
 ----------------------
 
 * Update Kudu client library version to ``1.10.0``. (:issue:`1086`)
 
-MongoDB Connector Changes
+MongoDB connector changes
 -------------------------
 
 * Allow passwords to contain the ``:`` or ``@`` characters. (:issue:`1094`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Add support for reading ``hstore`` data type. (:issue:`1101`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Allow delete to be implemented for non-legacy connectors. (:issue:`1015`)

--- a/docs/src/main/sphinx/release/release-318.rst
+++ b/docs/src/main/sphinx/release/release-318.rst
@@ -2,7 +2,7 @@
 Release 318 (26 Aug 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix query failure when using ``DISTINCT FROM`` with the ``UUID`` or
@@ -29,7 +29,7 @@ General Changes
 * Add queries that are in the queue or in the semantic analysis stage to the
   ``system.runtime.queries`` table. (:issue:`1079`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Display information about queries that are in the queue or in the semantic analysis
@@ -37,7 +37,7 @@ Web UI Changes
 * Add support for cancelling queries that are in the queue or in the semantic analysis
   stage. (:issue:`1079`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix query failure due to missing credentials while writing empty bucket files. (:issue:`1298`)
@@ -53,7 +53,7 @@ Hive Connector Changes
 * Allow inserting into bucketed, unpartitioned tables. (:issue:`1127`)
 * Allow inserting into existing partitions of bucketed, partitioned tables. (:issue:`1347`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Add support for providing JDBC credential in a separate file. This can be enabled by
@@ -65,7 +65,7 @@ PostgreSQL Connector Changes
   by setting ``jdbc-types-mapped-to-varchar`` to comma-separated list of type names. (:issue:`186`)
 * Add support for PostgreSQL ``timestamp[]`` type. (:issue:`1023`, :issue:`1262`, :issue:`1328`)
 
-MySQL Connector Changes
+MySQL connector changes
 -----------------------
 
 * Add support for providing JDBC credential in a separate file. This can be enabled by
@@ -76,7 +76,7 @@ MySQL Connector Changes
 * Add possibility to force mapping of certain types to ``varchar``. This can be enabled
   by setting ``jdbc-types-mapped-to-varchar`` to comma-separated list of type names. (:issue:`186`)
 
-Redshift Connector Changes
+Redshift connector changes
 --------------------------
 
 * Add support for providing JDBC credential in a separate file. This can be enabled by
@@ -87,7 +87,7 @@ Redshift Connector Changes
 * Add possibility to force mapping of certain types to ``varchar``. This can be enabled
   by setting ``jdbc-types-mapped-to-varchar`` to comma-separated list of type names. (:issue:`186`)
 
-SQL Server Connector Changes
+SQL Server connector changes
 ----------------------------
 
 * Add support for providing JDBC credential in a separate file. This can be enabled by
@@ -98,7 +98,7 @@ SQL Server Connector Changes
 * Add possibility to force mapping of certain types to ``varchar``. This can be enabled
   by setting ``jdbc-types-mapped-to-varchar`` to comma-separated list of type names. (:issue:`186`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Add ``Block.isLoaded()`` method. (:issue:`1216`)

--- a/docs/src/main/sphinx/release/release-319.rst
+++ b/docs/src/main/sphinx/release/release-319.rst
@@ -2,7 +2,7 @@
 Release 319 (22 Sep 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix planning failure for queries involving ``UNION`` and ``DISTINCT`` aggregates. (:issue:`1510`)
@@ -34,7 +34,7 @@ General Changes
   via the ``node-scheduler.network-topology.type`` configuration property. (:issue:`1500`)
 * Add support for ``SphericalGeography`` to :func:`ST_Length`. (:issue:`1551`)
 
-Security Changes
+Security changes
 ----------------
 
 * Allow configuring read-only access in :doc:`/security/built-in-system-access-control`. (:issue:`1153`)
@@ -43,19 +43,19 @@ Security Changes
   ``X-Forwarded-Proto`` header. This is disabled by default, but can be enabled using the
   ``http-server.authentication.allow-forwarded-https`` configuration property. (:issue:`1442`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix rendering bug in Query Timeline resulting in inconsistency of presented information after
   query finishes. (:issue:`1371`)
 * Show total memory in Query Timeline instead of user memory. (:issue:`1371`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Add ``--insecure`` option to skip validation of server certificates for debugging. (:issue:`1484`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix reading from ``information_schema``, as well as ``SHOW SCHEMAS``, ``SHOW TABLES``, and

--- a/docs/src/main/sphinx/release/release-320.rst
+++ b/docs/src/main/sphinx/release/release-320.rst
@@ -2,7 +2,7 @@
 Release 320 (10 Oct 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect parameter binding order for prepared statement execution when
@@ -18,18 +18,18 @@ General Changes
 * Add :func:`at_timezone`. (:issue:`1612`)
 * Add :func:`with_timezone`. (:issue:`1612`)
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Only report warnings on ``Statement``, not ``ResultSet``, as warnings
   are not associated with reads of the ``ResultSet``. (:issue:`1640`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Add multi-line editing and syntax highlighting. (:issue:`1380`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Add impersonation support for calls to the Hive metastore. This can be enabled using the
@@ -39,21 +39,21 @@ Hive Connector Changes
   SOCKS proxy. Previously, it was controlled with the ``hive.metastore.thrift.client.socks-proxy``
   configuration property. (:issue:`1469`)
 
-MySQL Connector Changes
+MySQL connector changes
 -----------------------
 
 * Add ``mysql.jdbc.use-information-schema`` configuration property to control whether
   the MySQL JDBC driver should use the MySQL ``information_schema`` to answer metadata
   queries. This may be helpful when diagnosing problems. (:issue:`1598`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Add support for reading PostgreSQL system tables, e.g., ``pg_catalog`` relations.
   The functionality is disabled by default and can be enabled using the
   ``postgresql.include-system-tables`` configuration property. (:issue:`1527`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Add support for ``VARBINARY``, ``TIMESTAMP``, ``TINYINT``, ``SMALLINT``,
@@ -62,7 +62,7 @@ Elasticsearch Connector Changes
 * Add support for special ``_id``, ``_score`` and ``_source`` columns. (:issue:`1639`)
 * Add support for :ref:`full text queries <elasticsearch-full-text-queries>`. (:issue:`1662`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Introduce a builder for ``Identity`` and deprecate its public constructors. (:issue:`1624`)

--- a/docs/src/main/sphinx/release/release-321.rst
+++ b/docs/src/main/sphinx/release/release-321.rst
@@ -4,7 +4,7 @@ Release 321 (15 Oct 2019)
 
 .. warning:: The server RPM is broken in this release.
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect result of :func:`round` when applied to a ``tinyint``, ``smallint``,
@@ -14,12 +14,12 @@ General Changes
   via the ``experimental.enable-dynamic-filtering`` configuration option or the
   ``enable_dynamic_filtering`` session property. (:issue:`1686`)
 
-Security Changes
+Security changes
 ----------------
 
 * Improve the security of query results with one-time tokens. (:issue:`1654`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix reading ``TEXT`` file collection delimiter set by Hive versions earlier
@@ -36,29 +36,29 @@ Hive Connector Changes
 * Allow caching directory listings for all tables or schemas. (:issue:`1668`)
 * Add support for dynamic filtering for broadcast joins. (:issue:`1686`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Support reading PostgreSQL arrays as the ``JSON`` data type. This can be enabled by
   setting the ``postgresql.experimental.array-mapping`` configuration property or the
   ``array_mapping`` catalog session property to ``AS_JSON``. (:issue:`682`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Add support for Amazon Elasticsearch Service. (:issue:`1693`)
 
-Cassandra Connector Changes
+Cassandra connector changes
 ---------------------------
 
 * Add TLS support. (:issue:`1680`)
 
-JMX Connector Changes
+JMX connector changes
 ---------------------
 
 * Add support for wildcards in configuration of history tables. (:issue:`1572`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Fix ``QueryStatistics.getWallTime()`` to report elapsed time rather than total

--- a/docs/src/main/sphinx/release/release-322.rst
+++ b/docs/src/main/sphinx/release/release-322.rst
@@ -2,18 +2,18 @@
 Release 322 (16 Oct 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Improve performance of certain join queries by reducing the amount of data
   that needs to be scanned. (:issue:`1673`)
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Fix a regression that caused zero-length files in the RPM. (:issue:`1767`)
 
-Connector Changes
+Connector changes
 -----------------
 
 These changes apply to MySQL, PostgreSQL, Redshift, and SQL Server.

--- a/docs/src/main/sphinx/release/release-323.rst
+++ b/docs/src/main/sphinx/release/release-323.rst
@@ -2,7 +2,7 @@
 Release 323 (23 Oct 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix query failure when referencing columns from a table that contains
@@ -15,18 +15,18 @@ General Changes
 * Allow using ``.*`` on expressions of type ``ROW`` in the ``SELECT`` clause to
   convert the fields of a row into multiple columns. (:issue:`1017`)
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Fix a compatibility issue when connecting to pre-321 servers. (:issue:`1785`)
 * Fix reporting of views in ``DatabaseMetaData.getTables()``. (:issue:`1488`)
 
-CLI Changes
+CLI changes
 ------------
 
 * Fix a compatibility issue when connecting to pre-321 servers. (:issue:`1785`)
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix the ORC writer to correctly write the file footers. Previously written files were
@@ -37,14 +37,14 @@ Hive Changes
 * Allow using multiple Hive catalogs that use different Kerberos or other authentication
   configurations. (:issue:`760`, :issue:`978`, :issue:`1820`)
 
-PostgreSQL Changes
+PostgreSQL changes
 ------------------
 
 * Support for PostgreSQL arrays is no longer considered experimental, therefore
   the configuration property ``postgresql.experimental.array-mapping`` is now named
   to ``postgresql.array-mapping``. (:issue:`1740`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Add support for unnesting dictionary blocks duration compaction. (:issue:`1761`)

--- a/docs/src/main/sphinx/release/release-324.rst
+++ b/docs/src/main/sphinx/release/release-324.rst
@@ -3,7 +3,7 @@ Release 324 (1 Nov 2019)
 ========================
 
 
-General Changes
+General changes
 ---------------
 
 * Fix query failure when ``CASE`` operands have different types. (:issue:`1825`)
@@ -15,20 +15,20 @@ General Changes
 * Configuration property ``experimental.reserved-pool-enabled`` was renamed to
   ``experimental.reserved-pool-disabled`` (with meaning reversed). (:issue:`1916`)
 
-Security Changes
+Security changes
 ----------------
 
 * Perform access control checks when displaying table or view definitions
   with ``SHOW CREATE``. (:issue:`1517`)
 
-Hive Changes
+Hive changes
 ------------
 
 * Allow using ``SHOW GRANTS`` on a Hive view when using the ``sql-standard``
   security mode. (:issue:`1842`)
 * Improve performance when filtering dictionary-encoded Parquet columns. (:issue:`1846`)
 
-PostgreSQL Changes
+PostgreSQL changes
 ------------------
 
 * Add support for inserting ``MAP(VARCHAR, VARCHAR)`` values into columns of
@@ -40,7 +40,7 @@ Elasticsearch Changes
 * Fix failure when reading datetime columns in Elasticsearch 5.x. (:issue:`1844`)
 * Add support for mixed-case field names. (:issue:`1914`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Introduce a builder for ``ColumnMetadata``. The various overloaded constructors

--- a/docs/src/main/sphinx/release/release-325.rst
+++ b/docs/src/main/sphinx/release/release-325.rst
@@ -4,7 +4,7 @@ Release 325 (14 Nov 2019)
 
 .. warning:: There is a performance regression in this release.
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect results for certain queries involving ``FULL`` or ``RIGHT`` joins and
@@ -22,12 +22,12 @@ General Changes
 * Add variant of :func:`strpos` that returns the Nth occurrence of a substring. (:issue:`1811`)
 * Add :func:`to_encoded_polyline` and :func:`from_encoded_polyline` geospatial functions. (:issue:`1827`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Show actual query for an ``EXECUTE`` statement. (:issue:`1980`)
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix incorrect behavior of ``CREATE TABLE`` when Hive metastore is configured
@@ -39,7 +39,7 @@ Hive Changes
   the precision in the table or partition schema. (:issue:`1949`)
 * Improve performance when reading Parquet files with small row groups. (:issue:`1925`)
 
-Other Connector Changes
+Other connector changes
 -----------------------
 
 These changes apply to the MySQL, PostgreSQL, Redshift, and SQL Server connectors.

--- a/docs/src/main/sphinx/release/release-326.rst
+++ b/docs/src/main/sphinx/release/release-326.rst
@@ -2,7 +2,7 @@
 Release 326 (27 Nov 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect query results when query contains ``LEFT JOIN`` over ``UNNEST``. (:issue:`2097`)
@@ -13,17 +13,17 @@ General Changes
   ``ORDER BY`` clauses. (:issue:`2044`)
 * Improve performance when processing columns of ``map`` type. (:issue:`2015`)
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Allow running Presto with :ref:`Java 11 or above <requirements-java>`. (:issue:`2057`)
 
-Security Changes
+Security changes
 ----------------
 
 * Deprecate Kerberos in favor of JWT for :doc:`/security/internal-communication`. (:issue:`2032`)
 
-Hive Changes
+Hive changes
 ------------
 
 * Fix table creation error for tables with S3 location when using ``file`` metastore. (:issue:`1664`)
@@ -32,12 +32,12 @@ Hive Changes
 * Improve performance for Glue metastore by fetching partitions in parallel. (:issue:`1465`)
 * Improve performance of ``sql-standard`` security. (:issue:`1922`, :issue:`1929`)
 
-Phoenix Connector Changes
+Phoenix connector changes
 -------------------------
 
 * Collect statistics on the count and duration of each call to Phoenix. (:issue:`2024`)
 
-Other Connector Changes
+Other connector changes
 -----------------------
 
 These changes apply to the MySQL, PostgreSQL, Redshift, and SQL Server connectors.

--- a/docs/src/main/sphinx/release/release-327.rst
+++ b/docs/src/main/sphinx/release/release-327.rst
@@ -2,7 +2,7 @@
 Release 327 (20 Dec 2019)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix join query failure when late materialization is enabled. (:issue:`2144`)
@@ -16,13 +16,13 @@ General Changes
 * Rename ``experimental.work-processor-pipelines`` configuration property to ``experimental.late-materialization.enabled``
   and rename ``work_processor_pipelines`` session property to ``late_materialization``. (:issue:`2275`)
 
-Security Changes
+Security changes
 ----------------
 
 * Allow using multiple system access controls. (:issue:`2178`)
 * Add :doc:`/security/password-file`. (:issue:`797`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix incorrect query results when reading ``timestamp`` values from ORC files written by
@@ -40,7 +40,7 @@ Hive Connector Changes
 * Allow configuring the ``hive.orc.use-column-names`` config property on a per-session
   basis using the ``orc_use_column_names`` session property. (:issue:`2248`)
 
-Kudu Connector Changes
+Kudu connector changes
 ----------------------
 
 * Support predicate pushdown for the ``decimal`` type. (:issue:`2131`)
@@ -48,35 +48,35 @@ Kudu Connector Changes
 * Improve predicate pushdown for queries that match a column against
   multiple values (typically using the ``IN`` operator). (:issue:`2253`)
 
-MongoDB Connector Changes
+MongoDB connector changes
 -------------------------
 
 * Add support for reading from views. (:issue:`2156`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Allow converting unsupported types to ``VARCHAR`` by setting the session property
   ``unsupported_type_handling`` or configuration property ``unsupported-type-handling``
   to ``CONVERT_TO_VARCHAR``. (:issue:`1182`)
 
-MySQL Connector Changes
+MySQL connector changes
 -----------------------
 
 * Fix ``INSERT`` query failure when ``GTID`` mode is enabled. (:issue:`2251`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Improve performance for queries involving equality and range filters
   over table columns. (:issue:`2310`)
 
-Google Sheets Connector Changes
+Google Sheets connector changes
 -------------------------------
 
 * Fix incorrect results when listing tables in ``information_schema``. (:issue:`2118`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Add ``executionTime`` to ``QueryStatistics`` for event listeners. (:issue:`2247`)

--- a/docs/src/main/sphinx/release/release-328.rst
+++ b/docs/src/main/sphinx/release/release-328.rst
@@ -2,7 +2,7 @@
 Release 328 (10 Jan 2020)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix correctness issue for certain correlated join queries when the correlated subquery on
@@ -19,14 +19,14 @@ General Changes
 * Add support for interpolating :doc:`/security/secrets` in server and catalog configuration
   files. (:issue:`2370`)
 
-Security Changes
+Security changes
 ----------------
 
 * Fix a security issue allowing users to gain unauthorized access to Presto cluster
   when using password authenticator with LDAP. (:issue:`2356`)
 * Add support for LDAP referrals in LDAP password authenticator. (:issue:`2354`)
 
-JDBC Driver
+JDBC driver
 -----------
 
 * Fix behavior of ``java.sql.Connection#commit()`` and ``java.sql.Connection#rollback()``
@@ -35,7 +35,7 @@ JDBC Driver
 * Fix failure when restoring autocommit mode with
   ``java.sql.Connection#setAutocommit()`` (:issue:`2338`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Reduce query latency and Hive metastore load when using the
@@ -44,7 +44,7 @@ Hive Connector Changes
 * Avoid redundant file system stat call when writing Parquet files. (:issue:`1746`)
 * Avoid retrying permanent errors for S3-related services such as STS. (:issue:`2331`)
 
-Kafka Connector Changes
+Kafka connector changes
 -----------------------
 
 * Remove internal columns: ``_segment_start``, ``_segment_end`` and
@@ -52,21 +52,21 @@ Kafka Connector Changes
 * Add new configuration property ``kafka.messages-per-split`` to control how many Kafka
   messages will be processed by a single Presto split. (:issue:`2303`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Fix query failure when an object in an Elasticsearch document
   does not have any fields. (:issue:`2217`)
 * Add support for querying index aliases. (:issue:`2324`)
 
-Phoenix Connector Changes
+Phoenix connector changes
 -------------------------
 
 * Add support for mapping unsupported data types to ``VARCHAR``. This can be enabled by setting
   the ``unsupported-type-handling`` configuration property or the ``unsupported_type_handling`` session
   property to ``CONVERT_TO_VARCHAR``. (:issue:`2427`)
 
-Other Connector Changes
+Other connector changes
 -----------------------
 
 These changes apply to the MySQL, PostgreSQL, Redshift and SQL Server connectors:

--- a/docs/src/main/sphinx/release/release-329.rst
+++ b/docs/src/main/sphinx/release/release-329.rst
@@ -2,7 +2,7 @@
 Release 329 (23 Jan 2020)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect result for :func:`last_day_of_month` function for first day of month. (:issue:`2452`)
@@ -27,13 +27,13 @@ General Changes
   ``information_schema.columns`` table. These columns can still be selected,
   but will no longer appear when describing the table. (:issue:`2306`)
 
-Security Changes
+Security changes
 ----------------
 
 * Add ``ldap.bind-dn`` and ``ldap.bind-password`` LDAP properties to allow LDAP authentication
   access LDAP server using service account. (:issue:`1917`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix incorrect data returned when using S3 Select on uncompressed files. In our testing, S3 Select
@@ -58,13 +58,13 @@ Hive Connector Changes
 * Add procedure ``system.drop_stats()`` to remove the column statistics
   for a table or selected partitions. (:issue:`2538`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Add support for :ref:`elasticsearch-array-types`. (:issue:`2441`)
 * Reduce load on Elasticsearch cluster and improve query performance. (:issue:`2561`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Fix mapping between PostgreSQL's ``TIME`` and Presto's ``TIME`` data types.

--- a/docs/src/main/sphinx/release/release-330.rst
+++ b/docs/src/main/sphinx/release/release-330.rst
@@ -2,7 +2,7 @@
 Release 330 (18 Feb 2020)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect behavior of :func:`format` for ``char`` values. Previously, the function
@@ -28,7 +28,7 @@ General Changes
 * Verify that the target schema exists for the :doc:`/sql/use` statement. (:issue:`2764`)
 * Verify that the session catalog exists when executing :doc:`/sql/set-role`. (:issue:`2768`)
 
-Server Changes
+Server changes
 --------------
 
 * Require running on :ref:`Java 11 or above <requirements-java>`. This requirement may be temporarily relaxed by adding
@@ -36,7 +36,7 @@ Server Changes
   This fallback will be removed in future versions of Presto after March 2020. (:issue:`2751`)
 * Add experimental support for running on Linux aarch64 (ARM64). (:issue:`2809`)
 
-Security Changes
+Security changes
 ----------------
 
 * :ref:`principal_rules` are deprecated and will be removed in a future release.
@@ -51,12 +51,12 @@ Security Changes
 * When authentication is disabled, the Presto user may now be set using standard
   HTTP basic authentication with an empty password. (:issue:`2653`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Display physical read time in detailed query view. (:issue:`2805`)
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Fix a performance issue on JDK 11+ when connecting using HTTP/2. (:issue:`2633`)
@@ -67,17 +67,17 @@ JDBC Driver Changes
 * Allow using the ``:`` character within an extra credential value specified via the
   ``extraCredentials`` property. (:issue:`2780`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix a performance issue on JDK 11+ when connecting using HTTP/2. (:issue:`2633`)
 
-Cassandra Connector Changes
+Cassandra connector changes
 ---------------------------
 
 * Fix query failure when identifiers should be quoted. (:issue:`2455`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix reading symlinks from HDFS when using Kerberos. (:issue:`2720`)
@@ -108,26 +108,26 @@ Hive Connector Changes
   procedures for adding partitions to and removing partitions from a partitioned table. (:issue:`2692`)
 * Allow running :doc:`/sql/analyze` collecting only basic table statistics. (:issue:`2762`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Improve performance of queries containing a ``LIMIT`` clause. (:issue:`2781`)
 * Add support for ``nested`` data type. (:issue:`754`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Add read support for PostgreSQL ``money`` data type. The type is mapped to ``varchar`` in Presto.
   (:issue:`2601`)
 
-Other Connector Changes
+Other connector changes
 -----------------------
 
 These changes apply to the MySQL, PostgreSQL, Redshift, Phoenix and SQL Server connectors.
 
 * Respect ``DEFAULT`` column clause when writing to a table. (:issue:`1185`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Allow procedures to have optional arguments with default values. (:issue:`2706`)

--- a/docs/src/main/sphinx/release/release-331.rst
+++ b/docs/src/main/sphinx/release/release-331.rst
@@ -2,7 +2,7 @@
 Release 331 (16 Mar 2020)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Prevent query failures when worker is shut down gracefully. (:issue:`2648`)
@@ -22,7 +22,7 @@ General Changes
 * Add :doc:`/connector/bigquery`. (:issue:`2532`)
 * Add support for large prepared statements. (:issue:`2719`)
 
-Security Changes
+Security changes
 ----------------
 
 * Remove unused ``internal-communication.jwt.enabled`` configuration property. (:issue:`2709`)
@@ -31,12 +31,12 @@ Security Changes
   configured using :ref:`query_rules` in :doc:`/security/file-system-access-control`. (:issue:`2213`)
 * Hide columns of tables for which the user has no privileges in :doc:`/security/file-system-access-control`. (:issue:`2925`)
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Implement ``PreparedStatement.getMetaData()``. (:issue:`2770`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix copying worker address to clipboard. (:issue:`2865`)
@@ -48,13 +48,13 @@ Web UI Changes
 * Add simple form based authentication that utilizes the configured password authenticator. (:issue:`2755`)
 * Allow disabling the UI via the ``web-ui.enabled`` configuration property. (:issue:`2755`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Fix formatting of ``varbinary`` in nested data types. (:issue:`2858`)
 * Add ``--timezone`` parameter. (:issue:`2961`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix incorrect results for reads from ``information_schema`` tables and
@@ -75,20 +75,20 @@ Hive Connector Changes
 * Hide the Hive system schema ``sys`` for security reasons. (:issue:`3008`)
 * Add support for changing the owner of a schema. (:issue:`2673`)
 
-MongoDB Connector Changes
+MongoDB connector changes
 -------------------------
 
 * Fix incorrect results when queries contain filters on certain data types, such
   as ``real`` or ``decimal``. (:issue:`1781`)
 
-Other Connector Changes
+Other connector changes
 -----------------------
 
 These changes apply to the MemSQL, MySQL, PostgreSQL, Redshift, Phoenix, and SQL Server connectors.
 
 * Add support for dropping schemas. (:issue:`2956`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Remove deprecated ``Identity`` constructors. (:issue:`2877`)

--- a/docs/src/main/sphinx/release/release-332.rst
+++ b/docs/src/main/sphinx/release/release-332.rst
@@ -2,7 +2,7 @@
 Release 332 (08 Apr 2020)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix query failure during planning phase for certain queries involving multiple joins. (:issue:`3149`)
@@ -25,32 +25,32 @@ General Changes
   to ``optimizer.push-aggregation-through-outer-join``. (:issue:`3205`)
 * Add operator statistics for the number of splits processed with a dynamic filter applied. (:issue:`3217`)
 
-Security Changes
+Security changes
 ----------------
 
 * Fix LDAP authentication when user belongs to multiple groups. (:issue:`3206`)
 * Verify access to table columns when running ``SHOW STATS``. (:issue:`2665`)
 * Only return views accessible to the user from ``information_schema.views``. (:issue:`3290`)
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Add ``clientInfo`` property to set extra information about the client. (:issue:`3188`)
 * Add ``traceToken`` property to set a trace token for correlating requests across systems. (:issue:`3188`)
 
-BigQuery Connector Changes
+BigQuery connector changes
 --------------------------
 
 * Extract parent project ID from service account before looking at the environment. (:issue:`3131`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Add support for ``ip`` type. (:issue:`3347`)
 * Add support for ``keyword`` fields with numeric values. (:issue:`3381`)
 * Remove unnecessary ``elasticsearch.aws.use-instance-credentials`` configuration property. (:issue:`3265`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix failure reading certain Parquet files larger than 2GB. (:issue:`2730`)
@@ -78,31 +78,31 @@ Hive Connector Changes
 * Allow using configured S3 credentials with IAM role. Previously,
   the configured IAM role was silently ignored. (:issue:`3351`)
 
-Kudu Connector Changes
+Kudu connector changes
 ----------------------
 
 * Fix incorrect column mapping in Kudu connector. (:issue:`3170`, :issue:`2963`)
 * Fix incorrect query result for certain queries involving ``IS NULL`` predicates with ``OR``. (:issue:`3274`)
 
-Memory Connector Changes
+Memory connector changes
 ------------------------
 
 * Include views in the list of tables returned to the JDBC driver. (:issue:`3208`)
 
-MongoDB Connector Changes
+MongoDB connector changes
 -------------------------
 
 * Add ``objectid_timestamp`` for extracting the timestamp from ``ObjectId``. (:issue:`3089`)
 * Delete document from ``_schema`` collection when ``DROP TABLE``
   is executed for a table that exists only in ``_schema``. (:issue:`3234`)
 
-SQL Server Connector
+SQL Server connector
 --------------------
 
 * Disallow renaming tables between schemas. Previously, such renames were allowed
   but the schema name was ignored when performing the rename. (:issue:`3284`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Expose row filters and column masks in ``QueryCompletedEvent``. (:issue:`3183`)

--- a/docs/src/main/sphinx/release/release-333.rst
+++ b/docs/src/main/sphinx/release/release-333.rst
@@ -2,7 +2,7 @@
 Release 333 (04 May 2020)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix planning failure when lambda expressions are repeated in a query. (:issue:`3218`)
@@ -23,44 +23,44 @@ General Changes
 * Add :doc:`/sql/show-create-schema`. (:issue:`3099`)
 * Add :func:`starts_with` function. (:issue:`3392`)
 
-Server Changes
+Server changes
 --------------
 
 * Require running on :ref:`Java 11 or above <requirements-java>`. (:issue:`2799`)
 
-Server RPM Changes
+Server RPM changes
 ------------------
 
 * Reduce size of RPM and disk usage after installation. (:issue:`3595`)
 
-Security Changes
+Security changes
 ----------------
 
 * Allow configuring trust certificate for LDAP password authenticator. (:issue:`3523`)
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Fix hangs on JDK 8u252 when using secure connections. (:issue:`3444`)
 
-BigQuery Connector Changes
+BigQuery connector changes
 --------------------------
 
 * Improve performance for queries that contain filters on table columns. (:issue:`3376`)
 * Add support for partitioned tables. (:issue:`3376`)
 
-Cassandra Connector Changes
+Cassandra connector changes
 ---------------------------
 
 * Allow :doc:`/sql/insert` statement for table having hidden ``id`` column. (:issue:`3499`)
 * Add support for :doc:`/sql/create-table` statement. (:issue:`3478`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Fix failure when querying Elasticsearch 7.x clusters. (:issue:`3447`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix incorrect query results when reading Parquet data with a ``varchar`` column predicate
@@ -82,13 +82,13 @@ Hive Connector Changes
   ``projection_pushdown_enabled`` session property. (:issue:`3490`)
 * Add support for connecting to the Thrift metastore using TLS. (:issue:`3440`)
 
-MongoDB Connector Changes
+MongoDB connector changes
 -------------------------
 
 * Skip unknown types in nested BSON object. (:issue:`2935`)
 * Fix query failure when the user does not have access privileges for ``system.views``. (:issue:`3355`)
 
-Other Connector Changes
+Other connector changes
 -----------------------
 
 These changes apply to the MemSQL, MySQL, PostgreSQL, Redshift, and SQL Server connectors.

--- a/docs/src/main/sphinx/release/release-334.rst
+++ b/docs/src/main/sphinx/release/release-334.rst
@@ -2,7 +2,7 @@
 Release 334 (29 May 2020)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect query results for certain queries involving comparisons of ``real`` and ``double`` types
@@ -27,36 +27,36 @@ General Changes
   ``dispatcher.forwarded-header`` configuration properties are no longer supported. (:issue:`3714`)
 * Add pluggable :doc:`/develop/certificate-authenticator`. (:issue:`3804`)
 
-JDBC Driver
+JDBC driver
 -----------
 
 * Implement ``toString()`` for ``java.sql.Array`` results. (:issue:`3803`)
 
-CLI Changes
+CLI changes
 -----------
 
 * Improve rendering of elapsed time for short queries. (:issue:`3311`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Add ``fixed``, ``certificate``, ``JWT``, and ``Kerberos`` to UI authentication. (:issue:`3433`)
 * Show join distribution type in Live Plan. (:issue:`1323`)
 
-JDBC Driver Changes
+JDBC driver changes
 -------------------
 
 * Improve performance of ``DatabaseMetaData.getColumns()`` when the
   parameters contain unescaped ``%`` or ``_``. (:issue:`1620`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Fix failure when executing ``SHOW CREATE TABLE``. (:issue:`3718`)
 * Improve performance for ``count(*)`` queries. (:issue:`3512`)
 * Add support for raw Elasticsearch queries. (:issue:`3735`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix matching bucket filenames without leading zeros. (:issue:`3702`)
@@ -78,18 +78,18 @@ Hive Connector Changes
   the ``hive.metastore.thrift.delegation-token.cache-ttl`` and ``hive.metastore.thrift.delegation-token.cache-maximum-size``
   configuration properties. (:issue:`3771`)
 
-MemSQL Connector Changes
+MemSQL connector changes
 ------------------------
 
 * Include :doc:`/connector/memsql` in the server tarball and RPM. (:issue:`3743`)
 
-MongoDB Connector Changes
+MongoDB connector changes
 -------------------------
 
 * Support case insensitive database and collection names. This can be enabled with the
   ``mongodb.case-insensitive-name-matching`` configuration property. (:issue:`3453`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Allow a ``SystemAccessControl`` to provide an ``EventListener``. (:issue:`3629`).

--- a/docs/src/main/sphinx/release/release-335.rst
+++ b/docs/src/main/sphinx/release/release-335.rst
@@ -2,7 +2,7 @@
 Release 335 (14 Jun 2020)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix failure when :func:`reduce_agg` is used as a window function. (:issue:`3883`)
@@ -17,22 +17,22 @@ General Changes
 * Add  ``information_schema.role_authorization_descriptors`` table that returns information about the roles
   granted to principals. (:issue:`3535`)
 
-Security Changes
+Security changes
 ----------------
 
 * Add schema access rules to :doc:`/security/file-system-access-control`. (:issue:`3766`)
 
-Web UI Changes
+Web UI changes
 --------------
 
 * Fix the value displayed in the worker memory pools bar. (:issue:`3920`)
 
-Accumulo Connector Changes
+Accumulo connector changes
 --------------------------
 
 * The server-side iterators are now in a JAR file named ``presto-accumulo-iterators``. (:issue:`3673`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Collect column statistics for inserts into empty tables. (:issue:`2469`)
@@ -51,13 +51,13 @@ Hive Connector Changes
 * Add support for dynamic partition pruning to improve performance of complex queries
   over partitioned data. (:issue:`1072`)
 
-Phoenix Connector Changes
+Phoenix connector changes
 -------------------------
 
 * Allow configuring whether ``DROP TABLE`` is allowed. This is controlled by the new ``allow-drop-table``
   catalog configuration property and defaults to ``true``, compatible with the previous behavior. (:issue:`3953`)
 
-SPI Changes
+SPI changes
 -----------
 
 * Add support for aggregation pushdown into connectors via the

--- a/docs/src/main/sphinx/release/release-336.rst
+++ b/docs/src/main/sphinx/release/release-336.rst
@@ -2,20 +2,20 @@
 Release 336 (16 Jun 2020)
 =========================
 
-General Changes
+General changes
 ---------------
 
 * Fix failure when querying timestamp columns from older clients. (:issue:`4036`)
 * Improve reporting of configuration errors. (:issue:`4050`)
 * Fix rare failure when recording server stats in T-Digests. (:issue:`3965`)
 
-Security Changes
+Security changes
 ----------------
 
 * Add table access rules to :doc:`/security/file-system-access-control`. (:issue:`3951`)
 * Add new ``default`` system access control that allows all operations except user impersonation. (:issue:`4040`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix incorrect query results when reading Parquet files with predicates

--- a/docs/src/main/sphinx/release/release-337.rst
+++ b/docs/src/main/sphinx/release/release-337.rst
@@ -6,7 +6,7 @@ Release 337 (25 Jun 2020)
    attacker can take advantage of this vulnerability to escalate privileges to internal APIs. We encourage everyone to upgrade as soon
    as possible.
 
-General Changes
+General changes
 ---------------
 
 * Fix incorrect results for inequality join involving ``NaN``. (:issue:`4120`)
@@ -23,7 +23,7 @@ General Changes
 * Add :func:`translate` function. (:issue:`4080`)
 * Reduce worker graceful shutdown duration. (:issue:`4192`)
 
-Security Changes
+Security changes
 ----------------
 
 * Disable insecure authentication over HTTP by default when HTTPS with authentication is enabled. This
@@ -32,12 +32,12 @@ Security Changes
 * Add :ref:`system_information_rules` which control the ability of a user to access to read and write system management information. (:issue:`4199`)
 * Disable user impersonation in default system security. (:issue:`4082`)
 
-Elasticsearch Connector Changes
+Elasticsearch connector changes
 -------------------------------
 
 * Add support for password authentication. (:issue:`4165`)
 
-Hive Connector Changes
+Hive connector changes
 ----------------------
 
 * Fix reading CSV tables with ``separatorChar``, ``quoteChar`` or ``escapeChar`` table property
@@ -57,14 +57,14 @@ Hive Connector Changes
 * Support ACID data files naming used when direct inserts are enabled in Hive (HIVE-21164).
   Direct inserts is an upcoming feature in Hive 4. (:issue:`4049`)
 
-PostgreSQL Connector Changes
+PostgreSQL connector changes
 ----------------------------
 
 * Improve performance of aggregation queries by computing aggregations within PostgreSQL database.
   Currently, the following aggregate functions are eligible for pushdown:
   ``count``,  ``min``, ``max``, ``sum`` and ``avg``. (:issue:`3881`)
 
-Base-JDBC Connector Library Changes
+Base-JDBC connector library changes
 -----------------------------------
 
 * Implement framework for aggregation pushdown. (:issue:`3881`)

--- a/docs/src/main/sphinx/release/release-338.md
+++ b/docs/src/main/sphinx/release/release-338.md
@@ -1,6 +1,6 @@
 # Release 338 (07 Jul 2020)
 
-## General Changes
+## General changes
 
 * Fix incorrect results when joining tables on a masked column. ({issue}`4251`)
 * Fix planning failure when multiple columns have a mask. ({issue}`4322`)
@@ -18,16 +18,16 @@
   configuration property or `omit_datetime_type_precision` session property. ({issue}`4349`, {issue}`4377`)
 * Enforce `NOT NULL` column declarations when writing data. ({issue}`4144`)
 
-## JDBC Driver Changes
+## JDBC driver changes
 
 * Fix excessive CPU usage when reading query results. ({issue}`3928`)
 * Implement `DatabaseMetaData.getClientInfoProperties()`. ({issue}`4318`)
 
-## Elasticsearch Connector Changes
+## Elasticsearch connector changes
 
 * Add support for reading numeric values encoded as strings. ({issue}`4341`)
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Fix incorrect query results when Parquet file has no min/max statistics for an integral column. ({issue}`4200`)
 * Fix query failure when reading from a table partitioned on a `real` or `double` column containing
@@ -39,20 +39,20 @@
 * Add support for setting column comments. ({issue}`2516`)
 * Add hidden `$partition` column for partitioned tables that contains the partition name. ({issue}`3582`)
 
-## Kafka Connector Changes
+## Kafka connector changes
 
 * Fix query failure when a column is projected and also referenced in a query predicate
   when reading from Kafka topic using `RAW` decoder. ({issue}`4183`)
 
-## MySQL Connector Changes
+## MySQL connector changes
 
 * Fix type mapping for unsigned integer types. ({issue}`4187`)
 
-## Oracle Connector Changes
+## Oracle connector changes
 
 * Exclude internal schemas (e.g., sys) from schema listings. ({issue}`3784`)
 * Add support for connection pooling. ({issue}`3770`)
 
-## Base-JDBC Connector Library Changes
+## Base-JDBC connector library changes
 
 * Exclude the underlying database's `information_schema` from schema listings. ({issue}`3834`)

--- a/docs/src/main/sphinx/release/release-339.md
+++ b/docs/src/main/sphinx/release/release-339.md
@@ -1,6 +1,6 @@
 # Release 339 (21 Jul 2020)
 
-## General Changes
+## General changes
 
 * Add {func}`approx_most_frequent`. ({issue}`3425`)
 * Physical bytes scan limit for queries can be configured via `query.max-scan-physical-bytes` configuration property
@@ -15,7 +15,7 @@
 * Fix failure when querying nested `TIMESTAMP` or `TIMESTAMP WITH TIME ZONE` for legacy clients. ({issue}`4475`, {issue}`4425`)
 * Fix failure when parsing timestamps with time zone with an offset of the form `+NNNN`. ({issue}`4490`)
 
-## JDBC Driver Changes
+## JDBC driver changes
 
 * Fix reading `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE` values with a negative year
   or a year higher than 9999. ({issue}`4364`)
@@ -25,11 +25,11 @@
   The previous behavior can temporarily be restored using `useSessionTimeZone` JDBC connection
   parameter. ({issue}`4017`)
 
-## Druid Connector Changes
+## Druid connector changes
 
 * Fix handling of table and column names containing non-ASCII characters. ({issue}`4312`)
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Add support for writing Bloom filters in ORC files. ({issue}`3939`)
 * Make `location` parameter optional for the `system.register_partition` procedure. ({issue}`4443`)
@@ -41,31 +41,31 @@
 * Fix a query failure when reading from Parquet file containing `real` or `double` `NaN` values,
   if the file was written by a non-conforming writer. ({issue}`4267`)
 
-## Kafka Connector Changes
+## Kafka connector changes
 
 * Add insert support for Avro. ({issue}`4418`)
 * Add insert support for CSV. ({issue}`4287`)
 
-## Kudu Connector Changes
+## Kudu connector changes
 
 * Add support for grouped execution. It can be enabled with the `kudu.grouped-execution.enabled`
   configuration property or the `grouped_execution` session property. ({issue}`3715`)
 
-## MongoDB Connector Changes
+## MongoDB connector changes
 
 * Allow querying Azure Cosmos DB. ({issue}`4415`)
 
-## Oracle Connector Changes
+## Oracle connector changes
 
 * Allow providing credentials via the `connection-user` and `connection-password`
   configuration properties. These properties were previously ignored if connection pooling
   was enabled. ({issue}`4430`)
 
-## Phoenix Connector Changes
+## Phoenix connector changes
 
 * Fix handling of row key definition with white space. ({issue}`3251`)
 
-## SPI Changes
+## SPI changes
 
 * Allow connectors to wait for dynamic filters before splits are generated via the new
   `DynamicFilter` object passed to `ConnectorSplitManager.getSplits()`. ({issue}`4224`)

--- a/docs/src/main/sphinx/release/release-340.md
+++ b/docs/src/main/sphinx/release/release-340.md
@@ -1,6 +1,6 @@
 # Release 340 (8 Aug 2020)
 
-## General Changes
+## General changes
 
 * Add support for query parameters in `LIMIT`, `OFFSET` and `FETCH FIRST` clauses. ({issue}`4529`, {issue}`4601`)
 * Add experimental support for recursive queries. ({issue}`4250`)
@@ -16,20 +16,20 @@
 * Fix failure when `GROUP BY` clause contains duplicate expressions. ({issue}`4609`)
 * Fix potential hang during query planning ({issue}`4635`).
 
-## Security Changes
+## Security changes
 
 * Fix unprivileged access to table's schema via `CREATE TABLE LIKE`. ({issue}`4472`)
 
-## JDBC Driver Changes
+## JDBC driver changes
 
 * Fix handling of dates before 1582-10-15. ({issue}`4563`)
 * Fix handling of timestamps before 1900-01-01. ({issue}`4563`)
 
-## Elasticsearch Connector Changes
+## Elasticsearch connector changes
 
 * Fix failure when index mapping is missing. ({issue}`4535`)
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Allow creating a table with `external_location` when schema's location is not valid. ({issue}`4069`)
 * Add read support for tables that were created as non-transactional and converted to be
@@ -45,27 +45,27 @@
 * Fix query failure when S3 data location contains a `_$folder$` marker object. ({issue}`4552`)
 * Fix failure when referencing nested fields of a `ROW` type when table and partition metadata differs. ({issue}`3967`)
 
-## Kafka Connector Changes
+## Kafka connector changes
 
 * Add insert support for Raw data format. ({issue}`4417`)
 * Add insert support for JSON. ({issue}`4477`)
 * Remove unused `kafka.connect-timeout` configuration properties. ({issue}`4664`)
 
-## MongoDB Connector Changes
+## MongoDB connector changes
 
 * Add `mongodb.max-connection-idle-time` properties to limit the maximum idle time of a pooled connection. ({issue}`4483`)
 
-## Phoenix Connector Changes
+## Phoenix connector changes
 
 * Add table level property to specify data block encoding when creating tables. ({issue}`4617`)
 * Fix query failure when listing schemas. ({issue}`4560`)
 
-## PostgreSQL Connector Changes
+## PostgreSQL connector changes
 
 * Push down {func}`count` aggregations over constant expressions.
   For example, `SELECT count(1)`. ({issue}`4362`)
 
-## SPI Changes
+## SPI changes
 
 * Expose information about query type in query Event Listener. ({issue}`4592`)
 * Add support for TopN pushdown via the `ConnectorMetadata.applyLimit()` method. ({issue}`4249`)

--- a/docs/src/main/sphinx/release/release-341.md
+++ b/docs/src/main/sphinx/release/release-341.md
@@ -1,6 +1,6 @@
 # Release 341 (8 Sep 2020)
 
-## General Changes
+## General changes
 
 * Add support for variable-precision `TIME` type. ({issue}`4381`)
 * Add support for variable precision `TIME WITH TIME ZONE` type. ({issue}`4905`)
@@ -36,7 +36,7 @@
 * Fail queries with a proper error message when `TABLESAMPLE` is used with a non-numeric sample ratio. ({issue}`5074`)
 * Fail with an explicit error rather than `OutOfMemoryError` for certain operations. ({issue}`4890`)
 
-## Security Changes
+## Security changes
 
 * Add [Salesforce password authentication](/security/salesforce). ({issue}`4372`)
 * Add support for interpolating [secrets](/security/secrets) into `access-control.properties`. ({issue}`4854`)
@@ -47,20 +47,20 @@
 
 * Fix display of physical input read time in detailed query view. ({issue}`4962`)
 
-## JDBC Driver Changes
+## JDBC driver changes
 
 * Implement `ResultSet.getStatement()`. ({issue}`4957`)
 
-## BigQuery Connector Changes
+## BigQuery connector changes
 
 * Add support for hourly partitioned tables. ({issue}`4968`)
 * Redact the value of `bigquery.credentials-key` in the server log. ({issue}`4968`)
 
-## Cassandra Connector Changes
+## Cassandra connector changes
 
 * Map Cassandra `TIMESTAMP` type to Presto `TIMESTAMP(3) WITH TIME ZONE` type. ({issue}`2269`)
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Skip stripes and row groups based on timestamp statistics for ORC files. ({issue}`1147`)
 * Skip S3 objects with the `DeepArchive` storage class (in addition to the `Glacier`
@@ -89,33 +89,33 @@
   and underwent a minor compaction. ({issue}`4623`)
 * Fix query failure when storage caching is enabled and cached data is evicted during query execution. ({issue}`3580`)
 
-## JMX Connector Changes
+## JMX connector changes
 
 * Change `timestamp` column type in history tables to `TIMESTAMP WITH TIME ZONE`. ({issue}`4753`)
 
-## Kafka Connector Changes
+## Kafka connector changes
 
 * Preserve time zone when parsing `TIMESTAMP WITH TIME ZONE` values. ({issue}`4799`)
 
-## Kinesis Connector Changes
+## Kinesis connector changes
 
 * Preserve time zone when parsing `TIMESTAMP WITH TIME ZONE` values. ({issue}`4799`)
 
-## Kudu Connector Changes
+## Kudu connector changes
 
 * Fix delete when applied on table having primary key of decimal type. ({issue}`4683`)
 
-## Local File Connector Changes
+## Local File connector changes
 
 * Change `timestamp` column type to `TIMESTAMP WITH TIME ZONE`. ({issue}`4752`)
 
-## MySQL Connector Changes
+## MySQL connector changes
 
 * Improve performance of aggregation queries by pushing the aggregation computation into the MySQL database.
   Currently, the following aggregate functions are eligible for pushdown: `count`,  `min`, `max`,
   `sum` and `avg`. ({issue}`4138`)
 
-## Oracle Connector Changes
+## Oracle connector changes
 
 * Add `oracle.connection-pool.inactive-timeout` configuration property to specify how long
   pooled connection can be inactive before it is closed. It defaults to 20 minutes. ({issue}`4779`)
@@ -126,11 +126,11 @@
   list of type names. ({issue}`4955`)
 * Prevent query failure for pushdown of predicates involving a large number of conjuncts. ({issue}`4918`)
 
-## Phoenix Connector Changes
+## Phoenix connector changes
 
 * Fix overwriting of former value when insert is applied without specifying that column. ({issue}`4670`)
 
-## Pinot Connector Changes
+## Pinot connector changes
 
 * Add support for `REAL` and `INTEGER` types. ({issue}`4725`)
 * Add support for functions in pass-through queries. ({issue}`4801`)
@@ -140,26 +140,26 @@
 * Fix incorrect results for queries involving {func}`avg` over columns of type `long`, `int`, or `float`. ({issue}`4802`)
 * Fix incorrect results when columns in pass-through query do not match selected columns. ({issue}`4802`)
 
-## Prometheus Connector Changes
+## Prometheus connector changes
 
 * Change the type of the `timestamp` column to `TIMESTAMP(3) WITH TIME ZONE` type. ({issue}`4799`)
 
-## PostgreSQL Connector Changes
+## PostgreSQL connector changes
 
 * Improve performance of aggregation queries with predicates by pushing the computation
   of both the filtering and aggregations into the PostgreSQL server where possible. ({issue}`4111`)
 * Fix handling of PostgreSQL arrays when `unsupported-type-handling` is set to `CONVERT_TO_VARCHAR`. ({issue}`4981`)
 
-## Raptor Connector Changes
+## Raptor connector changes
 
 * Remove the `storage.shard-day-boundary-time-zone` configuration property, which was used to work
   around legacy timestamp semantics in Presto. ({issue}`4799`)
 
-## Redis Connector Changes
+## Redis connector changes
 
 * Preserve time zone when parsing `TIMESTAMP WITH TIME ZONE` values. ({issue}`4799`)
 
-## SPI Changes
+## SPI changes
 
 * The `TIMESTAMP` type is encoded as a number of fractional seconds from `1970-01-01 00:00:00` in the proleptic
   Gregorian calendar. This value is no longer adjusted to the session time zone. Timestamps with precision less

--- a/docs/src/main/sphinx/release/release-342.md
+++ b/docs/src/main/sphinx/release/release-342.md
@@ -1,6 +1,6 @@
 # Release 342 (24 Sep 2020)
 
-## General Changes
+## General changes
 
 * Add {func}`from_iso8601_timestamp_nanos` function. ({issue}`5048`)
 * Improve performance of queries that use the `DECIMAL` type. ({issue}`4886`)
@@ -14,15 +14,15 @@
   session property. ({issue}`5262`)
 * Fix query failure when lambda expression references a table column containing a dot. ({issue}`5087`)
 
-## Atop Connector Changes
+## Atop connector changes
 
 * Fix incorrect query results when query contains predicates on `start_time` or `end_time` column. ({issue}`5125`)
 
-## Elasticsearch Connector Changes
+## Elasticsearch connector changes
 
 * Allow reading boolean values stored as strings. ({issue}`5269`)
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Add support for S3 encrypted files. ({issue}`2536`)
 * Add support for ABFS OAuth authentication. ({issue}`5052`)
@@ -39,11 +39,11 @@
 * Improve planning time for queries with non-equality filters on partition columns when using the Glue metastore. ({issue}`5060`)
 * Improve performance when reading `JSON` and `CSV` file formats. ({issue}`5142`)
 
-## Iceberg Connector Changes
+## Iceberg connector changes
 
 * Fix partition transforms for temporal columns for dates before 1970. ({issue}`5273`)
 
-## Kafka Connector Changes
+## Kafka connector changes
 
 * Expose message headers as a `_headers` column of `MAP(VARCHAR, ARRAY(VARBINARY))` type. ({issue}`4462`)
 * Add write support for `TIME`, `TIME WITH TIME ZONE`, `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE`
@@ -54,22 +54,22 @@
   - `milliseconds-since-epoch`: `TIME WITH TIME ZONE`, `TIMESTAMP WITH TIME ZONE`
   - `seconds-since-epoch`: `TIME WITH TIME ZONE`, `TIMESTAMP WITH TIME ZONE`
 
-## MySQL Connector Changes
+## MySQL connector changes
 
 * Improve performance of `INSERT` queries when GTID mode is disabled in MySQL. ({issue}`4995`)
 
-## PostgreSQL Connector Changes
+## PostgreSQL connector changes
 
 * Add support for variable-precision TIMESTAMP and TIMESTAMP WITH TIME ZONE types. ({issue}`5124`, {issue}`5105`)
 
-## SQL Server Connector Changes
+## SQL Server connector changes
 
 * Fix failure when inserting `NULL` into a `VARBINARY` column. ({issue}`4846`)
 * Improve performance of aggregation queries by computing aggregations within SQL Server database.
   Currently, the following aggregate functions are eligible for pushdown:
   `count`,  `min`, `max`, `sum` and `avg`. ({issue}`4139`)
 
-## SPI Changes
+## SPI changes
 
 * Add `DynamicFilter.isAwaitable()` method that returns whether or not the dynamic filter is complete
   and can be awaited for using the `isBlocked()` method. ({issue}`5043`)

--- a/docs/src/main/sphinx/release/release-343.md
+++ b/docs/src/main/sphinx/release/release-343.md
@@ -1,14 +1,14 @@
 # Release 343 (25 Sep 2020)
 
-## BigQuery Connector Changes
+## BigQuery connector changes
 
 * Add support for yearly partitioned tables. ({issue}`5298`)
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Fix query failure when read from or writing to a bucketed table containing a column of `timestamp` type. ({issue}`5295`)
 
-## SQL Server Connector Changes
+## SQL Server connector changes
 
 * Improve performance of aggregation queries with `stddev`, `stddev_samp`, `stddev_pop`, `variance`, `var_samp`, `var_pop`
   aggregate functions by computing aggregations within SQL Server database. ({issue}`5299`)

--- a/docs/src/main/sphinx/release/release-344.md
+++ b/docs/src/main/sphinx/release/release-344.md
@@ -1,6 +1,6 @@
 # Release 344 (9 Oct 2020)
 
-## General Changes
+## General changes
 
 * Add {func}`murmur3` function. ({issue}`5054`)
 * Add {func}`from_unixtime_nanos` function. ({issue}`5046`)
@@ -24,7 +24,7 @@
 * Fix incorrect timestamp values returned by the `queries`, `transactions`,
   and `tasks` tables in `system.runtime`. ({issue}`5462`)
 
-## Security Changes
+## Security changes
 
 ```{warning}
 The file-based system and catalog access controls have changed in ways that reduce or increase permissions.
@@ -46,7 +46,7 @@ Please, read these release notes carefully.
 * Change file-based catalog access control to deny permissions inspection and manipulation. ({issue}`5039`)
 * Add [file-based group provider](/security/group-file). ({issue}`5028`)
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Add support for `hive.security=allow-all`, which allows to skip all authorization checks. ({issue}`5416`)
 * Support Kerberos authentication for Hudi tables. ({issue}`5472`)
@@ -56,22 +56,22 @@ Please, read these release notes carefully.
 * Improve query concurrency by listing data files more efficiently. ({issue}`5260`)
 * Fix Parquet encoding for timestamps before 1970-01-01. ({issue}`5364`)
 
-## Kafka Connector Changes
+## Kafka connector changes
 
 * Expose message timestamp via `_timestamp` internal column. ({issue}`4805`)
 * Add predicate pushdown for `_timestamp`, `_partition_offset` and `_partition_id` columns. ({issue}`4805`)
 
-## Phoenix Connector Changes
+## Phoenix connector changes
 
 * Fix query failure when a column name in `CREATE TABLE` requires quoting. ({issue}`3601`)
 
-## PostgreSQL Connector Changes
+## PostgreSQL connector changes
 
 * Add support for setting a column comment. ({issue}`5307`)
 * Add support for variable-precision `time` type. ({issue}`5342`)
 * Allow `CREATE TABLE` and `CREATE TABLE AS` with `timestamp` and `timestamp with time zone` with precision higher than 6.
   The resulting column will be declared with precision of 6, maximal supported by PostgreSQL. ({issue}`5342`)
 
-## SQL Server Connector Changes
+## SQL Server connector changes
 
 * Improve performance of queries with aggregations and `WHERE` clause. ({issue}`5327`)

--- a/docs/src/main/sphinx/release/release-345.md
+++ b/docs/src/main/sphinx/release/release-345.md
@@ -1,6 +1,6 @@
 # Release 345 (23 Oct 2020)
 
-## General Changes
+## General changes
 
 * Add {func}`concat_ws` function. ({issue}`4680`)
 * Add support for {func}`extract` for `time with time zone` values with precision other than 3. ({issue}`5539`)
@@ -13,18 +13,18 @@
 * Improve performance of encrypted spilling. ({issue}`5557`)
 * Improve performance of queries that use the `decimal` type. ({issue}`5181`)
 
-## Security Changes
+## Security changes
 
 * Add support for JSON Web Key (JWK) to the existing JSON Web Token (JWT) authenticator.  This is enabled by
   setting the `jwt.key-file` configuration property to a `http` or `https` url. ({issue}`5419`)
 * Add column security, column mask and row filter to file-based access controls. ({issue}`5460`)
 * Enforce access control for column references in `USING` clause. ({issue}`5620`)
 
-## JDBC Driver Changes
+## JDBC driver changes
 
 * Add `source` parameter for directly setting the source name for a query. ({issue}`4739`)
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Add support for `INSERT` and `DELETE` for ACID tables. ({issue}`5402`)
 * Apply `hive.domain-compaction-threshold` to dynamic filters. ({issue}`5365`)
@@ -34,33 +34,33 @@
 * Fix disk space accounting for storage caching. ({issue}`5621`)
 * Fix failure when reading Parquet `timestamp` columns encoded as `int64`. ({issue}`5443`)
 
-## MongoDB Connector Changes
+## MongoDB connector changes
 
 * Add support for adding columns. ({issue}`5512`)
 * Fix incorrect result for `IS NULL` predicates on fields that do not exist in the document. ({issue}`5615`)
 
-## MemSQL Connector Changes
+## MemSQL connector changes
 
 * Fix representation for many MemSQL types. ({issue}`5495`)
 * Prevent a query failure when table column name contains a semicolon by explicitly forbidding such names. ({issue}`5495`)
 * Add support for case-insensitive table name matching. ({issue}`5495`)
 
-## MySQL Connector Changes
+## MySQL connector changes
 
 * Improve performance of queries with aggregations and `LIMIT` clause (but without `ORDER BY`). ({issue}`5261`)
 
-## PostgreSQL Connector Changes
+## PostgreSQL connector changes
 
 * Improve performance of queries with aggregations and `LIMIT` clause (but without `ORDER BY`). ({issue}`5261`)
 
-## Redshift Connector Changes
+## Redshift connector changes
 
 * Add support for setting column comments. ({issue}`5397`)
 
-## SQL Server Connector Changes
+## SQL Server connector changes
 
 * Improve performance of queries with aggregations and `LIMIT` clause (but without `ORDER BY`). ({issue}`5261`)
 
-## Thrift Connector Changes
+## Thrift connector changes
 
 * Fix handling of timestamp values. ({issue}`5596`)

--- a/docs/src/main/sphinx/release/release-346.md
+++ b/docs/src/main/sphinx/release/release-346.md
@@ -1,6 +1,6 @@
 # Release 346 (10 Nov 2020)
 
-## General Changes
+## General changes
 
 * Add support for `RANGE BETWEEN <value> PRECEDING AND <value> FOLLOWING` window frames. ({issue}`609`)
 * Add support for window frames based on `GROUPS`. ({issue}`5713`)
@@ -32,11 +32,11 @@
 * Fix failure when {func}`approx_distinct` is used with high precision `timestamp(p)`/`timestamp(p) with time zone`/`time(p) with time zone`
   data types. ({issue}`5392`)
 
-## Web UI Changes
+## Web UI changes
 
 * Fix "Capture Snapshot" button on the Worker page. ({issue}`5759`)
 
-## JDBC Driver Changes
+## JDBC driver changes
 
 * Support number accessor methods like `ResultSet.getLong()` or `ResultSet.getDouble()`
   on `decimal` values, as well as `char` or `varchar` values that can be unambiguously interpreted as numbers. ({issue}`5509`)
@@ -44,20 +44,20 @@
 * Remove legacy `useSessionTimeZone` JDBC connection parameter. ({issue}`4521`)
 * Implement `ResultSet.getRow()`. ({issue}`5769`)
 
-## BigQuery Connector Changes
+## BigQuery connector changes
 
 * Fix issue when query could return invalid results if some column references were pruned out during query optimization. ({issue}`5618`)
 
-## Cassandra Connector Changes
+## Cassandra connector changes
 
 * Improve performance of `INSERT` queries with batch statement. The batch size can be configured via the `cassandra.batch-size`
   configuration property. ({issue}`5047`)
 
-## Elasticsearch Connector Changes
+## Elasticsearch connector changes
 
 * Fix failure when index mappings do not contain a `properties` section. ({issue}`5807`)
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Add support for `ALTER TABLE ... SET AUTHORIZATION` SQL syntax to change the table owner. ({issue}`5717`)
 * Add support for writing timestamps with microsecond or nanosecond precision, in addition to milliseconds. ({issue}`5283`)
@@ -74,41 +74,41 @@
 * Fix failure when the declared length of a `varchar(n)` column in the partition schema differs from the table schema. ({issue}`5484`)
 * Fix Glue metastore pushdown for complex expressions. ({issue}`5698`)
 
-## Iceberg Connector Changes
+## Iceberg connector changes
 
 * Add support for materialized views. ({issue}`4832`)
 * Remove deprecated `parquet.fail-on-corrupted-statistics` (previously known as `hive.parquet.fail-on-corrupted-statistics`).
   A new configuration property, `parquet.ignore-statistics`, can be used to deal with Parquet files with incorrect metadata.  ({issue}`3077`)
 
-## Kafka Connector Changes
+## Kafka connector changes
 
 * Fix incorrect column comment. ({issue}`5751`)
 
-## Kudu Connector Changes
+## Kudu connector changes
 
 * Improve performance of queries having only `LIMIT` clause. ({issue}`3691`)
 
-## MySQL Connector Changes
+## MySQL connector changes
 
 * Improve performance for queries containing a predicate on a `varbinary` column. ({issue}`5672`)
 
-## Oracle Connector Changes
+## Oracle connector changes
 
 * Add support for setting column comments. ({issue}`5399`)
 * Allow enabling remarks reporting via `oracle.remarks-reporting.enabled` configuration property. ({issue}`5720`)
 
-## PostgreSQL Connector Changes
+## PostgreSQL connector changes
 
 * Improve performance of queries comparing a `timestamp` column with a `timestamp with time zone` constants
   for `timestamp with time zone` precision higher than 3. ({issue}`5543`)
 
-## Other Connector Changes
+## Other connector changes
 
 * Improve performance of queries with `DISTINCT` or `LIMIT`, or with `GROUP BY` and no aggregate functions and `LIMIT`,
   when the computation can be pushed down to the underlying database for the PostgreSQL, MySQL, Oracle, Redshift and
   SQL Server connectors. ({issue}`5522`)
 
-## SPI Changes
+## SPI changes
 
 * Fix propagation of connector session properties to `ConnectorNodePartitioningProvider`. ({issue}`5690`)
 * Add user groups to query events. ({issue}`5643`)

--- a/docs/src/main/sphinx/release/release-347.md
+++ b/docs/src/main/sphinx/release/release-347.md
@@ -1,6 +1,6 @@
 # Release 347 (25 Nov 2020)
 
-## General Changes
+## General changes
 
 * Add `ALTER VIEW ... SET AUTHORIZATION` syntax for changing owner of the view. ({issue}`5789`)
 * Add support for `INTERSECT ALL` and `EXCEPT ALL`. ({issue}`2152`)
@@ -18,24 +18,24 @@
 
 * A minimum Java version of 11.0.7 is now required for Presto to start. This is to mitigate JDK-8206955. ({issue}`5957`)
 
-## Security Changes
+## Security changes
 
 * Add support for multiple LDAP bind patterns. ({issue}`5874`)
 * Include groups for view owner when checking permissions for views. ({issue}`5945`)
 
-## JDBC Driver Changes
+## JDBC driver changes
 
 * Implement `addBatch()`, `clearBatch()` and `executeBatch()` methods in `PreparedStatement`. ({issue}`5507`)
 
-## CLI Changes
+## CLI changes
 
 * Add support for providing queries to presto-cli via shell redirection. ({issue}`5881`)
 
-## Docker Image Changes
+## Docker image changes
 
 * Update Presto docker image to use CentOS 8 as the base image. ({issue}`5920`)
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Add support for `ALTER VIEW  ... SET AUTHORIZATION` SQL syntax to change the view owner. This supports Presto and Hive views. ({issue}`5789`)
 * Allow configuring HDFS replication factor via the `hive.dfs.replication` config property. ({issue}`1829`)
@@ -43,16 +43,16 @@
 * Decrease latency of `INSERT` and `CREATE TABLE AS ...` queries by updating table and column statistics in parallel. ({issue}`3638`)
 * Fix leaking S3 connections when querying Avro tables. ({issue}`5562`)
 
-## Kudu Connector Changes
+## Kudu connector changes
 
 * Add dynamic filtering support. It can be enabled by setting a non-zero duration value for ``kudu.dynamic-filtering.wait-timeout`` config property
   or ``dynamic_filtering_wait_timeout`` session property. ({issue}`5594`)
 
-## MongoDB Connector Changes
+## MongoDB connector changes
 
 * Improve performance of queries containing a `LIMIT` clause. ({issue}`5870`)
 
-## Other Connector Changes
+## Other connector changes
 
 * Improve query performance by compacting large pushed down predicates for the PostgreSQL, MySQL, Oracle,
   Redshift and SQL Server connectors. Compaction threshold can be changed using the ``domain-compaction-threshold``
@@ -60,7 +60,7 @@
 * Improve performance for the PostgreSQL, MySQL, SQL Server connectors for certain complex queries involving
   aggregation and predicates by by pushing the aggregation and predicates computation into the remote database. ({issue}`4112`)
 
-## SPI Changes
+## SPI changes
 
 * Add support for connectors to redirect table scan operations to another connector. ({issue}`5792`)
 * Add physical input bytes and rows for table scan operation to query completion event. ({issue}`5872`)

--- a/docs/src/main/sphinx/release/release-348.md
+++ b/docs/src/main/sphinx/release/release-348.md
@@ -1,6 +1,6 @@
 # Release 348 (14 Dec 2020)
 
-## General Changes
+## General changes
 
 * Add support for `DISTINCT` clause in aggregations within correlated subqueries. ({issue}`5904`)
 * Support `SHOW STATS` for arbitrary queries. ({issue}`3109`)
@@ -21,7 +21,7 @@
 * Add support for OAuth2 authorization. ({issue}`5355`)
 * Fix invalid operator stats in Stage Performance view. ({issue}`6114`)
 
-## JDBC Driver Changes
+## JDBC driver changes
 
 * Allow reading `timestamp with time zone` value as `ZonedDateTime` using `ResultSet.getObject(int column, Class<?> type)` method. ({issue}`307`)
 * Accept `java.time.LocalDate` in `PreparedStatement.setObject(int, Object)`. ({issue}`6301`)
@@ -42,13 +42,13 @@
 * Fix `ResultSetMetaData.getColumnType` for `time with time zone`. Previously the type was miscategorized as `java.sql.Types.TIME`. ({issue}`6251`)
 * Fix failure when an instance of `SphericalGeography` geospatial type is returned in the `ResultSet`. ({issue}`6240`)
 
-## CLI Changes
+## CLI changes
 
 * Fix rendering of `row` values with unnamed fields. Previously they were printed using fake field names like `field0`, `field1`, etc. ({issue}`4587`)
 * Fix query progress reporting. ({issue}`6119`)
 * Fix failure when an instance of `SphericalGeography` geospatial type is returned to the client. ({issue}`6238`)
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Allow configuring S3 endpoint in security mapping. ({issue}`3869`)
 * Add support for S3 streaming uploads. Data is uploaded to S3 as it is written, rather
@@ -64,22 +64,22 @@
 * Add deserializer class name to split information exposed to the event listener. ({issue}`6006`)
 * Improve performance when querying tables that contain symlinks. ({issue}`6158`, {issue}`6213`)
 
-## Iceberg Connector Changes
+## Iceberg connector changes
 
 * Improve performance of queries containing filters on non-partition columns. Such filters are now used
   for optimizing split generation and table scan.  ({issue}`4932`)
 * Add support for Google Cloud Storage and Azure Storage. ({issue}`6186`)
 
-## Kafka Connector Changes
+## Kafka connector changes
 
 * Allow writing `timestamp with time zone` values into columns using `milliseconds-since-epoch` or
   `seconds-since-epoch` JSON encoders. ({issue}`6074`)
 
-## Other Connector Changes
+## Other connector changes
 
 * Fix ineffective table metadata caching for PostgreSQL, MySQL, SQL Server, Redshift, MemSQL and Phoenix connectors. ({issue}`6081`, {issue}`6167`)
 
-## SPI Changes
+## SPI changes
 
 * Change `SystemAccessControl#filterColumns` and `ConnectorAccessControl#filterColumns` methods to accept a set of
   column names, and return a set of visible column names. ({issue}`6084`)

--- a/docs/src/main/sphinx/release/release-350.md
+++ b/docs/src/main/sphinx/release/release-350.md
@@ -1,6 +1,6 @@
 # Release 350 (28 Dec 2020)
 
-## General Changes
+## General changes
 
 * Add HTTP client JMX metrics. ({issue}`6453`)
 * Improve query performance by reducing worker to worker communication overhead. ({issue}`6283`, {issue}`6349`)
@@ -14,40 +14,40 @@
 
 * Fix truncation of query text in cluster overview page. ({issue}`6216`)
 
-## JDBC Driver Changes
+## JDBC driver changes
 
 * Accept `java.time.OffsetTime` in `PreparedStatement.setObject(int, Object)`. ({issue}`6352`)
 * Extend `PreparedStatement.setObject(int, Object, int)` to allow setting `time with time zone` and `timestamp with time zone`
   values with precision higher than nanoseconds. This can be done via providing a `String` value representing a valid SQL literal. ({issue}`6352`)
 
-## BigQuery Connector Changes
+## BigQuery connector changes
 
 * Fix incorrect results for `count(*)` queries with views. ({issue}`5635`)
 
-## Cassandra Connector Changes
+## Cassandra connector changes
 
 * Support `DELETE` statement with primary key or partition key. ({issue}`4059`)
 
-## Elasticsearch Connector Changes
+## Elasticsearch connector changes
 
 * Improve query analysis performance when Elasticsearch contains many index mappings. ({issue}`6368`)
 
-## Kafka Connector Changes
+## Kafka connector changes
 
 * Support Kafka Schema Registry for Avro topics. ({issue}`6137`)
 
-## SQL Server Connector Changes
+## SQL Server connector changes
 
 * Add `data_compression` table property to control the target compression in SQL Server.
   The allowed values are `NONE`, `ROW` or `PAGE`. ({issue}`4693`)
 
-## Other Connector Changes
+## Other connector changes
 
 This change applies to the MySQL, Oracle, PostgreSQL, Redshift, and SQL Server connectors.
 
 * Send shorter and potentially more performant queries to remote database when a Presto query has a `NOT IN`
   predicate eligible for pushdown into the connector. ({issue}`6075`)
 
-## SPI Changes
+## SPI changes
 
 * Rename `LongTimeWithTimeZone.getPicoSeconds()` to `LongTimeWithTimeZone.getPicoseconds()`. ({issue}`6354`)

--- a/docs/src/main/sphinx/release/release-351.md
+++ b/docs/src/main/sphinx/release/release-351.md
@@ -1,13 +1,13 @@
 # Release 351 (3 Jan 2021)
 
-## General Changes
+## General changes
 
 * Rename client protocol headers to start with `X-Trino-`.
   Legacy clients can be supported by setting the configuration property
   `protocol.v1.alternate-header-name` to `Presto`. This configuration
   property is deprecated and will be removed in a future release.
 
-## JMX MBean Naming Changes
+## JMX MBean naming changes
 
 * Rename base domain name for server MBeans to `trino`. The name can
   be changed using the configuration property `jmx.base-name`.
@@ -15,22 +15,22 @@
   and Thrift connectors to `trino.plugin`. The name can be changed
   using the catalog configuration property `jmx.base-name`.
 
-## Server RPM Changes
+## Server RPM changes
 
 * Rename installation directories from `presto` to `trino`.
 
-## Docker Image Changes
+## Docker image changes
 
 * Publish image as [`trinodb/trino`](https://hub.docker.com/r/trinodb/trino).
 * Change base image to `azul/zulu-openjdk-centos`.
 * Change configuration directories to `/usr/lib/trino/etc` and `/etc/trino`.
 * Rename CLI in image to `trino`.
 
-## CLI Changes
+## CLI changes
 
 * Use new client protocol header names. The CLI is not compatible with older servers.
 
-## JDBC Driver Changes
+## JDBC driver changes
 
 * Use new client protocol header names. The driver is not compatible with older servers.
 * Change driver URL prefix to `jdbc:trino:`.
@@ -40,7 +40,7 @@
 * Rename Java package for all driver classes to `io.trino.jdbc` and rename
   various driver classes such as `TrinoConnection` to start with `Trino`.
 
-## Hive Connector Changes
+## Hive connector changes
 
 * Rename JMX name for `PrestoS3FileSystem` to `TrinoS3FileSystem`.
 * Change configuration properties
@@ -48,20 +48,20 @@
   `hive.hdfs.presto.keytab` to `hive.hdfs.trino.keytab`.
   The old names are deprecated and will be removed in a future release.
 
-## Local File Connector Changes
+## Local file connector changes
 
 * Change configuration properties
   `presto-logs.http-request-log.location` to `trino-logs.http-request-log.location` and
   `presto-logs.http-request-log.pattern` to `trino-logs.http-request-log.pattern`.
   The old names are deprecated and will be removed in a future release.
 
-## Thrift Connector Changes
+## Thrift connector changes
 
 * Rename Thrift service method names starting with `presto` to `trino`.
 * Rename all classes in the Thrift IDL starting with `Presto` to `Trino`.
 * Rename configuration properties starting with `presto` to `trino`.
 
-## SPI Changes
+## SPI changes
 
 * Rename Java package to `io.trino.spi`.
 * Rename `PrestoException` to `TrinoException`.

--- a/docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -1,5 +1,5 @@
 ==============================
-Built-in System Access Control
+Built-in system access control
 ==============================
 
 .. toctree::
@@ -37,17 +37,17 @@ Plugin Name                                        Description
 If you want to limit access on a system level in any other way than the ones
 listed above, you must implement a custom :doc:`/develop/system-access-control`.
 
-Default System Access Control
+Default system access control
 ===============================
 
 All operations are permitted, except for user impersonation. This plugin is enabled by default.
 
-Allow All System Access Control
+Allow all system access control
 ===============================
 
 All operations are permitted under this plugin.
 
-Read Only System Access Control
+Read only system access control
 ===============================
 
 Under this plugin, you are allowed to execute any operation that reads data or
@@ -61,7 +61,7 @@ file with the following contents:
 
    access-control.name=read-only
 
-File Based System Access Control
+File based system access control
 ================================
 
 This plugin allows you to specify access control rules in a JSON file.

--- a/docs/src/main/sphinx/security/cli.rst
+++ b/docs/src/main/sphinx/security/cli.rst
@@ -1,11 +1,11 @@
 ===========================
-CLI Kerberos Authentication
+CLI Kerberos authentication
 ===========================
 
 The Trino :doc:`/installation/cli` can connect to a :doc:`Trino coordinator
 </security/server>`, that has Kerberos authentication enabled.
 
-Environment Configuration
+Environment configuration
 -------------------------
 
 .. |subject_node| replace:: client
@@ -13,7 +13,7 @@ Environment Configuration
 .. include:: kerberos-services.fragment
 .. include:: kerberos-configuration.fragment
 
-Kerberos Principals and Keytab Files
+Kerberos principals and keytab files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Each user, who connects to the Trino coordinator, needs a Kerberos principal.
@@ -33,7 +33,7 @@ principal.
 
 .. include:: ktadd-note.fragment
 
-Java Keystore File for TLS
+Java keystore file for TLS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Access to the Trino coordinator must be through HTTPS when using Kerberos
@@ -87,7 +87,7 @@ Troubleshooting
 Many of the same steps, that can be used when troubleshooting the :ref:`Trino
 coordinator <coordinator-troubleshooting>`, apply to troubleshooting the CLI.
 
-Additional Kerberos Debugging Information
+Additional Kerberos debugging information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can enable additional Kerberos debugging information for the Trino CLI

--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -1,5 +1,5 @@
 ================================
-File Based System Access Control
+File based system access control
 ================================
 
 This access control plugin allows you to specify authorization rules in a JSON file.
@@ -34,7 +34,7 @@ Trino restart. The refresh period is specified in the ``etc/access-control.prope
 
    security.refresh-period=1s
 
-Catalog, Schema, and Table Access
+Catalog, schema, and table access
 ---------------------------------
 
 Access to catalogs, schemas, tables, and views is controlled by the catalog, schema, and table
@@ -95,7 +95,7 @@ need to already exist as any potential permission makes the item visible. Specif
 * schema: Visible if the user is the owner of the schema, or has permissions on any nested table.
 * table: Visible if the user has any permissions on the table.
 
-Catalog Rules
+Catalog rules
 ^^^^^^^^^^^^^
 
 Each catalog rule is composed of the following fields:
@@ -164,7 +164,7 @@ following rules:
 For group-based rules to match, users need to be assigned to groups by a
 :doc:`/develop/group-provider`.
 
-Schema Rules
+Schema rules
 ^^^^^^^^^^^^
 
 Each schema rule is composed of the following fields:
@@ -201,7 +201,7 @@ ownership of any schema, you can use the following rules:
       ]
     }
 
-Table Rules
+Table rules
 ^^^^^^^^^^^
 
 Each table rule is composed of the following fields:
@@ -217,7 +217,7 @@ Each table rule is composed of the following fields:
 * ``filter`` (optional): boolean filter expression for the table.
 * ``filter_environment`` (optional): environment use during filter evaluation.
 
-Column Constraint
+Column constraint
 ^^^^^^^^^^^^^^^^^
 
 These constraints can be used to restrict access to column data.
@@ -227,7 +227,7 @@ These constraints can be used to restrict access to column data.
 * ``mask`` (optional): mask expression applied to column.
 * ``mask_environment`` (optional): environment use during mask evaluation.
 
-Filter and Mask Environment
+Filter and mask environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * ``user`` (optional): username for checking permission of subqueries in mask.
@@ -291,7 +291,7 @@ The example below defines the following table access policy:
 
 .. _session_property_rules:
 
-Session Property Rules
+Session property rules
 ----------------------
 
 These rules control the ability of a user to set system and catalog session properties. The
@@ -321,7 +321,7 @@ The example below defines the following table access policy:
 
 .. _query_rules:
 
-Query Rules
+Query rules
 -----------
 
 These rules control the ability of a user to execute, view, or kill a query. The user is
@@ -347,7 +347,7 @@ the following rules:
 
 .. _impersonation_rules:
 
-Impersonation Rules
+Impersonation rules
 -------------------
 
 These rules control the ability of a user to impersonate another user.  In
@@ -379,7 +379,7 @@ impersonate the ``test`` user:
 
 .. _principal_rules:
 
-Principal Rules
+Principal rules
 ---------------
 
 .. warning::
@@ -453,7 +453,7 @@ name, and allow ``alice`` and ``bob`` to use a group principal named as
 
 .. _system_information_rules:
 
-System Information Rules
+System information rules
 ------------------------
 
 These rules specify which users can access the system information management interface.

--- a/docs/src/main/sphinx/security/group-file.rst
+++ b/docs/src/main/sphinx/security/group-file.rst
@@ -1,12 +1,12 @@
 =========================
-File Based Group Provider
+File based group provider
 =========================
 
 Trino can map user names onto groups for easier access control and
 resource group management. Group file resolves group membership using
 a file on the coordinator.
 
-Group File Configuration
+Group file configuration
 ------------------------
 
 Enable group file by creating an ``etc/group-provider.properties``
@@ -28,10 +28,10 @@ Property                             Description
                                      Defaults to ``5s``.
 ==================================== ==============================================
 
-Group Files
+Group files
 -----------
 
-File Format
+File format
 ^^^^^^^^^^^
 
 The group file contains a list of groups and members, one per line,

--- a/docs/src/main/sphinx/security/internal-communication.rst
+++ b/docs/src/main/sphinx/security/internal-communication.rst
@@ -1,11 +1,11 @@
 =============================
-Secure Internal Communication
+Secure internal communication
 =============================
 
 The Trino cluster can be configured to use secured communication. Communication
 between Trino nodes can be secured with SSL/TLS.
 
-Internal Authentication
+Internal authentication
 -----------------------
 
 Requests between Trino nodes are authenticated using a shared secret. For secure
@@ -142,7 +142,7 @@ window functions, which require repartitioning), the performance impact can be
 considerable. The slowdown may vary from 10% to even 100%+, depending on the network
 traffic and the CPU utilization.
 
-Advanced Performance Tuning
+Advanced performance tuning
 ---------------------------
 
 In some cases, changing the source of random numbers improves performance

--- a/docs/src/main/sphinx/security/kerberos-configuration.fragment
+++ b/docs/src/main/sphinx/security/kerberos-configuration.fragment
@@ -1,4 +1,4 @@
-MIT Kerberos Configuration
+MIT Kerberos configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Kerberos needs to be configured on the |subject_node|. At a minimum, there needs

--- a/docs/src/main/sphinx/security/kerberos-services.fragment
+++ b/docs/src/main/sphinx/security/kerberos-services.fragment
@@ -1,4 +1,4 @@
-Kerberos Services
+Kerberos services
 ^^^^^^^^^^^^^^^^^
 
 You will need a Kerberos :abbr:`KDC (Key Distribution Center)` running on a

--- a/docs/src/main/sphinx/security/ldap.rst
+++ b/docs/src/main/sphinx/security/ldap.rst
@@ -1,5 +1,5 @@
 ===================
-LDAP Authentication
+LDAP authentication
 ===================
 
 Trino can be configured to enable frontend LDAP authentication over
@@ -15,10 +15,10 @@ only the communication from the clients to the coordinator is authenticated.
 However, if you want to secure the communication between
 Trino nodes with SSL/TLS configure :doc:`/security/internal-communication`.
 
-Trino Server Configuration
+Trino server configuration
 ---------------------------
 
-Trino Coordinator Node Configuration
+Trino coordinator node configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Access to the Trino coordinator should be through HTTPS. You can do that
@@ -30,7 +30,7 @@ The first part is to enable HTTPS support and password authentication
 in the coordinator's ``config.properties`` file. The second part is
 to configure LDAP as the password authenticator plugin.
 
-Server Config Properties
+Server config properties
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following is an example of the required properties that need to be added
@@ -70,7 +70,7 @@ Property                                                      Description
                                                               :doc:`/security/user-mapping` for more information.
 ============================================================= ======================================================
 
-Password Authenticator Configuration
+Password authenticator configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Password authentication needs to be configured to use LDAP. Create an
@@ -139,7 +139,7 @@ Example:
 
     ldap.user-bind-pattern=uid=${USER},OU=America,DC=corp,DC=example,DC=com
 
-Authorization based on LDAP Group Membership
+Authorization based on LDAP group membership
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can further restrict the set of users allowed to connect to the Trino
@@ -237,10 +237,10 @@ property may be set as follows:
 Trino CLI
 ----------
 
-Environment Configuration
+Environment configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-TLS Configuration
+TLS configuration
 ~~~~~~~~~~~~~~~~~
 
 Access to the Trino coordinator should be through HTTPS when using LDAP
@@ -253,7 +253,7 @@ for its TLS configuration. If you are using truststore, you can either use
 default Java truststores or create a custom truststore on the CLI. We do not
 recommend using self-signed certificates in production.
 
-Trino CLI Execution
+Trino CLI execution
 ^^^^^^^^^^^^^^^^^^^^
 
 In addition to the options that are required when connecting to a Trino
@@ -304,13 +304,13 @@ Option                          Description
 Troubleshooting
 ---------------
 
-Java Keystore File Verification
+Java keystore file verification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Verify the password for a keystore file and view its contents using
 :ref:`troubleshooting_keystore`.
 
-Debug Trino to LDAP Server Issues
+Debug Trino to LDAP server issues
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 If you need to debug issues with Trino communicating with the LDAP server,
 you can change the :ref:`log level <log-levels>` for the LDAP authenticator:
@@ -319,7 +319,7 @@ you can change the :ref:`log level <log-levels>` for the LDAP authenticator:
 
     io.trino.plugin.password=DEBUG
 
-SSL Debugging for Trino CLI
+SSL debugging for Trino CLI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you encounter any SSL related errors when running the Trino CLI, you can run
@@ -348,7 +348,7 @@ Adding a SAN to this certificate is required in cases where ``https://`` uses IP
 than the domain contained in the coordinator's certificate, and the certificate does not contain the
 :abbr:`SAN (Subject Alternative Name)` parameter with the matching IP address as an alternative attribute.
 
-Authentication or SSL errors with JDK Upgrade
+Authentication or SSL errors with JDK upgrade
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting with the JDK 8u181 release, to improve the robustness of LDAPS

--- a/docs/src/main/sphinx/security/password-file.rst
+++ b/docs/src/main/sphinx/security/password-file.rst
@@ -1,5 +1,5 @@
 ============================
-Password File Authentication
+Password file authentication
 ============================
 
 Trino can be configured to enable frontend password authentication over
@@ -11,7 +11,7 @@ Password file authentication is very similar to :doc:`ldap`. Please see
 the LDAP documentation for generic instructions on configuring the server
 and clients to use TLS and authenticate with a username and password.
 
-Password Authenticator Configuration
+Password authenticator configuration
 ------------------------------------
 
 Enable password file authentication by creating an
@@ -36,10 +36,10 @@ Property                             Description
                                      Defaults to ``1000``.
 ==================================== ==============================================
 
-Password Files
+Password files
 --------------
 
-File Format
+File format
 ^^^^^^^^^^^
 
 The password file contains a list of usernames and passwords, one per line,
@@ -58,7 +58,7 @@ hex encoded salt and hash:
 
     test:1000:5b4240333032306164:f38d165fce8ce42f59d366139ef5d9e1ca1247f0e06e503ee1a611dd9ec40876bb5edb8409f5abe5504aab6628e70cfb3d3a18e99d70357d295002c3d0a308a0
 
-Creating a Password File
+Creating a password file
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 Password files utilizing the bcrypt format can be created using the

--- a/docs/src/main/sphinx/security/salesforce.rst
+++ b/docs/src/main/sphinx/security/salesforce.rst
@@ -1,5 +1,5 @@
 =========================
-Salesforce Authentication
+Salesforce authentication
 =========================
 
 Trino can be configured to enable frontend password authentication over
@@ -16,7 +16,7 @@ basic credentials.  This can also be used to secure the :ref:`Web UI <web-ui-aut
     Salesforce data. It's simply a means by which users can authenticate to Trino, similar
     to :doc:`ldap` or :doc:`password-file`.
 
-Salesforce Authenticator Configuration
+Salesforce authenticator configuration
 --------------------------------------
 
 Enable Salesforce authentication by creating an
@@ -45,14 +45,14 @@ Property                               Description
                                        Defaults to ``2m``.
 ====================================   ============================================================
 
-Salesforce Concepts
+Salesforce concepts
 -------------------
 
 There are two Salesforce specific aspects to this authenticator.  They are the use of the
 Salesforce security token, and configuration of one or more Salesforce.com Organization IDs.
 
 
-Security Token
+Security token
 ^^^^^^^^^^^^^^
 
 Credentials are a user's Salesforce username and password if Trino is connecting from a whitelisted
@@ -63,7 +63,7 @@ and security token is ``token``, use ``passwordtoken`` to authenticate.
 You can configure a public IP for Trino as a trusted IP by `whitelisting an IP range
 <https://help.salesforce.com/articleView?id=security_networkaccess.htm&type=5>`_.
 
-Salesforce.com Organization IDs
+Salesforce.com organization IDs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can configure one or more Salesforce Organization IDs for additional security.  When the user authenticates,

--- a/docs/src/main/sphinx/security/server.rst
+++ b/docs/src/main/sphinx/security/server.rst
@@ -1,5 +1,5 @@
 ===================================
-Coordinator Kerberos Authentication
+Coordinator Kerberos authentication
 ===================================
 
 Trino can be configured to enable Kerberos authentication over HTTPS for
@@ -12,7 +12,7 @@ The worker nodes continue to connect to the coordinator over
 unauthenticated HTTP. However, if you want to secure the communication between
 Trino nodes with SSL/TLS, configure :doc:`/security/internal-communication`.
 
-Environment Configuration
+Environment configuration
 -------------------------
 
 .. |subject_node| replace:: Trino coordinator
@@ -25,7 +25,7 @@ Environment Configuration
 
 .. _server_kerberos_principals:
 
-Kerberos Principals and Keytab Files
+Kerberos principals and keytab files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The Trino coordinator needs a Kerberos principal, as do users who are going to
@@ -46,22 +46,22 @@ In addition, the Trino coordinator needs a `keytab file
 
 .. include:: ktadd-note.fragment
 
-Java Keystore File for TLS
+Java keystore file for TLS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When using Kerberos authentication, access to the Trino coordinator should be
 through HTTPS. You can do it by creating a :ref:`server_java_keystore` on the
 coordinator.
 
-System Access Control Plugin
+System access control plugin
 ----------------------------
 
 A Trino coordinator with Kerberos enabled probably needs a
 :doc:`/develop/system-access-control` plugin to achieve
 the desired level of security.
 
-Trino Coordinator Node Configuration
--------------------------------------
+Trino coordinator node configuration
+------------------------------------
 
 You must make the above changes to the environment prior to configuring the
 Trino coordinator to use Kerberos authentication and HTTPS. After making the
@@ -159,7 +159,7 @@ See :doc:`/develop/system-access-control` for details.
 
 .. _coordinator-troubleshooting:
 
-User Mapping
+User mapping
 ------------
 
 After authenticating with Kerberos, the Trino server receives the user's principal which is typically similar to
@@ -177,7 +177,7 @@ Getting Kerberos authentication working can be challenging. You can
 independently verify some of the configuration outside of Trino, to help narrow
 your focus when trying to solve a problem.
 
-Kerberos Verification
+Kerberos verification
 ^^^^^^^^^^^^^^^^^^^^^
 
 Ensure that you can connect to the KDC from the Trino coordinator using
@@ -198,13 +198,13 @@ Verify that the keytab file can be used to successfully obtain a ticket using
     $ kinit -kt /etc/trino/trino.keytab trino@EXAMPLE.COM
     $ klist
 
-Java Keystore File Verification
+Java keystore file verification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Verify the password for a keystore file and view its contents using
 :ref:`troubleshooting_keystore`
 
-Additional Kerberos Debugging Information
+Additional Kerberos debugging information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can enable additional Kerberos debugging information for the Trino

--- a/docs/src/main/sphinx/security/tls.rst
+++ b/docs/src/main/sphinx/security/tls.rst
@@ -1,10 +1,10 @@
 ==============================
-Java Keystores and Truststores
+Java keystores and truststores
 ==============================
 
 .. _server_java_keystore:
 
-Java Keystore File for TLS
+Java keystore file for TLS
 --------------------------
 
 Access to the Trino coordinator must be through HTTPS when using Kerberos
@@ -46,7 +46,7 @@ that confirms the information is correct:
 
 .. _cli_java_truststore:
 
-Java Truststore File for TLS
+Java truststore file for TLS
 ----------------------------
 
 Truststore files contain certificates of trusted TLS/SSL servers, or of
@@ -73,7 +73,7 @@ Troubleshooting
 
 .. _troubleshooting_keystore:
 
-Java Keystore File Verification
+Java keystore file verification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Verify the password for a keystore file and view its contents using `keytool

--- a/docs/src/main/sphinx/security/user-mapping.rst
+++ b/docs/src/main/sphinx/security/user-mapping.rst
@@ -1,5 +1,5 @@
 ============
-User Mapping
+User mapping
 ============
 
 User mapping defines rules for mapping from users in the authentication system to Trino users.  This
@@ -9,7 +9,7 @@ are complex like ``alice@example`` or ``CN=Alice Smith, OU=Finance, O=Acme, C=US
 User mapping can be configured with a simple regex extraction pattern, or more complex rules in a
 separate configuration file.
 
-Pattern Mapping Rule
+Pattern mapping rule
 --------------------
 
 The pattern mapping rule maps the authentication user to the first matching group in the regular
@@ -29,7 +29,7 @@ Json Web Token                        ``http-server.authentication.jwt.user-mapp
 Insecure                              ``http-server.authentication.insecure.user-mapping.pattern``
 ===================================== ===============================================================
 
-File Mapping Rules
+File mapping rules
 ------------------
 
 The file mapping rules allow for more complex mappings from the authentication user.  These rules are

--- a/docs/src/main/sphinx/sql.rst
+++ b/docs/src/main/sphinx/sql.rst
@@ -1,5 +1,5 @@
 ********************
-SQL Statement Syntax
+SQL statement syntax
 ********************
 
 This chapter describes the SQL syntax used in Trino.

--- a/docs/src/main/sphinx/sql/alter-table.rst
+++ b/docs/src/main/sphinx/sql/alter-table.rst
@@ -69,7 +69,7 @@ Allow everyone with role public to drop and alter table ``people``::
 
     ALTER TABLE people SET AUTHORIZATION ROLE PUBLIC
 
-See Also
+See also
 --------
 
 :doc:`create-table`

--- a/docs/src/main/sphinx/sql/alter-view.rst
+++ b/docs/src/main/sphinx/sql/alter-view.rst
@@ -26,7 +26,7 @@ Change owner of VIEW ``people`` to user ``alice``::
 
     ALTER VIEW people SET AUTHORIZATION alice
 
-See Also
+See also
 --------
 
 :doc:`create-view`

--- a/docs/src/main/sphinx/sql/commit.rst
+++ b/docs/src/main/sphinx/sql/commit.rst
@@ -22,7 +22,7 @@ Examples
     COMMIT;
     COMMIT WORK;
 
-See Also
+See also
 --------
 
 :doc:`rollback`, :doc:`start-transaction`

--- a/docs/src/main/sphinx/sql/create-role.rst
+++ b/docs/src/main/sphinx/sql/create-role.rst
@@ -37,7 +37,7 @@ Limitations
 Some connectors do not support role management.
 See connector documentation for more details.
 
-See Also
+See also
 --------
 
 :doc:`drop-role`, :doc:`set-role`, :doc:`grant-roles`, :doc:`revoke-roles`

--- a/docs/src/main/sphinx/sql/create-schema.rst
+++ b/docs/src/main/sphinx/sql/create-schema.rst
@@ -63,7 +63,7 @@ and allow everyone to drop schema and create tables in schema ``web``::
 
     CREATE SCHEMA web AUTHORIZATION ROLE PUBLIC WITH ( LOCATION = '/hive/data/web' )
 
-See Also
+See also
 --------
 
 :doc:`alter-schema`, :doc:`drop-schema`

--- a/docs/src/main/sphinx/sql/create-table-as.rst
+++ b/docs/src/main/sphinx/sql/create-table-as.rst
@@ -62,7 +62,7 @@ Create a new ``empty_nation`` table with the same schema as ``nation`` and no da
     FROM nation
     WITH NO DATA
 
-See Also
+See also
 --------
 
 :doc:`create-table`, :doc:`select`

--- a/docs/src/main/sphinx/sql/create-table.rst
+++ b/docs/src/main/sphinx/sql/create-table.rst
@@ -84,7 +84,7 @@ plus additional columns at the start and end::
       another_orderdate date
     )
 
-See Also
+See also
 --------
 
 :doc:`alter-table`, :doc:`drop-table`, :doc:`create-table-as`, :doc:`show-create-table`

--- a/docs/src/main/sphinx/sql/create-view.rst
+++ b/docs/src/main/sphinx/sql/create-view.rst
@@ -61,7 +61,7 @@ Create a view that replaces an existing view::
     SELECT orderkey, orderstatus, totalprice / 4 AS quarter
     FROM orders
 
-See Also
+See also
 --------
 
 :doc:`drop-view`, :doc:`show-create-view`

--- a/docs/src/main/sphinx/sql/deallocate-prepare.rst
+++ b/docs/src/main/sphinx/sql/deallocate-prepare.rst
@@ -22,6 +22,6 @@ Deallocate a statement with the name ``my_query``::
 
     DEALLOCATE PREPARE my_query;
 
-See Also
+See also
 --------
 :doc:`prepare`

--- a/docs/src/main/sphinx/sql/describe-input.rst
+++ b/docs/src/main/sphinx/sql/describe-input.rst
@@ -56,7 +56,7 @@ Prepare and describe a query with no parameters:
     -----------------
     (0 rows)
 
-See Also
+See also
 --------
 
 :doc:`prepare`

--- a/docs/src/main/sphinx/sql/describe-output.rst
+++ b/docs/src/main/sphinx/sql/describe-output.rst
@@ -71,7 +71,7 @@ Prepare and describe a row count query::
      rows        |         |        |       | bigint |         8 | false
     (1 row)
 
-See Also
+See also
 --------
 
 :doc:`prepare`

--- a/docs/src/main/sphinx/sql/drop-role.rst
+++ b/docs/src/main/sphinx/sql/drop-role.rst
@@ -30,7 +30,7 @@ Limitations
 Some connectors do not support role management.
 See connector documentation for more details.
 
-See Also
+See also
 --------
 
 :doc:`create-role`, :doc:`set-role`, :doc:`grant-roles`, :doc:`revoke-roles`

--- a/docs/src/main/sphinx/sql/drop-schema.rst
+++ b/docs/src/main/sphinx/sql/drop-schema.rst
@@ -28,7 +28,7 @@ Drop the schema ``sales`` if it exists::
 
     DROP SCHEMA IF EXISTS sales
 
-See Also
+See also
 --------
 
 :doc:`alter-schema`, :doc:`create-schema`

--- a/docs/src/main/sphinx/sql/drop-table.rst
+++ b/docs/src/main/sphinx/sql/drop-table.rst
@@ -28,7 +28,7 @@ Drop the table ``orders_by_date`` if it exists::
 
     DROP TABLE IF EXISTS orders_by_date
 
-See Also
+See also
 --------
 
 :doc:`alter-table`, :doc:`create-table`

--- a/docs/src/main/sphinx/sql/drop-view.rst
+++ b/docs/src/main/sphinx/sql/drop-view.rst
@@ -28,7 +28,7 @@ Drop the view ``orders_by_date`` if it exists::
 
     DROP VIEW IF EXISTS orders_by_date
 
-See Also
+See also
 --------
 
 :doc:`create-view`

--- a/docs/src/main/sphinx/sql/execute.rst
+++ b/docs/src/main/sphinx/sql/execute.rst
@@ -40,7 +40,7 @@ This is equivalent to::
 
    SELECT name FROM nation WHERE regionkey = 1 AND nationkey < 3;
 
-See Also
+See also
 --------
 
 :doc:`prepare`

--- a/docs/src/main/sphinx/sql/explain-analyze.rst
+++ b/docs/src/main/sphinx/sql/explain-analyze.rst
@@ -99,7 +99,7 @@ For example, the window function operator will output the following::
      ...
 
 
-See Also
+See also
 --------
 
 :doc:`explain`

--- a/docs/src/main/sphinx/sql/explain.rst
+++ b/docs/src/main/sphinx/sql/explain.rst
@@ -265,7 +265,7 @@ IO::
     }
 
 
-See Also
+See also
 --------
 
 :doc:`explain-analyze`

--- a/docs/src/main/sphinx/sql/grant-roles.rst
+++ b/docs/src/main/sphinx/sql/grant-roles.rst
@@ -44,7 +44,7 @@ Limitations
 Some connectors do not support role management.
 See connector documentation for more details.
 
-See Also
+See also
 --------
 
 :doc:`create-role`, :doc:`drop-role`, :doc:`set-role`, :doc:`revoke-roles`

--- a/docs/src/main/sphinx/sql/grant.rst
+++ b/docs/src/main/sphinx/sql/grant.rst
@@ -54,7 +54,7 @@ Limitations
 Some connectors have no support for ``GRANT``.
 See connector documentation for more details.
 
-See Also
+See also
 --------
 
 :doc:`revoke`, :doc:`show-grants`

--- a/docs/src/main/sphinx/sql/insert.rst
+++ b/docs/src/main/sphinx/sql/insert.rst
@@ -48,7 +48,7 @@ That column will be ``null``::
     INSERT INTO nation (nationkey, name, regionkey)
     VALUES (26, 'POLAND', 3);
 
-See Also
+See also
 --------
 
 :doc:`values`

--- a/docs/src/main/sphinx/sql/prepare.rst
+++ b/docs/src/main/sphinx/sql/prepare.rst
@@ -36,7 +36,7 @@ Prepare an insert query::
     PREPARE my_insert FROM
     INSERT INTO cities VALUES (1, 'San Francisco');
 
-See Also
+See also
 --------
 
 :doc:`execute`, :doc:`deallocate-prepare`, :doc:`describe-input`, :doc:`describe-output`

--- a/docs/src/main/sphinx/sql/reset-session.rst
+++ b/docs/src/main/sphinx/sql/reset-session.rst
@@ -23,7 +23,7 @@ Examples
     RESET SESSION optimize_hash_generation;
     RESET SESSION hive.optimized_reader_enabled;
 
-See Also
+See also
 --------
 
 :doc:`set-session`, :doc:`show-session`

--- a/docs/src/main/sphinx/sql/revoke-roles.rst
+++ b/docs/src/main/sphinx/sql/revoke-roles.rst
@@ -45,7 +45,7 @@ Limitations
 Some connectors do not support role management.
 See connector documentation for more details.
 
-See Also
+See also
 --------
 
 :doc:`create-role`, :doc:`drop-role`, :doc:`set-role`, :doc:`grant-roles`

--- a/docs/src/main/sphinx/sql/revoke.rst
+++ b/docs/src/main/sphinx/sql/revoke.rst
@@ -54,7 +54,7 @@ Limitations
 Some connectors have no support for ``REVOKE``.
 See connector documentation for more details.
 
-See Also
+See also
 --------
 
 :doc:`grant`, :doc:`show-grants`

--- a/docs/src/main/sphinx/sql/rollback.rst
+++ b/docs/src/main/sphinx/sql/rollback.rst
@@ -22,7 +22,7 @@ Examples
     ROLLBACK;
     ROLLBACK WORK;
 
-See Also
+See also
 --------
 
 :doc:`commit`, :doc:`start-transaction`

--- a/docs/src/main/sphinx/sql/select.rst
+++ b/docs/src/main/sphinx/sql/select.rst
@@ -55,7 +55,7 @@ Description
 
 Retrieve rows from zero or more tables.
 
-WITH Clause
+WITH clause
 -----------
 
 The ``WITH`` clause defines named relations for use within a query.
@@ -92,7 +92,7 @@ Additionally, the relations within a ``WITH`` clause can chain::
     relation is used. This means that if the relation is used more than once and the query
     is non-deterministic, the results may be different each time.
 
-WITH RECURSIVE Clause
+WITH RECURSIVE clause
 ---------------------
 
 The ``WITH RECURSIVE`` clause is a variant of the ``WITH`` clause. It defines
@@ -163,7 +163,7 @@ You can adjust the recursion depth with the :doc:`session property
 </sql/set-session>` ``max_recursion_depth``. When changing the value consider
 that the size of the query plan growth is quadratic with the recursion depth.
 
-SELECT Clause
+SELECT clause
 -------------
 
 The ``SELECT`` clause specifies the output of the query. Each ``select_expression``
@@ -254,7 +254,7 @@ and in their absence, anonymous columns are produced::
     (1 row)
 
 
-GROUP BY Clause
+GROUP BY clause
 ---------------
 
 The ``GROUP BY`` clause divides the output of a ``SELECT`` statement into
@@ -294,7 +294,7 @@ the ``GROUP BY`` clause.
 
 .. _complex_grouping_operations:
 
-Complex Grouping Operations
+Complex grouping operations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Trino also supports complex aggregations using the ``GROUPING SETS``, ``CUBE``
@@ -543,7 +543,7 @@ only unique grouping sets are generated::
 
 The default set quantifier is ``ALL``.
 
-GROUPING Operation
+GROUPING operation
 ^^^^^^^^^^^^^^^^^^
 
 ``grouping(col1, ..., colN) -> bigint``
@@ -587,7 +587,7 @@ The first grouping in the above result only includes the ``origin_state`` column
 the ``origin_zip`` and ``destination_state`` columns. The bit set constructed for that grouping
 is ``011`` where the most significant bit represents ``origin_state``.
 
-HAVING Clause
+HAVING clause
 -------------
 
 The ``HAVING`` clause is used in conjunction with aggregate functions and
@@ -619,7 +619,7 @@ with an account balance greater than the specified value::
       1247 | FURNITURE  |         8 |  5701952
     (7 rows)
 
-Set Operations
+Set operations
 --------------
 
 ``UNION``  ``INTERSECT`` and ``EXCEPT`` are all set operations.  These clauses are used
@@ -650,7 +650,7 @@ specified via parentheses. Additionally, ``INTERSECT`` binds more tightly
 than ``EXCEPT`` and ``UNION``. That means ``A UNION B INTERSECT C EXCEPT D``
 is the same as ``A UNION (B INTERSECT C) EXCEPT D``.
 
-UNION Clause
+UNION clause
 ^^^^^^^^^^^^
 
 ``UNION`` combines all the rows that are in the result set from the
@@ -702,7 +702,7 @@ selects the values ``42`` and ``13``::
         13
     (2 rows)
 
-INTERSECT Clause
+INTERSECT clause
 ^^^^^^^^^^^^^^^^
 
 ``INTERSECT`` returns only the rows that are in the result sets of both the first and
@@ -722,7 +722,7 @@ is only in the result set of the first query, it is not included in the final re
         13
     (2 rows)
 
-EXCEPT Clause
+EXCEPT clause
 ^^^^^^^^^^^^^
 
 ``EXCEPT`` returns the rows that are in the result set of the first query,
@@ -744,7 +744,7 @@ is also in the result set of the second query, it is not included in the final r
 
 .. _order-by-clause:
 
-ORDER BY Clause
+ORDER BY clause
 ---------------
 
 The ``ORDER BY`` clause is used to sort a result set by one or more
@@ -792,7 +792,7 @@ More background information and details can be found in
 
 .. _offset-clause:
 
-OFFSET Clause
+OFFSET clause
 -------------
 
 The ``OFFSET`` clause is used to discard a number of leading rows
@@ -821,7 +821,7 @@ Otherwise, it is arbitrary which rows are discarded.
 If the count specified in the ``OFFSET`` clause equals or exceeds the size
 of the result set, the final result is empty.
 
-LIMIT or FETCH FIRST Clauses
+LIMIT or FETCH FIRST clauses
 ----------------------------
 
 The ``LIMIT`` or ``FETCH FIRST`` clause restricts the number of rows
@@ -1085,7 +1085,7 @@ computing the rows to be joined::
     CROSS JOIN LATERAL (SELECT name || ' :-' AS x)
     CROSS JOIN LATERAL (SELECT x || ')' AS y);
 
-Qualifying Column Names
+Qualifying column names
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 When two relations in a join have columns with the same name, the column
@@ -1149,7 +1149,7 @@ standard rules for nulls. The subquery must produce exactly one column::
          WHERE name = 'AMERICA' OR name = 'AFRICA'
     );
 
-Scalar Subquery
+Scalar subquery
 ^^^^^^^^^^^^^^^
 
 A scalar subquery is a non-correlated subquery that returns zero or

--- a/docs/src/main/sphinx/sql/set-role.rst
+++ b/docs/src/main/sphinx/sql/set-role.rst
@@ -30,7 +30,7 @@ Limitations
 Some connectors do not support role management.
 See connector documentation for more details.
 
-See Also
+See also
 --------
 
 :doc:`create-role`, :doc:`drop-role`, :doc:`grant-roles`, :doc:`revoke-roles`

--- a/docs/src/main/sphinx/sql/set-session.rst
+++ b/docs/src/main/sphinx/sql/set-session.rst
@@ -38,7 +38,7 @@ would use the following to set the catalog session property::
 This catalog session property does not apply to any other catalog, even if it
 also uses the Accumulo connector.
 
-See Also
+See also
 --------
 
 :doc:`reset-session`, :doc:`show-session`

--- a/docs/src/main/sphinx/sql/show-create-schema.rst
+++ b/docs/src/main/sphinx/sql/show-create-schema.rst
@@ -14,7 +14,7 @@ Description
 
 Show the SQL statement that creates the specified schema.
 
-See Also
+See also
 --------
 
 :doc:`create-schema`

--- a/docs/src/main/sphinx/sql/show-create-table.rst
+++ b/docs/src/main/sphinx/sql/show-create-table.rst
@@ -37,7 +37,7 @@ Show the SQL that can be run to create the ``orders`` table::
      )
     (1 row)
 
-See Also
+See also
 --------
 
 :doc:`create-table`

--- a/docs/src/main/sphinx/sql/show-create-view.rst
+++ b/docs/src/main/sphinx/sql/show-create-view.rst
@@ -14,7 +14,7 @@ Description
 
 Show the SQL statement that creates the specified view.
 
-See Also
+See also
 --------
 
 :doc:`create-view`

--- a/docs/src/main/sphinx/sql/show-grants.rst
+++ b/docs/src/main/sphinx/sql/show-grants.rst
@@ -39,7 +39,7 @@ Limitations
 Some connectors have no support for ``SHOW GRANTS``.
 See connector documentation for more details.
 
-See Also
+See also
 --------
 
 :doc:`grant`, :doc:`revoke`

--- a/docs/src/main/sphinx/sql/show-session.rst
+++ b/docs/src/main/sphinx/sql/show-session.rst
@@ -15,7 +15,7 @@ Description
 List the current session properties.
 The ``LIKE`` clause can be used to restrict the list of session properties.
 
-See Also
+See also
 --------
 
 :doc:`reset-session`, :doc:`set-session`

--- a/docs/src/main/sphinx/sql/start-transaction.rst
+++ b/docs/src/main/sphinx/sql/start-transaction.rst
@@ -32,7 +32,7 @@ Examples
     START TRANSACTION ISOLATION LEVEL READ COMMITTED, READ ONLY;
     START TRANSACTION READ WRITE, ISOLATION LEVEL SERIALIZABLE;
 
-See Also
+See also
 --------
 
 :doc:`commit`, :doc:`rollback`

--- a/docs/src/main/sphinx/sql/values.rst
+++ b/docs/src/main/sphinx/sql/values.rst
@@ -60,7 +60,7 @@ Create a new table with column ``id`` and ``name``::
             (3, 'c')
     ) AS t (id, name)
 
-See Also
+See also
 --------
 
 :doc:`insert`, :doc:`select`


### PR DESCRIPTION
As part of further adoption the Google style ..  it was a weird mixture of title case and sentence case usage .. now everything should be much more consistent.

Please merge ASAP @electrum to reduce churn .. 