### PR TITLE
Disable metastore caching on workers

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastoreModule.java
@@ -19,6 +19,7 @@ import com.google.inject.Provides;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HiveMetastoreDecorator;
+import io.trino.spi.NodeManager;
 
 import javax.inject.Singleton;
 
@@ -47,6 +48,7 @@ public class CachingHiveMetastoreModule
     @Provides
     @Singleton
     public HiveMetastore createCachingHiveMetastore(
+            NodeManager nodeManager,
             @ForCachingHiveMetastore HiveMetastore delegate,
             CachingHiveMetastoreConfig config,
             CatalogName catalogName,
@@ -55,6 +57,13 @@ public class CachingHiveMetastoreModule
         HiveMetastore decoratedDelegate = hiveMetastoreDecorator
                 .map(decorator -> decorator.decorate(delegate))
                 .orElse(delegate);
+
+        if (!nodeManager.getCurrentNode().isCoordinator()) {
+            // Disable caching on workers, because there currently is no way to invalidate such a cache.
+            // Note: while we could skip CachingHiveMetastoreModule altogether on workers, we retain it so that catalog
+            // configuration can remain identical for all nodes, making cluster configuration easier.
+            return decoratedDelegate;
+        }
 
         Executor executor = new ReentrantBoundedExecutor(
                 newCachedThreadPool(daemonThreadsNamed("hive-metastore-" + catalogName + "-%s")),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreQueries.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreQueries.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.metastore.cache;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.HiveQueryRunner;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.tpch.TpchTable.NATION;
+import static java.util.Collections.nCopies;
+
+public class TestCachingHiveMetastoreQueries
+        extends AbstractTestQueryFramework
+{
+    private static final int nodeCount = 3;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        verify(nodeCount > 1, "this test requires a multinode query runner");
+        return HiveQueryRunner.builder()
+                .setHiveProperties(ImmutableMap.of("hive.metastore-cache-ttl", "60m"))
+                // only so that tpch schema is created (TODO https://github.com/trinodb/trino/issues/6861)
+                .setInitialTables(ImmutableList.of(NATION))
+                .setNodeCount(nodeCount)
+                // Exclude coordinator from workers to make testPartitionAppend deterministically reproduce the original problem
+                .setCoordinatorProperties(ImmutableMap.of("node-scheduler.include-coordinator", "false"))
+                .build();
+    }
+
+    @Test
+    public void testPartitionAppend()
+    {
+        getQueryRunner().execute("CREATE TABLE test_part_append " +
+                "(name varchar, partkey varchar) " +
+                "WITH (partitioned_by = ARRAY['partkey'])");
+
+        String row = "('some name', 'part1')";
+
+        // if metastore caching was enabled on workers than any worker which tries to INSERT into same partition twice
+        // will fail because it would've cached the absence of the partition
+        for (int i = 0; i < nodeCount + 1; i++) {
+            getQueryRunner().execute("INSERT INTO test_part_append VALUES " + row);
+        }
+
+        String expected = Joiner.on(",").join(nCopies(nodeCount + 1, row));
+        assertQuery("SELECT * FROM test_part_append", "VALUES " + expected);
+    }
+}


### PR DESCRIPTION
Worker's metastore cache can be inconsistent with the cache on the
coordinator which can lead to bugs due to stale information in the
cache.