### PR TITLE
Document why covar_samp and covar_pop pushdowns are not implemented for SQL Server

### DIFF
--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -151,6 +151,7 @@ public class SqlServerClient
                         .add(new ImplementSqlServerStddevPop())
                         .add(new ImplementSqlServerVariance())
                         .add(new ImplementSqlServerVariancePop())
+                        // SQL Server doesn't have covar_samp and covar_pop functions so we can't implement pushdown for them
                         .build());
     }
 


### PR DESCRIPTION
Extracted from https://github.com/trinodb/trino/pull/6685.

cc: @findepi 