### PR TITLE
Load default cli configuration

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -51,52 +51,52 @@ public class ClientOptions
     public String server;
 
     @Option(names = "--krb5-service-principal-pattern", paramLabel = "<pattern>", defaultValue = "$${SERVICE}@$${HOST}", description = "Remote kerberos service principal pattern " + DEFAULT_VALUE)
-    public String krb5ServicePrincipalPattern;
+    public Optional<String> krb5ServicePrincipalPattern;
 
     @Option(names = "--krb5-remote-service-name", paramLabel = "<name>", description = "Remote peer's kerberos service name")
-    public String krb5RemoteServiceName;
+    public Optional<String> krb5RemoteServiceName;
 
     @Option(names = "--krb5-config-path", paramLabel = "<path>", defaultValue = "/etc/krb5.conf", description = "Kerberos config file path " + DEFAULT_VALUE)
-    public String krb5ConfigPath;
+    public Optional<String> krb5ConfigPath;
 
     @Option(names = "--krb5-keytab-path", paramLabel = "<path>", defaultValue = "/etc/krb5.keytab", description = "Kerberos key table path " + DEFAULT_VALUE)
-    public String krb5KeytabPath;
+    public Optional<String> krb5KeytabPath;
 
     @Option(names = "--krb5-credential-cache-path", paramLabel = "<path>", description = "Kerberos credential cache path")
-    public String krb5CredentialCachePath = defaultCredentialCachePath().orElse(null);
+    public Optional<String> krb5CredentialCachePath = defaultCredentialCachePath();
 
     @Option(names = "--krb5-principal", paramLabel = "<principal>", description = "Kerberos principal to be used")
-    public String krb5Principal;
+    public Optional<String> krb5Principal;
 
     @Option(names = "--krb5-disable-remote-service-hostname-canonicalization", description = "Disable service hostname canonicalization using the DNS reverse lookup")
     public boolean krb5DisableRemoteServiceHostnameCanonicalization;
 
     @Option(names = "--keystore-path", paramLabel = "<path>", description = "Keystore path")
-    public String keystorePath;
+    public Optional<String> keystorePath;
 
     @Option(names = "--keystore-password", paramLabel = "<password>", description = "Keystore password")
-    public String keystorePassword;
+    public Optional<String> keystorePassword;
 
     @Option(names = "--keystore-type", paramLabel = "<type>", description = "Keystore type")
-    public String keystoreType;
+    public Optional<String> keystoreType;
 
     @Option(names = "--truststore-path", paramLabel = "<path>", description = "Truststore path")
-    public String truststorePath;
+    public Optional<String> truststorePath;
 
     @Option(names = "--truststore-password", paramLabel = "<password>", description = "Truststore password")
-    public String truststorePassword;
+    public Optional<String> truststorePassword;
 
     @Option(names = "--truststore-type", paramLabel = "<type>", description = "Truststore type")
-    public String truststoreType;
+    public Optional<String> truststoreType;
 
     @Option(names = "--insecure", description = "Skip validation of HTTP server certificates (should only be used for debugging)")
     public boolean insecure;
 
     @Option(names = "--access-token", paramLabel = "<token>", description = "Access token")
-    public String accessToken;
+    public Optional<String> accessToken;
 
-    @Option(names = "--user", paramLabel = "<user>", description = "Username " + DEFAULT_VALUE)
-    public String user = System.getProperty("user.name");
+    @Option(names = "--user", paramLabel = "<user>", defaultValue = "${sys:user.name}", description = "Username " + DEFAULT_VALUE)
+    public Optional<String> user;
 
     @Option(names = "--password", paramLabel = "<password>", description = "Prompt for password")
     public boolean password;
@@ -150,10 +150,10 @@ public class ClientOptions
     public final List<ClientExtraCredential> extraCredentials = new ArrayList<>();
 
     @Option(names = "--socks-proxy", paramLabel = "<proxy>", description = "SOCKS proxy to use for server connections")
-    public HostAndPort socksProxy;
+    public Optional<HostAndPort> socksProxy;
 
     @Option(names = "--http-proxy", paramLabel = "<proxy>", description = "HTTP proxy to use for server connections")
-    public HostAndPort httpProxy;
+    public Optional<HostAndPort> httpProxy;
 
     @Option(names = "--client-request-timeout", paramLabel = "<timeout>", defaultValue = "2m", description = "Client request timeout " + DEFAULT_VALUE)
     public Duration clientRequestTimeout;
@@ -185,7 +185,7 @@ public class ClientOptions
     {
         return new ClientSession(
                 parseServer(server),
-                user,
+                user.orElse(null),
                 sessionUser,
                 source,
                 Optional.ofNullable(traceToken),

--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -161,24 +161,24 @@ public class Console
         try (QueryRunner queryRunner = new QueryRunner(
                 session,
                 clientOptions.debug,
-                Optional.ofNullable(clientOptions.socksProxy),
-                Optional.ofNullable(clientOptions.httpProxy),
-                Optional.ofNullable(clientOptions.keystorePath),
-                Optional.ofNullable(clientOptions.keystorePassword),
-                Optional.ofNullable(clientOptions.keystoreType),
-                Optional.ofNullable(clientOptions.truststorePath),
-                Optional.ofNullable(clientOptions.truststorePassword),
-                Optional.ofNullable(clientOptions.truststoreType),
+                clientOptions.socksProxy,
+                clientOptions.httpProxy,
+                clientOptions.keystorePath,
+                clientOptions.keystorePassword,
+                clientOptions.keystoreType,
+                clientOptions.truststorePath,
+                clientOptions.truststorePassword,
+                clientOptions.truststoreType,
                 clientOptions.insecure,
-                Optional.ofNullable(clientOptions.accessToken),
-                Optional.ofNullable(clientOptions.user),
+                clientOptions.accessToken,
+                clientOptions.user,
                 clientOptions.password ? Optional.of(getPassword()) : Optional.empty(),
-                Optional.ofNullable(clientOptions.krb5Principal),
-                Optional.ofNullable(clientOptions.krb5ServicePrincipalPattern),
-                Optional.ofNullable(clientOptions.krb5RemoteServiceName),
-                Optional.ofNullable(clientOptions.krb5ConfigPath),
-                Optional.ofNullable(clientOptions.krb5KeytabPath),
-                Optional.ofNullable(clientOptions.krb5CredentialCachePath),
+                clientOptions.krb5Principal,
+                clientOptions.krb5ServicePrincipalPattern,
+                clientOptions.krb5RemoteServiceName,
+                clientOptions.krb5ConfigPath,
+                clientOptions.krb5KeytabPath,
+                clientOptions.krb5CredentialCachePath,
                 !clientOptions.krb5DisableRemoteServiceHostnameCanonicalization)) {
             if (hasQuery) {
                 return executeCommand(
@@ -201,7 +201,7 @@ public class Console
 
     private String getPassword()
     {
-        checkState(clientOptions.user != null, "Username must be specified along with password");
+        checkState(clientOptions.user.isPresent(), "Username must be specified along with password");
         String defaultPassword = System.getenv("TRINO_PASSWORD");
         if (defaultPassword != null) {
             return defaultPassword;

--- a/client/trino-cli/src/main/java/io/trino/cli/Trino.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Trino.java
@@ -51,8 +51,7 @@ public final class Trino
                 .registerConverter(HostAndPort.class, HostAndPort::fromString)
                 .registerConverter(Duration.class, Duration::valueOf);
 
-        getConfigFile().ifPresent(file -> commandLine.setDefaultValueProvider(new CommandLine.PropertiesDefaultProvider(file)));
-
+        getConfigFile().ifPresent(file -> ValidatingPropertiesDefaultProvider.attach(commandLine, file));
         return commandLine;
     }
 

--- a/client/trino-cli/src/main/java/io/trino/cli/Trino.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Trino.java
@@ -21,7 +21,17 @@ import io.trino.cli.ClientOptions.ClientSessionProperty;
 import picocli.CommandLine;
 import picocli.CommandLine.IVersionProvider;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.stream.Stream;
+
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.StandardSystemProperty.USER_HOME;
+import static com.google.common.base.Strings.emptyToNull;
+import static java.lang.System.getenv;
 
 public final class Trino
 {
@@ -34,12 +44,43 @@ public final class Trino
 
     public static CommandLine createCommandLine(Object command)
     {
-        return new CommandLine(command)
+        CommandLine commandLine = new CommandLine(command)
                 .registerConverter(ClientResourceEstimate.class, ClientResourceEstimate::new)
                 .registerConverter(ClientSessionProperty.class, ClientSessionProperty::new)
                 .registerConverter(ClientExtraCredential.class, ClientExtraCredential::new)
                 .registerConverter(HostAndPort.class, HostAndPort::fromString)
                 .registerConverter(Duration.class, Duration::valueOf);
+
+        getConfigFile().ifPresent(file -> commandLine.setDefaultValueProvider(new CommandLine.PropertiesDefaultProvider(file)));
+
+        return commandLine;
+    }
+
+    private static Optional<File> getConfigFile()
+    {
+        return getConfigSearchPaths()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(Paths::get)
+                .filter(Files::exists)
+                .findFirst()
+                .map(Path::toFile);
+    }
+
+    private static Stream<Optional<String>> getConfigSearchPaths()
+    {
+        return Stream.of(
+                Optional.ofNullable(emptyToNull(getenv("TRINO_CONFIG"))),
+                resolveConfigPath(USER_HOME.value(), ".trino_config"),
+                resolveConfigPath(getenv("XDG_CONFIG_HOME"), "/trino/config"));
+    }
+
+    private static Optional<String> resolveConfigPath(String root, String file)
+    {
+        return Optional.ofNullable(emptyToNull(root))
+                .map(Paths::get)
+                .filter(Files::exists)
+                .map(path -> path.resolve(file).toString());
     }
 
     public static class VersionProvider

--- a/client/trino-cli/src/main/java/io/trino/cli/ValidatingPropertiesDefaultProvider.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ValidatingPropertiesDefaultProvider.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cli;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import picocli.CommandLine;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+
+public class ValidatingPropertiesDefaultProvider
+        extends CommandLine.PropertiesDefaultProvider
+{
+    protected ValidatingPropertiesDefaultProvider(File configFile)
+    {
+        super(configFile);
+    }
+
+    public static void attach(CommandLine commandLine, File configFile)
+    {
+        validateConfigurationProperties(commandLine.getCommandSpec(), configFile.getPath());
+        commandLine.setDefaultValueProvider(new ValidatingPropertiesDefaultProvider(configFile));
+    }
+
+    private static void validateConfigurationProperties(CommandLine.Model.CommandSpec commandSpec, String path)
+    {
+        CharMatcher isDash = CharMatcher.is('-');
+
+        try (InputStream inputStream = Files.newInputStream(Paths.get(path))) {
+            Properties properties = new Properties();
+            properties.load(inputStream);
+            Set<String> definedOptions = properties.stringPropertyNames();
+
+            Set<String> knownOptions = commandSpec.args().stream()
+                    .flatMap(ValidatingPropertiesDefaultProvider::getOptionNamesFromSpec)
+                    .map(isDash::trimLeadingFrom)
+                    .collect(toImmutableSet());
+
+            Sets.SetView<String> unknownOptions = Sets.difference(definedOptions, knownOptions);
+
+            if (!unknownOptions.isEmpty()) {
+                System.err.printf("Configuration file %s contains unknown properties %s\n", path, unknownOptions);
+                System.exit(1);
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static Stream<String> getOptionNames(CommandLine.Model.OptionSpec optionSpec)
+    {
+        if (optionSpec.usageHelp() || optionSpec.versionHelp()) {
+            return Stream.empty();
+        }
+        return ImmutableList.copyOf(optionSpec.names()).stream();
+    }
+
+    private static Stream<String> getOptionNamesFromSpec(CommandLine.Model.ArgSpec argSpec)
+    {
+        if (argSpec instanceof CommandLine.Model.OptionSpec) {
+            return getOptionNames((CommandLine.Model.OptionSpec) argSpec);
+        }
+
+        if (argSpec instanceof CommandLine.Model.PositionalParamSpec) {
+            return getOptionNames((CommandLine.Model.PositionalParamSpec) argSpec);
+        }
+
+        throw new RuntimeException("Unknown option " + argSpec);
+    }
+
+    private static Stream<String> getOptionNames(CommandLine.Model.PositionalParamSpec paramSpec)
+    {
+        return ImmutableList.of(paramSpec.paramLabel()).stream();
+    }
+}

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -224,7 +224,7 @@ public class TestClientOptions
     private static Console createConsole(String... args)
     {
         Console console = new Console();
-        createCommandLine(console).parseArgs(args);
+        createCommandLine(console).setDefaultValueProvider(null).parseArgs(args);
         return console;
     }
 }

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -37,7 +37,7 @@ public class TestClientOptions
     {
         Console console = createConsole();
         ClientOptions options = console.clientOptions;
-        assertEquals(options.krb5ServicePrincipalPattern, "${SERVICE}@${HOST}");
+        assertEquals(options.krb5ServicePrincipalPattern, Optional.of("${SERVICE}@${HOST}"));
         ClientSession session = options.toClientSession();
         assertEquals(session.getServer().toString(), "http://localhost:8080");
         assertEquals(session.getSource(), "trino-cli");
@@ -112,7 +112,7 @@ public class TestClientOptions
     {
         Console console = createConsole("--socks-proxy=abc:123");
         ClientOptions options = console.clientOptions;
-        assertEquals(options.socksProxy, HostAndPort.fromParts("abc", 123));
+        assertEquals(options.socksProxy, Optional.of(HostAndPort.fromParts("abc", 123)));
     }
 
     @Test

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/cli/TestTrinoCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/cli/TestTrinoCli.java
@@ -13,7 +13,9 @@
  */
 package io.trino.tests.cli;
 
+import com.google.common.base.CharMatcher;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import com.google.inject.Inject;
@@ -32,13 +34,17 @@ import java.io.UncheckedIOException;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
 import static io.trino.tempto.process.CliProcess.trimLines;
 import static io.trino.tests.TestGroups.AUTHORIZATION;
 import static io.trino.tests.TestGroups.CLI;
 import static io.trino.tests.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -201,6 +207,34 @@ public class TestTrinoCli
     }
 
     @Test(groups = CLI, timeOut = TIMEOUT)
+    public void shouldUseCatalogAndSchemaOptionsFromConfigFile()
+            throws Exception
+    {
+        launchTrinoCliWithConfigurationFile(ImmutableList.of("catalog", "hive", "schema", "default"), "--execute", "SELECT * FROM nation;");
+        assertThat(trimLines(trino.readRemainingOutputLines())).containsAll(nationTableBatchLines);
+        trino.waitForWithTimeoutAndKill();
+    }
+
+    @Test(groups = CLI, timeOut = TIMEOUT)
+    public void shouldPreferCommandLineArgumentOverConfigDefault()
+            throws Exception
+    {
+        launchTrinoCliWithConfigurationFile(ImmutableList.of("catalog", "some-other-catalog", "schema", "default"), "--catalog", "hive", "--execute", "SELECT * FROM nation;");
+        assertThat(trimLines(trino.readRemainingOutputLines())).containsAll(nationTableBatchLines);
+        trino.waitForWithTimeoutAndKill();
+    }
+
+    @Test(groups = CLI, timeOut = TIMEOUT)
+    public void shouldExitWithErrorOnUnknownPropertiesInConfigFile()
+            throws Exception
+    {
+        String configPath = launchTrinoCliWithConfigurationFile(ImmutableList.of("unknown", "property", "catalog", "hive"));
+        assertThat(trimLines(trino.readRemainingErrorLines())).containsExactly(format("Configuration file %s contains unknown properties [unknown]", configPath));
+
+        assertThatThrownBy(() -> trino.waitForWithTimeoutAndKill()).hasMessage("Child process exited with non-zero code: 1");
+    }
+
+    @Test(groups = CLI, timeOut = TIMEOUT)
     public void shouldRunQueryFromFile()
             throws Exception
     {
@@ -244,7 +278,7 @@ public class TestTrinoCli
             throws IOException
     {
         String sql = "select * from hive.default.nations; select * from hive.default.nation;";
-        launchTrinoCliWithServerArgument("--execute", sql, "--ignore-errors");
+        launchTrinoCliWithServerArgument("--execute", sql, "--ignore-errors", "true");
         assertThat(trimLines(trino.readRemainingOutputLines())).containsAll(nationTableBatchLines);
 
         assertThatThrownBy(() -> trino.waitForWithTimeoutAndKill()).hasMessage("Child process exited with non-zero code: 1");
@@ -257,7 +291,7 @@ public class TestTrinoCli
         try (TempFile file = new TempFile()) {
             Files.write("select * from hive.default.nations;\nselect * from hive.default.nation;\n", file.file(), UTF_8);
 
-            launchTrinoCliWithServerArgument("--file", file.file().getAbsolutePath(), "--ignore-errors");
+            launchTrinoCliWithServerArgument("--file", file.file().getAbsolutePath(), "--ignore-errors", "true");
             assertThat(trimLines(trino.readRemainingOutputLines())).containsAll(nationTableBatchLines);
 
             assertThatThrownBy(() -> trino.waitForWithTimeoutAndKill()).hasMessage("Child process exited with non-zero code: 1");
@@ -375,6 +409,27 @@ public class TestTrinoCli
         launchTrinoCli(getTrinoCliArguments(arguments));
     }
 
+    private String launchTrinoCliWithConfigurationFile(List<String> configuration, String... arguments)
+            throws IOException
+    {
+        CharMatcher matcher = CharMatcher.is('-');
+        ProcessBuilder processBuilder = getProcessBuilder(ImmutableList.copyOf(arguments));
+
+        String fileContent = getTrinoCliArguments(configuration.toArray(new String[0]))
+                .stream()
+                .map(matcher::trimLeadingFrom)
+                .collect(joining("\n"));
+
+        File tempFile = File.createTempFile(".trino_config", "");
+        tempFile.deleteOnExit();
+        Files.write(fileContent.getBytes(UTF_8), tempFile);
+
+        processBuilder.environment().put("TRINO_CONFIG", tempFile.getAbsolutePath());
+        trino = new TrinoCliProcess(processBuilder.start());
+
+        return tempFile.getPath();
+    }
+
     private void launchTrinoCliWithRedirectedStdin(File inputFile)
             throws IOException
     {
@@ -385,6 +440,8 @@ public class TestTrinoCli
 
     private List<String> getTrinoCliArguments(String... arguments)
     {
+        verify(arguments.length % 2 == 0, "arguments.length should be divisible by 2");
+
         ImmutableList.Builder<String> trinoClientOptions = ImmutableList.builder();
         trinoClientOptions.add("--server", serverAddress);
         trinoClientOptions.add("--user", jdbcUser);
@@ -409,12 +466,16 @@ public class TestTrinoCli
             trinoClientOptions.add("--krb5-config-path", kerberosConfigPath);
 
             if (!kerberosUseCanonicalHostname) {
-                trinoClientOptions.add("--krb5-disable-remote-service-hostname-canonicalization");
+                trinoClientOptions.add("--krb5-disable-remote-service-hostname-canonicalization", "true");
             }
         }
 
         trinoClientOptions.add(arguments);
-        return trinoClientOptions.build();
+
+        return Lists.partition(trinoClientOptions.build(), 2)
+                .stream()
+                .map(argument -> format("%s=%s", argument.get(0), argument.get(1)))
+                .collect(toImmutableList());
     }
 
     private static String removePrefix(String line)


### PR DESCRIPTION
Picocli has a nice mechanism of loading defaults for CLI arguments from a properties file.

That allows us to do:

`cat ${TRINO_CONFIG}` or `cat ~/.trino_config` or `cat ~/.config/trino/config` (exact order of load):
```
server=wendigo:20000
source=my-source
krb5-keytab-path=/etc/my-kerberos.keytab
timezone=Europe/Paris
output-format=TSV
user=wendigo
```

And in result:

```
./client/trino-cli/target/trino-cli-352-SNAPSHOT-executable.jar --help
Trino command line interface

USAGE:

trino [-h] [--debug] [--disable-compression] [--ignore-errors] [--insecure]
      [--krb5-disable-remote-service-hostname-canonicalization] [--password]
      [--progress] [--version] [--access-token=<token>] [--catalog=<catalog>]
      [--client-info=<info>] [--client-request-timeout=<timeout>]
      [--client-tags=<tags>] [--execute=<execute>] [-f=<file>]
      [--http-proxy=<proxy>] [--keystore-password=<password>]
      [--keystore-path=<path>] [--keystore-type=<type>]
      [--krb5-config-path=<path>] [--krb5-credential-cache-path=<path>]
      [--krb5-keytab-path=<path>] [--krb5-principal=<principal>]
      [--krb5-remote-service-name=<name>]
      [--krb5-service-principal-pattern=<pattern>] [--log-levels-file=<file>]
      [--output-format=<format>] [--schema=<schema>] [--server=<server>]
      [--socks-proxy=<proxy>] [--source=<source>] [--timezone=<timezone>]
      [--trace-token=<token>] [--truststore-password=<password>]
      [--truststore-path=<path>] [--truststore-type=<type>] [--user=<user>]
      [--extra-credential=<credential>]... [--resource-estimate=<estimate>]...
      [--session=<session>]...

OPTIONS:
      --access-token=<token> Access token
      --catalog=<catalog>    Default catalog
      --client-info=<info>   Extra information about client making query
      --client-request-timeout=<timeout>
                             Client request timeout (default: 2m)
      --client-tags=<tags>   Client tags
      --debug                Enable debug information
      --disable-compression  Disable compression of query results
      --execute=<execute>    Execute specified statements and exit
      --extra-credential=<credential>
                             Extra credentials (property can be used multiple
                               times; format is key=value)
  -f, --file=<file>          Execute statements from file and exit
  -h, --help                 Show this help message and exit
      --http-proxy=<proxy>   HTTP proxy to use for server connections
      --ignore-errors        Continue processing in batch mode when an error
                               occurs (default is to exit immediately)
      --insecure             Skip validation of HTTP server certificates
                               (should only be used for debugging)
      --keystore-password=<password>
                             Keystore password
      --keystore-path=<path> Keystore path
      --keystore-type=<type> Keystore type
      --krb5-config-path=<path>
                             Kerberos config file path (default: /etc/krb5.conf)
      --krb5-credential-cache-path=<path>
                             Kerberos credential cache path
      --krb5-disable-remote-service-hostname-canonicalization
                             Disable service hostname canonicalization using
                               the DNS reverse lookup
      --krb5-keytab-path=<path>
                             Kerberos key table path (default: /etc/my-kerberos.
                               keytab)
      --krb5-principal=<principal>
                             Kerberos principal to be used
      --krb5-remote-service-name=<name>
                             Remote peer's kerberos service name
      --krb5-service-principal-pattern=<pattern>
                             Remote kerberos service principal pattern
                               (default: ${SERVICE}@${HOST})
      --log-levels-file=<file>
                             Configure log levels for debugging using this file
      --output-format=<format>
                             Output format for batch mode [ALIGNED, VERTICAL,
                               TSV, TSV_HEADER, CSV, CSV_HEADER, CSV_UNQUOTED,
                               CSV_HEADER_UNQUOTED, JSON, NULL] (default: TSV)
      --password             Prompt for password
      --progress             Show query progress in batch mode
      --resource-estimate=<estimate>
                             Resource estimate (property can be used multiple
                               times; format is key=value)
      --schema=<schema>      Default schema
      --server=<server>      Trino server location (default: wendigo:20000)
      --session=<session>    Session property (property can be used multiple
                               times; format is key=value; use 'SHOW SESSION'
                               to see available properties)
      --socks-proxy=<proxy>  SOCKS proxy to use for server connections
      --source=<source>      Name of source making query (default: my-source)
      --timezone=<timezone>  Session time zone (default: Europe/Paris)
      --trace-token=<token>  Trace token
      --truststore-password=<password>
                             Truststore password
      --truststore-path=<path>
                             Truststore path
      --truststore-type=<type>
                             Truststore type
      --user=<user>          Username (default: wendigo)
      --version              Print version information and exit

```

Supersedes https://github.com/trinodb/trino/pull/6566 

For reference:
- https://clig.dev/#configuration
- https://picocli.info/#_propertiesdefaultprovider