### PR TITLE
Improve decimal aggregations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalAverageAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalAverageAggregation.java
@@ -73,6 +73,7 @@ public class DecimalAverageAggregation
     private static final MethodHandle COMBINE_FUNCTION = methodHandle(DecimalAverageAggregation.class, "combine", LongDecimalWithOverflowAndLongState.class, LongDecimalWithOverflowAndLongState.class);
 
     private static final BigInteger TWO = new BigInteger("2");
+    private static final BigInteger OVERFLOW_MULTIPLIER = TWO.shiftLeft(UNSCALED_DECIMAL_128_SLICE_LENGTH * 8 - 2);
 
     public DecimalAverageAggregation()
     {
@@ -220,8 +221,7 @@ public class DecimalAverageAggregation
 
         long overflow = state.getOverflow();
         if (overflow != 0) {
-            BigInteger overflowMultiplier = TWO.shiftLeft(UNSCALED_DECIMAL_128_SLICE_LENGTH * 8 - 2);
-            sum = sum.add(new BigDecimal(overflowMultiplier.multiply(BigInteger.valueOf(overflow))));
+            sum = sum.add(new BigDecimal(OVERFLOW_MULTIPLIER.multiply(BigInteger.valueOf(overflow))));
         }
         return sum.divide(count, type.getScale(), ROUND_HALF_UP);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalAverageAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalAverageAggregation.java
@@ -151,38 +151,45 @@ public class DecimalAverageAggregation
 
     public static void inputShortDecimal(Type type, LongDecimalWithOverflowAndLongState state, Block block, int position)
     {
-        accumulateValueInState(UnscaledDecimal128Arithmetic.unscaledDecimal(type.getLong(block, position)), state);
+        state.addLong(1); // row counter
+
+        Slice sum = state.getLongDecimal();
+        if (sum == null) {
+            sum = UnscaledDecimal128Arithmetic.unscaledDecimal();
+            state.setLongDecimal(sum);
+        }
+        long overflow = UnscaledDecimal128Arithmetic.addWithOverflow(sum, UnscaledDecimal128Arithmetic.unscaledDecimal(type.getLong(block, position)), sum);
+        state.addOverflow(overflow);
     }
 
     public static void inputLongDecimal(Type type, LongDecimalWithOverflowAndLongState state, Block block, int position)
     {
-        accumulateValueInState(type.getSlice(block, position), state);
-    }
+        state.addLong(1); // row counter
 
-    private static void accumulateValueInState(Slice unscaledValue, LongDecimalWithOverflowAndLongState state)
-    {
-        accumulateAndUpdateOverflow(unscaledValue, state);
-        state.setLong(state.getLong() + 1);
-    }
-
-    private static void initializeIfNeeded(LongDecimalWithOverflowAndLongState state)
-    {
-        if (state.getLongDecimal() == null) {
-            state.setLongDecimal(UnscaledDecimal128Arithmetic.unscaledDecimal());
+        Slice sum = state.getLongDecimal();
+        if (sum == null) {
+            sum = UnscaledDecimal128Arithmetic.unscaledDecimal();
+            state.setLongDecimal(sum);
         }
+        long overflow = UnscaledDecimal128Arithmetic.addWithOverflow(sum, type.getSlice(block, position), sum);
+        state.addOverflow(overflow);
     }
 
     public static void combine(LongDecimalWithOverflowAndLongState state, LongDecimalWithOverflowAndLongState otherState)
     {
-        state.setLong(state.getLong() + otherState.getLong());
-        state.setOverflow(state.getOverflow() + otherState.getOverflow());
+        state.addLong(otherState.getLong()); // row counter
 
-        if (state.getLongDecimal() == null) {
+        long overflow = otherState.getOverflow();
+
+        Slice sum = state.getLongDecimal();
+        if (sum == null) {
             state.setLongDecimal(otherState.getLongDecimal());
         }
         else {
-            accumulateAndUpdateOverflow(otherState.getLongDecimal(), state);
+            overflow += UnscaledDecimal128Arithmetic.addWithOverflow(sum, otherState.getLongDecimal(), sum);
         }
+
+        state.addOverflow(overflow);
     }
 
     public static void outputShortDecimal(DecimalType type, LongDecimalWithOverflowAndLongState state, BlockBuilder out)
@@ -211,19 +218,11 @@ public class DecimalAverageAggregation
         BigDecimal sum = new BigDecimal(Decimals.decodeUnscaledValue(state.getLongDecimal()), type.getScale());
         BigDecimal count = BigDecimal.valueOf(state.getLong());
 
-        if (state.getOverflow() != 0) {
+        long overflow = state.getOverflow();
+        if (overflow != 0) {
             BigInteger overflowMultiplier = TWO.shiftLeft(UNSCALED_DECIMAL_128_SLICE_LENGTH * 8 - 2);
-            BigInteger overflow = overflowMultiplier.multiply(BigInteger.valueOf(state.getOverflow()));
-            sum = sum.add(new BigDecimal(overflow));
+            sum = sum.add(new BigDecimal(overflowMultiplier.multiply(BigInteger.valueOf(overflow))));
         }
         return sum.divide(count, type.getScale(), ROUND_HALF_UP);
-    }
-
-    private static void accumulateAndUpdateOverflow(Slice unscaledValue, LongDecimalWithOverflowAndLongState state)
-    {
-        initializeIfNeeded(state);
-        Slice sum = state.getLongDecimal();
-        long overflow = UnscaledDecimal128Arithmetic.addWithOverflow(sum, unscaledValue, sum);
-        state.setOverflow(state.getOverflow() + overflow);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongState.java
@@ -22,4 +22,6 @@ public interface LongDecimalWithOverflowAndLongState
     long getLong();
 
     void setLong(long value);
+
+    void addLong(long value);
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
@@ -75,6 +75,12 @@ public class LongDecimalWithOverflowAndLongStateFactory
         }
 
         @Override
+        public void addLong(long value)
+        {
+            longs.add(getGroupId(), value);
+        }
+
+        @Override
         public long getEstimatedSize()
         {
             return INSTANCE_SIZE + unscaledDecimals.sizeOf() + overflows.sizeOf() + numberOfElements * SingleLongDecimalWithOverflowAndLongState.SIZE;
@@ -99,6 +105,12 @@ public class LongDecimalWithOverflowAndLongStateFactory
         public void setLong(long longValue)
         {
             this.longValue = longValue;
+        }
+
+        @Override
+        public void addLong(long value)
+        {
+            longValue += value;
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowState.java
@@ -28,4 +28,6 @@ public interface LongDecimalWithOverflowState
     long getOverflow();
 
     void setOverflow(long overflow);
+
+    void addOverflow(long overflow);
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
@@ -75,10 +75,10 @@ public class LongDecimalWithOverflowStateFactory
         public void setLongDecimal(Slice value)
         {
             requireNonNull(value, "value is null");
-            if (getLongDecimal() == null) {
+            boolean existed = unscaledDecimals.replace(getGroupId(), value);
+            if (!existed) {
                 numberOfElements++;
             }
-            unscaledDecimals.set(getGroupId(), value);
         }
 
         @Override
@@ -91,6 +91,14 @@ public class LongDecimalWithOverflowStateFactory
         public void setOverflow(long overflow)
         {
             overflows.set(getGroupId(), overflow);
+        }
+
+        @Override
+        public void addOverflow(long overflow)
+        {
+            if (overflow != 0) {
+                overflows.add(getGroupId(), overflow);
+            }
         }
 
         @Override
@@ -131,6 +139,12 @@ public class LongDecimalWithOverflowStateFactory
         public void setOverflow(long overflow)
         {
             this.overflow = overflow;
+        }
+
+        @Override
+        public void addOverflow(long overflow)
+        {
+            this.overflow += overflow;
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkDecimalAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkDecimalAggregation.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.GroupByIdBlock;
+import io.trino.spi.Page;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.UnscaledDecimal128Arithmetic;
+import io.trino.sql.tree.QualifiedName;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.openjdk.jmh.runner.options.WarmupMode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static org.testng.Assert.assertEquals;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(3)
+@Warmup(iterations = 10)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkDecimalAggregation
+{
+    private static final int ELEMENT_COUNT = 10_000;
+
+    @Benchmark
+    @OperationsPerInvocation(ELEMENT_COUNT)
+    public GroupedAccumulator benchmark(BenchmarkData data)
+    {
+        GroupedAccumulator accumulator = data.getAccumulator();
+        accumulator.addInput(data.getGroupIds(), data.getValues());
+        return accumulator;
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"SHORT", "LONG"})
+        private String type = "SHORT";
+
+        @Param({"avg", "sum"})
+        private String function = "avg";
+
+        @Param({"10", "1000"})
+        private int groupCount = 10;
+
+        private GroupedAccumulator accumulator;
+        private GroupByIdBlock groupIds;
+        private Page values;
+
+        @Setup
+        public void setup()
+        {
+            Metadata metadata = createTestMetadataManager();
+
+            switch (type) {
+                case "SHORT": {
+                    DecimalType type = createDecimalType(14, 3);
+                    values = createValues(metadata, type, type::writeLong);
+                    break;
+                }
+                case "LONG": {
+                    DecimalType type = createDecimalType(30, 10);
+                    values = createValues(metadata, type, (builder, value) -> type.writeSlice(builder, UnscaledDecimal128Arithmetic.unscaledDecimal(value)));
+                    break;
+                }
+            }
+
+            BlockBuilder ids = BIGINT.createBlockBuilder(null, ELEMENT_COUNT);
+            for (int i = 0; i < ELEMENT_COUNT; i++) {
+                BIGINT.writeLong(ids, ThreadLocalRandom.current().nextLong(groupCount));
+            }
+            groupIds = new GroupByIdBlock(groupCount, ids.build());
+        }
+
+        private Page createValues(Metadata metadata, DecimalType type, ValueWriter writer)
+        {
+            ResolvedFunction resolvedFunction = metadata.resolveFunction(QualifiedName.of(function), fromTypes(type));
+            InternalAggregationFunction implementation = metadata.getAggregateFunctionImplementation(resolvedFunction);
+            accumulator = implementation.bind(ImmutableList.of(0), Optional.empty()).createGroupedAccumulator();
+
+            BlockBuilder builder = type.createBlockBuilder(null, ELEMENT_COUNT);
+            for (int i = 0; i < ELEMENT_COUNT; i++) {
+                writer.write(builder, i);
+            }
+            return new Page(builder.build());
+        }
+
+        public GroupedAccumulator getAccumulator()
+        {
+            return accumulator;
+        }
+
+        public Page getValues()
+        {
+            return values;
+        }
+
+        public GroupByIdBlock getGroupIds()
+        {
+            return groupIds;
+        }
+
+        interface ValueWriter
+        {
+            void write(BlockBuilder valuesBuilder, int value);
+        }
+    }
+
+    @Test
+    public void verify()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+
+        assertEquals(data.groupIds.getPositionCount(), data.getValues().getPositionCount());
+
+        new BenchmarkDecimalAggregation().benchmark(data);
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        // ensure the benchmarks are valid before running
+        new BenchmarkDecimalAggregation().verify();
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .warmupMode(WarmupMode.BULK)
+                .include(".*" + BenchmarkDecimalAggregation.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+}

--- a/lib/trino-array/src/main/java/io/trino/array/ObjectBigArray.java
+++ b/lib/trino-array/src/main/java/io/trino/array/ObjectBigArray.java
@@ -76,10 +76,27 @@ public final class ObjectBigArray<T>
      * Sets the element of this big array at specified index.
      *
      * @param index a position in this big array.
+     * @return true if the previous value was null
      */
     public void set(long index, T value)
     {
         array[segment(index)][offset(index)] = value;
+    }
+
+    /**
+     * Replaces the element of this big array at specified index.
+     *
+     * @param index a position in this big array.
+     * @return true if the previous value was not null
+     */
+    public boolean replace(long index, T value)
+    {
+        Object[] segment = array[segment(index)];
+
+        boolean existed = segment[offset(index)] != null;
+        segment[offset(index)] = value;
+
+        return existed;
     }
 
     /**


### PR DESCRIPTION
Remove unnecessary calls to get state, which can be expensive due to
lookups in the underlying BigArrays.

https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/martint/f2685c5b8fc19f8feaa2a3ea03c43bda/raw/82b40a4efcbae857f901e9f51105902790cbf036/before.json,https://gist.githubusercontent.com/martint/f2685c5b8fc19f8feaa2a3ea03c43bda/raw/82b40a4efcbae857f901e9f51105902790cbf036/after.json