### PR TITLE
Deprecate DataTypeTest

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/datatype/DataTypeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/datatype/DataTypeTest.java
@@ -46,11 +46,21 @@ public class DataTypeTest
         this.runSelectWithWhere = runSelectWithWhere;
     }
 
+    /**
+     * @deprecated Use {@link SqlDataTypeTest#create()} imstead. You can find
+     * {@link DataTypeTestToSqlDataTypeTestConverter#create()} helpful for converting the code.
+     */
+    @Deprecated
     public static DataTypeTest create()
     {
         return new DataTypeTest(false);
     }
 
+    /**
+     * @deprecated Use {@link SqlDataTypeTest#create()} imstead. You can find
+     * {@link DataTypeTestToSqlDataTypeTestConverter#create()} helpful for converting the code.
+     */
+    @Deprecated
     public static DataTypeTest create(boolean runSelectWithWhere)
     {
         return new DataTypeTest(runSelectWithWhere);


### PR DESCRIPTION
This marks `DataTypeTest.create` as deprecated. It does not mark the
whole class as deprecated, not to inflate amount of warnings across the
code base, as the `DataTypeTest` is still in use.

Since `DataTypeTest.create` is the only entry point for creating
`DataTypeTest`, it should be sufficient.