### PR TITLE
Use exact Java version in RPM preinstall check

### DIFF
--- a/core/trino-server-rpm/pom.xml
+++ b/core/trino-server-rpm/pom.xml
@@ -15,8 +15,8 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-
         <server.tar.package>trino-server-${project.version}</server.tar.package>
+        <javaversion>${air.java.version}</javaversion>
     </properties>
 
     <dependencies>
@@ -142,7 +142,6 @@
 
                 <configuration>
                     <performCheckingForExtraFiles>false</performCheckingForExtraFiles>
-
                     <packages>
                         <package>
                             <name>trino-server-rpm</name>

--- a/core/trino-server-rpm/src/main/rpm/preinstall
+++ b/core/trino-server-rpm/src/main/rpm/preinstall
@@ -1,7 +1,20 @@
 # Pre installation script
 
-# Ensure that the proper version of Java exists on the system
+# Returns:
+# 1 when actual version >= expected
+# 0 otherwise
+version_ge() {
+    local expected="${1}"
+    local actual="${2}"
 
+    if [  "$expected" = $(echo -e "$actual\n$expected" | sort -V | head -n 1) ]; then
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+# Ensure that the proper version of Java exists on the system
 java_version() {
 # The one argument is the location of java (either $JAVA_HOME or a potential
 # candidate for JAVA_HOME.
@@ -21,9 +34,7 @@ check_if_correct_java_version() {
 # The one argument is the location of java (either $JAVA_HOME or a potential
 # candidate for JAVA_HOME).
   JAVA_VERSION=$(java_version "$1")
-  JAVA_UPDATE=$(echo $JAVA_VERSION | cut -d'_' -f2)
-  JAVA_MAJOR=$(echo $JAVA_VERSION | cut -d'.' -f1)
-  if [[ ("$JAVA_MAJOR" -ge "11") ]]; then
+  if [ $(version_ge "${project.properties.javaversion}" "$JAVA_VERSION") -eq "1" ]; then
     echo "JAVA_HOME=$1" > /tmp/trino_env.sh
     return 0
   else
@@ -54,7 +65,7 @@ fi
 if [ "$java_found" = false ]; then
   cat 1>&2 <<EOF
 +======================================================================+
-|      Error: Required Java version could not be found                 |
+|      Error: Required Java version ${project.properties.javaversion} could not be found          |
 +----------------------------------------------------------------------+
 | Please install JDK 11. On RHEL/CentOS, use java-11-openjdk-devel.    |
 |                                                                      |


### PR DESCRIPTION
From now on, RPM preinstall hook checks if installed Java version is greater than or equal to ${air.java.version}.

Expanded preinstall check can be seen when core/trino-server-rpm is built:

```
cat core/trino-server-rpm/target/trino-server-rpm-352-SNAPSHOT-preinstall-hook
```

```
# Pre installation script

# Returns 0 when versions match
# 1 when $1 is less than $2 and
# -1 when $1 is greater than $2.
version_compare() {
    if [ "$1" == "$2" ]; then
        echo 0
    elif [  "$1" = $(echo -e "$1\n$2" | sort -V | head -n 1) ]; then
        echo 1
    else
        echo -1
    fi
}

# Ensure that the proper version of Java exists on the system
java_version() {
# The one argument is the location of java (either $JAVA_HOME or a potential
# candidate for JAVA_HOME.
  JAVA="$1"/bin/java
  "$JAVA" -version 2>&1 | grep "\(java\|openjdk\) version" | awk '{ print substr($3, 2, length($3)-2); }'
}

check_if_correct_java_version() {

# If the string is empty return non-zero code.  We don't want false positives if /bin/java is
# a valid java version because that will leave JAVA_HOME unset and the init.d scripts will
# use the default java version, which may not be the correct version.
  if [ -z $1 ] ; then
    return 1
  fi

# The one argument is the location of java (either $JAVA_HOME or a potential
# candidate for JAVA_HOME).
  JAVA_VERSION=$(java_version "$1")
  if [ $(version_compare "11.0.7" "$JAVA_VERSION") -ge "0" ]; then
    echo "JAVA_HOME=$1" > /tmp/trino_env.sh
    return 0
  else
    return 1
  fi
}

# if Java version of $JAVA_HOME is not correct, then try to find it again below
if ! check_if_correct_java_version "$JAVA_HOME"; then
  java_found=false
  for candidate in \
      /usr/lib/jvm/java-11-* \
      /usr/lib/jvm/zulu-11 \
      /usr/lib/jvm/default-java \
      /usr/java/default \
      / \
      /usr ; do
      if [ -e "$candidate"/bin/java ]; then
        if check_if_correct_java_version "$candidate" ; then
          java_found=true
          break
        fi
      fi
  done
fi

# if no appropriate java found
if [ "$java_found" = false ]; then
  cat 1>&2 <<EOF
+======================================================================+
|      Error: Required Java version 11.0.7 could not be found          |
+----------------------------------------------------------------------+
| Please install JDK 11. On RHEL/CentOS, use java-11-openjdk-devel.    |
|                                                                      |
| You can also download an OpenJDK 11 build, such as Zulu Community:   |
|       >>> https://www.azul.com/downloads/zulu-community/ <<<         |
|                                                                      |
| NOTE: This script will attempt to find Java whether you install      |
|       using the binary or the RPM based installer.                   |
+======================================================================+
EOF
  exit 1
fi

getent group trino >/dev/null || /usr/sbin/groupadd -r trino
getent passwd trino >/dev/null || /usr/sbin/useradd --comment "Trino" -s /sbin/nologin -g trino -r -d /var/lib/trino trino

```