### PR TITLE
Allow TestingTrinoClient to use forwarded https

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
@@ -57,13 +57,18 @@ public abstract class AbstractTestingTrinoClient<T>
 {
     private final TestingTrinoServer trinoServer;
     private final Session defaultSession;
-
-    private final OkHttpClient httpClient = new OkHttpClient();
+    private final OkHttpClient httpClient;
 
     protected AbstractTestingTrinoClient(TestingTrinoServer trinoServer, Session defaultSession)
     {
+        this(trinoServer, defaultSession, new OkHttpClient());
+    }
+
+    protected AbstractTestingTrinoClient(TestingTrinoServer trinoServer, Session defaultSession, OkHttpClient httpClient)
+    {
         this.trinoServer = requireNonNull(trinoServer, "trinoServer is null");
         this.defaultSession = requireNonNull(defaultSession, "defaultSession is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
     }
 
     @Override

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingTrinoClient.java
@@ -36,6 +36,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 import io.trino.type.SqlIntervalDayTime;
 import io.trino.type.SqlIntervalYearMonth;
+import okhttp3.OkHttpClient;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -102,6 +103,11 @@ public class TestingTrinoClient
     public TestingTrinoClient(TestingTrinoServer trinoServer, Session defaultSession)
     {
         super(trinoServer, defaultSession);
+    }
+
+    public TestingTrinoClient(TestingTrinoServer trinoServer, Session defaultSession, OkHttpClient httpClient)
+    {
+        super(trinoServer, defaultSession, httpClient);
     }
 
     @Override

--- a/testing/trino-testing/src/test/java/io/trino/testing/TestTestingTrinoClient.java
+++ b/testing/trino-testing/src/test/java/io/trino/testing/TestTestingTrinoClient.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Key;
+import io.trino.Session;
+import io.trino.client.OkHttpUtil;
+import io.trino.execution.QueryIdGenerator;
+import io.trino.metadata.SessionPropertyManager;
+import io.trino.server.security.PasswordAuthenticatorManager;
+import io.trino.server.testing.TestingTrinoServer;
+import io.trino.spi.security.AccessDeniedException;
+import io.trino.spi.security.BasicPrincipal;
+import io.trino.spi.security.Identity;
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.security.Principal;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+
+public class TestTestingTrinoClient
+{
+    private static final String TEST_USER = "test_user";
+    private static final String PASSWORD = "password";
+    private static final QueryIdGenerator queryIdGenerator = new QueryIdGenerator();
+    private static final SessionPropertyManager sessionManager = new SessionPropertyManager();
+    private static final Session session = Session.builder(sessionManager)
+            .setIdentity(Identity.forUser(TEST_USER).build())
+            .setQueryId(queryIdGenerator.createNextQueryId())
+            .build();
+
+    private TestingTrinoServer server;
+
+    @BeforeClass
+    public void setup()
+    {
+        server = TestingTrinoServer.builder()
+                .setProperties(ImmutableMap.<String, String>builder()
+                        .put("http-server.authentication.type", "password")
+                        .put("http-server.authentication.allow-insecure-over-http", "false")
+                        .put("http-server.process-forwarded", "true")
+                        .build())
+                .build();
+
+        server.getInstance(Key.get(PasswordAuthenticatorManager.class)).setAuthenticator(TestTestingTrinoClient::authenticate);
+    }
+
+    private static Principal authenticate(String user, String password)
+    {
+        if ((TEST_USER.equals(user) && PASSWORD.equals(password))) {
+            return new BasicPrincipal(user);
+        }
+        throw new AccessDeniedException("Invalid credentials");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+            throws Exception
+    {
+        server.close();
+    }
+
+    @Test
+    public void testAuthenticationWithForwarding()
+    {
+        OkHttpClient httpClient = new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtil.basicAuth(TEST_USER, PASSWORD))
+                .addInterceptor(httpsForwarded())
+                .build();
+
+        try (TestingTrinoClient client = new TestingTrinoClient(server, session, httpClient)) {
+            MaterializedResult result = client.execute("SELECT 123").getResult();
+            assertEquals(result.getOnlyValue(), 123);
+        }
+    }
+
+    @Test
+    public void testAuthenticationWithoutForwarding()
+    {
+        OkHttpClient httpClient = new OkHttpClient.Builder()
+                .addInterceptor(OkHttpUtil.basicAuth(TEST_USER, PASSWORD))
+                .build();
+
+        try (TestingTrinoClient client = new TestingTrinoClient(server, session, httpClient)) {
+            assertThatThrownBy(() -> client.execute("SELECT 123"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("Error 403 Forbidden");
+        }
+    }
+
+    private static Interceptor httpsForwarded()
+    {
+        return chain -> {
+            Request request = chain.request();
+            return chain.proceed(request.newBuilder()
+                    .url(request.url().newBuilder().scheme("http").build())
+                    .addHeader("X-Forwarded-Proto", "https")
+                    .build());
+        };
+    }
+}


### PR DESCRIPTION
The original motivation of this pull request is testing `TestingTrinoServer` with authentication using `TestingTrinoClient`.

In the recent versions of Trino, authentication works over only HTTPS. However, `TestingTrinoClient` doesn't support HTTPS so `TestingTrinoClient` cannot test with authentication.

With this pull request, we can customize `OkHttpClient` instance used in `TestingTrinoClient` so that we can add an interceptor which emulates the behavior of HTTPS frontend by rewriting requests as adding `X-Forwarded-Proto` and `X-Forwarded-For` headers. See https://github.com/trinodb/trino/pull/6487 for more details about the background.

Of course, this customizability will also give test cases that use `TestingTrinoClient` more flexibility.

This closes #6487.