### PR TITLE
Remove redundant strategy.fail-fast from MemSQL CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,8 +255,6 @@ jobs:
 
   test-memsql:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
If my understanding is correct, this property is for matrix build.
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast