### PR TITLE
Do not overwrite version of zt-exec in module

### DIFF
--- a/testing/trino-product-tests/pom.xml
+++ b/testing/trino-product-tests/pom.xml
@@ -143,7 +143,6 @@
         <dependency>
             <groupId>org.zeroturnaround</groupId>
             <artifactId>zt-exec</artifactId>
-            <version>1.12</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Do not overwrite version of zt-exec in module
