### PR TITLE
Do not install SystemAccessControl on workers in tests

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -123,7 +123,7 @@ public class DistributedQueryRunner
                         environment,
                         additionalModule,
                         baseDataDir,
-                        systemAccessControls));
+                        ImmutableList.of()));
                 servers.add(worker);
             }
 


### PR DESCRIPTION
Administrators are not required to configure SAC on workers, so tests
should not do this either.