### PR TITLE
Use predefined operator id for WorkProcessorPipelineSourceOperator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -605,7 +605,7 @@ public class LocalExecutionPlanner
             }
 
             if (isLateMaterializationEnabled(taskContext.getSession())) {
-                operatorFactories = WorkProcessorPipelineSourceOperator.convertOperators(getNextOperatorId(), operatorFactories);
+                operatorFactories = WorkProcessorPipelineSourceOperator.convertOperators(operatorFactories);
             }
 
             driverFactories.add(new DriverFactory(getNextPipelineId(), inputDriver, outputDriver, operatorFactories, driverInstances, pipelineExecutionStrategy));

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -104,7 +104,6 @@ public class TestWorkProcessorPipelineSourceOperator
         TestWorkProcessorOperatorFactory secondOperatorFactory = new TestWorkProcessorOperatorFactory(3, secondOperatorPages);
 
         SourceOperatorFactory pipelineOperatorFactory = (SourceOperatorFactory) getOnlyElement(WorkProcessorPipelineSourceOperator.convertOperators(
-                99,
                 ImmutableList.of(sourceOperatorFactory, firstOperatorFactory, secondOperatorFactory)));
 
         DriverContext driverContext = TestingOperatorContext.create(scheduledExecutor).getDriverContext();


### PR DESCRIPTION
Operators passed to LocalExecutionPlanContext#addDriverFactory
might have operator ids from sub-context, therefore one
cannot rely on getNextOperatorId to return unique id.