### PR TITLE
Check and require exact Java version

### DIFF
--- a/core/trino-server-main/pom.xml
+++ b/core/trino-server-main/pom.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>io.trino</groupId>
         <artifactId>trino-root</artifactId>
@@ -14,20 +13,13 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <!-- allow dependencies with newer bytecode versions -->
-        <air.check.skip-enforcer>true</air.check.skip-enforcer>
-        <project.build.targetJdk>8</project.build.targetJdk>
+        <project.build.targetJdk>11</project.build.targetJdk>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/core/trino-server-main/src/main/java/io/trino/server/TrinoServer.java
+++ b/core/trino-server-main/src/main/java/io/trino/server/TrinoServer.java
@@ -13,12 +13,7 @@
  */
 package io.trino.server;
 
-import com.google.common.base.StandardSystemProperty;
-import com.google.common.primitives.Ints;
-
-import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Strings.nullToEmpty;
-import static java.lang.String.format;
+import java.util.Optional;
 
 public final class TrinoServer
 {
@@ -26,15 +21,15 @@ public final class TrinoServer
 
     public static void main(String[] args)
     {
-        String javaVersion = nullToEmpty(StandardSystemProperty.JAVA_VERSION.value());
-        String majorVersion = javaVersion.split("[^\\d]", 2)[0];
-        Integer major = Ints.tryParse(majorVersion);
-        if (major == null || major < 11) {
-            System.err.println(format("ERROR: Trino requires Java 11+ (found %s)", javaVersion));
+        Runtime.Version expectedVersion = Runtime.Version.parse("11.0.7");
+        Runtime.Version currentVersion = Runtime.version();
+
+        if (currentVersion.compareTo(expectedVersion) < 0) {
+            System.err.printf("ERROR: Trino requires Java %s (found %s)%n", expectedVersion, currentVersion);
             System.exit(100);
         }
 
         String version = TrinoServer.class.getPackage().getImplementationVersion();
-        new Server().start(firstNonNull(version, "unknown"));
+        new Server().start(Optional.ofNullable(version).orElse("unknown"));
     }
 }


### PR DESCRIPTION
Since we've been requiring JDK11 for some time (docker images are JDK11 based, RPMs check for JDK11) I propose to change `core/trino-server-main` target to 11 and use Java 9 version API to check for required Java version