### PR TITLE
Enable views in BigQuery tests

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -52,7 +52,10 @@ public class BigQueryQueryRunner
             queryRunner.createCatalog("tpch", "tpch");
 
             queryRunner.installPlugin(new BigQueryPlugin());
-            queryRunner.createCatalog("bigquery", "bigquery");
+            queryRunner.createCatalog(
+                    "bigquery",
+                    "bigquery",
+                    ImmutableMap.of("bigquery.views-enabled", "true"));
 
             return queryRunner;
         }


### PR DESCRIPTION
This is required by
TestBigQueryIntegrationSmokeTest.testPredicatePushdownPrunnedColumns.