### PR TITLE
Add property to allow fetching file sizes in Trino

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -26,6 +26,7 @@ public class IcebergConfig
 {
     private IcebergFileFormat fileFormat = ORC;
     private HiveCompressionCodec compressionCodec = GZIP;
+    private boolean useFileSizeFromMetadata = true;
 
     @NotNull
     public FileFormat getFileFormat()
@@ -50,6 +51,27 @@ public class IcebergConfig
     public IcebergConfig setCompressionCodec(HiveCompressionCodec compressionCodec)
     {
         this.compressionCodec = compressionCodec;
+        return this;
+    }
+
+    @Deprecated
+    public boolean isUseFileSizeFromMetadata()
+    {
+        return useFileSizeFromMetadata;
+    }
+
+    /**
+     * Some Iceberg writers populate incorrect file sizes in the metadata. When
+     * this property is set to false, Trino ignores the stored values and fetches
+     * them with a getFileStatus call. This means an additional call per split,
+     * so it is recommended for a Trino admin to fix the metadata, rather than
+     * relying on this property for too long.
+     */
+    @Deprecated
+    @Config("iceberg.use-file-size-from-metadata")
+    public IcebergConfig setUseFileSizeFromMetadata(boolean useFileSizeFromMetadata)
+    {
+        this.useFileSizeFromMetadata = useFileSizeFromMetadata;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -42,6 +42,7 @@ import static java.lang.String.format;
 public final class IcebergSessionProperties
 {
     private static final String COMPRESSION_CODEC = "compression_codec";
+    private static final String USE_FILE_SIZE_FROM_METADATA = "use_file_size_from_metadata";
     private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
     private static final String ORC_MAX_MERGE_DISTANCE = "orc_max_merge_distance";
     private static final String ORC_MAX_BUFFER_SIZE = "orc_max_buffer_size";
@@ -76,6 +77,11 @@ public final class IcebergSessionProperties
                         "Compression codec to use when writing files",
                         HiveCompressionCodec.class,
                         icebergConfig.getCompressionCodec(),
+                        false))
+                .add(booleanProperty(
+                        USE_FILE_SIZE_FROM_METADATA,
+                        "Use file size stored in Iceberg metadata",
+                        icebergConfig.isUseFileSizeFromMetadata(),
                         false))
                 .add(booleanProperty(
                         ORC_BLOOM_FILTERS_ENABLED,
@@ -269,6 +275,11 @@ public final class IcebergSessionProperties
     public static HiveCompressionCodec getCompressionCodec(ConnectorSession session)
     {
         return session.getProperty(COMPRESSION_CODEC, HiveCompressionCodec.class);
+    }
+
+    public static boolean isUseFileSizeFromMetadata(ConnectorSession session)
+    {
+        return session.getProperty(USE_FILE_SIZE_FROM_METADATA, Boolean.class);
     }
 
     public static DataSize getParquetMaxReadBlockSize(ConnectorSession session)

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -33,7 +33,8 @@ public class TestIcebergConfig
     {
         assertRecordedDefaults(recordDefaults(IcebergConfig.class)
                 .setFileFormat(ORC)
-                .setCompressionCodec(GZIP));
+                .setCompressionCodec(GZIP)
+                .setUseFileSizeFromMetadata(true));
     }
 
     @Test
@@ -42,11 +43,13 @@ public class TestIcebergConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("iceberg.file-format", "Parquet")
                 .put("iceberg.compression-codec", "NONE")
+                .put("iceberg.use-file-size-from-metadata", "false")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
                 .setFileFormat(PARQUET)
-                .setCompressionCodec(HiveCompressionCodec.NONE);
+                .setCompressionCodec(HiveCompressionCodec.NONE)
+                .setUseFileSizeFromMetadata(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
The config property helps users upgrade while avoiding #6369.