### PR TITLE
Fix writing Hive timestamps array/map/struct timestamps from Trino to Parquet

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
@@ -420,7 +420,7 @@ public final class FieldSetterFactory
         }
     }
 
-    private static class ArrayFieldSetter
+    private class ArrayFieldSetter
             extends FieldSetter
     {
         private final Type elementType;
@@ -438,14 +438,14 @@ public final class FieldSetterFactory
 
             List<Object> list = new ArrayList<>(arrayBlock.getPositionCount());
             for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
-                list.add(getField(elementType, arrayBlock, i));
+                list.add(getField(timeZone, elementType, arrayBlock, i));
             }
 
             rowInspector.setStructFieldData(row, field, list);
         }
     }
 
-    private static class MapFieldSetter
+    private class MapFieldSetter
             extends FieldSetter
     {
         private final Type keyType;
@@ -465,15 +465,15 @@ public final class FieldSetterFactory
             Map<Object, Object> map = new HashMap<>(mapBlock.getPositionCount() * 2);
             for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
                 map.put(
-                        getField(keyType, mapBlock, i),
-                        getField(valueType, mapBlock, i + 1));
+                        getField(timeZone, keyType, mapBlock, i),
+                        getField(timeZone, valueType, mapBlock, i + 1));
             }
 
             rowInspector.setStructFieldData(row, field, map);
         }
     }
 
-    private static class RowFieldSetter
+    private class RowFieldSetter
             extends FieldSetter
     {
         private final List<Type> fieldTypes;
@@ -495,7 +495,7 @@ public final class FieldSetterFactory
             // (multiple blocks vs all fields packed in a single block)
             List<Object> value = new ArrayList<>(fieldTypes.size());
             for (int i = 0; i < fieldTypes.size(); i++) {
-                value.add(getField(fieldTypes.get(i), rowBlock, i));
+                value.add(getField(timeZone, fieldTypes.get(i), rowBlock, i));
             }
 
             rowInspector.setStructFieldData(row, field, value);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FieldSetterFactory.java
@@ -17,20 +17,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import io.trino.spi.block.Block;
-import io.trino.spi.type.BigintType;
-import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
-import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalType;
-import io.trino.spi.type.DoubleType;
-import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.LongTimestamp;
-import io.trino.spi.type.RealType;
-import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimestampType;
-import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.serde2.io.DateWritableV2;
@@ -54,14 +48,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static io.trino.plugin.hive.util.HiveUtil.isArrayType;
-import static io.trino.plugin.hive.util.HiveUtil.isMapType;
-import static io.trino.plugin.hive.util.HiveUtil.isRowType;
+import static io.trino.plugin.hive.util.HiveWriteUtils.getField;
 import static io.trino.plugin.hive.util.HiveWriteUtils.getHiveDecimal;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
@@ -79,71 +80,55 @@ public final class FieldSetterFactory
 
     public FieldSetter create(SettableStructObjectInspector rowInspector, Object row, StructField field, Type type)
     {
-        if (type.equals(BooleanType.BOOLEAN)) {
+        if (BOOLEAN.equals(type)) {
             return new BooleanFieldSetter(rowInspector, row, field);
         }
-
-        if (type.equals(BigintType.BIGINT)) {
-            return new BigintFieldBuilder(rowInspector, row, field);
+        if (BIGINT.equals(type)) {
+            return new BigintFieldSetter(rowInspector, row, field);
         }
-
-        if (type.equals(IntegerType.INTEGER)) {
+        if (INTEGER.equals(type)) {
             return new IntFieldSetter(rowInspector, row, field);
         }
-
-        if (type.equals(SmallintType.SMALLINT)) {
+        if (SMALLINT.equals(type)) {
             return new SmallintFieldSetter(rowInspector, row, field);
         }
-
-        if (type.equals(TinyintType.TINYINT)) {
+        if (TINYINT.equals(type)) {
             return new TinyintFieldSetter(rowInspector, row, field);
         }
-
-        if (type.equals(RealType.REAL)) {
+        if (REAL.equals(type)) {
             return new FloatFieldSetter(rowInspector, row, field);
         }
-
-        if (type.equals(DoubleType.DOUBLE)) {
+        if (DOUBLE.equals(type)) {
             return new DoubleFieldSetter(rowInspector, row, field);
         }
-
         if (type instanceof VarcharType) {
             return new VarcharFieldSetter(rowInspector, row, field, type);
         }
-
         if (type instanceof CharType) {
             return new CharFieldSetter(rowInspector, row, field, type);
         }
-
-        if (type.equals(VarbinaryType.VARBINARY)) {
+        if (VARBINARY.equals(type)) {
             return new BinaryFieldSetter(rowInspector, row, field);
         }
-
-        if (type.equals(DateType.DATE)) {
+        if (DATE.equals(type)) {
             return new DateFieldSetter(rowInspector, row, field);
         }
-
         if (type instanceof TimestampType) {
             return new TimestampFieldSetter(rowInspector, row, field, (TimestampType) type, timeZone);
         }
-
         if (type instanceof DecimalType) {
             DecimalType decimalType = (DecimalType) type;
             return new DecimalFieldSetter(rowInspector, row, field, decimalType);
         }
-
-        if (isArrayType(type)) {
-            return new ArrayFieldSetter(rowInspector, row, field, type.getTypeParameters().get(0));
+        if (type instanceof ArrayType) {
+            return new ArrayFieldSetter(rowInspector, row, field, ((ArrayType) type).getElementType());
         }
-
-        if (isMapType(type)) {
-            return new MapFieldSetter(rowInspector, row, field, type.getTypeParameters().get(0), type.getTypeParameters().get(1));
+        if (type instanceof MapType) {
+            return new MapFieldSetter(rowInspector, row, field, ((MapType) type).getKeyType(), ((MapType) type).getValueType());
         }
-
-        if (isRowType(type)) {
+        if (type instanceof RowType) {
             return new RowFieldSetter(rowInspector, row, field, type.getTypeParameters());
         }
-
         throw new IllegalArgumentException("unsupported type: " + type);
     }
 
@@ -176,17 +161,17 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(BooleanType.BOOLEAN.getBoolean(block, position));
+            value.set(BOOLEAN.getBoolean(block, position));
             rowInspector.setStructFieldData(row, field, value);
         }
     }
 
-    private static class BigintFieldBuilder
+    private static class BigintFieldSetter
             extends FieldSetter
     {
         private final LongWritable value = new LongWritable();
 
-        public BigintFieldBuilder(SettableStructObjectInspector rowInspector, Object row, StructField field)
+        public BigintFieldSetter(SettableStructObjectInspector rowInspector, Object row, StructField field)
         {
             super(rowInspector, row, field);
         }
@@ -194,7 +179,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(BigintType.BIGINT.getLong(block, position));
+            value.set(BIGINT.getLong(block, position));
             rowInspector.setStructFieldData(row, field, value);
         }
     }
@@ -212,7 +197,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(toIntExact(IntegerType.INTEGER.getLong(block, position)));
+            value.set(toIntExact(INTEGER.getLong(block, position)));
             rowInspector.setStructFieldData(row, field, value);
         }
     }
@@ -230,7 +215,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(Shorts.checkedCast(SmallintType.SMALLINT.getLong(block, position)));
+            value.set(Shorts.checkedCast(SMALLINT.getLong(block, position)));
             rowInspector.setStructFieldData(row, field, value);
         }
     }
@@ -248,7 +233,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(SignedBytes.checkedCast(TinyintType.TINYINT.getLong(block, position)));
+            value.set(SignedBytes.checkedCast(TINYINT.getLong(block, position)));
             rowInspector.setStructFieldData(row, field, value);
         }
     }
@@ -266,7 +251,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(DoubleType.DOUBLE.getDouble(block, position));
+            value.set(DOUBLE.getDouble(block, position));
             rowInspector.setStructFieldData(row, field, value);
         }
     }
@@ -284,7 +269,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(intBitsToFloat((int) RealType.REAL.getLong(block, position)));
+            value.set(intBitsToFloat((int) REAL.getLong(block, position)));
             rowInspector.setStructFieldData(row, field, value);
         }
     }
@@ -342,7 +327,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            byte[] bytes = VarbinaryType.VARBINARY.getSlice(block, position).getBytes();
+            byte[] bytes = VARBINARY.getSlice(block, position).getBytes();
             value.set(bytes, 0, bytes.length);
             rowInspector.setStructFieldData(row, field, value);
         }
@@ -361,7 +346,7 @@ public final class FieldSetterFactory
         @Override
         public void setField(Block block, int position)
         {
-            value.set(toIntExact(DateType.DATE.getLong(block, position)));
+            value.set(toIntExact(DATE.getLong(block, position)));
             rowInspector.setStructFieldData(row, field, value);
         }
     }
@@ -453,8 +438,7 @@ public final class FieldSetterFactory
 
             List<Object> list = new ArrayList<>(arrayBlock.getPositionCount());
             for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
-                Object element = HiveWriteUtils.getField(elementType, arrayBlock, i);
-                list.add(element);
+                list.add(getField(elementType, arrayBlock, i));
             }
 
             rowInspector.setStructFieldData(row, field, list);
@@ -480,9 +464,9 @@ public final class FieldSetterFactory
             Block mapBlock = block.getObject(position, Block.class);
             Map<Object, Object> map = new HashMap<>(mapBlock.getPositionCount() * 2);
             for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
-                Object key = HiveWriteUtils.getField(keyType, mapBlock, i);
-                Object value = HiveWriteUtils.getField(valueType, mapBlock, i + 1);
-                map.put(key, value);
+                map.put(
+                        getField(keyType, mapBlock, i),
+                        getField(valueType, mapBlock, i + 1));
             }
 
             rowInspector.setStructFieldData(row, field, map);
@@ -511,8 +495,7 @@ public final class FieldSetterFactory
             // (multiple blocks vs all fields packed in a single block)
             List<Object> value = new ArrayList<>(fieldTypes.size());
             for (int i = 0; i < fieldTypes.size(); i++) {
-                Object element = HiveWriteUtils.getField(fieldTypes.get(i), rowBlock, i);
-                value.add(element);
+                value.add(getField(fieldTypes.get(i), rowBlock, i));
             }
 
             rowInspector.setStructFieldData(row, field, value);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -81,6 +81,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reporter;
+import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -117,7 +118,9 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
+import static io.trino.spi.type.Timestamps.MILLISECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
@@ -273,7 +276,7 @@ public final class HiveWriteUtils
     {
         ImmutableList.Builder<String> partitionValues = ImmutableList.builder();
         for (int field = 0; field < partitionColumns.getChannelCount(); field++) {
-            Object value = getField(partitionColumnTypes.get(field), partitionColumns.getBlock(field), position);
+            Object value = getField(DateTimeZone.UTC, partitionColumnTypes.get(field), partitionColumns.getBlock(field), position);
             if (value == null) {
                 partitionValues.add(HIVE_DEFAULT_DYNAMIC_PARTITION);
             }
@@ -290,7 +293,7 @@ public final class HiveWriteUtils
         return partitionValues.build();
     }
 
-    public static Object getField(Type type, Block block, int position)
+    public static Object getField(DateTimeZone localZone, Type type, Block block, int position)
     {
         if (block.isNull(position)) {
             return null;
@@ -330,7 +333,7 @@ public final class HiveWriteUtils
             return Date.ofEpochDay(toIntExact(type.getLong(block, position)));
         }
         if (type instanceof TimestampType) {
-            return getHiveTimestamp((TimestampType) type, block, position);
+            return getHiveTimestamp(localZone, (TimestampType) type, block, position);
         }
         if (type instanceof DecimalType) {
             DecimalType decimalType = (DecimalType) type;
@@ -342,7 +345,7 @@ public final class HiveWriteUtils
 
             List<Object> list = new ArrayList<>(arrayBlock.getPositionCount());
             for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
-                list.add(getField(elementType, arrayBlock, i));
+                list.add(getField(localZone, elementType, arrayBlock, i));
             }
             return unmodifiableList(list);
         }
@@ -354,8 +357,8 @@ public final class HiveWriteUtils
             Map<Object, Object> map = new HashMap<>();
             for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
                 map.put(
-                        getField(keyType, mapBlock, i),
-                        getField(valueType, mapBlock, i + 1));
+                        getField(localZone, keyType, mapBlock, i),
+                        getField(localZone, valueType, mapBlock, i + 1));
             }
             return unmodifiableMap(map);
         }
@@ -368,7 +371,7 @@ public final class HiveWriteUtils
                     "Expected row value field count does not match type field count");
             List<Object> row = new ArrayList<>(rowBlock.getPositionCount());
             for (int i = 0; i < rowBlock.getPositionCount(); i++) {
-                row.add(getField(fieldTypes.get(i), rowBlock, i));
+                row.add(getField(localZone, fieldTypes.get(i), rowBlock, i));
             }
             return unmodifiableList(row);
         }
@@ -728,7 +731,7 @@ public final class HiveWriteUtils
         return HiveDecimal.create(unscaledValue, decimalType.getScale());
     }
 
-    private static Timestamp getHiveTimestamp(TimestampType type, Block block, int position)
+    private static Timestamp getHiveTimestamp(DateTimeZone localZone, TimestampType type, Block block, int position)
     {
         verify(type.getPrecision() <= HiveTimestampPrecision.MAX.getPrecision(), "Timestamp precision too high for Hive");
 
@@ -743,7 +746,17 @@ public final class HiveWriteUtils
             epochMicros = timestamp.getEpochMicros();
             nanosOfMicro = timestamp.getPicosOfMicro() / PICOSECONDS_PER_NANOSECOND;
         }
-        long epochSeconds = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+
+        long epochSeconds;
+        if (DateTimeZone.UTC.equals(localZone)) {
+            epochSeconds = floorDiv(epochMicros, MICROSECONDS_PER_SECOND);
+        }
+        else {
+            long localEpochMillis = floorDiv(epochMicros, MICROSECONDS_PER_MILLISECOND);
+            long utcEpochMillis = localZone.convertLocalToUTC(localEpochMillis, false);
+            epochSeconds = floorDiv(utcEpochMillis, MILLISECONDS_PER_SECOND);
+        }
+
         int microsOfSecond = floorMod(epochMicros, MICROSECONDS_PER_SECOND);
         int nanosOfSecond = microsOfSecond * NANOSECONDS_PER_MICROSECOND + nanosOfMicro;
         return Timestamp.ofEpochSecond(epochSeconds, nanosOfSecond);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -38,21 +38,15 @@ import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.type.BigintType;
-import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.CharType;
-import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
-import io.trino.spi.type.DoubleType;
-import io.trino.spi.type.IntegerType;
 import io.trino.spi.type.LongTimestamp;
-import io.trino.spi.type.RealType;
-import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.TimestampType;
-import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
-import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -91,7 +85,6 @@ import org.apache.hadoop.mapred.Reporter;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -116,16 +109,27 @@ import static io.trino.plugin.hive.util.HiveUtil.isArrayType;
 import static io.trino.plugin.hive.util.HiveUtil.isMapType;
 import static io.trino.plugin.hive.util.HiveUtil.isRowType;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.Chars.padSpaces;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_SECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
 import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.floorDiv;
 import static java.lang.Math.floorMod;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.COMPRESSRESULT;
@@ -205,25 +209,25 @@ public final class HiveWriteUtils
 
     public static ObjectInspector getJavaObjectInspector(Type type)
     {
-        if (type.equals(BooleanType.BOOLEAN)) {
+        if (type.equals(BOOLEAN)) {
             return javaBooleanObjectInspector;
         }
-        if (type.equals(BigintType.BIGINT)) {
+        if (type.equals(BIGINT)) {
             return javaLongObjectInspector;
         }
-        if (type.equals(IntegerType.INTEGER)) {
+        if (type.equals(INTEGER)) {
             return javaIntObjectInspector;
         }
-        if (type.equals(SmallintType.SMALLINT)) {
+        if (type.equals(SMALLINT)) {
             return javaShortObjectInspector;
         }
-        if (type.equals(TinyintType.TINYINT)) {
+        if (type.equals(TINYINT)) {
             return javaByteObjectInspector;
         }
-        if (type.equals(RealType.REAL)) {
+        if (type.equals(REAL)) {
             return javaFloatObjectInspector;
         }
-        if (type.equals(DoubleType.DOUBLE)) {
+        if (type.equals(DOUBLE)) {
             return javaDoubleObjectInspector;
         }
         if (type instanceof VarcharType) {
@@ -232,10 +236,10 @@ public final class HiveWriteUtils
         if (type instanceof CharType) {
             return writableHiveCharObjectInspector;
         }
-        if (type.equals(VarbinaryType.VARBINARY)) {
+        if (type.equals(VARBINARY)) {
             return javaByteArrayObjectInspector;
         }
-        if (type.equals(DateType.DATE)) {
+        if (type.equals(DATE)) {
             return javaDateObjectInspector;
         }
         if (type instanceof TimestampType) {
@@ -291,25 +295,25 @@ public final class HiveWriteUtils
         if (block.isNull(position)) {
             return null;
         }
-        if (BooleanType.BOOLEAN.equals(type)) {
+        if (BOOLEAN.equals(type)) {
             return type.getBoolean(block, position);
         }
-        if (BigintType.BIGINT.equals(type)) {
+        if (BIGINT.equals(type)) {
             return type.getLong(block, position);
         }
-        if (IntegerType.INTEGER.equals(type)) {
+        if (INTEGER.equals(type)) {
             return toIntExact(type.getLong(block, position));
         }
-        if (SmallintType.SMALLINT.equals(type)) {
+        if (SMALLINT.equals(type)) {
             return Shorts.checkedCast(type.getLong(block, position));
         }
-        if (TinyintType.TINYINT.equals(type)) {
+        if (TINYINT.equals(type)) {
             return SignedBytes.checkedCast(type.getLong(block, position));
         }
-        if (RealType.REAL.equals(type)) {
+        if (REAL.equals(type)) {
             return intBitsToFloat((int) type.getLong(block, position));
         }
-        if (DoubleType.DOUBLE.equals(type)) {
+        if (DOUBLE.equals(type)) {
             return type.getDouble(block, position);
         }
         if (type instanceof VarcharType) {
@@ -319,10 +323,10 @@ public final class HiveWriteUtils
             CharType charType = (CharType) type;
             return new Text(padSpaces(type.getSlice(block, position), charType).toStringUtf8());
         }
-        if (VarbinaryType.VARBINARY.equals(type)) {
+        if (VARBINARY.equals(type)) {
             return type.getSlice(block, position).getBytes();
         }
-        if (DateType.DATE.equals(type)) {
+        if (DATE.equals(type)) {
             return Date.ofEpochDay(toIntExact(type.getLong(block, position)));
         }
         if (type instanceof TimestampType) {
@@ -332,46 +336,41 @@ public final class HiveWriteUtils
             DecimalType decimalType = (DecimalType) type;
             return getHiveDecimal(decimalType, block, position);
         }
-        if (isArrayType(type)) {
-            Type elementType = type.getTypeParameters().get(0);
-
+        if (type instanceof ArrayType) {
+            Type elementType = ((ArrayType) type).getElementType();
             Block arrayBlock = block.getObject(position, Block.class);
 
             List<Object> list = new ArrayList<>(arrayBlock.getPositionCount());
             for (int i = 0; i < arrayBlock.getPositionCount(); i++) {
-                Object element = getField(elementType, arrayBlock, i);
-                list.add(element);
+                list.add(getField(elementType, arrayBlock, i));
             }
-
-            return Collections.unmodifiableList(list);
+            return unmodifiableList(list);
         }
-        if (isMapType(type)) {
-            Type keyType = type.getTypeParameters().get(0);
-            Type valueType = type.getTypeParameters().get(1);
-
+        if (type instanceof MapType) {
+            Type keyType = ((MapType) type).getKeyType();
+            Type valueType = ((MapType) type).getValueType();
             Block mapBlock = block.getObject(position, Block.class);
+
             Map<Object, Object> map = new HashMap<>();
             for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
-                Object key = getField(keyType, mapBlock, i);
-                Object value = getField(valueType, mapBlock, i + 1);
-                map.put(key, value);
+                map.put(
+                        getField(keyType, mapBlock, i),
+                        getField(valueType, mapBlock, i + 1));
             }
-
-            return Collections.unmodifiableMap(map);
+            return unmodifiableMap(map);
         }
-        if (isRowType(type)) {
-            Block rowBlock = block.getObject(position, Block.class);
-
+        if (type instanceof RowType) {
             List<Type> fieldTypes = type.getTypeParameters();
-            checkCondition(fieldTypes.size() == rowBlock.getPositionCount(), StandardErrorCode.GENERIC_INTERNAL_ERROR, "Expected row value field count does not match type field count");
-
+            Block rowBlock = block.getObject(position, Block.class);
+            checkCondition(
+                    fieldTypes.size() == rowBlock.getPositionCount(),
+                    StandardErrorCode.GENERIC_INTERNAL_ERROR,
+                    "Expected row value field count does not match type field count");
             List<Object> row = new ArrayList<>(rowBlock.getPositionCount());
             for (int i = 0; i < rowBlock.getPositionCount(); i++) {
-                Object element = getField(fieldTypes.get(i), rowBlock, i);
-                row.add(element);
+                row.add(getField(fieldTypes.get(i), rowBlock, i));
             }
-
-            return Collections.unmodifiableList(row);
+            return unmodifiableList(row);
         }
         throw new TrinoException(NOT_SUPPORTED, "unsupported type: " + type);
     }
@@ -646,31 +645,31 @@ public final class HiveWriteUtils
 
     public static ObjectInspector getRowColumnInspector(Type type)
     {
-        if (type.equals(BooleanType.BOOLEAN)) {
+        if (type.equals(BOOLEAN)) {
             return writableBooleanObjectInspector;
         }
 
-        if (type.equals(BigintType.BIGINT)) {
+        if (type.equals(BIGINT)) {
             return writableLongObjectInspector;
         }
 
-        if (type.equals(IntegerType.INTEGER)) {
+        if (type.equals(INTEGER)) {
             return writableIntObjectInspector;
         }
 
-        if (type.equals(SmallintType.SMALLINT)) {
+        if (type.equals(SMALLINT)) {
             return writableShortObjectInspector;
         }
 
-        if (type.equals(TinyintType.TINYINT)) {
+        if (type.equals(TINYINT)) {
             return writableByteObjectInspector;
         }
 
-        if (type.equals(RealType.REAL)) {
+        if (type.equals(REAL)) {
             return writableFloatObjectInspector;
         }
 
-        if (type.equals(DoubleType.DOUBLE)) {
+        if (type.equals(DOUBLE)) {
             return writableDoubleObjectInspector;
         }
 
@@ -693,11 +692,11 @@ public final class HiveWriteUtils
             return getPrimitiveWritableObjectInspector(getCharTypeInfo(charLength));
         }
 
-        if (type.equals(VarbinaryType.VARBINARY)) {
+        if (type.equals(VARBINARY)) {
             return writableBinaryObjectInspector;
         }
 
-        if (type.equals(DateType.DATE)) {
+        if (type.equals(DATE)) {
             return writableDateObjectInspector;
         }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveStorageFormats.java
@@ -24,7 +24,6 @@ import io.trino.tempto.query.QueryResult;
 import io.trino.testng.services.Flaky;
 import io.trino.tests.utils.JdbcDriverUtils;
 import org.assertj.core.api.SoftAssertions;
-import org.assertj.core.util.Streams;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -241,16 +240,6 @@ public class TestHiveStorageFormats
         return Stream.of(storageFormats())
                 // everything but Avro supports nanoseconds
                 .filter(format -> !"AVRO".equals(format.getName()))
-                .iterator();
-    }
-
-    @DataProvider
-    public static Iterator<StorageFormat> storageFormatsWithNanosecondPrecisionExceptParquet()
-    {
-        return Streams.stream(storageFormatsWithNanosecondPrecision())
-                // TODO: Parquet doesn't support writing timestamps in arrays/maps/structs
-                //   See https://github.com/trinodb/trino/issues/6760
-                .filter(format -> !"PARQUET".equals(format.getName()))
                 .iterator();
     }
 
@@ -524,7 +513,7 @@ public class TestHiveStorageFormats
         onPresto().executeQuery("DROP TABLE " + tableName);
     }
 
-    @Test(dataProvider = "storageFormatsWithNanosecondPrecision", groups = STORAGE_FORMATS)
+    @Test(dataProvider = "storageFormatsWithNanosecondPrecision")
     public void testStructTimestampsFromHive(StorageFormat format)
     {
         String tableName = createStructTimestampTable("hive_struct_timestamp", format);
@@ -554,7 +543,7 @@ public class TestHiveStorageFormats
         onPresto().executeQuery(format("DROP TABLE %s", tableName));
     }
 
-    @Test(dataProvider = "storageFormatsWithNanosecondPrecisionExceptParquet", groups = STORAGE_FORMATS)
+    @Test(dataProvider = "storageFormatsWithNanosecondPrecision")
     public void testStructTimestampsFromTrino(StorageFormat format)
     {
         String tableName = createStructTimestampTable("trino_struct_timestamp", format);


### PR DESCRIPTION
The commits up to "Add tests for Hive struct timestamps inserted from Trino" are from #6622.

This addresses #6760.