### PR TITLE
Improve parallelism for writes to bucketed partitions

### DIFF
--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
@@ -233,6 +233,18 @@ public class TestHiveAlluxioMetastore
     }
 
     @Override
+    public void testInsertBucketedTableLayout()
+    {
+        // Alluxio metastore does not support insert layout operations
+    }
+
+    @Override
+    public void testInsertPartitionedBucketedTableLayout()
+    {
+        // Alluxio metastore does not support insert layout operations
+    }
+
+    @Override
     public void testStorePartitionWithStatistics()
     {
         // Alluxio metastore does not support create operations

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionedBucketFunction.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionedBucketFunction.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.plugin.hive.util.HiveBucketing;
+import io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.BucketFunction;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Throwables.throwIfUnchecked;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static java.util.Objects.requireNonNull;
+
+public class HivePartitionedBucketFunction
+        implements BucketFunction
+{
+    private final BucketingVersion bucketingVersion;
+    private final int hiveBucketCount;
+    private final List<TypeInfo> bucketTypeInfos;
+    private final int bucketCount;
+    private final int firstPartitionColumnIndex;
+    private final List<MethodHandle> hashCodeInvokers;
+
+    public HivePartitionedBucketFunction(
+            BucketingVersion bucketingVersion,
+            int hiveBucketCount,
+            List<HiveType> hiveBucketTypes,
+            List<Type> partitionColumnsTypes,
+            TypeOperators typeOperators,
+            int bucketCount)
+    {
+        this.bucketingVersion = requireNonNull(bucketingVersion, "bucketingVersion is null");
+        this.hiveBucketCount = hiveBucketCount;
+        this.bucketTypeInfos = requireNonNull(hiveBucketTypes, "hiveBucketTypes is null").stream()
+                .map(HiveType::getTypeInfo)
+                .collect(toImmutableList());
+        this.firstPartitionColumnIndex = hiveBucketTypes.size();
+        this.hashCodeInvokers = partitionColumnsTypes.stream()
+                .map(type -> typeOperators.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION)))
+                .collect(toImmutableList());
+        this.bucketCount = bucketCount;
+    }
+
+    @Override
+    public int getBucket(Page page, int position)
+    {
+        long partitionHash = 0;
+        for (int i = 0; i < hashCodeInvokers.size(); i++) {
+            try {
+                Block partitionColumn = page.getBlock(i + firstPartitionColumnIndex);
+                partitionHash = (31 * partitionHash) + hashCodeNullSafe(hashCodeInvokers.get(i), partitionColumn, position);
+            }
+            catch (Throwable throwable) {
+                throwIfUnchecked(throwable);
+                throw new RuntimeException(throwable);
+            }
+        }
+
+        int hiveBucket = HiveBucketing.getHiveBucket(bucketingVersion, hiveBucketCount, bucketTypeInfos, page, bucketTypeInfos.size(), position);
+
+        return (int) ((((31 * partitionHash) + hiveBucket) & Long.MAX_VALUE) % bucketCount);
+    }
+
+    private static long hashCodeNullSafe(MethodHandle hashCode, Block block, int position)
+            throws Throwable
+    {
+        if (block.isNull(position)) {
+            return 0;
+        }
+        return (long) hashCode.invokeExact(block, position);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("version", bucketingVersion)
+                .add("hiveBucketCount", hiveBucketCount)
+                .add("bucketTypeInfos", bucketTypeInfos)
+                .add("firstPartitionColumnIndex", firstPartitionColumnIndex)
+                .add("bucketCount", bucketCount)
+                .toString();
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitioningHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitioningHandle.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.OptionalInt;
 
-import static java.lang.String.format;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class HivePartitioningHandle
@@ -32,18 +32,21 @@ public class HivePartitioningHandle
     private final int bucketCount;
     private final List<HiveType> hiveTypes;
     private final OptionalInt maxCompatibleBucketCount;
+    private final boolean usePartitionedBucketing;
 
     @JsonCreator
     public HivePartitioningHandle(
             @JsonProperty("bucketingVersion") BucketingVersion bucketingVersion,
             @JsonProperty("bucketCount") int bucketCount,
-            @JsonProperty("hiveTypes") List<HiveType> hiveTypes,
-            @JsonProperty("maxCompatibleBucketCount") OptionalInt maxCompatibleBucketCount)
+            @JsonProperty("hiveBucketTypes") List<HiveType> hiveTypes,
+            @JsonProperty("maxCompatibleBucketCount") OptionalInt maxCompatibleBucketCount,
+            @JsonProperty("usePartitionedBucketing") boolean usePartitionedBucketing)
     {
         this.bucketingVersion = requireNonNull(bucketingVersion, "bucketingVersion is null");
         this.bucketCount = bucketCount;
         this.hiveTypes = requireNonNull(hiveTypes, "hiveTypes is null");
         this.maxCompatibleBucketCount = maxCompatibleBucketCount;
+        this.usePartitionedBucketing = usePartitionedBucketing;
     }
 
     @JsonProperty
@@ -70,10 +73,20 @@ public class HivePartitioningHandle
         return maxCompatibleBucketCount;
     }
 
+    @JsonProperty
+    public boolean isUsePartitionedBucketing()
+    {
+        return usePartitionedBucketing;
+    }
+
     @Override
     public String toString()
     {
-        return format("buckets=%s, hiveTypes=%s", bucketCount, hiveTypes);
+        return toStringHelper(this)
+                .add("buckets", bucketCount)
+                .add("hiveTypes", hiveTypes)
+                .add("usePartitionedBucketing", usePartitionedBucketing)
+                .toString();
     }
 
     @Override
@@ -87,12 +100,13 @@ public class HivePartitioningHandle
         }
         HivePartitioningHandle that = (HivePartitioningHandle) o;
         return bucketCount == that.bucketCount &&
+                usePartitionedBucketing == that.usePartitionedBucketing &&
                 Objects.equals(hiveTypes, that.hiveTypes);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(bucketCount, hiveTypes);
+        return Objects.hash(bucketCount, hiveTypes, usePartitionedBucketing);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketing.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketing.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Lists.cartesianProduct;
 import static io.trino.plugin.hive.HiveColumnHandle.BUCKET_COLUMN_NAME;
@@ -76,9 +77,9 @@ public final class HiveBucketing
             }
 
             @Override
-            int getBucketHashCode(List<TypeInfo> types, Page page, int position)
+            int getBucketHashCode(List<TypeInfo> types, Page page, int prefixChannels, int position)
             {
-                return HiveBucketingV1.getBucketHashCode(types, page, position);
+                return HiveBucketingV1.getBucketHashCode(types, page, prefixChannels, position);
             }
         },
         BUCKETING_V2(2) {
@@ -89,9 +90,9 @@ public final class HiveBucketing
             }
 
             @Override
-            int getBucketHashCode(List<TypeInfo> types, Page page, int position)
+            int getBucketHashCode(List<TypeInfo> types, Page page, int prefixChannels, int position)
             {
-                return HiveBucketingV2.getBucketHashCode(types, page, position);
+                return HiveBucketingV2.getBucketHashCode(types, page, prefixChannels, position);
             }
         },
         /**/;
@@ -110,7 +111,13 @@ public final class HiveBucketing
 
         abstract int getBucketHashCode(List<TypeInfo> types, Object[] values);
 
-        abstract int getBucketHashCode(List<TypeInfo> types, Page page, int position);
+        int getBucketHashCode(List<TypeInfo> types, Page page, int position)
+        {
+            checkArgument(types.size() == page.getChannelCount());
+            return getBucketHashCode(types, page, types.size(), position);
+        }
+
+        abstract int getBucketHashCode(List<TypeInfo> types, Page page, int prefixChannels, int position);
     }
 
     private static final long BUCKETS_EXPLORATION_LIMIT_FACTOR = 4;
@@ -129,6 +136,12 @@ public final class HiveBucketing
     public static int getHiveBucket(BucketingVersion bucketingVersion, int bucketCount, List<TypeInfo> types, Page page, int position)
     {
         return getBucketNumber(bucketingVersion.getBucketHashCode(types, page, position), bucketCount);
+    }
+
+    public static int getHiveBucket(BucketingVersion bucketingVersion, int bucketCount, List<TypeInfo> types, Page page, int prefixChannels, int position)
+    {
+        checkArgument(prefixChannels <= page.getChannelCount());
+        return getBucketNumber(bucketingVersion.getBucketHashCode(types, page, prefixChannels, position), bucketCount);
     }
 
     public static int getHiveBucket(BucketingVersion bucketingVersion, int bucketCount, List<TypeInfo> types, Object[] values)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
@@ -38,11 +38,10 @@ final class HiveBucketingV1
 {
     private HiveBucketingV1() {}
 
-    static int getBucketHashCode(List<TypeInfo> types, Page page, int position)
+    static int getBucketHashCode(List<TypeInfo> types, Page page, int prefixChannels, int position)
     {
-        checkArgument(types.size() == page.getChannelCount());
         int result = 0;
-        for (int i = 0; i < page.getChannelCount(); i++) {
+        for (int i = 0; i < prefixChannels; i++) {
             int fieldHash = hash(types.get(i), page.getBlock(i), position);
             result = result * 31 + fieldHash;
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
@@ -41,11 +41,10 @@ final class HiveBucketingV2
 {
     private HiveBucketingV2() {}
 
-    static int getBucketHashCode(List<TypeInfo> types, Page page, int position)
+    static int getBucketHashCode(List<TypeInfo> types, Page page, int prefixChannels, int position)
     {
-        checkArgument(types.size() == page.getChannelCount());
         int result = 0;
-        for (int i = 0; i < page.getChannelCount(); i++) {
+        for (int i = 0; i < prefixChannels; i++) {
             int fieldHash = hash(types.get(i), page.getBlock(i), position);
             result = result * 31 + fieldHash;
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePartitionedBucketFunction.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePartitionedBucketFunction.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.connector.BucketFunction;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.block.BlockAssertions.createLongRepeatBlock;
+import static io.trino.block.BlockAssertions.createLongsBlock;
+import static io.trino.plugin.hive.HiveType.HIVE_LONG;
+import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion;
+import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
+import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V2;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+
+public class TestHivePartitionedBucketFunction
+{
+    @DataProvider(name = "hiveBucketingVersion")
+    public static Object[][] hiveBucketingVersion()
+    {
+        return new Object[][] {{BUCKETING_V1}, {BUCKETING_V2}};
+    }
+
+    @Test(dataProvider = "hiveBucketingVersion")
+    public void testSinglePartition(BucketingVersion hiveBucketingVersion)
+    {
+        int numValues = 1024;
+        int numBuckets = 10;
+        Block bucketColumn = createLongSequenceBlockWithNull(numValues);
+        Page bucketedColumnPage = new Page(bucketColumn);
+        Block partitionColumn = createLongRepeatBlock(78758, numValues);
+        Page page = new Page(bucketColumn, partitionColumn);
+        BucketFunction hiveBucketFunction = bucketFunction(hiveBucketingVersion, numBuckets, ImmutableList.of(HIVE_LONG));
+        Multimap<Integer, Integer> bucketPositions = HashMultimap.create();
+
+        for (int i = 0; i < numValues; i++) {
+            int hiveBucket = hiveBucketFunction.getBucket(bucketedColumnPage, i);
+            // record list of positions for each hive bucket
+            bucketPositions.put(hiveBucket, i);
+        }
+
+        BucketFunction hivePartitionedBucketFunction = partitionedBucketFunction(hiveBucketingVersion, numBuckets, ImmutableList.of(HIVE_LONG), ImmutableList.of(BIGINT), 100);
+        // All positions of a bucket should hash to the same partitioned bucket
+        for (Map.Entry<Integer, Collection<Integer>> entry : bucketPositions.asMap().entrySet()) {
+            assertBucketCount(hivePartitionedBucketFunction, page, entry.getValue(), 1);
+        }
+
+        assertBucketCount(
+                hivePartitionedBucketFunction,
+                page,
+                IntStream.range(0, numValues).boxed().collect(toImmutableList()),
+                numBuckets);
+    }
+
+    @Test(dataProvider = "hiveBucketingVersion")
+    public void testMultiplePartitions(BucketingVersion hiveBucketingVersion)
+    {
+        int numValues = 1024;
+        int numBuckets = 10;
+        Block bucketColumn = createLongSequenceBlockWithNull(numValues);
+        Page bucketedColumnPage = new Page(bucketColumn);
+        BucketFunction hiveBucketFunction = bucketFunction(hiveBucketingVersion, numBuckets, ImmutableList.of(HIVE_LONG));
+
+        int numPartitions = 8;
+        ImmutableList.Builder<Long> partitionValuesBuilder = ImmutableList.builder();
+        for (int i = 0; i < numPartitions; i++) {
+            partitionValuesBuilder.addAll(Collections.nCopies(numValues / numPartitions, i * 348349L));
+        }
+        List<Long> partitionValues = partitionValuesBuilder.build();
+        Block partitionColumn = createLongsBlock(partitionValues);
+        Page page = new Page(bucketColumn, partitionColumn);
+        Map<Long, HashMultimap<Integer, Integer>> partitionedBucketPositions = new HashMap<>();
+
+        for (int i = 0; i < numValues; i++) {
+            int hiveBucket = hiveBucketFunction.getBucket(bucketedColumnPage, i);
+            long hivePartition = partitionValues.get(i);
+            // record list of positions for each combination of hive partition and bucket
+            partitionedBucketPositions.computeIfAbsent(hivePartition, ignored -> HashMultimap.create())
+                    .put(hiveBucket, i);
+        }
+
+        BucketFunction hivePartitionedBucketFunction = partitionedBucketFunction(hiveBucketingVersion, numBuckets, ImmutableList.of(HIVE_LONG), ImmutableList.of(BIGINT), 4000);
+        // All positions of a hive partition and bucket should hash to the same partitioned bucket
+        for (Map.Entry<Long, HashMultimap<Integer, Integer>> partitionEntry : partitionedBucketPositions.entrySet()) {
+            for (Map.Entry<Integer, Collection<Integer>> entry : partitionEntry.getValue().asMap().entrySet()) {
+                assertBucketCount(hivePartitionedBucketFunction, page, entry.getValue(), 1);
+            }
+        }
+
+        assertBucketCount(
+                hivePartitionedBucketFunction,
+                page,
+                IntStream.range(0, numValues).boxed().collect(toImmutableList()),
+                numBuckets * numPartitions);
+    }
+
+    private static void assertBucketCount(BucketFunction bucketFunction, Page page, Collection<Integer> positions, int bucketCount)
+    {
+        assertEquals(
+                positions.stream()
+                        .map(position -> bucketFunction.getBucket(page, position))
+                        .distinct()
+                        .count(),
+                bucketCount);
+    }
+
+    private static Block createLongSequenceBlockWithNull(int numValues)
+    {
+        BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(numValues);
+        int start = 923402935;
+        int end = 923402935 + numValues - 1;
+        for (int i = start; i < end; i++) {
+            BIGINT.writeLong(builder, i);
+        }
+        builder.appendNull();
+        return builder.build();
+    }
+
+    private static BucketFunction partitionedBucketFunction(BucketingVersion hiveBucketingVersion, int hiveBucketCount, List<HiveType> hiveBucketTypes, List<Type> partitionColumnsTypes, int bucketCount)
+    {
+        return new HivePartitionedBucketFunction(
+                hiveBucketingVersion,
+                hiveBucketCount,
+                hiveBucketTypes,
+                partitionColumnsTypes,
+                new TypeOperators(),
+                bucketCount);
+    }
+
+    private static BucketFunction bucketFunction(BucketingVersion hiveBucketingVersion, int hiveBucketCount, List<HiveType> hiveBucketTypes)
+    {
+        return new HiveBucketFunction(hiveBucketingVersion, hiveBucketCount, hiveBucketTypes);
+    }
+}


### PR DESCRIPTION
Added an implementation of BucketFunction which allows distributing
writes to hive buckets in different hive partitions to different nodes
to improve parallelism during writes.