### PR TITLE
Support Phoenix 5.1 and HBase 2.x

### DIFF
--- a/core/trino-server/src/main/provisio/presto.xml
+++ b/core/trino-server/src/main/provisio/presto.xml
@@ -140,6 +140,12 @@
         </artifact>
     </artifactSet>
 
+    <artifactSet to="plugin/phoenix-5">
+        <artifact id="${project.groupId}:trino-phoenix-5:zip:${project.version}">
+            <unpack />
+        </artifact>
+    </artifactSet>
+
     <artifactSet to="plugin/postgresql">
         <artifact id="${project.groupId}:trino-postgresql:zip:${project.version}">
             <unpack />

--- a/docs/src/main/sphinx/connector/phoenix.rst
+++ b/docs/src/main/sphinx/connector/phoenix.rst
@@ -9,7 +9,8 @@ The Phoenix connector allows querying data stored in
 Compatibility
 -------------
 
-The Phoenix connector is compatible with all Phoenix versions starting from 4.14.1.
+The Phoenix connector is compatible with all Phoenix 4.x versions starting from 4.14.1.
+The Phoenix-5 connector is compatible with all Phoenix 5.x versions starting from 5.1.0.
 
 Configuration
 -------------
@@ -27,6 +28,12 @@ nodes used for discovery of the HBase cluster:
 
 The optional paths to Hadoop resource files, such as ``hbase-site.xml`` are used
 to load custom Phoenix client connection properties.
+
+For HBase 2.x and Phoenix 5.x (5.1.0 or later) use:
+
+.. code-block:: text
+
+    connector.name=phoenix-5
 
 Configuration properties
 ------------------------

--- a/plugin/trino-phoenix-5/pom.xml
+++ b/plugin/trino-phoenix-5/pom.xml
@@ -1,0 +1,330 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>353-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-phoenix</artifactId>
+    <description>Trino - Phoenix Connector</description>
+    <packaging>trino-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+        <dep.hbase.version>1.4.0</dep.hbase.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-base-jdbc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.phoenix</groupId>
+            <artifactId>phoenix-client</artifactId>
+            <version>4.14.1-HBase-1.4</version>
+            <classifier>embedded</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
+
+        <!-- used by tests but also needed transitively -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log-manager</artifactId>
+            <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>jcl-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Trino SPI -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-testing</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs</artifactId>
+            <version>2.7.5</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-common</artifactId>
+            <version>${dep.hbase.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-hadoop-compat</artifactId>
+            <version>${dep.hbase.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-hadoop2-compat</artifactId>
+            <version>${dep.hbase.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-server</artifactId>
+            <version>${dep.hbase.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.yetus</groupId>
+                    <artifactId>audience-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredResourcePatterns>
+                        <ignoredResourcePattern>mrapp-generated-classpath</ignoredResourcePattern>
+                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                        <!-- org.apache.commons:commons-math3 french localization file duplicate-->
+                        <ignoredResourcePattern>assets/org/apache/commons/math3/exception/util/LocalizedFormats_fr.properties</ignoredResourcePattern>
+                        <!-- io.airlift:joni and phoenix-client's org.jruby.joni:joni resource duplicates-->
+                        <ignoredResourcePattern>tables/.*\.bin</ignoredResourcePattern>
+                    </ignoredResourcePatterns>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>com.clearspring.analytics</groupId>
+                            <artifactId>stream</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/plugin/trino-phoenix-5/pom.xml
+++ b/plugin/trino-phoenix-5/pom.xml
@@ -9,13 +9,13 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>trino-phoenix</artifactId>
-    <description>Trino - Phoenix Connector</description>
+    <artifactId>trino-phoenix-5</artifactId>
+    <description>Trino - Phoenix 5 Connector</description>
     <packaging>trino-plugin</packaging>
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.hbase.version>1.4.0</dep.hbase.version>
+        <dep.hbase.version>2.2.6</dep.hbase.version>
     </properties>
 
     <dependencies>
@@ -91,9 +91,15 @@
 
         <dependency>
             <groupId>org.apache.phoenix</groupId>
-            <artifactId>phoenix-client</artifactId>
-            <version>4.14.1-HBase-1.4</version>
-            <classifier>embedded</classifier>
+            <artifactId>phoenix-client-embedded-hbase-2.2</artifactId>
+            <version>5.1.0</version>
+            <exclusions>
+	        <!-- exlude all transitive dependencies -->
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -197,7 +203,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
-            <version>2.7.5</version>
+            <version>3.1.4</version>
             <type>test-jar</type>
             <scope>test</scope>
             <exclusions>
@@ -265,6 +271,20 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.hbase</groupId>
+            <artifactId>hbase-zookeeper</artifactId>
+            <version>${dep.hbase.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
             <exclusions>
@@ -316,11 +336,20 @@
                         <ignoredResourcePattern>assets/org/apache/commons/math3/exception/util/LocalizedFormats_fr.properties</ignoredResourcePattern>
                         <!-- io.airlift:joni and phoenix-client's org.jruby.joni:joni resource duplicates-->
                         <ignoredResourcePattern>tables/.*\.bin</ignoredResourcePattern>
+                        <ignoredResourcePattern>jetty-dir.css</ignoredResourcePattern>
                     </ignoredResourcePatterns>
                     <ignoredDependencies>
                         <dependency>
                             <groupId>com.clearspring.analytics</groupId>
                             <artifactId>stream</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>javax.activation</groupId>
+                            <artifactId>javax.activation-api</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>javax.xml.bind</groupId>
+                            <artifactId>jaxb-api</artifactId>
                         </dependency>
                     </ignoredDependencies>
                 </configuration>

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/MetadataUtil.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/MetadataUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import org.apache.phoenix.util.SchemaUtil;
+
+import java.util.Optional;
+
+import static io.trino.plugin.phoenix.PhoenixMetadata.DEFAULT_SCHEMA;
+import static org.apache.phoenix.query.QueryConstants.NULL_SCHEMA_NAME;
+
+public final class MetadataUtil
+{
+    private MetadataUtil() {}
+
+    public static String getEscapedTableName(Optional<String> schema, String table)
+    {
+        return SchemaUtil.getEscapedTableName(toPhoenixSchemaName(schema).orElse(null), table);
+    }
+
+    public static Optional<String> toPhoenixSchemaName(Optional<String> prestoSchemaName)
+    {
+        return prestoSchemaName.map(schemaName -> DEFAULT_SCHEMA.equalsIgnoreCase(schemaName) ? NULL_SCHEMA_NAME : schemaName);
+    }
+
+    public static Optional<String> toPrestoSchemaName(Optional<String> phoenixSchemaName)
+    {
+        return phoenixSchemaName.map(schemaName -> schemaName.isEmpty() ? DEFAULT_SCHEMA : schemaName);
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/MetadataUtil.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/MetadataUtil.java
@@ -18,7 +18,6 @@ import org.apache.phoenix.util.SchemaUtil;
 import java.util.Optional;
 
 import static io.trino.plugin.phoenix.PhoenixMetadata.DEFAULT_SCHEMA;
-import static org.apache.phoenix.query.QueryConstants.NULL_SCHEMA_NAME;
 
 public final class MetadataUtil
 {
@@ -31,7 +30,7 @@ public final class MetadataUtil
 
     public static Optional<String> toPhoenixSchemaName(Optional<String> prestoSchemaName)
     {
-        return prestoSchemaName.map(schemaName -> DEFAULT_SCHEMA.equalsIgnoreCase(schemaName) ? NULL_SCHEMA_NAME : schemaName);
+        return prestoSchemaName.map(schemaName -> DEFAULT_SCHEMA.equalsIgnoreCase(schemaName) ? "" : schemaName);
     }
 
     public static Optional<String> toPrestoSchemaName(Optional<String> phoenixSchemaName)

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -48,7 +48,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HTableDescriptor;
-import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
@@ -565,7 +566,7 @@ public class PhoenixClient
         ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
 
         try (PhoenixConnection connection = (PhoenixConnection) connectionFactory.openConnection(session);
-                HBaseAdmin admin = connection.getQueryServices().getAdmin()) {
+                Admin admin = connection.getQueryServices().getAdmin()) {
             String schemaName = toPhoenixSchemaName(Optional.ofNullable(handle.getSchemaName())).orElse(null);
             PTable table = getTable(connection, SchemaUtil.getTableName(schemaName, handle.getTableName()));
 
@@ -593,7 +594,7 @@ public class PhoenixClient
                 properties.put(PhoenixTableProperties.DEFAULT_COLUMN_FAMILY, defaultFamilyName);
             }
 
-            HTableDescriptor tableDesc = admin.getTableDescriptor(table.getPhysicalName().getBytes());
+            HTableDescriptor tableDesc = admin.getTableDescriptor(TableName.valueOf(table.getPhysicalName().getBytes()));
 
             HColumnDescriptor[] columnFamilies = tableDesc.getColumnFamilies();
             for (HColumnDescriptor columnFamily : columnFamilies) {
@@ -690,7 +691,7 @@ public class PhoenixClient
             PName physicalTableName = queryPlan.getTableRef().getTable().getPhysicalName();
             PhoenixConnection phoenixConnection = context.getConnection();
             ConnectionQueryServices services = phoenixConnection.getQueryServices();
-            services.clearTableRegionCache(physicalTableName.getBytes());
+            services.clearTableRegionCache(TableName.valueOf(physicalTableName.getBytes()));
 
             for (Scan scan : scans) {
                 scan = new Scan(scan);

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -1,0 +1,730 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.jdbc.BaseJdbcClient;
+import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcOutputTableHandle;
+import io.trino.plugin.jdbc.JdbcSplit;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.ObjectReadFunction;
+import io.trino.plugin.jdbc.ObjectWriteFunction;
+import io.trino.plugin.jdbc.PreparedQuery;
+import io.trino.plugin.jdbc.QueryBuilder;
+import io.trino.plugin.jdbc.WriteFunction;
+import io.trino.plugin.jdbc.WriteMapping;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.SchemaNotFoundException;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Decimals;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HColumnDescriptor;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HTableDescriptor;
+import org.apache.hadoop.hbase.client.HBaseAdmin;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.regionserver.BloomType;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.compile.QueryPlan;
+import org.apache.phoenix.compile.StatementContext;
+import org.apache.phoenix.exception.SQLExceptionCode;
+import org.apache.phoenix.iterate.ConcatResultIterator;
+import org.apache.phoenix.iterate.LookAheadResultIterator;
+import org.apache.phoenix.iterate.MapReduceParallelScanGrouper;
+import org.apache.phoenix.iterate.PeekingResultIterator;
+import org.apache.phoenix.iterate.ResultIterator;
+import org.apache.phoenix.iterate.RoundRobinResultIterator;
+import org.apache.phoenix.iterate.SequenceResultIterator;
+import org.apache.phoenix.iterate.TableResultIterator;
+import org.apache.phoenix.jdbc.DelegatePreparedStatement;
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
+import org.apache.phoenix.jdbc.PhoenixResultSet;
+import org.apache.phoenix.mapreduce.PhoenixInputSplit;
+import org.apache.phoenix.monitoring.ScanMetricsHolder;
+import org.apache.phoenix.query.ConnectionQueryServices;
+import org.apache.phoenix.query.HBaseFactoryProvider;
+import org.apache.phoenix.query.QueryConstants;
+import org.apache.phoenix.schema.PColumn;
+import org.apache.phoenix.schema.PName;
+import org.apache.phoenix.schema.PTable;
+import org.apache.phoenix.schema.TableProperty;
+import org.apache.phoenix.schema.types.PDataType;
+import org.apache.phoenix.util.SchemaUtil;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.JDBCType;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.function.BiFunction;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.booleanWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.charWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.dateColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.dateWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.decimalColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.defaultCharColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.defaultVarcharColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.doubleColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.doubleWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.integerColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.integerWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.longDecimalWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.realColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.smallintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.timeWriteFunctionUsingSqlTime;
+import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varbinaryWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
+import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
+import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
+import static io.trino.plugin.phoenix.MetadataUtil.getEscapedTableName;
+import static io.trino.plugin.phoenix.MetadataUtil.toPhoenixSchemaName;
+import static io.trino.plugin.phoenix.PhoenixClientModule.getConnectionProperties;
+import static io.trino.plugin.phoenix.PhoenixColumnProperties.isPrimaryKey;
+import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_METADATA_ERROR;
+import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_QUERY_ERROR;
+import static io.trino.plugin.phoenix.PhoenixMetadata.DEFAULT_SCHEMA;
+import static io.trino.plugin.phoenix.TypeUtils.getArrayElementPhoenixTypeName;
+import static io.trino.plugin.phoenix.TypeUtils.getJdbcObjectArray;
+import static io.trino.plugin.phoenix.TypeUtils.jdbcObjectArrayToBlock;
+import static io.trino.plugin.phoenix.TypeUtils.toBoxedArray;
+import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.TIME;
+import static io.trino.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.lang.Math.max;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.math.RoundingMode.UNNECESSARY;
+import static java.sql.Types.ARRAY;
+import static java.sql.Types.LONGNVARCHAR;
+import static java.sql.Types.LONGVARCHAR;
+import static java.sql.Types.NVARCHAR;
+import static java.sql.Types.TIMESTAMP;
+import static java.sql.Types.TIMESTAMP_WITH_TIMEZONE;
+import static java.sql.Types.TIME_WITH_TIMEZONE;
+import static java.sql.Types.VARCHAR;
+import static java.util.Locale.ENGLISH;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.hadoop.hbase.HConstants.FOREVER;
+import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.SKIP_REGION_BOUNDARY_CHECK;
+import static org.apache.phoenix.util.PhoenixRuntime.getTable;
+import static org.apache.phoenix.util.SchemaUtil.ESCAPE_CHARACTER;
+import static org.apache.phoenix.util.SchemaUtil.getEscapedArgument;
+
+public class PhoenixClient
+        extends BaseJdbcClient
+{
+    private static final String ROWKEY = "ROWKEY";
+
+    private final Configuration configuration;
+
+    @Inject
+    public PhoenixClient(PhoenixConfig config, ConnectionFactory connectionFactory)
+            throws SQLException
+    {
+        super(
+                ESCAPE_CHARACTER,
+                connectionFactory,
+                ImmutableSet.of(),
+                config.isCaseInsensitiveNameMatching(),
+                config.getCaseInsensitiveNameMatchingCacheTtl());
+        this.configuration = new Configuration(false);
+        getConnectionProperties(config).forEach((k, v) -> configuration.set((String) k, (String) v));
+    }
+
+    public PhoenixConnection getConnection(ConnectorSession session)
+            throws SQLException
+    {
+        return connectionFactory.openConnection(session).unwrap(PhoenixConnection.class);
+    }
+
+    public org.apache.hadoop.hbase.client.Connection getHConnection()
+            throws IOException
+    {
+        return HBaseFactoryProvider.getHConnectionFactory().createConnection(configuration);
+    }
+
+    @Override
+    public void execute(ConnectorSession session, String statement)
+    {
+        super.execute(session, statement);
+    }
+
+    @Override
+    protected Collection<String> listSchemas(Connection connection)
+    {
+        try (ResultSet resultSet = connection.getMetaData().getSchemas()) {
+            ImmutableSet.Builder<String> schemaNames = ImmutableSet.builder();
+            schemaNames.add(DEFAULT_SCHEMA);
+            while (resultSet.next()) {
+                String schemaName = getTableSchemaName(resultSet);
+                // skip internal schemas
+                if (filterSchema(schemaName)) {
+                    schemaNames.add(schemaName);
+                }
+            }
+            return schemaNames.build();
+        }
+        catch (SQLException e) {
+            throw new TrinoException(PHOENIX_METADATA_ERROR, e);
+        }
+    }
+
+    @Override
+    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
+            throws SQLException
+    {
+        PhoenixSplit phoenixSplit = (PhoenixSplit) split;
+        QueryBuilder queryBuilder = new QueryBuilder(this);
+        PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+                session,
+                connection,
+                table.getRelationHandle(),
+                Optional.empty(),
+                columnHandles,
+                ImmutableMap.of(),
+                phoenixSplit.getConstraint(),
+                split.getAdditionalPredicate());
+        preparedQuery = preparedQuery.transformQuery(tryApplyLimit(table.getLimit()));
+        PreparedStatement query = queryBuilder.prepareStatement(session, connection, preparedQuery);
+        QueryPlan queryPlan = getQueryPlan((PhoenixPreparedStatement) query);
+        ResultSet resultSet = getResultSet(phoenixSplit.getPhoenixInputSplit(), queryPlan);
+        return new DelegatePreparedStatement(query)
+        {
+            @Override
+            public ResultSet executeQuery()
+            {
+                return resultSet;
+            }
+        };
+    }
+
+    @Override
+    protected Optional<BiFunction<String, Long, String>> limitFunction()
+    {
+        return Optional.of((sql, limit) -> sql + " LIMIT " + limit);
+    }
+
+    @Override
+    public String buildInsertSql(JdbcOutputTableHandle handle, List<WriteFunction> columnWriters)
+    {
+        PhoenixOutputTableHandle outputHandle = (PhoenixOutputTableHandle) handle;
+        String params = columnWriters.stream()
+                .map(WriteFunction::getBindExpression)
+                .collect(joining(","));
+        String columns = handle.getColumnNames().stream()
+                .map(SchemaUtil::getEscapedArgument)
+                .collect(joining(","));
+        if (outputHandle.rowkeyColumn().isPresent()) {
+            String nextId = format(
+                    "NEXT VALUE FOR %s, ",
+                    quoted(null, handle.getSchemaName(), handle.getTableName() + "_sequence"));
+            params = nextId + params;
+            columns = outputHandle.rowkeyColumn().get() + ", " + columns;
+        }
+        return format(
+                "UPSERT INTO %s (%s) VALUES (%s)",
+                quoted(null, handle.getSchemaName(), handle.getTableName()),
+                columns,
+                params);
+    }
+
+    @Override
+    protected ResultSet getTables(Connection connection, Optional<String> schemaName, Optional<String> tableName)
+            throws SQLException
+    {
+        return super.getTables(connection, toPhoenixSchemaName(schemaName), tableName);
+    }
+
+    @Override
+    protected String getTableSchemaName(ResultSet resultSet)
+            throws SQLException
+    {
+        return firstNonNull(resultSet.getString("TABLE_SCHEM"), DEFAULT_SCHEMA);
+    }
+
+    @Override
+    public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
+    {
+        switch (typeHandle.getJdbcType()) {
+            case Types.BOOLEAN:
+                return Optional.of(booleanColumnMapping());
+
+            case Types.TINYINT:
+                return Optional.of(tinyintColumnMapping());
+
+            case Types.SMALLINT:
+                return Optional.of(smallintColumnMapping());
+
+            case Types.INTEGER:
+                return Optional.of(integerColumnMapping());
+
+            case Types.BIGINT:
+                return Optional.of(bigintColumnMapping());
+
+            case Types.FLOAT:
+                return Optional.of(realColumnMapping());
+
+            case Types.DOUBLE:
+                return Optional.of(doubleColumnMapping());
+
+            case Types.DECIMAL:
+                int precision = typeHandle.getRequiredColumnSize();
+                int decimalDigits = typeHandle.getDecimalDigits().orElseThrow(() -> new IllegalStateException("decimal digits not present"));
+                // TODO does phoenix support negative scale?
+                precision = precision + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
+                if (precision > Decimals.MAX_PRECISION) {
+                    break;
+                }
+                return Optional.of(decimalColumnMapping(createDecimalType(precision, max(decimalDigits, 0)), UNNECESSARY));
+
+            case Types.CHAR:
+                return Optional.of(defaultCharColumnMapping(typeHandle.getRequiredColumnSize(), true));
+
+            case VARCHAR:
+            case NVARCHAR:
+            case LONGVARCHAR:
+            case LONGNVARCHAR:
+                if (typeHandle.getColumnSize().isEmpty()) {
+                    return Optional.of(varcharColumnMapping(createUnboundedVarcharType(), true));
+                }
+                return Optional.of(defaultVarcharColumnMapping(typeHandle.getRequiredColumnSize(), true));
+
+            case Types.VARBINARY:
+                return Optional.of(varbinaryColumnMapping());
+
+            case Types.DATE:
+                return Optional.of(dateColumnMapping());
+
+            // TODO add support for TIMESTAMP after Phoenix adds support for LocalDateTime
+            case TIMESTAMP:
+            case TIME_WITH_TIMEZONE:
+            case TIMESTAMP_WITH_TIMEZONE:
+                if (getUnsupportedTypeHandling(session) == CONVERT_TO_VARCHAR) {
+                    return mapToUnboundedVarchar(typeHandle);
+                }
+                return Optional.empty();
+
+            case ARRAY:
+                JdbcTypeHandle elementTypeHandle = getArrayElementTypeHandle(typeHandle);
+                if (elementTypeHandle.getJdbcType() == Types.VARBINARY) {
+                    return Optional.empty();
+                }
+                return toColumnMapping(session, connection, elementTypeHandle)
+                        .map(elementMapping -> {
+                            ArrayType prestoArrayType = new ArrayType(elementMapping.getType());
+                            String jdbcTypeName = elementTypeHandle.getJdbcTypeName()
+                                    .orElseThrow(() -> new TrinoException(
+                                            PHOENIX_METADATA_ERROR,
+                                            "Type name is missing for jdbc type: " + JDBCType.valueOf(elementTypeHandle.getJdbcType())));
+                            return arrayColumnMapping(session, prestoArrayType, jdbcTypeName);
+                        });
+        }
+        return legacyToPrestoType(session, connection, typeHandle);
+    }
+
+    @Override
+    public WriteMapping toWriteMapping(ConnectorSession session, Type type)
+    {
+        if (type == BOOLEAN) {
+            return WriteMapping.booleanMapping("boolean", booleanWriteFunction());
+        }
+
+        if (type == TINYINT) {
+            return WriteMapping.longMapping("tinyint", tinyintWriteFunction());
+        }
+        if (type == SMALLINT) {
+            return WriteMapping.longMapping("smallint", smallintWriteFunction());
+        }
+        if (type == INTEGER) {
+            return WriteMapping.longMapping("integer", integerWriteFunction());
+        }
+        if (type == BIGINT) {
+            return WriteMapping.longMapping("bigint", bigintWriteFunction());
+        }
+        if (type == REAL) {
+            return WriteMapping.longMapping("float", realWriteFunction());
+        }
+        if (type == DOUBLE) {
+            return WriteMapping.doubleMapping("double", doubleWriteFunction());
+        }
+
+        if (type instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) type;
+            String dataType = format("decimal(%s, %s)", decimalType.getPrecision(), decimalType.getScale());
+            if (decimalType.isShort()) {
+                return WriteMapping.longMapping(dataType, shortDecimalWriteFunction(decimalType));
+            }
+            return WriteMapping.sliceMapping(dataType, longDecimalWriteFunction(decimalType));
+        }
+
+        if (type instanceof CharType) {
+            return WriteMapping.sliceMapping("char(" + ((CharType) type).getLength() + ")", charWriteFunction());
+        }
+        if (type instanceof VarcharType) {
+            VarcharType varcharType = (VarcharType) type;
+            String dataType;
+            if (varcharType.isUnbounded()) {
+                dataType = "varchar";
+            }
+            else {
+                dataType = "varchar(" + varcharType.getBoundedLength() + ")";
+            }
+            return WriteMapping.sliceMapping(dataType, varcharWriteFunction());
+        }
+        if (type instanceof VarbinaryType) {
+            return WriteMapping.sliceMapping("varbinary", varbinaryWriteFunction());
+        }
+
+        if (type == DATE) {
+            return WriteMapping.longMapping("date", dateWriteFunction());
+        }
+        if (TIME.equals(type)) {
+            return WriteMapping.longMapping("time", timeWriteFunctionUsingSqlTime());
+        }
+        // Phoenix doesn't support _WITH_TIME_ZONE
+        if (TIME_WITH_TIME_ZONE.equals(type) || TIMESTAMP_TZ_MILLIS.equals(type)) {
+            throw new TrinoException(NOT_SUPPORTED, "Unsupported column type: " + type.getDisplayName());
+        }
+        if (type instanceof ArrayType) {
+            Type elementType = ((ArrayType) type).getElementType();
+            String elementDataType = toWriteMapping(session, elementType).getDataType().toUpperCase(ENGLISH);
+            String elementWriteName = getArrayElementPhoenixTypeName(session, this, elementType);
+            return WriteMapping.objectMapping(elementDataType + " ARRAY", arrayWriteFunction(session, elementType, elementWriteName));
+        }
+        return legacyToWriteMapping(session, type);
+    }
+
+    @Override
+    public boolean isLimitGuaranteed(ConnectorSession session)
+    {
+        return false;
+    }
+
+    @Override
+    public JdbcOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata)
+    {
+        SchemaTableName schemaTableName = tableMetadata.getTable();
+        Optional<String> schema = Optional.of(schemaTableName.getSchemaName());
+        String table = schemaTableName.getTableName();
+
+        if (!getSchemaNames(session).contains(schema.orElse(null))) {
+            throw new SchemaNotFoundException(schema.orElse(null));
+        }
+
+        try (Connection connection = connectionFactory.openConnection(session)) {
+            boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
+            if (uppercase) {
+                schema = schema.map(schemaName -> schemaName.toUpperCase(ENGLISH));
+                table = table.toUpperCase(ENGLISH);
+            }
+            schema = toPhoenixSchemaName(schema);
+            LinkedList<ColumnMetadata> tableColumns = new LinkedList<>(tableMetadata.getColumns());
+            Map<String, Object> tableProperties = tableMetadata.getProperties();
+            Optional<Boolean> immutableRows = PhoenixTableProperties.getImmutableRows(tableProperties);
+            String immutable = immutableRows.isPresent() && immutableRows.get() ? "IMMUTABLE" : "";
+
+            ImmutableList.Builder<String> columnNames = ImmutableList.builder();
+            ImmutableList.Builder<Type> columnTypes = ImmutableList.builder();
+            ImmutableList.Builder<String> columnList = ImmutableList.builder();
+            Set<ColumnMetadata> rowkeyColumns = tableColumns.stream().filter(col -> isPrimaryKey(col, tableProperties)).collect(toSet());
+            ImmutableList.Builder<String> pkNames = ImmutableList.builder();
+            Optional<String> rowkeyColumn = Optional.empty();
+            if (rowkeyColumns.isEmpty()) {
+                // Add a rowkey when not specified in DDL
+                columnList.add(ROWKEY + " bigint not null");
+                pkNames.add(ROWKEY);
+                execute(session, format("CREATE SEQUENCE %s", getEscapedTableName(schema, table + "_sequence")));
+                rowkeyColumn = Optional.of(ROWKEY);
+            }
+            for (ColumnMetadata column : tableColumns) {
+                String columnName = column.getName();
+                if (uppercase) {
+                    columnName = columnName.toUpperCase(ENGLISH);
+                }
+                columnNames.add(columnName);
+                columnTypes.add(column.getType());
+                String typeStatement = toWriteMapping(session, column.getType()).getDataType();
+                if (rowkeyColumns.contains(column)) {
+                    typeStatement += " not null";
+                    pkNames.add(columnName);
+                }
+                columnList.add(format("%s %s", getEscapedArgument(columnName), typeStatement));
+            }
+
+            ImmutableList.Builder<String> tableOptions = ImmutableList.builder();
+            PhoenixTableProperties.getSaltBuckets(tableProperties).ifPresent(value -> tableOptions.add(TableProperty.SALT_BUCKETS + "=" + value));
+            PhoenixTableProperties.getSplitOn(tableProperties).ifPresent(value -> tableOptions.add("SPLIT ON (" + value.replace('"', '\'') + ")"));
+            PhoenixTableProperties.getDisableWal(tableProperties).ifPresent(value -> tableOptions.add(TableProperty.DISABLE_WAL + "=" + value));
+            PhoenixTableProperties.getDefaultColumnFamily(tableProperties).ifPresent(value -> tableOptions.add(TableProperty.DEFAULT_COLUMN_FAMILY + "=" + value));
+            PhoenixTableProperties.getBloomfilter(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.BLOOMFILTER + "='" + value + "'"));
+            PhoenixTableProperties.getVersions(tableProperties).ifPresent(value -> tableOptions.add(HConstants.VERSIONS + "=" + value));
+            PhoenixTableProperties.getMinVersions(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.MIN_VERSIONS + "=" + value));
+            PhoenixTableProperties.getCompression(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.COMPRESSION + "='" + value + "'"));
+            PhoenixTableProperties.getTimeToLive(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.TTL + "=" + value));
+            PhoenixTableProperties.getDataBlockEncoding(tableProperties).ifPresent(value -> tableOptions.add(HColumnDescriptor.DATA_BLOCK_ENCODING + "='" + value + "'"));
+
+            String sql = format(
+                    "CREATE %s TABLE %s (%s , CONSTRAINT PK PRIMARY KEY (%s)) %s",
+                    immutable,
+                    getEscapedTableName(schema, table),
+                    join(", ", columnList.build()),
+                    join(", ", pkNames.build()),
+                    join(", ", tableOptions.build()));
+
+            execute(session, sql);
+
+            return new PhoenixOutputTableHandle(
+                    schema,
+                    table,
+                    columnNames.build(),
+                    columnTypes.build(),
+                    Optional.empty(),
+                    rowkeyColumn);
+        }
+        catch (SQLException e) {
+            if (e.getErrorCode() == SQLExceptionCode.TABLE_ALREADY_EXIST.getErrorCode()) {
+                throw new TrinoException(ALREADY_EXISTS, "Phoenix table already exists", e);
+            }
+            throw new TrinoException(PHOENIX_METADATA_ERROR, "Error creating Phoenix table", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getTableProperties(ConnectorSession session, JdbcTableHandle handle)
+    {
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+
+        try (PhoenixConnection connection = (PhoenixConnection) connectionFactory.openConnection(session);
+                HBaseAdmin admin = connection.getQueryServices().getAdmin()) {
+            String schemaName = toPhoenixSchemaName(Optional.ofNullable(handle.getSchemaName())).orElse(null);
+            PTable table = getTable(connection, SchemaUtil.getTableName(schemaName, handle.getTableName()));
+
+            boolean salted = table.getBucketNum() != null;
+            StringJoiner joiner = new StringJoiner(",");
+            List<PColumn> pkColumns = table.getPKColumns();
+            for (PColumn pkColumn : pkColumns.subList(salted ? 1 : 0, pkColumns.size())) {
+                joiner.add(pkColumn.getName().getString());
+            }
+            properties.put(PhoenixTableProperties.ROWKEYS, joiner.toString());
+
+            if (table.getBucketNum() != null) {
+                properties.put(PhoenixTableProperties.SALT_BUCKETS, table.getBucketNum());
+            }
+            if (table.isWALDisabled()) {
+                properties.put(PhoenixTableProperties.DISABLE_WAL, table.isWALDisabled());
+            }
+            if (table.isImmutableRows()) {
+                properties.put(PhoenixTableProperties.IMMUTABLE_ROWS, table.isImmutableRows());
+            }
+
+            String defaultFamilyName = QueryConstants.DEFAULT_COLUMN_FAMILY;
+            if (table.getDefaultFamilyName() != null) {
+                defaultFamilyName = table.getDefaultFamilyName().getString();
+                properties.put(PhoenixTableProperties.DEFAULT_COLUMN_FAMILY, defaultFamilyName);
+            }
+
+            HTableDescriptor tableDesc = admin.getTableDescriptor(table.getPhysicalName().getBytes());
+
+            HColumnDescriptor[] columnFamilies = tableDesc.getColumnFamilies();
+            for (HColumnDescriptor columnFamily : columnFamilies) {
+                if (columnFamily.getNameAsString().equals(defaultFamilyName)) {
+                    if (columnFamily.getBloomFilterType() != BloomType.NONE) {
+                        properties.put(PhoenixTableProperties.BLOOMFILTER, columnFamily.getBloomFilterType());
+                    }
+                    if (columnFamily.getMaxVersions() != 1) {
+                        properties.put(PhoenixTableProperties.VERSIONS, columnFamily.getMaxVersions());
+                    }
+                    if (columnFamily.getMinVersions() > 0) {
+                        properties.put(PhoenixTableProperties.MIN_VERSIONS, columnFamily.getMinVersions());
+                    }
+                    if (columnFamily.getCompression() != Compression.Algorithm.NONE) {
+                        properties.put(PhoenixTableProperties.COMPRESSION, columnFamily.getCompression());
+                    }
+                    if (columnFamily.getTimeToLive() < FOREVER) {
+                        properties.put(PhoenixTableProperties.TTL, columnFamily.getTimeToLive());
+                    }
+                    if (columnFamily.getDataBlockEncoding() != DataBlockEncoding.NONE) {
+                        properties.put(PhoenixTableProperties.DATA_BLOCK_ENCODING, columnFamily.getDataBlockEncoding());
+                    }
+                    break;
+                }
+            }
+        }
+        catch (IOException | SQLException e) {
+            throw new TrinoException(PHOENIX_METADATA_ERROR, "Couldn't get Phoenix table properties", e);
+        }
+        return properties.build();
+    }
+
+    private static ColumnMapping arrayColumnMapping(ConnectorSession session, ArrayType arrayType, String elementJdbcTypeName)
+    {
+        return ColumnMapping.objectMapping(
+                arrayType,
+                arrayReadFunction(session, arrayType.getElementType()),
+                arrayWriteFunction(session, arrayType.getElementType(), elementJdbcTypeName));
+    }
+
+    private static ObjectReadFunction arrayReadFunction(ConnectorSession session, Type elementType)
+    {
+        return ObjectReadFunction.of(Block.class, (resultSet, columnIndex) -> {
+            Object[] objectArray = toBoxedArray(resultSet.getArray(columnIndex).getArray());
+            return jdbcObjectArrayToBlock(session, elementType, objectArray);
+        });
+    }
+
+    private static ObjectWriteFunction arrayWriteFunction(ConnectorSession session, Type elementType, String elementJdbcTypeName)
+    {
+        return ObjectWriteFunction.of(Block.class, (statement, index, block) -> {
+            Array jdbcArray = statement.getConnection().createArrayOf(elementJdbcTypeName, getJdbcObjectArray(session, elementType, block));
+            statement.setArray(index, jdbcArray);
+        });
+    }
+
+    private JdbcTypeHandle getArrayElementTypeHandle(JdbcTypeHandle arrayTypeHandle)
+    {
+        String arrayTypeName = arrayTypeHandle.getJdbcTypeName()
+                .orElseThrow(() -> new TrinoException(PHOENIX_METADATA_ERROR, "Type name is missing for jdbc type: " + JDBCType.valueOf(arrayTypeHandle.getJdbcType())));
+        checkArgument(arrayTypeName.endsWith(" ARRAY"), "array type must end with ' ARRAY'");
+        arrayTypeName = arrayTypeName.substring(0, arrayTypeName.length() - " ARRAY".length());
+        verify(arrayTypeHandle.getCaseSensitivity().isEmpty(), "Case sensitivity not supported");
+        return new JdbcTypeHandle(
+                PDataType.fromSqlTypeName(arrayTypeName).getSqlType(),
+                Optional.of(arrayTypeName),
+                arrayTypeHandle.getColumnSize(),
+                arrayTypeHandle.getDecimalDigits(),
+                arrayTypeHandle.getArrayDimensions(),
+                Optional.empty());
+    }
+
+    public QueryPlan getQueryPlan(PhoenixPreparedStatement inputQuery)
+    {
+        try {
+            // Optimize the query plan so that we potentially use secondary indexes
+            QueryPlan queryPlan = inputQuery.optimizeQuery();
+            // Initialize the query plan so it sets up the parallel scans
+            queryPlan.iterator(MapReduceParallelScanGrouper.getInstance());
+            return queryPlan;
+        }
+        catch (SQLException e) {
+            throw new TrinoException(PHOENIX_QUERY_ERROR, "Failed to get the Phoenix query plan", e);
+        }
+    }
+
+    private static ResultSet getResultSet(PhoenixInputSplit split, QueryPlan queryPlan)
+    {
+        List<Scan> scans = split.getScans();
+        try {
+            List<PeekingResultIterator> iterators = new ArrayList<>(scans.size());
+            StatementContext context = queryPlan.getContext();
+            // Clear the table region boundary cache to make sure long running jobs stay up to date
+            PName physicalTableName = queryPlan.getTableRef().getTable().getPhysicalName();
+            PhoenixConnection phoenixConnection = context.getConnection();
+            ConnectionQueryServices services = phoenixConnection.getQueryServices();
+            services.clearTableRegionCache(physicalTableName.getBytes());
+
+            for (Scan scan : scans) {
+                scan = new Scan(scan);
+                // For MR, skip the region boundary check exception if we encounter a split. ref: PHOENIX-2599
+                scan.setAttribute(SKIP_REGION_BOUNDARY_CHECK, Bytes.toBytes(true));
+
+                ScanMetricsHolder scanMetricsHolder = ScanMetricsHolder.getInstance(
+                        context.getReadMetricsQueue(),
+                        physicalTableName.getString(),
+                        scan,
+                        phoenixConnection.getLogLevel());
+
+                TableResultIterator tableResultIterator = new TableResultIterator(
+                        phoenixConnection.getMutationState(),
+                        scan,
+                        scanMetricsHolder,
+                        services.getRenewLeaseThresholdMilliSeconds(),
+                        queryPlan,
+                        MapReduceParallelScanGrouper.getInstance());
+                iterators.add(LookAheadResultIterator.wrap(tableResultIterator));
+            }
+            ResultIterator iterator = queryPlan.useRoundRobinIterator() ? RoundRobinResultIterator.newIterator(iterators, queryPlan) : ConcatResultIterator.newIterator(iterators);
+            if (context.getSequenceManager().getSequenceCount() > 0) {
+                iterator = new SequenceResultIterator(iterator, context.getSequenceManager());
+            }
+            // Clone the row projector as it's not thread safe and would be used simultaneously by
+            // multiple threads otherwise.
+            return new PhoenixResultSet(iterator, queryPlan.getProjector().cloneIfNecessary(), context);
+        }
+        catch (SQLException e) {
+            throw new TrinoException(PHOENIX_QUERY_ERROR, "Error while setting up Phoenix ResultSet", e);
+        }
+        catch (IOException e) {
+            throw new TrinoException(PhoenixErrorCode.PHOENIX_INTERNAL_ERROR, "Error while copying scan", e);
+        }
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixClientModule.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixClientModule.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.inject.Binder;
+import com.google.inject.Key;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.airlift.log.Logger;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorPageSinkProvider;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager;
+import io.trino.plugin.base.classloader.ForClassLoaderSafe;
+import io.trino.plugin.base.util.LoggingInvocationHandler;
+import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DriverConnectionFactory;
+import io.trino.plugin.jdbc.ForwardingJdbcClient;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcMetadataConfig;
+import io.trino.plugin.jdbc.JdbcMetadataSessionProperties;
+import io.trino.plugin.jdbc.JdbcPageSinkProvider;
+import io.trino.plugin.jdbc.JdbcRecordSetProvider;
+import io.trino.plugin.jdbc.MaxDomainCompactionThreshold;
+import io.trino.plugin.jdbc.TypeHandlingJdbcConfig;
+import io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties;
+import io.trino.plugin.jdbc.credential.EmptyCredentialProvider;
+import io.trino.plugin.jdbc.jmx.StatisticsAwareConnectionFactory;
+import io.trino.plugin.jdbc.jmx.StatisticsAwareJdbcClient;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorPageSinkProvider;
+import io.trino.spi.connector.ConnectorRecordSetProvider;
+import io.trino.spi.connector.ConnectorSplitManager;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.phoenix.jdbc.PhoenixDriver;
+import org.apache.phoenix.jdbc.PhoenixEmbeddedDriver;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Properties;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.reflect.Reflection.newProxy;
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
+import static io.trino.plugin.jdbc.JdbcModule.bindTablePropertiesProvider;
+import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_CONFIG_ERROR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class PhoenixClientModule
+        extends AbstractConfigurationAwareModule
+{
+    private final String catalogName;
+
+    public PhoenixClientModule(String catalogName)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        binder.bind(ConnectorSplitManager.class).annotatedWith(ForClassLoaderSafe.class).to(PhoenixSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorSplitManager.class).to(ClassLoaderSafeConnectorSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorRecordSetProvider.class).to(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorPageSinkProvider.class).annotatedWith(ForClassLoaderSafe.class).to(JdbcPageSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorPageSinkProvider.class).to(ClassLoaderSafeConnectorPageSinkProvider.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class));
+
+        configBinder(binder).bindConfig(TypeHandlingJdbcConfig.class);
+        bindSessionPropertiesProvider(binder, TypeHandlingJdbcSessionProperties.class);
+        bindSessionPropertiesProvider(binder, JdbcMetadataSessionProperties.class);
+
+        configBinder(binder).bindConfig(JdbcMetadataConfig.class);
+        configBinder(binder).bindConfigDefaults(JdbcMetadataConfig.class, config -> config.setAllowDropTable(true));
+
+        binder.bind(PhoenixClient.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorMetadata.class).annotatedWith(ForClassLoaderSafe.class).to(PhoenixMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(ConnectorMetadata.class).to(ClassLoaderSafeConnectorMetadata.class).in(Scopes.SINGLETON);
+
+        bindTablePropertiesProvider(binder, PhoenixTableProperties.class);
+        binder.bind(PhoenixColumnProperties.class).in(Scopes.SINGLETON);
+
+        binder.bind(PhoenixConnector.class).in(Scopes.SINGLETON);
+
+        checkConfiguration(buildConfigObject(PhoenixConfig.class).getConnectionUrl());
+
+        newExporter(binder).export(JdbcClient.class)
+                .as(generator -> generator.generatedNameOf(JdbcClient.class, catalogName));
+        newExporter(binder).export(ConnectionFactory.class)
+                .as(generator -> generator.generatedNameOf(ConnectionFactory.class, catalogName));
+    }
+
+    private void checkConfiguration(String connectionUrl)
+    {
+        try {
+            PhoenixDriver driver = PhoenixDriver.INSTANCE;
+            checkArgument(driver.acceptsURL(connectionUrl), "Invalid JDBC URL for Phoenix connector");
+        }
+        catch (SQLException e) {
+            throw new TrinoException(PHOENIX_CONFIG_ERROR, e);
+        }
+    }
+
+    @Provides
+    @Singleton
+    public JdbcClient createJdbcClientWithStats(PhoenixClient client)
+    {
+        StatisticsAwareJdbcClient statisticsAwareJdbcClient = new StatisticsAwareJdbcClient(client);
+
+        Logger logger = Logger.get(format("io.trino.plugin.jdbc.%s.jdbcclient", catalogName));
+
+        JdbcClient loggingInvocationsJdbcClient = newProxy(JdbcClient.class, new LoggingInvocationHandler(
+                statisticsAwareJdbcClient,
+                new LoggingInvocationHandler.ReflectiveParameterNamesProvider(),
+                logger::debug));
+
+        return ForwardingJdbcClient.of(() -> {
+            if (logger.isDebugEnabled()) {
+                return loggingInvocationsJdbcClient;
+            }
+            return statisticsAwareJdbcClient;
+        });
+    }
+
+    @Provides
+    @Singleton
+    public ConnectionFactory getConnectionFactory(PhoenixConfig config)
+            throws SQLException
+    {
+        return new StatisticsAwareConnectionFactory(
+                new DriverConnectionFactory(
+                        DriverManager.getDriver(config.getConnectionUrl()),
+                        config.getConnectionUrl(),
+                        getConnectionProperties(config),
+                        new EmptyCredentialProvider()));
+    }
+
+    public static Properties getConnectionProperties(PhoenixConfig config)
+            throws SQLException
+    {
+        Configuration resourcesConfig = readConfig(config);
+        Properties connectionProperties = new Properties();
+        for (Map.Entry<String, String> entry : resourcesConfig) {
+            connectionProperties.setProperty(entry.getKey(), entry.getValue());
+        }
+
+        PhoenixEmbeddedDriver.ConnectionInfo connectionInfo = PhoenixEmbeddedDriver.ConnectionInfo.create(config.getConnectionUrl());
+        connectionInfo.asProps().asMap().forEach(connectionProperties::setProperty);
+        return connectionProperties;
+    }
+
+    private static Configuration readConfig(PhoenixConfig config)
+    {
+        Configuration result = new Configuration(false);
+        for (String resourcePath : config.getResourceConfigFiles()) {
+            result.addResource(new Path(resourcePath));
+        }
+        return result;
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixColumnProperties.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixColumnProperties.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.session.PropertyMetadata;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.trino.plugin.phoenix.PhoenixTableProperties.getRowkeys;
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
+
+public class PhoenixColumnProperties
+{
+    public static final String PRIMARY_KEY = "primary_key";
+
+    private final List<PropertyMetadata<?>> columnProperties;
+
+    @Inject
+    public PhoenixColumnProperties()
+    {
+        columnProperties = ImmutableList.of(
+                booleanProperty(
+                        PRIMARY_KEY,
+                        "True if the column is part of the primary key",
+                        false,
+                        false));
+    }
+
+    public List<PropertyMetadata<?>> getColumnProperties()
+    {
+        return columnProperties;
+    }
+
+    public static boolean isPrimaryKey(ColumnMetadata col, Map<String, Object> tableProperties)
+    {
+        Optional<List<String>> rowkeysTableProp = getRowkeys(tableProperties);
+        if (rowkeysTableProp.isPresent()) {
+            return rowkeysTableProp.get().stream().anyMatch(col.getName()::equalsIgnoreCase);
+        }
+        Boolean isPk = (Boolean) col.getProperties().get(PRIMARY_KEY);
+        return isPk != null && isPk;
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixConfig.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixConfig.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import io.airlift.configuration.Config;
+import io.airlift.configuration.validation.FileExists;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class PhoenixConfig
+{
+    private String connectionUrl;
+    private List<String> resourceConfigFiles = ImmutableList.of();
+    private boolean caseInsensitiveNameMatching;
+    private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
+
+    @NotNull
+    public String getConnectionUrl()
+    {
+        return connectionUrl;
+    }
+
+    @Config("phoenix.connection-url")
+    public PhoenixConfig setConnectionUrl(String connectionUrl)
+    {
+        this.connectionUrl = connectionUrl;
+        return this;
+    }
+
+    @NotNull
+    public List<@FileExists String> getResourceConfigFiles()
+    {
+        return resourceConfigFiles;
+    }
+
+    @Config("phoenix.config.resources")
+    public PhoenixConfig setResourceConfigFiles(String files)
+    {
+        this.resourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files);
+        return this;
+    }
+
+    public boolean isCaseInsensitiveNameMatching()
+    {
+        return caseInsensitiveNameMatching;
+    }
+
+    @Config("case-insensitive-name-matching")
+    public PhoenixConfig setCaseInsensitiveNameMatching(boolean caseInsensitiveNameMatching)
+    {
+        this.caseInsensitiveNameMatching = caseInsensitiveNameMatching;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("0ms")
+    public Duration getCaseInsensitiveNameMatchingCacheTtl()
+    {
+        return caseInsensitiveNameMatchingCacheTtl;
+    }
+
+    @Config("case-insensitive-name-matching.cache-ttl")
+    public PhoenixConfig setCaseInsensitiveNameMatchingCacheTtl(Duration caseInsensitiveNameMatchingCacheTtl)
+    {
+        this.caseInsensitiveNameMatchingCacheTtl = caseInsensitiveNameMatchingCacheTtl;
+        return this;
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixConnector.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixConnector.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.inject.Inject;
+import io.airlift.bootstrap.LifeCycleManager;
+import io.trino.plugin.jdbc.JdbcTransactionHandle;
+import io.trino.plugin.jdbc.SessionPropertiesProvider;
+import io.trino.plugin.jdbc.TablePropertiesProvider;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorPageSinkProvider;
+import io.trino.spi.connector.ConnectorRecordSetProvider;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.transaction.IsolationLevel;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class PhoenixConnector
+        implements Connector
+{
+    private final LifeCycleManager lifeCycleManager;
+    private final ConnectorMetadata metadata;
+    private final ConnectorSplitManager splitManager;
+    private final ConnectorRecordSetProvider recordSetProvider;
+    private final ConnectorPageSinkProvider pageSinkProvider;
+    private final List<PropertyMetadata<?>> tableProperties;
+    private final PhoenixColumnProperties columnProperties;
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public PhoenixConnector(
+            LifeCycleManager lifeCycleManager,
+            ConnectorMetadata metadata,
+            ConnectorSplitManager splitManager,
+            ConnectorRecordSetProvider recordSetProvider,
+            ConnectorPageSinkProvider pageSinkProvider,
+            Set<TablePropertiesProvider> tableProperties,
+            PhoenixColumnProperties columnProperties,
+            Set<SessionPropertiesProvider> sessionProperties)
+    {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+        this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.tableProperties = requireNonNull(tableProperties, "tableProperties is null").stream()
+                .flatMap(tablePropertiesProvider -> tablePropertiesProvider.getTableProperties().stream())
+                .collect(toImmutableList());
+        this.columnProperties = requireNonNull(columnProperties, "columnProperties is null");
+        this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null").stream()
+                .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
+    {
+        return new JdbcTransactionHandle();
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
+    {
+        return metadata;
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return splitManager;
+    }
+
+    @Override
+    public ConnectorRecordSetProvider getRecordSetProvider()
+    {
+        return recordSetProvider;
+    }
+
+    @Override
+    public ConnectorPageSinkProvider getPageSinkProvider()
+    {
+        return pageSinkProvider;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getColumnProperties()
+    {
+        return columnProperties.getColumnProperties();
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    @Override
+    public final void shutdown()
+    {
+        lifeCycleManager.stop();
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixConnectorFactory.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixConnectorFactory.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.inject.Injector;
+import io.airlift.bootstrap.Bootstrap;
+import io.airlift.json.JsonModule;
+import io.trino.plugin.base.jmx.MBeanServerModule;
+import io.trino.spi.classloader.ThreadContextClassLoader;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.ConnectorFactory;
+import io.trino.spi.connector.ConnectorHandleResolver;
+import io.trino.spi.type.TypeManager;
+import org.weakref.jmx.guice.MBeanModule;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class PhoenixConnectorFactory
+        implements ConnectorFactory
+{
+    private final ClassLoader classLoader;
+
+    public PhoenixConnectorFactory(ClassLoader classLoader)
+    {
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return "phoenix";
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver()
+    {
+        return new PhoenixHandleResolver();
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> requiredConfig, ConnectorContext context)
+    {
+        requireNonNull(requiredConfig, "requiredConfig is null");
+
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            Bootstrap app = new Bootstrap(
+                    new JsonModule(),
+                    new MBeanServerModule(),
+                    new MBeanModule(),
+                    new PhoenixClientModule(catalogName),
+                    binder -> {
+                        binder.bind(ClassLoader.class).toInstance(PhoenixConnectorFactory.class.getClassLoader());
+                        binder.bind(TypeManager.class).toInstance(context.getTypeManager());
+                    });
+
+            Injector injector = app
+                    .strictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(requiredConfig)
+                    .initialize();
+
+            return injector.getInstance(PhoenixConnector.class);
+        }
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixConnectorFactory.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixConnectorFactory.java
@@ -42,7 +42,7 @@ public class PhoenixConnectorFactory
     @Override
     public String getName()
     {
-        return "phoenix";
+        return "phoenix-5";
     }
 
     @Override

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixErrorCode.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixErrorCode.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import io.trino.spi.ErrorCode;
+import io.trino.spi.ErrorCodeSupplier;
+import io.trino.spi.ErrorType;
+
+import static io.trino.spi.ErrorType.EXTERNAL;
+import static io.trino.spi.ErrorType.INTERNAL_ERROR;
+
+public enum PhoenixErrorCode
+        implements ErrorCodeSupplier
+{
+    PHOENIX_INTERNAL_ERROR(0, INTERNAL_ERROR),
+    PHOENIX_QUERY_ERROR(1, EXTERNAL),
+    PHOENIX_CONFIG_ERROR(2, INTERNAL_ERROR),
+    PHOENIX_METADATA_ERROR(3, EXTERNAL),
+    PHOENIX_SPLIT_ERROR(4, EXTERNAL);
+
+    private final ErrorCode errorCode;
+
+    PhoenixErrorCode(int code, ErrorType type)
+    {
+        errorCode = new ErrorCode(code + 0x0106_0000, name(), type);
+    }
+
+    @Override
+    public ErrorCode toErrorCode()
+    {
+        return errorCode;
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixHandleResolver.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixHandleResolver.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.JdbcTransactionHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorHandleResolver;
+import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.ConnectorOutputTableHandle;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+
+public class PhoenixHandleResolver
+        implements ConnectorHandleResolver
+{
+    @Override
+    public Class<? extends ConnectorTransactionHandle> getTransactionHandleClass()
+    {
+        return JdbcTransactionHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTableHandle> getTableHandleClass()
+    {
+        return JdbcTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ColumnHandle> getColumnHandleClass()
+    {
+        return JdbcColumnHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorSplit> getSplitClass()
+    {
+        return PhoenixSplit.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorOutputTableHandle> getOutputTableHandleClass()
+    {
+        return PhoenixOutputTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
+    {
+        return PhoenixOutputTableHandle.class;
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import io.airlift.slice.Slice;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcMetadata;
+import io.trino.plugin.jdbc.JdbcMetadataConfig;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.AggregationApplicationResult;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorInsertTableHandle;
+import io.trino.spi.connector.ConnectorNewTableLayout;
+import io.trino.spi.connector.ConnectorOutputMetadata;
+import io.trino.spi.connector.ConnectorOutputTableHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.security.TrinoPrincipal;
+import io.trino.spi.statistics.ComputedStatistics;
+
+import javax.inject.Inject;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.phoenix.MetadataUtil.getEscapedTableName;
+import static io.trino.plugin.phoenix.MetadataUtil.toPrestoSchemaName;
+import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_METADATA_ERROR;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static org.apache.phoenix.util.SchemaUtil.getEscapedArgument;
+
+public class PhoenixMetadata
+        extends JdbcMetadata
+{
+    // Maps to Phoenix's default empty schema
+    public static final String DEFAULT_SCHEMA = "default";
+    // col name used for PK if none provided in DDL
+    private static final String ROWKEY = "ROWKEY";
+    private final PhoenixClient phoenixClient;
+
+    @Inject
+    public PhoenixMetadata(PhoenixClient phoenixClient, JdbcMetadataConfig metadataConfig)
+    {
+        super(phoenixClient, metadataConfig.isAllowDropTable());
+        this.phoenixClient = requireNonNull(phoenixClient, "client is null");
+    }
+
+    @Override
+    public JdbcTableHandle getTableHandle(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        return phoenixClient.getTableHandle(session, schemaTableName)
+                .map(tableHandle -> new JdbcTableHandle(
+                        schemaTableName,
+                        tableHandle.getCatalogName(),
+                        toPrestoSchemaName(Optional.ofNullable(tableHandle.getSchemaName())).orElse(null),
+                        tableHandle.getTableName()))
+                .orElse(null);
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+    {
+        return getTableMetadata(session, table, false);
+    }
+
+    private ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table, boolean rowkeyRequired)
+    {
+        JdbcTableHandle handle = (JdbcTableHandle) table;
+        List<ColumnMetadata> columnMetadata = phoenixClient.getColumns(session, handle).stream()
+                .filter(column -> rowkeyRequired || !ROWKEY.equalsIgnoreCase(column.getColumnName()))
+                .map(JdbcColumnHandle::getColumnMetadata)
+                .collect(toImmutableList());
+        return new ConnectorTableMetadata(handle.getRequiredNamedRelation().getSchemaTableName(), columnMetadata, phoenixClient.getTableProperties(session, handle));
+    }
+
+    @Override
+    public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, TrinoPrincipal owner)
+    {
+        checkArgument(properties.isEmpty(), "Can't have properties for schema creation");
+        if (DEFAULT_SCHEMA.equalsIgnoreCase(schemaName)) {
+            throw new TrinoException(NOT_SUPPORTED, "Can't create 'default' schema which maps to Phoenix empty schema");
+        }
+        phoenixClient.execute(session, format("CREATE SCHEMA %s", getEscapedArgument(toMetadataCasing(session, schemaName))));
+    }
+
+    @Override
+    public void dropSchema(ConnectorSession session, String schemaName)
+    {
+        if (DEFAULT_SCHEMA.equalsIgnoreCase(schemaName)) {
+            throw new TrinoException(NOT_SUPPORTED, "Can't drop 'default' schema which maps to Phoenix empty schema");
+        }
+        phoenixClient.execute(session, format("DROP SCHEMA %s", getEscapedArgument(toMetadataCasing(session, schemaName))));
+    }
+
+    private String toMetadataCasing(ConnectorSession session, String schemaName)
+    {
+        try (Connection connection = phoenixClient.getConnection(session)) {
+            boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
+            if (uppercase) {
+                schemaName = schemaName.toUpperCase(ENGLISH);
+            }
+        }
+        catch (SQLException e) {
+            throw new TrinoException(PHOENIX_METADATA_ERROR, "Couldn't get casing for the schema name", e);
+        }
+        return schemaName;
+    }
+
+    @Override
+    public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+    {
+        phoenixClient.beginCreateTable(session, tableMetadata);
+    }
+
+    @Override
+    public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
+    {
+        return phoenixClient.beginCreateTable(session, tableMetadata);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean supportsMissingColumnsOnInsert()
+    {
+        return true;
+    }
+
+    @Override
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns)
+    {
+        JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
+        Optional<String> rowkeyColumn = phoenixClient.getColumns(session, handle).stream()
+                .map(JdbcColumnHandle::getColumnName)
+                .filter(ROWKEY::equalsIgnoreCase)
+                .findFirst();
+
+        List<JdbcColumnHandle> columnHandles = columns.stream()
+                .map(JdbcColumnHandle.class::cast)
+                .collect(toImmutableList());
+
+        return new PhoenixOutputTableHandle(
+                Optional.ofNullable(handle.getSchemaName()),
+                handle.getTableName(),
+                columnHandles.stream().map(JdbcColumnHandle::getColumnName).collect(toImmutableList()),
+                columnHandles.stream().map(JdbcColumnHandle::getColumnType).collect(toImmutableList()),
+                Optional.of(columnHandles.stream().map(JdbcColumnHandle::getJdbcTypeHandle).collect(toImmutableList())),
+                rowkeyColumn);
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
+    {
+        JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
+        phoenixClient.execute(session, format(
+                "ALTER TABLE %s ADD %s %s",
+                getEscapedTableName(Optional.ofNullable(handle.getSchemaName()), handle.getTableName()),
+                column.getName(),
+                phoenixClient.toWriteMapping(session, column.getType()).getDataType()));
+    }
+
+    @Override
+    public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
+    {
+        JdbcTableHandle handle = (JdbcTableHandle) tableHandle;
+        JdbcColumnHandle columnHandle = (JdbcColumnHandle) column;
+        phoenixClient.execute(session, format(
+                "ALTER TABLE %s DROP COLUMN %s",
+                getEscapedTableName(Optional.ofNullable(handle.getSchemaName()), handle.getTableName()),
+                columnHandle.getColumnName()));
+    }
+
+    @Override
+    public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        // if we autogenerated a ROWKEY for this table, delete the associated sequence as well
+        boolean hasRowkey = getColumnHandles(session, tableHandle).values().stream()
+                .map(JdbcColumnHandle.class::cast)
+                .map(JdbcColumnHandle::getColumnName)
+                .anyMatch(ROWKEY::equals);
+        if (hasRowkey) {
+            JdbcTableHandle jdbcHandle = (JdbcTableHandle) tableHandle;
+            phoenixClient.execute(session, format("DROP SEQUENCE %s", getEscapedTableName(Optional.ofNullable(jdbcHandle.getSchemaName()), jdbcHandle.getTableName() + "_sequence")));
+        }
+        phoenixClient.dropTable(session, (JdbcTableHandle) tableHandle);
+    }
+
+    @Override
+    public Optional<AggregationApplicationResult<ConnectorTableHandle>> applyAggregation(
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            List<AggregateFunction> aggregates,
+            Map<String, ColumnHandle> assignments,
+            List<List<ColumnHandle>> groupingSets)
+    {
+        // TODO support aggregation pushdown
+        return Optional.empty();
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixOutputTableHandle.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixOutputTableHandle.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.plugin.jdbc.JdbcOutputTableHandle;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.spi.type.Type;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class PhoenixOutputTableHandle
+        extends JdbcOutputTableHandle
+{
+    private final Optional<String> rowkeyColumn;
+
+    @JsonCreator
+    public PhoenixOutputTableHandle(
+            @JsonProperty("schemaName") Optional<String> schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("columnNames") List<String> columnNames,
+            @JsonProperty("columnTypes") List<Type> columnTypes,
+            @JsonProperty("jdbcColumnTypes") Optional<List<JdbcTypeHandle>> jdbcColumnTypes,
+            @JsonProperty("rowkeyColumn") Optional<String> rowkeyColumn)
+    {
+        super("", schemaName.orElse(null), tableName, columnNames, columnTypes, jdbcColumnTypes, "");
+        this.rowkeyColumn = requireNonNull(rowkeyColumn, "rowkeyColumn is null");
+    }
+
+    @JsonProperty
+    public Optional<String> rowkeyColumn()
+    {
+        return rowkeyColumn;
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixPlugin.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Plugin;
+import io.trino.spi.connector.ConnectorFactory;
+
+public class PhoenixPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(new PhoenixConnectorFactory(PhoenixPlugin.class.getClassLoader()));
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixSplit.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixSplit.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.plugin.jdbc.JdbcSplit;
+import io.trino.spi.HostAddress;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.predicate.TupleDomain;
+import org.apache.phoenix.mapreduce.PhoenixInputSplit;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class PhoenixSplit
+        extends JdbcSplit
+{
+    private final List<HostAddress> addresses;
+    private final WrappedPhoenixInputSplit phoenixInputSplit;
+    private final TupleDomain<ColumnHandle> constraint;
+
+    @JsonCreator
+    public PhoenixSplit(
+            @JsonProperty("addresses") List<HostAddress> addresses,
+            @JsonProperty("phoenixInputSplit") WrappedPhoenixInputSplit wrappedPhoenixInputSplit,
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
+    {
+        super(Optional.empty());
+        this.addresses = requireNonNull(addresses, "addresses is null");
+        this.phoenixInputSplit = requireNonNull(wrappedPhoenixInputSplit, "wrappedPhoenixInputSplit is null");
+        this.constraint = requireNonNull(constraint, "constraint is null");
+    }
+
+    @JsonProperty
+    @Override
+    public List<HostAddress> getAddresses()
+    {
+        return addresses;
+    }
+
+    @JsonProperty("phoenixInputSplit")
+    public WrappedPhoenixInputSplit getWrappedPhoenixInputSplit()
+    {
+        return phoenixInputSplit;
+    }
+
+    @JsonIgnore
+    public PhoenixInputSplit getPhoenixInputSplit()
+    {
+        return phoenixInputSplit.getPhoenixInputSplit();
+    }
+
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getConstraint()
+    {
+        return constraint;
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.PreparedQuery;
+import io.trino.plugin.jdbc.QueryBuilder;
+import io.trino.spi.HostAddress;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorSplitSource;
+import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.FixedSplitSource;
+import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.RegionLocator;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.phoenix.compile.QueryPlan;
+import org.apache.phoenix.jdbc.PhoenixConnection;
+import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
+import org.apache.phoenix.mapreduce.PhoenixInputSplit;
+import org.apache.phoenix.query.KeyRange;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_INTERNAL_ERROR;
+import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_SPLIT_ERROR;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.EXPECTED_UPPER_REGION_KEY;
+
+public class PhoenixSplitManager
+        implements ConnectorSplitManager
+{
+    private static final Logger log = Logger.get(PhoenixSplitManager.class);
+
+    private final PhoenixClient phoenixClient;
+
+    @Inject
+    public PhoenixSplitManager(PhoenixClient phoenixClient)
+    {
+        this.phoenixClient = requireNonNull(phoenixClient, "client is null");
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transaction,
+            ConnectorSession session,
+            ConnectorTableHandle table,
+            SplitSchedulingStrategy splitSchedulingStrategy,
+            DynamicFilter dynamicFilter)
+    {
+        JdbcTableHandle tableHandle = (JdbcTableHandle) table;
+        try (PhoenixConnection connection = phoenixClient.getConnection(session)) {
+            List<JdbcColumnHandle> columns = tableHandle.getColumns()
+                    .map(columnSet -> columnSet.stream().map(JdbcColumnHandle.class::cast).collect(toList()))
+                    .orElseGet(() -> phoenixClient.getColumns(session, tableHandle));
+            QueryBuilder queryBuilder = new QueryBuilder(phoenixClient);
+            PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+                    session,
+                    connection,
+                    tableHandle.getRelationHandle(),
+                    Optional.empty(),
+                    columns,
+                    ImmutableMap.of(),
+                    tableHandle.getConstraint(),
+                    Optional.empty());
+            PhoenixPreparedStatement inputQuery = (PhoenixPreparedStatement) queryBuilder.prepareStatement(session, connection, preparedQuery);
+
+            List<ConnectorSplit> splits = getSplits(inputQuery).stream()
+                    .map(PhoenixInputSplit.class::cast)
+                    .map(split -> new PhoenixSplit(
+                            getSplitAddresses(split),
+                            new WrappedPhoenixInputSplit(split),
+                            tableHandle.getConstraint()))
+                    .collect(toImmutableList());
+            return new FixedSplitSource(splits);
+        }
+        catch (IOException | SQLException e) {
+            throw new TrinoException(PHOENIX_SPLIT_ERROR, "Couldn't get Phoenix splits", e);
+        }
+    }
+
+    private List<HostAddress> getSplitAddresses(PhoenixInputSplit split)
+    {
+        try {
+            return ImmutableList.of(HostAddress.fromString(split.getLocations()[0]));
+        }
+        catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new TrinoException(PHOENIX_INTERNAL_ERROR, "Exception when getting split addresses", e);
+        }
+    }
+
+    private List<InputSplit> getSplits(PhoenixPreparedStatement inputQuery)
+            throws IOException
+    {
+        QueryPlan queryPlan = phoenixClient.getQueryPlan(inputQuery);
+        return generateSplits(queryPlan, queryPlan.getSplits());
+    }
+
+    // mostly copied from PhoenixInputFormat, but without the region size calculations
+    private List<InputSplit> generateSplits(QueryPlan queryPlan, List<KeyRange> splits)
+            throws IOException
+    {
+        requireNonNull(queryPlan, "queryPlan is null");
+        requireNonNull(splits, "splits is null");
+
+        try (org.apache.hadoop.hbase.client.Connection connection = phoenixClient.getHConnection()) {
+            RegionLocator regionLocator = connection.getRegionLocator(TableName.valueOf(queryPlan.getTableRef().getTable().getPhysicalName().toString()));
+            long regionSize = -1;
+            List<InputSplit> inputSplits = new ArrayList<>(splits.size());
+            for (List<Scan> scans : queryPlan.getScans()) {
+                HRegionLocation location = regionLocator.getRegionLocation(scans.get(0).getStartRow(), false);
+                String regionLocation = location.getHostname();
+
+                if (log.isDebugEnabled()) {
+                    log.debug(
+                            "Scan count[%d] : %s ~ %s",
+                            scans.size(),
+                            Bytes.toStringBinary(scans.get(0).getStartRow()),
+                            Bytes.toStringBinary(scans.get(scans.size() - 1).getStopRow()));
+                    log.debug("First scan : %swith scanAttribute : %s [scanCache, cacheBlock, scanBatch] : [%d, %s, %d] and  regionLocation : %s",
+                            scans.get(0), scans.get(0).getAttributesMap(), scans.get(0).getCaching(), scans.get(0).getCacheBlocks(), scans.get(0).getBatch(), regionLocation);
+                    for (int i = 0, limit = scans.size(); i < limit; i++) {
+                        log.debug("EXPECTED_UPPER_REGION_KEY[%d] : %s", i, Bytes.toStringBinary(scans.get(i).getAttribute(EXPECTED_UPPER_REGION_KEY)));
+                    }
+                }
+                inputSplits.add(new PhoenixInputSplit(scans, regionSize, regionLocation));
+            }
+            return inputSplits;
+        }
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixTableProperties.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/PhoenixTableProperties.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.jdbc.TablePropertiesProvider;
+import io.trino.spi.session.PropertyMetadata;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.regionserver.BloomType;
+import org.apache.hadoop.util.StringUtils;
+
+import javax.inject.Inject;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.session.PropertyMetadata.booleanProperty;
+import static io.trino.spi.session.PropertyMetadata.enumProperty;
+import static io.trino.spi.session.PropertyMetadata.integerProperty;
+import static io.trino.spi.session.PropertyMetadata.stringProperty;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Class contains all table properties for the Phoenix connector. Used when creating a table:
+ * <p>
+ * <pre>CREATE TABLE foo (a VARCHAR with (primary_key = true), b INT) WITH (SALT_BUCKETS=10, VERSIONS=5, COMPRESSION='lz');</pre>
+ */
+public final class PhoenixTableProperties
+        implements TablePropertiesProvider
+{
+    public static final String ROWKEYS = "rowkeys";
+    public static final String SALT_BUCKETS = "salt_buckets";
+    public static final String SPLIT_ON = "split_on";
+    public static final String DISABLE_WAL = "disable_wal";
+    public static final String IMMUTABLE_ROWS = "immutable_rows";
+    public static final String DEFAULT_COLUMN_FAMILY = "default_column_family";
+    public static final String BLOOMFILTER = "bloomfilter";
+    public static final String VERSIONS = "versions";
+    public static final String MIN_VERSIONS = "min_versions";
+    public static final String COMPRESSION = "compression";
+    public static final String TTL = "ttl";
+    public static final String DATA_BLOCK_ENCODING = "data_block_encoding";
+
+    private final List<PropertyMetadata<?>> tableProperties;
+
+    @Inject
+    public PhoenixTableProperties()
+    {
+        tableProperties = ImmutableList.of(
+                stringProperty(
+                        ROWKEYS,
+                        "Comma-separated list of columns to be the primary key.",
+                        null,
+                        false),
+                integerProperty(
+                        SALT_BUCKETS,
+                        "Number of salt buckets.  This causes an extra byte to be transparently prepended to every row key to ensure an evenly distributed read and write load across all region servers.",
+                        null,
+                        false),
+                stringProperty(
+                        SPLIT_ON,
+                        "Comma-separated list of keys to split on during table creation.",
+                        null,
+                        false),
+                booleanProperty(
+                        DISABLE_WAL,
+                        "If true, causes HBase not to write data to the write-ahead-log, thus making updates faster at the expense of potentially losing data in the event of a region server failure.",
+                        null,
+                        false),
+                booleanProperty(
+                        IMMUTABLE_ROWS,
+                        "Set to true if the table has rows which are write-once, append-only.",
+                        null,
+                        false),
+                stringProperty(
+                        DEFAULT_COLUMN_FAMILY,
+                        "The column family name to use by default.",
+                        null,
+                        false),
+                enumProperty(
+                        BLOOMFILTER,
+                        "NONE, ROW or ROWCOL to enable blooms per column family.",
+                        BloomType.class,
+                        null,
+                        false),
+                integerProperty(
+                        VERSIONS,
+                        "The maximum number of row versions to store, configured per column family via HColumnDescriptor.",
+                        null,
+                        false),
+                integerProperty(
+                        MIN_VERSIONS,
+                        "The minimum number of row versions to store, configured per column family via HColumnDescriptor.",
+                        null,
+                        false),
+                enumProperty(
+                        COMPRESSION,
+                        "Compression algorithm to use for HBase blocks. Options are: SNAPPY, GZIP, LZ, and others.",
+                        Compression.Algorithm.class,
+                        null,
+                        false),
+                integerProperty(
+                        TTL,
+                        "Number of seconds for cell TTL.  HBase will automatically delete rows once the expiration time is reached.",
+                        null,
+                        false),
+                enumProperty(
+                        DATA_BLOCK_ENCODING,
+                        "The block encoding algorithm to use for Cells in HBase blocks. Options are: NONE, PREFIX, DIFF, FAST_DIFF, ROW_INDEX_V1, and others.",
+                        DataBlockEncoding.class,
+                        null,
+                        false));
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getTableProperties()
+    {
+        return tableProperties;
+    }
+
+    public static Optional<Integer> getSaltBuckets(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        Integer value = (Integer) tableProperties.get(SALT_BUCKETS);
+        return Optional.ofNullable(value);
+    }
+
+    public static Optional<String> getSplitOn(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        String value = (String) tableProperties.get(SPLIT_ON);
+        return Optional.ofNullable(value);
+    }
+
+    public static Optional<List<String>> getRowkeys(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        String rowkeysCsv = (String) tableProperties.get(ROWKEYS);
+        if (rowkeysCsv == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(Arrays.stream(StringUtils.split(rowkeysCsv, ','))
+                .map(String::trim)
+                .collect(toImmutableList()));
+    }
+
+    public static Optional<Boolean> getDisableWal(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        Boolean value = (Boolean) tableProperties.get(DISABLE_WAL);
+        return Optional.ofNullable(value);
+    }
+
+    public static Optional<Boolean> getImmutableRows(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        Boolean value = (Boolean) tableProperties.get(IMMUTABLE_ROWS);
+        return Optional.ofNullable(value);
+    }
+
+    public static Optional<String> getDefaultColumnFamily(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        String value = (String) tableProperties.get(DEFAULT_COLUMN_FAMILY);
+        return Optional.ofNullable(value);
+    }
+
+    public static Optional<BloomType> getBloomfilter(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        BloomType value = (BloomType) tableProperties.get(BLOOMFILTER);
+        return Optional.ofNullable(value);
+    }
+
+    public static Optional<Integer> getVersions(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        Integer value = (Integer) tableProperties.get(VERSIONS);
+        return Optional.ofNullable(value);
+    }
+
+    public static Optional<Integer> getMinVersions(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        Integer value = (Integer) tableProperties.get(MIN_VERSIONS);
+        return Optional.ofNullable(value);
+    }
+
+    public static Optional<Compression.Algorithm> getCompression(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        Compression.Algorithm value = (Compression.Algorithm) tableProperties.get(COMPRESSION);
+        return Optional.ofNullable(value);
+    }
+
+    public static Optional<DataBlockEncoding> getDataBlockEncoding(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        DataBlockEncoding value = (DataBlockEncoding) tableProperties.get(DATA_BLOCK_ENCODING);
+        return Optional.ofNullable(value);
+    }
+
+    public static Optional<Integer> getTimeToLive(Map<String, Object> tableProperties)
+    {
+        requireNonNull(tableProperties);
+
+        Integer value = (Integer) tableProperties.get(TTL);
+        if (value == null) {
+            return Optional.empty();
+        }
+        return Optional.of(value);
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/TypeUtils.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/TypeUtils.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.primitives.Shorts;
+import com.google.common.primitives.SignedBytes;
+import io.airlift.slice.Slice;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+import org.joda.time.DateTimeZone;
+import org.joda.time.chrono.ISOChronology;
+
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.sql.Date;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.Decimals.decodeUnscaledValue;
+import static io.trino.spi.type.Decimals.encodeScaledValue;
+import static io.trino.spi.type.Decimals.encodeShortScaledValue;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.TypeUtils.readNativeValue;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.joda.time.DateTimeZone.UTC;
+
+public final class TypeUtils
+{
+    private TypeUtils() {}
+
+    public static String getArrayElementPhoenixTypeName(ConnectorSession session, PhoenixClient client, Type elementType)
+    {
+        if (elementType instanceof VarcharType) {
+            return "VARCHAR";
+        }
+
+        if (elementType instanceof CharType) {
+            return "CHAR";
+        }
+
+        if (elementType instanceof DecimalType) {
+            return "DECIMAL";
+        }
+
+        return client.toWriteMapping(session, elementType).getDataType().toUpperCase(ENGLISH);
+    }
+
+    public static Block jdbcObjectArrayToBlock(ConnectorSession session, Type type, Object[] elements)
+    {
+        BlockBuilder builder = type.createBlockBuilder(null, elements.length);
+        for (Object element : elements) {
+            writeNativeValue(type, builder, jdbcObjectToPrestoNative(session, element, type));
+        }
+        return builder.build();
+    }
+
+    public static Object[] getJdbcObjectArray(ConnectorSession session, Type elementType, Block block)
+    {
+        int positionCount = block.getPositionCount();
+        Object[] valuesArray = new Object[positionCount];
+        int subArrayLength = 1;
+        for (int i = 0; i < positionCount; i++) {
+            Object objectValue = prestoNativeToJdbcObject(session, elementType, readNativeValue(elementType, block, i));
+            valuesArray[i] = objectValue;
+            if (objectValue != null && objectValue.getClass().isArray()) {
+                subArrayLength = Math.max(subArrayLength, Array.getLength(objectValue));
+            }
+        }
+        if (elementType instanceof ArrayType) {
+            handleArrayNulls(valuesArray, subArrayLength);
+        }
+        return valuesArray;
+    }
+
+    public static Object[] toBoxedArray(Object jdbcArray)
+    {
+        requireNonNull(jdbcArray, "jdbcArray is null");
+        checkArgument(jdbcArray.getClass().isArray(), "object is not an array: %s", jdbcArray.getClass().getName());
+
+        if (!jdbcArray.getClass().getComponentType().isPrimitive()) {
+            return (Object[]) jdbcArray;
+        }
+
+        int elementCount = Array.getLength(jdbcArray);
+        Object[] elements = new Object[elementCount];
+        for (int i = 0; i < elementCount; i++) {
+            elements[i] = Array.get(jdbcArray, i);
+        }
+        return elements;
+    }
+
+    private static void handleArrayNulls(Object[] valuesArray, int length)
+    {
+        for (int i = 0; i < valuesArray.length; i++) {
+            if (valuesArray[i] == null) {
+                valuesArray[i] = new Object[length];
+            }
+        }
+    }
+
+    private static Object jdbcObjectToPrestoNative(ConnectorSession session, Object jdbcObject, Type prestoType)
+    {
+        if (jdbcObject == null) {
+            return null;
+        }
+
+        if (BOOLEAN.equals(prestoType)
+                || TINYINT.equals(prestoType)
+                || SMALLINT.equals(prestoType)
+                || INTEGER.equals(prestoType)
+                || BIGINT.equals(prestoType)
+                || DOUBLE.equals(prestoType)) {
+            return jdbcObject;
+        }
+
+        if (prestoType instanceof ArrayType) {
+            return jdbcObjectArrayToBlock(session, ((ArrayType) prestoType).getElementType(), (Object[]) jdbcObject);
+        }
+
+        if (prestoType instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) prestoType;
+            BigDecimal value = (BigDecimal) jdbcObject;
+            if (decimalType.isShort()) {
+                return encodeShortScaledValue(value, decimalType.getScale());
+            }
+            return encodeScaledValue(value, decimalType.getScale());
+        }
+
+        if (REAL.equals(prestoType)) {
+            return floatToRawIntBits((float) jdbcObject);
+        }
+
+        if (DATE.equals(prestoType)) {
+            long localMillis = ((Date) jdbcObject).getTime();
+            // Convert it to a ~midnight in UTC.
+            long utcMillis = ISOChronology.getInstance().getZone().getMillisKeepLocal(UTC, localMillis);
+            // convert to days
+            return MILLISECONDS.toDays(utcMillis);
+        }
+
+        if (prestoType instanceof VarcharType) {
+            return utf8Slice((String) jdbcObject);
+        }
+
+        if (prestoType instanceof CharType) {
+            return utf8Slice(CharMatcher.is(' ').trimTrailingFrom((String) jdbcObject));
+        }
+
+        throw new TrinoException(NOT_SUPPORTED, format("Unsupported type %s and object type %s", prestoType, jdbcObject.getClass()));
+    }
+
+    private static Object prestoNativeToJdbcObject(ConnectorSession session, Type prestoType, Object prestoNative)
+    {
+        if (prestoNative == null) {
+            return null;
+        }
+
+        if (DOUBLE.equals(prestoType) || BOOLEAN.equals(prestoType) || BIGINT.equals(prestoType)) {
+            return prestoNative;
+        }
+
+        if (prestoType instanceof DecimalType) {
+            DecimalType decimalType = (DecimalType) prestoType;
+            if (decimalType.isShort()) {
+                BigInteger unscaledValue = BigInteger.valueOf((long) prestoNative);
+                return new BigDecimal(unscaledValue, decimalType.getScale(), new MathContext(decimalType.getPrecision()));
+            }
+            BigInteger unscaledValue = decodeUnscaledValue((Slice) prestoNative);
+            return new BigDecimal(unscaledValue, decimalType.getScale(), new MathContext(decimalType.getPrecision()));
+        }
+
+        if (REAL.equals(prestoType)) {
+            return intBitsToFloat(toIntExact((long) prestoNative));
+        }
+
+        if (TINYINT.equals(prestoType)) {
+            return SignedBytes.checkedCast((long) prestoNative);
+        }
+
+        if (SMALLINT.equals(prestoType)) {
+            return Shorts.checkedCast((long) prestoNative);
+        }
+
+        if (INTEGER.equals(prestoType)) {
+            return toIntExact((long) prestoNative);
+        }
+
+        if (DATE.equals(prestoType)) {
+            // convert to midnight in default time zone
+            long millis = DAYS.toMillis((long) prestoNative);
+            return new Date(UTC.getMillisKeepLocal(DateTimeZone.getDefault(), millis));
+        }
+
+        if (prestoType instanceof VarcharType || prestoType instanceof CharType) {
+            return ((Slice) prestoNative).toStringUtf8();
+        }
+
+        if (prestoType instanceof ArrayType) {
+            // process subarray of multi-dimensional array
+            return getJdbcObjectArray(session, ((ArrayType) prestoType).getElementType(), (Block) prestoNative);
+        }
+
+        throw new TrinoException(NOT_SUPPORTED, "Unsupported type: " + prestoType);
+    }
+}

--- a/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/WrappedPhoenixInputSplit.java
+++ b/plugin/trino-phoenix-5/src/main/java/io/trino/plugin/phoenix/WrappedPhoenixInputSplit.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.io.ByteStreams;
+import org.apache.hadoop.io.WritableUtils;
+import org.apache.phoenix.mapreduce.PhoenixInputSplit;
+
+import java.io.IOException;
+
+public class WrappedPhoenixInputSplit
+{
+    private final PhoenixInputSplit phoenixInputSplit;
+
+    public WrappedPhoenixInputSplit(PhoenixInputSplit phoenixInputSplit)
+    {
+        this.phoenixInputSplit = phoenixInputSplit;
+    }
+
+    public PhoenixInputSplit getPhoenixInputSplit()
+    {
+        return phoenixInputSplit;
+    }
+
+    @JsonValue
+    public byte[] toBytes()
+    {
+        return WritableUtils.toByteArray(phoenixInputSplit);
+    }
+
+    @JsonCreator
+    public static WrappedPhoenixInputSplit fromBytes(byte[] bytes)
+            throws IOException
+    {
+        PhoenixInputSplit materialized = new PhoenixInputSplit();
+        materialized.readFields(ByteStreams.newDataInput(bytes));
+        return new WrappedPhoenixInputSplit(materialized);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return phoenixInputSplit.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (obj instanceof WrappedPhoenixInputSplit) {
+            PhoenixInputSplit otherSplit = ((WrappedPhoenixInputSplit) obj).getPhoenixInputSplit();
+            return phoenixInputSplit.equals(otherSplit);
+        }
+        return false;
+    }
+}

--- a/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/PhoenixQueryRunner.java
+++ b/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/PhoenixQueryRunner.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.airlift.log.Logging;
+import io.trino.Session;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.intellij.lang.annotations.Language;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.Properties;
+
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.tpch.TpchTable.LINE_ITEM;
+import static io.trino.tpch.TpchTable.ORDERS;
+import static io.trino.tpch.TpchTable.PART_SUPPLIER;
+import static java.lang.String.format;
+
+public final class PhoenixQueryRunner
+{
+    private static final Logger LOG = Logger.get(PhoenixQueryRunner.class);
+    private static final String TPCH_SCHEMA = "tpch";
+
+    private PhoenixQueryRunner()
+    {
+    }
+
+    public static DistributedQueryRunner createPhoenixQueryRunner(TestingPhoenixServer server, Map<String, String> extraProperties)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
+                .setExtraProperties(extraProperties)
+                .build();
+
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
+
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("phoenix.connection-url", server.getJdbcUrl())
+                .put("case-insensitive-name-matching", "true")
+                .build();
+
+        queryRunner.installPlugin(new PhoenixPlugin());
+        queryRunner.createCatalog("phoenix", "phoenix", properties);
+
+        if (!server.isTpchLoaded()) {
+            createSchema(server, TPCH_SCHEMA);
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), TpchTable.getTables());
+            server.setTpchLoaded();
+        }
+        else {
+            server.waitTpchLoaded();
+        }
+
+        return queryRunner;
+    }
+
+    private static void createSchema(TestingPhoenixServer phoenixServer, String schema)
+            throws SQLException
+    {
+        Properties properties = new Properties();
+        properties.setProperty("phoenix.schema.isNamespaceMappingEnabled", "true");
+        try (Connection connection = DriverManager.getConnection(phoenixServer.getJdbcUrl(), properties);
+                Statement statement = connection.createStatement()) {
+            statement.execute(format("CREATE SCHEMA %s", schema));
+        }
+    }
+
+    private static void copyTpchTables(
+            QueryRunner queryRunner,
+            String sourceCatalog,
+            String sourceSchema,
+            Session session,
+            Iterable<TpchTable<?>> tables)
+    {
+        LOG.debug("Loading data from %s.%s...", sourceCatalog, sourceSchema);
+        for (TpchTable<?> table : tables) {
+            copyTable(queryRunner, sourceCatalog, session, sourceSchema, table);
+        }
+    }
+
+    private static void copyTable(
+            QueryRunner queryRunner,
+            String catalog,
+            Session session,
+            String schema,
+            TpchTable<?> table)
+    {
+        QualifiedObjectName source = new QualifiedObjectName(catalog, schema, table.getTableName());
+        String target = table.getTableName();
+        String tableProperties = "";
+        if (LINE_ITEM.getTableName().equals(target)) {
+            tableProperties = "WITH (ROWKEYS = 'ORDERKEY,LINENUMBER', SALT_BUCKETS=10)";
+        }
+        else if (ORDERS.getTableName().equals(target)) {
+            tableProperties = "WITH (SALT_BUCKETS=10)";
+        }
+        else if (PART_SUPPLIER.getTableName().equals(target)) {
+            tableProperties = "WITH (ROWKEYS = 'PARTKEY,SUPPKEY')";
+        }
+        @Language("SQL")
+        String sql = format("CREATE TABLE %s %s AS SELECT * FROM %s", target, tableProperties, source);
+
+        LOG.debug("Running import for %s %s", target, sql);
+        long rows = queryRunner.execute(session, sql).getUpdateCount().getAsLong();
+        LOG.debug("%s rows loaded into %s", rows, target);
+    }
+
+    private static Session createSession()
+    {
+        return testSessionBuilder()
+                .setCatalog("phoenix")
+                .setSchema(TPCH_SCHEMA)
+                .build();
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Logging.initialize();
+
+        DistributedQueryRunner queryRunner = createPhoenixQueryRunner(
+                TestingPhoenixServer.getInstance(),
+                ImmutableMap.of("http-server.http.port", "8080"));
+
+        Logger log = Logger.get(PhoenixQueryRunner.class);
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+    }
+}

--- a/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/PhoenixQueryRunner.java
+++ b/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/PhoenixQueryRunner.java
@@ -63,7 +63,7 @@ public final class PhoenixQueryRunner
                 .build();
 
         queryRunner.installPlugin(new PhoenixPlugin());
-        queryRunner.createCatalog("phoenix", "phoenix", properties);
+        queryRunner.createCatalog("phoenix", "phoenix-5", properties);
 
         if (!server.isTpchLoaded()) {
             createSchema(server, TPCH_SCHEMA);

--- a/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/PhoenixSqlExecutor.java
+++ b/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/PhoenixSqlExecutor.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import io.trino.testing.sql.SqlExecutor;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+import static java.util.Objects.requireNonNull;
+
+public class PhoenixSqlExecutor
+        implements SqlExecutor
+{
+    private final String jdbcUrl;
+    private final Properties jdbcProperties;
+
+    public PhoenixSqlExecutor(String jdbcUrl)
+    {
+        this(jdbcUrl, new Properties());
+    }
+
+    public PhoenixSqlExecutor(String jdbcUrl, Properties jdbcProperties)
+    {
+        this.jdbcUrl = requireNonNull(jdbcUrl, "jdbcUrl is null");
+        this.jdbcProperties = new Properties();
+        this.jdbcProperties.putAll(requireNonNull(jdbcProperties, "jdbcProperties is null"));
+    }
+
+    @Override
+    public void execute(String sql)
+    {
+        sql = sql.replaceFirst("INSERT", "UPSERT");
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, jdbcProperties);
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+            connection.commit();
+        }
+        catch (SQLException e) {
+            throw new RuntimeException("Error executing sql:\n" + sql, e);
+        }
+    }
+}

--- a/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestPhoenixConfig.java
+++ b/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestPhoenixConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestPhoenixConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(PhoenixConfig.class)
+                .setConnectionUrl(null)
+                .setResourceConfigFiles("")
+                .setCaseInsensitiveNameMatching(false)
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+            throws IOException
+    {
+        Path configFile = Files.createTempFile(null, null);
+
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("phoenix.connection-url", "jdbc:phoenix:localhost:2181:/hbase")
+                .put("phoenix.config.resources", configFile.toString())
+                .put("case-insensitive-name-matching", "true")
+                .put("case-insensitive-name-matching.cache-ttl", "1s")
+                .build();
+
+        PhoenixConfig expected = new PhoenixConfig()
+                .setConnectionUrl("jdbc:phoenix:localhost:2181:/hbase")
+                .setResourceConfigFiles(configFile.toString())
+                .setCaseInsensitiveNameMatching(true)
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestPhoenixDistributedQueries.java
+++ b/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestPhoenixDistributedQueries.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestDistributedQueries;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.TestTable;
+import org.testng.SkipException;
+import org.testng.annotations.AfterClass;
+
+import static io.trino.plugin.phoenix.PhoenixQueryRunner.createPhoenixQueryRunner;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestPhoenixDistributedQueries
+        extends AbstractTestDistributedQueries
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createPhoenixQueryRunner(TestingPhoenixServer.getInstance(), ImmutableMap.of());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        TestingPhoenixServer.shutDown();
+    }
+
+    @Override
+    protected boolean supportsDelete()
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsViews()
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsArrays()
+    {
+        return true;
+    }
+
+    @Override
+    protected boolean supportsCommentOnTable()
+    {
+        return false;
+    }
+
+    @Override
+    protected boolean supportsCommentOnColumn()
+    {
+        return false;
+    }
+
+    @Override
+    protected TestTable createTableWithDefaultColumns()
+    {
+        throw new SkipException("Phoenix connector does not support column default values");
+    }
+
+    @Override
+    public void testRenameTable()
+    {
+        // Phoenix does not support renaming tables
+    }
+
+    @Override
+    public void testRenameColumn()
+    {
+        // Phoenix does not support renaming columns
+    }
+
+    @Override
+    public void testInsert()
+    {
+        String query = "SELECT orderdate, orderkey, totalprice FROM orders";
+
+        assertUpdate("CREATE TABLE test_insert WITH (ROWKEYS='orderkey') AS " + query + " WITH NO DATA", 0);
+        assertQuery("SELECT count(*) FROM test_insert", "SELECT 0");
+
+        assertUpdate("INSERT INTO test_insert " + query, "SELECT count(*) FROM orders");
+
+        assertQuery("SELECT * FROM test_insert", query);
+
+        assertUpdate("INSERT INTO test_insert (orderkey) VALUES (-1)", 1);
+        assertUpdate("INSERT INTO test_insert (orderkey) VALUES (-1)", 1); // Phoenix Upsert
+        assertUpdate("INSERT INTO test_insert (orderkey) VALUES (-2)", 1);
+        assertUpdate("INSERT INTO test_insert (orderkey, orderdate) VALUES (-3, DATE '2001-01-01')", 1);
+        assertUpdate("INSERT INTO test_insert (orderkey, orderdate) VALUES (-4, DATE '2001-01-02')", 1);
+        assertUpdate("INSERT INTO test_insert (orderdate, orderkey) VALUES (DATE '2001-01-03', -5)", 1);
+        assertUpdate("INSERT INTO test_insert (orderkey, totalprice) VALUES (-6, 1234)", 1);
+
+        assertQuery("SELECT * FROM test_insert", query
+                + " UNION ALL SELECT null, -1, null"
+                + " UNION ALL SELECT null, -2, null"
+                + " UNION ALL SELECT DATE '2001-01-01', -3, null"
+                + " UNION ALL SELECT DATE '2001-01-02', -4, null"
+                + " UNION ALL SELECT DATE '2001-01-03', -5, null"
+                + " UNION ALL SELECT null, -6, 1234");
+
+        // UNION query produces columns in the opposite order
+        // of how they are declared in the table schema
+        assertUpdate(
+                "INSERT INTO test_insert (orderkey, orderdate, totalprice) " +
+                        "SELECT orderkey, orderdate, totalprice FROM orders " +
+                        "UNION ALL " +
+                        "SELECT orderkey, orderdate, totalprice FROM orders",
+                "SELECT 2 * count(*) FROM orders");
+
+        assertUpdate("DROP TABLE test_insert");
+    }
+
+    @Override
+    public void testInsertArray()
+    {
+        assertThatThrownBy(super::testInsertArray)
+                // TODO (https://github.com/trinodb/trino/issues/6421) array with double null stored as array with 0
+                .hasMessageContaining("Actual rows (up to 100 of 1 extra rows shown, 2 rows in total):\n" +
+                        "    [0.0, null]\n" +
+                        "Expected rows (up to 100 of 1 missing rows shown, 2 rows in total):\n" +
+                        "    [null, null]");
+    }
+
+    @Override
+    public void testCreateSchema()
+    {
+        throw new SkipException("test disabled until issue fixed"); // TODO https://github.com/trinodb/trino/issues/2348
+    }
+
+    @Override
+    protected boolean isColumnNameRejected(Exception exception, String columnName, boolean delimited)
+    {
+        // TODO This should produce a reasonable exception message like "Invalid column name". Then, we should verify the actual exception message
+        return columnName.equals("a\"quote");
+    }
+
+    @Override
+    public void testDataMappingSmokeTest(DataMappingTestSetup dataMappingTestSetup)
+    {
+        // TODO enable the test
+        throw new SkipException("test fails on Phoenix");
+    }
+}

--- a/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestPhoenixIntegrationSmokeTest.java
+++ b/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestPhoenixIntegrationSmokeTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.jdbc.UnsupportedTypeHandling;
+import io.trino.testing.AbstractTestIntegrationSmokeTest;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.UNSUPPORTED_TYPE_HANDLING;
+import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
+import static io.trino.plugin.phoenix.PhoenixQueryRunner.createPhoenixQueryRunner;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class TestPhoenixIntegrationSmokeTest
+        // TODO extend BaseConnectorTest
+        extends AbstractTestIntegrationSmokeTest
+{
+    private TestingPhoenixServer testingPhoenixServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        testingPhoenixServer = TestingPhoenixServer.getInstance();
+        return createPhoenixQueryRunner(testingPhoenixServer, ImmutableMap.of());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        TestingPhoenixServer.shutDown();
+    }
+
+    @Override
+    public void testShowCreateTable()
+    {
+        assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
+                .isEqualTo("CREATE TABLE phoenix.tpch.orders (\n" +
+                        "   orderkey bigint,\n" +
+                        "   custkey bigint,\n" +
+                        "   orderstatus varchar(1),\n" +
+                        "   totalprice double,\n" +
+                        "   orderdate date,\n" +
+                        "   orderpriority varchar(15),\n" +
+                        "   clerk varchar(15),\n" +
+                        "   shippriority integer,\n" +
+                        "   comment varchar(79)\n" +
+                        ")\n" +
+                        "WITH (\n" +
+                        "   data_block_encoding = 'FAST_DIFF',\n" +
+                        "   rowkeys = 'ROWKEY',\n" +
+                        "   salt_buckets = 10\n" +
+                        ")");
+    }
+
+    @Test
+    public void testSchemaOperations()
+    {
+        assertUpdate("CREATE SCHEMA new_schema");
+        assertUpdate("CREATE TABLE new_schema.test (x bigint)");
+
+        try {
+            getQueryRunner().execute("DROP SCHEMA new_schema");
+            fail("Should not be able to drop non-empty schema");
+        }
+        catch (RuntimeException e) {
+        }
+
+        assertUpdate("DROP TABLE new_schema.test");
+        assertUpdate("DROP SCHEMA new_schema");
+    }
+
+    @Test
+    public void testMultipleSomeColumnsRangesPredicate()
+    {
+        assertQuery("SELECT orderkey, shippriority, clerk, totalprice, custkey FROM orders WHERE orderkey BETWEEN 10 AND 50 OR orderkey BETWEEN 100 AND 150");
+    }
+
+    @Test
+    public void testUnsupportedType()
+            throws Exception
+    {
+        executeInPhoenix("CREATE TABLE tpch.test_timestamp (pk bigint primary key, val1 timestamp)");
+        executeInPhoenix("UPSERT INTO tpch.test_timestamp (pk, val1) VALUES (1, null)");
+        executeInPhoenix("UPSERT INTO tpch.test_timestamp (pk, val1) VALUES (2, '2002-05-30T09:30:10.5')");
+        assertUpdate("INSERT INTO test_timestamp VALUES (3)", 1);
+        assertQuery("SELECT * FROM test_timestamp", "VALUES 1, 2, 3");
+        assertQuery(
+                withUnsupportedType(CONVERT_TO_VARCHAR),
+                "SELECT * FROM test_timestamp",
+                "VALUES " +
+                        "(1, null), " +
+                        "(2, '2002-05-30 09:30:10.500'), " +
+                        "(3, null)");
+        assertQueryFails(
+                withUnsupportedType(CONVERT_TO_VARCHAR),
+                "INSERT INTO test_timestamp VALUES (4, '2002-05-30 09:30:10.500')",
+                "Underlying type that is mapped to VARCHAR is not supported for INSERT: TIMESTAMP");
+        assertUpdate("DROP TABLE tpch.test_timestamp");
+    }
+
+    private Session withUnsupportedType(UnsupportedTypeHandling unsupportedTypeHandling)
+    {
+        return Session.builder(getSession())
+                .setCatalogSessionProperty("phoenix", UNSUPPORTED_TYPE_HANDLING, unsupportedTypeHandling.name())
+                .build();
+    }
+
+    @Test
+    public void testCreateTableWithProperties()
+    {
+        assertUpdate("CREATE TABLE test_create_table_with_properties (created_date date, a bigint, b double, c varchar(10), d varchar(10)) WITH(rowkeys = 'created_date row_timestamp, a,b,c', salt_buckets=10)");
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_table_with_properties"));
+        assertTableColumnNames("test_create_table_with_properties", "created_date", "a", "b", "c", "d");
+        assertThat(computeActual("SHOW CREATE TABLE test_create_table_with_properties").getOnlyValue())
+                .isEqualTo("CREATE TABLE phoenix.tpch.test_create_table_with_properties (\n" +
+                        "   created_date date,\n" +
+                        "   a bigint NOT NULL,\n" +
+                        "   b double NOT NULL,\n" +
+                        "   c varchar(10) NOT NULL,\n" +
+                        "   d varchar(10)\n" +
+                        ")\n" +
+                        "WITH (\n" +
+                        "   data_block_encoding = 'FAST_DIFF',\n" +
+                        "   rowkeys = 'A,B,C',\n" +
+                        "   salt_buckets = 10\n" +
+                        ")");
+
+        assertUpdate("DROP TABLE test_create_table_with_properties");
+    }
+
+    @Test
+    public void testCreateTableWithPresplits()
+    {
+        assertUpdate("CREATE TABLE test_create_table_with_presplits (rid varchar(10), val1 varchar(10)) with(rowkeys = 'rid', SPLIT_ON='\"1\",\"2\",\"3\"')");
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_create_table_with_presplits"));
+        assertTableColumnNames("test_create_table_with_presplits", "rid", "val1");
+        assertUpdate("DROP TABLE test_create_table_with_presplits");
+    }
+
+    @Test
+    public void testSecondaryIndex()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_primary_table (pk bigint, val1 double, val2 double, val3 double) with(rowkeys = 'pk')");
+        executeInPhoenix("CREATE LOCAL INDEX test_local_index ON tpch.test_primary_table (val1)");
+        executeInPhoenix("CREATE INDEX test_global_index ON tpch.test_primary_table (val2)");
+        assertUpdate("INSERT INTO test_primary_table VALUES (1, 1.1, 1.2, 1.3)", 1);
+        assertQuery("SELECT val1,val3 FROM test_primary_table where val1 < 1.2", "SELECT 1.1,1.3");
+        assertQuery("SELECT val2,val3 FROM test_primary_table where val2 < 1.3", "SELECT 1.2,1.3");
+        assertUpdate("DROP TABLE test_primary_table");
+    }
+
+    @Test
+    public void testCaseInsensitiveNameMatching()
+            throws Exception
+    {
+        executeInPhoenix("CREATE TABLE tpch.\"TestCaseInsensitive\" (\"pK\" bigint primary key, \"Val1\" double)");
+        assertUpdate("INSERT INTO testcaseinsensitive VALUES (1, 1.1)", 1);
+        assertQuery("SELECT Val1 FROM testcaseinsensitive where Val1 < 1.2", "SELECT 1.1");
+    }
+
+    @Test
+    public void testMissingColumnsOnInsert()
+            throws Exception
+    {
+        executeInPhoenix("CREATE TABLE tpch.test_col_insert(pk VARCHAR NOT NULL PRIMARY KEY, col1 VARCHAR, col2 VARCHAR)");
+        assertUpdate("INSERT INTO test_col_insert(pk, col1) VALUES('1', 'val1')", 1);
+        assertUpdate("INSERT INTO test_col_insert(pk, col2) VALUES('1', 'val2')", 1);
+        assertQuery("SELECT * FROM test_col_insert", "SELECT 1, 'val1', 'val2'");
+    }
+
+    private void executeInPhoenix(String sql)
+            throws SQLException
+    {
+        try (Connection connection = DriverManager.getConnection(testingPhoenixServer.getJdbcUrl());
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+            connection.commit();
+        }
+    }
+}

--- a/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestPhoenixSplit.java
+++ b/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestPhoenixSplit.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import io.airlift.json.ObjectMapperProvider;
+import io.trino.spi.HostAddress;
+import io.trino.spi.predicate.TupleDomain;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.phoenix.mapreduce.PhoenixInputSplit;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestPhoenixSplit
+{
+    private final ObjectMapper objectMapper = new ObjectMapperProvider().get();
+
+    @Test
+    public void testPhoenixSplitJsonRoundtrip()
+            throws Exception
+    {
+        List<HostAddress> addresses = ImmutableList.of(HostAddress.fromString("host:9000"));
+        List<Scan> scans = ImmutableList.of(new Scan().withStartRow(Bytes.toBytes("A")).withStopRow(Bytes.toBytes("Z")));
+        PhoenixInputSplit phoenixInputSplit = new PhoenixInputSplit(scans);
+        PhoenixSplit expected = new PhoenixSplit(
+                addresses,
+                new WrappedPhoenixInputSplit(phoenixInputSplit),
+                TupleDomain.all());
+
+        assertTrue(objectMapper.canSerialize(PhoenixSplit.class));
+
+        String json = objectMapper.writeValueAsString(expected);
+        PhoenixSplit actual = objectMapper.readValue(json, PhoenixSplit.class);
+        assertEquals(actual.getPhoenixInputSplit(), expected.getPhoenixInputSplit());
+        assertEquals(actual.getAddresses(), expected.getAddresses());
+        assertEquals(actual.getConstraint(), expected.getConstraint());
+    }
+}

--- a/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestPhoenixTypeMapping.java
+++ b/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestPhoenixTypeMapping.java
@@ -1,0 +1,422 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.TimeZoneKey;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.datatype.CreateAndInsertDataSetup;
+import io.trino.testing.datatype.CreateAsSelectDataSetup;
+import io.trino.testing.datatype.DataSetup;
+import io.trino.testing.datatype.DataType;
+import io.trino.testing.datatype.DataTypeTest;
+import io.trino.testing.datatype.SqlDataTypeTest;
+import io.trino.testing.sql.TrinoSqlExecutor;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.phoenix.PhoenixQueryRunner.createPhoenixQueryRunner;
+import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static io.trino.spi.type.VarbinaryType.VARBINARY;
+import static io.trino.testing.datatype.DataType.bigintDataType;
+import static io.trino.testing.datatype.DataType.booleanDataType;
+import static io.trino.testing.datatype.DataType.dataType;
+import static io.trino.testing.datatype.DataType.dateDataType;
+import static io.trino.testing.datatype.DataType.doubleDataType;
+import static io.trino.testing.datatype.DataType.integerDataType;
+import static io.trino.testing.datatype.DataType.realDataType;
+import static io.trino.testing.datatype.DataType.smallintDataType;
+import static io.trino.testing.datatype.DataType.tinyintDataType;
+import static io.trino.testing.datatype.DataType.varcharDataType;
+import static java.lang.String.format;
+import static java.math.RoundingMode.UNNECESSARY;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
+public class TestPhoenixTypeMapping
+        extends AbstractTestQueryFramework
+{
+    private TestingPhoenixServer phoenixServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        phoenixServer = TestingPhoenixServer.getInstance();
+        return createPhoenixQueryRunner(phoenixServer, ImmutableMap.of());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        TestingPhoenixServer.shutDown();
+    }
+
+    @Test
+    public void testBasicTypes()
+    {
+        DataTypeTest.create()
+                .addRoundTrip(booleanDataType(), true)
+                .addRoundTrip(booleanDataType(), false)
+                .addRoundTrip(bigintDataType(), 123_456_789_012L)
+                .addRoundTrip(integerDataType(), 1_234_567_890)
+                .addRoundTrip(smallintDataType(), (short) 32_456)
+                .addRoundTrip(tinyintDataType(), (byte) 5)
+                .addRoundTrip(doubleDataType(), 123.45d)
+                .addRoundTrip(realDataType(), 123.45f)
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_basic_types"));
+    }
+
+    @Test
+    public void testVarchar()
+    {
+        DataTypeTest varcharTypeTest = stringDataTypeTest(DataType::varcharDataType)
+                .addRoundTrip(varcharDataType(10485760), "text_f")
+                .addRoundTrip(varcharDataType(), "unbounded");
+
+        varcharTypeTest
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_varchar"));
+
+        varcharTypeTest
+                .addRoundTrip(primaryKey(), 1)
+                .execute(getQueryRunner(), phoenixCreateAndInsert("tpch.test_varchar"));
+    }
+
+    private DataTypeTest stringDataTypeTest(Function<Integer, DataType<String>> dataTypeFactory)
+    {
+        return DataTypeTest.create()
+                .addRoundTrip(dataTypeFactory.apply(10), "text_a")
+                .addRoundTrip(dataTypeFactory.apply(255), "text_b")
+                .addRoundTrip(dataTypeFactory.apply(65535), "text_d");
+    }
+
+    @Test
+    public void testChar()
+    {
+        stringDataTypeTest(DataType::charDataType)
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_char"));
+
+        stringDataTypeTest(DataType::charDataType)
+                .addRoundTrip(primaryKey(), 1)
+                .execute(getQueryRunner(), phoenixCreateAndInsert("tpch.test_char"));
+    }
+
+    @Test
+    public void testVarbinary()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("varbinary", "NULL", VARBINARY, "CAST(NULL AS varbinary)")
+                .addRoundTrip("varbinary", "X''", VARBINARY, "CAST(NULL AS varbinary)") // empty stored as NULL
+                .addRoundTrip("varbinary", "X'68656C6C6F'", VARBINARY, "to_utf8('hello')")
+                .addRoundTrip("varbinary", "X'5069C4996B6E6120C582C4856B61207720E69DB1E4BAACE983BD'", VARBINARY, "to_utf8('Piękna łąka w 東京都')")
+                .addRoundTrip("varbinary", "X'4261672066756C6C206F6620F09F92B0'", VARBINARY, "to_utf8('Bag full of 💰')")
+                .addRoundTrip("varbinary", "X'0001020304050607080DF9367AA7000000'", VARBINARY, "X'0001020304050607080DF9367AA7000000'") // non-text
+                .addRoundTrip("varbinary", "X'000000000000'", VARBINARY, "X'000000000000'")
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_varbinary"));
+
+        SqlDataTypeTest.create()
+                .addRoundTrip("integer primary key", "1", INTEGER, "1")
+                .addRoundTrip("varbinary", "NULL", VARBINARY, "CAST(NULL AS varbinary)")
+                .addRoundTrip("varbinary", "DECODE('', 'HEX')", VARBINARY, "CAST(NULL AS varbinary)") // empty stored as NULL
+                .addRoundTrip("varbinary", "DECODE('68656C6C6F', 'HEX')", VARBINARY, "to_utf8('hello')")
+                .addRoundTrip("varbinary", "DECODE('5069C4996B6E6120C582C4856B61207720E69DB1E4BAACE983BD', 'HEX')", VARBINARY, "to_utf8('Piękna łąka w 東京都')")
+                .addRoundTrip("varbinary", "DECODE('4261672066756C6C206F6620F09F92B0', 'HEX')", VARBINARY, "to_utf8('Bag full of 💰')")
+                .addRoundTrip("varbinary", "DECODE('0001020304050607080DF9367AA7000000', 'HEX')", VARBINARY, "X'0001020304050607080DF9367AA7000000'") // non-text
+                .addRoundTrip("varbinary", "DECODE('000000000000', 'HEX')", VARBINARY, "X'000000000000'")
+                .execute(getQueryRunner(), phoenixCreateAndInsert("tpch.test_varbinary"));
+    }
+
+    @Test
+    public void testDecimal()
+    {
+        decimalTests(DataType::decimalDataType)
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_decimal"));
+
+        decimalTests(TestPhoenixTypeMapping::phoenixDecimalDataType)
+                .addRoundTrip(primaryKey(), 1)
+                .execute(getQueryRunner(), phoenixCreateAndInsert("tpch.test_decimal"));
+    }
+
+    private DataTypeTest decimalTests(BiFunction<Integer, Integer, DataType<BigDecimal>> dataTypeFactory)
+    {
+        return DataTypeTest.create()
+                .addRoundTrip(dataTypeFactory.apply(3, 0), new BigDecimal("193"))
+                .addRoundTrip(dataTypeFactory.apply(3, 0), new BigDecimal("19"))
+                .addRoundTrip(dataTypeFactory.apply(3, 0), new BigDecimal("-193"))
+                .addRoundTrip(dataTypeFactory.apply(3, 1), new BigDecimal("10.0"))
+                .addRoundTrip(dataTypeFactory.apply(3, 1), new BigDecimal("10.1"))
+                .addRoundTrip(dataTypeFactory.apply(3, 1), new BigDecimal("-10.1"))
+                .addRoundTrip(dataTypeFactory.apply(4, 2), new BigDecimal("2"))
+                .addRoundTrip(dataTypeFactory.apply(4, 2), new BigDecimal("2.3"))
+                .addRoundTrip(dataTypeFactory.apply(24, 2), new BigDecimal("2"))
+                .addRoundTrip(dataTypeFactory.apply(24, 2), new BigDecimal("2.3"))
+                .addRoundTrip(dataTypeFactory.apply(24, 2), new BigDecimal("123456789.3"))
+                .addRoundTrip(dataTypeFactory.apply(24, 4), new BigDecimal("12345678901234567890.31"))
+                .addRoundTrip(dataTypeFactory.apply(30, 5), new BigDecimal("3141592653589793238462643.38327"))
+                .addRoundTrip(dataTypeFactory.apply(30, 5), new BigDecimal("-3141592653589793238462643.38327"))
+                .addRoundTrip(dataTypeFactory.apply(38, 0), new BigDecimal("27182818284590452353602874713526624977"))
+                .addRoundTrip(dataTypeFactory.apply(38, 0), new BigDecimal("-27182818284590452353602874713526624977"));
+    }
+
+    private static DataType<BigDecimal> phoenixDecimalDataType(int precision, int scale)
+    {
+        String databaseType = format("decimal(%s, %s)", precision, scale);
+        return dataType(
+                databaseType,
+                createDecimalType(precision, scale),
+                bigDecimal -> format("CAST(%s AS %s)", bigDecimal, databaseType),
+                bigDecimal -> bigDecimal.setScale(scale, UNNECESSARY));
+    }
+
+    @Test
+    public void testDate()
+    {
+        // Note: there is identical test for MySQL
+
+        ZoneId jvmZone = ZoneId.systemDefault();
+        checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        checkIsGap(jvmZone, dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay());
+
+        ZoneId someZone = ZoneId.of("Europe/Vilnius");
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInSomeZone = LocalDate.of(1983, 4, 1);
+        checkIsGap(someZone, dateOfLocalTimeChangeForwardAtMidnightInSomeZone.atStartOfDay());
+        LocalDate dateOfLocalTimeChangeBackwardAtMidnightInSomeZone = LocalDate.of(1983, 10, 1);
+        checkIsDoubled(someZone, dateOfLocalTimeChangeBackwardAtMidnightInSomeZone.atStartOfDay().minusMinutes(1));
+
+        DataTypeTest trinoTestCases = dateTests(
+                dateOfLocalTimeChangeForwardAtMidnightInJvmZone,
+                dateOfLocalTimeChangeForwardAtMidnightInSomeZone,
+                dateOfLocalTimeChangeBackwardAtMidnightInSomeZone,
+                dateDataType());
+
+        DataTypeTest phoenixTestCases = dateTests(
+                dateOfLocalTimeChangeForwardAtMidnightInJvmZone,
+                dateOfLocalTimeChangeForwardAtMidnightInSomeZone,
+                dateOfLocalTimeChangeBackwardAtMidnightInSomeZone,
+                phoenixDateDataType())
+                .addRoundTrip(primaryKey(), 1);
+
+        for (String timeZoneId : ImmutableList.of(UTC_KEY.getId(), jvmZone.getId(), someZone.getId())) {
+            Session session = Session.builder(getSession())
+                    .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(timeZoneId))
+                    .build();
+            trinoTestCases.execute(getQueryRunner(), session, trinoCreateAsSelect(session, "test_date"));
+            trinoTestCases.execute(getQueryRunner(), session, trinoCreateAsSelect(getSession(), "test_date"));
+            trinoTestCases.execute(getQueryRunner(), session, prestoCreateAndInsert(session, "test_date"));
+            phoenixTestCases.execute(getQueryRunner(), session, phoenixCreateAndInsert("tpch.test_date"));
+        }
+    }
+
+    @Test
+    public void testArray()
+    {
+        // basic types
+        DataTypeTest.create()
+                .addRoundTrip(arrayDataType(booleanDataType()), asList(true, false))
+                .addRoundTrip(arrayDataType(bigintDataType()), asList(123_456_789_012L))
+                .addRoundTrip(arrayDataType(integerDataType()), asList(1, 2, 1_234_567_890))
+                .addRoundTrip(arrayDataType(smallintDataType()), asList((short) 32_456))
+                .addRoundTrip(arrayDataType(doubleDataType()), asList(123.45d))
+                .addRoundTrip(arrayDataType(realDataType()), asList(123.45f))
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_array_basic"));
+
+        arrayDateTest(TestPhoenixTypeMapping::arrayDataType, dateDataType())
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_array_date"));
+        arrayDateTest(TestPhoenixTypeMapping::phoenixArrayDataType, phoenixDateDataType())
+                .addRoundTrip(primaryKey(), 1)
+                .execute(getQueryRunner(), phoenixCreateAndInsert("tpch.test_array_date"));
+
+        arrayDecimalTest(TestPhoenixTypeMapping::arrayDataType, DataType::decimalDataType)
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_array_decimal"));
+        arrayDecimalTest(TestPhoenixTypeMapping::phoenixArrayDataType, TestPhoenixTypeMapping::phoenixDecimalDataType)
+                .addRoundTrip(primaryKey(), 1)
+                .execute(getQueryRunner(), phoenixCreateAndInsert("tpch.test_array_decimal"));
+
+        arrayStringDataTypeTest(TestPhoenixTypeMapping::arrayDataType, DataType::charDataType)
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_array_char"));
+        arrayStringDataTypeTest(TestPhoenixTypeMapping::phoenixArrayDataType, DataType::charDataType)
+                .addRoundTrip(primaryKey(), 1)
+                .execute(getQueryRunner(), phoenixCreateAndInsert("tpch.test_array_char"));
+
+        arrayStringDataTypeTest(TestPhoenixTypeMapping::arrayDataType, DataType::varcharDataType)
+                .addRoundTrip(arrayDataType(varcharDataType(10485760)), asList("text_f"))
+                .addRoundTrip(arrayDataType(varcharDataType()), asList("unbounded"))
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_array_varchar"));
+        arrayStringDataTypeTest(TestPhoenixTypeMapping::phoenixArrayDataType, DataType::varcharDataType)
+                .addRoundTrip(phoenixArrayDataType(varcharDataType(10485760)), asList("text_f"))
+                .addRoundTrip(phoenixArrayDataType(varcharDataType()), asList("unbounded"))
+                .addRoundTrip(primaryKey(), 1)
+                .execute(getQueryRunner(), phoenixCreateAndInsert("tpch.test_array_varchar"));
+    }
+
+    @Test
+    public void testArrayNulls()
+    {
+        DataTypeTest.create()
+                .addRoundTrip(arrayDataType(booleanDataType()), null)
+                .addRoundTrip(arrayDataType(varcharDataType()), singletonList(null))
+                .addRoundTrip(arrayDataType(varcharDataType()), asList("foo", null, "bar", null))
+                .execute(getQueryRunner(), trinoCreateAsSelect("test_array_nulls"));
+    }
+
+    private DataTypeTest arrayDecimalTest(Function<DataType<BigDecimal>, DataType<List<BigDecimal>>> arrayTypeFactory, BiFunction<Integer, Integer, DataType<BigDecimal>> decimalTypeFactory)
+    {
+        return DataTypeTest.create()
+                .addRoundTrip(arrayTypeFactory.apply(decimalTypeFactory.apply(3, 0)), asList(new BigDecimal("193"), new BigDecimal("19"), new BigDecimal("-193")))
+                .addRoundTrip(arrayTypeFactory.apply(decimalTypeFactory.apply(3, 1)), asList(new BigDecimal("10.0"), new BigDecimal("10.1"), new BigDecimal("-10.1")))
+                .addRoundTrip(arrayTypeFactory.apply(decimalTypeFactory.apply(4, 2)), asList(new BigDecimal("2"), new BigDecimal("2.3")))
+                .addRoundTrip(arrayTypeFactory.apply(decimalTypeFactory.apply(24, 2)), asList(new BigDecimal("2"), new BigDecimal("2.3"), new BigDecimal("123456789.3")))
+                .addRoundTrip(arrayTypeFactory.apply(decimalTypeFactory.apply(24, 4)), asList(new BigDecimal("12345678901234567890.31")))
+                .addRoundTrip(arrayTypeFactory.apply(decimalTypeFactory.apply(30, 5)), asList(new BigDecimal("3141592653589793238462643.38327"), new BigDecimal("-3141592653589793238462643.38327")))
+                .addRoundTrip(arrayTypeFactory.apply(decimalTypeFactory.apply(38, 0)), asList(
+                        new BigDecimal("27182818284590452353602874713526624977"),
+                        new BigDecimal("-27182818284590452353602874713526624977")));
+    }
+
+    private DataTypeTest arrayStringDataTypeTest(Function<DataType<String>, DataType<List<String>>> arrayTypeFactory, Function<Integer, DataType<String>> dataTypeFactory)
+    {
+        return DataTypeTest.create()
+                .addRoundTrip(arrayTypeFactory.apply(dataTypeFactory.apply(10)), asList("text_a"))
+                .addRoundTrip(arrayTypeFactory.apply(dataTypeFactory.apply(255)), asList("text_b"))
+                .addRoundTrip(arrayTypeFactory.apply(dataTypeFactory.apply(65535)), asList("text_d"));
+    }
+
+    private DataTypeTest arrayDateTest(Function<DataType<LocalDate>, DataType<List<LocalDate>>> arrayTypeFactory, DataType<LocalDate> dateDataType)
+    {
+        ZoneId jvmZone = ZoneId.systemDefault();
+        checkState(jvmZone.getId().equals("America/Bahia_Banderas"), "This test assumes certain JVM time zone");
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
+        checkIsGap(jvmZone, dateOfLocalTimeChangeForwardAtMidnightInJvmZone.atStartOfDay());
+
+        ZoneId someZone = ZoneId.of("Europe/Vilnius");
+        LocalDate dateOfLocalTimeChangeForwardAtMidnightInSomeZone = LocalDate.of(1983, 4, 1);
+        checkIsGap(someZone, dateOfLocalTimeChangeForwardAtMidnightInSomeZone.atStartOfDay());
+        LocalDate dateOfLocalTimeChangeBackwardAtMidnightInSomeZone = LocalDate.of(1983, 10, 1);
+        checkIsDoubled(someZone, dateOfLocalTimeChangeBackwardAtMidnightInSomeZone.atStartOfDay().minusMinutes(1));
+
+        return DataTypeTest.create()
+                .addRoundTrip(arrayTypeFactory.apply(dateDataType), asList(LocalDate.of(1952, 4, 3))) // before epoch
+                .addRoundTrip(arrayTypeFactory.apply(dateDataType), asList(LocalDate.of(1970, 1, 1)))
+                .addRoundTrip(arrayTypeFactory.apply(dateDataType), asList(LocalDate.of(1970, 2, 3)))
+                .addRoundTrip(arrayTypeFactory.apply(dateDataType), asList(LocalDate.of(2017, 7, 1))) // summer on northern hemisphere (possible DST)
+                .addRoundTrip(arrayTypeFactory.apply(dateDataType), asList(LocalDate.of(2017, 1, 1))) // winter on northern hemisphere (possible DST on southern hemisphere)
+                .addRoundTrip(arrayTypeFactory.apply(dateDataType), asList(dateOfLocalTimeChangeForwardAtMidnightInJvmZone))
+                .addRoundTrip(arrayTypeFactory.apply(dateDataType), asList(dateOfLocalTimeChangeForwardAtMidnightInSomeZone))
+                .addRoundTrip(arrayTypeFactory.apply(dateDataType), asList(dateOfLocalTimeChangeBackwardAtMidnightInSomeZone));
+    }
+
+    private DataTypeTest dateTests(
+            LocalDate dateOfLocalTimeChangeForwardAtMidnightInJvmZone,
+            LocalDate dateOfLocalTimeChangeForwardAtMidnightInSomeZone,
+            LocalDate dateOfLocalTimeChangeBackwardAtMidnightInSomeZone,
+            DataType<LocalDate> dateDataType)
+    {
+        return DataTypeTest.create()
+                .addRoundTrip(dateDataType, LocalDate.of(1952, 4, 3)) // before epoch
+                .addRoundTrip(dateDataType, LocalDate.of(1970, 1, 1))
+                .addRoundTrip(dateDataType, LocalDate.of(1970, 2, 3))
+                .addRoundTrip(dateDataType, LocalDate.of(2017, 7, 1)) // summer on northern hemisphere (possible DST)
+                .addRoundTrip(dateDataType, LocalDate.of(2017, 1, 1)) // winter on northern hemisphere (possible DST on southern hemisphere)
+                .addRoundTrip(dateDataType, dateOfLocalTimeChangeForwardAtMidnightInJvmZone)
+                .addRoundTrip(dateDataType, dateOfLocalTimeChangeForwardAtMidnightInSomeZone)
+                .addRoundTrip(dateDataType, dateOfLocalTimeChangeBackwardAtMidnightInSomeZone);
+    }
+
+    private static <E> DataType<List<E>> arrayDataType(DataType<E> elementType)
+    {
+        return arrayDataType(elementType, format("ARRAY(%s)", elementType.getInsertType()));
+    }
+
+    private static <E> DataType<List<E>> phoenixArrayDataType(DataType<E> elementType)
+    {
+        return arrayDataType(elementType, elementType.getInsertType() + " ARRAY");
+    }
+
+    private static <E> DataType<List<E>> arrayDataType(DataType<E> elementType, String insertType)
+    {
+        return dataType(
+                insertType,
+                new ArrayType(elementType.getTrinoResultType()),
+                valuesList -> "ARRAY" + valuesList.stream().map(elementType::toLiteral).collect(toList()),
+                valuesList -> valuesList == null ? null : valuesList.stream().map(elementType::toTrinoQueryResult).collect(toList()));
+    }
+
+    public static DataType<LocalDate> phoenixDateDataType()
+    {
+        return dataType(
+                "date",
+                DATE,
+                value -> format("TO_DATE('%s', 'yyyy-MM-dd', 'local')", DateTimeFormatter.ofPattern("uuuu-MM-dd").format(value)));
+    }
+
+    private static void checkIsGap(ZoneId zone, LocalDateTime dateTime)
+    {
+        verify(isGap(zone, dateTime), "Expected %s to be a gap in %s", dateTime, zone);
+    }
+
+    private static boolean isGap(ZoneId zone, LocalDateTime dateTime)
+    {
+        return zone.getRules().getValidOffsets(dateTime).isEmpty();
+    }
+
+    private static void checkIsDoubled(ZoneId zone, LocalDateTime dateTime)
+    {
+        verify(zone.getRules().getValidOffsets(dateTime).size() == 2, "Expected %s to be doubled in %s", dateTime, zone);
+    }
+
+    private DataType<Integer> primaryKey()
+    {
+        return dataType("integer primary key", INTEGER, Object::toString);
+    }
+
+    private DataSetup trinoCreateAsSelect(String tableNamePrefix)
+    {
+        return trinoCreateAsSelect(getSession(), tableNamePrefix);
+    }
+
+    private DataSetup trinoCreateAsSelect(Session session, String tableNamePrefix)
+    {
+        return new CreateAsSelectDataSetup(new TrinoSqlExecutor(getQueryRunner(), session), tableNamePrefix);
+    }
+
+    private DataSetup prestoCreateAndInsert(Session session, String tableNamePrefix)
+    {
+        return new CreateAndInsertDataSetup(new TrinoSqlExecutor(getQueryRunner(), session), tableNamePrefix);
+    }
+
+    private DataSetup phoenixCreateAndInsert(String tableNamePrefix)
+    {
+        return new CreateAndInsertDataSetup(new PhoenixSqlExecutor(phoenixServer.getJdbcUrl()), tableNamePrefix);
+    }
+}

--- a/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestingPhoenixServer.java
+++ b/plugin/trino-phoenix-5/src/test/java/io/trino/plugin/phoenix/TestingPhoenixServer.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import io.airlift.log.Logger;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.MiniHBaseCluster;
+import org.apache.hadoop.hbase.zookeeper.MiniZooKeeperCluster;
+import org.apache.phoenix.shaded.org.apache.zookeeper.server.ZooKeeperServer;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+
+import static java.lang.String.format;
+import static org.apache.hadoop.hbase.HConstants.HBASE_CLIENT_RETRIES_NUMBER;
+import static org.apache.hadoop.hbase.HConstants.MASTER_INFO_PORT;
+import static org.apache.hadoop.hbase.HConstants.REGIONSERVER_INFO_PORT;
+
+public final class TestingPhoenixServer
+{
+    private static final Logger LOG = Logger.get(TestingPhoenixServer.class);
+
+    @GuardedBy("this")
+    private static int referenceCount;
+    @GuardedBy("this")
+    private static TestingPhoenixServer instance;
+
+    public static synchronized TestingPhoenixServer getInstance()
+    {
+        if (referenceCount == 0) {
+            instance = new TestingPhoenixServer();
+        }
+        referenceCount++;
+        return instance;
+    }
+
+    public static synchronized void shutDown()
+    {
+        referenceCount--;
+        if (referenceCount == 0) {
+            instance.shutdown();
+            instance = null;
+        }
+    }
+
+    private HBaseTestingUtility hbaseTestingUtility;
+    private final int port;
+    private final Configuration conf = HBaseConfiguration.create();
+    private final AtomicBoolean tpchLoaded = new AtomicBoolean();
+    private final CountDownLatch tpchLoadComplete = new CountDownLatch(1);
+
+    private final java.util.logging.Logger apacheLogger;
+
+    private final java.util.logging.Logger zookeeperLogger;
+
+    private final java.util.logging.Logger securityLogger;
+
+    private TestingPhoenixServer()
+    {
+        // keep references to prevent GC from resetting the log levels
+        apacheLogger = java.util.logging.Logger.getLogger("org.apache");
+        apacheLogger.setLevel(Level.SEVERE);
+        zookeeperLogger = java.util.logging.Logger.getLogger(ZooKeeperServer.class.getName());
+        zookeeperLogger.setLevel(Level.OFF);
+        securityLogger = java.util.logging.Logger.getLogger("SecurityLogger.org.apache");
+        securityLogger.setLevel(Level.SEVERE);
+        // to squelch the SecurityLogger,
+        // instantiate logger with config above before config is overriden again in HBase test franework
+        org.apache.commons.logging.LogFactory.getLog("SecurityLogger.org.apache.hadoop.hbase.server");
+        this.conf.set("hbase.security.logger", "ERROR");
+        this.conf.setInt(MASTER_INFO_PORT, -1);
+        this.conf.setInt(REGIONSERVER_INFO_PORT, -1);
+        this.conf.setInt(HBASE_CLIENT_RETRIES_NUMBER, 1);
+        this.conf.setBoolean("phoenix.schema.isNamespaceMappingEnabled", true);
+        this.conf.set("hbase.regionserver.wal.codec", "org.apache.hadoop.hbase.regionserver.wal.IndexedWALEditCodec");
+        this.hbaseTestingUtility = new HBaseTestingUtility(conf);
+
+        try {
+            MiniZooKeeperCluster zkCluster = this.hbaseTestingUtility.startMiniZKCluster();
+            port = zkCluster.getClientPort();
+
+            MiniHBaseCluster hbaseCluster = hbaseTestingUtility.startMiniHBaseCluster(1, 4);
+            hbaseCluster.waitForActiveAndReadyMaster();
+            LOG.info("Phoenix server ready: %s", getJdbcUrl());
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Can't start phoenix server.", e);
+        }
+    }
+
+    private void shutdown()
+    {
+        if (hbaseTestingUtility == null) {
+            return;
+        }
+        try {
+            LOG.info("Shutting down HBase cluster.");
+            hbaseTestingUtility.shutdownMiniHBaseCluster();
+            hbaseTestingUtility.shutdownMiniZKCluster();
+        }
+        catch (IOException e) {
+            Thread.currentThread().interrupt();
+            throw new UncheckedIOException("Failed to shutdown HBaseTestingUtility instance", e);
+        }
+        hbaseTestingUtility = null;
+    }
+
+    public String getJdbcUrl()
+    {
+        return format("jdbc:phoenix:localhost:%d:/hbase;phoenix.schema.isNamespaceMappingEnabled=true", port);
+    }
+
+    public boolean isTpchLoaded()
+    {
+        return tpchLoaded.getAndSet(true);
+    }
+
+    public void setTpchLoaded()
+    {
+        tpchLoadComplete.countDown();
+    }
+
+    public void waitTpchLoaded()
+            throws InterruptedException
+    {
+        tpchLoadComplete.await(2, TimeUnit.MINUTES);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
         <module>plugin/trino-oracle</module>
         <module>plugin/trino-password-authenticators</module>
         <module>plugin/trino-phoenix</module>
+        <module>plugin/trino-phoenix-5</module>
         <module>plugin/trino-pinot</module>
         <module>plugin/trino-postgresql</module>
         <module>plugin/trino-prometheus</module>


### PR DESCRIPTION
This adds the trino-phoenix-5 connector to support Phoenix 5.1.0 and HBase 2.x.

Fixes https://github.com/trinodb/trino/issues/1271 
