### PR TITLE
Notify coordinator on obtaining token

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/auth/external/ExternalAuthentication.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/ExternalAuthentication.java
@@ -58,7 +58,7 @@ class ExternalAuthentication
                 currentUri = result.getNextTokenUri();
                 continue;
             }
-
+            poller.tokenReceived(currentUri);
             return Optional.of(result.getToken());
         }
     }

--- a/client/trino-client/src/main/java/io/trino/client/auth/external/TokenPoller.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/external/TokenPoller.java
@@ -19,4 +19,6 @@ import java.time.Duration;
 public interface TokenPoller
 {
     TokenPollResult pollForToken(URI tokenUri, Duration timeout);
+
+    void tokenReceived(URI tokenUri);
 }

--- a/client/trino-client/src/test/java/io/trino/client/auth/external/MockTokenPoller.java
+++ b/client/trino-client/src/test/java/io/trino/client/auth/external/MockTokenPoller.java
@@ -21,11 +21,30 @@ import java.util.Map;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.function.Function;
 
 public final class MockTokenPoller
         implements TokenPoller
 {
     private final Map<URI, BlockingDeque<TokenPollResult>> results = new ConcurrentHashMap<>();
+    private URI tokenReceivedUri;
+
+    public static TokenPoller onPoll(Function<URI, TokenPollResult> pollingStrategy)
+    {
+        return new TokenPoller()
+        {
+            @Override
+            public TokenPollResult pollForToken(URI tokenUri, Duration timeout)
+            {
+                return pollingStrategy.apply(tokenUri);
+            }
+
+            @Override
+            public void tokenReceived(URI tokenUri)
+            {
+            }
+        };
+    }
 
     public MockTokenPoller withResult(URI tokenUri, TokenPollResult result)
     {
@@ -47,5 +66,16 @@ public final class MockTokenPoller
             throw new IllegalArgumentException("Unknown token URI: " + tokenUri);
         }
         return queue.remove();
+    }
+
+    @Override
+    public void tokenReceived(URI tokenUri)
+    {
+        this.tokenReceivedUri = tokenUri;
+    }
+
+    public URI tokenReceivedUri()
+    {
+        return tokenReceivedUri;
     }
 }

--- a/client/trino-client/src/test/java/io/trino/client/auth/external/TestHttpTokenPoller.java
+++ b/client/trino-client/src/test/java/io/trino/client/auth/external/TestHttpTokenPoller.java
@@ -13,9 +13,11 @@
  */
 package io.trino.client.auth.external;
 
+import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -32,6 +34,7 @@ import static java.net.HttpURLConnection.HTTP_GONE;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAVAILABLE;
 import static java.net.URI.create;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -159,6 +162,48 @@ public class TestHttpTokenPoller
                 .hasMessageEndingWith(": timeout");
     }
 
+    @Test
+    public void testTokenReceived()
+            throws InterruptedException
+    {
+        server.enqueue(status(HTTP_OK));
+
+        tokenPoller.tokenReceived(tokenUri());
+
+        RecordedRequest request = server.takeRequest(1, MILLISECONDS);
+        assertThat(request.getMethod()).isEqualTo("DELETE");
+        assertThat(request.getRequestUrl()).isEqualTo(HttpUrl.get(tokenUri()));
+    }
+
+    @Test
+    public void testTokenReceivedRetriesUntilHTTP_OK()
+    {
+        server.enqueue(status(HTTP_UNAVAILABLE));
+        server.enqueue(status(HTTP_UNAVAILABLE));
+        server.enqueue(status(HTTP_UNAVAILABLE));
+        server.enqueue(status(202));
+        server.enqueue(status(303));
+        server.enqueue(status(HTTP_OK));
+        server.enqueue(status(HTTP_OK));
+        server.enqueue(status(HTTP_OK));
+
+        tokenPoller.tokenReceived(tokenUri());
+
+        assertThat(server.getRequestCount()).isEqualTo(6);
+    }
+
+    @Test
+    public void testTokenReceivedDoesNotRetriesIndefinitely()
+    {
+        for (int i = 1; i <= 100; i++) {
+            server.enqueue(status(HTTP_UNAVAILABLE));
+        }
+
+        tokenPoller.tokenReceived(tokenUri());
+
+        assertThat(server.getRequestCount()).isLessThan(100);
+    }
+
     private URI tokenUri()
     {
         return create("http://" + server.getHostName() + ":" + server.getPort() + TOKEN_PATH);
@@ -175,5 +220,11 @@ public class TestHttpTokenPoller
                 .setResponseCode(status)
                 .addHeader(CONTENT_TYPE, JSON_UTF_8)
                 .setBody(body);
+    }
+
+    private static MockResponse status(int status)
+    {
+        return new MockResponse()
+                .setResponseCode(status);
     }
 }


### PR DESCRIPTION
After obtaining token in ExternalAuthorizer, server will keep it
in memmory, untill it times out. To prevent this, client should try
to notify coordinator that the token has been obtained, which
allows the coordinator to release it.