### PR TITLE
Mark serialization-only methods as @Deprecated

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableScanNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableScanNode.java
@@ -56,6 +56,11 @@ public class TableScanNode
         return new TableScanNode(id, table, outputs, assignments, TupleDomain.all(), forDelete);
     }
 
+    /*
+     * This constructor is for JSON deserialization only. Do not use.
+     * It's marked as @Deprecated to help avoid usage, and not because we plan to remove it.
+     */
+    @Deprecated
     @JsonCreator
     public TableScanNode(
             @JsonProperty("id") PlanNodeId id,
@@ -64,7 +69,6 @@ public class TableScanNode
             @JsonProperty("assignments") Map<Symbol, ColumnHandle> assignments,
             @JsonProperty("forDelete") boolean forDelete)
     {
-        // This constructor is for JSON deserialization only. Do not use.
         super(id);
         this.table = requireNonNull(table, "table is null");
         this.outputSymbols = ImmutableList.copyOf(requireNonNull(outputs, "outputs is null"));

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
@@ -159,8 +159,12 @@ public final class TupleDomain<T>
                         })));
     }
 
+    /*
+     * This method is for JSON serialization only. Do not use.
+     * It's marked as @Deprecated to help avoid usage, and not because we plan to remove it.
+     */
+    @Deprecated
     @JsonCreator
-    // Available for Jackson deserialization only!
     public static <T> TupleDomain<T> fromColumnDomains(@JsonProperty("columnDomains") Optional<List<ColumnDomain<T>>> columnDomains)
     {
         if (columnDomains.isEmpty()) {
@@ -170,8 +174,12 @@ public final class TupleDomain<T>
                 .collect(toLinkedMap(ColumnDomain::getColumn, ColumnDomain::getDomain)));
     }
 
+    /*
+     * This method is for JSON serialization only. Do not use.
+     * It's marked as @Deprecated to help avoid usage, and not because we plan to remove it.
+     */
+    @Deprecated
     @JsonProperty
-    // Available for Jackson serialization only!
     public Optional<List<ColumnDomain<T>>> getColumnDomains()
     {
         return domains.map(map -> map.entrySet().stream()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/PartitionFilter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/PartitionFilter.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive.metastore;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import io.trino.spi.predicate.TupleDomain;
 
 import javax.annotation.concurrent.Immutable;
@@ -40,7 +41,7 @@ public class PartitionFilter
             @JsonProperty("partitionKeysFilter") TupleDomain<String> partitionKeysFilter)
     {
         this.hiveTableName = requireNonNull(hiveTableName, "hiveTableName is null");
-        this.partitionColumnNames = partitionColumnNames;
+        this.partitionColumnNames = ImmutableList.copyOf(requireNonNull(partitionColumnNames, "partitionColumnNames is null"));
         this.partitionKeysFilter = requireNonNull(partitionKeysFilter, "partitionKeysFilter is null");
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/PartitionFilter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/PartitionFilter.java
@@ -41,7 +41,7 @@ public class PartitionFilter
     {
         this.hiveTableName = requireNonNull(hiveTableName, "hiveTableName is null");
         this.partitionColumnNames = partitionColumnNames;
-        this.partitionKeysFilter = TupleDomain.fromColumnDomains(requireNonNull(partitionKeysFilter.getColumnDomains(), "parts is null"));
+        this.partitionKeysFilter = requireNonNull(partitionKeysFilter, "partitionKeysFilter is null");
     }
 
     public static PartitionFilter partitionFilter(String databaseName, String tableName, List<String> partitionColumnNames, TupleDomain<String> partitionKeysFilter)


### PR DESCRIPTION
It is not ideal to mark a method we do not plan to remove as a
`@Deprecated`, but it is still better than mark it with a hard to see
comment as "do not use".

The alternative approaches -- like introducing a new annotation just for
that purpose and add a static code analysis to detect violations are
definitely possible, but not something that can be delivered quickly.