### PR TITLE
Allow to reuse few testing servers

### DIFF
--- a/plugin/trino-phoenix/pom.xml
+++ b/plugin/trino-phoenix/pom.xml
@@ -169,6 +169,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/SqlServerQueryRunner.java
@@ -15,11 +15,9 @@ package io.trino.plugin.sqlserver;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Streams;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
 import io.trino.Session;
-import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.spi.security.Identity;
 import io.trino.testing.DistributedQueryRunner;
@@ -28,14 +26,11 @@ import io.trino.tpch.TpchTable;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
-import static io.trino.testing.QueryAssertions.copyTable;
+import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
-import static java.util.Locale.ENGLISH;
 
 public final class SqlServerQueryRunner
 {
@@ -68,7 +63,7 @@ public final class SqlServerQueryRunner
             queryRunner.installPlugin(new SqlServerPlugin());
             queryRunner.createCatalog(CATALOG, "sqlserver", connectorProperties);
 
-            provisionTables(createSession(testingSqlServer.getUsername()), queryRunner, tables);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(testingSqlServer.getUsername()), tables);
 
             return queryRunner;
         }
@@ -76,17 +71,6 @@ public final class SqlServerQueryRunner
             closeAllSuppress(e, queryRunner);
             throw e;
         }
-    }
-
-    private static void provisionTables(Session session, QueryRunner queryRunner, Iterable<TpchTable<?>> tables)
-    {
-        Set<String> existingTables = queryRunner.listTables(session, CATALOG, TEST_SCHEMA).stream()
-                .map(QualifiedObjectName::getObjectName)
-                .collect(toImmutableSet());
-
-        Streams.stream(tables)
-                .filter(table -> !existingTables.contains(table.getTableName().toLowerCase(ENGLISH)))
-                .forEach(table -> copyTable(queryRunner, "tpch", TINY_SCHEMA_NAME, table.getTableName().toLowerCase(ENGLISH), session));
     }
 
     private static Session createSession(String username)

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -134,6 +134,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>

--- a/testing/trino-testing/src/main/java/io/trino/testing/containers/TestContainers.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/containers/TestContainers.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.testing.containers;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import java.io.Closeable;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.System.getenv;
+
+public final class TestContainers
+{
+    // To reuse container set TESTCONTAINERS_REUSE_ENABLE=true environment variable.
+    // TESTCONTAINERS_REUSE_ENABLE is an environment variable defined in testcontainers library.
+    private static final boolean TESTCONTAINERS_REUSE_ENABLE = parseBoolean(getenv("TESTCONTAINERS_REUSE_ENABLE"));
+
+    private TestContainers() {}
+
+    // You should not close the container directly if you want to reuse it.
+    // Instead you should close closeable returned by {@link this::startOrReuse}
+    public static Closeable startOrReuse(GenericContainer<?> container)
+    {
+        boolean reuse = TestcontainersConfiguration.getInstance().environmentSupportsReuse();
+        checkState(reuse == TESTCONTAINERS_REUSE_ENABLE, "Unable to enable or disable container reuse");
+
+        container.withReuse(TESTCONTAINERS_REUSE_ENABLE);
+        container.start();
+        if (reuse) {
+            return () -> {};
+        }
+        return container::stop;
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/tests/AbstractQueryAssertionsTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/AbstractQueryAssertionsTest.java
@@ -92,11 +92,7 @@ public abstract class AbstractQueryAssertionsTest
     {
         QueryAssert queryAssert = assertThat(query("SELECT X'001234'"));
         assertThatThrownBy(() -> queryAssert.matches("VALUES '001234'"))
-                .hasMessageContaining("[Output types] \n" +
-                        "Expecting:\n" +
-                        " <[varbinary]>\n" +
-                        "to be equal to:\n" +
-                        " <[varchar(6)]>");
+                .hasMessageContaining("[Output types] expected:<[var[char(6)]]> but was:<[var[binary]]>");
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/tests/AbstractQueryAssertionsTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/AbstractQueryAssertionsTest.java
@@ -75,7 +75,7 @@ public abstract class AbstractQueryAssertionsTest
 
         Map<String, String> jdbcWithAggregationPushdownDisabledConfigurationProperties = ImmutableMap.<String, String>builder()
                 .putAll(jdbcConfigurationProperties)
-                .put("allow-aggregation-pushdown", "false")
+                .put("aggregation-pushdown.enabled", "false")
                 .build();
         queryRunner.createCatalog("jdbc_with_aggregation_pushdown_disabled", "base-jdbc", jdbcWithAggregationPushdownDisabledConfigurationProperties);
     }

--- a/testing/trino-tests/src/test/java/io/trino/tests/AbstractQueryAssertionsTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/AbstractQueryAssertionsTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractQueryAssertionsTest
             throw new RuntimeException(e);
         }
 
-        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), List.of(NATION));
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, queryRunner.getDefaultSession(), List.of(NATION));
 
         Map<String, String> jdbcWithAggregationPushdownDisabledConfigurationProperties = ImmutableMap.<String, String>builder()
                 .putAll(jdbcConfigurationProperties)


### PR DESCRIPTION
Allow to reuse few testing servers

No plans to reuse containers in CI. This is only for development
purposes. Notice that it not always bring much value and some test do
not play well with reusing as they have side effects. Use it wisely on
your own responsibility.

Locally starting TestingMySqlServer and loading tpch data there takes
over a minute, with reusing it is barely noticeable.

Allow to reuse:
 - TestingSqlServer
 - TestingMySqlServer
