### PR TITLE
Update SQL Server type mapping docs

### DIFF
--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -128,6 +128,7 @@ SQL Server Type               Trino Type
 ``char(n)``                   ``char(n)``
 ``varchar(n)``                ``varchar(n)``
 ``date``                      ``date``
+``datetime2(n)``              ``timestamp(n)``
 ============================= ============================
 
 Complete list of `SQL Server data types


### PR DESCRIPTION
Add missing datetime2 to timestamp type mapping in SQL Server docs.

A follow-up to #6654.
