### PR TITLE
Rename aggregation pushdown test methods

### DIFF
--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlIntegrationSmokeTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlIntegrationSmokeTest.java
@@ -302,7 +302,7 @@ abstract class BaseMySqlIntegrationSmokeTest
     }
 
     @Test
-    public void testStddevPushdown()
+    public void testStddevAggregationPushdown()
     {
         String schemaName = getSession().getSchema().orElseThrow();
         try (TestTable testTable = new TestTable(mysqlServer::execute, schemaName + ".test_stddev_pushdown",
@@ -335,7 +335,7 @@ abstract class BaseMySqlIntegrationSmokeTest
     }
 
     @Test
-    public void testVariancePushdown()
+    public void testVarianceAggregationPushdown()
     {
         String schemaName = getSession().getSchema().orElseThrow();
         try (TestTable testTable = new TestTable(mysqlServer::execute, schemaName + ".test_variance_pushdown",

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerIntegrationSmokeTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerIntegrationSmokeTest.java
@@ -206,7 +206,7 @@ public class TestSqlServerIntegrationSmokeTest
     }
 
     @Test
-    public void testStddevPushdown()
+    public void testStddevAggregationPushdown()
     {
         try (TestTable testTable = new TestTable(sqlServer::execute, getSession().getSchema().orElseThrow() + ".test_stddev_pushdown",
                 "(t_double DOUBLE PRECISION)")) {
@@ -243,7 +243,7 @@ public class TestSqlServerIntegrationSmokeTest
     }
 
     @Test
-    public void testVariancePushdown()
+    public void testVarianceAggregationPushdown()
     {
         try (TestTable testTable = new TestTable(sqlServer::execute, getSession().getSchema().orElseThrow() + ".test_variance_pushdown",
                 "(t_double DOUBLE PRECISION)")) {


### PR DESCRIPTION
All other aggregation pushdown test methods follow the pattern
testFuncAggregationPushdown making it easy to search for them. This
makes the remaining test method names follow the same pattern.