### PR TITLE
Allow TrinoDriver to specify user to run query as

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -183,6 +183,7 @@ public class ClientOptions
         return new ClientSession(
                 parseServer(server),
                 user,
+                Optional.empty(), // TODO: https://github.com/trinodb/trino/issues/6567 Add option to specify session user separately from authentication user
                 source,
                 Optional.ofNullable(traceToken),
                 parseClientTags(nullToEmpty(clientTags)),

--- a/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
@@ -103,6 +103,7 @@ public class TestQueryRunner
         return new ClientSession(
                 server.url("/").uri(),
                 "user",
+                Optional.empty(),
                 "source",
                 Optional.empty(),
                 ImmutableSet.of(),

--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -34,7 +34,8 @@ import static java.util.Objects.requireNonNull;
 public class ClientSession
 {
     private final URI server;
-    private final String user;
+    private final String principal;
+    private final Optional<String> user;
     private final String source;
     private final Optional<String> traceToken;
     private final Set<String> clientTags;
@@ -67,7 +68,8 @@ public class ClientSession
 
     public ClientSession(
             URI server,
-            String user,
+            String principal,
+            Optional<String> user,
             String source,
             Optional<String> traceToken,
             Set<String> clientTags,
@@ -87,6 +89,7 @@ public class ClientSession
             boolean compressionDisabled)
     {
         this.server = requireNonNull(server, "server is null");
+        this.principal = principal;
         this.user = user;
         this.source = source;
         this.traceToken = requireNonNull(traceToken, "traceToken is null");
@@ -140,7 +143,12 @@ public class ClientSession
         return server;
     }
 
-    public String getUser()
+    public String getPrincipal()
+    {
+        return principal;
+    }
+
+    public Optional<String> getUser()
     {
         return user;
     }
@@ -243,6 +251,7 @@ public class ClientSession
     {
         return toStringHelper(this)
                 .add("server", server)
+                .add("principal", principal)
                 .add("user", user)
                 .add("clientTags", clientTags)
                 .add("clientInfo", clientInfo)
@@ -261,7 +270,8 @@ public class ClientSession
     public static final class Builder
     {
         private URI server;
-        private String user;
+        private String principal;
+        private Optional<String> user;
         private String source;
         private Optional<String> traceToken;
         private Set<String> clientTags;
@@ -284,6 +294,7 @@ public class ClientSession
         {
             requireNonNull(clientSession, "clientSession is null");
             server = clientSession.getServer();
+            principal = clientSession.getPrincipal();
             user = clientSession.getUser();
             source = clientSession.getSource();
             traceToken = clientSession.getTraceToken();
@@ -368,6 +379,7 @@ public class ClientSession
         {
             return new ClientSession(
                     server,
+                    principal,
                     user,
                     source,
                     traceToken,

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -101,7 +101,7 @@ class StatementClientV1
         this.timeZone = session.getTimeZone();
         this.query = query;
         this.requestTimeoutNanos = session.getClientRequestTimeout();
-        this.user = session.getUser();
+        this.user = session.getPrincipal();
         this.clientCapabilities = Joiner.on(",").join(ClientCapabilities.values());
         this.compressionDisabled = session.isCompressionDisabled();
 
@@ -132,6 +132,8 @@ class StatementClientV1
         }
 
         session.getTraceToken().ifPresent(token -> builder.addHeader(TRINO_HEADERS.requestTraceToken(), token));
+
+        session.getUser().ifPresent(user -> builder.header(TRINO_HEADERS.requestUser(), session.getUser().get()));
 
         if (session.getClientTags() != null && !session.getClientTags().isEmpty()) {
             builder.addHeader(TRINO_HEADERS.requestClientTags(), Joiner.on(",").join(session.getClientTags()));

--- a/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementClientV1.java
@@ -101,7 +101,7 @@ class StatementClientV1
         this.timeZone = session.getTimeZone();
         this.query = query;
         this.requestTimeoutNanos = session.getClientRequestTimeout();
-        this.user = session.getPrincipal();
+        this.user = session.getUser().orElse(session.getPrincipal());
         this.clientCapabilities = Joiner.on(",").join(ClientCapabilities.values());
         this.compressionDisabled = session.isCompressionDisabled();
 
@@ -132,8 +132,6 @@ class StatementClientV1
         }
 
         session.getTraceToken().ifPresent(token -> builder.addHeader(TRINO_HEADERS.requestTraceToken(), token));
-
-        session.getUser().ifPresent(user -> builder.header(TRINO_HEADERS.requestUser(), session.getUser().get()));
 
         if (session.getClientTags() != null && !session.getClientTags().isEmpty()) {
             builder.addHeader(TRINO_HEADERS.requestClientTags(), Joiner.on(",").join(session.getClientTags()));

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -127,6 +127,12 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-password-authenticators</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
             <scope>test</scope>
         </dependency>

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -48,6 +48,7 @@ final class ConnectionProperties
 
     public static final ConnectionProperty<String> USER = new User();
     public static final ConnectionProperty<String> PASSWORD = new Password();
+    public static final ConnectionProperty<String> SESSION_USER = new SessionUser();
     public static final ConnectionProperty<Map<String, ClientSelectedRole>> ROLES = new Roles();
     public static final ConnectionProperty<HostAndPort> SOCKS_PROXY = new SocksProxy();
     public static final ConnectionProperty<HostAndPort> HTTP_PROXY = new HttpProxy();
@@ -79,6 +80,7 @@ final class ConnectionProperties
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
             .add(USER)
             .add(PASSWORD)
+            .add(SESSION_USER)
             .add(ROLES)
             .add(SOCKS_PROXY)
             .add(HTTP_PROXY)
@@ -153,6 +155,15 @@ final class ConnectionProperties
         public Password()
         {
             super("password", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class SessionUser
+            extends AbstractConnectionProperty<String>
+    {
+        protected SessionUser()
+        {
+            super("sessionUser", NOT_REQUIRED, ALLOWED, NON_EMPTY_STRING_CONVERTER);
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -89,6 +89,7 @@ public class TrinoConnection
     private final URI jdbcUri;
     private final URI httpUri;
     private final String user;
+    private final Optional<String> sessionUser;
     private final boolean compressionDisabled;
     private final Map<String, String> extraCredentials;
     private final Optional<String> applicationNamePrefix;
@@ -109,6 +110,7 @@ public class TrinoConnection
         uri.getSchema().ifPresent(schema::set);
         uri.getCatalog().ifPresent(catalog::set);
         this.user = uri.getUser();
+        this.sessionUser = uri.getSessionUser();
         this.applicationNamePrefix = uri.getApplicationNamePrefix();
         this.source = uri.getSource();
         this.extraCredentials = uri.getExtraCredentials();
@@ -707,6 +709,7 @@ public class TrinoConnection
         ClientSession session = new ClientSession(
                 httpUri,
                 user,
+                sessionUser,
                 source,
                 Optional.ofNullable(clientInfo.get(TRACE_TOKEN)),
                 ImmutableSet.copyOf(clientTags),

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -59,6 +59,7 @@ import static io.trino.jdbc.ConnectionProperties.KERBEROS_USE_CANONICAL_HOSTNAME
 import static io.trino.jdbc.ConnectionProperties.PASSWORD;
 import static io.trino.jdbc.ConnectionProperties.ROLES;
 import static io.trino.jdbc.ConnectionProperties.SESSION_PROPERTIES;
+import static io.trino.jdbc.ConnectionProperties.SESSION_USER;
 import static io.trino.jdbc.ConnectionProperties.SOCKS_PROXY;
 import static io.trino.jdbc.ConnectionProperties.SOURCE;
 import static io.trino.jdbc.ConnectionProperties.SSL;
@@ -156,6 +157,12 @@ public final class TrinoDriverUri
             throws SQLException
     {
         return USER.getRequiredValue(properties);
+    }
+
+    public Optional<String> getSessionUser()
+            throws SQLException
+    {
+        return SESSION_USER.getValue(properties);
     }
 
     public Map<String, ClientSelectedRole> getRoles()

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestPrestoDriverImpersonateUser.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestPrestoDriverImpersonateUser.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Key;
+import io.trino.server.security.PasswordAuthenticatorManager;
+import io.trino.server.testing.TestingTrinoServer;
+import io.trino.spi.security.AccessDeniedException;
+import io.trino.spi.security.BasicPrincipal;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.security.Principal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.Properties;
+
+import static com.google.common.io.Resources.getResource;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestPrestoDriverImpersonateUser
+{
+    private static final String TEST_USER = "test_user";
+    private static final String PASSWORD = "password";
+
+    private TestingTrinoServer server;
+
+    @BeforeClass
+    public void setup()
+    {
+        server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .put("http-server.authentication.type", "password")
+                        .put("http-server.https.enabled", "true")
+                        .put("http-server.https.keystore.path", getResource("localhost.keystore").getPath())
+                        .put("http-server.https.keystore.key", "changeit")
+                        .build())
+                .build();
+
+        server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticator(TestPrestoDriverImpersonateUser::authenticate);
+    }
+
+    private static Principal authenticate(String user, String password)
+    {
+        if ((TEST_USER.equals(user) && PASSWORD.equals(password))) {
+            return new BasicPrincipal(user);
+        }
+        throw new AccessDeniedException("Invalid credentials");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+            throws Exception
+    {
+        server.close();
+    }
+
+    @Test
+    public void testInvalidCredentials()
+    {
+        assertThatThrownBy(() -> trySelectCurrentUser(ImmutableMap.of()));
+        assertThatThrownBy(() -> trySelectCurrentUser(ImmutableMap.of("user", "invalidUser", "password", PASSWORD)));
+        assertThatThrownBy(() -> trySelectCurrentUser(ImmutableMap.of("user", TEST_USER, "password", "invalidPassword")));
+        assertThatThrownBy(() -> trySelectCurrentUser(ImmutableMap.of("user", "invalidUser", "password", PASSWORD, "sessionUser", TEST_USER)));
+    }
+
+    @Test
+    public void testQueryUserNotSpecified()
+            throws SQLException
+    {
+        assertEquals(trySelectCurrentUser(ImmutableMap.of("user", TEST_USER, "password", PASSWORD)), TEST_USER);
+    }
+
+    @Test
+    public void testImpersonateUser()
+            throws SQLException
+    {
+        assertEquals(trySelectCurrentUser(ImmutableMap.of("user", TEST_USER, "password", PASSWORD, "sessionUser", "differentUser")), "differentUser");
+    }
+
+    private String trySelectCurrentUser(Map<String, String> additionalProperties)
+            throws SQLException
+    {
+        try (Connection connection = createConnection(additionalProperties);
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery("SELECT current_user")) {
+            assertTrue(resultSet.next());
+            return resultSet.getString(1);
+        }
+    }
+
+    private Connection createConnection(Map<String, String> additionalProperties)
+            throws SQLException
+    {
+        String url = format("jdbc:trino://localhost:%s", server.getHttpsAddress().getPort());
+        Properties properties = new Properties();
+        properties.setProperty("SSL", "true");
+        properties.setProperty("SSLTrustStorePath", getResource("localhost.truststore").getPath());
+        properties.setProperty("SSLTrustStorePassword", "changeit");
+        additionalProperties.forEach(properties::setProperty);
+        return DriverManager.getConnection(url, properties);
+    }
+}

--- a/testing/trino-benchmark-driver/src/main/java/io/trino/benchmark/driver/BenchmarkDriver.java
+++ b/testing/trino-benchmark-driver/src/main/java/io/trino/benchmark/driver/BenchmarkDriver.java
@@ -47,7 +47,7 @@ public class BenchmarkDriver
         this.clientSession = requireNonNull(clientSession, "clientSession is null");
         this.queries = ImmutableList.copyOf(requireNonNull(queries, "queries is null"));
 
-        queryRunner = new BenchmarkQueryRunner(warm, runs, debug, maxFailures, clientSession.getServer(), socksProxy, clientSession.getUser());
+        queryRunner = new BenchmarkQueryRunner(warm, runs, debug, maxFailures, clientSession.getServer(), socksProxy, clientSession.getPrincipal());
     }
 
     public void run(Suite suite)

--- a/testing/trino-benchmark-driver/src/main/java/io/trino/benchmark/driver/BenchmarkDriverOptions.java
+++ b/testing/trino-benchmark-driver/src/main/java/io/trino/benchmark/driver/BenchmarkDriverOptions.java
@@ -102,6 +102,7 @@ public class BenchmarkDriverOptions
         return new ClientSession(
                 parseServer(server),
                 user,
+                Optional.empty(),
                 "trino-benchmark",
                 Optional.empty(),
                 ImmutableSet.of(),

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
@@ -146,6 +146,7 @@ public abstract class AbstractTestingTrinoClient<T>
         return new ClientSession(
                 server,
                 session.getIdentity().getUser(),
+                Optional.empty(),
                 session.getSource().orElse(null),
                 session.getTraceToken(),
                 session.getClientTags(),

--- a/testing/trino-tests/pom.xml
+++ b/testing/trino-tests/pom.xml
@@ -40,6 +40,11 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
         </dependency>
 
@@ -101,6 +106,11 @@
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
         </dependency>
 
         <dependency>

--- a/testing/trino-tests/src/test/resources/access_control_rules.json
+++ b/testing/trino-tests/src/test/resources/access_control_rules.json
@@ -1,0 +1,19 @@
+{
+    "catalogs": [
+        {
+            "user": "alice",
+            "catalog": "tpch",
+            "allow": "all"
+        },
+        {
+            "user": "bob",
+            "catalog": "tpch",
+            "allow": "none"
+        },
+        {
+            "user": "charlie",
+            "catalog": "tpch",
+            "allow": "read-only"
+        }
+    ]
+}


### PR DESCRIPTION
The user property will still be used for authentication but once authenticated, the query will be run as the requested user.