### PR TITLE
Allow passing cli arguments with TRINO_* env variables

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/Trino.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Trino.java
@@ -39,7 +39,8 @@ public final class Trino
                 .registerConverter(ClientSessionProperty.class, ClientSessionProperty::new)
                 .registerConverter(ClientExtraCredential.class, ClientExtraCredential::new)
                 .registerConverter(HostAndPort.class, HostAndPort::fromString)
-                .registerConverter(Duration.class, Duration::valueOf);
+                .registerConverter(Duration.class, Duration::valueOf)
+                .setResourceBundle(new ClientOptions.DefaultsBundle());
     }
 
     public static class VersionProvider


### PR DESCRIPTION
WIP for the time being (no every arg could be passed with env key) so we can discuss that.

This adds other value: administrators could easily provide CLI defaults with profiles (or you can source a file and have everything set instead of passing those by env)

so i.e. instead:

`trino-cli --server some-long-host-name:9000`

you can do:

```
export TRINO_SERVER="some-long-host-name:9000"
trino-cli
```

We could make it `TRINO_CLI_SERVER` to make it explicit that it configures CLI.

WDYT?

Reference: https://clig.dev/#configuration
Reference: https://clig.dev/#environment-variables