### PR TITLE
Performance optimizations for streaming top N rank

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
@@ -91,7 +91,6 @@ public class GroupedTopNRankBuilder
                         return equalsAndHash.hashCode(page, position);
                     }
                 },
-                RowReferencePageManager.RESERVED_UNUSED_ROW_ID,
                 topN,
                 pageManager::dereference);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
@@ -127,10 +127,7 @@ public class GroupedTopNRankBuilder
             for (int position = 0; position < newPage.getPositionCount(); position++) {
                 long groupId = groupIds.getGroupId(position);
                 loadCursor.advance();
-                long rowId = loadCursor.allocateRowId();
-                if (!groupedTopNRankAccumulator.add(groupId, rowId)) {
-                    pageManager.dereference(rowId);
-                }
+                groupedTopNRankAccumulator.add(groupId, loadCursor);
             }
             verify(!loadCursor.advance());
         }

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankBuilder.java
@@ -16,7 +16,6 @@ package io.trino.operator;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import io.trino.array.LongBigArray;
-import io.trino.operator.GroupedTopNRankAccumulator.RowComparisonStrategy;
 import io.trino.operator.RowReferencePageManager.LoadCursor;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
@@ -62,7 +61,7 @@ public class GroupedTopNRankBuilder
         requireNonNull(comparator, "comparator is null");
         requireNonNull(equalsAndHash, "equalsAndHash is null");
         groupedTopNRankAccumulator = new GroupedTopNRankAccumulator(
-                new RowComparisonStrategy()
+                new RowIdComparisonHashStrategy()
                 {
                     @Override
                     public int compare(long leftRowId, long rightRowId)

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
@@ -116,9 +116,9 @@ public class GroupedTopNRowNumberBuilder
         return new GroupedTopNRowNumberAccumulator.RowReference()
         {
             @Override
-            public int compareTo(LongComparator rowIdComparator, long rowId)
+            public int compareTo(RowIdComparisonStrategy strategy, long rowId)
             {
-                return cursor.compareTo(rowIdComparator, rowId);
+                return cursor.compareTo(strategy, rowId);
             }
 
             @Override

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRowNumberBuilder.java
@@ -20,7 +20,6 @@ import io.trino.operator.RowReferencePageManager.LoadCursor;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.type.Type;
-import it.unimi.dsi.fastutil.longs.LongComparator;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Iterator;
@@ -99,34 +98,15 @@ public class GroupedTopNRowNumberBuilder
     private void processPage(Page newPage, GroupByIdBlock groupIds)
     {
         try (LoadCursor loadCursor = pageManager.add(newPage)) {
-            GroupedTopNRowNumberAccumulator.RowReference rowReferenceView = asRowReferenceView(loadCursor);
             for (int position = 0; position < newPage.getPositionCount(); position++) {
                 long groupId = groupIds.getGroupId(position);
                 loadCursor.advance();
-                groupedTopNRowNumberAccumulator.add(groupId, rowReferenceView);
+                groupedTopNRowNumberAccumulator.add(groupId, loadCursor);
             }
             verify(!loadCursor.advance());
         }
 
         pageManager.compactIfNeeded();
-    }
-
-    private static GroupedTopNRowNumberAccumulator.RowReference asRowReferenceView(LoadCursor cursor)
-    {
-        return new GroupedTopNRowNumberAccumulator.RowReference()
-        {
-            @Override
-            public int compareTo(RowIdComparisonStrategy strategy, long rowId)
-            {
-                return cursor.compareTo(strategy, rowId);
-            }
-
-            @Override
-            public long extractRowId()
-            {
-                return cursor.allocateRowId();
-            }
-        };
     }
 
     private class ResultIterator

--- a/core/trino-main/src/main/java/io/trino/operator/RowIdComparisonHashStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowIdComparisonHashStrategy.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+/**
+ * Strategy that combines both comparison and hash/equality over row IDs
+ */
+public interface RowIdComparisonHashStrategy
+        extends RowIdComparisonStrategy, RowIdHashStrategy
+{
+    @Override
+    default boolean equals(long leftRowId, long rightRowId)
+    {
+        return compare(leftRowId, rightRowId) == 0;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/RowIdComparisonStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowIdComparisonStrategy.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+/**
+ * Comparator strategy that evaluates over row IDs
+ */
+public interface RowIdComparisonStrategy
+{
+    int compare(long leftRowId, long rightRowId);
+}

--- a/core/trino-main/src/main/java/io/trino/operator/RowIdHashStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowIdHashStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+/**
+ * Hash strategy that evaluates over row IDs
+ */
+public interface RowIdHashStrategy
+{
+    boolean equals(long leftRowId, long rightRowId);
+
+    long hashCode(long rowId);
+}

--- a/core/trino-main/src/main/java/io/trino/operator/RowReference.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowReference.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+/**
+ * Reference to a row.
+ * <p>
+ * Note: RowReference gives us the ability to defer row ID generation (which can be expensive in tight loops).
+ */
+public interface RowReference
+{
+    /**
+     * Compares the referenced row to the specified row ID using the provided RowIdComparisonStrategy.
+     */
+    int compareTo(RowIdComparisonStrategy strategy, long rowId);
+
+    /**
+     * Checks equality of the referenced row with the specified row ID using the provided RowIdHashStrategy.
+     */
+    boolean equals(RowIdHashStrategy strategy, long rowId);
+
+    /**
+     * Calculates the hash of the referenced row using the provided RowIdHashStrategy.
+     */
+    long hash(RowIdHashStrategy strategy);
+
+    /**
+     * Allocate a stable row ID that can be used to reference this row at a future point.
+     */
+    long allocateRowId();
+}

--- a/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
@@ -20,7 +20,6 @@ import io.trino.spi.Page;
 import io.trino.util.LongBigArrayFIFOQueue;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongComparator;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -197,10 +196,10 @@ public class RowReferencePageManager
             return true;
         }
 
-        public int compareTo(LongComparator rowIdComparator, long rowId)
+        public int compareTo(RowIdComparisonStrategy strategy, long rowId)
         {
             checkState(currentPosition >= 0, "Not yet advanced");
-            return rowIdComparator.compare(RESERVED_ROW_ID_FOR_CURSOR, rowId);
+            return strategy.compare(RESERVED_ROW_ID_FOR_CURSOR, rowId);
         }
 
         public long allocateRowId()

--- a/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
@@ -40,7 +40,6 @@ public class RowReferencePageManager
     private static final long INSTANCE_SIZE = ClassLayout.parseClass(RowReferencePageManager.class).instanceSize();
     private static final long PAGE_ACCOUNTING_INSTANCE_SIZE = ClassLayout.parseClass(PageAccounting.class).instanceSize();
     private static final int RESERVED_ROW_ID_FOR_CURSOR = -1;
-    public static final long RESERVED_UNUSED_ROW_ID = -2;
 
     private final IdRegistry<PageAccounting> pages = new IdRegistry<>();
     private final RowIdBuffer rowIdBuffer = new RowIdBuffer();

--- a/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RowReferencePageManager.java
@@ -162,7 +162,7 @@ public class RowReferencePageManager
      * quickly skip positions that won't be needed.
      */
     public static class LoadCursor
-            implements AutoCloseable
+            implements RowReference, AutoCloseable
     {
         private final PageAccounting pageAccounting;
         private final Runnable closeCallback;
@@ -195,12 +195,28 @@ public class RowReferencePageManager
             return true;
         }
 
+        @Override
         public int compareTo(RowIdComparisonStrategy strategy, long rowId)
         {
             checkState(currentPosition >= 0, "Not yet advanced");
             return strategy.compare(RESERVED_ROW_ID_FOR_CURSOR, rowId);
         }
 
+        @Override
+        public boolean equals(RowIdHashStrategy strategy, long rowId)
+        {
+            checkState(currentPosition >= 0, "Not yet advanced");
+            return strategy.equals(RESERVED_ROW_ID_FOR_CURSOR, rowId);
+        }
+
+        @Override
+        public long hash(RowIdHashStrategy strategy)
+        {
+            checkState(currentPosition >= 0, "Not yet advanced");
+            return strategy.hashCode(RESERVED_ROW_ID_FOR_CURSOR);
+        }
+
+        @Override
         public long allocateRowId()
         {
             checkState(currentPosition >= 0, "Not yet advanced");

--- a/core/trino-main/src/main/java/io/trino/operator/TopNPeerGroupLookup.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TopNPeerGroupLookup.java
@@ -1,0 +1,374 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import io.trino.array.LongBigArray;
+import org.openjdk.jol.info.ClassLayout;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static it.unimi.dsi.fastutil.HashCommon.bigArraySize;
+import static it.unimi.dsi.fastutil.HashCommon.maxFill;
+import static it.unimi.dsi.fastutil.HashCommon.mix;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Optimized hash table for streaming Top N peer group lookup operations.
+ */
+// Note: this code was forked from fastutil (http://fastutil.di.unimi.it/) Long2LongOpenCustomHashMap.
+// Copyright (C) 2002-2019 Sebastiano Vigna
+public class TopNPeerGroupLookup
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TopNPeerGroupLookup.class).instanceSize();
+
+    /**
+     * The buffer containing key and value data.
+     */
+    private Buffer buffer;
+
+    /**
+     * The mask for wrapping a position counter.
+     */
+    private long mask;
+
+    /**
+     * The hash strategy.
+     */
+    private final RowIdHashStrategy strategy;
+
+    /**
+     * The current allocated table size.
+     */
+    private long tableSize;
+
+    /**
+     * Threshold after which we rehash.
+     */
+    private long maxFill;
+
+    /**
+     * The acceptable load factor.
+     */
+    private final float fillFactor;
+
+    /**
+     * Number of entries in the set.
+     */
+    private long entryCount;
+
+    /**
+     * The value denoting unmapped group IDs. Since group IDs need to co-exist at all times with row IDs,
+     * we only need to use one of the two IDs to indicate that a slot is unused. Group IDs have been arbitrarily selected
+     * for that purpose.
+     */
+    private final long unmappedGroupId;
+
+    /**
+     * The default return value for {@code get()}, {@code put()} and {@code remove()}.
+     */
+    private final long defaultReturnValue;
+
+    /**
+     * Standard hash table parameters are expected. {@code unmappedGroupId} specifies the internal marker value for unmapped group IDs.
+     */
+    public TopNPeerGroupLookup(long expected, float fillFactor, RowIdHashStrategy strategy, long unmappedGroupId, long defaultReturnValue)
+    {
+        checkArgument(expected >= 0, "The expected number of elements must be nonnegative");
+        checkArgument(fillFactor > 0 && fillFactor <= 1, "Load factor must be greater than 0 and smaller than or equal to 1");
+        this.fillFactor = fillFactor;
+        this.strategy = requireNonNull(strategy, "strategy is null");
+        this.unmappedGroupId = unmappedGroupId;
+        this.defaultReturnValue = defaultReturnValue;
+
+        tableSize = bigArraySize(expected, fillFactor);
+        mask = tableSize - 1;
+        maxFill = maxFill(tableSize, fillFactor);
+        buffer = new Buffer(tableSize, unmappedGroupId);
+    }
+
+    public TopNPeerGroupLookup(long expected, RowIdHashStrategy strategy, long unmappedGroupId, long defaultReturnValue)
+    {
+        this(expected, 0.75f, strategy, unmappedGroupId, defaultReturnValue);
+    }
+
+    /**
+     * Returns the size of this hash map in bytes.
+     */
+    public long sizeOf()
+    {
+        return INSTANCE_SIZE + buffer.sizeOf();
+    }
+
+    public long size()
+    {
+        return entryCount;
+    }
+
+    public boolean isEmpty()
+    {
+        return entryCount == 0;
+    }
+
+    public long get(long groupId, long rowId)
+    {
+        checkArgument(groupId != unmappedGroupId, "Group ID cannot be the unmapped group ID");
+
+        long hash = hash(groupId, rowId);
+        long index = hash & mask;
+        if (buffer.isEmptySlot(index)) {
+            return defaultReturnValue;
+        }
+        if (hash == buffer.getPrecomputedHash(index) && equals(groupId, rowId, index)) {
+            return buffer.getValue(index);
+        }
+        // There's always an unused entry.
+        while (true) {
+            index = (index + 1) & mask;
+            if (buffer.isEmptySlot(index)) {
+                return defaultReturnValue;
+            }
+            if (hash == buffer.getPrecomputedHash(index) && equals(groupId, rowId, index)) {
+                return buffer.getValue(index);
+            }
+        }
+    }
+
+    public long put(long groupId, long rowId, long value)
+    {
+        checkArgument(groupId != unmappedGroupId, "Group ID cannot be the unmapped group ID");
+
+        long hash = hash(groupId, rowId);
+
+        long index = find(groupId, rowId, hash);
+        if (index < 0) {
+            insert(twosComplement(index), groupId, rowId, hash, value);
+            return defaultReturnValue;
+        }
+        long oldValue = buffer.getValue(index);
+        buffer.setValue(index, value);
+        return oldValue;
+    }
+
+    private long hash(long groupId, long rowId)
+    {
+        return mix(groupId * 31 + strategy.hashCode(rowId));
+    }
+
+    private boolean equals(long groupId, long rowId, long index)
+    {
+        return groupId == buffer.getGroupId(index) && strategy.equals(rowId, buffer.getRowId(index));
+    }
+
+    private void insert(long index, long groupId, long rowId, long precomputedHash, long value)
+    {
+        buffer.set(index, groupId, rowId, precomputedHash, value);
+        entryCount++;
+        if (entryCount > maxFill) {
+            rehash(bigArraySize(entryCount + 1, fillFactor));
+        }
+    }
+
+    /**
+     * Locate the index for the specified {@code groupId} and {@code rowId} key pair. If the index is unpopulated,
+     * then return the index as the two's complement value (which will be negative).
+     */
+    private long find(long groupId, long rowId, long precomputedHash)
+    {
+        long index = precomputedHash & mask;
+        if (buffer.isEmptySlot(index)) {
+            return twosComplement(index);
+        }
+        if (precomputedHash == buffer.getPrecomputedHash(index) && equals(groupId, rowId, index)) {
+            return index;
+        }
+        // There's always an unused entry.
+        while (true) {
+            index = (index + 1) & mask;
+            if (buffer.isEmptySlot(index)) {
+                return twosComplement(index);
+            }
+            if (precomputedHash == buffer.getPrecomputedHash(index) && equals(groupId, rowId, index)) {
+                return index;
+            }
+        }
+    }
+
+    public long remove(long groupId, long rowId)
+    {
+        checkArgument(groupId != unmappedGroupId, "Group ID cannot be the unmapped group ID");
+
+        long hash = hash(groupId, rowId);
+        long index = hash & mask;
+        if (buffer.isEmptySlot(index)) {
+            return defaultReturnValue;
+        }
+        if (hash == buffer.getPrecomputedHash(index) && equals(groupId, rowId, index)) {
+            return removeEntry(index);
+        }
+        while (true) {
+            index = (index + 1) & mask;
+            if (buffer.isEmptySlot(index)) {
+                return defaultReturnValue;
+            }
+            if (hash == buffer.getPrecomputedHash(index) && equals(groupId, rowId, index)) {
+                return removeEntry(index);
+            }
+        }
+    }
+
+    private long removeEntry(long index)
+    {
+        long oldValue = buffer.getValue(index);
+        entryCount--;
+        shiftKeys(index);
+        return oldValue;
+    }
+
+    /**
+     * Shifts left entries with the specified hash code, starting at the specified
+     * index, and empties the resulting free entry.
+     *
+     * @param index a starting position.
+     */
+    private void shiftKeys(long index)
+    {
+        // Shift entries with the same hash.
+        while (true) {
+            long currentHash;
+
+            long initialIndex = index;
+            index = ((index) + 1) & mask;
+            while (true) {
+                if (buffer.isEmptySlot(index)) {
+                    buffer.clear(initialIndex);
+                    return;
+                }
+                currentHash = buffer.getPrecomputedHash(index);
+                long slot = currentHash & mask;
+                // Yes, this is dense logic. See fastutil Long2LongOpenCustomHashMap#shiftKeys implementation.
+                if (initialIndex <= index ? initialIndex >= slot || slot > index : initialIndex >= slot && slot > index) {
+                    break;
+                }
+                index = (index + 1) & mask;
+            }
+            buffer.set(initialIndex, buffer.getGroupId(index), buffer.getRowId(index), currentHash, buffer.getValue(index));
+        }
+    }
+
+    private void rehash(long newTableSize)
+    {
+        long newMask = newTableSize - 1; // Note that this is used by the hashing macro
+        Buffer newBuffer = new Buffer(newTableSize, unmappedGroupId);
+        long index = tableSize;
+        for (long i = entryCount; i > 0; i--) {
+            index--;
+            while (buffer.isEmptySlot(index)) {
+                index--;
+            }
+            long hash = buffer.getPrecomputedHash(index);
+            long newIndex = hash & newMask;
+            if (!newBuffer.isEmptySlot(newIndex)) {
+                newIndex = (newIndex + 1) & newMask;
+                while (!newBuffer.isEmptySlot(newIndex)) {
+                    newIndex = (newIndex + 1) & newMask;
+                }
+            }
+            newBuffer.set(newIndex, buffer.getGroupId(index), buffer.getRowId(index), hash, buffer.getValue(index));
+        }
+        tableSize = newTableSize;
+        mask = newMask;
+        maxFill = maxFill(tableSize, fillFactor);
+        buffer = newBuffer;
+    }
+
+    private static long twosComplement(long value)
+    {
+        return -(value + 1);
+    }
+
+    private static class Buffer
+    {
+        private static final long INSTANCE_SIZE = ClassLayout.parseClass(Buffer.class).instanceSize();
+
+        private static final int POSITIONS_PER_ENTRY = 4;
+        private static final int ROW_ID_OFFSET = 1;
+        private static final int PRECOMPUTED_HASH_OFFSET = 2;
+        private static final int VALUE_OFFSET = 3;
+
+        /*
+         *  Memory layout:
+         *  [LONG] groupId1, [LONG] rowId1, [LONG] precomputedHash1, [LONG] value1
+         *  [LONG] groupId2, [LONG] rowId2, [LONG] precomputedHash2, [LONG] value2
+         *  ...
+         */
+        private final LongBigArray buffer;
+        private final long unmappedGroupId;
+
+        public Buffer(long positions, long unmappedGroupId)
+        {
+            buffer = new LongBigArray(unmappedGroupId);
+            buffer.ensureCapacity(positions * POSITIONS_PER_ENTRY);
+            this.unmappedGroupId = unmappedGroupId;
+        }
+
+        public void set(long index, long groupId, long rowId, long precomputedHash, long value)
+        {
+            buffer.set(index * POSITIONS_PER_ENTRY, groupId);
+            buffer.set(index * POSITIONS_PER_ENTRY + ROW_ID_OFFSET, rowId);
+            buffer.set(index * POSITIONS_PER_ENTRY + PRECOMPUTED_HASH_OFFSET, precomputedHash);
+            buffer.set(index * POSITIONS_PER_ENTRY + VALUE_OFFSET, value);
+        }
+
+        public void clear(long index)
+        {
+            // Since all fields of an index are set/unset together as a unit, we only need to choose one field to serve
+            // as a marker for empty slots. Group IDs have been arbitrarily selected for that purpose.
+            buffer.set(index * POSITIONS_PER_ENTRY, unmappedGroupId);
+        }
+
+        public boolean isEmptySlot(long index)
+        {
+            return getGroupId(index) == unmappedGroupId;
+        }
+
+        public long getGroupId(long index)
+        {
+            return buffer.get(index * POSITIONS_PER_ENTRY);
+        }
+
+        public long getRowId(long index)
+        {
+            return buffer.get(index * POSITIONS_PER_ENTRY + ROW_ID_OFFSET);
+        }
+
+        public long getPrecomputedHash(long index)
+        {
+            return buffer.get(index * POSITIONS_PER_ENTRY + PRECOMPUTED_HASH_OFFSET);
+        }
+
+        public long getValue(long index)
+        {
+            return buffer.get(index * POSITIONS_PER_ENTRY + VALUE_OFFSET);
+        }
+
+        public void setValue(long index, long value)
+        {
+            buffer.set(index * POSITIONS_PER_ENTRY + VALUE_OFFSET, value);
+        }
+
+        public long sizeOf()
+        {
+            return INSTANCE_SIZE + buffer.sizeOf();
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankAccumulator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankAccumulator.java
@@ -25,28 +25,21 @@ import java.util.List;
 import static com.google.common.collect.Lists.cartesianProduct;
 import static java.lang.Math.min;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestGroupedTopNRankAccumulator
 {
-    private static final long NULL_ROW_ID = Long.MIN_VALUE;
-    private static final RowIdComparisonHashStrategy ROW_COMPARISON_STRATEGY = new RowIdComparisonHashStrategy()
+    private static final RowIdComparisonHashStrategy STRATEGY = new RowIdComparisonHashStrategy()
     {
         @Override
         public int compare(long leftRowId, long rightRowId)
         {
-            // Null rowIds should never be observed
-            assertNotEquals(leftRowId, NULL_ROW_ID);
-            assertNotEquals(rightRowId, NULL_ROW_ID);
             return Long.compare(leftRowId, rightRowId);
         }
 
         @Override
         public long hashCode(long rowId)
         {
-            // Null rowIds should never be observed
-            assertNotEquals(rowId, NULL_ROW_ID);
             return rowId;
         }
     };
@@ -74,7 +67,7 @@ public class TestGroupedTopNRankAccumulator
     public void testSinglePeerGroupInsert(int topN, long valueCount, long groupCount, boolean drainWithRanking)
     {
         List<Long> evicted = new LongArrayList();
-        GroupedTopNRankAccumulator accumulator = new GroupedTopNRankAccumulator(ROW_COMPARISON_STRATEGY, NULL_ROW_ID, topN, evicted::add);
+        GroupedTopNRankAccumulator accumulator = new GroupedTopNRankAccumulator(STRATEGY, topN, evicted::add);
         accumulator.verifyIntegrity();
 
         // Add the same value repeatedly, so everything should be accepted, and all results will have a rank of 1
@@ -115,7 +108,7 @@ public class TestGroupedTopNRankAccumulator
     public void testIncreasingAllUniqueValues(int topN, long valueCount, long groupCount, boolean drainWithRanking)
     {
         List<Long> evicted = new LongArrayList();
-        GroupedTopNRankAccumulator accumulator = new GroupedTopNRankAccumulator(ROW_COMPARISON_STRATEGY, NULL_ROW_ID, topN, evicted::add);
+        GroupedTopNRankAccumulator accumulator = new GroupedTopNRankAccumulator(STRATEGY, topN, evicted::add);
         accumulator.verifyIntegrity();
 
         for (int rowId = 0; rowId < valueCount; rowId++) {
@@ -156,7 +149,7 @@ public class TestGroupedTopNRankAccumulator
     public void testDecreasingAllUniqueValues(int topN, long valueCount, long groupCount, boolean drainWithRanking)
     {
         List<Long> evicted = new LongArrayList();
-        GroupedTopNRankAccumulator accumulator = new GroupedTopNRankAccumulator(ROW_COMPARISON_STRATEGY, NULL_ROW_ID, topN, evicted::add);
+        GroupedTopNRankAccumulator accumulator = new GroupedTopNRankAccumulator(STRATEGY, topN, evicted::add);
         accumulator.verifyIntegrity();
 
         List<Long> expectedEvicted = new ArrayList<>();
@@ -204,7 +197,7 @@ public class TestGroupedTopNRankAccumulator
         int topN = 3;
 
         List<Long> evicted = new LongArrayList();
-        GroupedTopNRankAccumulator accumulator = new GroupedTopNRankAccumulator(ROW_COMPARISON_STRATEGY, NULL_ROW_ID, topN, evicted::add);
+        GroupedTopNRankAccumulator accumulator = new GroupedTopNRankAccumulator(STRATEGY, topN, evicted::add);
         accumulator.verifyIntegrity();
 
         // Add rowId 0

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankAccumulator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRankAccumulator.java
@@ -14,7 +14,6 @@
 package io.trino.operator;
 
 import io.trino.array.LongBigArray;
-import io.trino.operator.GroupedTopNRankAccumulator.RowComparisonStrategy;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +31,7 @@ import static org.testng.Assert.assertTrue;
 public class TestGroupedTopNRankAccumulator
 {
     private static final long NULL_ROW_ID = Long.MIN_VALUE;
-    private static final RowComparisonStrategy ROW_COMPARISON_STRATEGY = new RowComparisonStrategy()
+    private static final RowIdComparisonHashStrategy ROW_COMPARISON_STRATEGY = new RowIdComparisonHashStrategy()
     {
         @Override
         public int compare(long leftRowId, long rightRowId)

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberAccumulator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberAccumulator.java
@@ -14,7 +14,6 @@
 package io.trino.operator;
 
 import io.trino.array.LongBigArray;
-import io.trino.operator.GroupedTopNRowNumberAccumulator.RowReference;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongArraySet;
 import org.testng.annotations.Test;
@@ -265,7 +264,19 @@ public class TestGroupedTopNRowNumberAccumulator
         }
 
         @Override
-        public long extractRowId()
+        public boolean equals(RowIdHashStrategy strategy, long otherRowId)
+        {
+            return strategy.equals(rowId, otherRowId);
+        }
+
+        @Override
+        public long hash(RowIdHashStrategy strategy)
+        {
+            return strategy.hashCode(rowId);
+        }
+
+        @Override
+        public long allocateRowId()
         {
             rowIdExtracted = true;
             return rowId;

--- a/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberAccumulator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestGroupedTopNRowNumberAccumulator.java
@@ -17,7 +17,6 @@ import io.trino.array.LongBigArray;
 import io.trino.operator.GroupedTopNRowNumberAccumulator.RowReference;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongArraySet;
-import it.unimi.dsi.fastutil.longs.LongComparator;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -260,9 +259,9 @@ public class TestGroupedTopNRowNumberAccumulator
         }
 
         @Override
-        public int compareTo(LongComparator rowIdComparator, long otherRowId)
+        public int compareTo(RowIdComparisonStrategy strategy, long otherRowId)
         {
-            return rowIdComparator.compare(rowId, otherRowId);
+            return strategy.compare(rowId, otherRowId);
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/operator/TestRowReferencePageManager.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestRowReferencePageManager.java
@@ -16,7 +16,6 @@ package io.trino.operator;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
-import it.unimi.dsi.fastutil.longs.LongComparator;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -50,7 +49,7 @@ public class TestRowReferencePageManager
     {
         RowReferencePageManager pageManager = new RowReferencePageManager();
 
-        LongComparator rowIdComparator = (rowId1, rowId2) -> {
+        RowIdComparisonStrategy strategy = (rowId1, rowId2) -> {
             long value1 = extractValue(pageManager, rowId1);
             long value2 = extractValue(pageManager, rowId2);
             return Long.compare(value1, value2);
@@ -66,18 +65,18 @@ public class TestRowReferencePageManager
             assertEquals(extractValue(pageManager, id0), 0L);
 
             assertTrue(cursor.advance());
-            assertTrue(cursor.compareTo(rowIdComparator, id0) > 0);
+            assertTrue(cursor.compareTo(strategy, id0) > 0);
             id1 = cursor.allocateRowId();
             assertEquals(extractValue(pageManager, id1), 1L);
 
             assertTrue(cursor.advance());
-            assertTrue(cursor.compareTo(rowIdComparator, id0) > 0);
-            assertTrue(cursor.compareTo(rowIdComparator, id1) > 0);
+            assertTrue(cursor.compareTo(strategy, id0) > 0);
+            assertTrue(cursor.compareTo(strategy, id1) > 0);
             // Skip this row by not allocating an ID
 
             assertTrue(cursor.advance());
-            assertTrue(cursor.compareTo(rowIdComparator, id0) > 0);
-            assertTrue(cursor.compareTo(rowIdComparator, id1) > 0);
+            assertTrue(cursor.compareTo(strategy, id0) > 0);
+            assertTrue(cursor.compareTo(strategy, id1) > 0);
             id3 = cursor.allocateRowId();
             assertEquals(extractValue(pageManager, id3), 3L);
 
@@ -97,7 +96,7 @@ public class TestRowReferencePageManager
     {
         RowReferencePageManager pageManager = new RowReferencePageManager();
 
-        LongComparator rowIdComparator = (rowId1, rowId2) -> {
+        RowIdComparisonStrategy strategy = (rowId1, rowId2) -> {
             long value1 = extractValue(pageManager, rowId1);
             long value2 = extractValue(pageManager, rowId2);
             return Long.compare(value1, value2);
@@ -125,7 +124,7 @@ public class TestRowReferencePageManager
         page = createBigIntSingleBlockPage(1, 2);
         try (RowReferencePageManager.LoadCursor cursor = pageManager.add(page)) {
             assertTrue(cursor.advance());
-            assertTrue(cursor.compareTo(rowIdComparator, id0) > 0);
+            assertTrue(cursor.compareTo(strategy, id0) > 0);
             id1 = cursor.allocateRowId();
             assertEquals(extractValue(pageManager, id1), 1L);
             assertFalse(cursor.advance());

--- a/core/trino-main/src/test/java/io/trino/operator/TestTopNPeerGroupLookup.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTopNPeerGroupLookup.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.collect.Lists.cartesianProduct;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestTopNPeerGroupLookup
+{
+    private static final RowIdHashStrategy HASH_STRATEGY = new RowIdHashStrategy()
+    {
+        @Override
+        public boolean equals(long leftRowId, long rightRowId)
+        {
+            return leftRowId == rightRowId;
+        }
+
+        @Override
+        public long hashCode(long rowId)
+        {
+            return rowId;
+        }
+    };
+    private static final long UNMAPPED_GROUP_ID = Long.MIN_VALUE;
+    private static final long DEFAULT_RETURN_VALUE = -1L;
+
+    @DataProvider
+    public static Object[][] parameters()
+    {
+        List<Integer> expectedSizes = Arrays.asList(0, 1, 2, 3, 1_000);
+        List<Float> fillFactors = Arrays.asList(0.1f, 0.9f, 1f);
+        List<Long> totalGroupIds = Arrays.asList(1L, 10L);
+        List<Long> totalRowIds = Arrays.asList(1L, 1_000L);
+
+        return to2DArray(cartesianProduct(expectedSizes, fillFactors, totalGroupIds, totalRowIds));
+    }
+
+    private static Object[][] to2DArray(List<List<Object>> nestedList)
+    {
+        Object[][] array = new Object[nestedList.size()][];
+        for (int i = 0; i < nestedList.size(); i++) {
+            array[i] = nestedList.get(i).toArray();
+        }
+        return array;
+    }
+
+    @Test(dataProvider = "parameters")
+    public void testCombinations(int expectedSize, float fillFactor, long totalGroupIds, long totalRowIds)
+    {
+        TopNPeerGroupLookup lookup = new TopNPeerGroupLookup(expectedSize, fillFactor, HASH_STRATEGY, UNMAPPED_GROUP_ID, DEFAULT_RETURN_VALUE);
+
+        assertEquals(lookup.size(), 0);
+        assertTrue(lookup.isEmpty());
+
+        // Put values
+        int count = 0;
+        for (int groupId = 0; groupId < totalGroupIds; groupId++) {
+            for (int rowId = 0; rowId < totalRowIds; rowId++) {
+                // Value should not exist yet
+                assertEquals(lookup.get(groupId, rowId), DEFAULT_RETURN_VALUE);
+                assertEquals(lookup.remove(groupId, rowId), DEFAULT_RETURN_VALUE);
+
+                // Insert the value
+                assertEquals(lookup.put(groupId, rowId, count), DEFAULT_RETURN_VALUE);
+
+                count++;
+
+                assertFalse(lookup.isEmpty());
+                assertEquals(lookup.size(), count);
+            }
+        }
+
+        // Get values
+        count = 0;
+        long totalEntries = totalGroupIds * totalRowIds;
+        for (int groupId = 0; groupId < totalGroupIds; groupId++) {
+            for (int rowId = 0; rowId < totalRowIds; rowId++) {
+                assertEquals(lookup.get(groupId, rowId), count);
+                count++;
+
+                assertFalse(lookup.isEmpty());
+                assertEquals(lookup.size(), totalEntries);
+            }
+        }
+
+        // Overwrite values
+        count = 0;
+        for (int groupId = 0; groupId < totalGroupIds; groupId++) {
+            for (int rowId = 0; rowId < totalRowIds; rowId++) {
+                assertEquals(lookup.put(groupId, rowId, count + 1), count);
+                count++;
+
+                assertFalse(lookup.isEmpty());
+                assertEquals(lookup.size(), totalEntries);
+            }
+        }
+
+        // Remove values
+        count = 0;
+        for (int groupId = 0; groupId < totalGroupIds; groupId++) {
+            for (int rowId = 0; rowId < totalRowIds; rowId++) {
+                assertFalse(lookup.isEmpty());
+                assertEquals(lookup.size(), totalEntries - count);
+
+                // Removed value should be the overwritten value
+                assertEquals(lookup.remove(groupId, rowId), count + 1);
+                count++;
+            }
+        }
+        assertTrue(lookup.isEmpty());
+        assertEquals(lookup.size(), 0);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/TestTopNPeerGroupLookup.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTopNPeerGroupLookup.java
@@ -77,6 +77,7 @@ public class TestTopNPeerGroupLookup
             for (int rowId = 0; rowId < totalRowIds; rowId++) {
                 // Value should not exist yet
                 assertEquals(lookup.get(groupId, rowId), DEFAULT_RETURN_VALUE);
+                assertEquals(lookup.get(groupId, toRowReference(rowId)), DEFAULT_RETURN_VALUE);
                 assertEquals(lookup.remove(groupId, rowId), DEFAULT_RETURN_VALUE);
 
                 // Insert the value
@@ -95,6 +96,7 @@ public class TestTopNPeerGroupLookup
         for (int groupId = 0; groupId < totalGroupIds; groupId++) {
             for (int rowId = 0; rowId < totalRowIds; rowId++) {
                 assertEquals(lookup.get(groupId, rowId), count);
+                assertEquals(lookup.get(groupId, toRowReference(rowId)), count);
                 count++;
 
                 assertFalse(lookup.isEmpty());
@@ -128,5 +130,35 @@ public class TestTopNPeerGroupLookup
         }
         assertTrue(lookup.isEmpty());
         assertEquals(lookup.size(), 0);
+    }
+
+    private static RowReference toRowReference(long rowId)
+    {
+        return new RowReference()
+        {
+            @Override
+            public int compareTo(RowIdComparisonStrategy strategy, long otherRowId)
+            {
+                return strategy.compare(rowId, otherRowId);
+            }
+
+            @Override
+            public boolean equals(RowIdHashStrategy strategy, long otherRowId)
+            {
+                return strategy.equals(rowId, otherRowId);
+            }
+
+            @Override
+            public long hash(RowIdHashStrategy strategy)
+            {
+                return strategy.hashCode(rowId);
+            }
+
+            @Override
+            public long allocateRowId()
+            {
+                return rowId;
+            }
+        };
     }
 }


### PR DESCRIPTION
More complex performance improvements for all categories of top N rank usage, ranging up to over 70% speed up.

BEFORE:
Benchmark                             (groupCount)  (positions)  (topN)   Mode  Cnt  Score   Error  Units
BenchmarkGroupedTopNRankBuilder.topN             1      1000000       1  thrpt    7  7.442 ± 0.692  ops/s
BenchmarkGroupedTopNRankBuilder.topN             1      1000000      10  thrpt    7  7.508 ± 0.681  ops/s
BenchmarkGroupedTopNRankBuilder.topN             1      1000000     100  thrpt    7  6.999 ± 0.771  ops/s
BenchmarkGroupedTopNRankBuilder.topN         10000      1000000       1  thrpt    7  4.990 ± 0.720  ops/s
BenchmarkGroupedTopNRankBuilder.topN         10000      1000000      10  thrpt    7  1.389 ± 0.142  ops/s
BenchmarkGroupedTopNRankBuilder.topN         10000      1000000     100  thrpt    7  0.293 ± 0.015  ops/s
BenchmarkGroupedTopNRankBuilder.topN       1000000      1000000       1  thrpt    7  0.679 ± 0.042  ops/s
BenchmarkGroupedTopNRankBuilder.topN       1000000      1000000      10  thrpt    7  0.675 ± 0.025  ops/s
BenchmarkGroupedTopNRankBuilder.topN       1000000      1000000     100  thrpt    7  0.674 ± 0.014  ops/s

AFTER
Benchmark                             (groupCount)  (positions)  (topN)   Mode  Cnt  Score   Error  Units
BenchmarkGroupedTopNRankBuilder.topN             1      1000000       1  thrpt    8  9.491 ± 0.487  ops/s => +27.5% faster
BenchmarkGroupedTopNRankBuilder.topN             1      1000000      10  thrpt    8  9.422 ± 0.655  ops/s => +25.6% faster
BenchmarkGroupedTopNRankBuilder.topN             1      1000000     100  thrpt    8  9.159 ± 0.497  ops/s => +30.9% faster
BenchmarkGroupedTopNRankBuilder.topN         10000      1000000       1  thrpt    8  6.530 ± 0.561  ops/s => +30.9% faster
BenchmarkGroupedTopNRankBuilder.topN         10000      1000000      10  thrpt    8  1.568 ± 0.059  ops/s => +12.9% faster
BenchmarkGroupedTopNRankBuilder.topN         10000      1000000     100  thrpt    8  0.363 ± 0.004  ops/s => +23.9% faster
BenchmarkGroupedTopNRankBuilder.topN       1000000      1000000       1  thrpt    8  1.158 ± 0.051  ops/s => +70.5% faster
BenchmarkGroupedTopNRankBuilder.topN       1000000      1000000      10  thrpt    8  1.120 ± 0.115  ops/s => +65.9% faster
BenchmarkGroupedTopNRankBuilder.topN       1000000      1000000     100  thrpt    8  1.158 ± 0.153  ops/s => +71.8% faster