### PR TITLE
Use long for {Primitive}BigArray#capacity

### DIFF
--- a/lib/trino-array/src/main/java/io/trino/array/BooleanBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/BooleanBigArray.java
@@ -34,7 +34,7 @@ public final class BooleanBigArray
     private final boolean initialValue;
 
     private boolean[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/lib/trino-array/src/main/java/io/trino/array/ByteBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/ByteBigArray.java
@@ -34,7 +34,7 @@ public final class ByteBigArray
     private final byte initialValue;
 
     private byte[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/lib/trino-array/src/main/java/io/trino/array/DoubleBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/DoubleBigArray.java
@@ -34,7 +34,7 @@ public final class DoubleBigArray
     private final double initialValue;
 
     private double[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/lib/trino-array/src/main/java/io/trino/array/IntBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/IntBigArray.java
@@ -34,7 +34,7 @@ public final class IntBigArray
     private final int initialValue;
 
     private int[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/lib/trino-array/src/main/java/io/trino/array/LongBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/LongBigArray.java
@@ -34,7 +34,7 @@ public final class LongBigArray
     private final long initialValue;
 
     private long[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/lib/trino-array/src/main/java/io/trino/array/ObjectBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/ObjectBigArray.java
@@ -34,7 +34,7 @@ public final class ObjectBigArray<T>
     private final Object initialValue;
 
     private Object[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/lib/trino-array/src/main/java/io/trino/array/ShortBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/ShortBigArray.java
@@ -34,7 +34,7 @@ public final class ShortBigArray
     private final short initialValue;
 
     private short[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**


### PR DESCRIPTION
Extracted relevant changes from https://github.com/prestodb/presto/pull/15604

Previous implementations supported accesses by `long` index, but used `int` as the capacity field which could overflow. Overflowing was mostly benign but would cause `#ensureCapacity(long capacity)` to proceed down the slow-path unnecessarily.