### PR TITLE
Remove obsolete conversion

### DIFF
--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -190,14 +190,6 @@ public class SqlServerClient
             return mapping;
         }
 
-        return toColumnMapping(typeHandle)
-                .or(() -> legacyToPrestoType(session, connection, typeHandle));
-    }
-
-    private Optional<ColumnMapping> toColumnMapping(JdbcTypeHandle typeHandle)
-    {
-        // TODO (https://github.com/trinodb/trino/issues/4593) implement proper type mapping
-
         String jdbcTypeName = typeHandle.getJdbcTypeName()
                 .orElseThrow(() -> new TrinoException(JDBC_ERROR, "Type name is missing: " + typeHandle));
 
@@ -263,7 +255,8 @@ public class SqlServerClient
                 return Optional.of(timestampColumnMappingUsingSqlTimestamp(TIMESTAMP));
         }
 
-        return Optional.empty();
+        // TODO (https://github.com/trinodb/trino/issues/4593) implement proper type mapping
+        return legacyToPrestoType(session, connection, typeHandle);
     }
 
     @Override

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -70,7 +70,6 @@ import static com.microsoft.sqlserver.jdbc.SQLServerConnection.TRANSACTION_SNAPS
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.jdbc.PredicatePushdownController.DISABLE_PUSHDOWN;
-import static io.trino.plugin.jdbc.PredicatePushdownController.FULL_PUSHDOWN;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
@@ -191,14 +190,8 @@ public class SqlServerClient
             return mapping;
         }
 
-        // TODO how to provide SIMPLIFY_UNSUPPORTED_PUSHDOWN in most readable & maintainable way?
         return toColumnMapping(typeHandle)
-                .or(() -> legacyToPrestoType(session, connection, typeHandle))
-                .map(columnMapping -> new ColumnMapping(
-                        columnMapping.getType(),
-                        columnMapping.getReadFunction(),
-                        columnMapping.getWriteFunction(),
-                        FULL_PUSHDOWN));
+                .or(() -> legacyToPrestoType(session, connection, typeHandle));
     }
 
     private Optional<ColumnMapping> toColumnMapping(JdbcTypeHandle typeHandle)


### PR DESCRIPTION
The conversion was needed until
d80ad8608e3e6e1eb1bc6e9c5022502dea044a7b, as SQL Server connector used
to apply some constraints on pushed down domains.