### PR TITLE
Make `getColumnMetadata()` consistent with `tableMetadata.getColumns()` in Elasticsearch connector

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/BuiltinColumns.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/BuiltinColumns.java
@@ -17,12 +17,14 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.type.Type;
 
-import java.util.Arrays;
-import java.util.Set;
+import java.util.Map;
+import java.util.Optional;
 
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Arrays.stream;
+import static java.util.function.Function.identity;
 
 enum BuiltinColumns
 {
@@ -30,9 +32,8 @@ enum BuiltinColumns
     SOURCE("_source", VARCHAR, false),
     SCORE("_score", REAL, false);
 
-    public static final Set<String> NAMES = Arrays.stream(values())
-            .map(BuiltinColumns::getName)
-            .collect(toImmutableSet());
+    private static final Map<String, BuiltinColumns> COLUMNS_BY_NAME = stream(values())
+            .collect(toImmutableMap(BuiltinColumns::getName, identity()));
 
     private final String name;
     private final Type type;
@@ -43,6 +44,16 @@ enum BuiltinColumns
         this.name = name;
         this.type = type;
         this.supportsPredicates = supportsPredicates;
+    }
+
+    public static Optional<BuiltinColumns> of(String name)
+    {
+        return Optional.ofNullable(COLUMNS_BY_NAME.get(name));
+    }
+
+    public static boolean isBuiltinColumn(String name)
+    {
+        return COLUMNS_BY_NAME.containsKey(name);
     }
 
     public String getName()

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -383,10 +383,12 @@ public class ElasticsearchMetadata
             throw new IllegalArgumentException(format("Unexpected column for table '%s$query': %s", table.getIndex(), column.getName()));
         }
 
-        return ColumnMetadata.builder()
-                .setName(column.getName())
-                .setType(column.getType())
-                .build();
+        return BuiltinColumns.of(column.getName())
+                .map(BuiltinColumns::getMetadata)
+                .orElse(ColumnMetadata.builder()
+                        .setName(column.getName())
+                        .setType(column.getType())
+                        .build());
     }
 
     @Override

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
@@ -59,6 +59,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.elasticsearch.BuiltinColumns.ID;
 import static io.trino.plugin.elasticsearch.BuiltinColumns.SCORE;
 import static io.trino.plugin.elasticsearch.BuiltinColumns.SOURCE;
+import static io.trino.plugin.elasticsearch.BuiltinColumns.isBuiltinColumn;
 import static io.trino.plugin.elasticsearch.ElasticsearchQueryBuilder.buildSearchQuery;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -120,7 +121,7 @@ public class ScanQueryPageSource
 
         List<String> requiredFields = columns.stream()
                 .map(ElasticsearchColumnHandle::getName)
-                .filter(name -> !BuiltinColumns.NAMES.contains(name))
+                .filter(name -> !isBuiltinColumn(name))
                 .collect(toList());
 
         // sorting by _doc (index order) get special treatment in Elasticsearch and is more efficient


### PR DESCRIPTION
`ElasticsearchMetadata.getColumnMetadata()` checks for metadata within
BuiltinColumns first. The same way as it is populated
in `ConnectorTableMetadata.getColumns()`

found during https://github.com/trinodb/trino/pull/6745