### PR TITLE
Change KdbTreeTree stack type back to Object

### DIFF
--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/KdbTreeType.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/KdbTreeType.java
@@ -32,7 +32,10 @@ public final class KdbTreeType
 
     private KdbTreeType()
     {
-        super(new TypeSignature(NAME), KdbTree.class);
+        // The KDB tree type should be KdbTree but can not be since KdbTree is in
+        // both the plugin class loader and the system class loader.  This was done
+        // so the plan optimizer can process geo spatial joins.
+        super(new TypeSignature(NAME), Object.class);
     }
 
     @Override


### PR DESCRIPTION
The KDB tree type should be KdbTree but can not be since KdbTree is in both the plugin class loader and the system class loader.  This was done so the plan optimizer can process geo spatial joins.

Fixes #6587