### PR TITLE
Allow referencing env.sh vars in configs

### DIFF
--- a/core/trino-server-rpm/src/main/resources/dist/config/env.sh
+++ b/core/trino-server-rpm/src/main/resources/dist/config/env.sh
@@ -1,0 +1,3 @@
+#JAVA_HOME=
+# Configuration properties exported as environment variables
+#CONFIG_ENV[key]=value

--- a/core/trino-server-rpm/src/main/resources/dist/etc/init.d/trino
+++ b/core/trino-server-rpm/src/main/resources/dist/etc/init.d/trino
@@ -25,45 +25,55 @@ SERVICE_USER='trino'
 # Use data-dir from node.properties file (assumes it to be at /etc/trino). For other args use defaults from rpm install
 NODE_PROPERTIES=/etc/trino/node.properties
 DATA_DIR=$(grep -Po "(?<=^node.data-dir=).*" $NODE_PROPERTIES | tail -n 1)
-SERVER_LOG_FILE=$(grep -Po "(?<=^node.server-log-file=).*" $NODE_PROPERTIES  | tail -n 1)
-LAUNCHER_LOG_FILE=$(grep -Po "(?<=^node.launcher-log-file=).*" $NODE_PROPERTIES  | tail -n 1)
-CONFIGURATION=(--launcher-config /usr/lib/trino/bin/launcher.properties --data-dir "$DATA_DIR" --node-config "$NODE_PROPERTIES" --jvm-config /etc/trino/jvm.config --config /etc/trino/config.properties --launcher-log-file "${LAUNCHER_LOG_FILE:-/var/log/trino/launcher.log}" --server-log-file "${SERVER_LOG_FILE:-/var/log/trino/server.log}")
+SERVER_LOG_FILE=$(grep -Po "(?<=^node.server-log-file=).*" $NODE_PROPERTIES | tail -n 1)
+LAUNCHER_LOG_FILE=$(grep -Po "(?<=^node.launcher-log-file=).*" $NODE_PROPERTIES | tail -n 1)
+CONFIGURATION=(
+    --launcher-config /usr/lib/trino/bin/launcher.properties
+    --data-dir "$DATA_DIR"
+    --node-config "$NODE_PROPERTIES"
+    --jvm-config /etc/trino/jvm.config
+    --config /etc/trino/config.properties
+    --launcher-log-file "${LAUNCHER_LOG_FILE:-/var/log/trino/launcher.log}"
+    --server-log-file "${SERVER_LOG_FILE:-/var/log/trino/server.log}"
+)
 
+# Don't need shellcheck to follow env.sh
+# shellcheck disable=1091
 source /etc/trino/env.sh
 
-start () {
+start() {
     echo "Starting ${SERVICE_NAME} "
-    if [ -z "${JAVA_HOME}" ]
-    then
-        echo "Warning: No value found for \$JAVA_HOME. Default Java will be used." >&2
+    if [ -z "${JAVA_HOME}" ]; then
+        # Don't expand JAVA_HOME in the error message
+        # shellcheck disable=2016
+        echo 'Warning: No value found for $JAVA_HOME. Default Java will be used.' >&2
         sudo -u $SERVICE_USER /usr/lib/trino/bin/launcher start "${CONFIGURATION[@]}"
     else
-        sudo -u $SERVICE_USER PATH=${JAVA_HOME}/bin:$PATH /usr/lib/trino/bin/launcher start "${CONFIGURATION[@]}"
+        sudo -u $SERVICE_USER PATH="${JAVA_HOME}/bin:$PATH" /usr/lib/trino/bin/launcher start "${CONFIGURATION[@]}"
     fi
     return $?
 }
 
-stop () {
+stop() {
     echo "Stopping ${SERVICE_NAME} "
     sudo -u $SERVICE_USER /usr/lib/trino/bin/launcher stop "${CONFIGURATION[@]}"
     return $?
 }
 
-status () {
+status() {
     echo "Getting status for ${SERVICE_NAME} "
     sudo -u $SERVICE_USER /usr/lib/trino/bin/launcher status "${CONFIGURATION[@]}"
     return $?
 }
 
-
-restart () {
+restart() {
     sudo -u $SERVICE_USER /usr/lib/trino/bin/launcher restart "${CONFIGURATION[@]}"
     return $?
 }
 
 # TODO: Add kill
 
-usage () {
+usage() {
     echo $"Usage: ${SCRIPT_NAME} {start|stop|restart|status}"
     return 3
 }
@@ -84,4 +94,5 @@ case "${ACTION_NAME}" in
     *)
         echo $"Usage: $0 {start|stop|restart|status}"
         exit 3
+        ;;
 esac

--- a/core/trino-server-rpm/src/main/resources/dist/etc/init.d/trino
+++ b/core/trino-server-rpm/src/main/resources/dist/etc/init.d/trino
@@ -37,37 +37,43 @@ CONFIGURATION=(
     --server-log-file "${SERVER_LOG_FILE:-/var/log/trino/server.log}"
 )
 
+declare -A CONFIG_ENV
 # Don't need shellcheck to follow env.sh
 # shellcheck disable=1091
 source /etc/trino/env.sh
 
+sudo_options=(-u "$SERVICE_USER")
+if [ -z "${JAVA_HOME}" ]; then
+    # Don't expand JAVA_HOME in the error message
+    # shellcheck disable=2016
+    echo 'Warning: No value found for $JAVA_HOME. Default Java will be used.' >&2
+else
+    sudo_options+=("PATH=${JAVA_HOME}/bin:$PATH")
+fi
+for key in "${!CONFIG_ENV[@]}"; do
+    sudo_options+=("$key=${CONFIG_ENV[$key]}")
+done
+
 start() {
     echo "Starting ${SERVICE_NAME} "
-    if [ -z "${JAVA_HOME}" ]; then
-        # Don't expand JAVA_HOME in the error message
-        # shellcheck disable=2016
-        echo 'Warning: No value found for $JAVA_HOME. Default Java will be used.' >&2
-        sudo -u $SERVICE_USER /usr/lib/trino/bin/launcher start "${CONFIGURATION[@]}"
-    else
-        sudo -u $SERVICE_USER PATH="${JAVA_HOME}/bin:$PATH" /usr/lib/trino/bin/launcher start "${CONFIGURATION[@]}"
-    fi
+    sudo "${sudo_options[@]}" /usr/lib/trino/bin/launcher start "${CONFIGURATION[@]}"
     return $?
 }
 
 stop() {
     echo "Stopping ${SERVICE_NAME} "
-    sudo -u $SERVICE_USER /usr/lib/trino/bin/launcher stop "${CONFIGURATION[@]}"
+    sudo "${sudo_options[@]}" /usr/lib/trino/bin/launcher stop "${CONFIGURATION[@]}"
     return $?
 }
 
 status() {
     echo "Getting status for ${SERVICE_NAME} "
-    sudo -u $SERVICE_USER /usr/lib/trino/bin/launcher status "${CONFIGURATION[@]}"
+    sudo "${sudo_options[@]}" /usr/lib/trino/bin/launcher status "${CONFIGURATION[@]}"
     return $?
 }
 
 restart() {
-    sudo -u $SERVICE_USER /usr/lib/trino/bin/launcher restart "${CONFIGURATION[@]}"
+    sudo "${sudo_options[@]}" /usr/lib/trino/bin/launcher restart "${CONFIGURATION[@]}"
     return $?
 }
 

--- a/core/trino-server-rpm/src/main/rpm/postinstall
+++ b/core/trino-server-rpm/src/main/rpm/postinstall
@@ -11,11 +11,10 @@ install --directory --mode=755 /var/log/trino
 sed -i "s/\$(uuid-generated-nodeid)/$(uuidgen)/g" /etc/trino/node.properties
 
 # move the trino_env.sh created during pre-install to Trino config location
-if [ -e /tmp/trino_env.sh ]
-then
+if [ -e /tmp/trino_env.sh ]; then
     mv /tmp/trino_env.sh /etc/trino/env.sh
 else
-    echo "#JAVA_HOME=" > /etc/trino/env.sh
+    echo "#JAVA_HOME=" >/etc/trino/env.sh
 fi
 
 chown -R trino:trino /var/lib/trino

--- a/core/trino-server-rpm/src/main/rpm/postinstall
+++ b/core/trino-server-rpm/src/main/rpm/postinstall
@@ -10,11 +10,14 @@ install --directory --mode=755 /var/log/trino
 # Populate node.id from uuidgen by replacing template with the node uuid
 sed -i "s/\$(uuid-generated-nodeid)/$(uuidgen)/g" /etc/trino/node.properties
 
-# move the trino_env.sh created during pre-install to Trino config location
-if [ -e /tmp/trino_env.sh ]; then
-    mv /tmp/trino_env.sh /etc/trino/env.sh
-else
-    echo "#JAVA_HOME=" >/etc/trino/env.sh
+# read /tmp/trino-rpm-install-java-home created during pre-install and save JAVA_HOME in env.sh at Trino config location
+if [ -r /tmp/trino-rpm-install-java-home ]; then
+    JAVA_HOME=$(cat /tmp/trino-rpm-install-java-home)
+    target=/etc/trino/env.sh
+    sed -i "/^#JAVA_HOME=$/d" $target
+    if ! grep -q '^JAVA_HOME=' $target >/dev/null; then
+        echo "JAVA_HOME=$JAVA_HOME" >> $target
+    fi
 fi
 
 chown -R trino:trino /var/lib/trino

--- a/core/trino-server-rpm/src/main/rpm/postremove
+++ b/core/trino-server-rpm/src/main/rpm/postremove
@@ -5,9 +5,6 @@ if [ "$1" -ne 0 ]; then
     exit 0
 fi
 
-# Delete /etc/trino/env.sh manually during uninstall.
-# rpm -e wont remove it, because this file is created during preinstall
-rm -f /etc/trino/env.sh
 # Delete the data directory manually during uninstall.
 # rpm -e wont remove it, because this directory may later contain files not
 # deployed by the rpm

--- a/core/trino-server-rpm/src/main/rpm/postremove
+++ b/core/trino-server-rpm/src/main/rpm/postremove
@@ -1,22 +1,22 @@
 # Post erase script
 
-# if this is the last version of the rpm being removed (i.e. not on upgrade)
-if [ "$1" -eq 0 ]
-then
-    # Delete /etc/trino/env.sh manually during uninstall.
-    # rpm -e wont remove it, because this file is created during preinstall
-    rm -f /etc/trino/env.sh
-    # Delete the data directory manually during uninstall.
-    # rpm -e wont remove it, because this directory may later contain files not
-    # deployed by the rpm
-    rm -rf /var/lib/trino
-    # The RPM instead of linking to /usr/lib/trino/ as a directory attribute
-    # now links to all the individual jar files in /usr/lib/trino/lib/ and
-    # /usr/lib/trino/plugin/. So remove the parent dir manually during uninstall
-    rm -rf /usr/lib/trino
-    # Remove /etc/trino directory if no other files present
-    if [ -z "$(ls -A /etc/trino)" ]
-    then
-        rm -rf /etc/trino
-    fi
+# Ensure this is the last version of the rpm being removed (i.e. not on upgrade)
+if [ "$1" -ne 0 ]; then
+    exit 0
+fi
+
+# Delete /etc/trino/env.sh manually during uninstall.
+# rpm -e wont remove it, because this file is created during preinstall
+rm -f /etc/trino/env.sh
+# Delete the data directory manually during uninstall.
+# rpm -e wont remove it, because this directory may later contain files not
+# deployed by the rpm
+rm -rf /var/lib/trino
+# The RPM instead of linking to /usr/lib/trino/ as a directory attribute
+# now links to all the individual jar files in /usr/lib/trino/lib/ and
+# /usr/lib/trino/plugin/. So remove the parent dir manually during uninstall
+rm -rf /usr/lib/trino
+# Remove /etc/trino directory if no other files present
+if [ -z "$(ls -A /etc/trino)" ]; then
+    rm -rf /etc/trino
 fi

--- a/core/trino-server-rpm/src/main/rpm/preinstall
+++ b/core/trino-server-rpm/src/main/rpm/preinstall
@@ -23,7 +23,7 @@ check_if_correct_java_version() {
     JAVA_VERSION=$(java_version "$1")
     JAVA_MAJOR=$(echo "$JAVA_VERSION" | cut -d'.' -f1)
     if [ "$JAVA_MAJOR" -ge "11" ]; then
-        echo "JAVA_HOME=$1" >/tmp/trino_env.sh
+        echo "$1" >/tmp/trino-rpm-install-java-home
         return 0
     else
         return 1

--- a/core/trino-server-rpm/src/main/rpm/preinstall
+++ b/core/trino-server-rpm/src/main/rpm/preinstall
@@ -3,56 +3,55 @@
 # Ensure that the proper version of Java exists on the system
 
 java_version() {
-# The one argument is the location of java (either $JAVA_HOME or a potential
-# candidate for JAVA_HOME.
-  JAVA="$1"/bin/java
-  "$JAVA" -version 2>&1 | grep "\(java\|openjdk\) version" | awk '{ print substr($3, 2, length($3)-2); }'
+    # The one argument is the location of java (either $JAVA_HOME or a potential
+    # candidate for JAVA_HOME.
+    JAVA="$1"/bin/java
+    "$JAVA" -version 2>&1 | grep "\(java\|openjdk\) version" | awk '{ print substr($3, 2, length($3)-2); }'
 }
 
 check_if_correct_java_version() {
 
-# If the string is empty return non-zero code.  We don't want false positives if /bin/java is
-# a valid java version because that will leave JAVA_HOME unset and the init.d scripts will
-# use the default java version, which may not be the correct version.
-  if [ -z $1 ] ; then
-    return 1
-  fi
+    # If the string is empty return non-zero code.  We don't want false positives if /bin/java is
+    # a valid java version because that will leave JAVA_HOME unset and the init.d scripts will
+    # use the default java version, which may not be the correct version.
+    if [ -z "$1" ]; then
+        return 1
+    fi
 
-# The one argument is the location of java (either $JAVA_HOME or a potential
-# candidate for JAVA_HOME).
-  JAVA_VERSION=$(java_version "$1")
-  JAVA_UPDATE=$(echo $JAVA_VERSION | cut -d'_' -f2)
-  JAVA_MAJOR=$(echo $JAVA_VERSION | cut -d'.' -f1)
-  if [[ ("$JAVA_MAJOR" -ge "11") ]]; then
-    echo "JAVA_HOME=$1" > /tmp/trino_env.sh
-    return 0
-  else
-    return 1
-  fi
+    # The one argument is the location of java (either $JAVA_HOME or a potential
+    # candidate for JAVA_HOME).
+    JAVA_VERSION=$(java_version "$1")
+    JAVA_MAJOR=$(echo "$JAVA_VERSION" | cut -d'.' -f1)
+    if [ "$JAVA_MAJOR" -ge "11" ]; then
+        echo "JAVA_HOME=$1" >/tmp/trino_env.sh
+        return 0
+    else
+        return 1
+    fi
 }
 
 # if Java version of $JAVA_HOME is not correct, then try to find it again below
 if ! check_if_correct_java_version "$JAVA_HOME"; then
-  java_found=false
-  for candidate in \
-      /usr/lib/jvm/java-11-* \
-      /usr/lib/jvm/zulu-11 \
-      /usr/lib/jvm/default-java \
-      /usr/java/default \
-      / \
-      /usr ; do
-      if [ -e "$candidate"/bin/java ]; then
-        if check_if_correct_java_version "$candidate" ; then
-          java_found=true
-          break
+    java_found=false
+    for candidate in \
+        /usr/lib/jvm/java-11-* \
+        /usr/lib/jvm/zulu-11 \
+        /usr/lib/jvm/default-java \
+        /usr/java/default \
+        / \
+        /usr; do
+        if [ -e "$candidate"/bin/java ]; then
+            if check_if_correct_java_version "$candidate"; then
+                java_found=true
+                break
+            fi
         fi
-      fi
-  done
+    done
 fi
 
 # if no appropriate java found
 if [ "$java_found" = false ]; then
-  cat 1>&2 <<EOF
+    cat 1>&2 <<EOF
 +======================================================================+
 |      Error: Required Java version could not be found                 |
 +----------------------------------------------------------------------+
@@ -65,7 +64,7 @@ if [ "$java_found" = false ]; then
 |       using the binary or the RPM based installer.                   |
 +======================================================================+
 EOF
-  exit 1
+    exit 1
 fi
 
 getent group trino >/dev/null || /usr/sbin/groupadd -r trino

--- a/core/trino-server-rpm/src/main/rpm/preremove
+++ b/core/trino-server-rpm/src/main/rpm/preremove
@@ -1,5 +1,5 @@
-/etc/init.d/trino status > /dev/null 2>&1
-if [[ $? != 3 ]]; then
+/etc/init.d/trino status >/dev/null 2>&1
+if [ "$?" != 3 ]; then
     echo "Please stop the Trino service before erasing RPM"
     exit 1
 fi

--- a/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
+++ b/core/trino-server-rpm/src/test/java/io/trino/server/rpm/ServerIT.java
@@ -102,9 +102,12 @@ public class ServerIT
                 "yum localinstall -q -y " + rpm + "\n" +
                 // create Hive catalog file
                 "mkdir /etc/trino/catalog\n" +
+                "echo CONFIG_ENV[HMS_PORT]=9083 >> /etc/trino/env.sh\n" +
+                "echo CONFIG_ENV[NODE_ID]=test-node-id-injected-via-env >> /etc/trino/env.sh\n" +
+                "sed -i \"s/^node.id=.*/node.id=\\${ENV:NODE_ID}/g\" /etc/trino/node.properties\n" +
                 "cat > /etc/trino/catalog/hive.properties <<\"EOT\"\n" +
                 "connector.name=hive-hadoop2\n" +
-                "hive.metastore.uri=thrift://localhost:9083\n" +
+                "hive.metastore.uri=thrift://localhost:${ENV:HMS_PORT}\n" +
                 "EOT\n" +
                 // create JMX catalog file
                 "cat > /etc/trino/catalog/jmx.properties <<\"EOT\"\n" +
@@ -124,6 +127,7 @@ public class ServerIT
                     .start();
             QueryRunner queryRunner = new QueryRunner(container.getContainerIpAddress(), container.getMappedPort(8080));
             assertEquals(queryRunner.execute("SHOW CATALOGS"), ImmutableSet.of(asList("system"), asList("hive"), asList("jmx")));
+            assertEquals(queryRunner.execute("SELECT node_id FROM system.runtime.nodes"), ImmutableSet.of(asList("test-node-id-injected-via-env")));
             // TODO remove usage of assertEventually once https://github.com/trinodb/trino/issues/2214 is fixed
             assertEventually(
                     new io.airlift.units.Duration(1, MINUTES),


### PR DESCRIPTION
Allow referencing env vars from `env.sh` in configs.

Since this would allow users to add their custom vars to `env.sh` treat it as a config file so it won't be removed automatically on uninstall. Note that by default `node.properties` also won't be removed, as reported in #314