### PR TITLE
Add sort_by property to hive tables

### DIFF
--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
@@ -77,6 +77,12 @@ public class TestHiveAlluxioMetastore
     }
 
     @Override
+    public void testSortBy()
+    {
+        // Alluxio metastore does not support create operations
+    }
+
+    @Override
     public void testBucketedTableEvolution()
     {
         // Alluxio metastore does not support create/insert/update operations

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveInsertTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveInsertTableHandle.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePageSinkMetadata;
+import io.trino.plugin.hive.metastore.SortingColumn;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 
 import java.util.List;
@@ -34,6 +35,7 @@ public class HiveInsertTableHandle
             @JsonProperty("pageSinkMetadata") HivePageSinkMetadata pageSinkMetadata,
             @JsonProperty("locationHandle") LocationHandle locationHandle,
             @JsonProperty("bucketProperty") Optional<HiveBucketProperty> bucketProperty,
+            @JsonProperty("sortBy") List<SortingColumn> sortBy,
             @JsonProperty("tableStorageFormat") HiveStorageFormat tableStorageFormat,
             @JsonProperty("partitionStorageFormat") HiveStorageFormat partitionStorageFormat,
             @JsonProperty("transaction") AcidTransaction transaction)
@@ -45,6 +47,7 @@ public class HiveInsertTableHandle
                 pageSinkMetadata,
                 locationHandle,
                 bucketProperty,
+                sortBy,
                 tableStorageFormat,
                 partitionStorageFormat,
                 transaction);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveOutputTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveOutputTableHandle.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePageSinkMetadata;
+import io.trino.plugin.hive.metastore.SortingColumn;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 
 import java.util.List;
@@ -47,6 +48,7 @@ public class HiveOutputTableHandle
             @JsonProperty("partitionStorageFormat") HiveStorageFormat partitionStorageFormat,
             @JsonProperty("partitionedBy") List<String> partitionedBy,
             @JsonProperty("bucketProperty") Optional<HiveBucketProperty> bucketProperty,
+            @JsonProperty("sortBy") List<SortingColumn> sortBy,
             @JsonProperty("tableOwner") String tableOwner,
             @JsonProperty("additionalTableParameters") Map<String, String> additionalTableParameters,
             @JsonProperty("transaction") AcidTransaction transaction,
@@ -59,6 +61,7 @@ public class HiveOutputTableHandle
                 pageSinkMetadata,
                 locationHandle,
                 bucketProperty,
+                sortBy,
                 tableStorageFormat,
                 partitionStorageFormat,
                 transaction);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.hive;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -124,7 +123,7 @@ public class HivePageSinkProvider
     private ConnectorPageSink createPageSink(HiveWritableTableHandle handle, boolean isCreateTable, ConnectorSession session, Map<String, String> additionalTableParameters)
     {
         OptionalInt bucketCount = OptionalInt.empty();
-        List<SortingColumn> sortedBy = ImmutableList.of();
+        List<SortingColumn> sortedBy = handle.getSortBy();
 
         if (handle.getBucketProperty().isPresent()) {
             bucketCount = OptionalInt.of(handle.getBucketProperty().get().getBucketCount());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProperties.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.metastore.SortingColumn;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
+import io.trino.plugin.hive.util.HiveUtil;
 import io.trino.spi.TrinoException;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.ArrayType;
@@ -31,8 +32,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.plugin.hive.metastore.SortingColumn.Order.ASCENDING;
-import static io.trino.plugin.hive.metastore.SortingColumn.Order.DESCENDING;
 import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
 import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V2;
 import static io.trino.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
@@ -122,11 +121,11 @@ public class HiveTableProperties
                         false,
                         value -> ((Collection<?>) value).stream()
                                 .map(String.class::cast)
-                                .map(HiveTableProperties::sortingColumnFromString)
+                                .map(HiveUtil::sortingColumnFromString)
                                 .collect(toImmutableList()),
                         value -> ((Collection<?>) value).stream()
                                 .map(SortingColumn.class::cast)
-                                .map(HiveTableProperties::sortingColumnToString)
+                                .map(HiveUtil::sortingColumnToString)
                                 .collect(toImmutableList())),
                 new PropertyMetadata<>(
                         ORC_BLOOM_FILTER_COLUMNS,
@@ -274,25 +273,6 @@ public class HiveTableProperties
             throw new TrinoException(INVALID_TABLE_PROPERTY, format("%s must be a single character string, but was: '%s'", key, stringValue));
         }
         return Optional.of(stringValue.charAt(0));
-    }
-
-    private static SortingColumn sortingColumnFromString(String name)
-    {
-        SortingColumn.Order order = ASCENDING;
-        String lower = name.toUpperCase(ENGLISH);
-        if (lower.endsWith(" ASC")) {
-            name = name.substring(0, name.length() - 4).trim();
-        }
-        else if (lower.endsWith(" DESC")) {
-            name = name.substring(0, name.length() - 5).trim();
-            order = DESCENDING;
-        }
-        return new SortingColumn(name, order);
-    }
-
-    private static String sortingColumnToString(SortingColumn column)
-    {
-        return column.getColumnName() + ((column.getOrder() == DESCENDING) ? " DESC" : "");
     }
 
     public static Optional<Boolean> isTransactional(Map<String, Object> tableProperties)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWritableTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWritableTableHandle.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.HivePageSinkMetadata;
+import io.trino.plugin.hive.metastore.SortingColumn;
 import io.trino.spi.connector.SchemaTableName;
 
 import java.util.List;
@@ -33,6 +34,7 @@ public class HiveWritableTableHandle
     private final HivePageSinkMetadata pageSinkMetadata;
     private final LocationHandle locationHandle;
     private final Optional<HiveBucketProperty> bucketProperty;
+    private final List<SortingColumn> sortBy;
     private final HiveStorageFormat tableStorageFormat;
     private final HiveStorageFormat partitionStorageFormat;
     private final AcidTransaction transaction;
@@ -44,6 +46,7 @@ public class HiveWritableTableHandle
             HivePageSinkMetadata pageSinkMetadata,
             LocationHandle locationHandle,
             Optional<HiveBucketProperty> bucketProperty,
+            List<SortingColumn> sortBy,
             HiveStorageFormat tableStorageFormat,
             HiveStorageFormat partitionStorageFormat,
             AcidTransaction transaction)
@@ -54,6 +57,7 @@ public class HiveWritableTableHandle
         this.pageSinkMetadata = requireNonNull(pageSinkMetadata, "pageSinkMetadata is null");
         this.locationHandle = requireNonNull(locationHandle, "locationHandle is null");
         this.bucketProperty = requireNonNull(bucketProperty, "bucketProperty is null");
+        this.sortBy = ImmutableList.copyOf(requireNonNull(sortBy, "sortBy is null"));
         this.tableStorageFormat = requireNonNull(tableStorageFormat, "tableStorageFormat is null");
         this.partitionStorageFormat = requireNonNull(partitionStorageFormat, "partitionStorageFormat is null");
         this.transaction = requireNonNull(transaction);
@@ -99,6 +103,12 @@ public class HiveWritableTableHandle
     public Optional<HiveBucketProperty> getBucketProperty()
     {
         return bucketProperty;
+    }
+
+    @JsonProperty
+    public List<SortingColumn> getSortBy()
+    {
+        return sortBy;
     }
 
     @JsonProperty

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -32,6 +32,7 @@ import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.avro.TrinoAvroSerDe;
 import io.trino.plugin.hive.metastore.Column;
+import io.trino.plugin.hive.metastore.SortingColumn;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.ErrorCodeSupplier;
 import io.trino.spi.TrinoException;
@@ -125,6 +126,8 @@ import static io.trino.plugin.hive.HivePartitionKey.HIVE_DEFAULT_DYNAMIC_PARTITI
 import static io.trino.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_COLUMNS;
 import static io.trino.plugin.hive.HiveTableProperties.ORC_BLOOM_FILTER_FPP;
 import static io.trino.plugin.hive.HiveType.toHiveTypes;
+import static io.trino.plugin.hive.metastore.SortingColumn.Order.ASCENDING;
+import static io.trino.plugin.hive.metastore.SortingColumn.Order.DESCENDING;
 import static io.trino.plugin.hive.util.ConfigurationUtils.copy;
 import static io.trino.plugin.hive.util.ConfigurationUtils.toJobConf;
 import static io.trino.plugin.hive.util.HiveBucketing.bucketedOnTimestamp;
@@ -151,6 +154,7 @@ import static java.lang.Long.parseLong;
 import static java.lang.Short.parseShort;
 import static java.lang.String.format;
 import static java.math.BigDecimal.ROUND_UNNECESSARY;
+import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static org.apache.hadoop.hive.common.FileUtils.unescapePathName;
@@ -1024,5 +1028,24 @@ public final class HiveUtil
             }
         }
         return orcWriterOptions;
+    }
+
+    public static SortingColumn sortingColumnFromString(String name)
+    {
+        SortingColumn.Order order = ASCENDING;
+        String lower = name.toUpperCase(ENGLISH);
+        if (lower.endsWith(" ASC")) {
+            name = name.substring(0, name.length() - 4).trim();
+        }
+        else if (lower.endsWith(" DESC")) {
+            name = name.substring(0, name.length() - 5).trim();
+            order = DESCENDING;
+        }
+        return new SortingColumn(name, order);
+    }
+
+    public static String sortingColumnToString(SortingColumn column)
+    {
+        return column.getColumnName() + ((column.getOrder() == DESCENDING) ? " DESC" : "");
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -269,6 +269,7 @@ public class TestHivePageSink
                 config.getHiveStorageFormat(),
                 ImmutableList.of(),
                 Optional.empty(),
+                ImmutableList.of(),
                 "test",
                 ImmutableMap.of(),
                 NO_ACID_TRANSACTION,


### PR DESCRIPTION
This allows writing sorted files without bucketing for improving
effectiveness of data skipping in orc and parquet file reads.
This is equivalent to SORT BY clause in Hive queries.
This sorting property is not used for planner optimisations as 
the sorting is best effort and not guaranteed.