### PR TITLE
Prefer ifPresent functional style in iterative rules

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -884,10 +884,7 @@ public final class DomainTranslator
         protected ExtractionResult visitLikePredicate(LikePredicate node, Boolean complement)
         {
             Optional<ExtractionResult> result = tryVisitLikePredicate(node, complement);
-            if (result.isPresent()) {
-                return result.get();
-            }
-            return super.visitLikePredicate(node, complement);
+            return result.orElseGet(() -> super.visitLikePredicate(node, complement));
         }
 
         private Optional<ExtractionResult> tryVisitLikePredicate(LikePredicate node, Boolean complement)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/EliminateCrossJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/EliminateCrossJoins.java
@@ -140,9 +140,7 @@ public class EliminateCrossJoins
                 Optional<PlanNode> firstNotVisitedNode = graph.getNodes().stream()
                         .filter(graphNode -> !visited.contains(graphNode))
                         .findFirst();
-                if (firstNotVisitedNode.isPresent()) {
-                    nodesToVisit.add(firstNotVisitedNode.get());
-                }
+                firstNotVisitedNode.ifPresent(nodesToVisit::add);
             }
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ActualProperties.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/ActualProperties.java
@@ -208,9 +208,7 @@ public class ActualProperties
         Map<Symbol, NullableValue> translatedConstants = new HashMap<>();
         for (Map.Entry<Symbol, NullableValue> entry : constants.entrySet()) {
             Optional<Symbol> translatedKey = translator.apply(entry.getKey());
-            if (translatedKey.isPresent()) {
-                translatedConstants.put(translatedKey.get(), entry.getValue());
-            }
+            translatedKey.ifPresent(symbol -> translatedConstants.put(symbol, entry.getValue()));
         }
         return translatedConstants;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanPrinter.java
@@ -813,9 +813,7 @@ public class PlanPrinter
                     ImmutableList.of(),
                     Optional.empty());
 
-            if (projectNode.isPresent()) {
-                printAssignments(nodeOutput, projectNode.get().getAssignments());
-            }
+            projectNode.ifPresent(value -> printAssignments(nodeOutput, value.getAssignments()));
 
             if (scanNode.isPresent()) {
                 printTableScanInfo(nodeOutput, scanNode.get());


### PR DESCRIPTION
Since the Trino project prefers functional style in general, we can use `ifPresent` functional style instead of `isPresent` check-in iterative rules. 