### PR TITLE
Add token polling for query submission authenticator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/ServerSecurityModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/ServerSecurityModule.java
@@ -28,6 +28,8 @@ import io.airlift.http.server.HttpServerConfig;
 import io.airlift.jmx.MBeanResource;
 import io.trino.server.security.jwt.JwtAuthenticator;
 import io.trino.server.security.jwt.JwtAuthenticatorSupportModule;
+import io.trino.server.security.oauth2.OAuth2AuthenticationSupportModule;
+import io.trino.server.security.oauth2.OAuth2Authenticator;
 
 import java.util.List;
 import java.util.Map;
@@ -73,6 +75,7 @@ public class ServerSecurityModule
         installAuthenticator("kerberos", KerberosAuthenticator.class, KerberosConfig.class);
         installAuthenticator("password", PasswordAuthenticator.class, PasswordAuthenticatorConfig.class);
         install(authenticatorModule("jwt", JwtAuthenticator.class, new JwtAuthenticatorSupportModule()));
+        install(authenticatorModule("oauth2", OAuth2Authenticator.class, new OAuth2AuthenticationSupportModule()));
 
         configBinder(binder).bindConfig(InsecureAuthenticatorConfig.class);
         binder.bind(InsecureAuthenticator.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2AuthenticationSupportModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2AuthenticationSupportModule.java
@@ -11,25 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.server.ui;
+package io.trino.server.security.oauth2;
 
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.trino.server.security.oauth2.OAuth2ServiceModule;
 
-import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 
-public class OAuth2WebUiModule
+public class OAuth2AuthenticationSupportModule
         extends AbstractConfigurationAwareModule
 {
     @Override
     protected void setup(Binder binder)
     {
-        newOptionalBinder(binder, OAuth2WebUiInstalled.class).setBinding().toInstance(OAuth2WebUiInstalled.INSTANCE);
-        binder.bind(WebUiAuthenticationFilter.class).to(OAuth2WebUiAuthenticationFilter.class).in(Scopes.SINGLETON);
-        jaxrsBinder(binder).bind(OAuth2WebUiLogoutResource.class);
+        binder.bind(OAuth2TokenExchange.class).in(Scopes.SINGLETON);
+        jaxrsBinder(binder).bind(OAuth2TokenExchangeResource.class);
         install(new OAuth2ServiceModule());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.trino.server.security.AuthenticationException;
+import io.trino.server.security.Authenticator;
+import io.trino.server.security.UserMapping;
+import io.trino.server.security.UserMappingException;
+import io.trino.spi.security.BasicPrincipal;
+import io.trino.spi.security.Identity;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+
+import java.net.URI;
+import java.util.UUID;
+
+import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static io.trino.server.security.oauth2.OAuth2CallbackResource.CALLBACK_ENDPOINT;
+import static io.trino.server.security.oauth2.OAuth2TokenExchangeResource.getTokenUri;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class OAuth2Authenticator
+        implements Authenticator
+{
+    private final OAuth2Service service;
+    private final UserMapping userMapping;
+
+    @Inject
+    public OAuth2Authenticator(OAuth2Service service, OAuth2Config oauth2Config)
+    {
+        this.service = requireNonNull(service, "service is null");
+        requireNonNull(oauth2Config, "oauth2Config is null");
+        this.userMapping = UserMapping.createUserMapping(oauth2Config.getUserMappingPattern(), oauth2Config.getUserMappingFile());
+    }
+
+    @Override
+    public Identity authenticate(ContainerRequestContext request)
+            throws AuthenticationException
+    {
+        String header = nullToEmpty(request.getHeaders().getFirst(AUTHORIZATION));
+
+        int space = header.indexOf(' ');
+        if ((space < 0) || !header.substring(0, space).equalsIgnoreCase("bearer")) {
+            throw needAuthentication(request, null);
+        }
+        String token = header.substring(space + 1).trim();
+        if (token.isEmpty()) {
+            throw needAuthentication(request, null);
+        }
+
+        try {
+            Jws<Claims> claimsJws = service.parseClaimsJws(token);
+            String subject = claimsJws.getBody().getSubject();
+            String authenticatedUser = userMapping.mapUser(subject);
+            return Identity.forUser(authenticatedUser)
+                    .withPrincipal(new BasicPrincipal(subject))
+                    .build();
+        }
+        catch (JwtException | UserMappingException e) {
+            throw needAuthentication(request, e.getMessage());
+        }
+        catch (RuntimeException e) {
+            throw new RuntimeException("Authentication error", e);
+        }
+    }
+
+    private AuthenticationException needAuthentication(ContainerRequestContext request, String message)
+    {
+        UUID authId = UUID.randomUUID();
+        URI redirectUri = service.startRestChallenge(request.getUriInfo().getBaseUri().resolve(CALLBACK_ENDPOINT), authId);
+        URI tokenUri = request.getUriInfo().getBaseUri().resolve(getTokenUri(authId));
+        return new AuthenticationException(message, format("Bearer x_redirect_server=\"%s\", x_token_server=\"%s\"", redirectUri, tokenUri));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
@@ -14,6 +14,7 @@
 package io.trino.server.security.oauth2;
 
 import com.google.common.collect.Ordering;
+import com.google.common.hash.Hashing;
 import com.google.common.io.Resources;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -28,29 +29,30 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.net.URI;
 import java.security.SecureRandom;
-import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.TemporalAmount;
+import java.time.ZonedDateTime;
 import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
 
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Verify.verify;
-import static com.google.common.hash.Hashing.sha256;
-import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 public class OAuth2Service
 {
-    private static final String STATE_AUDIENCE = "trino_oauth";
+    private static final String STATE_AUDIENCE_UI = "trino_oauth_ui";
+    private static final String STATE_AUDIENCE_REST = "trino_oauth_rest";
     private static final String FAILURE_REPLACEMENT_TEXT = "<!-- ERROR_MESSAGE -->";
 
     private final OAuth2Client client;
     private final JwtParser jwtParser;
 
+    private final String successHtml;
     private final String failureHtml;
 
-    private final TemporalAmount challengeTimeout;
+    private final long challengeTimeoutMillis;
     private final byte[] stateHmac;
 
     @Inject
@@ -60,22 +62,41 @@ public class OAuth2Service
         this.client = requireNonNull(client, "client is null");
         this.jwtParser = Jwts.parser().setSigningKeyResolver(signingKeyResolver);
 
+        this.successHtml = Resources.toString(Resources.getResource(getClass(), "/oauth2/success.html"), UTF_8);
         this.failureHtml = Resources.toString(Resources.getResource(getClass(), "/oauth2/failure.html"), UTF_8);
         verify(failureHtml.contains(FAILURE_REPLACEMENT_TEXT), "login.html does not contain the replacement text");
 
         requireNonNull(oauth2Config, "oauth2Config is null");
-        this.challengeTimeout = Duration.ofMillis(oauth2Config.getChallengeTimeout().toMillis());
-        this.stateHmac = oauth2Config.getStateKey()
-                .map(key -> sha256().hashString(key, UTF_8).asBytes())
-                .orElseGet(() -> secureRandomBytes(32));
+        this.challengeTimeoutMillis = oauth2Config.getChallengeTimeout().toMillis();
+        if (oauth2Config.getStateKey().isPresent()) {
+            stateHmac = Hashing.sha256().hashString(oauth2Config.getStateKey().get(), UTF_8).asBytes();
+        }
+        else {
+            stateHmac = new byte[32];
+            new SecureRandom().nextBytes(stateHmac);
+        }
     }
 
-    public URI startChallenge(URI callbackUri)
+    public URI startWebUiChallenge(URI callbackUri)
     {
         String state = Jwts.builder()
                 .signWith(SignatureAlgorithm.HS256, stateHmac)
-                .setAudience(STATE_AUDIENCE)
-                .setExpiration(Date.from(Instant.now().plus(challengeTimeout)))
+                .setAudience(STATE_AUDIENCE_UI)
+                .setExpiration(new Date(System.currentTimeMillis() + challengeTimeoutMillis))
+                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
+                .compact();
+
+        return client.getAuthorizationUri(state, callbackUri);
+    }
+
+    public URI startRestChallenge(URI callbackUri, UUID authId)
+    {
+        String state = Jwts.builder()
+                .signWith(SignatureAlgorithm.HS256, stateHmac)
+                .setAudience(STATE_AUDIENCE_REST)
+                .setId(authId.toString())
+                .setExpiration(new Date(System.currentTimeMillis() + challengeTimeoutMillis))
+                .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(5).toInstant()))
                 .compact();
 
         return client.getAuthorizationUri(state, callbackUri);
@@ -89,9 +110,21 @@ public class OAuth2Service
         requireNonNull(code, "code is null");
 
         Claims stateClaims = parseState(state);
-        if (!STATE_AUDIENCE.equals(stateClaims.getAudience())) {
+        Optional<UUID> authId;
+        if (STATE_AUDIENCE_UI.equals(stateClaims.getAudience())) {
+            authId = Optional.empty();
+        }
+        else if (STATE_AUDIENCE_REST.equals(stateClaims.getAudience())) {
+            try {
+                authId = Optional.of(UUID.fromString(stateClaims.getId()));
+            }
+            catch (RuntimeException e) {
+                throw new ChallengeFailedException("State is does not contain an auth id");
+            }
+        }
+        else {
             // this is very unlikely, but is a good safety check
-            throw new ChallengeFailedException(format("Unexpected state audience: %s. Expected audience: %s.", stateClaims.getAudience(), STATE_AUDIENCE));
+            throw new ChallengeFailedException("Unexpected state audience");
         }
 
         // fetch access token
@@ -105,14 +138,15 @@ public class OAuth2Service
                 .map(instant -> Ordering.natural().min(instant, parsedToken.getExpiration().toInstant()))
                 .orElse(parsedToken.getExpiration().toInstant());
 
-        return new OAuthResult(accessToken.getAccessToken(), validUntil);
+        return new OAuthResult(authId, accessToken.getAccessToken(), validUntil);
     }
 
     private Claims parseState(String state)
             throws ChallengeFailedException
     {
+        Claims stateClaims;
         try {
-            return Jwts.parser()
+            stateClaims = Jwts.parser()
                     .setSigningKey(stateHmac)
                     .parseClaimsJws(state)
                     .getBody();
@@ -120,6 +154,7 @@ public class OAuth2Service
         catch (RuntimeException e) {
             throw new ChallengeFailedException("State validation failed", e);
         }
+        return stateClaims;
     }
 
     public Jws<Claims> parseClaimsJws(String token)
@@ -127,9 +162,29 @@ public class OAuth2Service
         return jwtParser.parseClaimsJws(token);
     }
 
+    public String getSuccessHtml()
+    {
+        return successHtml;
+    }
+
     public String getCallbackErrorHtml(String errorCode)
     {
-        return failureHtml.replace(FAILURE_REPLACEMENT_TEXT, getOAuth2ErrorMessage(errorCode));
+        String message = "";
+        switch (errorCode) {
+            case "access_denied":
+                message = "OAuth2 server denied the login";
+                break;
+            case "unauthorized_client":
+                message = "OAuth2 server does not allow request from this Trino server";
+                break;
+            case "server_error":
+                message = "OAuth2 server had a failure";
+                break;
+            case "temporarily_unavailable":
+                message = "OAuth2 server is temporarily unavailable";
+                break;
+        }
+        return failureHtml.replace(FAILURE_REPLACEMENT_TEXT, message);
     }
 
     public String getInternalFailureHtml(String errorMessage)
@@ -137,38 +192,26 @@ public class OAuth2Service
         return failureHtml.replace(FAILURE_REPLACEMENT_TEXT, nullToEmpty(errorMessage));
     }
 
-    private static byte[] secureRandomBytes(int count)
-    {
-        byte[] bytes = new byte[count];
-        new SecureRandom().nextBytes(bytes);
-        return bytes;
-    }
-
-    private static String getOAuth2ErrorMessage(String errorCode)
-    {
-        switch (errorCode) {
-            case "access_denied":
-                return "OAuth2 server denied the login";
-            case "unauthorized_client":
-                return "OAuth2 server does not allow request from this Trino server";
-            case "server_error":
-                return "OAuth2 server had a failure";
-            case "temporarily_unavailable":
-                return "OAuth2 server is temporarily unavailable";
-            default:
-                return "OAuth2 unknown error code: " + errorCode;
-        }
-    }
-
     public static class OAuthResult
     {
+        private final Optional<UUID> authId;
         private final String accessToken;
         private final Instant tokenExpiration;
 
-        public OAuthResult(String accessToken, Instant tokenExpiration)
+        public OAuthResult(Optional<UUID> authId, String accessToken, Instant tokenExpiration)
         {
+            this.authId = requireNonNull(authId, "authId is null");
             this.accessToken = requireNonNull(accessToken, "accessToken is null");
             this.tokenExpiration = requireNonNull(tokenExpiration, "tokenExpiration is null");
+        }
+
+        /**
+         * Get authId if for rest client request.  This will be empty if the authentication request is
+         * a web ui login.
+         */
+        public Optional<UUID> getAuthId()
+        {
+            return authId;
         }
 
         public String getAccessToken()

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
@@ -23,6 +23,7 @@ import io.airlift.units.Duration;
 import io.jsonwebtoken.SigningKeyResolver;
 import io.trino.server.security.jwt.JwkService;
 import io.trino.server.security.jwt.JwkSigningKeyResolver;
+import io.trino.server.ui.OAuth2WebUiInstalled;
 
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +40,8 @@ public class OAuth2ServiceModule
     protected void setup(Binder binder)
     {
         jaxrsBinder(binder).bind(OAuth2CallbackResource.class);
+        newOptionalBinder(binder, OAuth2WebUiInstalled.class);
+        newOptionalBinder(binder, OAuth2TokenExchange.class);
 
         configBinder(binder).bindConfig(OAuth2Config.class);
         binder.bind(OAuth2Service.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchange.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchange.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListenableScheduledFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.SettableFuture;
+import io.airlift.units.Duration;
+import io.trino.dispatcher.DispatchExecutor;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class OAuth2TokenExchange
+{
+    public static final Duration MAX_POLL_TIME = new Duration(9, SECONDS);
+    private static final TokenPoll TOKEN_POLL_TIMED_OUT = TokenPoll.error("Authentication has timed out");
+
+    private final LoadingCache<UUID, SettableFuture<TokenPoll>> cache;
+    private final ListeningExecutorService responseExecutor;
+
+    @Inject
+    public OAuth2TokenExchange(OAuth2Config config, DispatchExecutor executor)
+    {
+        this.responseExecutor = requireNonNull(executor, "responseExecutor is null").getExecutor();
+
+        long challengeTimeoutMs = config.getChallengeTimeout().toMillis();
+        ListeningScheduledExecutorService scheduledExecutor = executor.getScheduledExecutor();
+        this.cache = CacheBuilder.newBuilder()
+                .expireAfterWrite((challengeTimeoutMs + MAX_POLL_TIME.toMillis()) * 2, MILLISECONDS)
+                .<UUID, SettableFuture<TokenPoll>>removalListener(notification -> notification.getValue().set(TOKEN_POLL_TIMED_OUT))
+                .build(new CacheLoader<>()
+                {
+                    @Override
+                    public SettableFuture<TokenPoll> load(UUID authId)
+                    {
+                        SettableFuture<TokenPoll> future = SettableFuture.create();
+                        ListenableScheduledFuture<?> timeout = scheduledExecutor.schedule(() -> future.set(TOKEN_POLL_TIMED_OUT), challengeTimeoutMs, MILLISECONDS);
+                        future.addListener(() -> timeout.cancel(true), responseExecutor);
+                        return future;
+                    }
+                });
+    }
+
+    public void setAccessToken(UUID authId, String accessToken)
+    {
+        cache.getUnchecked(authId).set(TokenPoll.token(accessToken));
+    }
+
+    public void setTokenExchangeError(UUID authId, String message)
+    {
+        cache.getUnchecked(authId).set(TokenPoll.error(message));
+    }
+
+    public ListenableFuture<TokenPoll> getTokenPoll(UUID authId)
+    {
+        return nonCancellationPropagating(cache.getUnchecked(authId));
+    }
+
+    public void dropToken(UUID authId)
+    {
+        cache.invalidate(authId);
+    }
+
+    public static class TokenPoll
+    {
+        private final Optional<String> token;
+        private final Optional<String> error;
+
+        private TokenPoll(String token, String error)
+        {
+            this.token = Optional.ofNullable(token);
+            this.error = Optional.ofNullable(error);
+        }
+
+        static TokenPoll token(String token)
+        {
+            requireNonNull(token, "token is null");
+
+            return new TokenPoll(token, null);
+        }
+
+        static TokenPoll error(String error)
+        {
+            requireNonNull(error, "token is null");
+
+            return new TokenPoll(null, error);
+        }
+
+        public Optional<String> getToken()
+        {
+            return token;
+        }
+
+        public Optional<String> getError()
+        {
+            return error;
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchangeResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchangeResource.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import io.trino.dispatcher.DispatchExecutor;
+import io.trino.server.security.ResourceSecurity;
+import io.trino.server.security.oauth2.OAuth2TokenExchange.TokenPoll;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import java.util.UUID;
+
+import static io.airlift.jaxrs.AsyncResponseHandler.bindAsyncResponse;
+import static io.trino.server.security.ResourceSecurity.AccessType.PUBLIC;
+import static io.trino.server.security.oauth2.OAuth2TokenExchange.MAX_POLL_TIME;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+
+@Path(OAuth2TokenExchangeResource.TOKEN_ENDPOINT)
+public class OAuth2TokenExchangeResource
+{
+    static final String TOKEN_ENDPOINT = "/oauth2/token/";
+    private static final String JSON_PAIR_TEMPLATE = "{ \"%s\":\"%s\" }";
+
+    private final OAuth2TokenExchange tokenExchange;
+    private final ListeningExecutorService responseExecutor;
+
+    @Inject
+    public OAuth2TokenExchangeResource(OAuth2TokenExchange tokenExchange, DispatchExecutor executor)
+    {
+        this.tokenExchange = requireNonNull(tokenExchange, "tokenExchange is null");
+        this.responseExecutor = requireNonNull(executor, "responseExecutor is null").getExecutor();
+    }
+
+    @ResourceSecurity(PUBLIC)
+    @Path("{authId}")
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public void getAuthenticationToken(@PathParam("authId") UUID authId, @Suspended AsyncResponse asyncResponse, @Context HttpServletRequest request)
+    {
+        if (authId == null) {
+            throw new BadRequestException();
+        }
+
+        // Do not drop the response from the cache in case the response fails, and
+        // the client retries the request, which would result in a hang.  Response
+        // will timeout eventually.
+        // todo if we are concerned about the temp memory usage, we can have clients acknowledge receipt of the key with the DELETE call below
+        ListenableFuture<TokenPoll> tokenFuture = tokenExchange.getTokenPoll(authId);
+        ListenableFuture<Response> responseFuture = Futures.transform(tokenFuture, OAuth2TokenExchangeResource::toResponse, responseExecutor);
+        bindAsyncResponse(asyncResponse, responseFuture, responseExecutor)
+                .withTimeout(MAX_POLL_TIME, pendingResponse(request));
+    }
+
+    private static Response toResponse(TokenPoll poll)
+    {
+        return poll.getError()
+                .map(error -> Response.ok(format(JSON_PAIR_TEMPLATE, "error", error), APPLICATION_JSON_TYPE).build())
+                .orElseGet(() -> poll.getToken()
+                        .map(token -> Response.ok(format(JSON_PAIR_TEMPLATE, "token", token), APPLICATION_JSON_TYPE).build())
+                        .orElseThrow());
+    }
+
+    private static Response pendingResponse(HttpServletRequest request)
+    {
+        return Response.ok(format(JSON_PAIR_TEMPLATE, "nextUri", request.getRequestURL()), APPLICATION_JSON_TYPE).build();
+    }
+
+    @ResourceSecurity(PUBLIC)
+    @DELETE
+    @Path("{authId}")
+    public void deleteAuthenticationToken(@PathParam("authId") UUID authId)
+    {
+        if (authId == null) {
+            throw new BadRequestException();
+        }
+
+        tokenExchange.dropToken(authId);
+    }
+
+    public static String getTokenUri(UUID authId)
+    {
+        return TOKEN_ENDPOINT + authId;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuthAuthenticationSupporterModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuthAuthenticationSupporterModule.java
@@ -11,25 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.server.ui;
+package io.trino.server.security.oauth2;
 
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.trino.server.security.oauth2.OAuth2ServiceModule;
 
-import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 
-public class OAuth2WebUiModule
+public class OAuthAuthenticationSupporterModule
         extends AbstractConfigurationAwareModule
 {
     @Override
     protected void setup(Binder binder)
     {
-        newOptionalBinder(binder, OAuth2WebUiInstalled.class).setBinding().toInstance(OAuth2WebUiInstalled.INSTANCE);
-        binder.bind(WebUiAuthenticationFilter.class).to(OAuth2WebUiAuthenticationFilter.class).in(Scopes.SINGLETON);
-        jaxrsBinder(binder).bind(OAuth2WebUiLogoutResource.class);
+        binder.bind(OAuth2TokenExchange.class).in(Scopes.SINGLETON);
+        jaxrsBinder(binder).bind(OAuth2TokenExchangeResource.class);
         install(new OAuth2ServiceModule());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuthAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuthAuthenticator.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security.oauth2;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.trino.server.security.AuthenticationException;
+import io.trino.server.security.Authenticator;
+import io.trino.server.security.UserMapping;
+import io.trino.server.security.UserMappingException;
+import io.trino.spi.security.BasicPrincipal;
+import io.trino.spi.security.Identity;
+
+import javax.inject.Inject;
+import javax.ws.rs.container.ContainerRequestContext;
+
+import java.net.URI;
+import java.util.UUID;
+
+import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static io.trino.server.security.oauth2.OAuth2CallbackResource.CALLBACK_ENDPOINT;
+import static io.trino.server.security.oauth2.OAuth2TokenExchangeResource.getTokenUri;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class OAuthAuthenticator
+        implements Authenticator
+{
+    private final OAuth2Service service;
+    private final UserMapping userMapping;
+
+    @Inject
+    public OAuthAuthenticator(OAuth2Service service, OAuth2Config oauth2Config)
+    {
+        this.service = requireNonNull(service, "service is null");
+        requireNonNull(oauth2Config, "oauth2Config is null");
+        this.userMapping = UserMapping.createUserMapping(oauth2Config.getUserMappingPattern(), oauth2Config.getUserMappingFile());
+    }
+
+    @Override
+    public Identity authenticate(ContainerRequestContext request)
+            throws AuthenticationException
+    {
+        String header = nullToEmpty(request.getHeaders().getFirst(AUTHORIZATION));
+
+        int space = header.indexOf(' ');
+        if ((space < 0) || !header.substring(0, space).equalsIgnoreCase("bearer")) {
+            throw needAuthentication(request, null);
+        }
+        String token = header.substring(space + 1).trim();
+        if (token.isEmpty()) {
+            throw needAuthentication(request, null);
+        }
+
+        try {
+            Jws<Claims> claimsJws = service.parseClaimsJws(token);
+            String subject = claimsJws.getBody().getSubject();
+            String authenticatedUser = userMapping.mapUser(subject);
+            return Identity.forUser(authenticatedUser)
+                    .withPrincipal(new BasicPrincipal(subject))
+                    .build();
+        }
+        catch (JwtException | UserMappingException e) {
+            throw needAuthentication(request, e.getMessage());
+        }
+        catch (RuntimeException e) {
+            throw new RuntimeException("Authentication error", e);
+        }
+    }
+
+    private AuthenticationException needAuthentication(ContainerRequestContext request, String message)
+    {
+        UUID authId = UUID.randomUUID();
+        URI redirectUri = service.startRestChallenge(request.getUriInfo().getBaseUri().resolve(CALLBACK_ENDPOINT), authId);
+        URI tokenUri = request.getUriInfo().getBaseUri().resolve(getTokenUri(authId));
+        return new AuthenticationException(message, format("Bearer x_redirect_server=\"%s\", x_token_server=\"%s\"", redirectUri, tokenUri));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiAuthenticationFilter.java
@@ -120,7 +120,7 @@ public class OAuth2WebUiAuthenticationFilter
 
     private void needAuthentication(ContainerRequestContext request)
     {
-        URI redirectLocation = service.startChallenge(request.getUriInfo().getBaseUri().resolve(CALLBACK_ENDPOINT));
+        URI redirectLocation = service.startWebUiChallenge(request.getUriInfo().getBaseUri().resolve(CALLBACK_ENDPOINT));
         request.abortWith(Response.seeOther(redirectLocation).build());
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiInstalled.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiInstalled.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.ui;
+
+public enum OAuth2WebUiInstalled
+{
+    INSTANCE
+}

--- a/core/trino-main/src/main/resources/oauth2/success.html
+++ b/core/trino-main/src/main/resources/oauth2/success.html
@@ -1,0 +1,60 @@
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta name="description" content="Web Interface - Presto">
+    <title>Cluster Overview - Presto</title>
+
+    <link rel="icon" href="/ui/assets/favicon.ico">
+
+    <!-- Bootstrap core -->
+    <link href="/ui/vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+    <!-- jQuery -->
+    <script type="text/javascript" src="/ui/vendor/jquery/jquery-3.5.1.min.js"></script>
+
+    <!-- Bootstrap JS -->
+    <script type="text/javascript" src="/ui/vendor/bootstrap/js/bootstrap.js"></script>
+
+    <!-- Sparkline -->
+    <script type="text/javascript" src="/ui/vendor/jquery.sparkline/jquery.sparkline.min.js"></script>
+
+    <!-- CSS loader -->
+    <link href="/ui/vendor/css-loaders/loader.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link href="/ui/assets/presto.css" rel="stylesheet">
+</head>
+
+<body>
+
+<h2 class="text-center">OAuth2 authentication succeeded</h2>
+
+<h4 class="text-center">This browser window can be closed</h4>
+
+<!-- Fonts -->
+<link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
+
+</body>
+</html>

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -13,6 +13,8 @@
  */
 package io.trino.server.security;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.google.inject.Key;
@@ -26,12 +28,14 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
 import io.trino.security.AccessControlManager;
+import io.trino.server.security.oauth2.OAuth2Client;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.BasicPrincipal;
 import io.trino.spi.security.SystemSecurityContext;
 import okhttp3.Credentials;
 import okhttp3.Headers;
+import okhttp3.JavaNetCookieJar;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -44,6 +48,8 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.CookieManager;
+import java.net.HttpCookie;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -51,19 +57,30 @@ import java.security.Principal;
 import java.security.PrivateKey;
 import java.time.ZonedDateTime;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.trino.client.OkHttpUtil.setupSsl;
 import static io.trino.client.ProtocolHeaders.TRINO_HEADERS;
 import static io.trino.spi.security.AccessDeniedException.denyReadSystemInformationAccess;
 import static io.trino.testing.assertions.Assert.assertEquals;
+import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static javax.ws.rs.core.HttpHeaders.WWW_AUTHENTICATE;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 @Test
 public class TestResourceSecurity
@@ -85,6 +102,7 @@ public class TestResourceSecurity
     private static final String MANAGEMENT_PASSWORD = "management-password";
     private static final String HMAC_KEY = Resources.getResource("hmac_key.txt").getPath();
     private static final PrivateKey JWK_PRIVATE_KEY;
+    private static final ObjectMapper json = new ObjectMapper();
 
     static {
         try {
@@ -368,6 +386,165 @@ public class TestResourceSecurity
         }
     }
 
+    @Test
+    public void testOAuth2Authenticator()
+            throws Exception
+    {
+        verifyOAuth2Authenticator(true);
+        verifyOAuth2Authenticator(false);
+    }
+
+    private void verifyOAuth2Authenticator(boolean webUiEnabled)
+            throws Exception
+    {
+        CookieManager cookieManager = new CookieManager();
+        OkHttpClient client = this.client.newBuilder()
+                .cookieJar(new JavaNetCookieJar(cookieManager))
+                .build();
+
+        Date tokenExpiration = Date.from(ZonedDateTime.now().plusMinutes(5).toInstant());
+        String token = Jwts.builder()
+                .signWith(SignatureAlgorithm.RS256, JWK_PRIVATE_KEY)
+                .setAudience("trino_oauth_rest")
+                .setHeaderParam(JwsHeader.KEY_ID, "test-rsa")
+                .setSubject("test-user")
+                .setExpiration(tokenExpiration)
+                .compact();
+
+        TestingHttpServer jwkServer = createTestingJwkServer();
+        jwkServer.start();
+        try (TestingTrinoServer server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .putAll(SECURE_PROPERTIES)
+                        .put("http-server.authentication.type", "oauth2")
+                        .put("web-ui.enabled", String.valueOf(webUiEnabled))
+                        .put("http-server.authentication.oauth2.jwks-url", jwkServer.getBaseUrl().toString())
+                        .put("http-server.authentication.oauth2.state-key", "test-state-key")
+                        .put("http-server.authentication.oauth2.auth-url", "http://example.com/")
+                        .put("http-server.authentication.oauth2.token-url", "http://example.com/")
+                        .put("http-server.authentication.oauth2.client-id", "client")
+                        .put("http-server.authentication.oauth2.client-secret", "client-secret")
+                        .build())
+                .setAdditionalModule(binder -> newOptionalBinder(binder, OAuth2Client.class)
+                        .setBinding()
+                        .toInstance(new OAuth2Client()
+                        {
+                            @Override
+                            public URI getAuthorizationUri(String state, URI callbackUri)
+                            {
+                                return URI.create("http://example.com/authorize?" + state);
+                            }
+
+                            @Override
+                            public AccessToken getAccessToken(String code, URI callbackUri)
+                            {
+                                if (!"TEST_CODE".equals(code)) {
+                                    throw new IllegalArgumentException("Expected TEST_CODE");
+                                }
+                                return new AccessToken(token, Optional.empty());
+                            }
+                        }))
+                .build()) {
+            server.getInstance(Key.get(AccessControlManager.class)).addSystemAccessControl(new TestSystemAccessControl());
+            HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+
+            assertAuthenticationDisabled(httpServerInfo.getHttpUri());
+
+            // not logged in
+            URI baseUri = httpServerInfo.getHttpsUri();
+            assertOk(client, getPublicLocation(baseUri));
+            OAuthBearer bearer = assertAuthenticateOAuth2Bearer(client, getAuthorizedUserLocation(baseUri), "http://example.com/authorize");
+            assertAuthenticateOAuth2Bearer(client, getManagementLocation(baseUri), "http://example.com/authorize");
+            assertResponseCode(client, getInternalLocation(baseUri), SC_FORBIDDEN);
+
+            // login with the callback endpoint
+            assertOk(
+                    client,
+                    uriBuilderFrom(baseUri)
+                            .replacePath("/oauth2/callback/")
+                            .addParameter("code", "TEST_CODE")
+                            .addParameter("state", bearer.getState())
+                            .toString());
+            assertEquals(getOauthToken(client, bearer.getTokenServer()), token);
+
+            // if Web UI is using oauth so we should get a cookie
+            if (webUiEnabled) {
+                HttpCookie cookie = getOnlyElement(cookieManager.getCookieStore().getCookies());
+                assertEquals(cookie.getValue(), token);
+                assertEquals(cookie.getPath(), "/ui/");
+                assertEquals(cookie.getDomain(), baseUri.getHost());
+                assertTrue(cookie.getMaxAge() > 0 && cookie.getMaxAge() < MINUTES.toSeconds(5));
+                assertTrue(cookie.isHttpOnly());
+                cookieManager.getCookieStore().removeAll();
+            }
+            else {
+                List<HttpCookie> cookies = cookieManager.getCookieStore().getCookies();
+                assertTrue(cookies.isEmpty(), "Expected no cookies when webUi is not enabled, but got: " + cookies);
+            }
+
+            OkHttpClient clientWithOAuthToken = client.newBuilder()
+                    .authenticator((route, response) -> response.request().newBuilder()
+                            .header(AUTHORIZATION, "Bearer " + token)
+                            .build())
+                    .build();
+            assertAuthenticationAutomatic(httpServerInfo.getHttpsUri(), clientWithOAuthToken);
+        }
+        finally {
+            jwkServer.stop();
+        }
+    }
+
+    private static OAuthBearer assertAuthenticateOAuth2Bearer(OkHttpClient client, String url, String expectedRedirect)
+            throws IOException
+    {
+        Request request = new Request.Builder()
+                .url(url)
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            assertEquals(response.code(), SC_UNAUTHORIZED, url);
+            String authenticateHeader = response.header(WWW_AUTHENTICATE);
+            assertNotNull(authenticateHeader);
+            Pattern oauth2BearerPattern = Pattern.compile(format("Bearer x_redirect_server=\"%s\\?(.+)\", x_token_server=\"(https://127.0.0.1:[0-9]+/oauth2/token/.+)\"", expectedRedirect));
+            Matcher matcher = oauth2BearerPattern.matcher(authenticateHeader);
+            assertTrue(matcher.matches(), format("Invalid authentication header.\nExpected: %s\nPattern: %s", authenticateHeader, oauth2BearerPattern));
+            return new OAuthBearer(matcher.group(1), matcher.group(2));
+        }
+    }
+
+    private static class OAuthBearer
+    {
+        private final String state;
+        private final String tokenServer;
+
+        public OAuthBearer(String state, String tokenServer)
+        {
+            this.state = requireNonNull(state, "state is null");
+            this.tokenServer = requireNonNull(tokenServer, "tokenServer is null");
+        }
+
+        public String getState()
+        {
+            return state;
+        }
+
+        public String getTokenServer()
+        {
+            return tokenServer;
+        }
+    }
+
+    private static String getOauthToken(OkHttpClient client, String url)
+            throws IOException
+    {
+        Request request = new Request.Builder()
+                .url(url)
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            String body = requireNonNull(response.body()).string();
+            return json.readValue(body, TokenDTO.class).token;
+        }
+    }
+
     private void assertInsecureAuthentication(URI baseUri)
             throws IOException
     {
@@ -569,5 +746,11 @@ public class TestResourceSecurity
             String jwkKeys = Resources.toString(Resources.getResource("jwk/jwk-public.json"), UTF_8);
             response.getWriter().println(jwkKeys);
         }
+    }
+
+    private static class TokenDTO
+    {
+        @JsonProperty
+        String token;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -514,7 +514,7 @@ public class TestWebUi
 
         String state = Jwts.builder()
                 .signWith(SignatureAlgorithm.HS256, Hashing.sha256().hashString("test-state-key", UTF_8).asBytes())
-                .setAudience("trino_oauth")
+                .setAudience("trino_oauth_ui")
                 .setExpiration(Date.from(ZonedDateTime.now().plusMinutes(10).toInstant()))
                 .compact();
 


### PR DESCRIPTION
Adding token polling for Oauth2 implementations for non-web clients. 
It's a server part that will work with changes contributed in #6576 