### PR TITLE
Reduce output buffer memory manager contention

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/buffer/ClientBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/ClientBuffer.java
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.trino.execution.buffer.BufferResult.emptyResults;
@@ -264,7 +263,7 @@ class ClientBuffer
      */
     private boolean loadPagesIfNecessary(PagesSupplier pagesSupplier, DataSize maxSize)
     {
-        checkState(!Thread.holdsLock(this), "Cannot load pages while holding a lock on this");
+        assertNotHoldsLock("Cannot load pages while holding a lock on this");
 
         boolean dataAddedOrNoMorePages;
         List<SerializedPageReference> pageReferences;
@@ -300,7 +299,7 @@ class ClientBuffer
 
     private void processRead(PendingRead pendingRead)
     {
-        checkState(!Thread.holdsLock(this), "Cannot process pending read while holding a lock on this");
+        assertNotHoldsLock("Cannot process pending read while holding a lock on this");
 
         if (pendingRead.getResultFuture().isDone()) {
             return;
@@ -414,6 +413,12 @@ class ClientBuffer
         }
         //  Dereference pages outside of synchronized block to trigger callbacks
         dereferencePages(removedPages.build(), onPagesReleased);
+    }
+
+    @SuppressWarnings("checkstyle:IllegalToken")
+    private void assertNotHoldsLock(String message)
+    {
+        assert !Thread.holdsLock(this) : message;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBufferMemoryManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBufferMemoryManager.java
@@ -15,21 +15,21 @@ package io.trino.execution.buffer;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.trino.memory.context.LocalMemoryContext;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -40,16 +40,19 @@ import static java.util.Objects.requireNonNull;
 @ThreadSafe
 class OutputBufferMemoryManager
 {
+    private static final ListenableFuture<?> NOT_BLOCKED = immediateFuture(null);
+
     private final long maxBufferedBytes;
     private final AtomicLong bufferedBytes = new AtomicLong();
     private final AtomicLong peakMemoryUsage = new AtomicLong();
 
     @GuardedBy("this")
     private boolean closed;
+    @Nullable
     @GuardedBy("this")
-    private SettableFuture<?> bufferBlockedFuture;
+    private SettableFuture<?> bufferBlockedFuture; // null indicates "no listener registered"
     @GuardedBy("this")
-    private ListenableFuture<?> blockedOnMemory = Futures.immediateFuture(null);
+    private ListenableFuture<?> blockedOnMemory = NOT_BLOCKED;
 
     private final AtomicBoolean blockOnFull = new AtomicBoolean(true);
 
@@ -63,58 +66,83 @@ class OutputBufferMemoryManager
         this.maxBufferedBytes = maxBufferedBytes;
         this.systemMemoryContextSupplier = Suppliers.memoize(systemMemoryContextSupplier::get);
         this.notificationExecutor = requireNonNull(notificationExecutor, "notificationExecutor is null");
-
-        bufferBlockedFuture = SettableFuture.create();
-        bufferBlockedFuture.set(null);
     }
 
-    public synchronized void updateMemoryUsage(long bytesAdded)
+    public void updateMemoryUsage(long bytesAdded)
     {
-        Optional<LocalMemoryContext> systemMemoryContext = getSystemMemoryContext();
-
-        // If closed is true, that means the task is completed. In that state,
-        // the output buffers already ignore the newly added pages, and therefore
-        // we can also safely ignore any calls after OutputBufferMemoryManager is closed.
         // If the systemMemoryContext doesn't exist, the task is probably already
-        // aborted, so we can just return (see the comment in getSystemMemoryContext()).
-        if (closed || systemMemoryContext.isEmpty()) {
+        // aborted, so we can just return (see the comment in getSystemMemoryContextOrNull()).
+        LocalMemoryContext systemMemoryContext = getSystemMemoryContextOrNull();
+        if (systemMemoryContext == null) {
             return;
         }
 
-        long currentBufferedBytes = bufferedBytes.updateAndGet(bytes -> {
-            long result = bytes + bytesAdded;
-            checkArgument(result >= 0, "bufferedBytes (%s) plus delta (%s) would be negative", bytes, bytesAdded);
-            return result;
-        });
+        ListenableFuture<?> waitForMemory = null;
+        SettableFuture<?> notifyUnblocked = null;
+        long currentBufferedBytes;
+        synchronized (this) {
+            // If closed is true, that means the task is completed. In that state,
+            // the output buffers already ignore the newly added pages, and therefore
+            // we can also safely ignore any calls after OutputBufferMemoryManager is closed.
+            if (closed) {
+                return;
+            }
 
+            currentBufferedBytes = bufferedBytes.updateAndGet(bytes -> {
+                long result = bytes + bytesAdded;
+                checkArgument(result >= 0, "bufferedBytes (%s) plus delta (%s) would be negative", bytes, bytesAdded);
+                return result;
+            });
+            ListenableFuture<?> blockedOnMemory = systemMemoryContext.setBytes(currentBufferedBytes);
+            if (!blockedOnMemory.isDone()) {
+                if (this.blockedOnMemory != blockedOnMemory) {
+                    this.blockedOnMemory = blockedOnMemory;
+                    waitForMemory = blockedOnMemory; // only register a callback when blocked and the future is different
+                }
+            }
+            else {
+                this.blockedOnMemory = NOT_BLOCKED;
+                if (currentBufferedBytes <= maxBufferedBytes || !blockOnFull.get()) {
+                    // Complete future in a new thread to avoid making a callback on the caller thread.
+                    // This make is easier for callers to use this class since they can update the memory
+                    // usage while holding locks.
+                    notifyUnblocked = this.bufferBlockedFuture;
+                    this.bufferBlockedFuture = null;
+                }
+            }
+        }
         peakMemoryUsage.accumulateAndGet(currentBufferedBytes, Math::max);
-        this.blockedOnMemory = systemMemoryContext.get().setBytes(currentBufferedBytes);
-        if (!isBufferFull() && !isBlockedOnMemory() && !bufferBlockedFuture.isDone()) {
-            // Complete future in a new thread to avoid making a callback on the caller thread.
-            // This make is easier for callers to use this class since they can update the memory
-            // usage while holding locks.
-            SettableFuture<?> future = this.bufferBlockedFuture;
-            notificationExecutor.execute(() -> future.set(null));
-            return;
+        // Notify listeners outside of the critical section
+        notifyListener(notifyUnblocked);
+        if (waitForMemory != null) {
+            waitForMemory.addListener(this::onMemoryAvailable, notificationExecutor);
         }
-        this.blockedOnMemory.addListener(this::onMemoryAvailable, notificationExecutor);
     }
 
     public synchronized ListenableFuture<?> getBufferBlockedFuture()
     {
-        if ((isBufferFull() || isBlockedOnMemory()) && bufferBlockedFuture.isDone()) {
+        if (bufferBlockedFuture == null) {
+            if (blockedOnMemory.isDone() && !isBufferFull()) {
+                return NOT_BLOCKED;
+            }
             bufferBlockedFuture = SettableFuture.create();
         }
         return bufferBlockedFuture;
     }
 
-    public synchronized void setNoBlockOnFull()
+    public void setNoBlockOnFull()
     {
-        blockOnFull.set(false);
+        SettableFuture<?> future = null;
+        synchronized (this) {
+            blockOnFull.set(false);
 
+            if (blockedOnMemory.isDone()) {
+                future = this.bufferBlockedFuture;
+                this.bufferBlockedFuture = null;
+            }
+        }
         // Complete future in a new thread to avoid making a callback on the caller thread.
-        SettableFuture<?> future = this.bufferBlockedFuture;
-        notificationExecutor.execute(() -> future.set(null));
+        notifyListener(future);
     }
 
     public long getBufferedBytes()
@@ -127,32 +155,35 @@ class OutputBufferMemoryManager
         return bufferedBytes.get() / (double) maxBufferedBytes;
     }
 
-    public synchronized boolean isOverutilized()
+    public boolean isOverutilized()
     {
         return isBufferFull();
     }
 
-    private synchronized boolean isBufferFull()
+    private boolean isBufferFull()
     {
         return bufferedBytes.get() > maxBufferedBytes && blockOnFull.get();
     }
 
-    private synchronized boolean isBlockedOnMemory()
-    {
-        return !blockedOnMemory.isDone();
-    }
-
     @VisibleForTesting
-    synchronized void onMemoryAvailable()
+    void onMemoryAvailable()
     {
-        // Do not notify the listeners if the buffer is full
-        if (bufferedBytes.get() > maxBufferedBytes) {
+        // Check if the buffer is full before synchronizing and skip notifying listeners
+        if (isBufferFull()) {
             return;
         }
 
+        SettableFuture<?> future;
+        synchronized (this) {
+            // re-check after synchronizing and ensure the current memory future is completed
+            if (isBufferFull() || !blockedOnMemory.isDone()) {
+                return;
+            }
+            future = this.bufferBlockedFuture;
+            this.bufferBlockedFuture = null;
+        }
         // notify listeners if the buffer is not full
-        SettableFuture<?> future = this.bufferBlockedFuture;
-        notificationExecutor.execute(() -> future.set(null));
+        notifyListener(future);
     }
 
     public long getPeakMemoryUsage()
@@ -163,19 +194,30 @@ class OutputBufferMemoryManager
     public synchronized void close()
     {
         updateMemoryUsage(-bufferedBytes.get());
-        getSystemMemoryContext().ifPresent(LocalMemoryContext::close);
+        LocalMemoryContext memoryContext = getSystemMemoryContextOrNull();
+        if (memoryContext != null) {
+            memoryContext.close();
+        }
         closed = true;
     }
 
-    private Optional<LocalMemoryContext> getSystemMemoryContext()
+    private void notifyListener(@Nullable SettableFuture<?> future)
+    {
+        if (future != null) {
+            notificationExecutor.execute(() -> future.set(null));
+        }
+    }
+
+    @Nullable
+    private LocalMemoryContext getSystemMemoryContextOrNull()
     {
         try {
-            return Optional.of(systemMemoryContextSupplier.get());
+            return systemMemoryContextSupplier.get();
         }
         catch (RuntimeException ignored) {
             // This is possible with races, e.g., a task is created and then immediately aborted,
             // so that the task context hasn't been created yet (as a result there's no memory context available).
+            return null;
         }
-        return Optional.empty();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/ExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExchangeClient.java
@@ -207,10 +207,16 @@ public class ExchangeClient
         });
     }
 
+    @SuppressWarnings("checkstyle:IllegalToken")
+    private void assertNotHoldsLock()
+    {
+        assert !Thread.holdsLock(this) : "Cannot get next page while holding a lock on this";
+    }
+
     @Nullable
     public SerializedPage pollPage()
     {
-        checkState(!Thread.holdsLock(this), "Cannot get next page while holding a lock on this");
+        assertNotHoldsLock();
 
         throwIfFailed();
 

--- a/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HttpPageBufferClient.java
@@ -333,7 +333,7 @@ public final class HttpPageBufferClient
             @Override
             public void onSuccess(PagesResponse result)
             {
-                checkNotHoldsLock(this);
+                assertNotHoldsLock(this);
 
                 backoff.success();
 
@@ -425,7 +425,7 @@ public final class HttpPageBufferClient
             public void onFailure(Throwable t)
             {
                 log.debug("Request to %s failed %s", uri, t);
-                checkNotHoldsLock(this);
+                assertNotHoldsLock(this);
 
                 if (t instanceof ChecksumVerificationException) {
                     switch (dataIntegrityVerification) {
@@ -467,7 +467,7 @@ public final class HttpPageBufferClient
             @Override
             public void onSuccess(@Nullable StatusResponse result)
             {
-                checkNotHoldsLock(this);
+                assertNotHoldsLock(this);
                 backoff.success();
                 synchronized (HttpPageBufferClient.this) {
                     closed = true;
@@ -483,7 +483,7 @@ public final class HttpPageBufferClient
             @Override
             public void onFailure(Throwable t)
             {
-                checkNotHoldsLock(this);
+                assertNotHoldsLock(this);
 
                 log.error("Request to delete %s failed %s", location, t);
                 if (!(t instanceof TrinoException) && backoff.failure()) {
@@ -499,15 +499,16 @@ public final class HttpPageBufferClient
         }, pageBufferClientCallbackExecutor);
     }
 
-    private static void checkNotHoldsLock(Object lock)
+    @SuppressWarnings("checkstyle:IllegalToken")
+    private static void assertNotHoldsLock(Object lock)
     {
-        checkState(!Thread.holdsLock(lock), "Cannot execute this method while holding a lock");
+        assert !Thread.holdsLock(lock) : "Cannot execute this method while holding a lock";
     }
 
     private void handleFailure(Throwable t, HttpResponseFuture<?> expectedFuture)
     {
         // Cannot delegate to other callback while holding a lock on this
-        checkNotHoldsLock(this);
+        assertNotHoldsLock(this);
 
         requestsFailed.incrementAndGet();
         requestsCompleted.incrementAndGet();

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSource.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSource.java
@@ -64,7 +64,7 @@ public class LocalExchangeSource
 
     void addPage(PageReference pageReference)
     {
-        checkNotHoldsLock();
+        assertNotHoldsLock();
 
         boolean added = false;
         SettableFuture<?> notEmptyFuture = null;
@@ -120,7 +120,7 @@ public class LocalExchangeSource
 
     public Page removePage()
     {
-        checkNotHoldsLock();
+        assertNotHoldsLock();
 
         // NOTE: there is no need to acquire a lock here. The buffer is concurrent
         // and buffered bytes is not expected to be consistent with the buffer (only
@@ -141,7 +141,7 @@ public class LocalExchangeSource
 
     public ListenableFuture<?> waitForReading()
     {
-        checkNotHoldsLock();
+        assertNotHoldsLock();
         // Fast path, definitely not blocked
         if (finishing || !buffer.isEmpty()) {
             return NOT_BLOCKED;
@@ -174,7 +174,7 @@ public class LocalExchangeSource
 
     public void finish()
     {
-        checkNotHoldsLock();
+        assertNotHoldsLock();
 
         SettableFuture<?> notEmptyFuture;
         synchronized (this) {
@@ -198,7 +198,7 @@ public class LocalExchangeSource
 
     public void close()
     {
-        checkNotHoldsLock();
+        assertNotHoldsLock();
 
         List<PageReference> remainingPages = new ArrayList<>();
         SettableFuture<?> notEmptyFuture;
@@ -227,7 +227,7 @@ public class LocalExchangeSource
 
     private void checkFinished()
     {
-        checkNotHoldsLock();
+        assertNotHoldsLock();
 
         if (isFinished()) {
             // notify finish listener outside of lock, since it may make a callback
@@ -238,8 +238,9 @@ public class LocalExchangeSource
         }
     }
 
-    private void checkNotHoldsLock()
+    @SuppressWarnings("checkstyle:IllegalToken")
+    private void assertNotHoldsLock()
     {
-        checkState(!Thread.holdsLock(this), "Cannot execute this method while holding the lock");
+        assert !Thread.holdsLock(this) : "Cannot execute this method while holding the lock";
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestClientBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestClientBuffer.java
@@ -358,6 +358,48 @@ public class TestClientBuffer
         assertBufferDestroyed(buffer, 1);
     }
 
+    @Test
+    public void testProcessReadLockHolderAssertionsFireInTest()
+    {
+        ClientBuffer buffer = new ClientBuffer(TASK_INSTANCE_ID, BUFFER_ID, NOOP_RELEASE_LISTENER);
+        try {
+            ListenableFuture<BufferResult> pendingRead = buffer.getPages(0, DataSize.succinctBytes(1));
+            synchronized (buffer) {
+                addPage(buffer, createPage(0));
+            }
+            fail("Expected AssertionError to be thrown, are assertions enabled in your testing environment?");
+            assertTrue(getFuture(pendingRead, NO_WAIT).isEmpty(), "Code should not reach here");
+        }
+        catch (AssertionError ae) {
+            assertEquals(ae.getMessage(), "Cannot process pending read while holding a lock on this");
+        }
+        finally {
+            buffer.destroy();
+        }
+    }
+
+    @Test
+    public void testGetPagesWithSupplierLockHolderAssertionsFireInTest()
+    {
+        ClientBuffer buffer = new ClientBuffer(TASK_INSTANCE_ID, BUFFER_ID, NOOP_RELEASE_LISTENER);
+        TestingPagesSupplier supplier = new TestingPagesSupplier();
+        supplier.addPage(createPage(0));
+        try {
+            ListenableFuture<BufferResult> result;
+            synchronized (buffer) {
+                result = buffer.getPages(0, sizeOfPages(1), Optional.of(supplier));
+            }
+            fail("Expected AssertionError to be thrown, are assertions enabled in your testing environment?");
+            assertTrue(getFuture(result, NO_WAIT).isEmpty(), "Code should not reach here");
+        }
+        catch (AssertionError ae) {
+            assertEquals(ae.getMessage(), "Cannot load pages while holding a lock on this");
+        }
+        finally {
+            buffer.destroy();
+        }
+    }
+
     private static void assertInvalidSequenceId(ClientBuffer buffer, int sequenceId)
     {
         try {


### PR DESCRIPTION
Extracted changes from https://github.com/prestodb/presto/pull/15626

Addresses lock contention bottlenecks in `OutputBufferMemoryManager` by:
- Reducing the scope of the critical section in `#updateMemoryUsage(long)`
- Removing synchronization from `isBufferFull()` and `isOverutilized()`, these methods are already atomic reads
- Avoiding redundant notifications when the `blockedOnMemory` future does not change or is already completed (aka: not blocked)
- Avoiding spurious notifications from `setNoBlockOnFull()` when still blocked on memory
- Adds an unsynchronized fast path in `onMemoryAvailable()` to skip the lock acquisition entirely when the buffer is full

Also modifies `ExchangeClient`, `HttpPageBufferClient`, `ClientBuffer`, and `LocalExchangeSource` implementations to replace `checkState(!Thread.holdsLock(this), ...)` with an `assert` since these checks have a runtime performance cost but will have caught any contract violations before being merged assuming tests run with assertions enabled.