### PR TITLE
Stats function pushdown cleanup

### DIFF
--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerStdev.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerStdev.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
+import static com.google.common.base.Verify.verifyNotNull;
 import static io.trino.matching.Capture.newCapture;
 import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
 import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
@@ -59,6 +60,7 @@ public class ImplementSqlServerStdev
     {
         Variable input = captures.get(INPUT);
         JdbcColumnHandle columnHandle = (JdbcColumnHandle) context.getAssignment(input.getName());
+        verifyNotNull(columnHandle, "Unbound variable: %s", input);
         verify(columnHandle.getColumnType().equals(DOUBLE));
         verify(aggregateFunction.getOutputType().equals(DOUBLE));
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerVariance.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerVariance.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
+import static com.google.common.base.Verify.verifyNotNull;
 import static io.trino.matching.Capture.newCapture;
 import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
 import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
@@ -59,6 +60,7 @@ public class ImplementSqlServerVariance
     {
         Variable input = captures.get(INPUT);
         JdbcColumnHandle columnHandle = (JdbcColumnHandle) context.getAssignment(input.getName());
+        verifyNotNull(columnHandle, "Unbound variable: %s", input);
         verify(columnHandle.getColumnType().equals(DOUBLE));
         verify(aggregateFunction.getOutputType().equals(DOUBLE));
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerVariancePop.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerVariancePop.java
@@ -26,6 +26,7 @@ import io.trino.spi.type.DoubleType;
 import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
+import static com.google.common.base.Verify.verifyNotNull;
 import static io.trino.matching.Capture.newCapture;
 import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
 import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
@@ -44,7 +45,7 @@ public class ImplementSqlServerVariancePop
     public Pattern<AggregateFunction> getPattern()
     {
         return basicAggregation()
-                .with(functionName().equalTo("var_pop"))
+                .with(functionName().matching(name -> name.equalsIgnoreCase("var_pop")))
                 .with(singleInput().matching(
                         variable()
                                 .with(expressionType().matching(DoubleType.class::isInstance))
@@ -56,6 +57,7 @@ public class ImplementSqlServerVariancePop
     {
         Variable input = captures.get(INPUT);
         JdbcColumnHandle columnHandle = (JdbcColumnHandle) context.getAssignment(input.getName());
+        verifyNotNull(columnHandle, "Unbound variable: %s", input);
         verify(columnHandle.getColumnType().equals(DOUBLE));
         verify(aggregateFunction.getOutputType().equals(DOUBLE));
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -142,6 +142,7 @@ public class SqlServerClient
                         .add(new ImplementSqlServerStddevPop())
                         .add(new ImplementSqlServerVariance())
                         .add(new ImplementSqlServerVariancePop())
+                        // SQL Server doesn't have covar_samp and covar_pop functions so we can't implement pushdown for them
                         .build());
     }
 


### PR DESCRIPTION
Cleans up SqlServer pushdown implementations to be more consistent.

Also documents why `covar_samp` and `covar_pop` are not implemented.