### PR TITLE
Add nonce parameter

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -204,6 +204,11 @@
 
         <dependency>
             <groupId>com.github.scribejava</groupId>
+            <artifactId>scribejava-apis</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.scribejava</groupId>
             <artifactId>scribejava-core</artifactId>
         </dependency>
 

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/NonceCookie.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/NonceCookie.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.NewCookie;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+
+import static io.trino.server.security.oauth2.OAuth2CallbackResource.CALLBACK_ENDPOINT;
+import static java.util.function.Predicate.not;
+import static javax.ws.rs.core.Cookie.DEFAULT_VERSION;
+import static javax.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
+
+public final class NonceCookie
+{
+    // prefix according to: https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05#section-4.1.3.1
+    public static final String NONCE_COOKIE = "__Secure-Trino-OAuth2-Token";
+
+    private NonceCookie() {}
+
+    public static NewCookie create(String nonce, Instant tokenExpiration)
+    {
+        return new NewCookie(
+                NONCE_COOKIE,
+                nonce,
+                CALLBACK_ENDPOINT,
+                null,
+                DEFAULT_VERSION,
+                null,
+                DEFAULT_MAX_AGE,
+                Date.from(tokenExpiration),
+                true,
+                true);
+    }
+
+    public static Optional<String> read(Cookie cookie)
+    {
+        return Optional.ofNullable(cookie)
+                .map(Cookie::getValue)
+                .filter(not(String::isBlank));
+    }
+
+    public static NewCookie delete()
+    {
+        return new NewCookie(
+                NONCE_COOKIE,
+                "delete",
+                CALLBACK_ENDPOINT,
+                null,
+                DEFAULT_VERSION,
+                null,
+                0,
+                null,
+                true,
+                true);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2CallbackResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2CallbackResource.java
@@ -100,7 +100,7 @@ public class OAuth2CallbackResource
         if (authId.isEmpty()) {
             return Response
                     .seeOther(URI.create(UI_LOCATION))
-                    .cookie(OAuthWebUiCookie.create(result.getAccessToken(), result.getTokenExpiration(), securityContext.isSecure()))
+                    .cookie(OAuthWebUiCookie.create(result.getAccessToken(), result.getTokenExpiration()))
                     .build();
         }
 
@@ -115,7 +115,7 @@ public class OAuth2CallbackResource
 
         ResponseBuilder builder = Response.ok(service.getSuccessHtml());
         if (webUiOAuthEnabled) {
-            builder.cookie(OAuthWebUiCookie.create(result.getAccessToken(), result.getTokenExpiration(), securityContext.isSecure()));
+            builder.cookie(OAuthWebUiCookie.create(result.getAccessToken(), result.getTokenExpiration()));
         }
         return builder.build();
     }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Client.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Client.java
@@ -21,7 +21,7 @@ import static java.util.Objects.requireNonNull;
 
 public interface OAuth2Client
 {
-    URI getAuthorizationUri(String state, URI callbackUri);
+    URI getAuthorizationUri(String state, URI callbackUri, Optional<String> nonceHash);
 
     AccessToken getAccessToken(String code, URI callbackUri)
             throws ChallengeFailedException;
@@ -30,11 +30,13 @@ public interface OAuth2Client
     {
         private final String accessToken;
         private final Optional<Instant> validUntil;
+        private final Optional<String> idToken;
 
-        public AccessToken(String accessToken, Optional<Instant> validUntil)
+        public AccessToken(String accessToken, Optional<Instant> validUntil, Optional<String> idToken)
         {
             this.accessToken = requireNonNull(accessToken, "accessToken is null");
             this.validUntil = requireNonNull(validUntil, "validUntil is null");
+            this.idToken = requireNonNull(idToken, "idToken is null");
         }
 
         public String getAccessToken()
@@ -45,6 +47,11 @@ public interface OAuth2Client
         public Optional<Instant> getValidUntil()
         {
             return validUntil;
+        }
+
+        public Optional<String> getIdToken()
+        {
+            return idToken;
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
@@ -163,7 +163,7 @@ public class OAuth2Config
     }
 
     @Config("http-server.authentication.oauth2.challenge-timeout")
-    @ConfigDescription("Maximum duration of OAuth2 login challenge")
+    @ConfigDescription("Maximum duration of OAuth2 authorization challenge")
     public OAuth2Config setChallengeTimeout(Duration challengeTimeout)
     {
         this.challengeTimeout = challengeTimeout;

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Config.java
@@ -13,6 +13,8 @@
  */
 package io.trino.server.security.oauth2;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.validation.FileExists;
@@ -23,7 +25,11 @@ import javax.validation.constraints.NotNull;
 
 import java.io.File;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.server.security.oauth2.OAuth2Service.OPENID_SCOPE;
 
 public class OAuth2Config
 {
@@ -34,6 +40,7 @@ public class OAuth2Config
     private String clientId;
     private String clientSecret;
     private Optional<String> audience = Optional.empty();
+    private Set<String> scopes = ImmutableSet.of(OPENID_SCOPE);
     private Duration challengeTimeout = new Duration(15, TimeUnit.MINUTES);
     private Optional<String> userMappingPattern = Optional.empty();
     private Optional<File> userMappingFile = Optional.empty();
@@ -131,6 +138,20 @@ public class OAuth2Config
     public OAuth2Config setAudience(String audience)
     {
         this.audience = Optional.ofNullable(audience);
+        return this;
+    }
+
+    @NotNull
+    public Set<String> getScopes()
+    {
+        return scopes;
+    }
+
+    @Config("http-server.authentication.oauth2.scopes")
+    @ConfigDescription("Scopes requested by the server during OAuth2 authorization challenge")
+    public OAuth2Config setScopes(String scopes)
+    {
+        this.scopes = Splitter.on(',').trimResults().omitEmptyStrings().splitToStream(scopes).collect(toImmutableSet());
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
@@ -68,6 +68,7 @@ public class OAuth2Service
         verify(failureHtml.contains(FAILURE_REPLACEMENT_TEXT), "login.html does not contain the replacement text");
 
         requireNonNull(oauth2Config, "oauth2Config is null");
+        this.scopes = oauth2Config.getScopes();
         this.challengeTimeout = Duration.ofMillis(oauth2Config.getChallengeTimeout().toMillis());
         this.stateHmac = oauth2Config.getStateKey()
                 .map(key -> sha256().hashString(key, UTF_8).asBytes())

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
@@ -14,10 +14,11 @@
 package io.trino.server.security.oauth2;
 
 import com.google.common.collect.Ordering;
+import com.google.common.hash.Hashing;
+import com.google.common.io.BaseEncoding;
 import com.google.common.io.Resources;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.SigningKeyResolver;
@@ -27,12 +28,15 @@ import javax.inject.Inject;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.TemporalAmount;
 import java.util.Date;
 import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 
 import static com.google.common.base.Strings.nullToEmpty;
@@ -43,16 +47,23 @@ import static java.util.Objects.requireNonNull;
 
 public class OAuth2Service
 {
+    public static final String REDIRECT_URI = "redirect_uri";
+    public static final String STATE = "state";
+    public static final String NONCE = "nonce";
+    public static final String OPENID_SCOPE = "openid";
+
     private static final String STATE_AUDIENCE_UI = "trino_oauth_ui";
     private static final String STATE_AUDIENCE_REST = "trino_oauth_rest";
     private static final String FAILURE_REPLACEMENT_TEXT = "<!-- ERROR_MESSAGE -->";
+    private static final Random SECURE_RANDOM = new SecureRandom();
 
     private final OAuth2Client client;
-    private final JwtParser jwtParser;
+    private final SigningKeyResolver signingKeyResolver;
 
     private final String successHtml;
     private final String failureHtml;
 
+    private final Set<String> scopes;
     private final TemporalAmount challengeTimeout;
     private final byte[] stateHmac;
 
@@ -61,7 +72,7 @@ public class OAuth2Service
             throws IOException
     {
         this.client = requireNonNull(client, "client is null");
-        this.jwtParser = Jwts.parser().setSigningKeyResolver(signingKeyResolver);
+        this.signingKeyResolver = requireNonNull(signingKeyResolver, "signingKeyResolver is null");
 
         this.successHtml = Resources.toString(Resources.getResource(getClass(), "/oauth2/success.html"), UTF_8);
         this.failureHtml = Resources.toString(Resources.getResource(getClass(), "/oauth2/failure.html"), UTF_8);
@@ -75,15 +86,25 @@ public class OAuth2Service
                 .orElseGet(() -> secureRandomBytes(32));
     }
 
-    public URI startWebUiChallenge(URI callbackUri)
+    public OAuthChallenge startWebUiChallenge(URI callbackUri)
     {
+        Instant challengeExpiration = Instant.now().plus(challengeTimeout);
         String state = Jwts.builder()
                 .signWith(SignatureAlgorithm.HS256, stateHmac)
                 .setAudience(STATE_AUDIENCE_UI)
-                .setExpiration(Date.from(Instant.now().plus(challengeTimeout)))
+                .setExpiration(Date.from(challengeExpiration))
                 .compact();
 
-        return client.getAuthorizationUri(state, callbackUri);
+        Optional<String> nonce;
+        // add nonce parameter to the authorization challenge only if `openid` scope is going to be requested
+        // since this scope is required in order to obtain the ID token which carriers the nonce back to the server
+        if (scopes.contains(OPENID_SCOPE)) {
+            nonce = Optional.of(randomNonce());
+        }
+        else {
+            nonce = Optional.empty();
+        }
+        return new OAuthChallenge(client.getAuthorizationUri(state, callbackUri, nonce.map(OAuth2Service::hashNonce)), challengeExpiration, nonce);
     }
 
     public URI startRestChallenge(URI callbackUri, UUID authId)
@@ -94,11 +115,10 @@ public class OAuth2Service
                 .setAudience(STATE_AUDIENCE_REST)
                 .setExpiration(Date.from(Instant.now().plus(challengeTimeout)))
                 .compact();
-
-        return client.getAuthorizationUri(state, callbackUri);
+        return client.getAuthorizationUri(state, callbackUri, Optional.empty());
     }
 
-    public OAuthResult finishChallenge(String state, String code, URI callbackUri)
+    public OAuthResult finishChallenge(String state, String code, URI callbackUri, Optional<String> nonce)
             throws ChallengeFailedException
     {
         requireNonNull(callbackUri, "callbackUri is null");
@@ -127,7 +147,21 @@ public class OAuth2Service
         AccessToken accessToken = client.getAccessToken(code, callbackUri);
 
         // validate access token is trusted by this server
-        Claims parsedToken = jwtParser.parseClaimsJws(accessToken.getAccessToken()).getBody();
+        Claims parsedToken = Jwts.parser()
+                .setSigningKeyResolver(signingKeyResolver)
+                .parseClaimsJws(accessToken.getAccessToken())
+                .getBody();
+
+        // user did not grant the requested scope `openid` so we don't have the ID token and therefore can't validate the nonce
+        // or the ID token is present but the nonce is not which means that someone is trying to obtain the token which he is not supposed to get
+        if (nonce.isPresent() != accessToken.getIdToken().isPresent()) {
+            throw new ChallengeFailedException("Cannot validate nonce parameter");
+        }
+        // validate nonce from the ID token
+        nonce.ifPresent(n -> Jwts.parser()
+                .setSigningKeyResolver(signingKeyResolver)
+                .require(NONCE, hashNonce(n))
+                .parseClaimsJws(accessToken.getIdToken().get()));
 
         // determine expiration
         Instant validUntil = accessToken.getValidUntil()
@@ -153,7 +187,9 @@ public class OAuth2Service
 
     public Jws<Claims> parseClaimsJws(String token)
     {
-        return jwtParser.parseClaimsJws(token);
+        return Jwts.parser()
+                .setSigningKeyResolver(signingKeyResolver)
+                .parseClaimsJws(token);
     }
 
     public String getSuccessHtml()
@@ -174,7 +210,7 @@ public class OAuth2Service
     private static byte[] secureRandomBytes(int count)
     {
         byte[] bytes = new byte[count];
-        new SecureRandom().nextBytes(bytes);
+        SECURE_RANDOM.nextBytes(bytes);
         return bytes;
     }
 
@@ -191,6 +227,49 @@ public class OAuth2Service
                 return "OAuth2 server is temporarily unavailable";
             default:
                 return "OAuth2 unknown error code: " + errorCode;
+        }
+    }
+
+    private static String randomNonce()
+    {
+        // https://developers.login.gov/oidc/#authorization
+        // min 22 chars so 24 chars obtained by encoding random 18 bytes using Base64 should be enough
+        return BaseEncoding.base64Url().encode(secureRandomBytes(18));
+    }
+
+    private static String hashNonce(String nonce)
+    {
+        return Hashing.sha256()
+                .hashString(nonce, StandardCharsets.UTF_8)
+                .toString();
+    }
+
+    public static class OAuthChallenge
+    {
+        private final URI redirectUrl;
+        private final Instant challengeExpiration;
+        private final Optional<String> nonce;
+
+        public OAuthChallenge(URI redirectUrl, Instant challengeExpiration, Optional<String> nonce)
+        {
+            this.redirectUrl = requireNonNull(redirectUrl, "redirectUrl is null");
+            this.challengeExpiration = requireNonNull(challengeExpiration, "challengeExpiration is null");
+            this.nonce = requireNonNull(nonce, "nonce is null");
+        }
+
+        public URI getRedirectUrl()
+        {
+            return redirectUrl;
+        }
+
+        public Instant getChallengeExpiration()
+        {
+            return challengeExpiration;
+        }
+
+        public Optional<String> getNonce()
+        {
+            return nonce;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/ScribeJavaOAuth2Client.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/ScribeJavaOAuth2Client.java
@@ -19,6 +19,7 @@ import com.github.scribejava.core.model.OAuthConstants;
 import com.github.scribejava.core.model.OAuthRequest;
 import com.github.scribejava.core.oauth.AccessTokenRequestParams;
 import com.github.scribejava.core.oauth.OAuth20Service;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 
 import javax.inject.Inject;
@@ -76,7 +77,7 @@ public class ScribeJavaOAuth2Client
                     config.getClientId(),
                     config.getClientSecret(),
                     null,
-                    "openid",
+                    Joiner.on(",").join(config.getScopes()),
                     "code",
                     null,
                     null,

--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
@@ -20,16 +20,18 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.trino.server.security.UserMapping;
 import io.trino.server.security.UserMappingException;
+import io.trino.server.security.oauth2.NonceCookie;
 import io.trino.server.security.oauth2.OAuth2Config;
 import io.trino.server.security.oauth2.OAuth2Service;
+import io.trino.server.security.oauth2.OAuth2Service.OAuthChallenge;
 import io.trino.spi.security.BasicPrincipal;
 import io.trino.spi.security.Identity;
 
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
@@ -121,8 +123,10 @@ public class OAuth2WebUiAuthenticationFilter
 
     private void needAuthentication(ContainerRequestContext request)
     {
-        URI redirectLocation = service.startWebUiChallenge(request.getUriInfo().getBaseUri().resolve(CALLBACK_ENDPOINT));
-        request.abortWith(Response.seeOther(redirectLocation).build());
+        OAuthChallenge challenge = service.startWebUiChallenge(request.getUriInfo().getBaseUri().resolve(CALLBACK_ENDPOINT));
+        ResponseBuilder response = Response.seeOther(challenge.getRedirectUrl());
+        challenge.getNonce().ifPresent(nonce -> response.cookie(NonceCookie.create(nonce, challenge.getChallengeExpiration())));
+        request.abortWith(response.build());
     }
 
     private boolean hasValidAudience(Object audience)

--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
@@ -42,6 +42,7 @@ import static io.trino.server.security.oauth2.OAuth2CallbackResource.CALLBACK_EN
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.DISABLED_LOCATION;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.DISABLED_LOCATION_URI;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.TRINO_FORM_LOGIN;
+import static io.trino.server.ui.OAuthWebUiCookie.OAUTH2_COOKIE;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 
@@ -106,7 +107,7 @@ public class OAuth2WebUiAuthenticationFilter
 
     private Optional<Jws<Claims>> getAccessToken(ContainerRequestContext request)
     {
-        return OAuthWebUiCookie.read(request)
+        return OAuthWebUiCookie.read(request.getCookies().get(OAUTH2_COOKIE))
                 .flatMap(token -> {
                     try {
                         return Optional.ofNullable(service.parseClaimsJws(token));

--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiLogoutResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiLogoutResource.java
@@ -36,7 +36,7 @@ public class OAuth2WebUiLogoutResource
     public Response logout(@Context HttpHeaders httpHeaders, @Context UriInfo uriInfo, @Context SecurityContext securityContext)
     {
         return Response.seeOther(UI_LOCATION_URI)
-                .cookie(delete(securityContext.isSecure()))
+                .cookie(delete())
                 .build();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuthWebUiCookie.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuthWebUiCookie.java
@@ -13,7 +13,6 @@
  */
 package io.trino.server.ui;
 
-import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Cookie;
 import javax.ws.rs.core.NewCookie;
 
@@ -23,47 +22,50 @@ import java.util.Optional;
 
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOCATION;
 import static java.util.function.Predicate.not;
+import static javax.ws.rs.core.Cookie.DEFAULT_VERSION;
+import static javax.ws.rs.core.NewCookie.DEFAULT_MAX_AGE;
 
 public final class OAuthWebUiCookie
 {
-    public static final String OAUTH2_COOKIE = "Trino-OAuth2-Token";
+    // prefix according to: https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05#section-4.1.3.1
+    public static final String OAUTH2_COOKIE = "__Secure-Trino-OAuth2-Token";
 
     private OAuthWebUiCookie() {}
 
-    public static NewCookie create(String accessToken, Instant tokenExpiration, boolean secure)
+    public static NewCookie create(String accessToken, Instant tokenExpiration)
     {
         return new NewCookie(
                 OAUTH2_COOKIE,
                 accessToken,
                 UI_LOCATION,
                 null,
-                Cookie.DEFAULT_VERSION,
+                DEFAULT_VERSION,
                 null,
-                NewCookie.DEFAULT_MAX_AGE,
+                DEFAULT_MAX_AGE,
                 Date.from(tokenExpiration),
-                secure,
+                true,
                 true);
     }
 
-    public static Optional<String> read(ContainerRequestContext request)
+    public static Optional<String> read(Cookie cookie)
     {
-        return Optional.ofNullable(request.getCookies().get(OAUTH2_COOKIE))
+        return Optional.ofNullable(cookie)
                 .map(Cookie::getValue)
                 .filter(not(String::isBlank));
     }
 
-    public static NewCookie delete(boolean secure)
+    public static NewCookie delete()
     {
         return new NewCookie(
                 OAUTH2_COOKIE,
                 "delete",
                 UI_LOCATION,
                 null,
-                Cookie.DEFAULT_VERSION,
+                DEFAULT_VERSION,
                 null,
                 0,
                 null,
-                secure,
+                true,
                 true);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -430,7 +430,7 @@ public class TestResourceSecurity
                         .toInstance(new OAuth2Client()
                         {
                             @Override
-                            public URI getAuthorizationUri(String state, URI callbackUri)
+                            public URI getAuthorizationUri(String state, URI callbackUri, Optional<String> nonceHash)
                             {
                                 return URI.create("http://example.com/authorize?" + state);
                             }
@@ -441,7 +441,7 @@ public class TestResourceSecurity
                                 if (!"TEST_CODE".equals(code)) {
                                     throw new IllegalArgumentException("Expected TEST_CODE");
                                 }
-                                return new AccessToken(token, Optional.empty());
+                                return new AccessToken(token, Optional.empty(), Optional.empty());
                             }
                         }))
                 .build()) {

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2Config.java
@@ -39,6 +39,7 @@ public class TestOAuth2Config
                 .setClientId(null)
                 .setClientSecret(null)
                 .setAudience(null)
+                .setScopes("openid")
                 .setChallengeTimeout(Duration.valueOf("15m"))
                 .setUserMappingPattern(null)
                 .setUserMappingFile(null));
@@ -57,6 +58,7 @@ public class TestOAuth2Config
                 .put("http-server.authentication.oauth2.client-id", "another-consumer")
                 .put("http-server.authentication.oauth2.client-secret", "consumer-secret")
                 .put("http-server.authentication.oauth2.audience", "https://127.0.0.1:8443")
+                .put("http-server.authentication.oauth2.scopes", "email,offline")
                 .put("http-server.authentication.oauth2.challenge-timeout", "90s")
                 .put("http-server.authentication.oauth2.user-mapping.pattern", "(.*)@something")
                 .put("http-server.authentication.oauth2.user-mapping.file", userMappingFile.toString())
@@ -70,6 +72,7 @@ public class TestOAuth2Config
                 .setClientId("another-consumer")
                 .setClientSecret("consumer-secret")
                 .setAudience("https://127.0.0.1:8443")
+                .setScopes("email, offline")
                 .setChallengeTimeout(Duration.valueOf("90s"))
                 .setUserMappingPattern("(.*)@something")
                 .setUserMappingFile(userMappingFile.toFile());

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -23,6 +23,7 @@ import io.airlift.http.server.testing.TestingHttpServer;
 import io.airlift.node.NodeInfo;
 import io.airlift.security.pem.PemReader;
 import io.jsonwebtoken.JwsHeader;
+import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.trino.server.security.PasswordAuthenticatorManager;
@@ -67,12 +68,14 @@ import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.trino.client.OkHttpUtil.setupSsl;
 import static io.trino.server.security.oauth2.OAuth2CallbackResource.CALLBACK_ENDPOINT;
+import static io.trino.server.security.oauth2.OAuth2Service.NONCE;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.DISABLED_LOCATION;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.LOGIN_FORM;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOGIN;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOGOUT;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
@@ -92,6 +95,16 @@ public class TestWebUi
             .put("http-server.https.keystore.key", "")
             .put("http-server.process-forwarded", "true")
             .put("http-server.authentication.allow-insecure-over-http", "true")
+            .build();
+    private static final String STATE_KEY = "test-state-key";
+    private static final ImmutableMap<String, String> OAUTH2_PROPERTIES = ImmutableMap.<String, String>builder()
+            .putAll(SECURE_PROPERTIES)
+            .put("web-ui.authentication.type", "oauth2")
+            .put("http-server.authentication.oauth2.state-key", STATE_KEY)
+            .put("http-server.authentication.oauth2.auth-url", "http://example.com/")
+            .put("http-server.authentication.oauth2.token-url", "http://example.com/")
+            .put("http-server.authentication.oauth2.client-id", "client")
+            .put("http-server.authentication.oauth2.client-secret", "client-secret")
             .build();
     private static final String TEST_USER = "test-user";
     private static final String TEST_PASSWORD = "test-password";
@@ -507,104 +520,105 @@ public class TestWebUi
     public void testOAuth2Authenticator()
             throws Exception
     {
+        String accessToken = createTokenBuilder().compact();
+        TestingHttpServer jwkServer = createTestingJwkServer();
+        jwkServer.start();
+        try (TestingTrinoServer server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(OAUTH2_PROPERTIES)
+                        .put("http-server.authentication.oauth2.jwks-url", jwkServer.getBaseUrl().toString())
+                        .build())
+                .setAdditionalModule(binder -> newOptionalBinder(binder, OAuth2Client.class)
+                        .setBinding()
+                        .toInstance(new OAuth2ClientStub(accessToken)))
+                .build()) {
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+            assertAuth2Authentication(httpServerInfo, accessToken);
+        }
+        finally {
+            jwkServer.stop();
+        }
+    }
+
+    @Test
+    public void testOAuth2AuthenticatorWithoutOpenIdScope()
+            throws Exception
+    {
+        String accessToken = createTokenBuilder().compact();
+        TestingHttpServer jwkServer = createTestingJwkServer();
+        jwkServer.start();
+        try (TestingTrinoServer server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(OAUTH2_PROPERTIES)
+                        .put("http-server.authentication.oauth2.jwks-url", jwkServer.getBaseUrl().toString())
+                        .put("http-server.authentication.oauth2.scopes", "")
+                        .build())
+                .setAdditionalModule(binder -> newOptionalBinder(binder, OAuth2Client.class)
+                        .setBinding()
+                        .toInstance(new OAuth2ClientStub(accessToken)))
+                .build()) {
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+            assertAuth2Authentication(httpServerInfo, accessToken);
+        }
+        finally {
+            jwkServer.stop();
+        }
+    }
+
+    private void assertAuth2Authentication(HttpServerInfo httpServerInfo, String accessToken)
+            throws Exception
+    {
+        String state = Jwts.builder()
+                .signWith(SignatureAlgorithm.HS256, Hashing.sha256().hashString(STATE_KEY, UTF_8).asBytes())
+                .setAudience("trino_oauth_ui")
+                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(10).toInstant()))
+                .compact();
+
         CookieManager cookieManager = new CookieManager();
         OkHttpClient client = this.client.newBuilder()
                 .cookieJar(new JavaNetCookieJar(cookieManager))
                 .build();
 
-        String state = Jwts.builder()
-                .signWith(SignatureAlgorithm.HS256, Hashing.sha256().hashString("test-state-key", UTF_8).asBytes())
-                .setAudience("trino_oauth_ui")
-                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(10).toInstant()))
-                .compact();
+        // HTTP is not allowed for OAuth
+        testDisabled(httpServerInfo.getHttpUri());
 
-        Date tokenExpiration = Date.from(ZonedDateTime.now().plusMinutes(5).toInstant());
-        String token = Jwts.builder()
-                .signWith(SignatureAlgorithm.RS256, JWK_PRIVATE_KEY)
-                .setHeaderParam(JwsHeader.KEY_ID, "test-rsa")
-                .setSubject("test-user")
-                .setExpiration(tokenExpiration)
-                .compact();
+        // verify HTTPS before login
+        URI baseUri = httpServerInfo.getHttpsUri();
+        testRootRedirect(baseUri, client);
+        assertRedirect(client, getUiLocation(baseUri), "http://example.com/authorize", false);
+        assertRedirect(client, getValidApiLocation(baseUri), "http://example.com/authorize", false);
+        assertRedirect(client, getLocation(baseUri, "/ui/unknown"), "http://example.com/authorize", false);
+        assertRedirect(client, getLocation(baseUri, "/ui/api/unknown"), "http://example.com/authorize", false);
 
-        TestingHttpServer jwkServer = createTestingJwkServer();
-        jwkServer.start();
-        try (TestingTrinoServer server = TestingTrinoServer.builder()
-                .setProperties(ImmutableMap.<String, String>builder()
-                        .putAll(SECURE_PROPERTIES)
-                        .put("web-ui.authentication.type", "oauth2")
-                        .put("http-server.authentication.oauth2.jwks-url", jwkServer.getBaseUrl().toString())
-                        .put("http-server.authentication.oauth2.state-key", "test-state-key")
-                        .put("http-server.authentication.oauth2.auth-url", "http://example.com/")
-                        .put("http-server.authentication.oauth2.token-url", "http://example.com/")
-                        .put("http-server.authentication.oauth2.client-id", "client")
-                        .put("http-server.authentication.oauth2.client-secret", "client-secret")
-                        .build())
-                .setAdditionalModule(binder -> newOptionalBinder(binder, OAuth2Client.class)
-                        .setBinding()
-                        .toInstance(new OAuth2Client()
-                        {
-                            @Override
-                            public URI getAuthorizationUri(String state, URI callbackUri)
-                            {
-                                return URI.create("http://example.com/authorize");
-                            }
+        // login with the callback endpoint
+        assertRedirect(
+                client,
+                uriBuilderFrom(baseUri)
+                        .replacePath(CALLBACK_ENDPOINT)
+                        .addParameter("code", "TEST_CODE")
+                        .addParameter("state", state)
+                        .toString(),
+                getUiLocation(baseUri),
+                false);
+        HttpCookie cookie = getOnlyElement(cookieManager.getCookieStore().getCookies());
+        assertEquals(cookie.getValue(), accessToken);
+        assertEquals(cookie.getPath(), "/ui/");
+        assertEquals(cookie.getDomain(), baseUri.getHost());
+        assertTrue(cookie.getMaxAge() > 0 && cookie.getMaxAge() < MINUTES.toSeconds(5));
+        assertTrue(cookie.isHttpOnly());
 
-                            @Override
-                            public AccessToken getAccessToken(String code, URI callbackUri)
-                            {
-                                if (!"TEST_CODE".equals(code)) {
-                                    throw new IllegalArgumentException("Expected TEST_CODE");
-                                }
-                                return new AccessToken(token, Optional.empty());
-                            }
-                        }))
-                .build()) {
-            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+        // authentication cookie is now set, so UI should work
+        testRootRedirect(baseUri, client);
+        assertOk(client, getUiLocation(baseUri));
+        assertOk(client, getUiLocation(baseUri));
+        assertOk(client, getValidApiLocation(baseUri));
+        assertResponseCode(client, getLocation(baseUri, "/ui/unknown"), SC_NOT_FOUND);
+        assertResponseCode(client, getLocation(baseUri, "/ui/api/unknown"), SC_NOT_FOUND);
 
-            // HTTP is not allowed for OAuth
-            testDisabled(httpServerInfo.getHttpUri());
-
-            // verify HTTPS before login
-            URI baseUri = httpServerInfo.getHttpsUri();
-            testRootRedirect(baseUri, client);
-            assertRedirect(client, getUiLocation(baseUri), "http://example.com/authorize", false);
-            assertRedirect(client, getValidApiLocation(baseUri), "http://example.com/authorize", false);
-            assertRedirect(client, getLocation(baseUri, "/ui/unknown"), "http://example.com/authorize", false);
-            assertRedirect(client, getLocation(baseUri, "/ui/api/unknown"), "http://example.com/authorize", false);
-
-            // login with the callback endpoint
-            assertRedirect(
-                    client,
-                    uriBuilderFrom(baseUri)
-                            .replacePath(CALLBACK_ENDPOINT)
-                            .addParameter("code", "TEST_CODE")
-                            .addParameter("state", state)
-                            .toString(),
-                    getUiLocation(baseUri),
-                    false);
-            HttpCookie cookie = getOnlyElement(cookieManager.getCookieStore().getCookies());
-            assertEquals(cookie.getValue(), token);
-            assertEquals(cookie.getPath(), "/ui/");
-            assertEquals(cookie.getDomain(), baseUri.getHost());
-            assertTrue(cookie.getMaxAge() > 0 && cookie.getMaxAge() < MINUTES.toSeconds(5));
-            assertTrue(cookie.isHttpOnly());
-
-            // authentication cookie is now set, so UI should work
-            testRootRedirect(baseUri, client);
-            assertOk(client, getUiLocation(baseUri));
-            assertOk(client, getUiLocation(baseUri));
-            assertOk(client, getValidApiLocation(baseUri));
-            assertResponseCode(client, getLocation(baseUri, "/ui/unknown"), SC_NOT_FOUND);
-            assertResponseCode(client, getLocation(baseUri, "/ui/api/unknown"), SC_NOT_FOUND);
-
-            // logout
-            assertRedirect(client, getLogoutLocation(baseUri), getUiLocation(baseUri), false);
-            assertThat(cookieManager.getCookieStore().getCookies()).isEmpty();
-            assertRedirect(client, getUiLocation(baseUri), "http://example.com/authorize", false);
-        }
-        finally {
-            jwkServer.stop();
-        }
+        // logout
+        assertRedirect(client, getLogoutLocation(baseUri), getUiLocation(baseUri), false);
+        assertThat(cookieManager.getCookieStore().getCookies()).isEmpty();
+        assertRedirect(client, getUiLocation(baseUri), "http://example.com/authorize", false);
     }
 
     private static void testAlwaysAuthorized(URI baseUri, OkHttpClient authorizedClient, String nodeId)
@@ -871,6 +885,16 @@ public class TestWebUi
         return uriBuilderFrom(baseUri).replacePath(path).replaceParameter(query).toString();
     }
 
+    private static JwtBuilder createTokenBuilder()
+    {
+        Date tokenExpiration = Date.from(ZonedDateTime.now().plusMinutes(5).toInstant());
+        return Jwts.builder()
+                .signWith(SignatureAlgorithm.RS256, JWK_PRIVATE_KEY)
+                .setHeaderParam(JwsHeader.KEY_ID, "test-rsa")
+                .setSubject("test-user")
+                .setExpiration(tokenExpiration);
+    }
+
     private static TestingHttpServer createTestingJwkServer()
             throws IOException
     {
@@ -890,6 +914,34 @@ public class TestWebUi
         {
             String jwkKeys = Resources.toString(Resources.getResource("jwk/jwk-public.json"), UTF_8);
             response.getWriter().println(jwkKeys);
+        }
+    }
+
+    private static class OAuth2ClientStub
+            implements OAuth2Client
+    {
+        private final String accessToken;
+        private Optional<JwtBuilder> idTokenBuilder = Optional.empty();
+
+        public OAuth2ClientStub(String accessToken)
+        {
+            this.accessToken = requireNonNull(accessToken, "accessToken is null");
+        }
+
+        @Override
+        public URI getAuthorizationUri(String state, URI callbackUri, Optional<String> nonceHash)
+        {
+            nonceHash.ifPresent(nonce -> idTokenBuilder = Optional.of(createTokenBuilder().claim(NONCE, nonce)));
+            return URI.create("http://example.com/authorize");
+        }
+
+        @Override
+        public AccessToken getAccessToken(String code, URI callbackUri)
+        {
+            if (!"TEST_CODE".equals(code)) {
+                throw new IllegalArgumentException("Expected TEST_CODE");
+            }
+            return new AccessToken(accessToken, Optional.empty(), idTokenBuilder.map(JwtBuilder::compact));
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <dep.jdbi3.version>3.17.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
         <dep.drift.version>1.14</dep.drift.version>
+        <dep.scribejava.version>6.9.0</dep.scribejava.version>
         <dep.selenium.version>3.141.59</dep.selenium.version>
         <dep.tempto.version>183</dep.tempto.version>
         <dep.gcs.version>2.0.0</dep.gcs.version>
@@ -969,8 +970,14 @@
 
             <dependency>
                 <groupId>com.github.scribejava</groupId>
+                <artifactId>scribejava-apis</artifactId>
+                <version>${dep.scribejava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.scribejava</groupId>
                 <artifactId>scribejava-core</artifactId>
-                <version>6.9.0</version>
+                <version>${dep.scribejava.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
 The `nonce` parameter is being added to the authorization request in order to prevent against replay attacks. The authorization server is going to return given `nonce` in the ID token after the successful authorization. The value from the token and the value stored in user's browser will be compared in order to ensure that only eligible user and only once can get an access token using single authorization code.