### PR TITLE
[wip] Parallel writes to multiple buckets per worker with preferred write partitioning

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/NewTableLayout.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/NewTableLayout.java
@@ -62,9 +62,14 @@ public class NewTableLayout
                 .map(partitioning -> new PartitioningHandle(Optional.of(catalogName), Optional.of(transactionHandle), partitioning));
     }
 
-    public List<String> getPartitionColumns()
+    public Optional<List<String>> getPartitioningColumns()
     {
-        return layout.getPartitionColumns();
+        return layout.getPartitioningColumns();
+    }
+
+    public Optional<List<String>> getPreferredPartitionColumns()
+    {
+        return layout.getPreferredPartitionColumns();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2745,8 +2745,11 @@ public class LocalExecutionPlanner
 
             int operatorsCount = subContext.getDriverInstanceCount().orElse(1);
             List<Type> types = getSourceOperatorTypes(node, context.getTypes());
+            PartitioningHandle handle = node.getPartitioningScheme().getPartitioning().getHandle();
             LocalExchangeFactory exchangeFactory = new LocalExchangeFactory(
-                    node.getPartitioningScheme().getPartitioning().getHandle(),
+                    nodePartitioningManager::getPartitioningProvider,
+                    session,
+                    handle,
                     operatorsCount,
                     types,
                     ImmutableList.of(),
@@ -2819,8 +2822,11 @@ public class LocalExecutionPlanner
                 }
             }
 
+            PartitioningHandle handle = node.getPartitioningScheme().getPartitioning().getHandle();
             LocalExchangeFactory localExchangeFactory = new LocalExchangeFactory(
-                    node.getPartitioningScheme().getPartitioning().getHandle(),
+                    nodePartitioningManager::getPartitioningProvider,
+                    session,
+                    handle,
                     driverInstanceCount,
                     types,
                     channels,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -277,7 +277,6 @@ import static io.trino.sql.planner.SortExpressionExtractor.extractSortExpression
 import static io.trino.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
-import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SCALED_WRITER_DISTRIBUTION;
 import static io.trino.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static io.trino.sql.planner.plan.AggregationNode.Step.FINAL;
@@ -2482,9 +2481,7 @@ public class LocalExecutionPlanner
         {
             // Set table writer count
             if (node.getPartitioningScheme().isPresent()) {
-                PartitioningHandle partitioningHandle = node.getPartitioningScheme().get().getPartitioning().getHandle();
-                // TODO: add support for arbitrary partitioning in local exchanges
-                if (partitioningHandle.equals(FIXED_HASH_DISTRIBUTION)) {
+                if (node.getExchangePartitioningScheme().isPresent()) {
                     context.setDriverInstanceCount(getTaskWriterCount(session));
                 }
                 else {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
@@ -72,6 +72,13 @@ public class NodePartitioningManager
                 "NodePartitioningProvider for connector '%s' is already registered", catalogName);
     }
 
+    public ConnectorNodePartitioningProvider getPartitioningProvider(CatalogName catalogName)
+    {
+        ConnectorNodePartitioningProvider partitioningProvider = partitioningProviders.get(catalogName);
+        checkArgument(partitioningProvider != null, "No partitioning provider for connector %s", catalogName);
+        return partitioningProvider;
+    }
+
     public void removePartitioningProvider(CatalogName catalogName)
     {
         partitioningProviders.remove(catalogName);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
@@ -317,7 +317,10 @@ public class PlanFragmenter
         @Override
         public PlanNode visitTableWriter(TableWriterNode node, RewriteContext<FragmentProperties> context)
         {
-            if (node.getPartitioningScheme().isPresent()) {
+            if (node.getExchangePartitioningScheme().isPresent()) {
+                context.get().setDistribution(node.getExchangePartitioningScheme().get().getPartitioning().getHandle(), metadata, session);
+            }
+            else if (node.getPartitioningScheme().isPresent()) {
                 context.get().setDistribution(node.getPartitioningScheme().get().getPartitioning().getHandle(), metadata, session);
             }
             return context.defaultRewrite(node, context.get());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushTableWriteThroughUnion.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushTableWriteThroughUnion.java
@@ -50,7 +50,7 @@ public class PushTableWriteThroughUnion
             // guaranteed regardless of this optimizer. The level of local parallelism will be
             // determined by LocalExecutionPlanner separately, and shouldn't be a concern of
             // this optimizer.
-            .matching(tableWriter -> tableWriter.getPartitioningScheme().isEmpty())
+            .matching(tableWriter -> tableWriter.getPartitioningScheme().isEmpty() && tableWriter.getExchangePartitioningScheme().isEmpty())
             .with(source().matching(union().capturedAs(CHILD)));
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -532,7 +532,11 @@ public class AddExchanges
         {
             PlanWithProperties source = node.getSource().accept(this, preferredProperties);
 
-            Optional<PartitioningScheme> partitioningScheme = node.getPartitioningScheme();
+            Optional<PartitioningScheme> partitioningScheme = node.getExchangePartitioningScheme();
+            if (partitioningScheme.isEmpty()) {
+                partitioningScheme = node.getPartitioningScheme();
+            }
+
             if (partitioningScheme.isEmpty()) {
                 if (scaleWriters) {
                     partitioningScheme = Optional.of(new PartitioningScheme(Partitioning.create(SCALED_WRITER_DISTRIBUTION, ImmutableList.of()), source.getNode().getOutputSymbols()));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -95,7 +95,6 @@ import static io.trino.sql.planner.plan.ExchangeNode.gatheringExchange;
 import static io.trino.sql.planner.plan.ExchangeNode.mergingExchange;
 import static io.trino.sql.planner.plan.ExchangeNode.partitionedExchange;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Predicate.isEqual;
 import static java.util.stream.Collectors.toList;
 
 public class AddLocalExchanges
@@ -536,19 +535,23 @@ public class AddLocalExchanges
         {
             StreamPreferredProperties requiredProperties;
             StreamPreferredProperties preferredProperties;
-            // TODO: add support for arbitrary partitioning in local exchanges
             if (getTaskWriterCount(session) > 1) {
-                boolean hasFixedHashDistribution = node.getPartitioningScheme()
-                        .map(scheme -> scheme.getPartitioning().getHandle())
-                        .filter(isEqual(FIXED_HASH_DISTRIBUTION))
-                        .isPresent();
                 if (node.getPartitioningScheme().isEmpty()) {
                     requiredProperties = fixedParallelism();
                     preferredProperties = fixedParallelism();
                 }
-                else if (hasFixedHashDistribution) {
-                    requiredProperties = exactlyPartitionedOn(node.getPartitioningScheme().get().getPartitioning().getColumns());
+                else if (node.getExchangePartitioningScheme().isPresent()) {
+                    requiredProperties = exactlyPartitionedOn(node.getExchangePartitioningScheme().get().getPartitioning().getColumns());
                     preferredProperties = requiredProperties;
+                    PlanWithProperties child = planAndEnforce(node.getSource(), requiredProperties, preferredProperties);
+                    PlanWithProperties exchange = deriveProperties(
+                            partitionedExchange(
+                                    idAllocator.getNextId(),
+                                    LOCAL,
+                                    child.getNode(),
+                                    node.getPartitioningScheme().get()),
+                            child.getProperties());
+                    return rebaseAndDeriveProperties(node, ImmutableList.of(exchange));
                 }
                 else {
                     requiredProperties = singleStream();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
@@ -102,6 +102,7 @@ public class BeginTableWrite
                     node.getColumnNames(),
                     node.getNotNullColumnSymbols(),
                     node.getPartitioningScheme(),
+                    node.getExchangePartitioningScheme(),
                     node.getStatisticsAggregation(),
                     node.getStatisticsAggregationDescriptor());
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -665,6 +665,11 @@ public class PruneUnreferencedOutputs
                 partitioningScheme.getPartitioning().getColumns().forEach(expectedInputs::add);
                 partitioningScheme.getHashColumn().ifPresent(expectedInputs::add);
             }
+            if (node.getExchangePartitioningScheme().isPresent()) {
+                PartitioningScheme partitioningScheme = node.getExchangePartitioningScheme().get();
+                partitioningScheme.getPartitioning().getColumns().forEach(expectedInputs::add);
+                partitioningScheme.getHashColumn().ifPresent(expectedInputs::add);
+            }
             if (node.getStatisticsAggregation().isPresent()) {
                 StatisticAggregations aggregations = node.getStatisticsAggregation().get();
                 expectedInputs.addAll(aggregations.getGroupingSymbols());
@@ -681,6 +686,7 @@ public class PruneUnreferencedOutputs
                     node.getColumnNames(),
                     node.getNotNullColumnSymbols(),
                     node.getPartitioningScheme(),
+                    node.getExchangePartitioningScheme(),
                     node.getStatisticsAggregation(),
                     node.getStatisticsAggregationDescriptor());
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -301,6 +301,7 @@ public class SymbolMapper
                 node.getColumnNames(),
                 node.getNotNullColumnSymbols(),
                 node.getPartitioningScheme().map(partitioningScheme -> map(partitioningScheme, source.getOutputSymbols())),
+                node.getExchangePartitioningScheme().map(partitioningScheme -> map(partitioningScheme, source.getOutputSymbols())),
                 node.getStatisticsAggregation().map(this::map),
                 node.getStatisticsAggregationDescriptor().map(descriptor -> descriptor.map(this::map)));
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
@@ -52,6 +52,7 @@ public class TableWriterNode
     private final List<String> columnNames;
     private final Set<Symbol> notNullColumnSymbols;
     private final Optional<PartitioningScheme> partitioningScheme;
+    private final Optional<PartitioningScheme> exchangePartitioningScheme;
     private final Optional<StatisticAggregations> statisticsAggregation;
     private final Optional<StatisticAggregationsDescriptor<Symbol>> statisticsAggregationDescriptor;
     private final List<Symbol> outputs;
@@ -67,6 +68,7 @@ public class TableWriterNode
             @JsonProperty("columnNames") List<String> columnNames,
             @JsonProperty("notNullColumnSymbols") Set<Symbol> notNullColumnSymbols,
             @JsonProperty("partitioningScheme") Optional<PartitioningScheme> partitioningScheme,
+            @JsonProperty("exchangePartitioningScheme") Optional<PartitioningScheme> exchangePartitioningScheme,
             @JsonProperty("statisticsAggregation") Optional<StatisticAggregations> statisticsAggregation,
             @JsonProperty("statisticsAggregationDescriptor") Optional<StatisticAggregationsDescriptor<Symbol>> statisticsAggregationDescriptor)
     {
@@ -84,6 +86,7 @@ public class TableWriterNode
         this.columnNames = ImmutableList.copyOf(columnNames);
         this.notNullColumnSymbols = ImmutableSet.copyOf(requireNonNull(notNullColumnSymbols, "notNullColumns is null"));
         this.partitioningScheme = requireNonNull(partitioningScheme, "partitioningScheme is null");
+        this.exchangePartitioningScheme = requireNonNull(exchangePartitioningScheme, "exchangePartitioningScheme is null");
         this.statisticsAggregation = requireNonNull(statisticsAggregation, "statisticsAggregation is null");
         this.statisticsAggregationDescriptor = requireNonNull(statisticsAggregationDescriptor, "statisticsAggregationDescriptor is null");
         checkArgument(statisticsAggregation.isPresent() == statisticsAggregationDescriptor.isPresent(), "statisticsAggregation and statisticsAggregationDescriptor must be either present or absent");
@@ -147,6 +150,12 @@ public class TableWriterNode
     }
 
     @JsonProperty
+    public Optional<PartitioningScheme> getExchangePartitioningScheme()
+    {
+        return exchangePartitioningScheme;
+    }
+
+    @JsonProperty
     public Optional<StatisticAggregations> getStatisticsAggregation()
     {
         return statisticsAggregation;
@@ -179,7 +188,7 @@ public class TableWriterNode
     @Override
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
-        return new TableWriterNode(getId(), Iterables.getOnlyElement(newChildren), target, rowCountSymbol, fragmentSymbol, columns, columnNames, notNullColumnSymbols, partitioningScheme, statisticsAggregation, statisticsAggregationDescriptor);
+        return new TableWriterNode(getId(), Iterables.getOnlyElement(newChildren), target, rowCountSymbol, fragmentSymbol, columns, columnNames, notNullColumnSymbols, partitioningScheme, exchangePartitioningScheme, statisticsAggregation, statisticsAggregationDescriptor);
     }
 
     @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashJoinOperator.java
@@ -93,6 +93,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -1555,6 +1556,10 @@ public class TestHashJoinOperator
 
         int partitionCount = parallelBuild ? PARTITION_COUNT : 1;
         LocalExchangeFactory localExchangeFactory = new LocalExchangeFactory(
+                (catalogName) -> {
+                    throw new IllegalStateException("connectorPartitioningProvider should be not required here");
+                },
+                testSessionBuilder().build(),
                 FIXED_HASH_DISTRIBUTION,
                 partitionCount,
                 buildPages.getTypes(),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -968,6 +968,7 @@ public class PlanBuilder
                 columnNames,
                 ImmutableSet.of(),
                 partitioningScheme,
+                Optional.empty(),
                 statisticAggregations,
                 statisticAggregationsDescriptor);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/Page.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Page.java
@@ -335,6 +335,17 @@ public final class Page
         return wrapBlocksWithoutCopy(length, blocks);
     }
 
+    public Page extractChannels(int[] channels)
+    {
+        requireNonNull(channels, "channels is null");
+
+        Block[] blocks = new Block[channels.length];
+        for (int i = 0; i < channels.length; i++) {
+            blocks[i] = this.blocks[channels[i]];
+        }
+        return wrapBlocksWithoutCopy(positionCount, blocks);
+    }
+
     public Page getColumns(int column)
     {
         return wrapBlocksWithoutCopy(positionCount, new Block[] {this.blocks[column]});

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorNewTableLayout.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorNewTableLayout.java
@@ -21,22 +21,30 @@ import static java.util.Objects.requireNonNull;
 public class ConnectorNewTableLayout
 {
     private final Optional<ConnectorPartitioningHandle> partitioning;
-    private final List<String> partitionColumns;
+    private final Optional<List<String>> partitioningColumns;
+    private final Optional<List<String>> preferredPartitionColumns;
 
-    public ConnectorNewTableLayout(ConnectorPartitioningHandle partitioning, List<String> partitionColumns)
+    public ConnectorNewTableLayout(ConnectorPartitioningHandle partitioning, List<String> partitioningColumns)
+    {
+        this(partitioning, partitioningColumns, Optional.empty());
+    }
+
+    public ConnectorNewTableLayout(ConnectorPartitioningHandle partitioning, List<String> partitioningColumns, Optional<List<String>> preferredPartitionColumns)
     {
         this.partitioning = Optional.of(requireNonNull(partitioning, "partitioning is null"));
-        this.partitionColumns = requireNonNull(partitionColumns, "partitionColumns is null");
+        this.partitioningColumns = Optional.of(requireNonNull(partitioningColumns, "partitionColumns is null"));
+        this.preferredPartitionColumns = requireNonNull(preferredPartitionColumns, "preferredPartitionColumns is null");
     }
 
     /**
      * Creates a preferred table layout that is evenly partitioned on given columns by the engine.
      * Such layout might be ignored by Trino planner.
      */
-    public ConnectorNewTableLayout(List<String> partitionColumns)
+    public ConnectorNewTableLayout(List<String> preferredPartitionColumns)
     {
         this.partitioning = Optional.empty();
-        this.partitionColumns = requireNonNull(partitionColumns, "partitionColumns is null");
+        this.partitioningColumns = Optional.empty();
+        this.preferredPartitionColumns = Optional.of(requireNonNull(preferredPartitionColumns, "preferredPartitionColumns is null"));
     }
 
     public Optional<ConnectorPartitioningHandle> getPartitioning()
@@ -44,8 +52,13 @@ public class ConnectorNewTableLayout
         return partitioning;
     }
 
-    public List<String> getPartitionColumns()
+    public Optional<List<String>> getPartitioningColumns()
     {
-        return partitionColumns;
+        return partitioningColumns;
+    }
+
+    public Optional<List<String>> getPreferredPartitionColumns()
+    {
+        return preferredPartitionColumns;
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -4933,7 +4933,8 @@ public abstract class AbstractTestHive
                 Optional<ConnectorNewTableLayout> insertLayout = metadata.getInsertLayout(session, tableHandle);
                 assertTrue(insertLayout.isPresent());
                 assertFalse(insertLayout.get().getPartitioning().isPresent());
-                assertEquals(insertLayout.get().getPartitionColumns(), ImmutableList.of(partitioningColumn.getName()));
+                assertFalse(insertLayout.get().getPartitioningColumns().isPresent());
+                assertEquals(insertLayout.get().getPreferredPartitionColumns(), Optional.of(ImmutableList.of(partitioningColumn.getName())));
             }
         }
         finally {
@@ -4961,7 +4962,8 @@ public abstract class AbstractTestHive
                                     SORTED_BY_PROPERTY, ImmutableList.of())));
             assertTrue(newTableLayout.isPresent());
             assertFalse(newTableLayout.get().getPartitioning().isPresent());
-            assertEquals(newTableLayout.get().getPartitionColumns(), ImmutableList.of("column2"));
+            assertFalse(newTableLayout.get().getPartitioningColumns().isPresent());
+            assertEquals(newTableLayout.get().getPreferredPartitionColumns(), Optional.of(ImmutableList.of("column2")));
         }
     }
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorMetadata.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorMetadata.java
@@ -388,7 +388,7 @@ public class TestRaptorMetadata
                 BUCKETED_ON_PROPERTY, ImmutableList.of("orderkey", "custkey")));
 
         ConnectorNewTableLayout layout = metadata.getNewTableLayout(SESSION, ordersTable).get();
-        assertEquals(layout.getPartitionColumns(), ImmutableList.of("orderkey", "custkey"));
+        assertEquals(layout.getPartitioningColumns(), Optional.of(ImmutableList.of("orderkey", "custkey")));
         assertTrue(layout.getPartitioning().isPresent());
         assertInstanceOf(layout.getPartitioning().get(), RaptorPartitioningHandle.class);
         RaptorPartitioningHandle partitioning = (RaptorPartitioningHandle) layout.getPartitioning().get();


### PR DESCRIPTION
Currently use_preferred_write_partitioning is ignored for bucketed tables
and the number of writers used is equal to (number of buckets) % number of workers.
With this change, for writes to partitioned bucketed tables when
use_preferred_write_partitioning is enabled, we will use 
(P * task.writer-count) writers where P is number of partitions written
by the query.