### PR TITLE
Cache JDBC connector stats between transactions

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -72,6 +72,7 @@ public class CachingJdbcClient
     private final Cache<TableHandleCacheKey, Optional<JdbcTableHandle>> tableHandleCache;
     private final Cache<ColumnsCacheKey, List<JdbcColumnHandle>> columnsCache;
     private final List<PropertyMetadata<?>> sessionProperties;
+    private final Cache<TableStatisticsCacheKey, TableStatistics> statisticsCache;
 
     @Inject
     public CachingJdbcClient(@StatsCollecting JdbcClient delegate, Set<SessionPropertiesProvider> sessionPropertiesProviders, BaseJdbcConfig config)
@@ -101,6 +102,7 @@ public class CachingJdbcClient
         tableNamesCache = cacheBuilder.build();
         tableHandleCache = cacheBuilder.build();
         columnsCache = cacheBuilder.build();
+        statisticsCache = cacheBuilder.build();
     }
 
     @Override
@@ -286,7 +288,24 @@ public class CachingJdbcClient
     @Override
     public TableStatistics getTableStatistics(ConnectorSession session, JdbcTableHandle handle, TupleDomain<ColumnHandle> tupleDomain)
     {
-        return delegate.getTableStatistics(session, handle, tupleDomain);
+        if (!handle.isNamedRelation()) {
+            // only cache named relation as we need to be able to invalidate the cache by table name
+            // TODO https://github.com/trinodb/trino/issues/6832 - to support other JdbcTableHandle types
+            return delegate.getTableStatistics(session, handle, tupleDomain);
+        }
+
+        TableStatisticsCacheKey key = new TableStatisticsCacheKey(handle, tupleDomain);
+
+        TableStatistics cachedStatistics = statisticsCache.getIfPresent(key);
+        if (cachedStatistics != null) {
+            return cachedStatistics;
+        }
+
+        TableStatistics statistics = delegate.getTableStatistics(session, handle, tupleDomain);
+        if (!statistics.equals(TableStatistics.empty()) || cacheMissing) {
+            statisticsCache.put(key, statistics);
+        }
+        return statistics;
     }
 
     @Override
@@ -404,6 +423,7 @@ public class CachingJdbcClient
         invalidateColumnsCache(schemaTableName);
         invalidateCache(tableHandleCache, key -> key.tableName.equals(schemaTableName));
         invalidateCache(tableNamesCache, key -> key.schemaName.equals(Optional.of(schemaTableName.getSchemaName())));
+        invalidateCache(statisticsCache, key -> key.tableHandle.getRequiredNamedRelation().getSchemaTableName().equals(schemaTableName));
     }
 
     private void invalidateColumnsCache(SchemaTableName table)
@@ -415,6 +435,12 @@ public class CachingJdbcClient
     CacheStats getColumnsCacheStats()
     {
         return columnsCache.stats();
+    }
+
+    @VisibleForTesting
+    CacheStats getStatisticsCacheStats()
+    {
+        return statisticsCache.stats();
     }
 
     private static <T, V> void invalidateCache(Cache<T, V> cache, Predicate<T> filterFunction)
@@ -552,6 +578,39 @@ public class CachingJdbcClient
         catch (ExecutionException e) {
             throwIfInstanceOf(e.getCause(), TrinoException.class);
             throw new UncheckedExecutionException(e);
+        }
+    }
+
+    private static final class TableStatisticsCacheKey
+    {
+        // TODO depend on Identity when needed
+        private final JdbcTableHandle tableHandle;
+        private final TupleDomain<ColumnHandle> tupleDomain;
+
+        private TableStatisticsCacheKey(JdbcTableHandle tableHandle, TupleDomain<ColumnHandle> tupleDomain)
+        {
+            this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
+            this.tupleDomain = requireNonNull(tupleDomain, "tupleDomain is null");
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TableStatisticsCacheKey that = (TableStatisticsCacheKey) o;
+            return tableHandle.equals(that.tableHandle)
+                    && tupleDomain.equals(that.tupleDomain);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(tableHandle, tupleDomain);
         }
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcQueryRelationHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcQueryRelationHandle.java
@@ -16,6 +16,8 @@ package io.trino.plugin.jdbc;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 import static java.lang.String.format;
 
 public class JdbcQueryRelationHandle
@@ -39,5 +41,24 @@ public class JdbcQueryRelationHandle
     public String toString()
     {
         return format("Query[%s]", preparedQuery.getQuery());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        JdbcQueryRelationHandle that = (JdbcQueryRelationHandle) o;
+        return preparedQuery.equals(that.preparedQuery);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(preparedQuery);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/PreparedQuery.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/PreparedQuery.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
@@ -51,5 +52,25 @@ public final class PreparedQuery
         return new PreparedQuery(
                 sqlFunction.apply(query),
                 parameters);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PreparedQuery that = (PreparedQuery) o;
+        return query.equals(that.query)
+                && parameters.equals(that.parameters);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(query, parameters);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryParameter.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryParameter.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -71,5 +72,26 @@ public final class QueryParameter
     public Optional<Object> getValue()
     {
         return value;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QueryParameter that = (QueryParameter) o;
+        return jdbcType.equals(that.jdbcType)
+                && type.equals(that.type)
+                && value.equals(that.value);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(jdbcType, type, value);
     }
 }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableHandle.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableHandle.java
@@ -13,9 +13,16 @@
  */
 package io.trino.plugin.jdbc;
 
+import com.google.common.collect.ImmutableList;
 import io.airlift.testing.EquivalenceTester;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.type.IntegerType;
 import org.testng.annotations.Test;
+
+import java.sql.Types;
+import java.util.Optional;
+import java.util.OptionalLong;
 
 import static io.trino.plugin.jdbc.MetadataUtil.TABLE_CODEC;
 import static io.trino.plugin.jdbc.MetadataUtil.assertJsonRoundTrip;
@@ -42,6 +49,38 @@ public class TestJdbcTableHandle
                         new JdbcTableHandle(new SchemaTableName("schemaX", "table"), "jdbcCatalogX", "jdbcSchema", "jdbcTable"),
                         new JdbcTableHandle(new SchemaTableName("schemaX", "table"), "jdbcCatalog", "jdbcSchemaX", "jdbcTable"),
                         new JdbcTableHandle(new SchemaTableName("schemaX", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTableX"))
+                .addEquivalentGroup(createNamedHandle())
+                .addEquivalentGroup(createQueryBasedHandle())
                 .check();
+    }
+
+    private JdbcTableHandle createQueryBasedHandle()
+    {
+        JdbcTypeHandle type = new JdbcTypeHandle(Types.INTEGER, Optional.of("int"), Optional.of(1), Optional.of(2), Optional.of(3), Optional.of(CaseSensitivity.CASE_INSENSITIVE));
+        return new JdbcTableHandle(
+                new JdbcQueryRelationHandle(
+                        new PreparedQuery(
+                                "query",
+                                ImmutableList.of(new QueryParameter(
+                                        type,
+                                        IntegerType.INTEGER,
+                                        Optional.of(1))))),
+                TupleDomain.all(),
+                OptionalLong.of(1),
+                Optional.of(ImmutableList.of(new JdbcColumnHandle("i", type, IntegerType.INTEGER))),
+                0);
+    }
+
+    private JdbcTableHandle createNamedHandle()
+    {
+        JdbcTypeHandle type = new JdbcTypeHandle(Types.INTEGER, Optional.of("int"), Optional.of(1), Optional.of(2), Optional.of(3), Optional.of(CaseSensitivity.CASE_INSENSITIVE));
+        return new JdbcTableHandle(
+                new JdbcNamedRelationHandle(
+                        new SchemaTableName("schema", "table"),
+                        new RemoteTableName(Optional.of("catalog"), Optional.of("schema"), "table")),
+                TupleDomain.all(),
+                OptionalLong.of(1),
+                Optional.of(ImmutableList.of(new JdbcColumnHandle("i", type, IntegerType.INTEGER))),
+                0);
     }
 }


### PR DESCRIPTION
Cache JDBC connector stats between transactions

Currently it was cached only within a transaction.
