### PR TITLE
Fix planning failure with hidden columns in CTE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1371,16 +1371,21 @@ class StatementAnalyzer
                 fields = fieldBuilder.build();
             }
             else {
-                fields = queryDescriptor.getAllFields().stream()
-                        .map(field -> Field.newQualified(
+                ImmutableList.Builder<Field> fieldBuilder = ImmutableList.builder();
+                for (int i = 0; i < queryDescriptor.getAllFieldCount(); i++) {
+                    Field inputField = queryDescriptor.getFieldByIndex(i);
+                    if (!inputField.isHidden()) {
+                        fieldBuilder.add(Field.newQualified(
                                 QualifiedName.of(table.getName().getSuffix()),
-                                field.getName(),
-                                field.getType(),
-                                field.isHidden(),
-                                field.getOriginTable(),
-                                field.getOriginColumnName(),
-                                field.isAliased()))
-                        .collect(toImmutableList());
+                                inputField.getName(),
+                                inputField.getType(),
+                                false,
+                                inputField.getOriginTable(),
+                                inputField.getOriginColumnName(),
+                                inputField.isAliased()));
+                    }
+                }
+                fields = fieldBuilder.build();
             }
 
             return createAndAssignScope(table, scope, fields);

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWith.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWith.java
@@ -25,6 +25,7 @@ import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestWith
 {
@@ -73,5 +74,15 @@ public class TestWith
                 "WITH t(a, b, c, d) AS (TABLE nation) " +
                         "SELECT a, b FROM t WHERE a = 1"))
                 .matches("VALUES (BIGINT '1', CAST('ARGENTINA' AS VARCHAR(25)))");
+
+        // Test CTE specified as TABLE without columns aliases
+        assertThat(assertions.query("WITH t AS (TABLE nation) " +
+                "SELECT * FROM t"))
+                .matches("SELECT * FROM nation");
+
+        // try access hidden column
+        assertThatThrownBy(() -> assertions.query("WITH t AS (TABLE nation) " +
+                "SELECT min(row_number) FROM t"))
+                .hasMessage("line 1:37: Column 'row_number' cannot be resolved");
     }
 }


### PR DESCRIPTION
https://github.com/trinodb/trino/issues/6837

When CTE is defined as TABLE, and no column aliases are specified, e.g.
`WITH t AS (TABLE nation)`
an error occured during planning if the table had hidden columns.
The hidden columns were unexpectedly exposed from the table,
causing mismatch during coercion.
This issue was fixed by excluding hidden columns from the CTE's scope
during analysis.
Additionally, the method `RelationType.getAllFields()` was used
to iterate over input fields and build output descriptor.
This was incorrect, because this method does not guarantee
the order of fields. It was replaced by calls to `RelationType.getFieldByIndex()`.