### PR TITLE
Mark testOutputDuplicatesInsensitiveJoin as Flaky

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestJoinQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestJoinQueries.java
@@ -20,6 +20,7 @@ import io.trino.execution.QueryStats;
 import io.trino.operator.OperatorStats;
 import io.trino.spi.type.Decimals;
 import io.trino.sql.analyzer.FeaturesConfig;
+import io.trino.testng.services.Flaky;
 import io.trino.tests.QueryTemplate;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
@@ -2285,6 +2286,7 @@ public abstract class AbstractTestJoinQueries
     }
 
     @Test
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5172", match = ".*expected.*but found.*")
     public void testOutputDuplicatesInsensitiveJoin()
     {
         assertJoinOutputPositions(


### PR DESCRIPTION
Fixes: https://github.com/trinodb/trino/issues/6715