### PR TITLE
Document square bracket and quote example of json path

### DIFF
--- a/docs/src/main/sphinx/functions/json.rst
+++ b/docs/src/main/sphinx/functions/json.rst
@@ -176,6 +176,8 @@ JSON functions
     (a string containing JSON) and returns the result as a JSON string::
 
         SELECT json_extract(json, '$.store.book');
+        SELECT json_extract(json, '$.store[book]');
+        SELECT json_extract(json, '$.store["book name"]');
 
     .. _JSONPath: http://goessner.net/articles/JsonPath/
 


### PR DESCRIPTION
Fixes #6686