### PR TITLE
Override Accumulo Docker entrypoint for Mac

### DIFF
--- a/plugin/trino-accumulo/pom.xml
+++ b/plugin/trino-accumulo/pom.xml
@@ -242,6 +242,7 @@
         </dependency>
 
         <!-- for testing -->
+
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
@@ -263,6 +264,13 @@
         <dependency>
             <groupId>io.trino.tpch</groupId>
             <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <version>3.2.7</version>
             <scope>test</scope>
         </dependency>
 

--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestingAccumuloServer.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestingAccumuloServer.java
@@ -50,6 +50,10 @@ public class TestingAccumuloServer
         accumuloContainer.withFixedExposedPort(ACCUMULO_MASTER_PORT, ACCUMULO_MASTER_PORT);
         accumuloContainer.withFixedExposedPort(ACCUMULO_TSERVER_PORT, ACCUMULO_TSERVER_PORT);
         accumuloContainer.withExposedPorts(ZOOKEEPER_PORT);
+        accumuloContainer.withCreateContainerCmdModifier(cmd -> cmd
+                .withHostName("localhost")
+                .withEnv("ADDRESS=0.0.0.0")
+                .withEntrypoint("supervisord", "-c", "/etc/supervisord.conf"));
         accumuloContainer.waitingFor(Wait.forHealthcheck().withStartupTimeout(Duration.ofMinutes(10)));
         accumuloContainer.withCopyFileToContainer(forClasspathResource(ITERATORS_JAR), ACCUMULO_EXT_PATH + "/" + ITERATORS_JAR);
 


### PR DESCRIPTION
Docker containerrs on Mac are not accessible from the host via their IP
addresses. Previously, the Accumulo containers would advertise this IP
address in ZooKeeper, causing the tests to hang when running them on MacOS.
This commit changes that address to 0.0.0.0, which will have Accumulo bind
to all ports and advertise the hostname of the container in ZooKeeper.
We also change the hostname of the container to 'localhost' so clients will
connect to the containers at the local address.