### PR TITLE
Add OAuth2 support to JDBC

### DIFF
--- a/client/trino-client/pom.xml
+++ b/client/trino-client/pom.xml
@@ -69,10 +69,21 @@
             <artifactId>okhttp-urlconnection</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/DesktopBrowserRedirectHandler.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/DesktopBrowserRedirectHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import java.io.IOException;
+import java.net.URI;
+
+import static java.awt.Desktop.Action.BROWSE;
+import static java.awt.Desktop.getDesktop;
+import static java.awt.Desktop.isDesktopSupported;
+
+public final class DesktopBrowserRedirectHandler
+        implements RedirectHandler
+{
+    @Override
+    public void redirectTo(URI uri)
+            throws RedirectException
+    {
+        if (!isDesktopSupported() || !getDesktop().isSupported(BROWSE)) {
+            throw new RedirectException("Desktop Browser is not available. Make sure your Java process is not in headless mode (-Djava.awt.headless=false)");
+        }
+
+        try {
+            getDesktop().browse(uri);
+        }
+        catch (IOException e) {
+            throw new RedirectException("Failed to redirect", e);
+        }
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/ExternalAuthentication.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/ExternalAuthentication.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.trino.client.ClientException;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+class ExternalAuthentication
+{
+    private final URI tokenUri;
+    private final Optional<URI> redirectUri;
+
+    public ExternalAuthentication(URI tokenUri, Optional<URI> redirectUri)
+    {
+        this.tokenUri = requireNonNull(tokenUri, "tokenUri is null");
+        this.redirectUri = requireNonNull(redirectUri, "redirectUri is null");
+    }
+
+    public Optional<Token> obtainToken(Duration timeout, RedirectHandler handler, TokenPoller poller)
+    {
+        redirectUri.ifPresent(handler::redirectTo);
+
+        URI currentUri = tokenUri;
+
+        long start = System.nanoTime();
+        long timeoutNanos = timeout.toNanos();
+
+        while (true) {
+            long remaining = timeoutNanos - (System.nanoTime() - start);
+            if (remaining < 0) {
+                return Optional.empty();
+            }
+
+            TokenPollResult result = poller.pollForToken(currentUri, Duration.ofNanos(remaining));
+
+            if (result.isFailed()) {
+                throw new ClientException(result.getError());
+            }
+
+            if (result.isPending()) {
+                currentUri = result.getNextTokenUri();
+                continue;
+            }
+
+            return Optional.of(result.getToken());
+        }
+    }
+
+    @VisibleForTesting
+    Optional<URI> getRedirectUri()
+    {
+        return redirectUri;
+    }
+
+    @VisibleForTesting
+    URI getTokenUri()
+    {
+        return tokenUri;
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/ExternalAuthenticator.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/ExternalAuthenticator.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.trino.client.ClientException;
+import okhttp3.Authenticator;
+import okhttp3.Challenge;
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.Route;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ExternalAuthenticator
+        implements Authenticator, Interceptor
+{
+    public static final String TOKEN_URI_FIELD = "x_token_server";
+    public static final String REDIRECT_URI_FIELD = "x_redirect_server";
+
+    private final TokenPoller tokenPoller;
+    private final RedirectHandler redirectHandler;
+    private final Duration timeout;
+    private Token knownToken;
+
+    public ExternalAuthenticator(RedirectHandler redirect, TokenPoller tokenPoller, Duration timeout)
+    {
+        this.tokenPoller = requireNonNull(tokenPoller, "tokenPoller is null");
+        this.redirectHandler = requireNonNull(redirect, "redirect is null");
+        this.timeout = requireNonNull(timeout, "timeout is null");
+    }
+
+    @Nullable
+    @Override
+    public Request authenticate(Route route, Response response)
+    {
+        knownToken = null;
+
+        Optional<ExternalAuthentication> authentication = toAuthentication(response);
+        if (!authentication.isPresent()) {
+            return null;
+        }
+
+        Optional<Token> token = authentication.get().obtainToken(timeout, redirectHandler, tokenPoller);
+        if (!token.isPresent()) {
+            return null;
+        }
+
+        knownToken = token.get();
+        return withBearerToken(response.request(), knownToken);
+    }
+
+    @Override
+    public Response intercept(Chain chain)
+            throws IOException
+    {
+        if (knownToken != null) {
+            return chain.proceed(withBearerToken(chain.request(), knownToken));
+        }
+
+        return chain.proceed(chain.request());
+    }
+
+    private static Request withBearerToken(Request request, Token token)
+    {
+        return request.newBuilder()
+                .addHeader(AUTHORIZATION, "Bearer " + token.token())
+                .build();
+    }
+
+    @VisibleForTesting
+    static Optional<ExternalAuthentication> toAuthentication(Response response)
+    {
+        for (Challenge challenge : response.challenges()) {
+            if (challenge.scheme().equalsIgnoreCase("Bearer")) {
+                Optional<URI> tokenUri = parseField(challenge.authParams(), TOKEN_URI_FIELD);
+                Optional<URI> redirectUri = parseField(challenge.authParams(), REDIRECT_URI_FIELD);
+                if (tokenUri.isPresent()) {
+                    return Optional.of(new ExternalAuthentication(tokenUri.get(), redirectUri));
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static Optional<URI> parseField(Map<String, String> fields, String key)
+    {
+        return Optional.ofNullable(fields.get(key)).map(value -> {
+            try {
+                return new URI(value);
+            }
+            catch (URISyntaxException e) {
+                throw new ClientException(format("Failed to parse URI for field '%s'", key), e);
+            }
+        });
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/HttpTokenPoller.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/HttpTokenPoller.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.json.JsonCodec;
+import io.trino.client.JsonResponse;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.FailsafeException;
+import net.jodah.failsafe.RetryPolicy;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.time.Duration;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.net.HttpHeaders.USER_AGENT;
+import static io.airlift.json.JsonCodec.jsonCodec;
+import static io.trino.client.JsonResponse.execute;
+import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.util.Objects.requireNonNull;
+
+public class HttpTokenPoller
+        implements TokenPoller
+{
+    private static final JsonCodec<TokenPollRepresentation> TOKEN_POLL_CODEC = jsonCodec(TokenPollRepresentation.class);
+    private static final String USER_AGENT_VALUE = "TrinoTokenPoller/" +
+            firstNonNull(HttpTokenPoller.class.getPackage().getImplementationVersion(), "unknown");
+
+    private final OkHttpClient client;
+
+    public HttpTokenPoller(OkHttpClient client)
+    {
+        this.client = requireNonNull(client, "client is null");
+    }
+
+    @Override
+    public TokenPollResult pollForToken(URI tokenUri, Duration timeout)
+    {
+        try {
+            return Failsafe.with(new RetryPolicy<TokenPollResult>()
+                    .withMaxAttempts(-1)
+                    .withMaxDuration(timeout)
+                    .withBackoff(100, 500, MILLIS)
+                    .handle(IOException.class))
+                    .get(() -> executePoll(createRequest(tokenUri)));
+        }
+        catch (FailsafeException e) {
+            if (e.getCause() instanceof IOException) {
+                throw new UncheckedIOException((IOException) e.getCause());
+            }
+            throw e;
+        }
+    }
+
+    private static Request createRequest(URI tokenUri)
+    {
+        HttpUrl url = HttpUrl.get(tokenUri);
+        if (url == null) {
+            throw new IllegalArgumentException("Invalid token URI: " + tokenUri);
+        }
+
+        return new Request.Builder()
+                .url(url)
+                .addHeader(USER_AGENT, USER_AGENT_VALUE)
+                .build();
+    }
+
+    private TokenPollResult executePoll(Request request)
+            throws IOException
+    {
+        JsonResponse<TokenPollRepresentation> response = executeRequest(request);
+
+        if ((response.getStatusCode() == HTTP_OK) && response.hasValue()) {
+            return response.getValue().toResult();
+        }
+
+        String message = format("Request to %s failed: %s [Error: %s]", request.url(), response, response.getResponseBody());
+
+        if (response.getStatusCode() == HTTP_UNAVAILABLE) {
+            throw new IOException(message);
+        }
+
+        return TokenPollResult.failed(message);
+    }
+
+    private JsonResponse<TokenPollRepresentation> executeRequest(Request request)
+            throws IOException
+    {
+        try {
+            return execute(TOKEN_POLL_CODEC, client, request);
+        }
+        catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    public static class TokenPollRepresentation
+    {
+        private final String token;
+        private final URI nextUri;
+        private final String error;
+
+        @JsonCreator
+        public TokenPollRepresentation(
+                @JsonProperty("token") String token,
+                @JsonProperty("nextUri") URI nextUri,
+                @JsonProperty("error") String error)
+        {
+            this.token = token;
+            this.nextUri = nextUri;
+            this.error = error;
+        }
+
+        TokenPollResult toResult()
+        {
+            if (token != null) {
+                return TokenPollResult.successful(new Token(token));
+            }
+            if (error != null) {
+                return TokenPollResult.failed(error);
+            }
+            if (nextUri != null) {
+                return TokenPollResult.pending(nextUri);
+            }
+            return TokenPollResult.failed("Failed to poll for token. No fields set in response.");
+        }
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/RedirectException.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/RedirectException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+public class RedirectException
+        extends RuntimeException
+{
+    public RedirectException(String message, Throwable throwable)
+    {
+        super(message, throwable);
+    }
+
+    public RedirectException(String message)
+    {
+        super(message);
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/RedirectHandler.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/RedirectHandler.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import java.net.URI;
+
+public interface RedirectHandler
+{
+    void redirectTo(URI uri)
+            throws RedirectException;
+}

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/Token.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/Token.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import static java.util.Objects.requireNonNull;
+
+class Token
+{
+    private final String token;
+
+    public Token(String token)
+    {
+        this.token = requireNonNull(token, "token is null");
+    }
+
+    public String token()
+    {
+        return token;
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/TokenPollResult.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/TokenPollResult.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class TokenPollResult
+{
+    private enum State
+    {
+        PENDING, SUCCESSFUL, FAILED
+    }
+
+    private final State state;
+    private final Optional<String> errorMessage;
+    private final Optional<URI> nextTokenUri;
+    private final Optional<Token> token;
+
+    public static TokenPollResult failed(String error)
+    {
+        return new TokenPollResult(State.FAILED, null, error, null);
+    }
+
+    public static TokenPollResult pending(URI uri)
+    {
+        return new TokenPollResult(State.PENDING, null, null, uri);
+    }
+
+    public static TokenPollResult successful(Token token)
+    {
+        return new TokenPollResult(State.SUCCESSFUL, token, null, null);
+    }
+
+    private TokenPollResult(State state, Token token, String error, URI nextTokenUri)
+    {
+        this.state = requireNonNull(state, "state is null");
+        this.token = Optional.ofNullable(token);
+        this.errorMessage = Optional.ofNullable(error);
+        this.nextTokenUri = Optional.ofNullable(nextTokenUri);
+    }
+
+    public boolean isFailed()
+    {
+        return state == State.FAILED;
+    }
+
+    public boolean isPending()
+    {
+        return state == State.PENDING;
+    }
+
+    public Token getToken()
+    {
+        return token.orElseThrow(() -> new IllegalStateException("state is " + state));
+    }
+
+    public String getError()
+    {
+        return errorMessage.orElseThrow(() -> new IllegalStateException("state is " + state));
+    }
+
+    public URI getNextTokenUri()
+    {
+        return nextTokenUri.orElseThrow(() -> new IllegalStateException("state is " + state));
+    }
+}

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/TokenPoller.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/TokenPoller.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import java.net.URI;
+import java.time.Duration;
+
+public interface TokenPoller
+{
+    TokenPollResult pollForToken(URI tokenUri, Duration timeout);
+}

--- a/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthentication.java
+++ b/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthentication.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.client.ClientException;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+
+import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
+import static java.net.URI.create;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestExternalAuthentication
+{
+    private static final String AUTH_TOKEN = "authToken";
+    private static final URI REDIRECT_URI = create("https://redirect.uri");
+    private static final URI TOKEN_URI = create("https://token.uri");
+    private static final Duration TIMEOUT = Duration.ofSeconds(1);
+
+    @Test
+    public void testObtainTokenWhenTokenAlreadyExists()
+    {
+        MockRedirectHandler redirectHandler = new MockRedirectHandler();
+
+        TokenPoller poller = new MockTokenPoller()
+                .withResult(TOKEN_URI, TokenPollResult.successful(new Token(AUTH_TOKEN)));
+
+        Optional<Token> token = new ExternalAuthentication(TOKEN_URI, Optional.of(REDIRECT_URI))
+                .obtainToken(TIMEOUT, redirectHandler, poller);
+
+        assertThat(redirectHandler.redirectedTo()).isEqualTo(REDIRECT_URI);
+        assertThat(token).map(Token::token).hasValue(AUTH_TOKEN);
+    }
+
+    @Test
+    public void testObtainTokenWhenTokenIsReadyAtSecondAttempt()
+    {
+        RedirectHandler redirectHandler = new MockRedirectHandler();
+
+        URI nextTokenUri = TOKEN_URI.resolve("/next");
+        TokenPoller poller = new MockTokenPoller()
+                .withResult(TOKEN_URI, TokenPollResult.pending(nextTokenUri))
+                .withResult(nextTokenUri, TokenPollResult.successful(new Token(AUTH_TOKEN)));
+
+        Optional<Token> token = new ExternalAuthentication(TOKEN_URI, Optional.of(REDIRECT_URI))
+                .obtainToken(TIMEOUT, redirectHandler, poller);
+
+        assertThat(token).map(Token::token).hasValue(AUTH_TOKEN);
+    }
+
+    @Test
+    public void testObtainTokenWhenTokenIsNeverAvailable()
+    {
+        RedirectHandler redirectHandler = new MockRedirectHandler();
+
+        TokenPoller poller = (tokenUri, timeout) -> {
+            sleepUninterruptibly(Duration.ofMillis(20));
+            return TokenPollResult.pending(TOKEN_URI);
+        };
+
+        Optional<Token> token = new ExternalAuthentication(TOKEN_URI, Optional.of(REDIRECT_URI))
+                .obtainToken(TIMEOUT, redirectHandler, poller);
+
+        assertThat(token).isEmpty();
+    }
+
+    @Test
+    public void testObtainTokenWhenPollingFails()
+    {
+        RedirectHandler redirectHandler = new MockRedirectHandler();
+
+        TokenPoller poller = new MockTokenPoller()
+                .withResult(TOKEN_URI, TokenPollResult.failed("error"));
+
+        assertThatThrownBy(() -> new ExternalAuthentication(TOKEN_URI, Optional.of(REDIRECT_URI))
+                .obtainToken(TIMEOUT, redirectHandler, poller))
+                .isInstanceOf(ClientException.class)
+                .hasMessage("error");
+    }
+
+    @Test
+    public void testObtainTokenWhenPollingFailsWithException()
+    {
+        RedirectHandler redirectHandler = new MockRedirectHandler();
+
+        TokenPoller poller = (tokenUri, timeout) -> {
+            throw new UncheckedIOException(new IOException("polling error"));
+        };
+
+        assertThatThrownBy(() -> new ExternalAuthentication(TOKEN_URI, Optional.of(REDIRECT_URI))
+                .obtainToken(TIMEOUT, redirectHandler, poller))
+                .isInstanceOf(UncheckedIOException.class)
+                .hasRootCauseInstanceOf(IOException.class)
+                .hasRootCauseMessage("polling error");
+    }
+
+    @Test
+    public void testObtainTokenWhenNoRedirectUriHasBeenProvided()
+    {
+        MockRedirectHandler redirectHandler = new MockRedirectHandler();
+
+        TokenPoller poller = new MockTokenPoller()
+                .withResult(TOKEN_URI, TokenPollResult.successful(new Token(AUTH_TOKEN)));
+
+        Optional<Token> token = new ExternalAuthentication(TOKEN_URI, Optional.empty())
+                .obtainToken(TIMEOUT, redirectHandler, poller);
+
+        assertThat(redirectHandler.redirectedTo()).isNull();
+        assertThat(token).map(Token::token).hasValue(AUTH_TOKEN);
+    }
+
+    private static class MockRedirectHandler
+            implements RedirectHandler
+    {
+        private URI redirectedTo;
+
+        @Override
+        public void redirectTo(URI uri)
+                throws RedirectException
+        {
+            redirectedTo = uri;
+        }
+
+        public URI redirectedTo()
+        {
+            return redirectedTo;
+        }
+    }
+
+    private static final class MockTokenPoller
+            implements TokenPoller
+    {
+        private final Map<URI, Queue<TokenPollResult>> results = new HashMap<>();
+
+        public MockTokenPoller withResult(URI tokenUri, TokenPollResult result)
+        {
+            results.put(tokenUri, new ArrayDeque<>(ImmutableList.of(result)));
+            return this;
+        }
+
+        @Override
+        public TokenPollResult pollForToken(URI tokenUri, Duration ignored)
+        {
+            Queue<TokenPollResult> queue = results.get(tokenUri);
+            if (queue == null) {
+                throw new IllegalArgumentException("Unknown token URI: " + tokenUri);
+            }
+            return queue.remove();
+        }
+    }
+}

--- a/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthenticator.java
+++ b/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthenticator.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import io.trino.client.ClientException;
+import okhttp3.HttpUrl;
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.testng.annotations.Test;
+
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+import static com.google.common.net.HttpHeaders.WWW_AUTHENTICATE;
+import static io.trino.client.auth.external.ExternalAuthenticator.TOKEN_URI_FIELD;
+import static io.trino.client.auth.external.ExternalAuthenticator.toAuthentication;
+import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
+import static java.net.URI.create;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestExternalAuthenticator
+{
+    @Test
+    public void testChallengeWithOnlyTokenServerUri()
+    {
+        assertThat(buildAuthentication("Bearer x_token_server=\"http://token.uri\""))
+                .hasValueSatisfying(authentication -> {
+                    assertThat(authentication.getRedirectUri()).isEmpty();
+                    assertThat(authentication.getTokenUri()).isEqualTo(create("http://token.uri"));
+                });
+    }
+
+    @Test
+    public void testChallengeWithBothUri()
+    {
+        assertThat(buildAuthentication("Bearer x_redirect_server=\"http://redirect.uri\", x_token_server=\"http://token.uri\""))
+                .hasValueSatisfying(authentication -> {
+                    assertThat(authentication.getRedirectUri()).hasValue(create("http://redirect.uri"));
+                    assertThat(authentication.getTokenUri()).isEqualTo(create("http://token.uri"));
+                });
+    }
+
+    @Test
+    public void testChallengeWithValuesWithoutQuotes()
+    {
+        // this is legal according to RFC 7235
+        assertThat(buildAuthentication("Bearer x_redirect_server=http://redirect.uri, x_token_server=http://token.uri"))
+                .hasValueSatisfying(authentication -> {
+                    assertThat(authentication.getRedirectUri()).hasValue(create("http://redirect.uri"));
+                    assertThat(authentication.getTokenUri()).isEqualTo(create("http://token.uri"));
+                });
+    }
+
+    @Test
+    public void testChallengeWithAdditionalFields()
+    {
+        assertThat(buildAuthentication("Bearer type=\"token\", x_redirect_server=\"http://redirect.uri\", x_token_server=\"http://token.uri\", description=\"oauth challenge\""))
+                .hasValueSatisfying(authentication -> {
+                    assertThat(authentication.getRedirectUri()).hasValue(create("http://redirect.uri"));
+                    assertThat(authentication.getTokenUri()).isEqualTo(create("http://token.uri"));
+                });
+    }
+
+    @Test
+    public void testInvalidChallenges()
+    {
+        // no authentication parameters
+        assertThat(buildAuthentication("Bearer")).isEmpty();
+
+        // no Bearer scheme prefix
+        assertThat(buildAuthentication("x_redirect_server=\"http://redirect.uri\", x_token_server=\"http://token.uri\"")).isEmpty();
+
+        // space instead of comma
+        assertThat(buildAuthentication("Bearer x_redirect_server=\"http://redirect.uri\" x_token_server=\"http://token.uri\"")).isEmpty();
+
+        // equals sign instead of comma
+        assertThat(buildAuthentication("Bearer x_redirect_server=\"http://redirect.uri\"=x_token_server=\"http://token.uri\"")).isEmpty();
+    }
+
+    @Test
+    public void testChallengeWithMalformedUri()
+    {
+        assertThatThrownBy(() -> buildAuthentication("Bearer x_token_server=\"http://[1.1.1.1]\""))
+                .isInstanceOf(ClientException.class)
+                .hasMessageContaining(format("Failed to parse URI for field '%s'", TOKEN_URI_FIELD))
+                .hasRootCauseInstanceOf(URISyntaxException.class)
+                .hasRootCauseMessage("Malformed IPv6 address at index 8: http://[1.1.1.1]");
+    }
+
+    private static Optional<ExternalAuthentication> buildAuthentication(String challengeHeader)
+    {
+        return toAuthentication(new Response.Builder()
+                .request(new Request.Builder()
+                        .url(HttpUrl.get("http://example.com"))
+                        .build())
+                .protocol(Protocol.HTTP_1_1)
+                .code(HTTP_UNAUTHORIZED)
+                .message("Unauthorized")
+                .header(WWW_AUTHENTICATE, challengeHeader)
+                .build());
+    }
+}

--- a/client/trino-client/src/test/java/io/trino/client/auth/external/TestHttpTokenPoller.java
+++ b/client/trino-client/src/test/java/io/trino/client/auth/external/TestHttpTokenPoller.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.client.auth.external;
+
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.time.Duration;
+
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_GONE;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
+import static java.net.URI.create;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Test(singleThreaded = true)
+public class TestHttpTokenPoller
+{
+    private static final String TOKEN_PATH = "/v1/authentications/sso/test/token";
+    private static final Duration ONE_SECOND = Duration.ofSeconds(1);
+
+    private TokenPoller tokenPoller;
+    private MockWebServer server;
+
+    @BeforeMethod(alwaysRun = true)
+    public void setup()
+            throws Exception
+    {
+        server = new MockWebServer();
+        server.start();
+
+        tokenPoller = new HttpTokenPoller(new OkHttpClient.Builder()
+                .callTimeout(Duration.ofMillis(500))
+                .build());
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardown()
+            throws IOException
+    {
+        server.close();
+        server = null;
+    }
+
+    @Test
+    public void testTokenReady()
+    {
+        server.enqueue(statusAndBody(HTTP_OK, jsonPair("token", "token")));
+
+        TokenPollResult result = tokenPoller.pollForToken(tokenUri(), ONE_SECOND);
+
+        assertThat(result.getToken().token()).isEqualTo("token");
+        assertThat(server.getRequestCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testTokenNotReady()
+    {
+        server.enqueue(statusAndBody(HTTP_OK, jsonPair("nextUri", tokenUri())));
+
+        TokenPollResult result = tokenPoller.pollForToken(tokenUri(), ONE_SECOND);
+
+        assertThat(result.isPending()).isTrue();
+        assertThat(server.getRequestCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testErrorResponse()
+    {
+        server.enqueue(statusAndBody(HTTP_OK, jsonPair("error", "test failure")));
+
+        TokenPollResult result = tokenPoller.pollForToken(tokenUri(), ONE_SECOND);
+
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.getError()).contains("test failure");
+    }
+
+    @Test
+    public void testBadHttpStatus()
+    {
+        server.enqueue(new MockResponse().setResponseCode(HTTP_GONE));
+
+        TokenPollResult result = tokenPoller.pollForToken(tokenUri(), ONE_SECOND);
+
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.getError())
+                .matches("Request to http://.* failed: JsonResponse\\{statusCode=410, .*");
+    }
+
+    @Test
+    public void testInvalidJsonBody()
+    {
+        server.enqueue(statusAndBody(HTTP_OK, jsonPair("foo", "bar")));
+
+        TokenPollResult result = tokenPoller.pollForToken(tokenUri(), ONE_SECOND);
+
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.getError())
+                .isEqualTo("Failed to poll for token. No fields set in response.");
+    }
+
+    @Test
+    public void testInvalidNextUri()
+    {
+        server.enqueue(statusAndBody(HTTP_OK, jsonPair("nextUri", ":::")));
+
+        TokenPollResult result = tokenPoller.pollForToken(tokenUri(), ONE_SECOND);
+
+        assertThat(result.isFailed()).isTrue();
+        assertThat(result.getError())
+                .matches("Request to http://.* failed: JsonResponse\\{statusCode=200, .*, hasValue=false} .*");
+    }
+
+    @Test
+    public void testHttpStatus503()
+    {
+        for (int i = 1; i <= 100; i++) {
+            server.enqueue(statusAndBody(HTTP_UNAVAILABLE, "Server failure #" + i));
+        }
+
+        assertThatThrownBy(() -> tokenPoller.pollForToken(tokenUri(), ONE_SECOND))
+                .isInstanceOf(UncheckedIOException.class)
+                .hasRootCauseExactlyInstanceOf(IOException.class)
+                .hasMessageFindingMatch("Request to http://.* failed: JsonResponse\\{statusCode=503,")
+                .hasMessageContaining("[Error: Server failure #");
+
+        assertThat(server.getRequestCount()).isGreaterThan(1);
+    }
+
+    @Test
+    public void testHttpTimeout()
+    {
+        // force request to timeout by not enqueuing response
+
+        assertThatThrownBy(() -> tokenPoller.pollForToken(tokenUri(), ONE_SECOND))
+                .isInstanceOf(UncheckedIOException.class)
+                .hasMessageEndingWith(": timeout");
+    }
+
+    private URI tokenUri()
+    {
+        return create("http://" + server.getHostName() + ":" + server.getPort() + TOKEN_PATH);
+    }
+
+    private static String jsonPair(String key, Object value)
+    {
+        return format("{\"%s\": \"%s\"}", key, value);
+    }
+
+    private static MockResponse statusAndBody(int status, String body)
+    {
+        return new MockResponse()
+                .setResponseCode(status)
+                .addHeader(CONTENT_TYPE, JSON_UTF_8)
+                .setBody(body);
+    }
+}

--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -151,6 +151,18 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>jaxrs</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>log-manager</artifactId>
             <scope>test</scope>
         </dependency>
@@ -183,6 +195,18 @@
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -278,6 +302,10 @@
                                 <relocation>
                                     <pattern>okio</pattern>
                                     <shadedPattern>${shadeBase}.okio</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>net.jodah.failsafe</pattern>
+                                    <shadedPattern>${shadeBase}.net.jodah.failsafe</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -18,6 +18,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
+import io.airlift.units.Duration;
 import io.trino.client.ClientSelectedRole;
 
 import java.io.File;
@@ -70,6 +71,8 @@ final class ConnectionProperties
     public static final ConnectionProperty<File> KERBEROS_KEYTAB_PATH = new KerberosKeytabPath();
     public static final ConnectionProperty<File> KERBEROS_CREDENTIAL_CACHE_PATH = new KerberosCredentialCachePath();
     public static final ConnectionProperty<String> ACCESS_TOKEN = new AccessToken();
+    public static final ConnectionProperty<Boolean> EXTERNAL_AUTHENTICATION = new ExternalAuthentication();
+    public static final ConnectionProperty<Duration> EXTERNAL_AUTHENTICATION_TIMEOUT = new ExternalAuthenticationTimeout();
     public static final ConnectionProperty<Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
     public static final ConnectionProperty<String> CLIENT_INFO = new ClientInfo();
     public static final ConnectionProperty<String> CLIENT_TAGS = new ClientTags();
@@ -108,6 +111,8 @@ final class ConnectionProperties
             .add(TRACE_TOKEN)
             .add(SESSION_PROPERTIES)
             .add(SOURCE)
+            .add(EXTERNAL_AUTHENTICATION)
+            .add(EXTERNAL_AUTHENTICATION_TIMEOUT)
             .build();
 
     private static final Map<String, ConnectionProperty<?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -432,6 +437,27 @@ final class ConnectionProperties
         public AccessToken()
         {
             super("accessToken", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class ExternalAuthentication
+            extends AbstractConnectionProperty<Boolean>
+    {
+        public ExternalAuthentication()
+        {
+            super("externalAuthentication", Optional.of("false"), NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
+        }
+    }
+
+    private static class ExternalAuthenticationTimeout
+            extends AbstractConnectionProperty<Duration>
+    {
+        private static final Predicate<Properties> IF_EXTERNAL_AUTHENTICATION_ENABLED =
+                checkedPredicate(properties -> EXTERNAL_AUTHENTICATION.getValue(properties).orElse(false));
+
+        public ExternalAuthenticationTimeout()
+        {
+            super("externalAuthenticationTimeout", NOT_REQUIRED, IF_EXTERNAL_AUTHENTICATION_ENABLED, Duration::valueOf);
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -13,24 +13,32 @@
  */
 package io.trino.jdbc;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
 import io.trino.client.ClientException;
 import io.trino.client.ClientSelectedRole;
+import io.trino.client.auth.external.DesktopBrowserRedirectHandler;
+import io.trino.client.auth.external.ExternalAuthenticator;
+import io.trino.client.auth.external.HttpTokenPoller;
+import io.trino.client.auth.external.RedirectHandler;
+import io.trino.client.auth.external.TokenPoller;
 import okhttp3.OkHttpClient;
 
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.trino.client.KerberosUtil.defaultCredentialCachePath;
@@ -47,6 +55,8 @@ import static io.trino.jdbc.ConnectionProperties.APPLICATION_NAME_PREFIX;
 import static io.trino.jdbc.ConnectionProperties.CLIENT_INFO;
 import static io.trino.jdbc.ConnectionProperties.CLIENT_TAGS;
 import static io.trino.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
+import static io.trino.jdbc.ConnectionProperties.EXTERNAL_AUTHENTICATION;
+import static io.trino.jdbc.ConnectionProperties.EXTERNAL_AUTHENTICATION_TIMEOUT;
 import static io.trino.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static io.trino.jdbc.ConnectionProperties.HTTP_PROXY;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_CONFIG_PATH;
@@ -90,6 +100,7 @@ public final class TrinoDriverUri
 
     private static final Splitter QUERY_SPLITTER = Splitter.on('&').omitEmptyStrings();
     private static final Splitter ARG_SPLITTER = Splitter.on('=').limit(2);
+    private static final AtomicReference<RedirectHandler> REDIRECT_HANDLER = new AtomicReference<>(new DesktopBrowserRedirectHandler());
 
     private final HostAndPort address;
     private final URI uri;
@@ -285,6 +296,24 @@ public final class TrinoDriverUri
                 }
                 builder.addInterceptor(tokenAuth(ACCESS_TOKEN.getValue(properties).get()));
             }
+
+            if (EXTERNAL_AUTHENTICATION.getValue(properties).orElse(false)) {
+                if (!useSecureConnection) {
+                    throw new SQLException("Authentication using external authorization requires SSL to be enabled");
+                }
+
+                // create HTTP client that shares the same settings, but without the external authenticator
+                TokenPoller poller = new HttpTokenPoller(builder.build());
+
+                Duration timeout = EXTERNAL_AUTHENTICATION_TIMEOUT.getValue(properties)
+                        .map(value -> Duration.ofMillis(value.toMillis()))
+                        .orElse(Duration.ofMinutes(2));
+
+                ExternalAuthenticator authenticator = new ExternalAuthenticator(REDIRECT_HANDLER.get(), poller, timeout);
+
+                builder.authenticator(authenticator);
+                builder.addInterceptor(authenticator);
+            }
         }
         catch (ClientException e) {
             throw new SQLException(e.getMessage(), e);
@@ -435,5 +464,11 @@ public final class TrinoDriverUri
         for (ConnectionProperty<?> property : ConnectionProperties.allProperties()) {
             property.validate(connectionProperties);
         }
+    }
+
+    @VisibleForTesting
+    static void setRedirectHandler(RedirectHandler handler)
+    {
+        REDIRECT_HANDLER.set(requireNonNull(handler, "handler is null"));
     }
 }

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcExternalAuthentication.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcExternalAuthentication.java
@@ -1,0 +1,505 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.jdbc;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Key;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.log.Logging;
+import io.trino.client.ClientException;
+import io.trino.client.auth.external.DesktopBrowserRedirectHandler;
+import io.trino.client.auth.external.RedirectException;
+import io.trino.client.auth.external.RedirectHandler;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.server.security.AuthenticationException;
+import io.trino.server.security.Authenticator;
+import io.trino.server.security.ResourceSecurity;
+import io.trino.server.testing.TestingTrinoServer;
+import io.trino.spi.security.Identity;
+import okhttp3.HttpUrl;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.net.URI;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.ConcurrentModificationException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntSupplier;
+
+import static com.google.common.io.Resources.getResource;
+import static com.google.inject.Scopes.SINGLETON;
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static io.airlift.testing.Closeables.closeAll;
+import static io.trino.jdbc.TestJdbcExternalAuthentication.RedirectHandlerFixture.withHandler;
+import static io.trino.jdbc.TestJdbcExternalAuthentication.TokenPollingErrorFixture.withPollingError;
+import static io.trino.jdbc.TestJdbcExternalAuthentication.WwwAuthenticateHeaderFixture.withWwwAuthenticate;
+import static io.trino.jdbc.TrinoDriverUri.setRedirectHandler;
+import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
+import static io.trino.server.security.ServerSecurityModule.authenticatorModule;
+import static java.lang.String.format;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Test(singleThreaded = true)
+public class TestJdbcExternalAuthentication
+{
+    private static final String TEST_CATALOG = "test_catalog";
+    private TestingTrinoServer server;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        Logging.initialize();
+
+        server = TestingTrinoServer.builder()
+                .setAdditionalModule(new DummyExternalAuthModule(() -> server.getAddress().getPort()))
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .put("http-server.authentication.type", "dummy-external")
+                        .put("http-server.https.enabled", "true")
+                        .put("http-server.https.keystore.path", getResource("localhost.keystore").getPath())
+                        .put("http-server.https.keystore.key", "changeit")
+                        .put("web-ui.enabled", "false")
+                        .build())
+                .build();
+        server.installPlugin(new TpchPlugin());
+        server.createCatalog(TEST_CATALOG, "tpch");
+        server.waitForNodeRefresh(Duration.ofSeconds(10));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+            throws Exception
+    {
+        closeAll(server);
+        server = null;
+    }
+
+    @BeforeMethod(alwaysRun = true)
+    public void clearUpLoggingSessions()
+    {
+        invalidateAllTokens();
+    }
+
+    @Test
+    public void testSuccessfulAuthenticationWithHttpGetOnlyRedirectHandler()
+            throws Exception
+    {
+        try (RedirectHandlerFixture ignore = withHandler(new HttpGetOnlyRedirectHandler());
+                Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            assertThat(statement.execute("SELECT 123")).isTrue();
+        }
+    }
+
+    /**
+     * Ignored due to lack of ui environment with web-browser on CI servers.
+     * Still this test is useful for local environments.
+     */
+    @Test(enabled = false)
+    public void testSuccessfulAuthenticationWithDefaultBrowserRedirect()
+            throws Exception
+    {
+        try (Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            assertThat(statement.execute("SELECT 123")).isTrue();
+        }
+    }
+
+    @Test
+    public void testAuthenticationFailsAfterUnfinishedRedirect()
+            throws Exception
+    {
+        try (RedirectHandlerFixture ignore = withHandler(new NoOpRedirectHandler());
+                Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            assertThatThrownBy(() -> statement.execute("SELECT 123"))
+                    .isInstanceOf(SQLException.class);
+        }
+    }
+
+    @Test
+    public void testAuthenticationFailsAfterRedirectException()
+            throws Exception
+    {
+        try (RedirectHandlerFixture ignore = withHandler(new FailingRedirectHandler());
+                Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            assertThatThrownBy(() -> statement.execute("SELECT 123"))
+                    .isInstanceOf(SQLException.class)
+                    .hasCauseExactlyInstanceOf(RedirectException.class);
+        }
+    }
+
+    @Test
+    public void testAuthenticationFailsAfterServerAuthenticationFailure()
+            throws Exception
+    {
+        try (RedirectHandlerFixture ignore = withHandler(new HttpGetOnlyRedirectHandler());
+                AutoCloseable ignore2 = withPollingError("error occurred during token polling");
+                Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            assertThatThrownBy(() -> statement.execute("SELECT 123"))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessage("error occurred during token polling");
+        }
+    }
+
+    @Test
+    public void testAuthenticationFailsAfterReceivingMalformedHeaderFromServer()
+            throws Exception
+    {
+        try (RedirectHandlerFixture ignore = withHandler(new HttpGetOnlyRedirectHandler());
+                AutoCloseable ignored = withWwwAuthenticate("Bearer no-valid-fields");
+                Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            assertThatThrownBy(() -> statement.execute("SELECT 123"))
+                    .isInstanceOf(SQLException.class)
+                    .hasCauseInstanceOf(ClientException.class)
+                    .hasMessage("Authentication failed: Authentication required");
+        }
+    }
+
+    @Test
+    public void testAuthenticationReusesObtainedTokenPerConnection()
+            throws Exception
+    {
+        try (RedirectHandlerFixture ignore = withHandler(new HttpGetOnlyRedirectHandler());
+                Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("SELECT 123");
+            statement.execute("SELECT 123");
+            statement.execute("SELECT 123");
+
+            assertThat(countIssuedTokens()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void testAuthenticationAfterInitialTokenHasBeenInvalidated()
+            throws Exception
+    {
+        try (RedirectHandlerFixture ignore = withHandler(new HttpGetOnlyRedirectHandler());
+                Connection connection = createConnection();
+                Statement statement = connection.createStatement()) {
+            statement.execute("SELECT 123");
+
+            invalidateAllTokens();
+            assertThat(countIssuedTokens()).isEqualTo(0);
+
+            assertThat(statement.execute("SELECT 123")).isTrue();
+        }
+    }
+
+    private Connection createConnection()
+            throws SQLException
+    {
+        String url = format("jdbc:presto://localhost:%s", server.getHttpsAddress().getPort());
+        Properties properties = new Properties();
+        properties.setProperty("user", "test");
+        properties.setProperty("SSL", "true");
+        properties.setProperty("SSLTrustStorePath", getResource("localhost.truststore").getPath());
+        properties.setProperty("SSLTrustStorePassword", "changeit");
+        properties.setProperty("externalAuthentication", "true");
+        properties.setProperty("externalAuthenticationTimeout", "2s");
+        return DriverManager.getConnection(url, properties);
+    }
+
+    private static class DummyExternalAuthModule
+            extends AbstractConfigurationAwareModule
+    {
+        private final IntSupplier port;
+
+        public DummyExternalAuthModule(IntSupplier port)
+        {
+            this.port = requireNonNull(port, "port is null");
+        }
+
+        @Override
+        protected void setup(Binder ignored)
+        {
+            install(authenticatorModule("dummy-external", DummyAuthenticator.class, binder -> {
+                binder.bind(Authentications.class).in(SINGLETON);
+                binder.bind(IntSupplier.class).toInstance(port);
+                jaxrsBinder(binder).bind(DummyExternalAuthResources.class);
+            }));
+        }
+    }
+
+    private static class Authentications
+    {
+        private final Map<String, String> logginSessions = new ConcurrentHashMap<>();
+        private final Set<String> validTokens = ConcurrentHashMap.newKeySet();
+
+        public String startAuthentication()
+        {
+            String sessionId = UUID.randomUUID().toString();
+            logginSessions.put(sessionId, "");
+            return sessionId;
+        }
+
+        public void logIn(String sessionId)
+        {
+            String token = sessionId + "_token";
+            validTokens.add(token);
+            logginSessions.put(sessionId, token);
+        }
+
+        public Optional<String> getToken(String sessionId)
+                throws IllegalArgumentException
+        {
+            return Optional.ofNullable(logginSessions.get(sessionId))
+                    .filter(s -> !s.isEmpty());
+        }
+
+        public boolean verifyToken(String token)
+        {
+            return validTokens.contains(token);
+        }
+
+        public void invalidateAllTokens()
+        {
+            validTokens.clear();
+        }
+
+        public int countValidTokens()
+        {
+            return validTokens.size();
+        }
+    }
+
+    private void invalidateAllTokens()
+    {
+        Authentications authentications = server.getInstance(Key.get(Authentications.class));
+        authentications.invalidateAllTokens();
+    }
+
+    private int countIssuedTokens()
+    {
+        Authentications authentications = server.getInstance(Key.get(Authentications.class));
+        return authentications.countValidTokens();
+    }
+
+    public static class DummyAuthenticator
+            implements Authenticator
+    {
+        private final IntSupplier port;
+        private final Authentications authentications;
+
+        @Inject
+        public DummyAuthenticator(IntSupplier port, Authentications authentications)
+        {
+            this.port = requireNonNull(port, "port is null");
+            this.authentications = requireNonNull(authentications, "authentications is null");
+        }
+
+        @Override
+        public Identity authenticate(ContainerRequestContext request)
+                throws AuthenticationException
+        {
+            List<String> bearerHeaders = request.getHeaders().getOrDefault(AUTHORIZATION, ImmutableList.of());
+            if (bearerHeaders.stream()
+                    .filter(header -> header.startsWith("Bearer "))
+                    .anyMatch(header -> authentications.verifyToken(header.substring("Bearer ".length())))) {
+                return Identity.ofUser("user");
+            }
+
+            String sessionId = authentications.startAuthentication();
+
+            throw Optional.ofNullable(WwwAuthenticateHeaderFixture.HEADER.get())
+                    .map(header -> new AuthenticationException("Authentication required", header))
+                    .orElseGet(() -> new AuthenticationException(
+                            "Authentication required",
+                            format("Bearer x_redirect_server=\"http://localhost:%s/v1/authentications/dummy/logins/%s\", " +
+                                            "x_token_server=\"http://localhost:%s/v1/authentications/dummy/%s\"",
+                                    port.getAsInt(), sessionId, port.getAsInt(), sessionId)));
+        }
+    }
+
+    @Path("/v1/authentications/dummy")
+    public static class DummyExternalAuthResources
+    {
+        private final Authentications authentications;
+
+        @Inject
+        public DummyExternalAuthResources(Authentications authentications)
+        {
+            this.authentications = authentications;
+        }
+
+        @GET
+        @Produces(TEXT_PLAIN)
+        @ResourceSecurity(PUBLIC)
+        @Path("logins/{sessionId}")
+        public String logInUser(@PathParam("sessionId") String sessionId)
+        {
+            authentications.logIn(sessionId);
+            return "User has been successfully logged in during " + sessionId + " session";
+        }
+
+        @GET
+        @ResourceSecurity(PUBLIC)
+        @Path("{sessionId}")
+        public Response getToken(@PathParam("sessionId") String sessionId, @Context HttpServletRequest request)
+        {
+            try {
+                return Optional.ofNullable(TokenPollingErrorFixture.ERROR.get())
+                        .map(error -> Response.ok(format("{ \"error\" : \"%s\"}", error), APPLICATION_JSON_TYPE).build())
+                        .orElseGet(() -> authentications.getToken(sessionId)
+                                .map(token -> Response.ok(format("{ \"token\" : \"%s\"}", token), APPLICATION_JSON_TYPE).build())
+                                .orElseGet(() -> Response.ok(format("{ \"nextUri\" : \"%s\" }", request.getRequestURI()), APPLICATION_JSON_TYPE).build()));
+            }
+            catch (IllegalArgumentException ex) {
+                return Response.status(NOT_FOUND).build();
+            }
+        }
+    }
+
+    public static class HttpGetOnlyRedirectHandler
+            implements RedirectHandler
+    {
+        @Override
+        public void redirectTo(URI uri)
+                throws RedirectException
+        {
+            OkHttpClient client = new OkHttpClient();
+
+            Request request = new Request.Builder()
+                    .url(HttpUrl.get(uri.toString()))
+                    .build();
+
+            try (okhttp3.Response response = client.newCall(request).execute()) {
+                if (response.code() != HTTP_OK) {
+                    throw new RedirectException("HTTP GET failed with status " + response.code());
+                }
+            }
+            catch (IOException e) {
+                throw new RedirectException("Redirection failed", e);
+            }
+        }
+    }
+
+    public static class NoOpRedirectHandler
+            implements RedirectHandler
+    {
+        @Override
+        public void redirectTo(URI uri)
+                throws RedirectException {}
+    }
+
+    public static class FailingRedirectHandler
+            implements RedirectHandler
+    {
+        @Override
+        public void redirectTo(URI uri)
+                throws RedirectException
+        {
+            throw new RedirectException("Redirect to uri has failed " + uri);
+        }
+    }
+
+    static class RedirectHandlerFixture
+            implements AutoCloseable
+    {
+        private static final RedirectHandlerFixture INSTANCE = new RedirectHandlerFixture();
+
+        private RedirectHandlerFixture() {}
+
+        public static RedirectHandlerFixture withHandler(RedirectHandler handler)
+        {
+            setRedirectHandler(handler);
+            return INSTANCE;
+        }
+
+        @Override
+        public void close()
+        {
+            setRedirectHandler(new DesktopBrowserRedirectHandler());
+        }
+    }
+
+    static class TokenPollingErrorFixture
+            implements AutoCloseable
+    {
+        private static final AtomicReference<String> ERROR = new AtomicReference<>(null);
+
+        public static AutoCloseable withPollingError(String error)
+        {
+            if (ERROR.compareAndSet(null, error)) {
+                return new TokenPollingErrorFixture();
+            }
+            throw new ConcurrentModificationException("polling errors can't be invoked in parallel");
+        }
+
+        @Override
+        public void close()
+        {
+            ERROR.set(null);
+        }
+    }
+
+    static class WwwAuthenticateHeaderFixture
+            implements AutoCloseable
+    {
+        private static final AtomicReference<String> HEADER = new AtomicReference<>(null);
+
+        public static AutoCloseable withWwwAuthenticate(String header)
+        {
+            if (HEADER.compareAndSet(null, header)) {
+                return new WwwAuthenticateHeaderFixture();
+            }
+            throw new ConcurrentModificationException("with WWW-Authenticate header can't be invoked in parallel");
+        }
+
+        @Override
+        public void close()
+        {
+            HEADER.set(null);
+        }
+    }
+}


### PR DESCRIPTION
Add ExternalAuthorizer to JDBC that handles the "Bearer"
WWW-Authenticate challenge and blocks until the external
authentication flow is complete.

This replaces the first commit from #6196