### PR TITLE
Add support for current_user() in Hive views

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dep.errorprone.version>2.5.1</dep.errorprone.version>
         <dep.testcontainers.version>1.15.1</dep.testcontainers.version>
         <dep.docker-java.version>3.2.7</dep.docker-java.version>
-        <dep.coral.version>1.0.12</dep.coral.version>
+        <dep.coral.version>1.0.25</dep.coral.version>
         <dep.confluent.version>5.5.2</dep.confluent.version>
 
         <!--

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/hive/AbstractTestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/hive/AbstractTestHiveViews.java
@@ -348,6 +348,17 @@ public abstract class AbstractTestHiveViews
         ).hasMessageContaining("timestamp(9) projected from query view at position 0 cannot be coerced to column [ts] of type timestamp(3) stored in view definition");
     }
 
+    @Test
+    public void testCurrentUser()
+    {
+        onHive().executeQuery("DROP VIEW IF EXISTS current_user_hive_view");
+        onHive().executeQuery("CREATE VIEW current_user_hive_view as SELECT current_user() AS cu FROM nation LIMIT 1");
+
+        String testQuery = "SELECT cu FROM current_user_hive_view";
+        assertThat(query(testQuery)).containsOnly(row("hive"));
+        assertThat(connectToPresto("alice@presto").executeQuery(testQuery)).containsOnly(row("alice"));
+    }
+
     protected static void assertViewQuery(String query, Consumer<QueryAssert> assertion)
     {
         // Ensure Hive and Presto view compatibility by comparing the results

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveViewsLegacy.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveViewsLegacy.java
@@ -132,4 +132,12 @@ public class TestHiveViewsLegacy
         executor.executeQuery("SET SESSION hive.legacy_hive_view_translation = true");
         return executor;
     }
+
+    @Override
+    @Test
+    public void testCurrentUser()
+    {
+        assertThatThrownBy(super::testCurrentUser)
+                .hasMessageContaining("Failed parsing stored view 'hive.default.current_user_hive_view': line 1:20: mismatched input '('");
+    }
 }


### PR DESCRIPTION
Fixes #6718

Add support for current_user in Hive views by bumping Coral version 1.0.25 (support for current_user was introduced in 1.0.22)

~Depends on release of Coral 1.0.22+ which includes https://github.com/linkedin/coral/pull/40~
