### PR TITLE
Add support for TopN pushdown in JDBC connectors

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -590,6 +590,7 @@ public class PlanOptimizers
                         .add(new PushJoinIntoTableScan(metadata))
                         .add(new PushAggregationIntoTableScan(metadata))
                         .add(new PushDistinctLimitIntoTableScan(metadata))
+                        .add(new PushTopNIntoTableScan(metadata))
                         .build());
         builder.add(pushIntoTableScanOptimizer);
         builder.add(new UnaliasSymbolReferences(metadata));
@@ -712,8 +713,7 @@ public class PlanOptimizers
                         new CreatePartialTopN(),
                         new PushTopNThroughProject(),
                         new PushTopNThroughOuterJoin(),
-                        new PushTopNThroughUnion(),
-                        new PushTopNIntoTableScan(metadata))));
+                        new PushTopNThroughUnion())));
         builder.add(new IterativeOptimizer(
                 ruleStats,
                 statsCalculator,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushTopNIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushTopNIntoTableScan.java
@@ -160,7 +160,7 @@ public class TestPushTopNIntoTableScan
                     .withSession(MOCK_SESSION)
                     .matches(
                             topN(1, ImmutableList.of(sort(dimensionName, ASCENDING, FIRST)),
-                                    TopNNode.Step.FINAL,
+                                    TopNNode.Step.SINGLE,
                                     tableScan(
                                             equalTo(connectorHandle),
                                             TupleDomain.all(),

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SortItem.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SortItem.java
@@ -13,6 +13,9 @@
  */
 package io.trino.spi.connector;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -22,17 +25,20 @@ public class SortItem
     private final String name;
     private final SortOrder sortOrder;
 
+    @JsonCreator
     public SortItem(String name, SortOrder sortOrder)
     {
         this.name = requireNonNull(name, "name is null");
         this.sortOrder = requireNonNull(sortOrder, "name is null");
     }
 
+    @JsonProperty
     public String getName()
     {
         return name;
     }
 
+    @JsonProperty
     public SortOrder getSortOrder()
     {
         return sortOrder;
@@ -55,5 +61,17 @@ public class SortItem
     public int hashCode()
     {
         return Objects.hash(name, sortOrder);
+    }
+
+    @Override
+    public String toString()
+    {
+        return new StringBuilder("SortItem{")
+                .append("name=")
+                .append(name)
+                .append(", sortOrder=")
+                .append(sortOrder)
+                .append("}")
+                .toString();
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -28,6 +28,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SortItem;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.predicate.TupleDomain;
@@ -202,6 +203,18 @@ public class CachingJdbcClient
             throws SQLException
     {
         return delegate.buildSql(session, connection, split, table, columns);
+    }
+
+    @Override
+    public boolean supportsTopN(ConnectorSession session, JdbcTableHandle handle, List<SortItem> sortOrder)
+    {
+        return delegate.supportsTopN(session, handle, sortOrder);
+    }
+
+    @Override
+    public boolean isTopNLimitGuaranteed(ConnectorSession session)
+    {
+        return delegate.isTopNLimitGuaranteed(session);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -20,6 +20,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SortItem;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.predicate.TupleDomain;
@@ -213,6 +214,18 @@ public abstract class ForwardingJdbcClient
     public TableStatistics getTableStatistics(ConnectorSession session, JdbcTableHandle handle, TupleDomain<ColumnHandle> tupleDomain)
     {
         return delegate().getTableStatistics(session, handle, tupleDomain);
+    }
+
+    @Override
+    public boolean supportsTopN(ConnectorSession session, JdbcTableHandle handle, List<SortItem> sortOrder)
+    {
+        return delegate().supportsTopN(session, handle, sortOrder);
+    }
+
+    @Override
+    public boolean isTopNLimitGuaranteed(ConnectorSession session)
+    {
+        return delegate().isTopNLimitGuaranteed(session);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SortItem;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.predicate.TupleDomain;
@@ -91,6 +92,10 @@ public interface JdbcClient
 
     PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns)
             throws SQLException;
+
+    boolean supportsTopN(ConnectorSession session, JdbcTableHandle handle, List<SortItem> sortOrder);
+
+    boolean isTopNLimitGuaranteed(ConnectorSession session);
 
     boolean supportsLimit();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
@@ -23,7 +23,10 @@ public class JdbcMetadataConfig
 {
     private boolean allowDropTable;
     private boolean aggregationPushdownEnabled = true;
-    private boolean topNPushdownEnabled = true;
+
+    // TODO: https://github.com/trinodb/trino/issues/7031
+    private boolean topNPushdownEnabled;
+
     // Pushed domains are transformed into SQL IN lists
     // (or sequence of range predicates) in JDBC connectors.
     // Too large IN lists cause significant performance regression.

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
@@ -23,6 +23,7 @@ public class JdbcMetadataConfig
 {
     private boolean allowDropTable;
     private boolean aggregationPushdownEnabled = true;
+    private boolean topNPushdownEnabled = true;
     // Pushed domains are transformed into SQL IN lists
     // (or sequence of range predicates) in JDBC connectors.
     // Too large IN lists cause significant performance regression.
@@ -55,6 +56,19 @@ public class JdbcMetadataConfig
     {
         this.aggregationPushdownEnabled = aggregationPushdownEnabled;
         return this;
+    }
+
+    @Config("topn-pushdown.enabled")
+    @ConfigDescription("Enable TopN pushdown")
+    public JdbcMetadataConfig setTopNPushdownEnabled(boolean enabled)
+    {
+        this.topNPushdownEnabled = enabled;
+        return this;
+    }
+
+    public Boolean isTopNPushdownEnabled()
+    {
+        return this.topNPushdownEnabled;
     }
 
     @Min(1)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataSessionProperties.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataSessionProperties.java
@@ -32,6 +32,7 @@ public class JdbcMetadataSessionProperties
         implements SessionPropertiesProvider
 {
     public static final String AGGREGATION_PUSHDOWN_ENABLED = "aggregation_pushdown_enabled";
+    public static final String TOPN_PUSHDOWN_ENABLED = "topn_pushdown_enabled";
     public static final String DOMAIN_COMPACTION_THRESHOLD = "domain_compaction_threshold";
 
     private final List<PropertyMetadata<?>> properties;
@@ -52,6 +53,11 @@ public class JdbcMetadataSessionProperties
                         jdbcMetadataConfig.getDomainCompactionThreshold(),
                         value -> validateDomainCompactionThreshold(value, maxDomainCompactionThreshold),
                         false))
+                .add(booleanProperty(
+                        TOPN_PUSHDOWN_ENABLED,
+                        "Enable TopN pushdown",
+                        jdbcMetadataConfig.isTopNPushdownEnabled(),
+                        false))
                 .build();
     }
 
@@ -64,6 +70,11 @@ public class JdbcMetadataSessionProperties
     public static boolean isAggregationPushdownEnabled(ConnectorSession session)
     {
         return session.getProperty(AGGREGATION_PUSHDOWN_ENABLED, Boolean.class);
+    }
+
+    public static boolean isTopNPushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(TOPN_PUSHDOWN_ENABLED, Boolean.class);
     }
 
     public static int getDomainCompactionThreshold(ConnectorSession session)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -32,6 +32,7 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SortItem;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.connector.TableScanRedirectApplicationResult;
 import io.trino.spi.predicate.TupleDomain;
@@ -267,6 +268,18 @@ public final class StatisticsAwareJdbcClient
     public TableStatistics getTableStatistics(ConnectorSession session, JdbcTableHandle handle, TupleDomain<ColumnHandle> tupleDomain)
     {
         return stats.getGetTableStatistics().wrap(() -> delegate().getTableStatistics(session, handle, tupleDomain));
+    }
+
+    @Override
+    public boolean supportsTopN(ConnectorSession session, JdbcTableHandle handle, List<SortItem> sortOrder)
+    {
+        return delegate().supportsTopN(session, handle, sortOrder);
+    }
+
+    @Override
+    public boolean isTopNLimitGuaranteed(ConnectorSession session)
+    {
+        return delegate().isTopNLimitGuaranteed(session);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
@@ -30,6 +30,7 @@ public class TestJdbcMetadataConfig
         assertRecordedDefaults(recordDefaults(JdbcMetadataConfig.class)
                 .setAllowDropTable(false)
                 .setAggregationPushdownEnabled(true)
+                .setTopNPushdownEnabled(true)
                 .setDomainCompactionThreshold(32));
     }
 
@@ -40,11 +41,13 @@ public class TestJdbcMetadataConfig
                 .put("allow-drop-table", "true")
                 .put("aggregation-pushdown.enabled", "false")
                 .put("domain-compaction-threshold", "42")
+                .put("topn-pushdown.enabled", "false")
                 .build();
 
         JdbcMetadataConfig expected = new JdbcMetadataConfig()
                 .setAllowDropTable(true)
                 .setAggregationPushdownEnabled(false)
+                .setTopNPushdownEnabled(false)
                 .setDomainCompactionThreshold(42);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadataConfig.java
@@ -30,7 +30,7 @@ public class TestJdbcMetadataConfig
         assertRecordedDefaults(recordDefaults(JdbcMetadataConfig.class)
                 .setAllowDropTable(false)
                 .setAggregationPushdownEnabled(true)
-                .setTopNPushdownEnabled(true)
+                .setTopNPushdownEnabled(false)
                 .setDomainCompactionThreshold(32));
     }
 
@@ -41,13 +41,13 @@ public class TestJdbcMetadataConfig
                 .put("allow-drop-table", "true")
                 .put("aggregation-pushdown.enabled", "false")
                 .put("domain-compaction-threshold", "42")
-                .put("topn-pushdown.enabled", "false")
+                .put("topn-pushdown.enabled", "true")
                 .build();
 
         JdbcMetadataConfig expected = new JdbcMetadataConfig()
                 .setAllowDropTable(true)
                 .setAggregationPushdownEnabled(false)
-                .setTopNPushdownEnabled(false)
+                .setTopNPushdownEnabled(true)
                 .setDomainCompactionThreshold(42);
 
         assertFullMapping(properties, expected);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSetProvider.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcRecordSetProvider.java
@@ -186,6 +186,7 @@ public class TestJdbcRecordSetProvider
         jdbcTableHandle = new JdbcTableHandle(
                 jdbcTableHandle.getRelationHandle(),
                 domain,
+                Optional.empty(),
                 OptionalLong.empty(),
                 Optional.empty(),
                 jdbcTableHandle.getNextSyntheticColumnId());

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableHandle.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableHandle.java
@@ -66,6 +66,7 @@ public class TestJdbcTableHandle
                                         IntegerType.INTEGER,
                                         Optional.of(1))))),
                 TupleDomain.all(),
+                Optional.empty(),
                 OptionalLong.of(1),
                 Optional.of(ImmutableList.of(new JdbcColumnHandle("i", type, IntegerType.INTEGER))),
                 0);
@@ -79,6 +80,7 @@ public class TestJdbcTableHandle
                         new SchemaTableName("schema", "table"),
                         new RemoteTableName(Optional.of("catalog"), Optional.of("schema"), "table")),
                 TupleDomain.all(),
+                Optional.empty(),
                 OptionalLong.of(1),
                 Optional.of(ImmutableList.of(new JdbcColumnHandle("i", type, IntegerType.INTEGER))),
                 0);

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -186,6 +186,7 @@ public class DruidJdbcClient
                                     table.getRequiredNamedRelation().getRemoteTableName().getSchemaName(),
                                     table.getRequiredNamedRelation().getRemoteTableName().getTableName())),
                     table.getConstraint(),
+                    table.getSortOrder(),
                     table.getLimit(),
                     table.getColumns(),
                     table.getNextSyntheticColumnId());

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -255,7 +255,7 @@ public class PhoenixClient
                 ImmutableMap.of(),
                 phoenixSplit.getConstraint(),
                 split.getAdditionalPredicate());
-        preparedQuery = preparedQuery.transformQuery(tryApplyLimit(table.getLimit()));
+        preparedQuery = applyQueryTransformations(table, preparedQuery);
         PreparedStatement query = queryBuilder.prepareStatement(session, connection, preparedQuery);
         QueryPlan queryPlan = getQueryPlan((PhoenixPreparedStatement) query);
         ResultSet resultSet = getResultSet(phoenixSplit.getPhoenixInputSplit(), queryPlan);

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -254,7 +254,7 @@ public class PhoenixClient
                 ImmutableMap.of(),
                 phoenixSplit.getConstraint(),
                 split.getAdditionalPredicate());
-        preparedQuery = preparedQuery.transformQuery(tryApplyLimit(table.getLimit()));
+        preparedQuery = applyQueryTransformations(table, preparedQuery);
         PreparedStatement query = queryBuilder.prepareStatement(session, connection, preparedQuery);
         QueryPlan queryPlan = getQueryPlan((PhoenixPreparedStatement) query);
         ResultSet resultSet = getResultSet(phoenixSplit.getPhoenixInputSplit(), queryPlan);

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -61,6 +61,7 @@ public class TestPostgreSqlConnectorTest
             postgreSqlServer.close();
             postgreSqlServer = null;
         });
+        // TODO: https://github.com/trinodb/trino/issues/7031
         return createPostgreSqlQueryRunner(postgreSqlServer, Map.of(), Map.of("topn-pushdown.enabled", "true"), REQUIRED_TPCH_TABLES);
     }
 

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -286,6 +286,23 @@ public class TestPostgreSqlConnectorTest
         assertThat(query("SELECT regionkey, sum(nationkey) FROM nation GROUP BY regionkey HAVING sum(nationkey) = 77"))
                 .matches("VALUES (BIGINT '3', BIGINT '77')")
                 .isFullyPushedDown();
+
+        // predicate over TopN result
+        assertThat(query("" +
+                "SELECT orderkey " +
+                "FROM (SELECT * FROM orders ORDER BY orderdate DESC, orderkey ASC LIMIT 10)" +
+                "WHERE orderdate = DATE '1998-08-01'"))
+                .matches("VALUES BIGINT '27588', 22403, 37735")
+                .ordered()
+                .isFullyPushedDown();
+
+        assertThat(query("" +
+                "SELECT custkey " +
+                "FROM (SELECT SUM(totalprice) as sum, custkey, COUNT(*) as cnt FROM orders GROUP BY custkey order by sum desc limit 10) " +
+                "WHERE cnt > 30"))
+                .matches("VALUES BIGINT '643', 898")
+                .ordered()
+                .isFullyPushedDown();
     }
 
     @Test
@@ -466,6 +483,13 @@ public class TestPostgreSqlConnectorTest
                 "GROUP BY regionkey"))
                 .isFullyPushedDown();
 
+        // GROUP BY above TopN
+        assertThat(query("" +
+                "SELECT clerk, sum(totalprice) " +
+                "FROM (SELECT clerk, totalprice FROM orders ORDER BY orderdate ASC, totalprice ASC LIMIT 10) " +
+                "GROUP BY clerk"))
+                .isFullyPushedDown();
+
         // decimals
         String schemaName = getSession().getSchema().orElseThrow();
         try (TestTable testTable = new TestTable(postgreSqlServer::execute,
@@ -489,6 +513,61 @@ public class TestPostgreSqlConnectorTest
 
         // approx_set returns HyperLogLog, which is not supported
         assertThat(query("SELECT approx_set(nationkey) FROM nation")).isNotFullyPushedDown(AggregationNode.class);
+    }
+
+    @Test
+    public void testTopNPushdown()
+    {
+        assertThat(query("SELECT orderkey FROM orders ORDER BY orderkey limit 10"))
+                .ordered()
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT orderkey FROM orders ORDER BY orderkey DESC limit 10"))
+                .ordered()
+                .isFullyPushedDown();
+
+        // multiple sort columns with different orders
+        assertThat(query("SELECT * FROM orders ORDER BY orderpriority DESC, totalprice ASC LIMIT 10"))
+                .ordered()
+                .isFullyPushedDown();
+
+        // TopN over aggregation column
+        assertThat(query("SELECT sum(totalprice) AS total FROM orders GROUP BY custkey ORDER BY total DESC LIMIT 10"))
+                .ordered()
+                .isFullyPushedDown();
+
+        // TopN over TopN
+        assertThat(query("SELECT orderkey, totalprice FROM (SELECT orderkey, totalprice FROM orders ORDER BY 1, 2 LIMIT 10) ORDER BY 2, 1 LIMIT 5"))
+                .ordered()
+                .isFullyPushedDown();
+
+        assertThat(query("" +
+                "SELECT orderkey, totalprice " +
+                "FROM (SELECT orderkey, totalprice FROM (SELECT orderkey, totalprice FROM orders ORDER BY 1, 2 LIMIT 10) " +
+                "ORDER BY 2, 1 LIMIT 5) ORDER BY 1, 2 LIMIT 3"))
+                .ordered()
+                .isFullyPushedDown();
+
+        // TopN over limit
+        assertThat(query("SELECT orderkey, totalprice FROM (SELECT orderkey, totalprice FROM orders LIMIT 20) ORDER BY totalprice ASC LIMIT 5"))
+                .ordered()
+                .isFullyPushedDown();
+
+        // TopN over limit with filter
+        assertThat(query("" +
+                "SELECT orderkey, totalprice " +
+                "FROM (SELECT orderkey, totalprice FROM orders WHERE orderpriority = '1-URGENT' LIMIT 20) " +
+                "ORDER BY totalprice ASC LIMIT 5"))
+                .ordered()
+                .isFullyPushedDown();
+
+        // TopN over aggregation with filter
+        assertThat(query("" +
+                "SELECT * " +
+                "FROM (SELECT SUM(totalprice) as sum, custkey AS total FROM orders GROUP BY custkey HAVING COUNT(*) > 3) " +
+                "ORDER BY sum DESC LIMIT 10"))
+                .ordered()
+                .isFullyPushedDown();
     }
 
     @Test
@@ -680,6 +759,9 @@ public class TestPostgreSqlConnectorTest
         // with filter and aggregation
         assertThat(query("SELECT regionkey, count(*) FROM nation WHERE nationkey < 5 GROUP BY regionkey LIMIT 3")).isFullyPushedDown();
         assertThat(query("SELECT regionkey, count(*) FROM nation WHERE name < 'EGYPT' GROUP BY regionkey LIMIT 3")).isFullyPushedDown();
+
+        // with TopN
+        assertThat(query("SELECT * FROM (SELECT regionkey FROM nation ORDER BY name ASC LIMIT 10) LIMIT 5")).isFullyPushedDown();
     }
 
     /**

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -61,7 +61,7 @@ public class TestPostgreSqlConnectorTest
             postgreSqlServer.close();
             postgreSqlServer = null;
         });
-        return createPostgreSqlQueryRunner(postgreSqlServer, Map.of(), Map.of(), REQUIRED_TPCH_TABLES);
+        return createPostgreSqlQueryRunner(postgreSqlServer, Map.of(), Map.of("topn-pushdown.enabled", "true"), REQUIRED_TPCH_TABLES);
     }
 
     @BeforeClass


### PR DESCRIPTION
Partially based on https://github.com/trinodb/trino/pull/4784.

The main difference is to use `JdbcQueryRelationHandle`, instead of carrying `List<SortItem>` in the `JdbcTableHandle`.