### PR TITLE
Fix planning failure with hidden columns in CTAS

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -1286,7 +1286,7 @@ class QueryPlanner
         return new NodeAndMappings(coerced, mappings.build());
     }
 
-    private static List<Symbol> visibleFields(RelationPlan subPlan)
+    public static List<Symbol> visibleFields(RelationPlan subPlan)
     {
         RelationType descriptor = subPlan.getDescriptor();
         return descriptor.getAllFields().stream()


### PR DESCRIPTION
https://github.com/trinodb/trino/issues/6835

Before this change, CREATE statement of the form:
`CREATE TABLE xxx AS TABLE t`
failed during planning if table t had hidden columns.
Hidden columns were not expected in `LogicalPlanner.createTableWriterPlan()`,
and they caused mismatch with column names.
It was solved by specifying the columns of interest as visible columns.