### PR TITLE
Add generated name sequencer to JdbcTableHandle

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
@@ -45,6 +45,8 @@ public final class JdbcTableHandle
     // columns of the relation described by this handle
     private final Optional<List<JdbcColumnHandle>> columns;
 
+    private final int nextSyntheticColumnId;
+
     @Deprecated
     public JdbcTableHandle(SchemaTableName schemaTableName, @Nullable String catalogName, @Nullable String schemaName, String tableName)
     {
@@ -57,7 +59,8 @@ public final class JdbcTableHandle
                 new JdbcNamedRelationHandle(schemaTableName, remoteTableName),
                 TupleDomain.all(),
                 OptionalLong.empty(),
-                Optional.empty());
+                Optional.empty(),
+                0);
     }
 
     @JsonCreator
@@ -65,7 +68,8 @@ public final class JdbcTableHandle
             @JsonProperty("relationHandle") JdbcRelationHandle relationHandle,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
             @JsonProperty("limit") OptionalLong limit,
-            @JsonProperty("columns") Optional<List<JdbcColumnHandle>> columns)
+            @JsonProperty("columns") Optional<List<JdbcColumnHandle>> columns,
+            @JsonProperty("nextSyntheticColumnId") int nextSyntheticColumnId)
     {
         this.relationHandle = requireNonNull(relationHandle, "relationHandle is null");
         this.constraint = requireNonNull(constraint, "constraint is null");
@@ -74,6 +78,7 @@ public final class JdbcTableHandle
 
         requireNonNull(columns, "columns is null");
         this.columns = columns.map(ImmutableList::copyOf);
+        this.nextSyntheticColumnId = nextSyntheticColumnId;
     }
 
     /**
@@ -170,6 +175,12 @@ public final class JdbcTableHandle
         return columns;
     }
 
+    @JsonProperty
+    public int getMextSyntheticColumnId()
+    {
+        return nextSyntheticColumnId;
+    }
+
     @JsonIgnore
     public boolean isSynthetic()
     {
@@ -195,13 +206,14 @@ public final class JdbcTableHandle
         return Objects.equals(this.relationHandle, o.relationHandle) &&
                 Objects.equals(this.constraint, o.constraint) &&
                 Objects.equals(this.limit, o.limit) &&
-                Objects.equals(this.columns, o.columns);
+                Objects.equals(this.columns, o.columns) &&
+                this.nextSyntheticColumnId == o.nextSyntheticColumnId;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(relationHandle, constraint, limit, columns);
+        return Objects.hash(relationHandle, constraint, limit, columns, nextSyntheticColumnId);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadata.java
@@ -312,7 +312,7 @@ public class TestJdbcMetadata
                 Optional.of(ImmutableMap.of(groupByColumn, secondDomain)));
         assertEquals(
                 ((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
-                "SELECT \"TEXT\", count(*) AS \"_pfgnrtd_1\" " +
+                "SELECT \"TEXT\", count(*) AS \"_pfgnrtd_0\" " +
                         "FROM \"" + database.getDatabaseName() + "\".\"EXAMPLE\".\"NUMBERS\" " +
                         "WHERE \"TEXT\" IN (?,?) " +
                         "GROUP BY \"TEXT\"");
@@ -341,7 +341,7 @@ public class TestJdbcMetadata
                 Optional.of(ImmutableMap.of(nonGroupByColumn, domain)));
         assertEquals(
                 ((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
-                "SELECT \"TEXT\", count(*) AS \"_pfgnrtd_1\" " +
+                "SELECT \"TEXT\", count(*) AS \"_pfgnrtd_0\" " +
                         "FROM \"" + database.getDatabaseName() + "\".\"EXAMPLE\".\"NUMBERS\" " +
                         "GROUP BY \"TEXT\"");
     }
@@ -370,7 +370,7 @@ public class TestJdbcMetadata
                 Optional.of(ImmutableMap.of(valueColumn, domain)));
         assertEquals(
                 ((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
-                "SELECT \"TEXT\", \"VALUE\", count(*) AS \"_pfgnrtd_1\" " +
+                "SELECT \"TEXT\", \"VALUE\", count(*) AS \"_pfgnrtd_0\" " +
                         "FROM \"" + database.getDatabaseName() + "\".\"EXAMPLE\".\"NUMBERS\" " +
                         "GROUP BY GROUPING SETS ((\"TEXT\", \"VALUE\"), (\"TEXT\"))");
     }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSetProvider.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSetProvider.java
@@ -187,7 +187,8 @@ public class TestJdbcRecordSetProvider
                 jdbcTableHandle.getRelationHandle(),
                 domain,
                 OptionalLong.empty(),
-                Optional.empty());
+                Optional.empty(),
+                jdbcTableHandle.getMextSyntheticColumnId());
 
         ConnectorSplitSource splits = jdbcClient.getSplits(SESSION, jdbcTableHandle);
         JdbcSplit split = (JdbcSplit) getOnlyElement(getFutureValue(splits.getNextBatch(NOT_PARTITIONED, 1000)).getSplits());

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -187,7 +187,8 @@ public class DruidJdbcClient
                                     table.getRequiredNamedRelation().getRemoteTableName().getTableName())),
                     table.getConstraint(),
                     table.getLimit(),
-                    table.getColumns());
+                    table.getColumns(),
+                    table.getMextSyntheticColumnId());
         }
 
         return table;


### PR DESCRIPTION
During query pushdown we need to create synthetic columns, with unique
names. Inspecting existing columns is only as useful, as an subquery
enclosed in a table handle can some names used but not visible.