### PR TITLE
Rename errorprone profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Error Prone Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          ./mvnw ${MAVEN_TEST} -T C1 clean test-compile -P errorprone-compiler-trino \
+          ./mvnw ${MAVEN_TEST} -T C1 clean test-compile -P errorprone-compiler \
             -pl '!:trino-docs,!:trino-server,!:trino-server-rpm'
 
   web-ui-checks:

--- a/pom.xml
+++ b/pom.xml
@@ -1742,8 +1742,7 @@
         </profile>
 
         <profile>
-            <!-- airbase defines "errorprone-compiler" profile but set up this ourselves -->
-            <id>errorprone-compiler-trino</id>
+            <id>errorprone-compiler</id>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
Airbase no longer defines an `errorprone-compiler` profile, so we can
use a simpler profile name.

Depends on https://github.com/trinodb/trino/pull/6627