### PR TITLE
Update docs for property rename

### DIFF
--- a/core/trino-server-main/etc/catalog/localfile.properties
+++ b/core/trino-server-main/etc/catalog/localfile.properties
@@ -6,5 +6,5 @@
 #
 
 connector.name=localfile
-presto-logs.http-request-log.location=var/log
-presto-logs.http-request-log.pattern=http-request.log*
+trino-logs.http-request-log.location=var/log
+trino-logs.http-request-log.pattern=http-request.log*

--- a/docs/src/main/sphinx/admin/properties-optimizer.rst
+++ b/docs/src/main/sphinx/admin/properties-optimizer.rst
@@ -44,8 +44,8 @@ partition keys for partitions that have no rows. In particular, the Hive connect
 can return empty partitions, if they were created by other systems. Trino cannot
 create them.
 
-``optimizer.push-aggregation-through-join``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``optimizer.push-aggregation-through-outer-join``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **Type:** ``boolean``
 * **Default value:** ``true``

--- a/docs/src/main/sphinx/connector/localfile.rst
+++ b/docs/src/main/sphinx/connector/localfile.rst
@@ -21,8 +21,8 @@ Configuration properties
 =========================================   ==============================================================
 Property Name                               Description
 =========================================   ==============================================================
-``presto-logs.http-request-log.location``   Directory or file where HTTP request logs are written
-``presto-logs.http-request-log.pattern``    If the log location is a directory, this glob is used
+``trino-logs.http-request-log.location``    Directory or file where HTTP request logs are written
+``trino-logs.http-request-log.pattern``     If the log location is a directory, this glob is used
                                             to match file names in the directory
 =========================================   ==============================================================
 

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -312,7 +312,7 @@ Type mapping configuration properties
     - Description
     - Default
   * - ``unsupported-type.handling-strategy``
-    - ``unsupported_type_handling_strategy``
+    - ``unsupported_type_handling``
     - Configures how unsupported column data types are handled:
 
       - ``IGNORE`` - column is not accessible.

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -311,7 +311,7 @@ Type mapping configuration properties
     - Session property name
     - Description
     - Default
-  * - ``unsupported-type.handling-strategy``
+  * - ``unsupported-type-handling``
     - ``unsupported_type_handling``
     - Configures how unsupported column data types are handled:
 


### PR DESCRIPTION
The previous name is retained as legacy config.