### PR TITLE
Remove "changes" from release note sections

### DIFF
--- a/docs/src/main/sphinx/release/release-0.100.rst
+++ b/docs/src/main/sphinx/release/release-0.100.rst
@@ -11,8 +11,8 @@ schema that is available in every catalog. Additionally, connectors may now
 provide system tables that are available within that connector's catalog by
 implementing the ``getSystemTables()`` method on the ``Connector`` interface.
 
-General changes
----------------
+General
+-------
 
 * Fix ``%f`` specifier in :func:`date_format` and :func:`date_parse`.
 * Add ``WITH ORDINALITY`` support to ``UNNEST``.

--- a/docs/src/main/sphinx/release/release-0.101.rst
+++ b/docs/src/main/sphinx/release/release-0.101.rst
@@ -2,8 +2,8 @@
 Release 0.101
 =============
 
-General changes
----------------
+General
+-------
 
 * Add support for :doc:`/sql/create-table` (in addition to :doc:`/sql/create-table-as`).
 * Add ``IF EXISTS`` support to :doc:`/sql/drop-table` and :doc:`/sql/drop-view`.
@@ -35,15 +35,15 @@ General changes
 * Make ``UNION`` run partitioned, if underlying plan is partitioned.
 * Add ``hash_partition_count`` session property to control hash partitions.
 
-Web UI changes
---------------
+Web UI
+------
 
 The main page of the web UI has been completely rewritten to use ReactJS. It also has
 a number of new features, such as the ability to pause auto-refresh via the "Z" key and
 also with a toggle in the UI.
 
-Hive changes
-------------
+Hive
+----
 
 * Add support for connecting to S3 using EC2 instance credentials.
   This feature is enabled by default. To disable it, set
@@ -64,8 +64,8 @@ Hive changes
 * Add ``hive.recursive-directories`` config option to recursively scan
   partition directories for data.
 
-SPI changes
------------
+SPI
+---
 
 * Add connector callback for rollback of ``INSERT`` and ``CREATE TABLE AS``.
 * Introduce an abstraction for representing physical organizations of a table

--- a/docs/src/main/sphinx/release/release-0.102.rst
+++ b/docs/src/main/sphinx/release/release-0.102.rst
@@ -24,8 +24,8 @@ orders of magnitude faster (due to removal of quadratic behavior).
 This change introduced some minor incompatibilities that are explained
 in the documentation for the functions.
 
-General changes
----------------
+General
+-------
 
 * Add support for partitioned right outer joins, which allows for larger tables to
   be joined on the inner side.
@@ -42,8 +42,8 @@ General changes
 * Implement implicit coercions in ``VALUES`` expressions.
 * Fix potential deadlock in scheduler.
 
-Hive changes
-------------
+Hive
+----
 
 * Collect more metrics from ``PrestoS3FileSystem``.
 * Retry when seeking in ``PrestoS3FileSystem``.

--- a/docs/src/main/sphinx/release/release-0.103.rst
+++ b/docs/src/main/sphinx/release/release-0.103.rst
@@ -35,16 +35,16 @@ This is an experimental feature and will likely change in a future release.  It
 is also expected that this will eventually be handled automatically by the
 query planner and these options will be removed entirely.
 
-Hive changes
-------------
+Hive
+----
 
 * Removed the ``hive.max-split-iterator-threads`` parameter and renamed
   ``hive.max-global-split-iterator-threads`` to ``hive.max-split-iterator-threads``.
 * Fix excessive object creation when querying tables with a large number of partitions.
 * Do not retry requests when an S3 path is not found.
 
-General changes
----------------
+General
+-------
 
 * Add :func:`array_remove`.
 * Fix NPE in :func:`max_by` and :func:`min_by` caused when few rows were present in the aggregation.

--- a/docs/src/main/sphinx/release/release-0.104.rst
+++ b/docs/src/main/sphinx/release/release-0.104.rst
@@ -2,8 +2,8 @@
 Release 0.104
 =============
 
-General changes
----------------
+General
+-------
 
 * Handle thread interruption in StatementClient.
 * Fix CLI hang when server becomes unreachable during a query.
@@ -22,8 +22,8 @@ General changes
 * Support ``TIMESTAMP`` for :func:`first_value`, :func:`last_value`,
   :func:`nth_value`, :func:`lead` and :func:`lag`.
 
-Hive changes
-------------
+Hive
+----
 
 * Upgrade to Parquet 1.6.0.
 * Collect request time and retry statistics in ``PrestoS3FileSystem``.

--- a/docs/src/main/sphinx/release/release-0.105.rst
+++ b/docs/src/main/sphinx/release/release-0.105.rst
@@ -2,16 +2,16 @@
 Release 0.105
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix issue which can cause queries to be blocked permanently.
 * Close connections correctly in JDBC connectors.
 * Add implicit coercions for values of equi-join criteria.
 * Fix detection of window function calls without an ``OVER`` clause.
 
-SPI changes
------------
+SPI
+---
 
 * Remove ``ordinalPosition`` from ``ColumnMetadata``.
 

--- a/docs/src/main/sphinx/release/release-0.106.rst
+++ b/docs/src/main/sphinx/release/release-0.106.rst
@@ -2,8 +2,8 @@
 Release 0.106
 =============
 
-General changes
----------------
+General
+-------
 
 * Parallelize startup of table scan task splits.
 * Fixed index join driver resource leak.

--- a/docs/src/main/sphinx/release/release-0.107.rst
+++ b/docs/src/main/sphinx/release/release-0.107.rst
@@ -2,8 +2,8 @@
 Release 0.107
 =============
 
-General changes
----------------
+General
+-------
 
 * Added ``query_max_memory`` session property. Note: this session property cannot
   increase the limit above the limit set by the ``query.max-memory`` configuration option.

--- a/docs/src/main/sphinx/release/release-0.108.rst
+++ b/docs/src/main/sphinx/release/release-0.108.rst
@@ -2,8 +2,8 @@
 Release 0.108
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect query results when a window function follows a :func:`row_number`
   function and both are partitioned on the same column(s).
@@ -31,8 +31,8 @@ General changes
 * Fix printing of table layouts in :doc:`/sql/explain`.
 * Add :doc:`/connector/blackhole`.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Randomly select Cassandra node for split generation.
 * Fix handling of ``UUID`` partition keys.

--- a/docs/src/main/sphinx/release/release-0.109.rst
+++ b/docs/src/main/sphinx/release/release-0.109.rst
@@ -2,8 +2,8 @@
 Release 0.109
 =============
 
-General changes
----------------
+General
+-------
 
 * Add :func:`slice`, :func:`md5`, :func:`array_min` and :func:`array_max` functions.
 * Fix bug that could cause queries submitted soon after startup to hang forever.

--- a/docs/src/main/sphinx/release/release-0.110.rst
+++ b/docs/src/main/sphinx/release/release-0.110.rst
@@ -2,8 +2,8 @@
 Release 0.110
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix result truncation bug in window function :func:`row_number` when performing a
   partitioned top-N that chooses the maximum or minimum ``N`` rows. For example::

--- a/docs/src/main/sphinx/release/release-0.111.rst
+++ b/docs/src/main/sphinx/release/release-0.111.rst
@@ -2,8 +2,8 @@
 Release 0.111
 =============
 
-General changes
----------------
+General
+-------
 
 * Add :func:`histogram` function.
 * Optimize ``CASE`` expressions on a constant.

--- a/docs/src/main/sphinx/release/release-0.112.rst
+++ b/docs/src/main/sphinx/release/release-0.112.rst
@@ -2,15 +2,15 @@
 Release 0.112
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect handling of filters and limits in :func:`row_number` optimizer.
   This caused certain query shapes to produce incorrect results.
 * Fix non-string object arrays in JMX connector.
 
-Hive changes
-------------
+Hive
+----
 
 * Tables created using :doc:`/sql/create-table` (not :doc:`/sql/create-table-as`)
   had invalid metadata and were not readable.

--- a/docs/src/main/sphinx/release/release-0.113.rst
+++ b/docs/src/main/sphinx/release/release-0.113.rst
@@ -36,8 +36,8 @@ can be validated and converted to any Java type using
     implementation and callers of ``ConnectorSession.getProperty()`` will now
     need the expected Java type of the property.
 
-General changes
----------------
+General
+-------
 
 * Allow using any type with value window functions :func:`first_value`,
   :func:`last_value`, :func:`nth_value`, :func:`lead` and :func:`lag`.
@@ -48,8 +48,8 @@ General changes
 * Fix handling of literal ``NULL`` in ``IS DISTINCT FROM``.
 * Fix an issue that caused some specific queries to fail in planning.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix the Hive metadata cache to properly handle negative responses.
   This makes the background refresh work properly by clearing the cached
@@ -58,8 +58,8 @@ Hive changes
   Hive but Presto thinks it still exists.
 * Fix metastore socket leak when SOCKS connect fails.
 
-SPI changes
------------
+SPI
+---
 
 * Changed the internal representation of structural types.
 

--- a/docs/src/main/sphinx/release/release-0.114.rst
+++ b/docs/src/main/sphinx/release/release-0.114.rst
@@ -2,13 +2,13 @@
 Release 0.114
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix ``%k`` specifier for :func:`date_format` and :func:`date_parse`.
   It previously used ``24`` rather than ``0`` for the midnight hour.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix ORC reader for Hive connector.

--- a/docs/src/main/sphinx/release/release-0.115.rst
+++ b/docs/src/main/sphinx/release/release-0.115.rst
@@ -2,16 +2,16 @@
 Release 0.115
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix an issue with hierarchical queue rules where queries could be rejected after being accepted.
 * Add :func:`sha1`, :func:`sha256` and :func:`sha512` functions.
 * Add :func:`power` as an alias for :func:`pow`.
 * Add support for ``LIMIT ALL`` syntax.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix a race condition which could cause queries to finish without reading all the data.
 * Fix a bug in Parquet reader that causes failures while reading lists that has an element

--- a/docs/src/main/sphinx/release/release-0.116.rst
+++ b/docs/src/main/sphinx/release/release-0.116.rst
@@ -28,8 +28,8 @@ with the ``query.low-memory-killer.enabled`` config flag, and the delay between
 when the cluster runs low on memory and when the killer will be invoked can be
 configured with the ``query.low-memory-killer.delay`` option.
 
-General changes
----------------
+General
+-------
 
 * Add :func:`multimap_agg` function.
 * Add :func:`checksum` function.

--- a/docs/src/main/sphinx/release/release-0.117.rst
+++ b/docs/src/main/sphinx/release/release-0.117.rst
@@ -2,8 +2,8 @@
 Release 0.117
 =============
 
-General changes
----------------
+General
+-------
 
 * Add back casts between JSON and VARCHAR to provide an easier migration path
   to :func:`json_parse` and :func:`json_format`. These will be removed in a

--- a/docs/src/main/sphinx/release/release-0.118.rst
+++ b/docs/src/main/sphinx/release/release-0.118.rst
@@ -2,8 +2,8 @@
 Release 0.118
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix planning error for ``UNION`` queries that require implicit coercions.
 * Fix null pointer exception when using :func:`checksum`.

--- a/docs/src/main/sphinx/release/release-0.119.rst
+++ b/docs/src/main/sphinx/release/release-0.119.rst
@@ -2,8 +2,8 @@
 Release 0.119
 =============
 
-General changes
----------------
+General
+-------
 
 * Add :doc:`/connector/redis`.
 * Add :func:`geometric_mean` function.
@@ -25,8 +25,8 @@ General changes
   the same side.
 * Support ``RENAME COLUMN`` in :doc:`/sql/alter-table`.
 
-SPI changes
------------
+SPI
+---
 
 * Add more system table distribution modes.
 * Add owner to view metadata.
@@ -37,8 +37,8 @@ SPI changes
     new APIs.
 
 
-CLI changes
------------
+CLI
+---
 
 * Fix handling of full width characters.
 * Skip printing query URL if terminal is too narrow.
@@ -47,28 +47,28 @@ CLI changes
 * Fix handling of query abortion after result has been partially received.
 * Fix handling of ``ctrl-C`` when displaying results without a pager.
 
-Verifier changes
-----------------
+Verifier
+--------
 
 * Add ``expected-double-precision`` config to specify the expected level of
   precision when comparing double values.
 * Return non-zero exit code when there are failures.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Add support for Cassandra blob types.
 
-Hive changes
-------------
+Hive
+----
 
 * Support adding and renaming columns using :doc:`/sql/alter-table`.
 * Automatically configure the S3 region when running in EC2.
 * Allow configuring multiple Hive metastores for high availability.
 * Add support for ``TIMESTAMP`` and ``VARBINARY`` in Parquet.
 
-MySQL and PostgreSQL changes
-----------------------------
+MySQL and PostgreSQL
+--------------------
 
 * Enable streaming results instead of buffering everything in memory.
 * Fix handling of pattern characters when matching table or column names.

--- a/docs/src/main/sphinx/release/release-0.121.rst
+++ b/docs/src/main/sphinx/release/release-0.121.rst
@@ -2,8 +2,8 @@
 Release 0.121
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix regression that causes task scheduler to not retry requests in some cases.
 * Throttle task info refresher on errors.

--- a/docs/src/main/sphinx/release/release-0.122.rst
+++ b/docs/src/main/sphinx/release/release-0.122.rst
@@ -7,8 +7,8 @@ Release 0.122
    There is a bug in this release that will cause queries to fail when the
    ``optimizer.optimize-hash-generation`` config is disabled.
 
-General changes
----------------
+General
+-------
 
 * The deprecated casts between JSON and VARCHAR will now fail and provide the
   user with instructions to migrate their query. For more details, see

--- a/docs/src/main/sphinx/release/release-0.123.rst
+++ b/docs/src/main/sphinx/release/release-0.123.rst
@@ -2,8 +2,8 @@
 Release 0.123
 =============
 
-General changes
----------------
+General
+-------
 
 * Remove ``node-scheduler.location-aware-scheduling-enabled`` config.
 * Fixed query failures that occur when the ``optimizer.optimize-hash-generation``
@@ -28,8 +28,8 @@ properties, run the following query::
 
     SELECT * FROM system.metadata.table_properties
 
-Hive changes
-------------
+Hive
+----
 
 We have implemented ``INSERT`` and ``DELETE`` for Hive.  Both ``INSERT`` and ``CREATE``
 statements support partitioned tables.  For example, to create a partitioned table

--- a/docs/src/main/sphinx/release/release-0.124.rst
+++ b/docs/src/main/sphinx/release/release-0.124.rst
@@ -2,8 +2,8 @@
 Release 0.124
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix race in memory tracking of ``JOIN`` which could cause the cluster to become over
   committed and possibly crash.
@@ -29,8 +29,8 @@ General changes
   ``optimizer.use-intermediate-aggregations`` config property or
   ``task_intermediate_aggregation`` session property.
 
-Hive changes
-------------
+Hive
+----
 
 * Do not count expected exceptions as errors in the Hive metastore client stats.
 * Improve performance when reading ORC files with many tiny stripes.

--- a/docs/src/main/sphinx/release/release-0.125.rst
+++ b/docs/src/main/sphinx/release/release-0.125.rst
@@ -2,8 +2,8 @@
 Release 0.125
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix an issue where certain operations such as ``GROUP BY``, ``DISTINCT``, etc. on the
   output of a ``RIGHT`` or ``FULL OUTER JOIN`` can return incorrect results if they reference columns

--- a/docs/src/main/sphinx/release/release-0.126.rst
+++ b/docs/src/main/sphinx/release/release-0.126.rst
@@ -2,8 +2,8 @@
 Release 0.126
 =============
 
-General changes
----------------
+General
+-------
 
 * Add error location information (line and column number) for semantic errors.
 * Fix a CLI crash during tab-completion when no schema is currently selected.
@@ -35,8 +35,8 @@ General changes
 * Fix memory leak in coordinator.
 * Add validation for names of table properties.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix reading structural types containing nulls in Parquet.
 * Fix writing DATE type when timezone offset is negative. Previous versions

--- a/docs/src/main/sphinx/release/release-0.127.rst
+++ b/docs/src/main/sphinx/release/release-0.127.rst
@@ -2,8 +2,8 @@
 Release 0.127
 =============
 
-General changes
----------------
+General
+-------
 
 * Disable index join repartitioning when it disrupts streaming execution.
 * Fix memory accounting leak in some ``JOIN`` queries.

--- a/docs/src/main/sphinx/release/release-0.128.rst
+++ b/docs/src/main/sphinx/release/release-0.128.rst
@@ -10,8 +10,8 @@ request to ``/v1/info/state`` with the body ``"SHUTTING_DOWN"``. Once instructed
 to shutdown, the worker will no longer receive new tasks, and will exit once
 all existing tasks have completed.
 
-General changes
----------------
+General
+-------
 
 * Fix cast from json to structural types when rows or maps have arrays,
   rows, or maps nested in them.
@@ -23,7 +23,7 @@ General changes
   ``GROUP BY``, ``DISTINCT``, etc. When this triggers, the join may fail to
   produce some of the output rows.
 
-MySQL changes
--------------
+MySQL
+-----
 
 * Fix handling of MySQL database names with underscores.

--- a/docs/src/main/sphinx/release/release-0.129.rst
+++ b/docs/src/main/sphinx/release/release-0.129.rst
@@ -8,8 +8,8 @@ Release 0.129
    queries when the length of the keys is between 16 and 31 bytes. This is fixed
    in :doc:`/release/release-0.130`.
 
-General changes
----------------
+General
+-------
 
 * Fix a planner issue that could cause queries involving ``OUTER JOIN`` to
   return incorrect results.
@@ -28,8 +28,8 @@ General changes
   structure that trades off accuracy and memory requirements when handling small sets for an
   improvement in performance.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Throw exception when using :doc:`/sql/set-session` or :doc:`/sql/reset-session`
   rather than silently ignoring the command.
@@ -37,8 +37,8 @@ JDBC driver changes
   The ``Statement`` interface supports all variants of the ``execute`` methods.
   It also supports the ``getUpdateCount`` and ``getLargeUpdateCount`` methods.
 
-CLI changes
------------
+CLI
+---
 
 * Always clear screen when canceling query with ``ctrl-C``.
 * Make client request timeout configurable.
@@ -50,8 +50,8 @@ The scheduler can now be configured to take network topology into account when
 scheduling splits. This is set using the ``node-scheduler.network-topology``
 config. See :doc:`/admin/tuning` for more information.
 
-Hive changes
-------------
+Hive
+----
 
 * The S3 region is no longer automatically configured when running in EC2.
   To enable this feature, use ``hive.s3.pin-client-to-current-region=true``

--- a/docs/src/main/sphinx/release/release-0.130.rst
+++ b/docs/src/main/sphinx/release/release-0.130.rst
@@ -2,8 +2,8 @@
 Release 0.130
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix a performance regression in ``GROUP BY`` and ``JOIN`` queries when the
   length of the keys is between 16 and 31 bytes.

--- a/docs/src/main/sphinx/release/release-0.131.rst
+++ b/docs/src/main/sphinx/release/release-0.131.rst
@@ -2,8 +2,8 @@
 Release 0.131
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix poor performance of transporting dictionary encoded data over the network.
 * Fix code generator to prevent "Method code too large" error.

--- a/docs/src/main/sphinx/release/release-0.132.rst
+++ b/docs/src/main/sphinx/release/release-0.132.rst
@@ -7,8 +7,8 @@ Release 0.132
    :func:`concat` on :ref:`array_type`, or enabling ``columnar_processing_dictionary``
    may cause queries to fail in this release. This is fixed in :doc:`/release/release-0.133`.
 
-General changes
----------------
+General
+-------
 
 * Fix a correctness issue that can occur when any join depends on the output
   of another outer join that has an inner side (or either side for the full outer
@@ -31,13 +31,13 @@ General changes
 * Various performance optimizations for functions operating on :ref:`array_type`.
 * Add server version to web UI.
 
-CLI changes
------------
+CLI
+---
 
 * Fix sporadic *"Failed to disable interrupt character"* error after exiting pager.
 
-Hive changes
-------------
+Hive
+----
 
 * Report metastore and namenode latency in milliseconds rather than seconds in
   JMX stats.

--- a/docs/src/main/sphinx/release/release-0.133.rst
+++ b/docs/src/main/sphinx/release/release-0.133.rst
@@ -2,8 +2,8 @@
 Release 0.133
 =============
 
-General changes
----------------
+General
+-------
 
 * Add support for calling connector-defined procedures using :doc:`/sql/call`.
 * Add :doc:`/connector/system` procedure for killing running queries.

--- a/docs/src/main/sphinx/release/release-0.134.rst
+++ b/docs/src/main/sphinx/release/release-0.134.rst
@@ -2,8 +2,8 @@
 Release 0.134
 =============
 
-General changes
----------------
+General
+-------
 
 * Add cumulative memory statistics tracking and expose the stat in the web interface.
 * Remove nullability and partition key flags from :doc:`/sql/show-columns`.
@@ -11,13 +11,13 @@ General changes
 * Fix performance regression in creation of ``DictionaryBlock``.
 * Fix rare memory accounting leak in queries with ``JOIN``.
 
-Hive changes
-------------
+Hive
+----
 
 * The comment for partition keys is now prefixed with *"Partition Key"*.
 
-SPI changes
------------
+SPI
+---
 
 * Remove legacy partition API methods and classes.
 

--- a/docs/src/main/sphinx/release/release-0.135.rst
+++ b/docs/src/main/sphinx/release/release-0.135.rst
@@ -2,8 +2,8 @@
 Release 0.135
 =============
 
-General changes
----------------
+General
+-------
 
 * Add summary of change in CPU usage to verifier output.
 * Add cast between JSON and VARCHAR, BOOLEAN, DOUBLE, BIGINT. For the old

--- a/docs/src/main/sphinx/release/release-0.136.rst
+++ b/docs/src/main/sphinx/release/release-0.136.rst
@@ -2,8 +2,8 @@
 Release 0.136
 =============
 
-General changes
----------------
+General
+-------
 
 * Add ``control.query-types`` and ``test.query-types`` to verifier, which can
   be used to select the type of queries to run.

--- a/docs/src/main/sphinx/release/release-0.137.rst
+++ b/docs/src/main/sphinx/release/release-0.137.rst
@@ -2,8 +2,8 @@
 Release 0.137
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix ``current_date`` to return correct results for all time zones.
 * Fix invalid plans when scalar subqueries use ``GROUP BY``, ``DISTINCT`` or ``JOIN``.
@@ -19,8 +19,8 @@ General changes
   percentiles.
 * Add API to JDBC driver to track query progress.
 
-Hive changes
-------------
+Hive
+----
 
 * Do not allow inserting into tables when the Hive type does not match
   the Presto type. Previously, Presto would insert data that did not

--- a/docs/src/main/sphinx/release/release-0.138.rst
+++ b/docs/src/main/sphinx/release/release-0.138.rst
@@ -2,8 +2,8 @@
 Release 0.138
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix planning bug with ``NULL`` literal coercions.
 * Reduce query startup time by reducing lock contention in scheduler.

--- a/docs/src/main/sphinx/release/release-0.139.rst
+++ b/docs/src/main/sphinx/release/release-0.139.rst
@@ -12,8 +12,8 @@ can be used to change how frequently adjustments happen. The session properties
 ``initial_splits_per_node`` and ``split_concurrency_adjustment_interval`` can
 also be used.
 
-General changes
----------------
+General
+-------
 
 * Fix planning bug that causes some joins to not be redistributed when
   ``distributed-joins-enabled`` is true.
@@ -21,8 +21,8 @@ General changes
 * Add experimental ``task.join-concurrency`` config which can be used to increase
   concurrency for the probe side of joins.
 
-Hive changes
-------------
+Hive
+----
 
 * Remove cursor-based readers for ORC and DWRF file formats, as they have been
   replaced by page-based readers.

--- a/docs/src/main/sphinx/release/release-0.140.rst
+++ b/docs/src/main/sphinx/release/release-0.140.rst
@@ -2,8 +2,8 @@
 Release 0.140
 =============
 
-General changes
----------------
+General
+-------
 
 * Add the ``TRY`` function to handle specific data exceptions. See
   :doc:`/functions/conditional`.
@@ -22,15 +22,15 @@ General changes
   duplicated columns.
 * Optimize ``NOT IN`` queries to produce more compact predicates.
 
-Hive changes
-------------
+Hive
+----
 
 * Remove bogus "from deserializer" column comments.
 * Change categorization of Hive writer errors to be more specific.
 * Add date and timestamp support to new Parquet Reader
 
-SPI changes
------------
+SPI
+---
 
 * Remove partition key from ``ColumnMetadata``.
 * Change return type of ``ConnectorTableLayout.getDiscretePredicates()``.

--- a/docs/src/main/sphinx/release/release-0.141.rst
+++ b/docs/src/main/sphinx/release/release-0.141.rst
@@ -2,7 +2,7 @@
 Release 0.141
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix server returning an HTTP 500 response for queries with parse errors.

--- a/docs/src/main/sphinx/release/release-0.142.rst
+++ b/docs/src/main/sphinx/release/release-0.142.rst
@@ -2,8 +2,8 @@
 Release 0.142
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix planning bug for ``JOIN`` criteria that optimizes to a ``FALSE`` expression.
 * Fix planning bug when the output of ``UNION`` doesn't match the table column order
@@ -20,8 +20,8 @@ General changes
 * Add support for non-correlated subqueries in aggregation queries.
 * Improve performance of :func:`json_extract`.
 
-Hive changes
-------------
+Hive
+----
 
 * Change ORC input format to report actual bytes read as opposed to estimated bytes.
 * Fix cache invalidation when renaming tables.

--- a/docs/src/main/sphinx/release/release-0.143.rst
+++ b/docs/src/main/sphinx/release/release-0.143.rst
@@ -2,8 +2,8 @@
 Release 0.143
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix race condition in output buffer that can cause a page to be lost.
 * Fix case-sensitivity issue when de-referencing row fields.
@@ -19,8 +19,8 @@ General changes
 * Improve query startup time in large clusters.
 * Improve error messages for ``CAST`` and :func:`slice`.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix native memory leak when reading or writing gzip compressed data.
 * Fix performance regression due to complex expressions not being applied

--- a/docs/src/main/sphinx/release/release-0.144.1.rst
+++ b/docs/src/main/sphinx/release/release-0.144.1.rst
@@ -2,7 +2,7 @@
 Release 0.144.1
 ===============
 
-Hive changes
-------------
+Hive
+----
 
 * Fix bug when grouping on a bucketed column which causes incorrect results.

--- a/docs/src/main/sphinx/release/release-0.144.2.rst
+++ b/docs/src/main/sphinx/release/release-0.144.2.rst
@@ -2,8 +2,8 @@
 Release 0.144.2
 ===============
 
-General changes
----------------
+General
+-------
 
 * Fix potential memory leak in coordinator query history.
 * Add ``driver.max-page-partitioning-buffer-size`` config to control buffer size

--- a/docs/src/main/sphinx/release/release-0.144.3.rst
+++ b/docs/src/main/sphinx/release/release-0.144.3.rst
@@ -2,8 +2,8 @@
 Release 0.144.3
 ===============
 
-General changes
----------------
+General
+-------
 
 * Fix bugs in planner where coercions were not taken into account when computing
   types.
@@ -12,7 +12,7 @@ General changes
 * Fix race condition that can cause queries that process data from non-columnar data
   sources to fail.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix reading symlinks when the target is in a different HDFS instance.

--- a/docs/src/main/sphinx/release/release-0.144.4.rst
+++ b/docs/src/main/sphinx/release/release-0.144.4.rst
@@ -2,7 +2,7 @@
 Release 0.144.4
 ===============
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect results for grouping sets for some queries with filters.

--- a/docs/src/main/sphinx/release/release-0.144.5.rst
+++ b/docs/src/main/sphinx/release/release-0.144.5.rst
@@ -2,8 +2,8 @@
 Release 0.144.5
 ===============
 
-General changes
----------------
+General
+-------
 
 * Fix window functions to correctly handle empty frames between unbounded and
   bounded in the same direction. For example, a frame such as

--- a/docs/src/main/sphinx/release/release-0.144.6.rst
+++ b/docs/src/main/sphinx/release/release-0.144.6.rst
@@ -2,8 +2,8 @@
 Release 0.144.6
 ===============
 
-General changes
----------------
+General
+-------
 
 This release fixes several problems with large and negative intervals.
 

--- a/docs/src/main/sphinx/release/release-0.144.7.rst
+++ b/docs/src/main/sphinx/release/release-0.144.7.rst
@@ -2,8 +2,8 @@
 Release 0.144.7
 ===============
 
-General changes
----------------
+General
+-------
 
 * Fail queries with non-equi conjuncts in ``OUTER JOIN``\s, instead of silently
   dropping such conjuncts from the query and producing incorrect results.

--- a/docs/src/main/sphinx/release/release-0.144.rst
+++ b/docs/src/main/sphinx/release/release-0.144.rst
@@ -7,8 +7,8 @@ Release 0.144
    Querying bucketed tables in the Hive connector may produce incorrect results.
    This is fixed in :doc:`/release/release-0.144.1`, and :doc:`/release/release-0.145`.
 
-General changes
----------------
+General
+-------
 
 * Fix already exists check when adding a column to be case-insensitive.
 * Fix correctness issue when complex grouping operations have a partitioned source.
@@ -24,8 +24,8 @@ General changes
 * Improve performance when processing results in CLI and JDBC driver.
 * Improve performance of ``GROUP BY`` queries.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix ORC reader to actually use ``hive.orc.stream-buffer-size`` configuration property.
 * Add support for creating and inserting into bucketed tables.

--- a/docs/src/main/sphinx/release/release-0.145.rst
+++ b/docs/src/main/sphinx/release/release-0.145.rst
@@ -2,8 +2,8 @@
 Release 0.145
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix potential memory leak in coordinator query history.
 * Fix column resolution issue when qualified name refers to a view.
@@ -22,21 +22,21 @@ General changes
 * Improve reliability in highly congested networks by adjusting the default
   connection idle timeouts.
 
-Verifier changes
-----------------
+Verifier
+--------
 
 * Change verifier to only run read-only queries by default. This behavior can be
   changed with the ``control.query-types`` and ``test.query-types`` config flags.
 
-CLI changes
------------
+CLI
+---
 
 * Improve performance of output in batch mode.
 * Fix hex rendering in batch mode.
 * Abort running queries when CLI is terminated.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix bug when grouping on a bucketed column which causes incorrect results.
 * Add ``max_split_size`` and ``max_initial_split_size`` session properties to control

--- a/docs/src/main/sphinx/release/release-0.146.rst
+++ b/docs/src/main/sphinx/release/release-0.146.rst
@@ -2,16 +2,16 @@
 Release 0.146
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix error in :func:`map_concat` when the second map is empty.
 * Require at least 4096 file descriptors to run Presto.
 * Support casting between map types.
 * Add :doc:`/connector/mongodb`.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix incorrect skipping of data in Parquet during predicate push-down.
 * Fix reading of Parquet maps and lists containing nulls.
@@ -22,12 +22,12 @@ Hive changes
   security system. Specifically, the ``sql-standard`` authorization system
   does not enforce these settings.
 
-Black Hole changes
-------------------
+Black Hole
+----------
 
 * Add support for ``varchar(n)``.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Add support for Cassandra 3.0.

--- a/docs/src/main/sphinx/release/release-0.147.rst
+++ b/docs/src/main/sphinx/release/release-0.147.rst
@@ -2,8 +2,8 @@
 Release 0.147
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix race condition that can cause queries that process data from non-columnar
   data sources to fail.
@@ -32,8 +32,8 @@ General changes
   property replaces the ``task_join_concurrency``, ``task_hash_build_concurrency``, and
   ``task_aggregation_concurrency`` properties.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix reading symlinks when the target is in a different HDFS instance.
 * Fix ``NoClassDefFoundError`` for ``SubnetUtils`` in HDFS client.
@@ -45,19 +45,19 @@ Hive changes
 * Rename table property ``clustered_by`` to ``bucketed_by``.
 * Add support for ``varchar(n)``.
 
-Kafka changes
--------------
+Kafka
+-----
 
 * Fix ``error code 6`` when reading data from Kafka.
 * Add support for ``varchar(n)``.
 
-Redis changes
--------------
+Redis
+-----
 
 * Add support for ``varchar(n)``.
 
-MySQL and PostgreSQL changes
-----------------------------
+MySQL and PostgreSQL
+--------------------
 
 * Cleanup temporary data when a ``CREATE TABLE AS`` fails.
 * Add support for ``varchar(n)``.

--- a/docs/src/main/sphinx/release/release-0.148.rst
+++ b/docs/src/main/sphinx/release/release-0.148.rst
@@ -2,8 +2,8 @@
 Release 0.148
 =============
 
-General changes
----------------
+General
+-------
 * Fix issue where auto-commit transaction can be rolled back for a successfully
   completed query.
 * Fix detection of colocated joins.
@@ -71,15 +71,15 @@ Functions and language features
 * Add support for ``SMALLINT`` and ``TINYINT`` types.
 * Add support for non-equi outer joins.
 
-Verifier changes
-----------------
+Verifier
+--------
 
 * Add ``skip-cpu-check-regex`` config property which can be used to skip the CPU
   time comparison for queries that match the given regex.
 * Add ``check-cpu`` config property which can be used to disable CPU time comparison.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix ``NoClassDefFoundError`` for ``KMSClientProvider`` in HDFS client.
 * Fix creating tables on S3 in an empty database.
@@ -90,29 +90,29 @@ Hive changes
 * Push down filters for columns of type ``DECIMAL``.
 * Improve CPU efficiency when reading ORC files.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Allow configuring load balancing policy and no host available retry.
 * Add support for ``varchar(n)``.
 
-Kafka changes
--------------
+Kafka
+-----
 
 * Update to Kafka client 0.8.2.2. This enables support for LZ4 data.
 
-JMX changes
------------
+JMX
+---
 
 * Add ``jmx.history`` schema with in-memory periodic samples of values from JMX MBeans.
 
-MySQL and PostgreSQL changes
-----------------------------
+MySQL and PostgreSQL
+--------------------
 
 * Push down predicates for ``VARCHAR``, ``DATE``, ``TIME`` and ``TIMESTAMP`` types.
 
-Other connector changes
------------------------
+Other connectors
+----------------
 
 * Add support for ``varchar(n)`` to the Redis, TPCH, MongoDB, Local File
   and Example HTTP connectors.

--- a/docs/src/main/sphinx/release/release-0.149.rst
+++ b/docs/src/main/sphinx/release/release-0.149.rst
@@ -2,8 +2,8 @@
 Release 0.149
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix runtime failure for queries that use grouping sets over unions.
 * Do not ignore null values in :func:`array_agg`.
@@ -32,8 +32,8 @@ General changes
 * Improve performance of subscript operator for the ``MAP`` type.
 * Improve performance of ``JOIN`` and ``GROUP BY`` queries.
 
-Hive changes
-------------
+Hive
+----
 
 * Clean up empty staging directories after inserts.
 * Add ``hive.dfs.ipc-ping-interval`` config for HDFS.

--- a/docs/src/main/sphinx/release/release-0.150.rst
+++ b/docs/src/main/sphinx/release/release-0.150.rst
@@ -8,8 +8,8 @@ Release 0.150
     disable them by adding ``hive.bucket-execution=false`` to your
     Hive catalog properties.
 
-General changes
----------------
+General
+-------
 
 * Fix web UI bug that caused rendering to fail when a stage has no tasks.
 * Fix failure due to ambiguity when calling :func:`round` on ``tinyint`` arguments.
@@ -17,8 +17,8 @@ General changes
 * Add support for parsing timestamps with nanosecond precision in :func:`date_parse`.
 * Add CPU quotas to resource groups.
 
-Hive changes
-------------
+Hive
+----
 
 * Add support for writing to bucketed tables.
 * Add execution optimizations for bucketed tables.

--- a/docs/src/main/sphinx/release/release-0.151.rst
+++ b/docs/src/main/sphinx/release/release-0.151.rst
@@ -2,8 +2,8 @@
 Release 0.151
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix issue where aggregations may produce the wrong result when ``task.concurrency`` is set to ``1``.
 * Fix query failure when ``array``, ``map``, or ``row`` type is used in non-equi ``JOIN``.
@@ -16,14 +16,14 @@ General changes
 * Add :func:`cosine_similarity` function.
 * Allow Tableau web connector to use catalogs other than ``hive``.
 
-Verifier changes
-----------------
+Verifier
+--------
 
 * Add ``shadow-writes.enabled`` option which can be used to transform ``CREATE TABLE AS SELECT``
   queries to write to a temporary table (rather than the originally specified table).
 
-SPI changes
------------
+SPI
+---
 
 * Remove ``getDataSourceName`` from ``ConnectorSplitSource``.
 * Remove ``dataSourceName`` constructor parameter from ``FixedSplitSource``.

--- a/docs/src/main/sphinx/release/release-0.152.1.rst
+++ b/docs/src/main/sphinx/release/release-0.152.1.rst
@@ -2,8 +2,8 @@
 Release 0.152.1
 ===============
 
-General changes
----------------
+General
+-------
 
 * Fix race which could cause failed queries to have no error details.
 * Fix race in HTTP layer which could cause queries to fail.

--- a/docs/src/main/sphinx/release/release-0.152.2.rst
+++ b/docs/src/main/sphinx/release/release-0.152.2.rst
@@ -2,7 +2,7 @@
 Release 0.152.2
 ===============
 
-Hive changes
-------------
+Hive
+----
 
 * Improve performance of ORC reader when decoding dictionary encoded :ref:`map_type`.

--- a/docs/src/main/sphinx/release/release-0.152.3.rst
+++ b/docs/src/main/sphinx/release/release-0.152.3.rst
@@ -2,7 +2,7 @@
 Release 0.152.3
 ===============
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect results for grouping sets when ``task.concurrency`` is greater than one.

--- a/docs/src/main/sphinx/release/release-0.152.rst
+++ b/docs/src/main/sphinx/release/release-0.152.rst
@@ -2,8 +2,8 @@
 Release 0.152
 =============
 
-General changes
----------------
+General
+-------
 
 * Add :func:`array_union` function.
 * Add :func:`reverse` function for arrays.
@@ -19,14 +19,14 @@ General changes
 * Rename ``FLOAT`` type to ``REAL`` for better compatibility with the SQL standard.
 * Fix potential performance regression when transporting rows between nodes.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Fix sizes returned from ``DatabaseMetaData.getColumns()`` for
   ``COLUMN_SIZE``, ``DECIMAL_DIGITS``, ``NUM_PREC_RADIX`` and ``CHAR_OCTET_LENGTH``.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix resource leak in Parquet reader.
 * Rename JMX stat ``AllViews`` to ``GetAllViews`` in ``ThriftHiveMetastore``.
@@ -36,22 +36,22 @@ Hive changes
 * Add support for custom S3 credentials providers using the
   ``presto.s3.credentials-provider`` Hadoop configuration property.
 
-MySQL changes
--------------
+MySQL
+-----
 
 * Fix reading MySQL ``tinyint(1)`` columns. Previously, these columns were
   incorrectly returned as a boolean rather than an integer.
 * Add support for ``INSERT``.
 * Add support for reading data as ``tinyint`` and ``smallint`` types rather than ``integer``.
 
-PostgreSQL changes
-------------------
+PostgreSQL
+----------
 
 * Add support for ``INSERT``.
 * Add support for reading data as ``tinyint`` and ``smallint`` types rather than ``integer``.
 
-SPI changes
------------
+SPI
+---
 
 * Remove ``owner`` from ``ConnectorTableMetadata``.
 * Replace the  generic ``getServices()`` method in ``Plugin`` with specific
@@ -72,12 +72,12 @@ SPI changes
     If you have written a plugin, you will need to update your code
     before deploying this release.
 
-Verifier changes
-----------------
+Verifier
+--------
 
 * Fix handling of shadow write queries with a ``LIMIT``.
 
-Local file changes
-------------------
+Local file
+----------
 
 * Fix file descriptor leak.

--- a/docs/src/main/sphinx/release/release-0.153.rst
+++ b/docs/src/main/sphinx/release/release-0.153.rst
@@ -2,8 +2,8 @@
 Release 0.153
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect results for grouping sets when ``task.concurrency`` is greater than one.
 * Fix silent numeric overflow when casting ``INTEGER`` to large ``DECIMAL`` types.
@@ -60,8 +60,8 @@ configuration file by setting the ``resource-groups.configuration-manager``
 property. See the ``presto-resource-group-managers`` plugin for an example
 and :doc:`/admin/resource-groups` for more details.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix rendering failures due to null nested data structures.
 * Do not include coordinator in active worker count on cluster overview page.
@@ -70,18 +70,18 @@ Web UI changes
 * Add option to filter task lists by status on query details page.
 * Add copy button for query text, query ID, and user to query details page.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Add support for ``real`` data type, which corresponds to the Java ``float`` type.
 
-CLI changes
------------
+CLI
+---
 
 * Add support for configuring the HTTPS Truststore.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix permissions for new tables when using SQL-standard authorization.
 * Improve performance of ORC reader when decoding dictionary encoded :ref:`map_type`.
@@ -117,31 +117,31 @@ Hive changes
 * Allow configuring a custom S3 encryption materials provider using the
   ``hive.s3.encryption-materials-provider`` configuration property.
 
-JMX changes
------------
+JMX
+---
 
 * Make name configuration for history tables case-insensitive.
 
-MySQL changes
--------------
+MySQL
+-----
 
 * Optimize fetching column names when describing a single table.
 * Add support for ``char(x)`` and ``real`` data types.
 
-PostgreSQL changes
-------------------
+PostgreSQL
+----------
 
 * Optimize fetching column names when describing a single table.
 * Add support for ``char(x)`` and ``real`` data types.
 * Add support for querying materialized views.
 
-Blackhole changes
------------------
+Blackhole
+---------
 
 * Add ``page_processing_delay`` table property.
 
-SPI changes
------------
+SPI
+---
 
 * Add ``schemaExists()`` method to ``ConnectorMetadata``.
 * Add transaction to grant/revoke in ``ConnectorAccessControl``.

--- a/docs/src/main/sphinx/release/release-0.154.rst
+++ b/docs/src/main/sphinx/release/release-0.154.rst
@@ -2,8 +2,8 @@
 Release 0.154
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix planning issue that could cause ``JOIN`` queries involving functions
   that return null on non-null input to produce incorrect results.
@@ -22,8 +22,8 @@ General changes
 * Add support for ``DESCRIBE INPUT`` to describe the requirements for
   the input parameters to a prepared statement.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix handling of metastore cache TTL. With the introduction of the
   per-transaction cache, the cache timeout was reset after each access,

--- a/docs/src/main/sphinx/release/release-0.155.rst
+++ b/docs/src/main/sphinx/release/release-0.155.rst
@@ -2,8 +2,8 @@
 Release 0.155
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect results when queries contain multiple grouping sets that
   resolve to the same set.
@@ -20,15 +20,15 @@ General changes
 * Properly account for time spent creating page source.
 * Various optimizations to reduce coordinator CPU usage.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix schema evolution support in new Parquet reader.
 * Fix ``NoClassDefFoundError`` when using Hadoop KMS.
 * Add support for Avro file format.
 * Always produce dictionary blocks for DWRF dictionary encoded streams.
 
-SPI changes
------------
+SPI
+---
 
 * Remove legacy connector API.

--- a/docs/src/main/sphinx/release/release-0.156.rst
+++ b/docs/src/main/sphinx/release/release-0.156.rst
@@ -8,8 +8,8 @@ Release 0.156
     if the ``optimize_mixed_distinct_aggregations`` session property or
     the ``optimizer.optimize-mixed-distinct-aggregations`` config option is enabled.
 
-General changes
----------------
+General
+-------
 
 * Fix potential correctness issue in queries that contain correlated scalar aggregation subqueries.
 * Fix query failure when using ``AT TIME ZONE`` in ``VALUES`` list.
@@ -24,18 +24,18 @@ General changes
   via the ``optimize_mixed_distinct_aggregations`` session property.
 * Change default task concurrency to 16.
 
-Hive changes
-------------
+Hive
+----
 
 * Add support for legacy RCFile header version in new RCFile reader.
 
-Redis changes
--------------
+Redis
+-----
 
 * Support ``iso8601`` data format for the ``hash`` row decoder.
 
-SPI changes
------------
+SPI
+---
 
 * Make ``ConnectorPageSink#finish()`` asynchronous.
 

--- a/docs/src/main/sphinx/release/release-0.157.1.rst
+++ b/docs/src/main/sphinx/release/release-0.157.1.rst
@@ -2,8 +2,8 @@
 Release 0.157.1
 ===============
 
-General changes
----------------
+General
+-------
 
 * Fix regression that could cause high CPU and heap usage on coordinator,
   when processing certain types of long running queries.

--- a/docs/src/main/sphinx/release/release-0.157.rst
+++ b/docs/src/main/sphinx/release/release-0.157.rst
@@ -2,8 +2,8 @@
 Release 0.157
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix regression that could cause queries containing scalar subqueries to fail
   during planning.
@@ -18,8 +18,8 @@ General changes
   ``node-scheduler.max-pending-splits-per-task``. The old name may still be used, but is
   deprecated and will be removed in a future version.
 
-Hive changes
-------------
+Hive
+----
 
 * Fail attempts to create tables that are bucketed on non-existent columns.
 * Improve error message when trying to query tables that are bucketed on non-existent columns.

--- a/docs/src/main/sphinx/release/release-0.158.rst
+++ b/docs/src/main/sphinx/release/release-0.158.rst
@@ -2,8 +2,8 @@
 Release 0.158
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix regression that could cause high CPU and heap usage on coordinator
   when processing certain types of long running queries.
@@ -21,8 +21,8 @@ General changes
   the ``experimental.spill-enabled`` configuration flag.
 * Push down predicates for ``DECIMAL``, ``TINYINT``, ``SMALLINT`` and ``REAL`` data types.
 
-Hive changes
-------------
+Hive
+----
 
 * Add hidden ``$bucket`` column for bucketed tables that
   contains the bucket number for the current row.
@@ -30,7 +30,7 @@ Hive changes
 * Add configurable size limit to Hive metastore cache to avoid using too much
   coordinator memory.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Allow starting the server even if a contact point hostname cannot be resolved.

--- a/docs/src/main/sphinx/release/release-0.159.rst
+++ b/docs/src/main/sphinx/release/release-0.159.rst
@@ -2,13 +2,13 @@
 Release 0.159
 =============
 
-General changes
----------------
+General
+-------
 
 * Improve predicate performance for ``JOIN`` queries.
 
-Hive changes
-------------
+Hive
+----
 
 * Optimize filtering of partition names to reduce object creation.
 * Add limit on the number of partitions that can potentially be read per table scan.

--- a/docs/src/main/sphinx/release/release-0.160.rst
+++ b/docs/src/main/sphinx/release/release-0.160.rst
@@ -2,8 +2,8 @@
 Release 0.160
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix planning failure when query has multiple unions with identical underlying columns.
 * Fix planning failure when multiple ``IN`` predicates contain an identical subquery.
@@ -11,8 +11,8 @@ General changes
   comes back before coordinator times out the query.
 * Add :doc:`/functions/lambda`.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix planning failure when inserting into columns of struct types with uppercase field names.
 * Fix resource leak when using Kerberos authentication with impersonation.

--- a/docs/src/main/sphinx/release/release-0.161.rst
+++ b/docs/src/main/sphinx/release/release-0.161.rst
@@ -2,8 +2,8 @@
 Release 0.161
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix correctness issue for queries involving multiple nested EXCEPT clauses.
   A query such as ``a EXCEPT (b EXCEPT c)`` was incorrectly evaluated as

--- a/docs/src/main/sphinx/release/release-0.162.rst
+++ b/docs/src/main/sphinx/release/release-0.162.rst
@@ -7,8 +7,8 @@ Release 0.162
     The :func:`xxhash64` function introduced in this release will return a
     varbinary instead of a bigint in the next release.
 
-General changes
----------------
+General
+-------
 
 * Fix correctness issue when the type of the value in the ``IN`` predicate does
   not match the type of the elements in the subquery.
@@ -26,13 +26,13 @@ General changes
 * Add aggregated operator statistics to final query statistics.
 * Allow specifying column comments for :doc:`/sql/create-table`.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix performance regression when querying Hive tables with large numbers of partitions.
 
-SPI changes
------------
+SPI
+---
 
 * Connectors can now return optional output metadata for write operations.
 * Add ability for event listeners to get connector-specific output metadata.

--- a/docs/src/main/sphinx/release/release-0.163.rst
+++ b/docs/src/main/sphinx/release/release-0.163.rst
@@ -2,8 +2,8 @@
 Release 0.163
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix data corruption when transporting dictionary-encoded data.
 * Fix potential deadlock when resource groups are configured with memory limits.
@@ -20,23 +20,23 @@ General changes
 * Improve tolerance to communication errors for long running queries. This can be adjusted
   with the ``query.remote-task.max-error-duration`` config option.
 
-Accumulo changes
-----------------
+Accumulo
+--------
 
 * Fix issue that could cause incorrect results for large rows.
 
-MongoDB changes
----------------
+MongoDB
+-------
 
 * Fix NullPointerException when a field contains a null.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Add support for ``VARBINARY``, ``TIMESTAMP`` and ``REAL`` data types.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix issue that would prevent predicates from being pushed into Parquet reader.
 * Fix Hive metastore user permissions caching when tables are dropped or renamed.

--- a/docs/src/main/sphinx/release/release-0.164.rst
+++ b/docs/src/main/sphinx/release/release-0.164.rst
@@ -2,8 +2,8 @@
 Release 0.164
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix correctness issue for queries that perform ``DISTINCT`` and ``LIMIT`` on the results of a ``JOIN``.
 * Fix correctness issue when casting between maps where the key or value is the ``REAL`` type.
@@ -19,13 +19,13 @@ General changes
 * Improve client error message for invalid session.
 * Add ``VALIDATE`` mode for :doc:`/sql/explain`.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Add resource group to query detail page.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix handling of ORC files containing extremely large metadata.
 * Fix failure when creating views in file based metastore.

--- a/docs/src/main/sphinx/release/release-0.165.rst
+++ b/docs/src/main/sphinx/release/release-0.165.rst
@@ -2,8 +2,8 @@
 Release 0.165
 =============
 
-General changes
----------------
+General
+-------
 
 * Make ``AT`` a non-reserved keyword.
 * Improve performance of :func:`transform`.
@@ -12,12 +12,12 @@ General changes
   config option.
 * Add input and hash collision statistics to :doc:`/sql/explain-analyze` output.
 
-Hive changes
-------------
+Hive
+----
 
 * Add support for MAP and ARRAY types in optimized Parquet reader.
 
-MySQL and PostgreSQL changes
-----------------------------
+MySQL and PostgreSQL
+--------------------
 
 * Fix connection leak on workers.

--- a/docs/src/main/sphinx/release/release-0.166.rst
+++ b/docs/src/main/sphinx/release/release-0.166.rst
@@ -2,8 +2,8 @@
 Release 0.166
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix failure due to implicit coercion issue in ``IN`` expressions for
   certain combinations of data types (e.g., ``double`` and ``decimal``).
@@ -11,18 +11,18 @@ General changes
   The default maximum length is 1MB.
 * Improve performance of :func:`approx_percentile`.
 
-Hive changes
-------------
+Hive
+----
 
 * Include original exception from metastore for ``AlreadyExistsException`` when adding partitions.
 * Add support for the Hive JSON file format (``org.apache.hive.hcatalog.data.JsonSerDe``).
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Add configuration properties for speculative execution.
 
-SPI changes
------------
+SPI
+---
 
 * Add peak memory reservation to ``SplitStatistics`` in split completion events.

--- a/docs/src/main/sphinx/release/release-0.167.rst
+++ b/docs/src/main/sphinx/release/release-0.167.rst
@@ -2,8 +2,8 @@
 Release 0.167
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix planning failure when a window function depends on the output of another window function.
 * Fix planning failure for certain aggregation with both ``DISTINCT`` and ``GROUP BY``.
@@ -21,8 +21,8 @@ General changes
 * Add JMX stats for compiler caches.
 * Raise required Java version to 8u92.
 
-Security changes
-----------------
+Security
+--------
 
 * The ``http.server.authentication.enabled`` config option that previously enabled
   Kerberos has been replaced with ``http-server.authentication.type=KERBEROS``.
@@ -31,20 +31,20 @@ Security changes
 * Allow access controls to filter the results of listing catalogs, schemas and tables.
 * Add access control checks for :doc:`/sql/show-schemas` and :doc:`/sql/show-tables`.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Add operator-level performance analysis.
 * Improve visibility of blocked and reserved query states.
 * Lots of minor improvements.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Allow escaping in ``DatabaseMetaData`` patterns.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix write operations for ``ViewFileSystem`` by using a relative location.
 * Remove support for the ``hive-cdh4`` and ``hive-hadoop1`` connectors which
@@ -53,16 +53,16 @@ Hive changes
 * Remove support for the legacy S3 block-based file system.
 * Add support for KMS-managed keys for S3 server-side encryption.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Add support for Cassandra 3.x by removing the deprecated Thrift interface used to
   connect to Cassandra. The following config options are now defunct and must be removed:
   ``cassandra.thrift-port``, ``cassandra.thrift-connection-factory-class``,
   ``cassandra.transport-factory-options`` and ``cassandra.partitioner``.
 
-SPI changes
------------
+SPI
+---
 
 * Add methods to ``SystemAccessControl`` and ``ConnectorAccessControl`` to
   filter the list of catalogs, schemas and tables.

--- a/docs/src/main/sphinx/release/release-0.168.rst
+++ b/docs/src/main/sphinx/release/release-0.168.rst
@@ -2,8 +2,8 @@
 Release 0.168
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix correctness issues for certain ``JOIN`` queries that require implicit coercions
   for terms in the join criteria.
@@ -26,15 +26,15 @@ General changes
   This allows using them in comparison expressions, ``ORDER BY`` and
   functions that require orderable types (e.g., :func:`max`).
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Update ``DatabaseMetaData`` to reflect features that are now supported.
 * Update advertised JDBC version to 4.2, which part of Java 8.
 * Return correct driver and server versions rather than ``1.0``.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix reading decimals for RCFile text format using non-optimized reader.
 * Fix bug which prevented the file based metastore from being used.
@@ -44,18 +44,18 @@ Hive changes
   ``rcfile_optimized_writer_enabled`` session property or the ``hive.rcfile-optimized-writer.enabled``
   Hive catalog property.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Add predicate pushdown for clustering key.
 
-MongoDB changes
----------------
+MongoDB
+-------
 
 * Allow SSL connections using the ``mongodb.ssl.enabled`` config flag.
 
-SPI changes
------------
+SPI
+---
 
 * ConnectorIndex now returns ``ConnectorPageSource`` instead of ``RecordSet``.  Existing connectors
   that support index join can use the ``RecordPageSource`` to adapt to the new API.

--- a/docs/src/main/sphinx/release/release-0.169.rst
+++ b/docs/src/main/sphinx/release/release-0.169.rst
@@ -2,8 +2,8 @@
 Release 0.169
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix regression that could cause queries involving ``JOIN`` and certain language features
   such as ``current_date``, ``current_time`` or ``extract`` to fail during planning.
@@ -11,17 +11,17 @@ General changes
 * Improve performance of :func:`map_agg` and :func:`multimap_agg`.
 * Improve memory accounting when grouping on a single ``BIGINT`` column.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Return correct class name for ``ARRAY`` type from ``ResultSetMetaData.getColumnClassName()``.
 
-CLI changes
------------
+CLI
+---
 
 * Fix support for non-standard offset time zones (e.g., ``GMT+01:00``).
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Add custom error codes.

--- a/docs/src/main/sphinx/release/release-0.170.rst
+++ b/docs/src/main/sphinx/release/release-0.170.rst
@@ -2,33 +2,33 @@
 Release 0.170
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix race condition that could cause queries to fail with ``InterruptedException`` in rare cases.
 * Fix a performance regression for ``GROUP BY`` queries over ``UNION``.
 * Fix a performance regression that occurs when a significant number of exchange
   sources produce no data during an exchange (e.g., in a skewed hash join).
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix broken rendering when catalog properties are set.
 * Fix rendering of live plan when query is queued.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Add support for ``DatabaseMetaData.getTypeInfo()``.
 
-Hive changes
-------------
+Hive
+----
 
 * Improve decimal support for the Parquet reader.
 * Remove misleading "HDFS" string from error messages.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Fix an intermittent connection issue for Cassandra 2.1.
 * Remove support for selecting by partition key when the partition key is only partially specified.
@@ -40,7 +40,7 @@ Cassandra changes
   ``cassandra.no-host-available-retry-timeout`` config option, which has a default value of ``1m``.
   The ``cassandra.no-host-available-retry-count`` config option is no longer supported.
 
-Verifier changes
-----------------
+Verifier
+--------
 
 * Add support for ``INSERT`` queries.

--- a/docs/src/main/sphinx/release/release-0.171.rst
+++ b/docs/src/main/sphinx/release/release-0.171.rst
@@ -2,8 +2,8 @@
 Release 0.171
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix planning regression for queries that compute a mix of distinct and non-distinct aggregations.
 * Fix casting from certain complex types to ``JSON`` when source type contains ``JSON`` or ``DECIMAL``.
@@ -16,13 +16,13 @@ General changes
 * Improve validation of resource group configuration.
 * Fail queries when casting unsupported types to JSON; see :doc:`/functions/json` for supported types.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix the threads UI (``/ui/thread``).
 
-Hive changes
-------------
+Hive
+----
 
 * Fix issue where some files are not deleted on cancellation of ``INSERT`` or ``CREATE`` queries.
 * Allow writing to non-managed (external) Hive tables. This is disabled by default but can be

--- a/docs/src/main/sphinx/release/release-0.172.rst
+++ b/docs/src/main/sphinx/release/release-0.172.rst
@@ -2,8 +2,8 @@
 Release 0.172
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix correctness issue in ``ORDER BY`` queries due to improper implicit coercions.
 * Fix planning failure when ``GROUP BY`` queries contain lambda expressions.

--- a/docs/src/main/sphinx/release/release-0.173.rst
+++ b/docs/src/main/sphinx/release/release-0.173.rst
@@ -2,8 +2,8 @@
 Release 0.173
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix issue where ``FILTER`` was ignored for :func:`count` with a constant argument.
 * Support table comments for :doc:`/sql/create-table` and :doc:`/sql/create-table-as`.

--- a/docs/src/main/sphinx/release/release-0.174.rst
+++ b/docs/src/main/sphinx/release/release-0.174.rst
@@ -2,8 +2,8 @@
 Release 0.174
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix correctness issue for correlated subqueries containing a ``LIMIT`` clause.
 * Fix query failure when :func:`reduce` function is used with lambda expressions
@@ -24,20 +24,20 @@ General changes
 * Add support for escaped unicode sequences in string literals.
 * Add :doc:`/sql/show-grants` and ``information_schema.table_privileges`` table.
 
-Hive changes
-------------
+Hive
+----
 
 * Change default value of ``hive.metastore-cache-ttl`` and ``hive.metastore-refresh-interval`` to 0
   to disable cross-transaction metadata caching.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix ES6 compatibility issue with older browsers.
 * Display buffered bytes for every stage in the live plan UI.
 
-SPI changes
------------
+SPI
+---
 
 * Add support for retrieving table grants.
 * Rename SPI access control check from ``checkCanShowTables`` to ``checkCanShowTablesMetadata``,

--- a/docs/src/main/sphinx/release/release-0.175.rst
+++ b/docs/src/main/sphinx/release/release-0.175.rst
@@ -2,8 +2,8 @@
 Release 0.175
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix *"position is not valid"* query execution failures.
 * Fix memory accounting bug that can potentially cause ``OutOfMemoryError``.
@@ -24,13 +24,13 @@ General changes
 * Add support for ``INT`` as an alias for the ``INTEGER`` data type.
 * Add resource group information to query events.
 
-Hive changes
-------------
+Hive
+----
 
 * Make table creation metastore operations idempotent, which allows
   recovery when retrying timeouts or other errors.
 
-MongoDB changes
----------------
+MongoDB
+-------
 
 * Rename ``mongodb.connection-per-host`` config option to ``mongodb.connections-per-host``.

--- a/docs/src/main/sphinx/release/release-0.176.rst
+++ b/docs/src/main/sphinx/release/release-0.176.rst
@@ -2,8 +2,8 @@
 Release 0.176
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix an issue where a query (and some of its tasks) continues to
   consume CPU/memory on the coordinator and workers after the query fails.
@@ -13,17 +13,17 @@ General changes
 * Add support for casting from ``JSON`` to ``REAL`` type.
 * Add :func:`parse_duration` function.
 
-MySQL changes
--------------
+MySQL
+-----
 
 * Disallow having a database in the ``connection-url`` config property.
 
-Accumulo changes
-----------------
+Accumulo
+--------
 
 * Decrease planning time by fetching index metrics in parallel.
 
-MongoDB changes
----------------
+MongoDB
+-------
 
 * Allow predicate pushdown for ObjectID.

--- a/docs/src/main/sphinx/release/release-0.177.rst
+++ b/docs/src/main/sphinx/release/release-0.177.rst
@@ -9,8 +9,8 @@ Release 0.177
     the ``optimizer.optimize-mixed-distinct-aggregations`` config option is enabled.
     This optimization was introduced in Presto version 0.156.
 
-General changes
----------------
+General
+-------
 
 * Fix correctness issue when performing range comparisons over columns of type ``CHAR``.
 * Fix correctness issue due to mishandling of nulls and non-deterministic expressions in
@@ -39,8 +39,8 @@ General changes
 * Improve error message when a lambda expression has a different number of arguments than expected.
 * Improve error message when certain invalid ``GROUP BY`` expressions containing lambda expressions.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix handling of trailing spaces for the ``CHAR`` type when reading RCFile.
 * Allow inserts into tables that have more partitions than the partitions-per-scan limit.
@@ -48,8 +48,8 @@ Hive changes
   can be turned on via the ``statistics_enabled`` session property.
 * Ensure file name is always present for error messages about corrupt ORC files.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Remove caching of metadata in the Cassandra connector. Metadata caching makes Presto violate
   the consistency defined by the Cassandra cluster. It's also unnecessary because the Cassandra
@@ -58,8 +58,8 @@ Cassandra changes
   been removed.
 * Fix intermittent issue in the connection retry mechanism.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Change cluster HUD realtime statistics to be aggregated across all running queries.
 * Change parallelism statistic on cluster HUD to be averaged per-worker.
@@ -69,8 +69,8 @@ Web UI changes
 * Change query details page refresh interval to three seconds.
 * Add uptime and connected status indicators to every page.
 
-CLI changes
------------
+CLI
+---
 
 * Add support for preprocessing commands.  When the ``PRESTO_PREPROCESSOR`` environment
   variable is set, all commands are piped through the specified program before being sent to

--- a/docs/src/main/sphinx/release/release-0.178.rst
+++ b/docs/src/main/sphinx/release/release-0.178.rst
@@ -2,8 +2,8 @@
 Release 0.178
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix various memory accounting bugs, which reduces the likelihood of full GCs/OOMs.
 * Fix a regression that causes queries that use the keyword "stats" to fail to parse.
@@ -13,19 +13,19 @@ General changes
 * Add support for correlated subqueries in ``IN`` predicates.
 * Add :func:`to_ieee754_32` and :func:`to_ieee754_64` functions.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix high CPU usage due to schema caching when reading Avro files.
 * Preserve decompression error causes when decoding ORC files.
 
-Memory connector changes
-------------------------
+Memory connector
+----------------
 
 * Fix a bug that prevented creating empty tables.
 
-SPI changes
------------
+SPI
+---
 
 * Make environment available to resource group configuration managers.
 * Add additional performance statistics to query completion event.

--- a/docs/src/main/sphinx/release/release-0.179.rst
+++ b/docs/src/main/sphinx/release/release-0.179.rst
@@ -2,8 +2,8 @@
 Release 0.179
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix issue which could cause incorrect results when processing dictionary encoded data.
   If the expression can fail on bad input, the results from filtered-out rows containing
@@ -24,17 +24,17 @@ General changes
   for more details.
 * Add support for configuring query runtime and queueing time limits to resource groups.
 
-Hive changes
-------------
+Hive
+----
 
 * Fail queries that access encrypted S3 objects that do not have their unencrypted content lengths set in their metadata.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Add support for setting query timeout through ``Statement.setQueryTimeout()``.
 
-SPI changes
------------
+SPI
+---
 
 * Add grantee and revokee to ``GRANT`` and ``REVOKE`` security checks.

--- a/docs/src/main/sphinx/release/release-0.180.rst
+++ b/docs/src/main/sphinx/release/release-0.180.rst
@@ -2,8 +2,8 @@
 Release 0.180
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix a rare bug where rows containing only ``null`` values are not returned
   to the client. This only occurs when an entire result page contains only
@@ -25,8 +25,8 @@ General changes
   external systems without the need to implement a custom connector.
 * Add experimental ``/v1/resourceGroupState`` REST endpoint on coordinator.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix skipping short decimal values in the optimized Parquet reader
   when they are backed by the ``int32`` or ``int64`` types.
@@ -39,25 +39,25 @@ Hive changes
   writing. Validation is disabled by default, but can be enabled with the
   ``hive.rcfile.writer.validate`` config option.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Add support for ``INSERT``.
 * Add support for pushdown of non-equality predicates on clustering keys.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Add support for authenticating using Kerberos.
 * Allow configuring SSL/TLS and Kerberos properties on a per-connection basis.
 * Add support for executing queries using a SOCKS or HTTP proxy.
 
-CLI changes
------------
+CLI
+---
 
 * Add support for executing queries using an HTTP proxy.
 
-SPI changes
------------
+SPI
+---
 
 * Add running time limit and queued time limit to ``ResourceGroupInfo``.

--- a/docs/src/main/sphinx/release/release-0.181.rst
+++ b/docs/src/main/sphinx/release/release-0.181.rst
@@ -2,8 +2,8 @@
 Release 0.181
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix query failure and memory usage tracking when query contains
   :func:`transform_keys` or :func:`transform_values`.
@@ -36,31 +36,31 @@ General changes
   has an effect when ``task.level-absolute-priority=true`` and
   ``task.legacy-scheduling-behavior=false``.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix potential native memory leak when writing tables using RCFile.
 * Correctly categorize certain errors when writing tables using RCFile.
 * Decrease the number of file system metadata calls when reading tables.
 * Add support for dropping columns.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Add support for query cancellation using ``Statement.cancel()``.
 
-PostgreSQL changes
-------------------
+PostgreSQL
+----------
 
 * Add support for operations on external tables.
 
-Accumulo changes
-----------------
+Accumulo
+--------
 
 * Improve query performance by scanning index ranges in parallel.
 
-SPI changes
------------
+SPI
+---
 
 * Fix regression that broke serialization for ``SchemaTableName``.
 * Add access control check for ``DROP COLUMN``.

--- a/docs/src/main/sphinx/release/release-0.182.rst
+++ b/docs/src/main/sphinx/release/release-0.182.rst
@@ -2,8 +2,8 @@
 Release 0.182
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix correctness issue that causes :func:`corr` to return positive numbers for inverse correlations.
 * Fix the :doc:`/sql/explain` query plan for tables that are partitioned
@@ -25,13 +25,13 @@ General changes
 * Add :doc:`/connector/tpcds`. This connector provides a set of schemas to
   support the TPC Benchmark™ DS (TPC-DS).
 
-CLI changes
------------
+CLI
+---
 
 * Fix an issue that would sometimes prevent queries from being cancelled when exiting from the pager.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix reading decimal values in the optimized Parquet reader when they are backed
   by the ``int32`` or ``int64`` types.

--- a/docs/src/main/sphinx/release/release-0.183.rst
+++ b/docs/src/main/sphinx/release/release-0.183.rst
@@ -2,8 +2,8 @@
 Release 0.183
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix planning failure for queries that use ``GROUPING`` and contain aggregation expressions
   that require implicit coercions.
@@ -25,13 +25,13 @@ General changes
   from disk using the ``experimental.aggregation-operator-unspill-memory-limit`` config
   property or the ``aggregation_operator_unspill_memory_limit`` session property.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Add output rows, output size, written rows and written size to query detail page.
 
-Hive changes
-------------
+Hive
+----
 
 * Work around `ORC-222 <https://issues.apache.org/jira/browse/ORC-222>`_ which results in
   invalid summary statistics in ORC or DWRF files when the input data contains invalid string data.
@@ -42,18 +42,18 @@ Hive changes
 * Improve error message for small ORC files that are completely corrupt or not actually ORC.
 * Add predicate pushdown for the hidden column ``"$path"``.
 
-TPCH changes
-------------
+TPCH
+----
 
 * Add column statistics for schemas ``tiny`` and ``sf1``.
 
-TPCDS changes
--------------
+TPCDS
+-----
 
 * Add column statistics for schemas ``tiny`` and ``sf1``.
 
-SPI changes
------------
+SPI
+---
 
 * Map columns or values represented with ``ArrayBlock`` and ``InterleavedBlock`` are
   no longer supported. They must be represented as ``MapBlock`` or ``SingleMapBlock``.

--- a/docs/src/main/sphinx/release/release-0.184.rst
+++ b/docs/src/main/sphinx/release/release-0.184.rst
@@ -2,8 +2,8 @@
 Release 0.184
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix query execution failure for ``split_to_map(...)[...]``.
 * Fix issue that caused queries containing ``CROSS JOIN`` to continue using CPU resources
@@ -17,32 +17,32 @@ General changes
 * Require ``coalesce()`` to have at least two arguments, as mandated by the SQL standard.
 * Add :func:`hamming_distance` function.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Always invoke the progress callback with the final stats at query completion.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Add worker status page with information about currently running threads
   and resource utilization (CPU, heap, memory pools). This page is accessible
   by clicking a hostname on a query task list.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix partition filtering for keys of ``CHAR``, ``DECIMAL``, or ``DATE`` type.
 * Reduce system memory usage when reading table columns containing string values
   from ORC or DWRF files. This can prevent high GC overhead or out-of-memory crashes.
 
-TPCDS changes
--------------
+TPCDS
+-----
 
 * Fix display of table statistics when running ``SHOW STATS FOR ...``.
 
-SPI changes
------------
+SPI
+---
 
 * Row columns or values represented with ``ArrayBlock`` and ``InterleavedBlock`` are
   no longer supported. They must be represented as ``RowBlock`` or ``SingleRowBlock``.

--- a/docs/src/main/sphinx/release/release-0.185.rst
+++ b/docs/src/main/sphinx/release/release-0.185.rst
@@ -2,8 +2,8 @@
 Release 0.185
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect column names in ``QueryCompletedEvent``.
 * Fix excessive CPU usage in coordinator for queries that have
@@ -23,15 +23,15 @@ General changes
 * Add cast from ``JSON`` to ``ROW``.
 * Allow usage of ``TRY`` within lambda expressions.
 
-Hive changes
-------------
+Hive
+----
 
 * Improve ORC reader efficiency by only reading small ORC streams when accessed in the query.
 * Improve RCFile IO efficiency by increasing the buffer size from 1 to 8 MB.
 * Fix native memory leak for optimized RCFile writer.
 * Fix potential native memory leak for optimized ORC writer.
 
-Memory connector changes
-------------------------
+Memory connector
+----------------
 
 * Add support for views.

--- a/docs/src/main/sphinx/release/release-0.186.rst
+++ b/docs/src/main/sphinx/release/release-0.186.rst
@@ -7,8 +7,8 @@ Release 0.186
     This release has a stability issue that may cause query failures in large deployments
     due to HTTP requests timing out.
 
-General changes
----------------
+General
+-------
 
 * Fix excessive GC overhead caused by map to map cast.
 * Fix implicit coercions for ``ROW`` types, allowing operations between
@@ -31,8 +31,8 @@ General changes
 * Add :doc:`/admin/spill` for joins.
 * Add :doc:`/connector/redshift`.
 
-Resource groups changes
------------------------
+Resource groups
+---------------
 
 * Query Queues are deprecated in favor of :doc:`/admin/resource-groups`
   and will be removed in a future release.
@@ -40,21 +40,21 @@ Resource groups changes
   property name is deprecated and will be removed in a future release.
 * Fail on unknown property names when loading the JSON config file.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Allow specifying an empty password.
 * Add ``getQueuedTimeMillis()`` and ``getElapsedTimeMillis()`` to ``QueryStats``.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix ``FileSystem closed`` errors when using Kerberos authentication.
 * Add support for path style access to the S3 file system. This can be enabled
   by setting the ``hive.s3.path-style-access=true`` config property.
 
-SPI changes
------------
+SPI
+---
 
 * Add an ``ignoreExisting`` flag to ``ConnectorMetadata::createTable()``.
 * Remove the ``getTotalBytes()`` method from ``RecordCursor`` and ``ConnectorPageSource``.

--- a/docs/src/main/sphinx/release/release-0.187.rst
+++ b/docs/src/main/sphinx/release/release-0.187.rst
@@ -2,8 +2,8 @@
 Release 0.187
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix a stability issue that may cause query failures due to a large number of HTTP requests timing out.
   The issue has been observed in a large deployment under stress.

--- a/docs/src/main/sphinx/release/release-0.188.rst
+++ b/docs/src/main/sphinx/release/release-0.188.rst
@@ -2,8 +2,8 @@
 Release 0.188
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix handling of negative start indexes in array :func:`slice` function.
 * Fix inverted sign for time zones ``Etc/GMT-12``, ``Etc/GMT-11``, ..., ``Etc/GMT-1``,
@@ -20,27 +20,27 @@ General changes
 * Mitigate performance issue caused by JVM when generated code is used
   for multiple hours or days.
 
-CLI changes
------------
+CLI
+---
 
 * Fix transaction support. Previously, after the first statement in the
   transaction, the transaction would be abandoned and the session would
   silently revert to auto-commit mode.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Support using ``Statement.cancel()`` for all types of statements.
 
-Resource group changes
-----------------------
+Resource group
+--------------
 
 * Add environment support to the ``db`` resource groups manager.
   Previously, configurations for different clusters had to be stored in separate databases.
   With this change, different cluster configurations can be stored in the same table and
   Presto will use the new ``environment`` column to differentiate them.
 
-SPI changes
------------
+SPI
+---
 
 * Add query plan to the query completed event.

--- a/docs/src/main/sphinx/release/release-0.189.rst
+++ b/docs/src/main/sphinx/release/release-0.189.rst
@@ -2,8 +2,8 @@
 Release 0.189
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix query failure while logging the query plan.
 * Fix a bug that causes clients to hang when executing ``LIMIT`` queries when
@@ -20,8 +20,8 @@ General changes
   field in the ``ROW``.
 * Add support for dereferencing row fields in lambda expressions.
 
-Security changes
-----------------
+Security
+--------
 
 * Support configuring multiple authentication types, which allows supporting
   clients that have different authentication requirements or gracefully
@@ -37,8 +37,8 @@ Security changes
   yet supported).
 * Skip sending final leg of SPNEGO authentication when using Kerberos.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Per the JDBC specification, close the ``ResultSet`` when ``Statement`` is closed.
 * Add support for TLS client certificate authentication by configuring the
@@ -49,13 +49,13 @@ JDBC driver changes
   to use ``setCatalog()`` and ``setSchema()`` on ``Connection`` is recommended.
 * Allow executing ``SET SESSION`` and ``RESET SESSION``.
 
-Resource group changes
-----------------------
+Resource group
+--------------
 
 * Add ``WEIGHTED_FAIR`` resource group scheduling policy.
 
-Hive changes
-------------
+Hive
+----
 
 * Do not require setting ``hive.metastore.uri`` when using the file metastore.
 * Reduce memory usage when reading string columns from ORC or DWRF files.
@@ -67,18 +67,18 @@ MySQL, PostgreSQL, Redshift, and SQL Server shanges
 * Change mapping for columns with ``DECIMAL(p,s)`` data type from Presto ``DOUBLE``
   type to the corresponding Presto ``DECIMAL`` type.
 
-Kafka changes
--------------
+Kafka
+-----
 
 * Fix documentation for raw decoder.
 
-Thrift connector changes
-------------------------
+Thrift connector
+----------------
 
 * Add support for index joins.
 
-SPI changes
------------
+SPI
+---
 
 * Deprecate ``SliceArrayBlock``.
 * Add ``SessionPropertyConfigurationManager`` plugin to enable overriding default

--- a/docs/src/main/sphinx/release/release-0.190.rst
+++ b/docs/src/main/sphinx/release/release-0.190.rst
@@ -2,8 +2,8 @@
 Release 0.190
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix correctness issue for :func:`array_min` and :func:`array_max` when arrays contain ``NaN``.
 * Fix planning failure for queries involving ``GROUPING`` that require implicit coercions
@@ -29,29 +29,29 @@ General changes
   config property or the ``parse_decimal_literals_as_double`` session property to ``false``.
 * Add JMX counter to track the number of submitted queries.
 
-Resource groups changes
------------------------
+Resource groups
+---------------
 
 * Add priority column to the DB resource group selectors.
 * Add exact match source selector to the DB resource group selectors.
 
-CLI changes
------------
+CLI
+---
 
 * Add support for setting client tags.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Add ``getPeakMemoryBytes()`` to ``QueryStats``.
 
-Accumulo changes
-----------------
+Accumulo
+--------
 
 * Improve table scan parallelism.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix query failures for the file-based metastore implementation when partition
   column values contain a colon.
@@ -62,14 +62,14 @@ Hive changes
   the default value is substantially higher than the previous hard-coded limit,
   which can prevent certain queries from failing.
 
-Thrift connector changes
-------------------------
+Thrift connector
+----------------
 
 * Make Thrift retry configurable.
 * Add JMX counters for Thrift requests.
 
-SPI changes
------------
+SPI
+---
 
 * Remove the ``RecordSink`` interface, which was difficult to use
   correctly and had no advantages over the ``PageSink`` interface.

--- a/docs/src/main/sphinx/release/release-0.191.rst
+++ b/docs/src/main/sphinx/release/release-0.191.rst
@@ -2,8 +2,8 @@
 Release 0.191
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix regression that could cause high CPU usage for join queries when dictionary
   processing for joins is enabled.
@@ -30,18 +30,18 @@ General changes
   The tradeoff for writer scaling is that write queries can take longer to run
   due to the decreased writer parallelism while the writer count ramps up.
 
-Resource groups changes
------------------------
+Resource groups
+---------------
 
 *  Add query type to the exact match source selector in the DB resource group selectors.
 
-CLI changes
------------
+CLI
+---
 
 * Improve display of values of the Geometry type.
 
-Hive changes
-------------
+Hive
+----
 
 * Add support for grouped join execution for Hive tables when both
   sides of a join have the same bucketing property.
@@ -51,13 +51,13 @@ Hive changes
   This is especially important for tables that have many small partitions, as
   small files can take a disproportionately longer time to read.
 
-Thrift connector changes
-------------------------
+Thrift connector
+----------------
 
 * Add page size distribution metrics.
 
-MySQL, PostgreSQL, Redshift, and SQL Server Changes
----------------------------------------------------
+MySQL, PostgreSQL, Redshift, and SQL Server
+-------------------------------------------
 
 * Fix querying ``information_schema.columns`` if there are tables with
   no columns or no supported columns.

--- a/docs/src/main/sphinx/release/release-0.192.rst
+++ b/docs/src/main/sphinx/release/release-0.192.rst
@@ -2,8 +2,8 @@
 Release 0.192
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix performance regression in split scheduling introduced in 0.191. If a query
   scans a non-trivial number of splits (~1M splits in an hour), the coordinator
@@ -29,20 +29,20 @@ General changes
 * Remove ``dictionary-processing-joins-enabled`` configuration option and ``dictionary_processing_join``
   session property.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix incorrect reporting of input size and positions in live plan view.
 
-CLI changes
------------
+CLI
+---
 
 * Fix update of prompt after ``USE`` statement.
 * Fix correctness issue when rendering arrays of Bing tiles that causes
   the first entry to be repeated multiple times.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix reading partitioned table statistics from newer Hive metastores.
 * Do not treat file system errors as corruptions for ORC.
@@ -57,33 +57,33 @@ Hive changes
 * Improve error reporting when the target table of an insert query is dropped.
 * Remove retry when creating Hive record reader. This can help queries fail faster.
 
-MySQL changes
--------------
+MySQL
+-----
 
 * Remove support for ``TIME WITH TIME ZONE`` and ``TIMESTAMP WITH TIME ZONE``
   types due to MySQL types not being able to store timezone information.
 * Add support for ``REAL`` type, which maps to MySQL's ``FLOAT`` type.
 
-PostgreSQL changes
-------------------
+PostgreSQL
+----------
 
 * Add support for ``VARBINARY`` type, which maps to PostgreSQL's ``BYTEA`` type.
 
-MongoDB changes
----------------
+MongoDB
+-------
 
 * Fix support for pushing down inequality operators for string types.
 * Add support for reading documents as ``MAP`` values.
 * Add support for MongoDB's ``Decimal128`` type.
 * Treat document and array of documents as ``JSON`` instead of ``VARCHAR``.
 
-JMX changes
------------
+JMX
+---
 
 * Allow nulls in history table values.
 
-SPI changes
------------
+SPI
+---
 
 * Remove ``SliceArrayBlock`` class.
 * Add ``offset`` and ``length`` parameters to ``Block.getPositions()``.

--- a/docs/src/main/sphinx/release/release-0.193.rst
+++ b/docs/src/main/sphinx/release/release-0.193.rst
@@ -2,8 +2,8 @@
 Release 0.193
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix an infinite loop during planning for queries containing non-trivial predicates.
 * Fix ``row_number()`` optimization that causes query failure or incorrect results
@@ -20,25 +20,25 @@ General changes
 * Turn on new local scheduling algorithm by default (see :doc:`release-0.181`).
 * Remove the ``information_schema.__internal_partitions__`` table.
 
-Security changes
-----------------
+Security
+--------
 
 * Apply the authentication methods in the order they are listed in the
   ``http-server.authentication.type`` configuration.
 
-CLI changes
------------
+CLI
+---
 
 * Fix rendering of maps of Bing tiles.
 * Abort the query when the result pager exits.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Use SSL by default for port 443.
 
-Hive changes
-------------
+Hive
+----
 
 * Allow dropping any column in a table. Previously, dropping columns other
   than the last one would fail with ``ConcurrentModificationException``.
@@ -52,19 +52,19 @@ Hive changes
   that have more than ``hive.max-partitions-per-scan`` partitions as long as
   the specified ``<condition>`` reduces the number of partitions to below this limit.
 
-Blackhole changes
------------------
+Blackhole
+---------
 
 * Do not allow creating tables in a nonexistent schema.
 * Add support for ``CREATE SCHEMA``.
 
-Memory connector changes
-------------------------
+Memory connector
+----------------
 
 * Allow renaming tables across schemas. Previously, the target schema was ignored.
 * Do not allow creating tables in a nonexistent schema.
 
-MongoDB changes
----------------
+MongoDB
+-------
 
 * Add ``INSERT`` support. It was previously removed in 0.155.

--- a/docs/src/main/sphinx/release/release-0.194.rst
+++ b/docs/src/main/sphinx/release/release-0.194.rst
@@ -2,8 +2,8 @@
 Release 0.194
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix planning performance regression that can affect queries over Hive tables
   with many partitions.
@@ -16,13 +16,13 @@ General changes
 * Improve coordinator CPU efficiency when discovering splits.
 * Include minimum and maximum values for columns in ``SHOW STATS``.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix previously empty peak memory display in the query details page.
 
-CLI changes
------------
+CLI
+---
 
 * Fix regression in CLI that makes it always print "query aborted by user" when
   the result is displayed with a pager, even if the query completes successfully.
@@ -30,15 +30,15 @@ CLI changes
 * Add ``--client-info`` option for specifying client info.
 * Add ``--ignore-errors`` option to continue processing in batch mode when an error occurs.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Allow configuring connection network timeout with ``setNetworkTimeout()``.
 * Allow setting client tags via the ``ClientTags`` client info property.
 * Expose update type via ``getUpdateType()`` on ``PrestoStatement``.
 
-Hive changes
-------------
+Hive
+----
 
 * Consistently fail queries that attempt to read partitions that are offline.
   Previously, the query can have one of the following outcomes: fail as expected,
@@ -49,7 +49,7 @@ Hive changes
 * Reduce ORC file reader memory consumption by allocating buffers lazily.
   Buffers are only allocated for columns that are actually accessed.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Fix failure when querying ``information_schema.columns`` when there is no equality predicate on ``table_name``.

--- a/docs/src/main/sphinx/release/release-0.195.rst
+++ b/docs/src/main/sphinx/release/release-0.195.rst
@@ -2,8 +2,8 @@
 Release 0.195
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix :func:`histogram` for map type when type coercion is required.
 * Fix ``nullif`` for map type when type coercion is required.
@@ -19,8 +19,8 @@ General changes
   the system when workers are offline for long periods due to GC or network errors.
 * Remove the ``compiler.interpreter-enabled`` config property.
 
-Security changes
-----------------
+Security
+--------
 
 * Presto now supports generic password authentication using a pluggable :doc:`/develop/password-authenticator`.
   Enable password authentication by setting ``http-server.authentication.type`` to include ``PASSWORD`` as an
@@ -28,25 +28,25 @@ Security changes
 * :doc:`/security/ldap` is now implemented as a password authentication
   plugin. You will need to update your configuration if you are using it.
 
-CLI and JDBC changes
---------------------
+CLI and JDBC
+------------
 
 * Provide a better error message when TLS client certificates are expired or not yet valid.
 
-MySQL changes
--------------
+MySQL
+-----
 
 * Fix an error that can occur while listing tables if one of the listed tables is dropped.
 
-Hive changes
-------------
+Hive
+----
 
 * Add support for LZ4 compressed ORC files.
 * Add support for reading Zstandard compressed ORC files.
 * Validate ORC compression block size when reading ORC files.
 * Set timeout of Thrift metastore client. This was accidentally removed in 0.191.
 
-MySQL, Redis, Kafka, and MongoDB changes
-----------------------------------------
+MySQL, Redis, Kafka, and MongoDB
+--------------------------------
 
 * Fix failure when querying ``information_schema.columns`` when there is no equality predicate on ``table_name``.

--- a/docs/src/main/sphinx/release/release-0.196.rst
+++ b/docs/src/main/sphinx/release/release-0.196.rst
@@ -2,8 +2,8 @@
 Release 0.196
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix behavior of ``JOIN ... USING`` to conform to standard SQL semantics.
   The old behavior can be restored by setting the ``deprecated.legacy-join-using``
@@ -33,8 +33,8 @@ Security
   to enforce a specific matching between authentication credentials and a
   executing username.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix a correctness issue where non-null values can be treated as null values
   when writing dictionary-encoded strings to ORC files with the new ORC writer.

--- a/docs/src/main/sphinx/release/release-0.197.rst
+++ b/docs/src/main/sphinx/release/release-0.197.rst
@@ -2,8 +2,8 @@
 Release 0.197
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix query scheduling hang when the ``concurrent_lifespans_per_task`` session property is set.
 * Fix failure when a query contains a ``TIMESTAMP`` literal corresponding to a local time that
@@ -19,8 +19,8 @@ General changes
 * Add :func:`ST_IsSimple` geospatial function.
 * Add support for broadcast spatial joins.
 
-Resource groups changes
------------------------
+Resource groups
+---------------
 
 * Change configuration check for weights in resource group policy to validate that
   either all of the subgroups or none of the subgroups have a scheduling weight configured.
@@ -28,8 +28,8 @@ Resource groups changes
   used to parameterize resource group names.
 * Add support for optional fields in DB resource group exact match selectors.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix reading of Hive partition statistics with unset fields. Previously, unset fields
   were incorrectly interpreted as having a value of zero.
@@ -46,13 +46,13 @@ Hive changes
 * Use the view owner returned from the metastore at the time of the query rather than
   always using the user who created the view. This allows changing the owner of a view.
 
-CLI changes
------------
+CLI
+---
 
 * Fix hang when CLI fails to communicate with Presto server.
 
-SPI changes
------------
+SPI
+---
 
 * Include connector session properties for the connector metadata calls made
   when running ``SHOW`` statements or querying ``information_schema``.

--- a/docs/src/main/sphinx/release/release-0.198.rst
+++ b/docs/src/main/sphinx/release/release-0.198.rst
@@ -2,8 +2,8 @@
 Release 0.198
 =============
 
-General changes
----------------
+General
+-------
 
 * Perform semantic analysis before enqueuing queries.
 * Add support for selective aggregates (``FILTER``) with ``DISTINCT`` argument qualifiers.
@@ -34,36 +34,36 @@ General changes
 * Improve parallelism of queries that have an empty grouping set.
 * Improve performance of join queries involving the :func:`ST_Distance` function.
 
-Resource groups changes
------------------------
+Resource groups
+---------------
 
 * Query Queues have been removed. Resource Groups are always enabled. The
   config property ``experimental.resource-groups-enabled`` has been removed.
 * Change ``WEIGHTED_FAIR`` scheduling policy to select oldest eligible sub group
   of groups where utilization and share are identical.
 
-CLI changes
------------
+CLI
+---
 
 * The ``--enable-authentication`` option has been removed. Kerberos authentication
   is automatically enabled when ``--krb5-remote-service-name`` is specified.
 * Kerberos authentication now requires HTTPS.
 
-Hive changes
-------------
+Hive
+----
 
 * Add support for using `AWS Glue <https://aws.amazon.com/glue/>`_ as the metastore.
   Enable it by setting the ``hive.metastore`` config property to ``glue``.
 * Fix a bug in the ORC writer that will write incorrect data of type ``VARCHAR`` or ``VARBINARY``
   into files.
 
-JMX changes
------------
+JMX
+---
 
 * Add wildcard character ``*`` which allows querying several MBeans with a single query.
 
-SPI changes
------------
+SPI
+---
 
 * Add performance statistics to query plan in ``QueryCompletedEvent``.
 * Remove ``Page.getBlocks()``. This call was rarely used and performed an expensive copy.

--- a/docs/src/main/sphinx/release/release-0.199.rst
+++ b/docs/src/main/sphinx/release/release-0.199.rst
@@ -2,8 +2,8 @@
 Release 0.199
 =============
 
-General changes
----------------
+General
+-------
 
 * Allow users to create views for their own use when they do not have permission
   to grant others access to the underlying tables or views. To enable this,
@@ -38,23 +38,23 @@ General changes
 * Improve the performance of functions that return maps.
 * Improve the performance of joins and aggregations that include map columns.
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Add support for installing on machines with OpenJDK.
 
-Security changes
-----------------
+Security
+--------
 
 * Add support for authentication with JWT access token.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Make driver compatible with Java 9+. It previously failed with ``IncompatibleClassChangeError``.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix ORC writer failure when writing ``NULL`` values into columns of type ``ROW``, ``MAP``,  or ``ARRAY``.
 * Fix ORC writers incorrectly writing non-null values as ``NULL`` for all types.
@@ -70,15 +70,15 @@ Hive changes
   ``hive.max-partitions-per-scan`` config option.
 * Allow marking partitions as offline via the ``presto_offline`` partition property.
 
-Thrift connector changes
-------------------------
+Thrift connector
+----------------
 
 * Most of the config property names are different due to replacing the
   underlying Thrift client implementation. Please see :doc:`/connector/thrift`
   for details on the new properties.
 
-SPI changes
------------
+SPI
+---
 
 * Allow connectors to provide system tables dynamically.
 * Add ``resourceGroupId`` and ``queryType`` fields to ``SessionConfigurationContext``.

--- a/docs/src/main/sphinx/release/release-0.200.rst
+++ b/docs/src/main/sphinx/release/release-0.200.rst
@@ -2,8 +2,8 @@
 Release 0.200
 =============
 
-General changes
----------------
+General
+-------
 
 * Disable early termination of inner or right joins when the right side
   has zero rows. This optimization can cause indefinite query hangs
@@ -19,8 +19,8 @@ General changes
 * Add :func:`from_ieee754_32` and :func:`from_ieee754_64` functions.
 * Add :func:`ST_GeometryType` geospatial function.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix reading min/max statistics for columns of ``REAL`` type in partitioned tables.
 * Fix failure when reading Parquet files with optimized Parquet reader
@@ -29,8 +29,8 @@ Hive changes
 * Fix failure when reading ORC files that contain UTF-8 Bloom filter streams.
   Such Bloom filters are now ignored.
 
-MySQL changes
--------------
+MySQL
+-----
 
 * Avoid reading extra rows from MySQL at query completion.
   This typically affects queries with a ``LIMIT`` clause.

--- a/docs/src/main/sphinx/release/release-0.201.rst
+++ b/docs/src/main/sphinx/release/release-0.201.rst
@@ -2,8 +2,8 @@
 Release 0.201
 =============
 
-General changes
----------------
+General
+-------
 
 * Change grouped aggregations to use ``IS NOT DISTINCT FROM`` semantics rather than equality
   semantics. This fixes incorrect results and degraded performance when grouping on ``NaN``
@@ -21,15 +21,15 @@ General changes
   aggregations for queries that do not benefit.
 * Add support for ``current_user`` (see :doc:`/functions/session`).
 
-Security changes
-----------------
+Security
+--------
 
 * Change rules in the :doc:`/security/built-in-system-access-control` for enforcing matches
   between authentication credentials and a chosen username to allow more fine-grained
   control and ability to define superuser-like credentials.
 
-Hive changes
-------------
+Hive
+----
 
 * Replace ORC writer stripe minimum row configuration ``hive.orc.writer.stripe-min-rows``
   with stripe minimum data size ``hive.orc.writer.stripe-min-size``.
@@ -41,7 +41,7 @@ Hive changes
 * Fix impersonation for the simple HDFS authentication to use login user rather than current
   user.
 
-SPI changes
------------
+SPI
+---
 
 * Support resource group selection based on resource estimates.

--- a/docs/src/main/sphinx/release/release-0.202.rst
+++ b/docs/src/main/sphinx/release/release-0.202.rst
@@ -2,8 +2,8 @@
 Release 0.202
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix correctness issue for queries involving aggregations over the result of an outer join (:issue:`x10592`).
 * Fix :func:`map` to raise an error on duplicate keys rather than silently producing a corrupted map.
@@ -36,8 +36,8 @@ General changes
 * Add :func:`wilson_interval_lower` and :func:`wilson_interval_upper` functions.
 * Add ``IS DISTINCT FROM`` for ``json`` and ``ipaddress`` type.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix optimized ORC writer encoding of ``TIMESTAMP`` before ``1970-01-01``.  Previously, the
   written value was off by one second.
@@ -57,12 +57,12 @@ Hive changes
   read multiple consecutive stripes or entire fires at once. Previously, this feature
   piggybacks on other properties.
 
-CLI changes
------------
+CLI
+---
 
 * Add peak memory usage to ``--debug`` output.
 
-SPI changes
------------
+SPI
+---
 
 * Make ``PageSorter`` and ``PageIndexer`` supported interfaces.

--- a/docs/src/main/sphinx/release/release-0.203.rst
+++ b/docs/src/main/sphinx/release/release-0.203.rst
@@ -2,8 +2,8 @@
 Release 0.203
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix spurious duplicate key errors from :func:`map`.
 * Fix planning failure when a correlated subquery containing a ``LIMIT``
@@ -21,8 +21,8 @@ General changes
 * Remove support for legacy ``ORDER BY`` semantics.
 * Distinguish between inner and left spatial joins in explain plans.
 
-Security changes
-----------------
+Security
+--------
 
 * Fix sending authentication challenge when at least two of the
   ``KERBEROS``, ``PASSWORD``, or ``JWT`` authentication types are configured.
@@ -30,28 +30,28 @@ Security changes
   and the HTTP client used for internal communication. This was already supported
   for the CLI and JDBC driver.
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Declare a dependency on ``uuidgen``. The ``uuidgen`` program is required during
   installation of the Presto server RPM package and lack of it resulted in an invalid
   config file being generated during installation.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix complex type handling in the optimized Parquet reader. Previously, null values,
   optional fields, and Parquet backward compatibility rules were not handled correctly.
 * Fix an issue that could cause the optimized ORC writer to fail with a ``LazyBlock`` error.
 * Improve error message for max open writers.
 
-Thrift connector changes
-------------------------
+Thrift connector
+----------------
 
 * Fix retry of requests when the remote Thrift server indicates that the
   error is retryable.
 
-Local file connector changes
-----------------------------
+Local file connector
+--------------------
 
 * Fix parsing of timestamps when the JVM time zone is UTC (:issue:`x9601`).

--- a/docs/src/main/sphinx/release/release-0.204.rst
+++ b/docs/src/main/sphinx/release/release-0.204.rst
@@ -2,8 +2,8 @@
 Release 0.204
 =============
 
-General changes
----------------
+General
+-------
 
 * Use distributed join if one side is naturally partitioned on join keys.
 * Improve performance of correlated subqueries when filters from outer query
@@ -18,24 +18,24 @@ General changes
   The missing positions are filled with ``NULL``.
 * Track execution statistics of ``AddExchanges`` and ``PredicatePushdown`` optimizer rules.
 
-Event listener changes
-----------------------
+Event listener
+--------------
 
 * Add resource estimates to query events.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix kill query button.
 * Display resource estimates in Web UI query details page.
 
-Resource group changes
-----------------------
+Resource group
+--------------
 
 * Fix unnecessary queuing in deployments where no resource group configuration was specified.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix over-estimation of memory usage for scan operators when reading ORC files.
 * Fix memory accounting for sort buffer used for writing sorted bucketed tables.
@@ -46,8 +46,8 @@ Hive connector changes
   highly compressed, dictionary encoded columns.
 * Enable optimized Parquet reader and predicate pushdown by default.
 
-Cassandra connector changes
----------------------------
+Cassandra connector
+-------------------
 
 * Add support for reading from materialized views.
 * Optimize partition list retrieval for Cassandra 2.2+.

--- a/docs/src/main/sphinx/release/release-0.205.rst
+++ b/docs/src/main/sphinx/release/release-0.205.rst
@@ -2,8 +2,8 @@
 Release 0.205
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix parsing of row types where the field types contain spaces.
   Previously, row expressions that included spaces would fail to parse.
@@ -31,8 +31,8 @@ General changes
 * Do not allow using the ``FILTER`` clause for the ``COALESCE``, ``IF``, or ``NULLIF`` functions.
   The syntax was previously allowed but was otherwise ignored.
 
-Security changes
-----------------
+Security
+--------
 
 * Remove unnecessary check for ``SELECT`` privileges for ``DELETE`` queries.
   Previously, ``DELETE`` queries could fail if the user only has ``DELETE``
@@ -46,29 +46,29 @@ Security changes
 * Improve the error message when access is denied when selecting from a view due to the
   view owner having insufficient permissions to create the view.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Add support for prepared statements.
 * Add partial query cancellation via ``partialCancel()`` on ``PrestoStatement``.
 * Use ``VARCHAR`` rather than ``LONGNVARCHAR`` for the Presto ``varchar`` type.
 * Use ``VARBINARY`` rather than ``LONGVARBINARY`` for the Presto ``varbinary`` type.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Improve the performance of ``INSERT`` queries when all partition column values are constants.
 * Improve stripe size estimation for the optimized ORC writer.
   This reduces the number of cases where tiny ORC stripes will be written.
 * Respect the ``skip.footer.line.count`` Hive table property.
 
-CLI changes
------------
+CLI
+---
 
 * Prevent the CLI from crashing when running on certain 256 color terminals.
 
-SPI changes
------------
+SPI
+---
 
 * Add a context parameter to the ``create()`` method in ``SessionPropertyConfigurationManagerFactory``.
 * Disallow non-static methods to be annotated with ``@ScalarFunction``. Non-static SQL function

--- a/docs/src/main/sphinx/release/release-0.206.rst
+++ b/docs/src/main/sphinx/release/release-0.206.rst
@@ -2,8 +2,8 @@
 Release 0.206
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix execution failure for certain queries containing a join followed by an aggregation
   when ``dictionary_aggregation`` is enabled.
@@ -36,14 +36,14 @@ General changes
   In addition, the new semantics are not yet stable as more breaking changes are planned,
   particularly around the ``TIME WITH TIME ZONE`` type.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Add ``applicationNamePrefix`` parameter, which is combined with
   the ``ApplicationName`` property to construct the client source name.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Reduce ORC reader memory usage by reducing unnecessarily large internal buffers.
 * Support reading from tables with ``skip.footer.line.count`` and ``skip.header.line.count``

--- a/docs/src/main/sphinx/release/release-0.207.rst
+++ b/docs/src/main/sphinx/release/release-0.207.rst
@@ -2,8 +2,8 @@
 Release 0.207
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix a planning issue for queries where correlated references were used in ``VALUES``.
 * Remove support for legacy ``JOIN ... USING`` behavior.
@@ -32,19 +32,19 @@ General changes
   can be reordered at once using cost-based join reordering.
 * Add support for ``char`` type to :func:`approx_distinct`.
 
-Security changes
-----------------
+Security
+--------
 
 * Fail on startup when configuration for file based system access control is invalid.
 * Add support for securing communication between cluster nodes with Kerberos authentication.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Add peak total (user + system) memory to query details UI.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix handling of ``VARCHAR(length)`` type in the optimized Parquet reader. Previously, predicate pushdown
   failed with ``Mismatched Domain types: varchar(length) vs varchar``.
@@ -55,13 +55,13 @@ Hive connector changes
 * Change collector for columns statistics to only consider a sample of partitions. The sample size can be
   changed by setting the ``hive.partition-statistics-sample-size`` property.
 
-Memory connector changes
-------------------------
+Memory connector
+----------------
 
 * Add support for dropping schemas.
 
-SPI changes
------------
+SPI
+---
 
 * Remove deprecated table/view-level access control methods.
 * Change predicate in constraint for accessing table layout to be optional.

--- a/docs/src/main/sphinx/release/release-0.208.rst
+++ b/docs/src/main/sphinx/release/release-0.208.rst
@@ -7,8 +7,8 @@ Release 0.208
     This release has the potential for data loss in the Hive connector
     when writing bucketed sorted tables.
 
-General changes
----------------
+General
+-------
 
 * Fix an issue with memory accounting that would lead to garbage collection pauses
   and out of memory exceptions.
@@ -28,14 +28,14 @@ General changes
 * Add support for correlated subqueries requiring coercions.
 * Add experimental support for running on Linux ppc64le.
 
-CLI changes
------------
+CLI
+---
 
 * Fix creation of the history file when it does not exist.
 * Add ``PRESTO_HISTORY_FILE`` environment variable to override location of history file.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Remove size limit for writing bucketed sorted tables.
 * Support writer scaling for Parquet.
@@ -45,7 +45,7 @@ Hive connector changes
 * Collect column level statistics when writing tables. This is disabled by default,
   and can be enabled by setting the ``hive.collect-column-statistics-on-write`` property.
 
-Thrift connector changes
-------------------------
+Thrift connector
+----------------
 
 * Include error message from remote server in query failure message.

--- a/docs/src/main/sphinx/release/release-0.209.rst
+++ b/docs/src/main/sphinx/release/release-0.209.rst
@@ -2,8 +2,8 @@
 Release 0.209
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect predicate pushdown when grouping sets contain the empty grouping set (:issue:`x11296`).
 * Fix ``X-Forwarded-Proto`` header handling for requests to the ``/`` path (:issue:`x11168`).
@@ -32,23 +32,23 @@ General changes
 * Raise required Java version to 8u151. This avoids correctness issues for
   map to map cast when running under some earlier JVM versions, including 8u92.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix the kill query button on the live plan and stage performance pages.
 
-CLI changes
+CLI
+---
+
+* Prevent spurious *"No route to host"* errors on macOS when using IPv6.
+
+JDBC driver
 -----------
 
 * Prevent spurious *"No route to host"* errors on macOS when using IPv6.
 
-JDBC driver changes
--------------------
-
-* Prevent spurious *"No route to host"* errors on macOS when using IPv6.
-
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix data loss when writing bucketed sorted tables. Partitions would
   be missing arbitrary rows if any of the temporary files for a bucket
@@ -64,14 +64,14 @@ Hive connector changes
   This correctly handles missing or extra struct fields in the ORC file.
 * Add procedure ``system.create_empty_partition()`` for creating empty partitions.
 
-Kafka connector changes
------------------------
+Kafka connector
+---------------
 
 * Support Avro formatted Kafka messages.
 * Support backward compatible Avro schema evolution.
 
-SPI changes
------------
+SPI
+---
 
 * Allow using ``Object`` as a parameter type or return type for SQL
   functions when the corresponding SQL type is an unbounded generic.

--- a/docs/src/main/sphinx/release/release-0.210.rst
+++ b/docs/src/main/sphinx/release/release-0.210.rst
@@ -2,8 +2,8 @@
 Release 0.210
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix planning failure when aliasing columns of tables containing hidden
   columns (:issue:`x11385`).
@@ -14,8 +14,8 @@ General changes
 * Remove user CPU time tracking as introduces non-trivial overhead.
 * Select join distribution type automatically for queries involving outer joins.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix a security bug introduced in 0.209 when using ``hive.security=file``,
   which would allow any user to create, drop, or rename schemas.
@@ -26,15 +26,15 @@ Hive connector changes
 * Support backward compatible Avro schema evolution.
 * Support cross-realm Kerberos authentication for HDFS and Hive Metastore.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Deallocate prepared statement when ``PreparedStatement`` is closed. Previously,
   ``Connection`` became unusable after many prepared statements were created.
 * Remove ``getUserTimeMillis()`` from ``QueryStats`` and ``StageStats``.
 
-SPI changes
------------
+SPI
+---
 
 * ``SystemAccessControl.checkCanSetUser()`` now takes an ``Optional<Principal>``
   rather than a nullable ``Principal``.

--- a/docs/src/main/sphinx/release/release-0.211.rst
+++ b/docs/src/main/sphinx/release/release-0.211.rst
@@ -2,8 +2,8 @@
 Release 0.211
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix missing final query plan in ``QueryCompletedEvent``. Statistics and cost estimates
   are removed from the plan text because they may not be available during event generation.
@@ -23,8 +23,8 @@ General changes
   to automate the setting of session properties based on query characteristics.
 * Allow running on a JVM from any vendor that meets the functional requirements.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix regression in 0.210 that causes query failure when writing ORC or DWRF files
   that occurs for specific patterns of input data. When the writer attempts to give up
@@ -33,13 +33,13 @@ Hive connector changes
 * Fix coordinator OOM when a query scans many partitions of a Hive table (:issue:`x11322`).
 * Improve readability of columns, partitioning, and transactions in explain plains.
 
-Thrift connector changes
-------------------------
+Thrift connector
+----------------
 
 * Fix lack of retry for network errors while sending requests.
 
-Resource group changes
-----------------------
+Resource group
+--------------
 
 * Add documentation for new resource group scheduling policies.
 * Remove running and queue time limits from resource group configuration.
@@ -47,8 +47,8 @@ Resource group changes
   :doc:`file based property manager </admin/session-property-managers>`
   to set session properties.
 
-SPI changes
------------
+SPI
+---
 
 * Clarify semantics of ``predicate`` in ``ConnectorTableLayout``.
 * Reduce flexibility of ``unenforcedConstraint`` that a connector can return in ``getTableLayouts``.

--- a/docs/src/main/sphinx/release/release-0.212.rst
+++ b/docs/src/main/sphinx/release/release-0.212.rst
@@ -2,8 +2,8 @@
 Release 0.212
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix query failures when the :func:`ST_GeomFromBinary` function is run on multiple rows.
 * Fix memory accounting for the build side of broadcast joins.
@@ -14,8 +14,8 @@ General changes
 * Remove ``round(x, d)`` and ``truncate(x, d)`` functions where ``d`` is a ``BIGINT`` (:issue:`x11462`).
 * Add :func:`ST_LineString` function to form a ``LineString`` from an array of points.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Prevent ORC writer from writing stripes larger than the max configured size for some rare data
   patterns (:issue:`x11526`).
@@ -25,13 +25,13 @@ Hive connector changes
   statistics can be ignored by setting the ``hive.ignore-corrupted-statistics``
   configuration property or the ``ignore_corrupted_statistics`` session property.
 
-Thrift connector changes
-------------------------
+Thrift connector
+----------------
 
 * Fix retry for network errors that occur while sending a Thrift request.
 * Remove failed connections from connection pool.
 
-Verifier changes
-----------------
+Verifier
+--------
 
 * Record the query ID of the test query regardless of query outcome.

--- a/docs/src/main/sphinx/release/release-0.213.rst
+++ b/docs/src/main/sphinx/release/release-0.213.rst
@@ -2,8 +2,8 @@
 Release 0.213
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix split scheduling backpressure when plan contains colocated join. Previously, splits
   for the second and subsequent scan nodes (in scheduling order) were scheduled continuously
@@ -39,8 +39,8 @@ General changes
 * Add experimental config option ``experimental.reserved-pool-enabled`` to disable the reserved memory pool.
 * Add ``targetResultSize`` query parameter to ``/v1/statement`` endpoint to control response data size.
 
-Geospatial changes
-------------------
+Geospatial
+----------
 
 * Fix :func:`ST_Distance` function to return ``NULL`` if any of the inputs is an
   empty geometry as required by the SQL/MM specification.
@@ -48,21 +48,21 @@ Geospatial changes
 * Add :func:`geometry_union` function to efficiently union arrays of geometries.
 * Add support for distributed spatial joins (:issue:`x11072`).
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Allow running on a JVM from any vendor.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Remove legacy plan UI.
 * Add support for filtering queries by all error categories.
 * Add dialog to show errors refreshing data from coordinator.
 * Change worker thread list to not show thread stacks by default to improve page peformance.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix LZO and LZOP decompression to work with certain data compressed by Hadoop.
 * Fix ORC writer validation percentage so that zero does not result in 100% validation.
@@ -88,18 +88,18 @@ Hive connector changes
   configuration properties and ``parquet_writer_block_size`` and
   ``parquet_writer_page_size`` session properties for tuning Parquet writer options.
 
-Memory connector changes
-------------------------
+Memory connector
+----------------
 
 * Improve table data size accounting.
 
-Thrift connector changes
-------------------------
+Thrift connector
+----------------
 
 * Include constraint in explain plan for index joins.
 * Improve readability of columns, tables, layouts, and indexes in explain plans.
 
-Verifier changes
-----------------
+Verifier
+--------
 
 * Rewrite queries in parallel when shadowing writes.

--- a/docs/src/main/sphinx/release/release-0.214.rst
+++ b/docs/src/main/sphinx/release/release-0.214.rst
@@ -2,8 +2,8 @@
 Release 0.214
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix history leak in coordinator for failed or canceled queries.
 * Fix memory leak related to query tracking in coordinator that was introduced
@@ -31,26 +31,26 @@ General changes
 * Remove experimental pre-allocated memory system, and the related configuration
   property ``experimental.preallocate-memory-threshold``.
 
-Security changes
-----------------
+Security
+--------
 
 * Add functionality to refresh the configuration of file-based access controllers.
   The refresh interval can be set using the ``security.refresh-period``
   configuration property.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Clear update count after calling ``Statement.getMoreResults()``.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Show query warnings on the query detail page.
 * Allow selecting non-default sort orders in query list view.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Prevent ORC writer from writing stripes larger than the maximum configured size.
 * Add ``hive.s3.upload-acl-type`` configuration property to specify the type of
@@ -58,7 +58,7 @@ Hive connector changes
 * Add Hive metastore API recording tool for remote debugging purposes.
 * Add support for retrying on metastore connection errors.
 
-Verifier changes
-----------------
+Verifier
+--------
 
 * Handle SQL execution timeouts while rewriting queries.

--- a/docs/src/main/sphinx/release/release-0.215.rst
+++ b/docs/src/main/sphinx/release/release-0.215.rst
@@ -2,8 +2,8 @@
 Release 0.215
 =============
 
-General changes
----------------
+General
+-------
 
 * Fix regression in 0.214 that could cause queries to produce incorrect results for queries
   using map types.
@@ -31,15 +31,15 @@ General changes
   The default value for the filter factor can be configured with the ``default_filter_factor_enabled``
   session property or the ``optimizer.default-filter-factor-enabled``.
 
-Geospatial changes
-------------------
+Geospatial
+----------
 
 * Add input validation checks to :func:`ST_LineString` to conform with the specification.
 * Improve spatial join performance.
 * Enable spatial joins for join conditions expressed with the :func:`ST_Within` function.
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix *Capture Snapshot* button for showing current thread stacks.
 * Fix dropdown for expanding stage skew component on the query details page.
@@ -47,13 +47,13 @@ Web UI changes
 * Make the reporting of *Cumulative Memory* usage consistent on the query list and query details pages.
 * Remove legacy thread UI.
 
-Hive changes
-------------
+Hive
+----
 
 * Add predicate pushdown support for the ``DATE`` type to the Parquet reader. This change also fixes
   a bug that may cause queries with predicates on ``DATE`` columns to fail with type mismatch errors.
 
-Redis changes
--------------
+Redis
+-----
 
 * Prevent printing the value of the ``redis.password`` configuration property to log files.

--- a/docs/src/main/sphinx/release/release-0.60.rst
+++ b/docs/src/main/sphinx/release/release-0.60.rst
@@ -39,8 +39,8 @@ with the following contents:
 Additionally, update the ``datasources`` property in the config properties file,
 ``etc/config.properties``, for the workers to include ``tpch``.
 
-SPI changes
------------
+SPI
+---
 
 The ``Connector`` interface now has explicit methods for supplying the services
 expected by the query engine. Previously, this was handled by a generic

--- a/docs/src/main/sphinx/release/release-0.66.rst
+++ b/docs/src/main/sphinx/release/release-0.66.rst
@@ -141,8 +141,8 @@ Optimizations
   upgrade was using inadvertently GZIP compression and has a bug in the
   buffer management resulting in high CPU usage.
 
-SPI changes
------------
+SPI
+---
 
 In this release we have made a number of backward incompatible changes to the SPI:
 

--- a/docs/src/main/sphinx/release/release-0.67.rst
+++ b/docs/src/main/sphinx/release/release-0.67.rst
@@ -8,8 +8,8 @@ Release 0.67
 
 * Fix planning issue with certain queries using window functions
 
-SPI changes
------------
+SPI
+---
 
 The ``ConnectorSplitSource`` interface now extends ``Closeable``.
 

--- a/docs/src/main/sphinx/release/release-0.69.rst
+++ b/docs/src/main/sphinx/release/release-0.69.rst
@@ -92,8 +92,8 @@ Presto now supports the ``varbinary`` type for variable length binary data.
 Currently, the only supported function is :func:`length`.
 The Hive connector now maps the Hive ``BINARY`` type to ``varbinary``.
 
-General changes
----------------
+General
+-------
 
 * Add missing operator: ``timestamp with time zone`` - ``interval year to month``
 * Support explaining sampled queries

--- a/docs/src/main/sphinx/release/release-0.70.rst
+++ b/docs/src/main/sphinx/release/release-0.70.rst
@@ -52,8 +52,8 @@ by advanced users familiar with LIBSVM. The functions are
 ``learn_libsvm_classifier`` and ``learn_libsvm_regressor``. Both take a
 parameters string which has the form ``key=value,key=value``
 
-General changes
----------------
+General
+-------
 
 * New comparison functions: :func:`greatest` and :func:`least`
 
@@ -80,8 +80,8 @@ General changes
 
 * Fix processing of empty or commented out statements in the CLI.
 
-Hive changes
-------------
+Hive
+----
 
 * There are two new configuration options for the Hive connector,
   ``hive.max-initial-split-size``, which configures the size of the

--- a/docs/src/main/sphinx/release/release-0.73.rst
+++ b/docs/src/main/sphinx/release/release-0.73.rst
@@ -9,8 +9,8 @@ The Cassandra connector now supports CREATE TABLE and DROP TABLE. Additionally,
 the connector now takes into account Cassandra indexes when generating CQL.
 This release also includes several bug fixes and performance improvements.
 
-General changes
----------------
+General
+-------
 
 * New window functions: :func:`lead`, and :func:`lag`
 

--- a/docs/src/main/sphinx/release/release-0.74.rst
+++ b/docs/src/main/sphinx/release/release-0.74.rst
@@ -17,8 +17,8 @@ The storage format to use when writing data to Hive can now be configured via th
 in your Hive catalog properties file. Valid options are ``RCBINARY``, ``RCTEXT``, ``SEQUENCEFILE`` and ``TEXTFILE``.
 The default format if the property is not set is ``RCBINARY``.
 
-General changes
----------------
+General
+-------
 
 * Show column comments in ``DESCRIBE``
 * Add :func:`try_cast` which works like :func:`cast` but returns ``null`` if the cast fails

--- a/docs/src/main/sphinx/release/release-0.75.rst
+++ b/docs/src/main/sphinx/release/release-0.75.rst
@@ -2,8 +2,8 @@
 Release 0.75
 ============
 
-Hive changes
-------------
+Hive
+----
 
 * The Hive S3 file system has a new configuration option,
   ``hive.s3.max-connections``, which sets the maximum number of
@@ -13,8 +13,8 @@ Hive changes
   is not enabled. To enable it, set ``hive.allow-rename-table=true`` in
   your Hive catalog properties file.
 
-General changes
----------------
+General
+-------
 
 * Optimize :func:`count` with a constant to execute as the much faster ``count(*)``
 * Add support for binary types to the JDBC driver
@@ -31,8 +31,8 @@ General changes
 * Add basic support for inserting data using the :doc:`/sql/insert` statement.
   This is currently only supported for the Raptor connector.
 
-JSON function changes
----------------------
+JSON function
+-------------
 
 The :func:`json_extract` and :func:`json_extract_scalar` functions now support
 the square bracket syntax::
@@ -46,8 +46,8 @@ Additionally, colons cannot be used in a un-quoted bracketed path segment.
 Use the new bracket syntax with quotes to match elements that contain
 special characters.
 
-Scheduler changes
------------------
+Scheduler
+---------
 
 The scheduler now assigns splits to a node based on the current load on the node across all queries.
 Previously, the scheduler load balanced splits across nodes on a per query level. Every node can have
@@ -85,8 +85,8 @@ from ``orders`` for each ``orderstatus``::
 Use the :doc:`/sql/explain` statement to see if any of these optimizations
 have been applied to your query.
 
-SPI changes
------------
+SPI
+---
 
 The core Presto engine no longer automatically adds a column for ``count(*)``
 queries. Instead, the ``RecordCursorProvider`` will receive an empty list of

--- a/docs/src/main/sphinx/release/release-0.76.rst
+++ b/docs/src/main/sphinx/release/release-0.76.rst
@@ -22,8 +22,8 @@ for querying and creating tables in external relational databases. These can
 be used to join or copy data between different systems like MySQL and Hive,
 or between two different MySQL or PostgreSQL instances, or any combination.
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 The :doc:`/connector/cassandra` configuration properties
 ``cassandra.client.read-timeout`` and ``cassandra.client.connect-timeout``
@@ -35,8 +35,8 @@ The retry policy for the Cassandra client is now configurable via the
 ``cassandra.retry-policy`` property. In particular, the custom ``BACKOFF``
 retry policy may be useful.
 
-Hive changes
-------------
+Hive
+----
 
 The new :doc:`/connector/hive` configuration property ``hive.s3.socket-timeout``
 allows changing the socket timeout for queries that read or write to Amazon S3.
@@ -57,8 +57,8 @@ The property ``hive.storage-format`` is broken and has been disabled. It
 sets the storage format on the metadata but always writes the table using
 ``RCBINARY``. This will be implemented in a future release.
 
-General changes
----------------
+General
+-------
 
 * Fix hang in verifier when an exception occurs.
 * Fix :func:`chr` function to work with Unicode code points instead of ASCII code points.

--- a/docs/src/main/sphinx/release/release-0.77.rst
+++ b/docs/src/main/sphinx/release/release-0.77.rst
@@ -20,20 +20,20 @@ and can be enabled with the ``distributed-joins-enabled`` flag. It may perform w
 broadcast join implementation because it requires redistributing both tables.
 This feature is still experimental, and should be used with caution.
 
-Hive changes
-------------
+Hive
+----
 * Handle spurious ``AbortedException`` when closing S3 input streams
 * Add support for ORC, DWRF and Parquet in Hive
 * Add support for ``DATE`` type in Hive
 * Fix performance regression in Hive when reading ``VARCHAR`` columns
 
-Kafka changes
--------------
+Kafka
+-----
 * Fix Kafka handling of default port
 * Add support for Kafka messages with a null key
 
-General changes
----------------
+General
+-------
 * Fix race condition in scheduler that could cause queries to hang
 * Add ConnectorPageSource which is a more efficient interface for column-oriented sources
 * Add support for string partition keys in Cassandra

--- a/docs/src/main/sphinx/release/release-0.78.rst
+++ b/docs/src/main/sphinx/release/release-0.78.rst
@@ -40,8 +40,8 @@ For JDBC, the properties can be set by unwrapping the ``Connection`` as follows:
     property values. Additionally, the Presto grammar will be extended to
     allow setting properties via a query.
 
-Hive changes
-------------
+Hive
+----
 
 * Add ``storage_format`` session property to override format used for creating tables.
 * Add write support for ``VARBINARY``, ``DATE`` and ``TIMESTAMP``.
@@ -49,8 +49,8 @@ Hive changes
 * Add support for partition keys with null values (``__HIVE_DEFAULT_PARTITION__``).
 * Fix ``hive.storage-format`` option (see :doc:`release-0.76`).
 
-General changes
----------------
+General
+-------
 
 * Fix expression optimizer, so that it runs in linear time instead of exponential time.
 * Add :func:`cardinality` for maps.

--- a/docs/src/main/sphinx/release/release-0.79.rst
+++ b/docs/src/main/sphinx/release/release-0.79.rst
@@ -2,8 +2,8 @@
 Release 0.79
 ============
 
-Hive changes
-------------
+Hive
+----
 
 * Add configuration option ``hive.force-local-scheduling`` and session property
   ``force_local_scheduling`` to force local scheduling of splits.
@@ -11,8 +11,8 @@ Hive changes
   setting the configuration option ``hive.optimized-reader.enabled`` or session
   property ``optimized_reader_enabled``.
 
-General changes
----------------
+General
+-------
 
 * Add support for :ref:`unnest`, which can be used as a replacement for the ``explode()`` function in Hive.
 * Fix a bug in the scan operator that can cause data to be missed. It currently only affects queries

--- a/docs/src/main/sphinx/release/release-0.80.rst
+++ b/docs/src/main/sphinx/release/release-0.80.rst
@@ -15,15 +15,15 @@ disable the new reader on a per-query basis by setting the
 the reader by default by setting the Hive catalog property
 ``hive.optimized-reader.enabled=false``.
 
-Hive changes
-------------
+Hive
+----
 
 * The maximum retry time for the Hive S3 file system can be configured
   by setting ``hive.s3.max-retry-time``.
 * Fix Hive partition pruning for null keys (i.e. ``__HIVE_DEFAULT_PARTITION__``).
 
-Cassandra changes
------------------
+Cassandra
+---------
 
 * Update Cassandra driver to 2.1.0.
 * Map Cassandra ``TIMESTAMP`` type to Presto ``TIMESTAMP`` type.
@@ -77,8 +77,8 @@ to the coordinator config properties.
       Hive connector will produce incorrect results if your Hive warehouse
       contains partitions without data.
 
-General changes
----------------
+General
+-------
 
 * Add support implicit joins. The following syntax is now allowed::
 

--- a/docs/src/main/sphinx/release/release-0.81.rst
+++ b/docs/src/main/sphinx/release/release-0.81.rst
@@ -2,14 +2,14 @@
 Release 0.81
 ============
 
-Hive changes
-------------
+Hive
+----
 
 * Fix ORC predicate pushdown.
 * Fix column selection in RCFile.
 
-General changes
----------------
+General
+-------
 
 * Fix handling of null and out-of-range offsets for
   :func:`lead`, :func:`lag` and :func:`nth_value` functions.

--- a/docs/src/main/sphinx/release/release-0.83.rst
+++ b/docs/src/main/sphinx/release/release-0.83.rst
@@ -2,13 +2,13 @@
 Release 0.83
 ============
 
-Raptor changes
---------------
+Raptor
+------
 * Raptor now enables specifying the backup storage location. This feature is highly experimental.
 * Fix the handling of shards not assigned to any node.
 
-General changes
----------------
+General
+-------
 
 * Fix resource leak in query queues.
 * Fix NPE when writing null ``ARRAY/MAP`` to Hive.

--- a/docs/src/main/sphinx/release/release-0.86.rst
+++ b/docs/src/main/sphinx/release/release-0.86.rst
@@ -2,8 +2,8 @@
 Release 0.86
 ============
 
-General changes
----------------
+General
+-------
 
 * Add support for inequality ``INNER JOIN`` when each term of the condition refers to only one side of the join.
 * Add :func:`ntile` function.

--- a/docs/src/main/sphinx/release/release-0.87.rst
+++ b/docs/src/main/sphinx/release/release-0.87.rst
@@ -2,8 +2,8 @@
 Release 0.87
 ============
 
-General changes
----------------
+General
+-------
 
 * Fixed a bug where :ref:`row_type` types could have the wrong field names.
 * Changed the minimum JDK version to 1.8.

--- a/docs/src/main/sphinx/release/release-0.88.rst
+++ b/docs/src/main/sphinx/release/release-0.88.rst
@@ -2,8 +2,8 @@
 Release 0.88
 ============
 
-General changes
----------------
+General
+-------
 
 * Added :func:`arbitrary` aggregation function.
 * Allow using all :doc:`/functions/aggregate` as :doc:`/functions/window`.

--- a/docs/src/main/sphinx/release/release-0.89.rst
+++ b/docs/src/main/sphinx/release/release-0.89.rst
@@ -12,8 +12,8 @@ using a 32-bit signed integer.
     representation, so if you have written a connector, you will need to update
     your code before deploying this release.
 
-General changes
----------------
+General
+-------
 
 * ``USE CATALOG`` and ``USE SCHEMA`` have been replaced with :doc:`/sql/use`.
 * Fix issue where ``SELECT NULL`` incorrectly returns 0 rows.

--- a/docs/src/main/sphinx/release/release-0.90.rst
+++ b/docs/src/main/sphinx/release/release-0.90.rst
@@ -4,8 +4,8 @@ Release 0.90
 
 .. warning:: This release has a memory leak and should not be used.
 
-General changes
----------------
+General
+-------
 
 * Initial support for partition and placement awareness in the query planner. This can
   result in better plans for queries involving ``JOIN`` and ``GROUP BY`` over the same
@@ -41,16 +41,16 @@ Functions and language features
 * Improve formatting of ``EXPLAIN (TYPE DISTRIBUTED)`` output and include additional
   information such as output layout, task placement policy and partitioning functions.
 
-Hive changes
-------------
+Hive
+----
 * Disable optimized metastore partition fetching for non-string partition keys.
   This fixes an issue were Presto might silently ignore data with non-canonical
   partition values. To enable this option, add ``hive.assume-canonical-partition-keys=true``
   to the coordinator and worker config properties.
 * Don't retry operations against S3 that fail due to lack of permissions.
 
-SPI changes
------------
+SPI
+---
 * Add ``getColumnTypes`` to ``RecordSink``.
 * Use ``Slice`` for table writer fragments.
 * Add ``ConnectorPageSink`` which is a more efficient interface for column-oriented sources.

--- a/docs/src/main/sphinx/release/release-0.91.rst
+++ b/docs/src/main/sphinx/release/release-0.91.rst
@@ -4,7 +4,7 @@ Release 0.91
 
 .. warning:: This release has a memory leak and should not be used.
 
-General changes
----------------
+General
+-------
 
 * Clear ``LazyBlockLoader`` reference after load to free memory earlier.

--- a/docs/src/main/sphinx/release/release-0.92.rst
+++ b/docs/src/main/sphinx/release/release-0.92.rst
@@ -2,7 +2,7 @@
 Release 0.92
 ============
 
-General changes
----------------
+General
+-------
 
 * Fix buffer leak when a query fails.

--- a/docs/src/main/sphinx/release/release-0.93.rst
+++ b/docs/src/main/sphinx/release/release-0.93.rst
@@ -29,8 +29,8 @@ If you're upgrading from 0.92, you need to alter your verifier_queries table
     ALTER TABLE verifier_queries add control_username VARCHAR(256) NOT NULL default 'verifier-test';
     ALTER TABLE verifier_queries add control_password VARCHAR(256);
 
-General changes
----------------
+General
+-------
 
 * Add optimizer for ``LIMIT 0``
 * Fix incorrect check to disable string statistics in ORC

--- a/docs/src/main/sphinx/release/release-0.94.rst
+++ b/docs/src/main/sphinx/release/release-0.94.rst
@@ -15,8 +15,8 @@ single ORC buffer, and for larger columns we instead stream the data. This
 reduces heap fragmentation and excessive buffers in ORC at the expense of
 HDFS IOPS. The default value is ``8MB``.
 
-General changes
----------------
+General
+-------
 
 * Update Hive CDH 4 connector to CDH 4.7.1
 * Fix ``ORDER BY`` with ``LIMIT 0``

--- a/docs/src/main/sphinx/release/release-0.95.rst
+++ b/docs/src/main/sphinx/release/release-0.95.rst
@@ -2,7 +2,7 @@
 Release 0.95
 ============
 
-General changes
----------------
+General
+-------
 
 * Fix task and stage leak, caused when a stage finishes before its substages.

--- a/docs/src/main/sphinx/release/release-0.96.rst
+++ b/docs/src/main/sphinx/release/release-0.96.rst
@@ -2,8 +2,8 @@
 Release 0.96
 ============
 
-General changes
----------------
+General
+-------
 
 * Fix :func:`try_cast` for ``TIMESTAMP`` and other types that
   need access to session information.
@@ -16,7 +16,7 @@ General changes
 * Fixed "running queries" JMX stat.
 * Add ``distributed_join`` session property to enable/disable distributed joins.
 
-Hive changes
-------------
+Hive
+----
 
 * Add support for tables partitioned by ``DATE``.

--- a/docs/src/main/sphinx/release/release-0.97.rst
+++ b/docs/src/main/sphinx/release/release-0.97.rst
@@ -2,8 +2,8 @@
 Release 0.97
 ============
 
-General changes
----------------
+General
+-------
 
 * The queueing policy in Presto may now be injected.
 * Speed up detection of ASCII strings in implementation of ``LIKE`` operator.
@@ -13,8 +13,8 @@ General changes
 * Fix a planning issue in queries that use ``SELECT *``, window functions and implicit coercions.
 * Fix scheduler deadlock for queries with a ``UNION`` between ``VALUES`` and ``SELECT``.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix decoding of ``STRUCT`` type from Parquet files.
 * Speed up decoding of ORC files with very small stripes.

--- a/docs/src/main/sphinx/release/release-0.98.rst
+++ b/docs/src/main/sphinx/release/release-0.98.rst
@@ -13,13 +13,13 @@ instead of ``JSON``.
     so if you have written a connector or function, you will need to update
     your code before deploying this release.
 
-Hive changes
-------------
+Hive
+----
 
 * Fix handling of ORC files with corrupt checkpoints.
 
-SPI changes
------------
+SPI
+---
 
 * Rename ``Index`` to ``ConnectorIndex``.
 
@@ -27,8 +27,8 @@ SPI changes
     This is a backwards incompatible change, so if you have written a connector
     that uses ``Index``, you will need to update your code before deploying this release.
 
-General changes
----------------
+General
+-------
 
 * Fix bug in ``UNNEST`` when output is unreferenced or partially referenced.
 * Make :func:`max` and :func:`min` functions work on all orderable types.

--- a/docs/src/main/sphinx/release/release-0.99.rst
+++ b/docs/src/main/sphinx/release/release-0.99.rst
@@ -2,8 +2,8 @@
 Release 0.99
 ============
 
-General changes
----------------
+General
+-------
 * Reduce lock contention in ``TaskExecutor``.
 * Fix reading maps with null keys from ORC.
 * Fix precomputed hash optimization for nulls values.

--- a/docs/src/main/sphinx/release/release-300.rst
+++ b/docs/src/main/sphinx/release/release-300.rst
@@ -2,8 +2,8 @@
 Release 300 (22 Jan 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix :func:`array_intersect` and :func:`array_distinct`
   skipping zeros when input also contains nulls.
@@ -19,8 +19,8 @@ General changes
   to filters that can be pushed down to connectors.
 * Return final results to clients immediately for failed queries.
 
-JMX MBean naming changes
-------------------------
+JMX MBean naming
+----------------
 
 * The base domain name for server MBeans is now ``presto``. The old names can be
   used by setting the configuration property ``jmx.base-name`` to ``com.facebook.presto``.
@@ -34,18 +34,18 @@ Web UI
 
 * Fix rendering of live plan view for queries involving index joins.
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Change driver class name to ``io.prestosql.jdbc.PrestoDriver``.
 
-System connector changes
-------------------------
+System connector
+----------------
 
 * Remove ``node_id`` column from ``system.runtime.queries`` table.
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix accounting of time spent reading Parquet data.
 * Fix corner case where the ORC writer fails with integer overflow when writing
@@ -57,50 +57,50 @@ Hive connector changes
 * Add support for :ref:`s3selectpushdown`, which enables pushing down
   column selection and range filters into S3 for text files.
 
-Kudu connector changes
-----------------------
+Kudu connector
+--------------
 
 * Add ``number_of_replicas`` table property to ``SHOW CREATE TABLE`` output.
 
-Cassandra connector changes
----------------------------
+Cassandra connector
+-------------------
 
 * Add ``cassandra.splits-per-node`` and ``cassandra.protocol-version`` configuration
   properties to allow connecting to Cassandra servers older than 2.1.5.
 
-MySQL connector changes
+MySQL connector
+---------------
+
+* Add support for predicate pushdown for columns of ``char(x)`` type.
+
+PostgreSQL connector
+--------------------
+
+* Add support for predicate pushdown for columns of ``char(x)`` type.
+
+Redshift connector
+-------------------
+
+* Add support for predicate pushdown for columns of ``char(x)`` type.
+
+SQL Server connector
+--------------------
+
+* Add support for predicate pushdown for columns of ``char(x)`` type.
+
+Raptor Legacy connector
 -----------------------
-
-* Add support for predicate pushdown for columns of ``char(x)`` type.
-
-PostgreSQL connector changes
-----------------------------
-
-* Add support for predicate pushdown for columns of ``char(x)`` type.
-
-Redshift connector changes
----------------------------
-
-* Add support for predicate pushdown for columns of ``char(x)`` type.
-
-SQL Server connector changes
-----------------------------
-
-* Add support for predicate pushdown for columns of ``char(x)`` type.
-
-Raptor Legacy connector changes
--------------------------------
 
 * Change name of connector to ``raptor-legacy``.
 
-Verifier changes
-----------------
+Verifier
+--------
 
 * Add ``run-teardown-on-result-mismatch`` configuration property to facilitate debugging.
   When set to false, temporary tables will not be dropped after checksum failures.
 
-SPI changes
------------
+SPI
+---
 
 * Change base package to ``io.prestosql.spi``.
 * Move connector related classes to package ``io.prestosql.spi.connector``.

--- a/docs/src/main/sphinx/release/release-301.rst
+++ b/docs/src/main/sphinx/release/release-301.rst
@@ -2,8 +2,8 @@
 Release 301 (31 Jan 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix reporting of aggregate input data size stats. (:issue:`100`)
 * Add support for role management (see :doc:`/sql/create-role`).  Note, using :doc:`/sql/set-role`
@@ -20,18 +20,18 @@ General changes
 * Improve performance of queries involving ``SYSTEM`` table sampling and computations over the
   columns of the sampled table. (:issue:`29`)
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Do not allow uninstalling RPM while server is still running. (:issue:`67`)
 
-Security changes
-----------------
+Security
+--------
 
 * Support LDAP with anonymous bind disabled. (:issue:`97`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Add procedure for dumping metastore recording to a file. (:issue:`54`)
 * Add Metastore recorder support for Glue. (:issue:`61`)
@@ -43,19 +43,19 @@ Hive connector changes
   staging directory that is used for write operations. The ``${USER}`` placeholder can be used to
   use a different location for each user (e.g., ``/tmp/${USER}``). (:issue:`70`)
 
-Kafka connector changes
------------------------
+Kafka connector
+---------------
 
 * The minimum supported Kafka broker version is now 0.10.0. (:issue:`53`)
 
-Base-JDBC connector library changes
------------------------------------
+Base-JDBC connector library
+---------------------------
 
 * Add support for defining procedures. (:issue:`73`)
 * Add support for providing table statistics. (:issue:`72`)
 
-SPI changes
------------
+SPI
+---
 
 * Include session trace token in ``QueryCreatedEvent`` and ``QueryCompletedEvent``. (:issue:`24`)
 * Fix regression in ``NodeManager`` where node list was not being refreshed on workers.  (:issue:`27`)

--- a/docs/src/main/sphinx/release/release-302.rst
+++ b/docs/src/main/sphinx/release/release-302.rst
@@ -2,8 +2,8 @@
 Release 302 (6 Feb 2019)
 ========================
 
-General changes
----------------
+General
+-------
 
 * Fix cluster starvation when wait for minimum number of workers is enabled. (:issue:`155`)
 * Fix backup of queries blocked waiting for minimum number of workers. (:issue:`155`)
@@ -17,26 +17,26 @@ General changes
 * Remove deprecated system memory pool. (:issue:`168`)
 * Improve query performance for certain queries involving ``ROLLUP``. (:issue:`105`)
 
-CLI changes
------------
+CLI
+---
 
 * Add ``--trace-token`` option to set the trace token. (:issue:`117`)
 * Display spilled data size as part of debug information. (:issue:`161`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Add spilled data size to query details page. (:issue:`161`)
 
-Security changes
-----------------
+Security
+--------
 
 * Add ``http.server.authentication.krb5.principal-hostname`` configuration option to set the hostname
   for the Kerberos service principal. (:issue:`146`, :issue:`153`)
 * Add support for client-provided extra credentials that can be utilized by connectors. (:issue:`124`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix Parquet predicate pushdown for ``smallint``, ``tinyint`` types. (:issue:`131`)
 * Add support for Google Cloud Storage (GCS). Credentials can be provided globally using the
@@ -46,18 +46,18 @@ Hive connector changes
 * Reduce GC pressure from Parquet reader by constraining the maximum column read size. (:issue:`58`)
 * Reduce network utilization and latency for S3 when reading ORC or Parquet. (:issue:`142`)
 
-Kafka connector changes
------------------------
+Kafka connector
+---------------
 
 * Fix query failure when reading ``information_schema.columns`` without an equality condition on ``table_name``. (:issue:`120`)
 
-Redis connector changes
------------------------
+Redis connector
+---------------
 
 * Fix query failure when reading ``information_schema.columns`` without an equality condition on ``table_name``. (:issue:`120`)
 
-SPI changes
------------
+SPI
+---
 
 * Include query peak task user memory in ``QueryCreatedEvent`` and ``QueryCompletedEvent``. (:issue:`163`)
 * Include plan node cost and statistics estimates in ``QueryCompletedEvent``. (:issue:`134`)

--- a/docs/src/main/sphinx/release/release-303.rst
+++ b/docs/src/main/sphinx/release/release-303.rst
@@ -2,8 +2,8 @@
 Release 303 (13 Feb 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect padding for ``CHAR`` values containing Unicode supplementary characters.
   Previously, such values would be incorrectly padded with too few spaces. (:issue:`195`)
@@ -16,36 +16,36 @@ General changes
 * Expand grouped execution support to window functions, making it possible
   to execute them with less peak memory usage. (:issue:`169`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Add additional details to and improve rendering of live plan. (:issue:`182`)
 
-CLI changes
------------
+CLI
+---
 
 * Add ``--progress`` option to show query progress in batch mode. (:issue:`34`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix query failure when reading Parquet data with no columns selected.
   This affects queries such as ``SELECT count(*)``. (:issue:`203`)
 
-Mongo connector changes
------------------------
+Mongo connector
+---------------
 
 * Fix failure for queries involving joins or aggregations on ``ObjectId`` type. (:issue:`215`)
 
 
-Base-JDBC connector library changes
------------------------------------
+Base-JDBC connector library
+---------------------------
 
 * Allow customizing how query predicates are pushed down to the underlying database. (:issue:`109`)
 * Allow customizing how values are written to the underlying database. (:issue:`109`)
 
-SPI changes
------------
+SPI
+---
 
 * Remove deprecated methods ``getSchemaName`` and ``getTableName`` from the ``SchemaTablePrefix``
   class. These were replaced by the ``getSchema`` and ``getTable`` methods. (:issue:`89`)

--- a/docs/src/main/sphinx/release/release-304.rst
+++ b/docs/src/main/sphinx/release/release-304.rst
@@ -2,8 +2,8 @@
 Release 304 (27 Feb 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix wrong results for queries involving ``FULL OUTER JOIN`` and ``coalesce`` expressions
   over the join keys. (:issue:`288`)
@@ -15,20 +15,20 @@ General changes
 * Avoid opening an unnecessary HTTP listener on an arbitrary port. (:issue:`239`)
 * Add experimental support for spilling for queries involving ``ORDER BY`` or window functions. (:issue:`228`)
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Preserve modified configuration files when the RPM is uninstalled. (:issue:`267`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix broken timeline view. (:issue:`283`)
 * Show data size and position count reported by connectors and by worker-to-worker data transfers
   in detailed query view. (:issue:`271`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix authorization failure when using SQL Standard Based Authorization mode with user identifiers
   that contain capital letters. (:issue:`289`)
@@ -50,13 +50,13 @@ Hive connector changes
   in the metastore with the partitions that are physically on the file system. (:issue:`223`)
 * Improve performance of ORC reader for columns that only contain nulls. (:issue:`229`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Map PostgreSQL ``json`` and ``jsonb`` types to Presto ``json`` type. (:issue:`81`)
 
-Cassandra connector changes
----------------------------
+Cassandra connector
+-------------------
 
 * Support queries over tables containing partitioning columns of any type. (:issue:`252`)
 * Support ``smallint``, ``tinyint`` and  ``date`` Cassandra types. (:issue:`141`)

--- a/docs/src/main/sphinx/release/release-305.rst
+++ b/docs/src/main/sphinx/release/release-305.rst
@@ -2,8 +2,8 @@
 Release 305 (7 Mar 2019)
 ========================
 
-General changes
----------------
+General
+-------
 
 * Fix failure of :doc:`/functions/regexp` for certain patterns and inputs
   when using the default ``JONI`` library. (:issue:`350`)
@@ -17,24 +17,24 @@ General changes
 * Add a system table ``system.metadata.analyze_properties``
   to list all :doc:`/sql/analyze` properties. (:issue:`376`)
 
-Resource groups changes
------------------------
+Resource groups
+---------------
 
 * Fix resource group selection when selector uses regular expression variables. (:issue:`373`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Display peak revocable memory, current total memory,
   and peak total memory in detailed query view. (:issue:`273`)
 
-CLI changes
------------
+CLI
+---
 
 * Add option to output CSV without quotes. (:issue:`319`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix handling of updated credentials for Google Cloud Storage (GCS). (:issue:`398`)
 * Fix calculation of bucket number for timestamps that contain a non-zero
@@ -48,7 +48,7 @@ Hive connector changes
 * Remove legacy writers for ORC and RCFile. (:issue:`353`)
 * Remove support for the DWRF file format. (:issue:`353`)
 
-Base-JDBC connector library changes
------------------------------------
+Base-JDBC connector library
+---------------------------
 
 * Allow access to extra credentials when opening a JDBC connection. (:issue:`281`)

--- a/docs/src/main/sphinx/release/release-306.rst
+++ b/docs/src/main/sphinx/release/release-306.rst
@@ -2,8 +2,8 @@
 Release 306 (16 Mar 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix planning failure for queries containing a ``LIMIT`` after a global
   aggregation. (:issue:`437`)
@@ -33,42 +33,42 @@ General changes
 * Remove deprecated ``distributed_join`` system property. Use ``join_distribution_type``
   instead. (:issue:`452`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix calling procedures immediately after startup, before any other queries are run.
   Previously, the procedure call would fail and also cause all subsequent Hive queries
   to fail. (:issue:`414`)
 * Improve ORC reader performance for decoding ``REAL`` and ``DOUBLE`` types. (:issue:`465`)
 
-MySQL connector changes
------------------------
+MySQL connector
+---------------
 
 * Allow creating or renaming tables, and adding, renaming, or dropping columns. (:issue:`418`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Fix predicate pushdown for PostgreSQL ``ENUM`` type. (:issue:`408`)
 * Allow creating or renaming tables, and adding, renaming, or dropping columns. (:issue:`418`)
 
-Redshift connector changes
---------------------------
+Redshift connector
+------------------
 
 * Allow creating or renaming tables, and adding, renaming, or dropping columns. (:issue:`418`)
 
-SQL Server connector changes
-----------------------------
+SQL Server connector
+--------------------
 
 * Allow creating or renaming tables, and adding, renaming, or dropping columns. (:issue:`418`)
 
-Base-JDBC connector library changes
------------------------------------
+Base-JDBC connector library
+---------------------------
 
 * Allow mapping column type to Presto type based on ``Block``. (:issue:`454`)
 
-SPI changes
------------
+SPI
+---
 
 * Deprecate Table Layout APIs. Connectors can opt out of the legacy behavior by implementing
   ``ConnectorMetadata.usesLegacyTableLayouts()``. (:issue:`420`)

--- a/docs/src/main/sphinx/release/release-307.rst
+++ b/docs/src/main/sphinx/release/release-307.rst
@@ -2,8 +2,8 @@
 Release 307 (3 Apr 2019)
 ========================
 
-General changes
----------------
+General
+-------
 
 * Fix cleanup of spill files for queries using window functions or ``ORDER BY``. (:issue:`543`)
 * Optimize queries containing ``ORDER BY`` together with ``LIMIT`` over an ``OUTER JOIN``
@@ -14,67 +14,49 @@ General changes
 * Add support for outer joins involving lateral derived tables (i.e., ``LATERAL``). (:issue:`390`)
 * Add support for setting table comments via the :doc:`/sql/comment` syntax. (:issue:`200`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Allow UI to work when opened as ``/ui`` (no trailing slash). (:issue:`500`)
 
-Security changes
-----------------
+Security
+--------
 
 * Make query result and cancellation URIs secure. Previously, an authenticated
   user could potentially steal the result data of any running query. (:issue:`561`)
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Prevent JVM from allocating large amounts of native memory. The new configuration is applied
   automatically when Presto is installed from RPM. When Presto is installed another way, or when
   you provide your own ``jvm.config``, we recommend adding ``-Djdk.nio.maxCachedBufferSize=2000000``
   to your ``jvm.config``. See :doc:`/installation/deployment` for details. (:issue:`542`)
 
-CLI changes
------------
+CLI
+---
 
 * Always abort query in batch mode when CLI is killed. (:issue:`508`, :issue:`580`)
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Abort query synchronously when the ``ResultSet`` is closed or when the
   ``Statement`` is cancelled. Previously, the abort was sent in the background,
   allowing the JVM to exit before the abort was received by the server. (:issue:`580`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Add safety checks for Hive bucketing version. Hive 3.0 introduced a new
   bucketing version that uses an incompatible hash function. The Hive connector
   will treat such tables as not bucketed when reading and disallows writing. (:issue:`512`)
 * Add support for setting table comments via the :doc:`/sql/comment` syntax. (:issue:`200`)
 
-MySQL connector changes
------------------------
+Other connectors
+----------------
 
-See `Base-JDBC connector library changes <#base-jdbc-connector-library-changes>`__.
-
-PostgreSQL connector changes
-----------------------------
-
-See `Base-JDBC connector library changes <#base-jdbc-connector-library-changes>`__.
-
-Redshift connector changes
---------------------------
-
-See `Base-JDBC connector library changes <#base-jdbc-connector-library-changes>`__.
-
-SQL Server connector changes
-----------------------------
-
-See `Base-JDBC connector library changes <#base-jdbc-connector-library-changes>`__.
-
-Base-JDBC connector library changes
------------------------------------
+These changes apply to the MySQL, PostgreSQL, Redshift, and SQL Server connectors.
 
 * Fix reading and writing of ``timestamp`` values. Previously, an incorrect value
   could be read, depending on the Presto JVM time zone. (:issue:`495`)
@@ -82,8 +64,8 @@ Base-JDBC connector library changes
   names can be configured using the ``user-credential-name`` and ``password-credential-name``
   configuration properties. (:issue:`482`)
 
-SPI changes
------------
+SPI
+---
 
 * ``LongDecimalType`` and ``IpAddressType`` now use ``Int128ArrayBlock`` instead
   of ``FixedWithBlock``. Any code that creates blocks directly, rather than using

--- a/docs/src/main/sphinx/release/release-308.rst
+++ b/docs/src/main/sphinx/release/release-308.rst
@@ -2,31 +2,31 @@
 Release 308 (11 Apr 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix a regression that prevented the server from starting on Java 9+. (:issue:`610`)
 * Fix correctness issue for queries involving ``FULL OUTER JOIN`` and ``coalesce``. (:issue:`622`)
 
-Security changes
-----------------
+Security
+--------
 
 * Add authorization for listing table columns. (:issue:`507`)
 
-CLI changes
------------
+CLI
+---
 
 * Add option for specifying Kerberos service principal pattern. (:issue:`597`)
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Correctly report precision and column display size in ``ResultSetMetaData``
   for ``char`` and ``varchar`` columns. (:issue:`615`)
 * Add option for specifying Kerberos service principal pattern. (:issue:`597`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix regression that could cause queries to fail with ``Query can potentially
   read more than X partitions`` error. (:issue:`619`)
@@ -36,24 +36,24 @@ Hive connector changes
 * Add directory listing cache for specific tables. The list of tables is specified
   using the  ``hive.file-status-cache-tables`` configuration property. (:issue:`343`)
 
-MySQL connector changes
------------------------
+MySQL connector
+---------------
 
 * Fix ``ALTER TABLE ... RENAME TO ...`` statement. (:issue:`586`)
 * Push simple ``LIMIT`` queries into the external database. (:issue:`589`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Push simple ``LIMIT`` queries into the external database. (:issue:`589`)
 
-Redshift connector changes
---------------------------
+Redshift connector
+------------------
 
 * Push simple ``LIMIT`` queries into the external database. (:issue:`589`)
 
-SQL Server connector changes
-----------------------------
+SQL Server connector
+--------------------
 
 * Fix writing ``varchar`` values with non-Latin characters in ``CREATE TABLE AS``. (:issue:`573`)
 * Support writing ``varchar`` and ``char`` values with length longer than 4000
@@ -61,8 +61,8 @@ SQL Server connector changes
 * Support writing ``boolean`` values in ``CREATE TABLE AS``. (:issue:`573`)
 * Push simple ``LIMIT`` queries into the external database. (:issue:`589`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Add support for Search Guard in Elasticsearch connector. Please refer to :doc:`/connector/elasticsearch`
   for the relevant configuration properties. (:issue:`438`)

--- a/docs/src/main/sphinx/release/release-309.rst
+++ b/docs/src/main/sphinx/release/release-309.rst
@@ -2,8 +2,8 @@
 Release 309 (25 Apr 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect match result for :doc:`/functions/regexp` when pattern ends
   with a word boundary matcher. This only affects the default ``JONI`` library.
@@ -11,33 +11,33 @@ General changes
 * Fix failures for queries involving spatial joins. (:issue:`652`)
 * Add support for ``SphericalGeography`` to :func:`ST_Area()`. (:issue:`383`)
 
-Security changes
-----------------
+Security
+--------
 
 * Add option for specifying the Kerberos GSS name type. (:issue:`645`)
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Update default JVM configuration to recommended settings (see :doc:`/installation/deployment`).
   (:issue:`642`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix rare failure when reading ``DECIMAL`` values from ORC files. (:issue:`664`)
 * Add a hidden ``$properties`` table for each table that describes its Hive table
   properties. For example, a table named ``example`` will have an associated
   properties table named ``example$properties``. (:issue:`268`)
 
-MySQL connector changes
------------------------
+MySQL connector
+---------------
 
 * Match schema and table names case insensitively. This behavior can be enabled by setting
   the ``case-insensitive-name-matching`` catalog configuration option to true. (:issue:`614`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Add support for ``ARRAY`` type. (:issue:`317`)
 * Add support writing ``TINYINT`` values. (:issue:`317`)
@@ -45,27 +45,27 @@ PostgreSQL connector changes
   the ``case-insensitive-name-matching`` catalog configuration option to true. (:issue:`614`)
 
 
-Redshift connector changes
---------------------------
+Redshift connector
+------------------
 
 * Match schema and table names case insensitively. This behavior can be enabled by setting
   the ``case-insensitive-name-matching`` catalog configuration option to true. (:issue:`614`)
 
 
-SQL Server connector changes
-----------------------------
+SQL Server connector
+--------------------
 
 * Match schema and table names case insensitively. This behavior can be enabled by setting
   the ``case-insensitive-name-matching`` catalog configuration option to true. (:issue:`614`)
 
-Cassandra connector changes
----------------------------
+Cassandra connector
+-------------------
 
 * Allow reading from tables which have Cassandra column types that are not supported by Presto.
   These columns will not be visible in Presto. (:issue:`592`)
 
-SPI changes
------------
+SPI
+---
 
 * Add session parameter to the ``applyFilter()`` and ``applyLimit()`` methods in
   ``ConnectorMetadata``. (:issue:`636`)

--- a/docs/src/main/sphinx/release/release-310.rst
+++ b/docs/src/main/sphinx/release/release-310.rst
@@ -2,8 +2,8 @@
 Release 310 (3 May 2019)
 ========================
 
-General changes
----------------
+General
+-------
 
 * Reduce compilation failures for expressions over types containing an extremely
   large number of nested types. (:issue:`537`)
@@ -17,13 +17,13 @@ General changes
   experience significant CPU and performance improvement. (:issue:`602`)
 * Add support for ``FETCH FIRST`` syntax. (:issue:`666`)
 
-CLI changes
------------
+CLI
+---
 
 * Make the final query time consistent with query stats. (:issue:`692`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Ignore boolean column statistics when the count is ``-1``. (:issue:`241`)
 * Prevent failures for ``information_schema`` queries when a table has an invalid
@@ -33,12 +33,12 @@ Hive connector changes
   partition and table schema mismatch. (:issue:`352`)
 * Fix typo in Metastore recorder duration property name. (:issue:`711`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Support for the ``ARRAY`` type has been disabled by default.  (:issue:`687`)
 
-Blackhole connector changes
----------------------------
+Blackhole connector
+-------------------
 
 * Support having tables with same name in different Blackhole schemas. (:issue:`550`)

--- a/docs/src/main/sphinx/release/release-311.rst
+++ b/docs/src/main/sphinx/release/release-311.rst
@@ -2,8 +2,8 @@
 Release 311 (14 May 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect results for aggregation query that contains a ``HAVING`` clause but no
   ``GROUP BY`` clause. (:issue:`733`)
@@ -14,25 +14,25 @@ General changes
 * Print cost metrics using appropriate units in the output of ``EXPLAIN``. (:issue:`68`)
 * Add :func:`combinations` function. (:issue:`714`)
 
-Hive connector changes
-------------------------
+Hive connector
+----------------
 
 * Add support for static AWS credentials for the Glue metastore. (:issue:`748`)
 
-Cassandra connector changes
----------------------------
+Cassandra connector
+-------------------
 
 * Support collections nested in other collections. (:issue:`657`)
 * Automatically discover the Cassandra protocol version when the previously required
   ``cassandra.protocol-version`` configuration property is not set. (:issue:`596`)
 
-Black Hole connector changes
-----------------------------
+Black Hole connector
+--------------------
 
 * Fix rendering of tables and columns in plans. (:issue:`728`)
 * Add table and column statistics. (:issue:`728`)
 
-System connector changes
-------------------------
+System connector
+----------------
 
 * Add ``system.metadata.table_comments`` table that contains table comments. (:issue:`531`)

--- a/docs/src/main/sphinx/release/release-312.rst
+++ b/docs/src/main/sphinx/release/release-312.rst
@@ -2,8 +2,8 @@
 Release 312 (29 May 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect results for queries using ``IS [NOT] DISTINCT FROM``. (:issue:`795`)
 * Fix ``array_distinct``, ``array_intersect`` semantics with respect to indeterminate
@@ -28,8 +28,8 @@ General changes
 * Report operator statistics when ``experimental.work-processor-pipelines``
   is enabled. (:issue:`788`)
 
-Server changes
---------------
+Server
+------
 
 * Raise required Java version to 8u161. This version allows unlimited strength crypto. (:issue:`779`)
 * Show JVM configuration hint when JMX agent fails to start on Java 9+. (:issue:`838`)
@@ -41,8 +41,8 @@ Server changes
   ``query-manager.required-workers`` and ``query-manager.required-workers-max-wait`` configuration
   properties instead. (:issue:`95`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix ``SHOW GRANTS`` failure when metastore contains few tables. (:issue:`791`)
 * Fix failure reading from ``information_schema.table_privileges`` table when metastore
@@ -56,18 +56,18 @@ Hive connector changes
   but can be disabled using the ``hive.create-empty-bucket-files`` configuration property
   or the ``create_empty_bucket_files`` session property. (:issue:`822`)
 
-MySQL connector changes
------------------------
+MySQL connector
+---------------
 
 * Map MySQL ``json`` type to Presto ``json`` type. (:issue:`824`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Add support for PostgreSQL's ``TIMESTAMP WITH TIME ZONE`` data type. (:issue:`640`)
 
-SPI changes
------------
+SPI
+---
 
 * Add support for pushing ``TABLESAMPLE`` into connectors via the
   ``ConnectorMetadata.applySample()`` method. (:issue:`753`)

--- a/docs/src/main/sphinx/release/release-313.rst
+++ b/docs/src/main/sphinx/release/release-313.rst
@@ -2,25 +2,25 @@
 Release 313 (31 May 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix leak in operator peak memory computations. (:issue:`843`)
 * Fix incorrect results for queries involving ``GROUPING SETS`` and ``LIMIT``. (:issue:`864`)
 * Add compression and encryption support for :doc:`/admin/spill`. (:issue:`778`)
 
-CLI changes
+CLI
+---
+
+* Fix failure when selecting a value of type :ref:`uuid_type`. (:issue:`854`)
+
+JDBC driver
 -----------
 
 * Fix failure when selecting a value of type :ref:`uuid_type`. (:issue:`854`)
 
-JDBC driver changes
+Phoenix connector
 -------------------
-
-* Fix failure when selecting a value of type :ref:`uuid_type`. (:issue:`854`)
-
-Phoenix connector changes
----------------------------
 
 * Allow matching schema and table names case insensitively. This can be enabled by setting
   the ``case-insensitive-name-matching`` configuration property to true. (:issue:`872`)

--- a/docs/src/main/sphinx/release/release-314.rst
+++ b/docs/src/main/sphinx/release/release-314.rst
@@ -2,8 +2,8 @@
 Release 314 (7 Jun 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect results for ``BETWEEN`` involving ``NULL`` values. (:issue:`877`)
 * Fix query history leak in coordinator. (:issue:`939`, :issue:`944`)
@@ -13,24 +13,24 @@ General changes
 * Add support for positional access to ``ROW`` fields via the subscript
   operator. (:issue:`860`)
 
-CLI changes
------------
+CLI
+---
 
 * Add JSON output format. (:issue:`878`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix queued queries counter in UI. (:issue:`894`)
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Change default location of the ``http-request.log`` to ``/var/log/presto``. Previously,
   the log would be located in ``/var/lib/presto/data/var/log`` by default. (:issue:`919`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix listing tables and views from Hive 2.3+ Metastore on certain databases,
   including Derby and Oracle. This fixes ``SHOW TABLES``, ``SHOW VIEWS`` and
@@ -49,24 +49,24 @@ Hive connector changes
   the split discovery rate, which can reduce load on the file system. (:issue:`534`)
 * Support overwriting unpartitioned tables for insert queries. (:issue:`924`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Support PostgreSQL arrays declared using internal type
   name, for example ``_int4`` (rather than ``int[]``). (:issue:`659`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Add support for mixed-case field names. (:issue:`887`)
 
-Base-JDBC connector library changes
------------------------------------
+Base-JDBC connector library
+---------------------------
 
 * Allow connectors to customize how they store ``NULL`` values. (:issue:`918`)
 
-SPI changes
------------
+SPI
+---
 
 * Expose the SQL text of the executed prepared statement to ``EventListener``. (:issue:`908`)
 * Deprecate table layouts for ``ConnectorMetadata.makeCompatiblePartitioning()``. (:issue:`689`)

--- a/docs/src/main/sphinx/release/release-315.rst
+++ b/docs/src/main/sphinx/release/release-315.rst
@@ -2,26 +2,26 @@
 Release 315 (14 Jun 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect results when dividing certain decimal numbers. (:issue:`958`)
 * Add support for ``FETCH FIRST ... WITH TIES`` syntax. (:issue:`832`)
 * Add locality awareness to default split scheduler. (:issue:`680`)
 * Add :func:`format` function. (:issue:`548`)
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Require JDK version 8u161+ during installation, which is the version the server requires. (:issue:`983`)
 
-CLI changes
------------
+CLI
+---
 
 * Fix alignment of nulls for numeric columns in aligned output format. (:issue:`871`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix regression in partition pruning for certain query shapes. (:issue:`984`)
 * Correctly identify EMRFS as S3 when deciding to use a temporary location for writes. (:issue:`935`)
@@ -33,14 +33,14 @@ Hive connector changes
   by turning on ``DEBUG`` logging for
   ``io.prestosql.plugin.hive.metastore.thrift.ThriftHiveMetastoreClient``. (:issue:`946`)
 
-MongoDB connector changes
--------------------------
+MongoDB connector
+-----------------
 
 * Fix query failure when ``ROW`` with an ``ObjectId`` field is used as a join key. (:issue:`933`)
 * Add cast from ``ObjectId`` to ``VARCHAR``. (:issue:`933`)
 
-SPI changes
------------
+SPI
+---
 
 * Allow connectors to provide view definitions. ``ConnectorViewDefinition`` now contains
   the real view definition rather than an opaque blob. Connectors that support view storage

--- a/docs/src/main/sphinx/release/release-316.rst
+++ b/docs/src/main/sphinx/release/release-316.rst
@@ -2,22 +2,22 @@
 Release 316 (8 Jul 2019)
 ========================
 
-General changes
----------------
+General
+-------
 
 * Fix ``date_format`` function failure when format string contains non-ASCII
   characters. (:issue:`1056`)
 * Improve performance of queries using ``UNNEST``.  (:issue:`901`)
 * Improve error message when statement parsing fails. (:issue:`1042`)
 
-CLI changes
------------
+CLI
+---
 
 * Fix refresh of completion cache when catalog or schema is changed. (:issue:`1016`)
 * Allow reading password from console when stdout is a pipe. (:issue:`982`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Acquire S3 credentials from the default AWS locations if not configured explicitly. (:issue:`741`)
 * Only allow using roles and grants with SQL standard based authorization. (:issue:`972`)
@@ -28,39 +28,39 @@ Hive connector changes
   ``collect_column_statistics_on_write`` session property. (:issue:`981`)
 * Eliminate unused idle threads when using the metastore cache. (:issue:`1061`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Add support for columns of type ``UUID``. (:issue:`1011`)
 * Export JMX statistics for various JDBC and connector operations. (:issue:`906`).
 
-MySQL connector changes
------------------------
+MySQL connector
+---------------
 
 * Export JMX statistics for various JDBC and connector operations. (:issue:`906`).
 
-Redshift connector changes
---------------------------
+Redshift connector
+------------------
 
 * Export JMX statistics for various JDBC and connector operations. (:issue:`906`).
 
-SQL Server connector changes
-----------------------------
+SQL Server connector
+--------------------
 
 * Export JMX statistics for various JDBC and connector operations. (:issue:`906`).
 
-TPC-H connector changes
------------------------
+TPC-H connector
+---------------
 
 * Fix ``SHOW TABLES`` failure when used with a hidden schema. (:issue:`1005`)
 
-TPC-DS connector changes
-------------------------
+TPC-DS connector
+----------------
 
 * Fix ``SHOW TABLES`` failure when used with a hidden schema. (:issue:`1005`)
 
-SPI changes
------------
+SPI
+---
 
 * Add support for pushing simple column and row field reference expressions into
   connectors via the ``ConnectorMetadata.applyProjection()`` method. (:issue:`676`)

--- a/docs/src/main/sphinx/release/release-317.rst
+++ b/docs/src/main/sphinx/release/release-317.rst
@@ -2,8 +2,8 @@
 Release 317 (1 Aug 2019)
 ========================
 
-General changes
----------------
+General
+-------
 
 * Fix :func:`url_extract_parameter` when the query string contains an encoded ``&`` or ``=`` character.
 * Export MBeans from the ``db`` resource group configuration manager. (:issue:`1151`)
@@ -14,14 +14,14 @@ General changes
 * Allow overriding session time zone for clients via the
   ``sql.forced-session-time-zone`` configuration property. (:issue:`1164`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix tooltip visibility on stage performance details page. (:issue:`1113`)
 * Add planning time to query details page. (:issue:`1115`)
 
-Security changes
-----------------
+Security
+--------
 
 * Allow schema owner to create, drop, and rename schema when using file-based
   connector access control. (:issue:`1139`)
@@ -32,18 +32,18 @@ Security changes
   configuration property, as the header should only be used when the Presto
   coordinator is behind a proxy. (:issue:`1033`)
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Fix ``DatabaseMetaData.getURL()`` to include the ``jdbc:`` prefix. (:issue:`1211`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Add support for nested fields. (:issue:`1001`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix bucketing version safety check to correctly disallow writes
   to tables that use an unsupported bucketing version. (:issue:`1199`)
@@ -51,23 +51,23 @@ Hive connector changes
 * Improve performance of file listings in ``system.sync_partition_metadata`` procedure,
   especially for S3. (:issue:`1093`)
 
-Kudu connector changes
-----------------------
+Kudu connector
+--------------
 
 * Update Kudu client library version to ``1.10.0``. (:issue:`1086`)
 
-MongoDB connector changes
--------------------------
+MongoDB connector
+-----------------
 
 * Allow passwords to contain the ``:`` or ``@`` characters. (:issue:`1094`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Add support for reading ``hstore`` data type. (:issue:`1101`)
 
-SPI changes
------------
+SPI
+---
 
 * Allow delete to be implemented for non-legacy connectors. (:issue:`1015`)
 * Remove deprecated method from ``ConnectorPageSourceProvider``. (:issue:`1095`)

--- a/docs/src/main/sphinx/release/release-318.rst
+++ b/docs/src/main/sphinx/release/release-318.rst
@@ -2,8 +2,8 @@
 Release 318 (26 Aug 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix query failure when using ``DISTINCT FROM`` with the ``UUID`` or
   ``IPADDRESS`` types. (:issue:`1180`)
@@ -29,16 +29,16 @@ General changes
 * Add queries that are in the queue or in the semantic analysis stage to the
   ``system.runtime.queries`` table. (:issue:`1079`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Display information about queries that are in the queue or in the semantic analysis
   stage. (:issue:`1079`)
 * Add support for cancelling queries that are in the queue or in the semantic analysis
   stage. (:issue:`1079`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix query failure due to missing credentials while writing empty bucket files. (:issue:`1298`)
 * Fix bucketing of ``NaN`` values of ``real`` type. Previously ``NaN`` values
@@ -53,8 +53,8 @@ Hive connector changes
 * Allow inserting into bucketed, unpartitioned tables. (:issue:`1127`)
 * Allow inserting into existing partitions of bucketed, partitioned tables. (:issue:`1347`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Add support for providing JDBC credential in a separate file. This can be enabled by
   setting the ``credential-provider.type=FILE`` and ``connection-credential-file``
@@ -65,8 +65,8 @@ PostgreSQL connector changes
   by setting ``jdbc-types-mapped-to-varchar`` to comma-separated list of type names. (:issue:`186`)
 * Add support for PostgreSQL ``timestamp[]`` type. (:issue:`1023`, :issue:`1262`, :issue:`1328`)
 
-MySQL connector changes
------------------------
+MySQL connector
+---------------
 
 * Add support for providing JDBC credential in a separate file. This can be enabled by
   setting the ``credential-provider.type=FILE`` and ``connection-credential-file``
@@ -76,8 +76,8 @@ MySQL connector changes
 * Add possibility to force mapping of certain types to ``varchar``. This can be enabled
   by setting ``jdbc-types-mapped-to-varchar`` to comma-separated list of type names. (:issue:`186`)
 
-Redshift connector changes
---------------------------
+Redshift connector
+------------------
 
 * Add support for providing JDBC credential in a separate file. This can be enabled by
   setting the ``credential-provider.type=FILE`` and ``connection-credential-file``
@@ -87,8 +87,8 @@ Redshift connector changes
 * Add possibility to force mapping of certain types to ``varchar``. This can be enabled
   by setting ``jdbc-types-mapped-to-varchar`` to comma-separated list of type names. (:issue:`186`)
 
-SQL Server connector changes
-----------------------------
+SQL Server connector
+--------------------
 
 * Add support for providing JDBC credential in a separate file. This can be enabled by
   setting the ``credential-provider.type=FILE`` and ``connection-credential-file``
@@ -98,8 +98,8 @@ SQL Server connector changes
 * Add possibility to force mapping of certain types to ``varchar``. This can be enabled
   by setting ``jdbc-types-mapped-to-varchar`` to comma-separated list of type names. (:issue:`186`)
 
-SPI changes
------------
+SPI
+---
 
 * Add ``Block.isLoaded()`` method. (:issue:`1216`)
 * Update security APIs to accept the new ``ConnectorSecurityContext``

--- a/docs/src/main/sphinx/release/release-319.rst
+++ b/docs/src/main/sphinx/release/release-319.rst
@@ -2,8 +2,8 @@
 Release 319 (22 Sep 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix planning failure for queries involving ``UNION`` and ``DISTINCT`` aggregates. (:issue:`1510`)
 * Fix excessive runtime when parsing expressions involving ``CASE``. (:issue:`1407`)
@@ -34,8 +34,8 @@ General changes
   via the ``node-scheduler.network-topology.type`` configuration property. (:issue:`1500`)
 * Add support for ``SphericalGeography`` to :func:`ST_Length`. (:issue:`1551`)
 
-Security changes
-----------------
+Security
+--------
 
 * Allow configuring read-only access in :doc:`/security/built-in-system-access-control`. (:issue:`1153`)
 * Add missing checks for schema create, rename, and drop in file-based ``SystemAccessControl``. (:issue:`1153`)
@@ -43,20 +43,20 @@ Security changes
   ``X-Forwarded-Proto`` header. This is disabled by default, but can be enabled using the
   ``http-server.authentication.allow-forwarded-https`` configuration property. (:issue:`1442`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix rendering bug in Query Timeline resulting in inconsistency of presented information after
   query finishes. (:issue:`1371`)
 * Show total memory in Query Timeline instead of user memory. (:issue:`1371`)
 
-CLI changes
------------
+CLI
+---
 
 * Add ``--insecure`` option to skip validation of server certificates for debugging. (:issue:`1484`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix reading from ``information_schema``, as well as ``SHOW SCHEMAS``, ``SHOW TABLES``, and
   ``SHOW COLUMNS`` when connecting to a Hive 3.x metastore that contains an ``information_schema``

--- a/docs/src/main/sphinx/release/release-320.rst
+++ b/docs/src/main/sphinx/release/release-320.rst
@@ -2,8 +2,8 @@
 Release 320 (10 Oct 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect parameter binding order for prepared statement execution when
   parameters appear inside a ``WITH`` clause. (:issue:`1191`)
@@ -18,19 +18,19 @@ General changes
 * Add :func:`at_timezone`. (:issue:`1612`)
 * Add :func:`with_timezone`. (:issue:`1612`)
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Only report warnings on ``Statement``, not ``ResultSet``, as warnings
   are not associated with reads of the ``ResultSet``. (:issue:`1640`)
 
-CLI changes
------------
+CLI
+---
 
 * Add multi-line editing and syntax highlighting. (:issue:`1380`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Add impersonation support for calls to the Hive metastore. This can be enabled using the
   ``hive.metastore.thrift.impersonation.enabled`` configuration property. (:issue:`43`)
@@ -39,22 +39,22 @@ Hive connector changes
   SOCKS proxy. Previously, it was controlled with the ``hive.metastore.thrift.client.socks-proxy``
   configuration property. (:issue:`1469`)
 
-MySQL connector changes
------------------------
+MySQL connector
+---------------
 
 * Add ``mysql.jdbc.use-information-schema`` configuration property to control whether
   the MySQL JDBC driver should use the MySQL ``information_schema`` to answer metadata
   queries. This may be helpful when diagnosing problems. (:issue:`1598`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Add support for reading PostgreSQL system tables, e.g., ``pg_catalog`` relations.
   The functionality is disabled by default and can be enabled using the
   ``postgresql.include-system-tables`` configuration property. (:issue:`1527`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Add support for ``VARBINARY``, ``TIMESTAMP``, ``TINYINT``, ``SMALLINT``,
   and ``REAL`` data types. (:issue:`1639`)
@@ -62,7 +62,7 @@ Elasticsearch connector changes
 * Add support for special ``_id``, ``_score`` and ``_source`` columns. (:issue:`1639`)
 * Add support for :ref:`full text queries <elasticsearch-full-text-queries>`. (:issue:`1662`)
 
-SPI changes
------------
+SPI
+---
 
 * Introduce a builder for ``Identity`` and deprecate its public constructors. (:issue:`1624`)

--- a/docs/src/main/sphinx/release/release-321.rst
+++ b/docs/src/main/sphinx/release/release-321.rst
@@ -4,8 +4,8 @@ Release 321 (15 Oct 2019)
 
 .. warning:: The server RPM is broken in this release.
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect result of :func:`round` when applied to a ``tinyint``, ``smallint``,
   ``integer``, or ``bigint`` type with negative decimal places. (:issue:`42`)
@@ -14,13 +14,13 @@ General changes
   via the ``experimental.enable-dynamic-filtering`` configuration option or the
   ``enable_dynamic_filtering`` session property. (:issue:`1686`)
 
-Security changes
-----------------
+Security
+--------
 
 * Improve the security of query results with one-time tokens. (:issue:`1654`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix reading ``TEXT`` file collection delimiter set by Hive versions earlier
   than 3.0. (:issue:`1714`)
@@ -36,30 +36,30 @@ Hive connector changes
 * Allow caching directory listings for all tables or schemas. (:issue:`1668`)
 * Add support for dynamic filtering for broadcast joins. (:issue:`1686`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Support reading PostgreSQL arrays as the ``JSON`` data type. This can be enabled by
   setting the ``postgresql.experimental.array-mapping`` configuration property or the
   ``array_mapping`` catalog session property to ``AS_JSON``. (:issue:`682`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Add support for Amazon Elasticsearch Service. (:issue:`1693`)
 
-Cassandra connector changes
----------------------------
+Cassandra connector
+-------------------
 
 * Add TLS support. (:issue:`1680`)
 
-JMX connector changes
----------------------
+JMX connector
+-------------
 
 * Add support for wildcards in configuration of history tables. (:issue:`1572`)
 
-SPI changes
------------
+SPI
+---
 
 * Fix ``QueryStatistics.getWallTime()`` to report elapsed time rather than total
   scheduled time. (:issue:`1719`)

--- a/docs/src/main/sphinx/release/release-322.rst
+++ b/docs/src/main/sphinx/release/release-322.rst
@@ -2,19 +2,19 @@
 Release 322 (16 Oct 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Improve performance of certain join queries by reducing the amount of data
   that needs to be scanned. (:issue:`1673`)
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Fix a regression that caused zero-length files in the RPM. (:issue:`1767`)
 
-Connector changes
------------------
+Other connectors
+----------------
 
 These changes apply to MySQL, PostgreSQL, Redshift, and SQL Server.
 

--- a/docs/src/main/sphinx/release/release-323.rst
+++ b/docs/src/main/sphinx/release/release-323.rst
@@ -2,8 +2,8 @@
 Release 323 (23 Oct 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix query failure when referencing columns from a table that contains
   hidden columns. (:issue:`1796`)
@@ -15,19 +15,19 @@ General changes
 * Allow using ``.*`` on expressions of type ``ROW`` in the ``SELECT`` clause to
   convert the fields of a row into multiple columns. (:issue:`1017`)
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Fix a compatibility issue when connecting to pre-321 servers. (:issue:`1785`)
 * Fix reporting of views in ``DatabaseMetaData.getTables()``. (:issue:`1488`)
 
-CLI changes
-------------
+CLI
+----
 
 * Fix a compatibility issue when connecting to pre-321 servers. (:issue:`1785`)
 
-Hive changes
-------------
+Hive
+----
 
 * Fix the ORC writer to correctly write the file footers. Previously written files were
   sometimes unreadable in Hive 3.1 when querying the table for a second (or subsequent)
@@ -37,15 +37,15 @@ Hive changes
 * Allow using multiple Hive catalogs that use different Kerberos or other authentication
   configurations. (:issue:`760`, :issue:`978`, :issue:`1820`)
 
-PostgreSQL changes
-------------------
+PostgreSQL
+----------
 
 * Support for PostgreSQL arrays is no longer considered experimental, therefore
   the configuration property ``postgresql.experimental.array-mapping`` is now named
   to ``postgresql.array-mapping``. (:issue:`1740`)
 
-SPI changes
------------
+SPI
+---
 
 * Add support for unnesting dictionary blocks duration compaction. (:issue:`1761`)
 * Change ``LazyBlockLoader`` to directly return the loaded block. (:issue:`1744`)

--- a/docs/src/main/sphinx/release/release-324.rst
+++ b/docs/src/main/sphinx/release/release-324.rst
@@ -3,8 +3,8 @@ Release 324 (1 Nov 2019)
 ========================
 
 
-General changes
----------------
+General
+-------
 
 * Fix query failure when ``CASE`` operands have different types. (:issue:`1825`)
 * Add support for ``ESCAPE`` clause in ``SHOW CATALOGS LIKE ...``. (:issue:`1691`)
@@ -15,33 +15,33 @@ General changes
 * Configuration property ``experimental.reserved-pool-enabled`` was renamed to
   ``experimental.reserved-pool-disabled`` (with meaning reversed). (:issue:`1916`)
 
-Security changes
-----------------
+Security
+--------
 
 * Perform access control checks when displaying table or view definitions
   with ``SHOW CREATE``. (:issue:`1517`)
 
-Hive changes
-------------
+Hive
+----
 
 * Allow using ``SHOW GRANTS`` on a Hive view when using the ``sql-standard``
   security mode. (:issue:`1842`)
 * Improve performance when filtering dictionary-encoded Parquet columns. (:issue:`1846`)
 
-PostgreSQL changes
-------------------
+PostgreSQL
+----------
 
 * Add support for inserting ``MAP(VARCHAR, VARCHAR)`` values into columns of
   ``hstore`` type. (:issue:`1894`)
 
-Elasticsearch Changes
----------------------
+Elasticsearch
+-------------
 
 * Fix failure when reading datetime columns in Elasticsearch 5.x. (:issue:`1844`)
 * Add support for mixed-case field names. (:issue:`1914`)
 
-SPI changes
------------
+SPI
+---
 
 * Introduce a builder for ``ColumnMetadata``. The various overloaded constructors
   are now deprecated. (:issue:`1891`)

--- a/docs/src/main/sphinx/release/release-325.rst
+++ b/docs/src/main/sphinx/release/release-325.rst
@@ -4,8 +4,8 @@ Release 325 (14 Nov 2019)
 
 .. warning:: There is a performance regression in this release.
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect results for certain queries involving ``FULL`` or ``RIGHT`` joins and
   ``LATERAL``. (:issue:`1952`)
@@ -22,13 +22,13 @@ General changes
 * Add variant of :func:`strpos` that returns the Nth occurrence of a substring. (:issue:`1811`)
 * Add :func:`to_encoded_polyline` and :func:`from_encoded_polyline` geospatial functions. (:issue:`1827`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Show actual query for an ``EXECUTE`` statement. (:issue:`1980`)
 
-Hive changes
-------------
+Hive
+----
 
 * Fix incorrect behavior of ``CREATE TABLE`` when Hive metastore is configured
   with ``metastore.create.as.acid`` set to ``true``. (:issue:`1958`)
@@ -39,8 +39,8 @@ Hive changes
   the precision in the table or partition schema. (:issue:`1949`)
 * Improve performance when reading Parquet files with small row groups. (:issue:`1925`)
 
-Other connector changes
------------------------
+Other connectors
+----------------
 
 These changes apply to the MySQL, PostgreSQL, Redshift, and SQL Server connectors.
 

--- a/docs/src/main/sphinx/release/release-326.rst
+++ b/docs/src/main/sphinx/release/release-326.rst
@@ -2,8 +2,8 @@
 Release 326 (27 Nov 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect query results when query contains ``LEFT JOIN`` over ``UNNEST``. (:issue:`2097`)
 * Fix performance regression in queries involving ``JOIN``. (:issue:`2047`)
@@ -13,18 +13,18 @@ General changes
   ``ORDER BY`` clauses. (:issue:`2044`)
 * Improve performance when processing columns of ``map`` type. (:issue:`2015`)
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Allow running Presto with :ref:`Java 11 or above <requirements-java>`. (:issue:`2057`)
 
-Security changes
-----------------
+Security
+--------
 
 * Deprecate Kerberos in favor of JWT for :doc:`/security/internal-communication`. (:issue:`2032`)
 
-Hive changes
-------------
+Hive
+----
 
 * Fix table creation error for tables with S3 location when using ``file`` metastore. (:issue:`1664`)
 * Fix a compatibility issue with the CDH 5.x metastore which results in stats
@@ -32,13 +32,13 @@ Hive changes
 * Improve performance for Glue metastore by fetching partitions in parallel. (:issue:`1465`)
 * Improve performance of ``sql-standard`` security. (:issue:`1922`, :issue:`1929`)
 
-Phoenix connector changes
--------------------------
+Phoenix connector
+-----------------
 
 * Collect statistics on the count and duration of each call to Phoenix. (:issue:`2024`)
 
-Other connector changes
------------------------
+Other connectors
+----------------
 
 These changes apply to the MySQL, PostgreSQL, Redshift, and SQL Server connectors.
 

--- a/docs/src/main/sphinx/release/release-327.rst
+++ b/docs/src/main/sphinx/release/release-327.rst
@@ -2,8 +2,8 @@
 Release 327 (20 Dec 2019)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix join query failure when late materialization is enabled. (:issue:`2144`)
 * Fix failure of :func:`word_stem` for certain inputs. (:issue:`2145`)
@@ -16,14 +16,14 @@ General changes
 * Rename ``experimental.work-processor-pipelines`` configuration property to ``experimental.late-materialization.enabled``
   and rename ``work_processor_pipelines`` session property to ``late_materialization``. (:issue:`2275`)
 
-Security changes
-----------------
+Security
+--------
 
 * Allow using multiple system access controls. (:issue:`2178`)
 * Add :doc:`/security/password-file`. (:issue:`797`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix incorrect query results when reading ``timestamp`` values from ORC files written by
   Hive 3.1 or later. (:issue:`2099`)
@@ -40,43 +40,43 @@ Hive connector changes
 * Allow configuring the ``hive.orc.use-column-names`` config property on a per-session
   basis using the ``orc_use_column_names`` session property. (:issue:`2248`)
 
-Kudu connector changes
-----------------------
+Kudu connector
+--------------
 
 * Support predicate pushdown for the ``decimal`` type. (:issue:`2131`)
 * Fix column position swap for delete operations that may result in deletion of the wrong records. (:issue:`2252`)
 * Improve predicate pushdown for queries that match a column against
   multiple values (typically using the ``IN`` operator). (:issue:`2253`)
 
-MongoDB connector changes
--------------------------
+MongoDB connector
+-----------------
 
 * Add support for reading from views. (:issue:`2156`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Allow converting unsupported types to ``VARCHAR`` by setting the session property
   ``unsupported_type_handling`` or configuration property ``unsupported-type-handling``
   to ``CONVERT_TO_VARCHAR``. (:issue:`1182`)
 
-MySQL connector changes
------------------------
+MySQL connector
+---------------
 
 * Fix ``INSERT`` query failure when ``GTID`` mode is enabled. (:issue:`2251`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Improve performance for queries involving equality and range filters
   over table columns. (:issue:`2310`)
 
-Google Sheets connector changes
--------------------------------
+Google Sheets connector
+-----------------------
 
 * Fix incorrect results when listing tables in ``information_schema``. (:issue:`2118`)
 
-SPI changes
------------
+SPI
+---
 
 * Add ``executionTime`` to ``QueryStatistics`` for event listeners. (:issue:`2247`)

--- a/docs/src/main/sphinx/release/release-328.rst
+++ b/docs/src/main/sphinx/release/release-328.rst
@@ -2,8 +2,8 @@
 Release 328 (10 Jan 2020)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix correctness issue for certain correlated join queries when the correlated subquery on
   the right produces no rows. (:issue:`1969`)
@@ -19,8 +19,8 @@ General changes
 * Add support for interpolating :doc:`/security/secrets` in server and catalog configuration
   files. (:issue:`2370`)
 
-Security changes
-----------------
+Security
+--------
 
 * Fix a security issue allowing users to gain unauthorized access to Presto cluster
   when using password authenticator with LDAP. (:issue:`2356`)
@@ -35,8 +35,8 @@ JDBC driver
 * Fix failure when restoring autocommit mode with
   ``java.sql.Connection#setAutocommit()`` (:issue:`2338`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Reduce query latency and Hive metastore load when using the
   ``AUTOMATIC`` join reordering strategy. (:issue:`2184`)
@@ -44,30 +44,30 @@ Hive connector changes
 * Avoid redundant file system stat call when writing Parquet files. (:issue:`1746`)
 * Avoid retrying permanent errors for S3-related services such as STS. (:issue:`2331`)
 
-Kafka connector changes
------------------------
+Kafka connector
+---------------
 
 * Remove internal columns: ``_segment_start``, ``_segment_end`` and
   ``_segment_count``. (:issue:`2303`)
 * Add new configuration property ``kafka.messages-per-split`` to control how many Kafka
   messages will be processed by a single Presto split. (:issue:`2303`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Fix query failure when an object in an Elasticsearch document
   does not have any fields. (:issue:`2217`)
 * Add support for querying index aliases. (:issue:`2324`)
 
-Phoenix connector changes
--------------------------
+Phoenix connector
+-----------------
 
 * Add support for mapping unsupported data types to ``VARCHAR``. This can be enabled by setting
   the ``unsupported-type-handling`` configuration property or the ``unsupported_type_handling`` session
   property to ``CONVERT_TO_VARCHAR``. (:issue:`2427`)
 
-Other connector changes
------------------------
+Other connectors
+----------------
 
 These changes apply to the MySQL, PostgreSQL, Redshift and SQL Server connectors:
 

--- a/docs/src/main/sphinx/release/release-329.rst
+++ b/docs/src/main/sphinx/release/release-329.rst
@@ -2,8 +2,8 @@
 Release 329 (23 Jan 2020)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect result for :func:`last_day_of_month` function for first day of month. (:issue:`2452`)
 * Fix incorrect results when handling ``DOUBLE`` or ``REAL`` types with ``NaN`` values. (:issue:`2582`)
@@ -27,14 +27,14 @@ General changes
   ``information_schema.columns`` table. These columns can still be selected,
   but will no longer appear when describing the table. (:issue:`2306`)
 
-Security changes
-----------------
+Security
+--------
 
 * Add ``ldap.bind-dn`` and ``ldap.bind-password`` LDAP properties to allow LDAP authentication
   access LDAP server using service account. (:issue:`1917`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix incorrect data returned when using S3 Select on uncompressed files. In our testing, S3 Select
   was apparently returning incorrect results when reading uncompressed files, so S3 Select is disabled
@@ -58,14 +58,14 @@ Hive connector changes
 * Add procedure ``system.drop_stats()`` to remove the column statistics
   for a table or selected partitions. (:issue:`2538`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Add support for :ref:`elasticsearch-array-types`. (:issue:`2441`)
 * Reduce load on Elasticsearch cluster and improve query performance. (:issue:`2561`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Fix mapping between PostgreSQL's ``TIME`` and Presto's ``TIME`` data types.
   Previously the mapping was incorrect, shifting it by the relative offset between the session

--- a/docs/src/main/sphinx/release/release-330.rst
+++ b/docs/src/main/sphinx/release/release-330.rst
@@ -2,8 +2,8 @@
 Release 330 (18 Feb 2020)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect behavior of :func:`format` for ``char`` values. Previously, the function
   did not preserve trailing whitespace of the value being formatted. (:issue:`2629`)
@@ -28,16 +28,16 @@ General changes
 * Verify that the target schema exists for the :doc:`/sql/use` statement. (:issue:`2764`)
 * Verify that the session catalog exists when executing :doc:`/sql/set-role`. (:issue:`2768`)
 
-Server changes
---------------
+Server
+------
 
 * Require running on :ref:`Java 11 or above <requirements-java>`. This requirement may be temporarily relaxed by adding
   ``-Dpresto-temporarily-allow-java8=true`` to the Presto :ref:`trino_jvm_config`.
   This fallback will be removed in future versions of Presto after March 2020. (:issue:`2751`)
 * Add experimental support for running on Linux aarch64 (ARM64). (:issue:`2809`)
 
-Security changes
-----------------
+Security
+--------
 
 * :ref:`principal_rules` are deprecated and will be removed in a future release.
   These rules have been replaced with :doc:`/security/user-mapping`, which
@@ -51,13 +51,13 @@ Security changes
 * When authentication is disabled, the Presto user may now be set using standard
   HTTP basic authentication with an empty password. (:issue:`2653`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Display physical read time in detailed query view. (:issue:`2805`)
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Fix a performance issue on JDK 11+ when connecting using HTTP/2. (:issue:`2633`)
 * Implement ``PreparedStatement.setTimestamp()`` variant that takes a ``Calendar``. (:issue:`2732`)
@@ -67,18 +67,18 @@ JDBC driver changes
 * Allow using the ``:`` character within an extra credential value specified via the
   ``extraCredentials`` property. (:issue:`2780`)
 
-CLI changes
------------
+CLI
+---
 
 * Fix a performance issue on JDK 11+ when connecting using HTTP/2. (:issue:`2633`)
 
-Cassandra connector changes
----------------------------
+Cassandra connector
+-------------------
 
 * Fix query failure when identifiers should be quoted. (:issue:`2455`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix reading symlinks from HDFS when using Kerberos. (:issue:`2720`)
 * Reduce Hive metastore load when updating partition statistics. (:issue:`2734`)
@@ -108,27 +108,27 @@ Hive connector changes
   procedures for adding partitions to and removing partitions from a partitioned table. (:issue:`2692`)
 * Allow running :doc:`/sql/analyze` collecting only basic table statistics. (:issue:`2762`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Improve performance of queries containing a ``LIMIT`` clause. (:issue:`2781`)
 * Add support for ``nested`` data type. (:issue:`754`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Add read support for PostgreSQL ``money`` data type. The type is mapped to ``varchar`` in Presto.
   (:issue:`2601`)
 
-Other connector changes
------------------------
+Other connectors
+----------------
 
 These changes apply to the MySQL, PostgreSQL, Redshift, Phoenix and SQL Server connectors.
 
 * Respect ``DEFAULT`` column clause when writing to a table. (:issue:`1185`)
 
-SPI changes
------------
+SPI
+---
 
 * Allow procedures to have optional arguments with default values. (:issue:`2706`)
 * ``SystemAccessControl.checkCanSetUser()`` is is deprecated and has been replaced

--- a/docs/src/main/sphinx/release/release-331.rst
+++ b/docs/src/main/sphinx/release/release-331.rst
@@ -2,8 +2,8 @@
 Release 331 (16 Mar 2020)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Prevent query failures when worker is shut down gracefully. (:issue:`2648`)
 * Fix join failures for queries involving ``OR`` predicate with non-comparable functions. (:issue:`2861`)
@@ -22,8 +22,8 @@ General changes
 * Add :doc:`/connector/bigquery`. (:issue:`2532`)
 * Add support for large prepared statements. (:issue:`2719`)
 
-Security changes
-----------------
+Security
+--------
 
 * Remove unused ``internal-communication.jwt.enabled`` configuration property. (:issue:`2709`)
 * Rename JWT configuration properties from ``http.authentication.jwt.*`` to ``http-server.authentication.jwt.*``. (:issue:`2712`)
@@ -31,13 +31,13 @@ Security changes
   configured using :ref:`query_rules` in :doc:`/security/file-system-access-control`. (:issue:`2213`)
 * Hide columns of tables for which the user has no privileges in :doc:`/security/file-system-access-control`. (:issue:`2925`)
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Implement ``PreparedStatement.getMetaData()``. (:issue:`2770`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix copying worker address to clipboard. (:issue:`2865`)
 * Fix copying query ID to clipboard. (:issue:`2872`)
@@ -48,14 +48,14 @@ Web UI changes
 * Add simple form based authentication that utilizes the configured password authenticator. (:issue:`2755`)
 * Allow disabling the UI via the ``web-ui.enabled`` configuration property. (:issue:`2755`)
 
-CLI changes
------------
+CLI
+---
 
 * Fix formatting of ``varbinary`` in nested data types. (:issue:`2858`)
 * Add ``--timezone`` parameter. (:issue:`2961`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix incorrect results for reads from ``information_schema`` tables and
   metadata queries when using a Hive 3.x metastore. (:issue:`3008`)
@@ -75,21 +75,21 @@ Hive connector changes
 * Hide the Hive system schema ``sys`` for security reasons. (:issue:`3008`)
 * Add support for changing the owner of a schema. (:issue:`2673`)
 
-MongoDB connector changes
--------------------------
+MongoDB connector
+-----------------
 
 * Fix incorrect results when queries contain filters on certain data types, such
   as ``real`` or ``decimal``. (:issue:`1781`)
 
-Other connector changes
------------------------
+Other connectors
+----------------
 
 These changes apply to the MemSQL, MySQL, PostgreSQL, Redshift, Phoenix, and SQL Server connectors.
 
 * Add support for dropping schemas. (:issue:`2956`)
 
-SPI changes
------------
+SPI
+---
 
 * Remove deprecated ``Identity`` constructors. (:issue:`2877`)
 * Introduce a builder for ``ConnectorIdentity`` and deprecate its public constructors. (:issue:`2877`)

--- a/docs/src/main/sphinx/release/release-332.rst
+++ b/docs/src/main/sphinx/release/release-332.rst
@@ -2,8 +2,8 @@
 Release 332 (08 Apr 2020)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix query failure during planning phase for certain queries involving multiple joins. (:issue:`3149`)
 * Fix execution failure for queries involving large ``IN`` predicates on decimal values with precision larger than 18. (:issue:`3191`)
@@ -25,33 +25,33 @@ General changes
   to ``optimizer.push-aggregation-through-outer-join``. (:issue:`3205`)
 * Add operator statistics for the number of splits processed with a dynamic filter applied. (:issue:`3217`)
 
-Security changes
-----------------
+Security
+--------
 
 * Fix LDAP authentication when user belongs to multiple groups. (:issue:`3206`)
 * Verify access to table columns when running ``SHOW STATS``. (:issue:`2665`)
 * Only return views accessible to the user from ``information_schema.views``. (:issue:`3290`)
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Add ``clientInfo`` property to set extra information about the client. (:issue:`3188`)
 * Add ``traceToken`` property to set a trace token for correlating requests across systems. (:issue:`3188`)
 
-BigQuery connector changes
---------------------------
+BigQuery connector
+------------------
 
 * Extract parent project ID from service account before looking at the environment. (:issue:`3131`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Add support for ``ip`` type. (:issue:`3347`)
 * Add support for ``keyword`` fields with numeric values. (:issue:`3381`)
 * Remove unnecessary ``elasticsearch.aws.use-instance-credentials`` configuration property. (:issue:`3265`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix failure reading certain Parquet files larger than 2GB. (:issue:`2730`)
 * Improve performance when reading gzip-compressed Parquet data. (:issue:`3175`)
@@ -78,19 +78,19 @@ Hive connector changes
 * Allow using configured S3 credentials with IAM role. Previously,
   the configured IAM role was silently ignored. (:issue:`3351`)
 
-Kudu connector changes
-----------------------
+Kudu connector
+--------------
 
 * Fix incorrect column mapping in Kudu connector. (:issue:`3170`, :issue:`2963`)
 * Fix incorrect query result for certain queries involving ``IS NULL`` predicates with ``OR``. (:issue:`3274`)
 
-Memory connector changes
-------------------------
+Memory connector
+----------------
 
 * Include views in the list of tables returned to the JDBC driver. (:issue:`3208`)
 
-MongoDB connector changes
--------------------------
+MongoDB connector
+-----------------
 
 * Add ``objectid_timestamp`` for extracting the timestamp from ``ObjectId``. (:issue:`3089`)
 * Delete document from ``_schema`` collection when ``DROP TABLE``
@@ -102,8 +102,8 @@ SQL Server connector
 * Disallow renaming tables between schemas. Previously, such renames were allowed
   but the schema name was ignored when performing the rename. (:issue:`3284`)
 
-SPI changes
------------
+SPI
+---
 
 * Expose row filters and column masks in ``QueryCompletedEvent``. (:issue:`3183`)
 * Expose referenced functions and procedures in ``QueryCompletedEvent``. (:issue:`3246`)

--- a/docs/src/main/sphinx/release/release-333.rst
+++ b/docs/src/main/sphinx/release/release-333.rst
@@ -2,8 +2,8 @@
 Release 333 (04 May 2020)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix planning failure when lambda expressions are repeated in a query. (:issue:`3218`)
 * Fix failure when input to ``TRY`` is a constant ``NULL``. (:issue:`3408`)
@@ -23,45 +23,45 @@ General changes
 * Add :doc:`/sql/show-create-schema`. (:issue:`3099`)
 * Add :func:`starts_with` function. (:issue:`3392`)
 
-Server changes
---------------
+Server
+------
 
 * Require running on :ref:`Java 11 or above <requirements-java>`. (:issue:`2799`)
 
-Server RPM changes
-------------------
+Server RPM
+----------
 
 * Reduce size of RPM and disk usage after installation. (:issue:`3595`)
 
-Security changes
-----------------
+Security
+--------
 
 * Allow configuring trust certificate for LDAP password authenticator. (:issue:`3523`)
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Fix hangs on JDK 8u252 when using secure connections. (:issue:`3444`)
 
-BigQuery connector changes
---------------------------
+BigQuery connector
+------------------
 
 * Improve performance for queries that contain filters on table columns. (:issue:`3376`)
 * Add support for partitioned tables. (:issue:`3376`)
 
-Cassandra connector changes
----------------------------
+Cassandra connector
+-------------------
 
 * Allow :doc:`/sql/insert` statement for table having hidden ``id`` column. (:issue:`3499`)
 * Add support for :doc:`/sql/create-table` statement. (:issue:`3478`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Fix failure when querying Elasticsearch 7.x clusters. (:issue:`3447`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix incorrect query results when reading Parquet data with a ``varchar`` column predicate
   which is a comparison with a value containing non-ASCII characters. (:issue:`3517`)
@@ -82,14 +82,14 @@ Hive connector changes
   ``projection_pushdown_enabled`` session property. (:issue:`3490`)
 * Add support for connecting to the Thrift metastore using TLS. (:issue:`3440`)
 
-MongoDB connector changes
--------------------------
+MongoDB connector
+-----------------
 
 * Skip unknown types in nested BSON object. (:issue:`2935`)
 * Fix query failure when the user does not have access privileges for ``system.views``. (:issue:`3355`)
 
-Other connector changes
------------------------
+Other connectors
+----------------
 
 These changes apply to the MemSQL, MySQL, PostgreSQL, Redshift, and SQL Server connectors.
 

--- a/docs/src/main/sphinx/release/release-334.rst
+++ b/docs/src/main/sphinx/release/release-334.rst
@@ -2,8 +2,8 @@
 Release 334 (29 May 2020)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect query results for certain queries involving comparisons of ``real`` and ``double`` types
   when values include negative zero. (:issue:`3745`)
@@ -32,32 +32,32 @@ JDBC driver
 
 * Implement ``toString()`` for ``java.sql.Array`` results. (:issue:`3803`)
 
-CLI changes
------------
+CLI
+---
 
 * Improve rendering of elapsed time for short queries. (:issue:`3311`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Add ``fixed``, ``certificate``, ``JWT``, and ``Kerberos`` to UI authentication. (:issue:`3433`)
 * Show join distribution type in Live Plan. (:issue:`1323`)
 
-JDBC driver changes
--------------------
+JDBC driver
+-----------
 
 * Improve performance of ``DatabaseMetaData.getColumns()`` when the
   parameters contain unescaped ``%`` or ``_``. (:issue:`1620`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Fix failure when executing ``SHOW CREATE TABLE``. (:issue:`3718`)
 * Improve performance for ``count(*)`` queries. (:issue:`3512`)
 * Add support for raw Elasticsearch queries. (:issue:`3735`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix matching bucket filenames without leading zeros. (:issue:`3702`)
 * Fix creation of external tables using ``CREATE TABLE AS``. Previously, the
@@ -78,18 +78,18 @@ Hive connector changes
   the ``hive.metastore.thrift.delegation-token.cache-ttl`` and ``hive.metastore.thrift.delegation-token.cache-maximum-size``
   configuration properties. (:issue:`3771`)
 
-MemSQL connector changes
-------------------------
+MemSQL connector
+----------------
 
 * Include :doc:`/connector/memsql` in the server tarball and RPM. (:issue:`3743`)
 
-MongoDB connector changes
--------------------------
+MongoDB connector
+-----------------
 
 * Support case insensitive database and collection names. This can be enabled with the
   ``mongodb.case-insensitive-name-matching`` configuration property. (:issue:`3453`)
 
-SPI changes
------------
+SPI
+---
 
 * Allow a ``SystemAccessControl`` to provide an ``EventListener``. (:issue:`3629`).

--- a/docs/src/main/sphinx/release/release-335.rst
+++ b/docs/src/main/sphinx/release/release-335.rst
@@ -2,8 +2,8 @@
 Release 335 (14 Jun 2020)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix failure when :func:`reduce_agg` is used as a window function. (:issue:`3883`)
 * Fix incorrect cast from ``TIMESTAMP`` (without time zone) to ``TIME`` type. (:issue:`3848`)
@@ -17,23 +17,23 @@ General changes
 * Add  ``information_schema.role_authorization_descriptors`` table that returns information about the roles
   granted to principals. (:issue:`3535`)
 
-Security changes
-----------------
+Security
+--------
 
 * Add schema access rules to :doc:`/security/file-system-access-control`. (:issue:`3766`)
 
-Web UI changes
---------------
+Web UI
+------
 
 * Fix the value displayed in the worker memory pools bar. (:issue:`3920`)
 
-Accumulo connector changes
---------------------------
+Accumulo connector
+------------------
 
 * The server-side iterators are now in a JAR file named ``presto-accumulo-iterators``. (:issue:`3673`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Collect column statistics for inserts into empty tables. (:issue:`2469`)
 * Add support for ``information_schema.role_authorization_descriptors`` table when using the ``sql-standard``
@@ -51,14 +51,14 @@ Hive connector changes
 * Add support for dynamic partition pruning to improve performance of complex queries
   over partitioned data. (:issue:`1072`)
 
-Phoenix connector changes
--------------------------
+Phoenix connector
+-----------------
 
 * Allow configuring whether ``DROP TABLE`` is allowed. This is controlled by the new ``allow-drop-table``
   catalog configuration property and defaults to ``true``, compatible with the previous behavior. (:issue:`3953`)
 
-SPI changes
------------
+SPI
+---
 
 * Add support for aggregation pushdown into connectors via the
   ``ConnectorMetadata.applyAggregation()`` method. (:issue:`3697`)

--- a/docs/src/main/sphinx/release/release-336.rst
+++ b/docs/src/main/sphinx/release/release-336.rst
@@ -2,21 +2,21 @@
 Release 336 (16 Jun 2020)
 =========================
 
-General changes
----------------
+General
+-------
 
 * Fix failure when querying timestamp columns from older clients. (:issue:`4036`)
 * Improve reporting of configuration errors. (:issue:`4050`)
 * Fix rare failure when recording server stats in T-Digests. (:issue:`3965`)
 
-Security changes
-----------------
+Security
+--------
 
 * Add table access rules to :doc:`/security/file-system-access-control`. (:issue:`3951`)
 * Add new ``default`` system access control that allows all operations except user impersonation. (:issue:`4040`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix incorrect query results when reading Parquet files with predicates
   when ``hive.parquet.use-column-names`` is set to ``false`` (the default). (:issue:`3574`)

--- a/docs/src/main/sphinx/release/release-337.rst
+++ b/docs/src/main/sphinx/release/release-337.rst
@@ -6,8 +6,8 @@ Release 337 (25 Jun 2020)
    attacker can take advantage of this vulnerability to escalate privileges to internal APIs. We encourage everyone to upgrade as soon
    as possible.
 
-General changes
----------------
+General
+-------
 
 * Fix incorrect results for inequality join involving ``NaN``. (:issue:`4120`)
 * Fix peak non-revocable memory metric in event listener. (:issue:`4096`)
@@ -23,8 +23,8 @@ General changes
 * Add :func:`translate` function. (:issue:`4080`)
 * Reduce worker graceful shutdown duration. (:issue:`4192`)
 
-Security changes
-----------------
+Security
+--------
 
 * Disable insecure authentication over HTTP by default when HTTPS with authentication is enabled. This
   can be overridden via the ``http-server.authentication.allow-insecure-over-http`` configuration property. (:issue:`4199`)
@@ -32,13 +32,13 @@ Security changes
 * Add :ref:`system_information_rules` which control the ability of a user to access to read and write system management information. (:issue:`4199`)
 * Disable user impersonation in default system security. (:issue:`4082`)
 
-Elasticsearch connector changes
--------------------------------
+Elasticsearch connector
+-----------------------
 
 * Add support for password authentication. (:issue:`4165`)
 
-Hive connector changes
-----------------------
+Hive connector
+--------------
 
 * Fix reading CSV tables with ``separatorChar``, ``quoteChar`` or ``escapeChar`` table property
   containing more than one character. For compatibility with Hive, only first character is considered
@@ -57,14 +57,14 @@ Hive connector changes
 * Support ACID data files naming used when direct inserts are enabled in Hive (HIVE-21164).
   Direct inserts is an upcoming feature in Hive 4. (:issue:`4049`)
 
-PostgreSQL connector changes
-----------------------------
+PostgreSQL connector
+--------------------
 
 * Improve performance of aggregation queries by computing aggregations within PostgreSQL database.
   Currently, the following aggregate functions are eligible for pushdown:
   ``count``,  ``min``, ``max``, ``sum`` and ``avg``. (:issue:`3881`)
 
-Base-JDBC connector library changes
------------------------------------
+Base-JDBC connector library
+---------------------------
 
 * Implement framework for aggregation pushdown. (:issue:`3881`)

--- a/docs/src/main/sphinx/release/release-338.md
+++ b/docs/src/main/sphinx/release/release-338.md
@@ -1,6 +1,6 @@
 # Release 338 (07 Jul 2020)
 
-## General changes
+## General
 
 * Fix incorrect results when joining tables on a masked column. ({issue}`4251`)
 * Fix planning failure when multiple columns have a mask. ({issue}`4322`)
@@ -18,16 +18,16 @@
   configuration property or `omit_datetime_type_precision` session property. ({issue}`4349`, {issue}`4377`)
 * Enforce `NOT NULL` column declarations when writing data. ({issue}`4144`)
 
-## JDBC driver changes
+## JDBC driver
 
 * Fix excessive CPU usage when reading query results. ({issue}`3928`)
 * Implement `DatabaseMetaData.getClientInfoProperties()`. ({issue}`4318`)
 
-## Elasticsearch connector changes
+## Elasticsearch connector
 
 * Add support for reading numeric values encoded as strings. ({issue}`4341`)
 
-## Hive connector changes
+## Hive connector
 
 * Fix incorrect query results when Parquet file has no min/max statistics for an integral column. ({issue}`4200`)
 * Fix query failure when reading from a table partitioned on a `real` or `double` column containing
@@ -39,20 +39,20 @@
 * Add support for setting column comments. ({issue}`2516`)
 * Add hidden `$partition` column for partitioned tables that contains the partition name. ({issue}`3582`)
 
-## Kafka connector changes
+## Kafka connector
 
 * Fix query failure when a column is projected and also referenced in a query predicate
   when reading from Kafka topic using `RAW` decoder. ({issue}`4183`)
 
-## MySQL connector changes
+## MySQL connector
 
 * Fix type mapping for unsigned integer types. ({issue}`4187`)
 
-## Oracle connector changes
+## Oracle connector
 
 * Exclude internal schemas (e.g., sys) from schema listings. ({issue}`3784`)
 * Add support for connection pooling. ({issue}`3770`)
 
-## Base-JDBC connector library changes
+## Base-JDBC connector library
 
 * Exclude the underlying database's `information_schema` from schema listings. ({issue}`3834`)

--- a/docs/src/main/sphinx/release/release-339.md
+++ b/docs/src/main/sphinx/release/release-339.md
@@ -1,6 +1,6 @@
 # Release 339 (21 Jul 2020)
 
-## General changes
+## General
 
 * Add {func}`approx_most_frequent`. ({issue}`3425`)
 * Physical bytes scan limit for queries can be configured via `query.max-scan-physical-bytes` configuration property
@@ -15,7 +15,7 @@
 * Fix failure when querying nested `TIMESTAMP` or `TIMESTAMP WITH TIME ZONE` for legacy clients. ({issue}`4475`, {issue}`4425`)
 * Fix failure when parsing timestamps with time zone with an offset of the form `+NNNN`. ({issue}`4490`)
 
-## JDBC driver changes
+## JDBC driver
 
 * Fix reading `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE` values with a negative year
   or a year higher than 9999. ({issue}`4364`)
@@ -25,11 +25,11 @@
   The previous behavior can temporarily be restored using `useSessionTimeZone` JDBC connection
   parameter. ({issue}`4017`)
 
-## Druid connector changes
+## Druid connector
 
 * Fix handling of table and column names containing non-ASCII characters. ({issue}`4312`)
 
-## Hive connector changes
+## Hive connector
 
 * Add support for writing Bloom filters in ORC files. ({issue}`3939`)
 * Make `location` parameter optional for the `system.register_partition` procedure. ({issue}`4443`)
@@ -41,31 +41,31 @@
 * Fix a query failure when reading from Parquet file containing `real` or `double` `NaN` values,
   if the file was written by a non-conforming writer. ({issue}`4267`)
 
-## Kafka connector changes
+## Kafka connector
 
 * Add insert support for Avro. ({issue}`4418`)
 * Add insert support for CSV. ({issue}`4287`)
 
-## Kudu connector changes
+## Kudu connector
 
 * Add support for grouped execution. It can be enabled with the `kudu.grouped-execution.enabled`
   configuration property or the `grouped_execution` session property. ({issue}`3715`)
 
-## MongoDB connector changes
+## MongoDB connector
 
 * Allow querying Azure Cosmos DB. ({issue}`4415`)
 
-## Oracle connector changes
+## Oracle connector
 
 * Allow providing credentials via the `connection-user` and `connection-password`
   configuration properties. These properties were previously ignored if connection pooling
   was enabled. ({issue}`4430`)
 
-## Phoenix connector changes
+## Phoenix connector
 
 * Fix handling of row key definition with white space. ({issue}`3251`)
 
-## SPI changes
+## SPI
 
 * Allow connectors to wait for dynamic filters before splits are generated via the new
   `DynamicFilter` object passed to `ConnectorSplitManager.getSplits()`. ({issue}`4224`)

--- a/docs/src/main/sphinx/release/release-340.md
+++ b/docs/src/main/sphinx/release/release-340.md
@@ -1,6 +1,6 @@
 # Release 340 (8 Aug 2020)
 
-## General changes
+## General
 
 * Add support for query parameters in `LIMIT`, `OFFSET` and `FETCH FIRST` clauses. ({issue}`4529`, {issue}`4601`)
 * Add experimental support for recursive queries. ({issue}`4250`)
@@ -16,20 +16,20 @@
 * Fix failure when `GROUP BY` clause contains duplicate expressions. ({issue}`4609`)
 * Fix potential hang during query planning ({issue}`4635`).
 
-## Security changes
+## Security
 
 * Fix unprivileged access to table's schema via `CREATE TABLE LIKE`. ({issue}`4472`)
 
-## JDBC driver changes
+## JDBC driver
 
 * Fix handling of dates before 1582-10-15. ({issue}`4563`)
 * Fix handling of timestamps before 1900-01-01. ({issue}`4563`)
 
-## Elasticsearch connector changes
+## Elasticsearch connector
 
 * Fix failure when index mapping is missing. ({issue}`4535`)
 
-## Hive connector changes
+## Hive connector
 
 * Allow creating a table with `external_location` when schema's location is not valid. ({issue}`4069`)
 * Add read support for tables that were created as non-transactional and converted to be
@@ -45,27 +45,27 @@
 * Fix query failure when S3 data location contains a `_$folder$` marker object. ({issue}`4552`)
 * Fix failure when referencing nested fields of a `ROW` type when table and partition metadata differs. ({issue}`3967`)
 
-## Kafka connector changes
+## Kafka connector
 
 * Add insert support for Raw data format. ({issue}`4417`)
 * Add insert support for JSON. ({issue}`4477`)
 * Remove unused `kafka.connect-timeout` configuration properties. ({issue}`4664`)
 
-## MongoDB connector changes
+## MongoDB connector
 
 * Add `mongodb.max-connection-idle-time` properties to limit the maximum idle time of a pooled connection. ({issue}`4483`)
 
-## Phoenix connector changes
+## Phoenix connector
 
 * Add table level property to specify data block encoding when creating tables. ({issue}`4617`)
 * Fix query failure when listing schemas. ({issue}`4560`)
 
-## PostgreSQL connector changes
+## PostgreSQL connector
 
 * Push down {func}`count` aggregations over constant expressions.
   For example, `SELECT count(1)`. ({issue}`4362`)
 
-## SPI changes
+## SPI
 
 * Expose information about query type in query Event Listener. ({issue}`4592`)
 * Add support for TopN pushdown via the `ConnectorMetadata.applyLimit()` method. ({issue}`4249`)

--- a/docs/src/main/sphinx/release/release-341.md
+++ b/docs/src/main/sphinx/release/release-341.md
@@ -1,6 +1,6 @@
 # Release 341 (8 Sep 2020)
 
-## General changes
+## General
 
 * Add support for variable-precision `TIME` type. ({issue}`4381`)
 * Add support for variable precision `TIME WITH TIME ZONE` type. ({issue}`4905`)
@@ -36,7 +36,7 @@
 * Fail queries with a proper error message when `TABLESAMPLE` is used with a non-numeric sample ratio. ({issue}`5074`)
 * Fail with an explicit error rather than `OutOfMemoryError` for certain operations. ({issue}`4890`)
 
-## Security changes
+## Security
 
 * Add [Salesforce password authentication](/security/salesforce). ({issue}`4372`)
 * Add support for interpolating [secrets](/security/secrets) into `access-control.properties`. ({issue}`4854`)
@@ -47,20 +47,20 @@
 
 * Fix display of physical input read time in detailed query view. ({issue}`4962`)
 
-## JDBC driver changes
+## JDBC driver
 
 * Implement `ResultSet.getStatement()`. ({issue}`4957`)
 
-## BigQuery connector changes
+## BigQuery connector
 
 * Add support for hourly partitioned tables. ({issue}`4968`)
 * Redact the value of `bigquery.credentials-key` in the server log. ({issue}`4968`)
 
-## Cassandra connector changes
+## Cassandra connector
 
 * Map Cassandra `TIMESTAMP` type to Presto `TIMESTAMP(3) WITH TIME ZONE` type. ({issue}`2269`)
 
-## Hive connector changes
+## Hive connector
 
 * Skip stripes and row groups based on timestamp statistics for ORC files. ({issue}`1147`)
 * Skip S3 objects with the `DeepArchive` storage class (in addition to the `Glacier`
@@ -89,33 +89,33 @@
   and underwent a minor compaction. ({issue}`4623`)
 * Fix query failure when storage caching is enabled and cached data is evicted during query execution. ({issue}`3580`)
 
-## JMX connector changes
+## JMX connector
 
 * Change `timestamp` column type in history tables to `TIMESTAMP WITH TIME ZONE`. ({issue}`4753`)
 
-## Kafka connector changes
+## Kafka connector
 
 * Preserve time zone when parsing `TIMESTAMP WITH TIME ZONE` values. ({issue}`4799`)
 
-## Kinesis connector changes
+## Kinesis connector
 
 * Preserve time zone when parsing `TIMESTAMP WITH TIME ZONE` values. ({issue}`4799`)
 
-## Kudu connector changes
+## Kudu connector
 
 * Fix delete when applied on table having primary key of decimal type. ({issue}`4683`)
 
-## Local File connector changes
+## Local File connector
 
 * Change `timestamp` column type to `TIMESTAMP WITH TIME ZONE`. ({issue}`4752`)
 
-## MySQL connector changes
+## MySQL connector
 
 * Improve performance of aggregation queries by pushing the aggregation computation into the MySQL database.
   Currently, the following aggregate functions are eligible for pushdown: `count`,  `min`, `max`,
   `sum` and `avg`. ({issue}`4138`)
 
-## Oracle connector changes
+## Oracle connector
 
 * Add `oracle.connection-pool.inactive-timeout` configuration property to specify how long
   pooled connection can be inactive before it is closed. It defaults to 20 minutes. ({issue}`4779`)
@@ -126,11 +126,11 @@
   list of type names. ({issue}`4955`)
 * Prevent query failure for pushdown of predicates involving a large number of conjuncts. ({issue}`4918`)
 
-## Phoenix connector changes
+## Phoenix connector
 
 * Fix overwriting of former value when insert is applied without specifying that column. ({issue}`4670`)
 
-## Pinot connector changes
+## Pinot connector
 
 * Add support for `REAL` and `INTEGER` types. ({issue}`4725`)
 * Add support for functions in pass-through queries. ({issue}`4801`)
@@ -140,26 +140,26 @@
 * Fix incorrect results for queries involving {func}`avg` over columns of type `long`, `int`, or `float`. ({issue}`4802`)
 * Fix incorrect results when columns in pass-through query do not match selected columns. ({issue}`4802`)
 
-## Prometheus connector changes
+## Prometheus connector
 
 * Change the type of the `timestamp` column to `TIMESTAMP(3) WITH TIME ZONE` type. ({issue}`4799`)
 
-## PostgreSQL connector changes
+## PostgreSQL connector
 
 * Improve performance of aggregation queries with predicates by pushing the computation
   of both the filtering and aggregations into the PostgreSQL server where possible. ({issue}`4111`)
 * Fix handling of PostgreSQL arrays when `unsupported-type-handling` is set to `CONVERT_TO_VARCHAR`. ({issue}`4981`)
 
-## Raptor connector changes
+## Raptor connector
 
 * Remove the `storage.shard-day-boundary-time-zone` configuration property, which was used to work
   around legacy timestamp semantics in Presto. ({issue}`4799`)
 
-## Redis connector changes
+## Redis connector
 
 * Preserve time zone when parsing `TIMESTAMP WITH TIME ZONE` values. ({issue}`4799`)
 
-## SPI changes
+## SPI
 
 * The `TIMESTAMP` type is encoded as a number of fractional seconds from `1970-01-01 00:00:00` in the proleptic
   Gregorian calendar. This value is no longer adjusted to the session time zone. Timestamps with precision less

--- a/docs/src/main/sphinx/release/release-342.md
+++ b/docs/src/main/sphinx/release/release-342.md
@@ -1,6 +1,6 @@
 # Release 342 (24 Sep 2020)
 
-## General changes
+## General
 
 * Add {func}`from_iso8601_timestamp_nanos` function. ({issue}`5048`)
 * Improve performance of queries that use the `DECIMAL` type. ({issue}`4886`)
@@ -14,15 +14,15 @@
   session property. ({issue}`5262`)
 * Fix query failure when lambda expression references a table column containing a dot. ({issue}`5087`)
 
-## Atop connector changes
+## Atop connector
 
 * Fix incorrect query results when query contains predicates on `start_time` or `end_time` column. ({issue}`5125`)
 
-## Elasticsearch connector changes
+## Elasticsearch connector
 
 * Allow reading boolean values stored as strings. ({issue}`5269`)
 
-## Hive connector changes
+## Hive connector
 
 * Add support for S3 encrypted files. ({issue}`2536`)
 * Add support for ABFS OAuth authentication. ({issue}`5052`)
@@ -39,11 +39,11 @@
 * Improve planning time for queries with non-equality filters on partition columns when using the Glue metastore. ({issue}`5060`)
 * Improve performance when reading `JSON` and `CSV` file formats. ({issue}`5142`)
 
-## Iceberg connector changes
+## Iceberg connector
 
 * Fix partition transforms for temporal columns for dates before 1970. ({issue}`5273`)
 
-## Kafka connector changes
+## Kafka connector
 
 * Expose message headers as a `_headers` column of `MAP(VARCHAR, ARRAY(VARBINARY))` type. ({issue}`4462`)
 * Add write support for `TIME`, `TIME WITH TIME ZONE`, `TIMESTAMP` and `TIMESTAMP WITH TIME ZONE`
@@ -54,22 +54,22 @@
   - `milliseconds-since-epoch`: `TIME WITH TIME ZONE`, `TIMESTAMP WITH TIME ZONE`
   - `seconds-since-epoch`: `TIME WITH TIME ZONE`, `TIMESTAMP WITH TIME ZONE`
 
-## MySQL connector changes
+## MySQL connector
 
 * Improve performance of `INSERT` queries when GTID mode is disabled in MySQL. ({issue}`4995`)
 
-## PostgreSQL connector changes
+## PostgreSQL connector
 
 * Add support for variable-precision TIMESTAMP and TIMESTAMP WITH TIME ZONE types. ({issue}`5124`, {issue}`5105`)
 
-## SQL Server connector changes
+## SQL Server connector
 
 * Fix failure when inserting `NULL` into a `VARBINARY` column. ({issue}`4846`)
 * Improve performance of aggregation queries by computing aggregations within SQL Server database.
   Currently, the following aggregate functions are eligible for pushdown:
   `count`,  `min`, `max`, `sum` and `avg`. ({issue}`4139`)
 
-## SPI changes
+## SPI
 
 * Add `DynamicFilter.isAwaitable()` method that returns whether or not the dynamic filter is complete
   and can be awaited for using the `isBlocked()` method. ({issue}`5043`)

--- a/docs/src/main/sphinx/release/release-343.md
+++ b/docs/src/main/sphinx/release/release-343.md
@@ -1,14 +1,14 @@
 # Release 343 (25 Sep 2020)
 
-## BigQuery connector changes
+## BigQuery connector
 
 * Add support for yearly partitioned tables. ({issue}`5298`)
 
-## Hive connector changes
+## Hive connector
 
 * Fix query failure when read from or writing to a bucketed table containing a column of `timestamp` type. ({issue}`5295`)
 
-## SQL Server connector changes
+## SQL Server connector
 
 * Improve performance of aggregation queries with `stddev`, `stddev_samp`, `stddev_pop`, `variance`, `var_samp`, `var_pop`
   aggregate functions by computing aggregations within SQL Server database. ({issue}`5299`)

--- a/docs/src/main/sphinx/release/release-344.md
+++ b/docs/src/main/sphinx/release/release-344.md
@@ -1,6 +1,6 @@
 # Release 344 (9 Oct 2020)
 
-## General changes
+## General
 
 * Add {func}`murmur3` function. ({issue}`5054`)
 * Add {func}`from_unixtime_nanos` function. ({issue}`5046`)
@@ -24,7 +24,7 @@
 * Fix incorrect timestamp values returned by the `queries`, `transactions`,
   and `tasks` tables in `system.runtime`. ({issue}`5462`)
 
-## Security changes
+## Security
 
 ```{warning}
 The file-based system and catalog access controls have changed in ways that reduce or increase permissions.
@@ -46,7 +46,7 @@ Please, read these release notes carefully.
 * Change file-based catalog access control to deny permissions inspection and manipulation. ({issue}`5039`)
 * Add [file-based group provider](/security/group-file). ({issue}`5028`)
 
-## Hive connector changes
+## Hive connector
 
 * Add support for `hive.security=allow-all`, which allows to skip all authorization checks. ({issue}`5416`)
 * Support Kerberos authentication for Hudi tables. ({issue}`5472`)
@@ -56,22 +56,22 @@ Please, read these release notes carefully.
 * Improve query concurrency by listing data files more efficiently. ({issue}`5260`)
 * Fix Parquet encoding for timestamps before 1970-01-01. ({issue}`5364`)
 
-## Kafka connector changes
+## Kafka connector
 
 * Expose message timestamp via `_timestamp` internal column. ({issue}`4805`)
 * Add predicate pushdown for `_timestamp`, `_partition_offset` and `_partition_id` columns. ({issue}`4805`)
 
-## Phoenix connector changes
+## Phoenix connector
 
 * Fix query failure when a column name in `CREATE TABLE` requires quoting. ({issue}`3601`)
 
-## PostgreSQL connector changes
+## PostgreSQL connector
 
 * Add support for setting a column comment. ({issue}`5307`)
 * Add support for variable-precision `time` type. ({issue}`5342`)
 * Allow `CREATE TABLE` and `CREATE TABLE AS` with `timestamp` and `timestamp with time zone` with precision higher than 6.
   The resulting column will be declared with precision of 6, maximal supported by PostgreSQL. ({issue}`5342`)
 
-## SQL Server connector changes
+## SQL Server connector
 
 * Improve performance of queries with aggregations and `WHERE` clause. ({issue}`5327`)

--- a/docs/src/main/sphinx/release/release-345.md
+++ b/docs/src/main/sphinx/release/release-345.md
@@ -1,6 +1,6 @@
 # Release 345 (23 Oct 2020)
 
-## General changes
+## General
 
 * Add {func}`concat_ws` function. ({issue}`4680`)
 * Add support for {func}`extract` for `time with time zone` values with precision other than 3. ({issue}`5539`)
@@ -13,18 +13,18 @@
 * Improve performance of encrypted spilling. ({issue}`5557`)
 * Improve performance of queries that use the `decimal` type. ({issue}`5181`)
 
-## Security changes
+## Security
 
 * Add support for JSON Web Key (JWK) to the existing JSON Web Token (JWT) authenticator.  This is enabled by
   setting the `jwt.key-file` configuration property to a `http` or `https` url. ({issue}`5419`)
 * Add column security, column mask and row filter to file-based access controls. ({issue}`5460`)
 * Enforce access control for column references in `USING` clause. ({issue}`5620`)
 
-## JDBC driver changes
+## JDBC driver
 
 * Add `source` parameter for directly setting the source name for a query. ({issue}`4739`)
 
-## Hive connector changes
+## Hive connector
 
 * Add support for `INSERT` and `DELETE` for ACID tables. ({issue}`5402`)
 * Apply `hive.domain-compaction-threshold` to dynamic filters. ({issue}`5365`)
@@ -34,33 +34,33 @@
 * Fix disk space accounting for storage caching. ({issue}`5621`)
 * Fix failure when reading Parquet `timestamp` columns encoded as `int64`. ({issue}`5443`)
 
-## MongoDB connector changes
+## MongoDB connector
 
 * Add support for adding columns. ({issue}`5512`)
 * Fix incorrect result for `IS NULL` predicates on fields that do not exist in the document. ({issue}`5615`)
 
-## MemSQL connector changes
+## MemSQL connector
 
 * Fix representation for many MemSQL types. ({issue}`5495`)
 * Prevent a query failure when table column name contains a semicolon by explicitly forbidding such names. ({issue}`5495`)
 * Add support for case-insensitive table name matching. ({issue}`5495`)
 
-## MySQL connector changes
+## MySQL connector
 
 * Improve performance of queries with aggregations and `LIMIT` clause (but without `ORDER BY`). ({issue}`5261`)
 
-## PostgreSQL connector changes
+## PostgreSQL connector
 
 * Improve performance of queries with aggregations and `LIMIT` clause (but without `ORDER BY`). ({issue}`5261`)
 
-## Redshift connector changes
+## Redshift connector
 
 * Add support for setting column comments. ({issue}`5397`)
 
-## SQL Server connector changes
+## SQL Server connector
 
 * Improve performance of queries with aggregations and `LIMIT` clause (but without `ORDER BY`). ({issue}`5261`)
 
-## Thrift connector changes
+## Thrift connector
 
 * Fix handling of timestamp values. ({issue}`5596`)

--- a/docs/src/main/sphinx/release/release-346.md
+++ b/docs/src/main/sphinx/release/release-346.md
@@ -1,6 +1,6 @@
 # Release 346 (10 Nov 2020)
 
-## General changes
+## General
 
 * Add support for `RANGE BETWEEN <value> PRECEDING AND <value> FOLLOWING` window frames. ({issue}`609`)
 * Add support for window frames based on `GROUPS`. ({issue}`5713`)
@@ -32,11 +32,11 @@
 * Fix failure when {func}`approx_distinct` is used with high precision `timestamp(p)`/`timestamp(p) with time zone`/`time(p) with time zone`
   data types. ({issue}`5392`)
 
-## Web UI changes
+## Web UI
 
 * Fix "Capture Snapshot" button on the Worker page. ({issue}`5759`)
 
-## JDBC driver changes
+## JDBC driver
 
 * Support number accessor methods like `ResultSet.getLong()` or `ResultSet.getDouble()`
   on `decimal` values, as well as `char` or `varchar` values that can be unambiguously interpreted as numbers. ({issue}`5509`)
@@ -44,20 +44,20 @@
 * Remove legacy `useSessionTimeZone` JDBC connection parameter. ({issue}`4521`)
 * Implement `ResultSet.getRow()`. ({issue}`5769`)
 
-## BigQuery connector changes
+## BigQuery connector
 
 * Fix issue when query could return invalid results if some column references were pruned out during query optimization. ({issue}`5618`)
 
-## Cassandra connector changes
+## Cassandra connector
 
 * Improve performance of `INSERT` queries with batch statement. The batch size can be configured via the `cassandra.batch-size`
   configuration property. ({issue}`5047`)
 
-## Elasticsearch connector changes
+## Elasticsearch connector
 
 * Fix failure when index mappings do not contain a `properties` section. ({issue}`5807`)
 
-## Hive connector changes
+## Hive connector
 
 * Add support for `ALTER TABLE ... SET AUTHORIZATION` SQL syntax to change the table owner. ({issue}`5717`)
 * Add support for writing timestamps with microsecond or nanosecond precision, in addition to milliseconds. ({issue}`5283`)
@@ -74,41 +74,41 @@
 * Fix failure when the declared length of a `varchar(n)` column in the partition schema differs from the table schema. ({issue}`5484`)
 * Fix Glue metastore pushdown for complex expressions. ({issue}`5698`)
 
-## Iceberg connector changes
+## Iceberg connector
 
 * Add support for materialized views. ({issue}`4832`)
 * Remove deprecated `parquet.fail-on-corrupted-statistics` (previously known as `hive.parquet.fail-on-corrupted-statistics`).
   A new configuration property, `parquet.ignore-statistics`, can be used to deal with Parquet files with incorrect metadata.  ({issue}`3077`)
 
-## Kafka connector changes
+## Kafka connector
 
 * Fix incorrect column comment. ({issue}`5751`)
 
-## Kudu connector changes
+## Kudu connector
 
 * Improve performance of queries having only `LIMIT` clause. ({issue}`3691`)
 
-## MySQL connector changes
+## MySQL connector
 
 * Improve performance for queries containing a predicate on a `varbinary` column. ({issue}`5672`)
 
-## Oracle connector changes
+## Oracle connector
 
 * Add support for setting column comments. ({issue}`5399`)
 * Allow enabling remarks reporting via `oracle.remarks-reporting.enabled` configuration property. ({issue}`5720`)
 
-## PostgreSQL connector changes
+## PostgreSQL connector
 
 * Improve performance of queries comparing a `timestamp` column with a `timestamp with time zone` constants
   for `timestamp with time zone` precision higher than 3. ({issue}`5543`)
 
-## Other connector changes
+## Other connectors
 
 * Improve performance of queries with `DISTINCT` or `LIMIT`, or with `GROUP BY` and no aggregate functions and `LIMIT`,
   when the computation can be pushed down to the underlying database for the PostgreSQL, MySQL, Oracle, Redshift and
   SQL Server connectors. ({issue}`5522`)
 
-## SPI changes
+## SPI
 
 * Fix propagation of connector session properties to `ConnectorNodePartitioningProvider`. ({issue}`5690`)
 * Add user groups to query events. ({issue}`5643`)

--- a/docs/src/main/sphinx/release/release-347.md
+++ b/docs/src/main/sphinx/release/release-347.md
@@ -1,6 +1,6 @@
 # Release 347 (25 Nov 2020)
 
-## General changes
+## General
 
 * Add `ALTER VIEW ... SET AUTHORIZATION` syntax for changing owner of the view. ({issue}`5789`)
 * Add support for `INTERSECT ALL` and `EXCEPT ALL`. ({issue}`2152`)
@@ -14,28 +14,28 @@
 * Throw a user error when session property value cannot be decoded. ({issue}`5731`)
 * Fix query failure when expressions that produce values of type `row` are used in a `VALUES` clause. ({issue}`3398`)
 
-## Server Changes
+## Server
 
 * A minimum Java version of 11.0.7 is now required for Presto to start. This is to mitigate JDK-8206955. ({issue}`5957`)
 
-## Security changes
+## Security
 
 * Add support for multiple LDAP bind patterns. ({issue}`5874`)
 * Include groups for view owner when checking permissions for views. ({issue}`5945`)
 
-## JDBC driver changes
+## JDBC driver
 
 * Implement `addBatch()`, `clearBatch()` and `executeBatch()` methods in `PreparedStatement`. ({issue}`5507`)
 
-## CLI changes
+## CLI
 
 * Add support for providing queries to presto-cli via shell redirection. ({issue}`5881`)
 
-## Docker image changes
+## Docker image
 
 * Update Presto docker image to use CentOS 8 as the base image. ({issue}`5920`)
 
-## Hive connector changes
+## Hive connector
 
 * Add support for `ALTER VIEW  ... SET AUTHORIZATION` SQL syntax to change the view owner. This supports Presto and Hive views. ({issue}`5789`)
 * Allow configuring HDFS replication factor via the `hive.dfs.replication` config property. ({issue}`1829`)
@@ -43,16 +43,16 @@
 * Decrease latency of `INSERT` and `CREATE TABLE AS ...` queries by updating table and column statistics in parallel. ({issue}`3638`)
 * Fix leaking S3 connections when querying Avro tables. ({issue}`5562`)
 
-## Kudu connector changes
+## Kudu connector
 
 * Add dynamic filtering support. It can be enabled by setting a non-zero duration value for ``kudu.dynamic-filtering.wait-timeout`` config property
   or ``dynamic_filtering_wait_timeout`` session property. ({issue}`5594`)
 
-## MongoDB connector changes
+## MongoDB connector
 
 * Improve performance of queries containing a `LIMIT` clause. ({issue}`5870`)
 
-## Other connector changes
+## Other connectors
 
 * Improve query performance by compacting large pushed down predicates for the PostgreSQL, MySQL, Oracle,
   Redshift and SQL Server connectors. Compaction threshold can be changed using the ``domain-compaction-threshold``
@@ -60,7 +60,7 @@
 * Improve performance for the PostgreSQL, MySQL, SQL Server connectors for certain complex queries involving
   aggregation and predicates by by pushing the aggregation and predicates computation into the remote database. ({issue}`4112`)
 
-## SPI changes
+## SPI
 
 * Add support for connectors to redirect table scan operations to another connector. ({issue}`5792`)
 * Add physical input bytes and rows for table scan operation to query completion event. ({issue}`5872`)

--- a/docs/src/main/sphinx/release/release-348.md
+++ b/docs/src/main/sphinx/release/release-348.md
@@ -1,6 +1,6 @@
 # Release 348 (14 Dec 2020)
 
-## General changes
+## General
 
 * Add support for `DISTINCT` clause in aggregations within correlated subqueries. ({issue}`5904`)
 * Support `SHOW STATS` for arbitrary queries. ({issue}`3109`)
@@ -21,7 +21,7 @@
 * Add support for OAuth2 authorization. ({issue}`5355`)
 * Fix invalid operator stats in Stage Performance view. ({issue}`6114`)
 
-## JDBC driver changes
+## JDBC driver
 
 * Allow reading `timestamp with time zone` value as `ZonedDateTime` using `ResultSet.getObject(int column, Class<?> type)` method. ({issue}`307`)
 * Accept `java.time.LocalDate` in `PreparedStatement.setObject(int, Object)`. ({issue}`6301`)
@@ -42,13 +42,13 @@
 * Fix `ResultSetMetaData.getColumnType` for `time with time zone`. Previously the type was miscategorized as `java.sql.Types.TIME`. ({issue}`6251`)
 * Fix failure when an instance of `SphericalGeography` geospatial type is returned in the `ResultSet`. ({issue}`6240`)
 
-## CLI changes
+## CLI
 
 * Fix rendering of `row` values with unnamed fields. Previously they were printed using fake field names like `field0`, `field1`, etc. ({issue}`4587`)
 * Fix query progress reporting. ({issue}`6119`)
 * Fix failure when an instance of `SphericalGeography` geospatial type is returned to the client. ({issue}`6238`)
 
-## Hive connector changes
+## Hive connector
 
 * Allow configuring S3 endpoint in security mapping. ({issue}`3869`)
 * Add support for S3 streaming uploads. Data is uploaded to S3 as it is written, rather
@@ -64,22 +64,22 @@
 * Add deserializer class name to split information exposed to the event listener. ({issue}`6006`)
 * Improve performance when querying tables that contain symlinks. ({issue}`6158`, {issue}`6213`)
 
-## Iceberg connector changes
+## Iceberg connector
 
 * Improve performance of queries containing filters on non-partition columns. Such filters are now used
   for optimizing split generation and table scan.  ({issue}`4932`)
 * Add support for Google Cloud Storage and Azure Storage. ({issue}`6186`)
 
-## Kafka connector changes
+## Kafka connector
 
 * Allow writing `timestamp with time zone` values into columns using `milliseconds-since-epoch` or
   `seconds-since-epoch` JSON encoders. ({issue}`6074`)
 
-## Other connector changes
+## Other connectors
 
 * Fix ineffective table metadata caching for PostgreSQL, MySQL, SQL Server, Redshift, MemSQL and Phoenix connectors. ({issue}`6081`, {issue}`6167`)
 
-## SPI changes
+## SPI
 
 * Change `SystemAccessControl#filterColumns` and `ConnectorAccessControl#filterColumns` methods to accept a set of
   column names, and return a set of visible column names. ({issue}`6084`)

--- a/docs/src/main/sphinx/release/release-350.md
+++ b/docs/src/main/sphinx/release/release-350.md
@@ -1,6 +1,6 @@
 # Release 350 (28 Dec 2020)
 
-## General changes
+## General
 
 * Add HTTP client JMX metrics. ({issue}`6453`)
 * Improve query performance by reducing worker to worker communication overhead. ({issue}`6283`, {issue}`6349`)
@@ -14,40 +14,40 @@
 
 * Fix truncation of query text in cluster overview page. ({issue}`6216`)
 
-## JDBC driver changes
+## JDBC driver
 
 * Accept `java.time.OffsetTime` in `PreparedStatement.setObject(int, Object)`. ({issue}`6352`)
 * Extend `PreparedStatement.setObject(int, Object, int)` to allow setting `time with time zone` and `timestamp with time zone`
   values with precision higher than nanoseconds. This can be done via providing a `String` value representing a valid SQL literal. ({issue}`6352`)
 
-## BigQuery connector changes
+## BigQuery connector
 
 * Fix incorrect results for `count(*)` queries with views. ({issue}`5635`)
 
-## Cassandra connector changes
+## Cassandra connector
 
 * Support `DELETE` statement with primary key or partition key. ({issue}`4059`)
 
-## Elasticsearch connector changes
+## Elasticsearch connector
 
 * Improve query analysis performance when Elasticsearch contains many index mappings. ({issue}`6368`)
 
-## Kafka connector changes
+## Kafka connector
 
 * Support Kafka Schema Registry for Avro topics. ({issue}`6137`)
 
-## SQL Server connector changes
+## SQL Server connector
 
 * Add `data_compression` table property to control the target compression in SQL Server.
   The allowed values are `NONE`, `ROW` or `PAGE`. ({issue}`4693`)
 
-## Other connector changes
+## Other connectors
 
 This change applies to the MySQL, Oracle, PostgreSQL, Redshift, and SQL Server connectors.
 
 * Send shorter and potentially more performant queries to remote database when a Presto query has a `NOT IN`
   predicate eligible for pushdown into the connector. ({issue}`6075`)
 
-## SPI changes
+## SPI
 
 * Rename `LongTimeWithTimeZone.getPicoSeconds()` to `LongTimeWithTimeZone.getPicoseconds()`. ({issue}`6354`)

--- a/docs/src/main/sphinx/release/release-351.md
+++ b/docs/src/main/sphinx/release/release-351.md
@@ -1,13 +1,13 @@
 # Release 351 (3 Jan 2021)
 
-## General changes
+## General
 
 * Rename client protocol headers to start with `X-Trino-`.
   Legacy clients can be supported by setting the configuration property
   `protocol.v1.alternate-header-name` to `Presto`. This configuration
   property is deprecated and will be removed in a future release.
 
-## JMX MBean naming changes
+## JMX MBean naming
 
 * Rename base domain name for server MBeans to `trino`. The name can
   be changed using the configuration property `jmx.base-name`.
@@ -15,22 +15,22 @@
   and Thrift connectors to `trino.plugin`. The name can be changed
   using the catalog configuration property `jmx.base-name`.
 
-## Server RPM changes
+## Server RPM
 
 * Rename installation directories from `presto` to `trino`.
 
-## Docker image changes
+## Docker image
 
 * Publish image as [`trinodb/trino`](https://hub.docker.com/r/trinodb/trino).
 * Change base image to `azul/zulu-openjdk-centos`.
 * Change configuration directory to `/etc/trino`.
 * Rename CLI in image to `trino`.
 
-## CLI changes
+## CLI
 
 * Use new client protocol header names. The CLI is not compatible with older servers.
 
-## JDBC driver changes
+## JDBC driver
 
 * Use new client protocol header names. The driver is not compatible with older servers.
 * Change driver URL prefix to `jdbc:trino:`.
@@ -40,7 +40,7 @@
 * Rename Java package for all driver classes to `io.trino.jdbc` and rename
   various driver classes such as `TrinoConnection` to start with `Trino`.
 
-## Hive connector changes
+## Hive connector
 
 * Rename JMX name for `PrestoS3FileSystem` to `TrinoS3FileSystem`.
 * Change configuration properties
@@ -48,20 +48,20 @@
   `hive.hdfs.presto.keytab` to `hive.hdfs.trino.keytab`.
   The old names are deprecated and will be removed in a future release.
 
-## Local file connector changes
+## Local file connector
 
 * Change configuration properties
   `presto-logs.http-request-log.location` to `trino-logs.http-request-log.location` and
   `presto-logs.http-request-log.pattern` to `trino-logs.http-request-log.pattern`.
   The old names are deprecated and will be removed in a future release.
 
-## Thrift connector changes
+## Thrift connector
 
 * Rename Thrift service method names starting with `presto` to `trino`.
 * Rename all classes in the Thrift IDL starting with `Presto` to `Trino`.
 * Rename configuration properties starting with `presto` to `trino`.
 
-## SPI changes
+## SPI
 
 * Rename Java package to `io.trino.spi`.
 * Rename `PrestoException` to `TrinoException`.


### PR DESCRIPTION
This makes the contents sidebar look better.

## Old
<img width="1042" alt="Screen Shot 2021-01-13 at 11 50 17 AM" src="https://user-images.githubusercontent.com/9230/104503274-b0d26a80-5595-11eb-8796-60fb8dc0a79e.png">

## New: 
<img width="984" alt="Screen Shot 2021-01-13 at 11 50 31 AM" src="https://user-images.githubusercontent.com/9230/104503251-aa43f300-5595-11eb-8982-d722e1902d64.png">

