### PR TITLE
Document where to save access controls config files

### DIFF
--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -23,6 +23,11 @@ The config file is specified in JSON format. It contains rules that define
 which users have access to which resources. The rules are read from top to bottom
 and the first matching rule is applied. If no rule matches, access is denied.
 
+.. note::
+
+    Access control is enforced on coordinator. Therefore access control
+    configuration files are only required on coordinator node.
+
 Refresh
 --------
 


### PR DESCRIPTION
This is based on answers from slack channel on where to save the configuration files for access control. see https://trinodb.slack.com/archives/CGGL0EZ9N/p1611848020001600?thread_ts=1611847702.001500&cid=CGGL0EZ9N

It saved me lots of maintenance effort when scaling worker nodes (by not providing ACL config files on worker nodes).