### PR TITLE
Enable (almost) all errorprone checks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -182,7 +182,7 @@ public class SqlTask
             }
 
             try {
-                onDone.apply(SqlTask.this);
+                onDone(onDone);
             }
             catch (Exception e) {
                 log.warn(e, "Error running task cleanup callback %s", SqlTask.this.taskId);
@@ -191,6 +191,12 @@ public class SqlTask
             // notify that task is finished
             notifyStatusChanged();
         });
+    }
+
+    @SuppressWarnings("ReturnValueIgnored") // onDone should probably be a Consumer, but that would change the public API
+    private void onDone(Function<SqlTask, ?> onDone)
+    {
+        onDone.apply(SqlTask.this);
     }
 
     public boolean isOutputBufferOverutilized()

--- a/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunctionBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunctionBuilder.java
@@ -102,7 +102,7 @@ public final class PolymorphicScalarFunctionBuilder
             argumentDefinitions = nCopies(signature.getArgumentTypes().size(), new FunctionArgumentDefinition(false));
         }
         ChoiceBuilder choiceBuilder = new ChoiceBuilder(clazz, signature);
-        choiceSpecification.apply(choiceBuilder);
+        choiceBuilder = choiceSpecification.apply(choiceBuilder);
         choices.add(choiceBuilder.build());
         return this;
     }
@@ -278,7 +278,7 @@ public final class PolymorphicScalarFunctionBuilder
                 argumentConventions = nCopies(signature.getArgumentTypes().size(), NEVER_NULL);
             }
             MethodsGroupBuilder methodsGroupBuilder = new MethodsGroupBuilder(clazz, signature, argumentConventions);
-            methodsGroupSpecification.apply(methodsGroupBuilder);
+            methodsGroupBuilder = methodsGroupSpecification.apply(methodsGroupBuilder);
             methodsGroups.add(methodsGroupBuilder.build());
             return this;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/ValuesOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ValuesOperator.java
@@ -82,6 +82,7 @@ public class ValuesOperator
     }
 
     @Override
+    @SuppressWarnings("CheckReturnValue") // uses an Iterator helper to consume the remainder of the pages Iterator
     public void finish()
     {
         Iterators.size(pages);

--- a/core/trino-main/src/main/java/io/trino/operator/annotations/ImplementationDependency.java
+++ b/core/trino-main/src/main/java/io/trino/operator/annotations/ImplementationDependency.java
@@ -139,7 +139,7 @@ public interface ImplementationDependency
                         type);
             }
 
-            throw new IllegalArgumentException("Unsupported annotation " + annotation.getClass().getSimpleName());
+            throw new IllegalArgumentException("Unsupported annotation " + annotation);
         }
 
         private static InvocationConvention toInvocationConvention(Convention convention)

--- a/core/trino-main/src/main/java/io/trino/operator/project/MergePages.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/MergePages.java
@@ -101,7 +101,7 @@ public final class MergePages
             checkArgument(minRowCount >= 0, "minRowCount must be greater or equal than zero");
             checkArgument(maxPageSizeInBytes > 0, "maxPageSizeInBytes must be greater than zero");
             checkArgument(maxPageSizeInBytes >= minPageSizeInBytes, "maxPageSizeInBytes must be greater or equal than minPageSizeInBytes");
-            checkArgument(minPageSizeInBytes <= MAX_MIN_PAGE_SIZE, "minPageSizeInBytes must be less or equal than %d", MAX_MIN_PAGE_SIZE);
+            checkArgument(minPageSizeInBytes <= MAX_MIN_PAGE_SIZE, "minPageSizeInBytes must be less or equal than %s", MAX_MIN_PAGE_SIZE);
             this.minPageSizeInBytes = minPageSizeInBytes;
             this.minRowCount = minRowCount;
             this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToJsonCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToJsonCast.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandle;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.trino.metadata.Signature.castableToTypeParameter;
 import static io.trino.operator.scalar.JsonOperators.JSON_FACTORY;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
@@ -90,7 +89,6 @@ public class ArrayToJsonCast
             return output.slice();
         }
         catch (IOException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapToJsonCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapToJsonCast.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.trino.metadata.Signature.castableToTypeParameter;
 import static io.trino.operator.scalar.JsonOperators.JSON_FACTORY;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
@@ -108,7 +107,6 @@ public class MapToJsonCast
             return output.slice();
         }
         catch (IOException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/RowToJsonCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/RowToJsonCast.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.trino.operator.scalar.JsonOperators.JSON_FACTORY;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
@@ -101,7 +100,6 @@ public class RowToJsonCast
             return output.slice();
         }
         catch (IOException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/LambdaCapture.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/LambdaCapture.java
@@ -21,8 +21,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 
-import static com.google.common.base.Throwables.throwIfUnchecked;
-
 public final class LambdaCapture
 {
     public static final Method LAMBDA_CAPTURE_METHOD;
@@ -59,7 +57,6 @@ public final class LambdaCapture
                     instantiatedMethodType);
         }
         catch (LambdaConversionException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/Util.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/Util.java
@@ -96,7 +96,7 @@ final class Util
 
         checkArgument(
                 (node.getSources().size() == permittedChildOutputs.size()),
-                "Mismatched child (%d) and permitted outputs (%d) sizes",
+                "Mismatched child (%s) and permitted outputs (%s) sizes",
                 node.getSources().size(),
                 permittedChildOutputs.size());
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
@@ -356,11 +356,11 @@ public class IoPlanPrinter
                 @JsonProperty("maxMemory") double maxMemory,
                 @JsonProperty("networkCost") double networkCost)
         {
-            this.outputRowCount = requireNonNull(outputRowCount, "outputRowCount is null");
-            this.outputSizeInBytes = requireNonNull(outputSizeInBytes, "outputSizeInBytes is null");
-            this.cpuCost = requireNonNull(cpuCost, "cpuCost is null");
-            this.maxMemory = requireNonNull(maxMemory, "maxMemory is null");
-            this.networkCost = requireNonNull(networkCost, "networkCost is null");
+            this.outputRowCount = outputRowCount;
+            this.outputSizeInBytes = outputSizeInBytes;
+            this.cpuCost = cpuCost;
+            this.maxMemory = maxMemory;
+            this.networkCost = networkCost;
         }
 
         @JsonProperty

--- a/core/trino-main/src/main/java/io/trino/util/CompilerUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/CompilerUtils.java
@@ -35,7 +35,7 @@ public final class CompilerUtils
     private static final Logger log = Logger.get(CompilerUtils.class);
 
     private static final AtomicLong CLASS_ID = new AtomicLong();
-    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("YYYYMMdd_HHmmss");
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
 
     private CompilerUtils() {}
 

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestAggregationFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestAggregationFunction.java
@@ -41,6 +41,7 @@ import static io.trino.operator.aggregation.AggregationTestUtils.makeValidityAss
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractTestAggregationFunction
 {
@@ -185,9 +186,10 @@ public abstract class AbstractTestAggregationFunction
             oldStart = start;
             oldWidth = width;
             Block block = getFinalBlock(aggregation);
-            makeValidityAssertion(expectedValues[start]).apply(
+            assertThat(makeValidityAssertion(expectedValues[start]).apply(
                     BlockAssertions.getOnlyValue(aggregation.getFinalType(), block),
-                    expectedValues[start]);
+                    expectedValues[start]))
+                    .isTrue();
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
@@ -388,8 +388,7 @@ public final class FunctionAssertions
                     new DriverYieldSignal(),
                     newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
                     SOURCE_PAGE);
-            // consume the iterator
-            Iterators.getOnlyElement(output);
+            consume(output);
 
             long retainedSize = processor.getProjections().stream()
                     .mapToLong(this::getRetainedSizeOfCachedInstance)
@@ -403,6 +402,12 @@ public final class FunctionAssertions
                 fail(format("The retained size of cached instance of function invocation is likely unbounded: %s", projection));
             }
         }
+    }
+
+    @SuppressWarnings("CheckReturnValue")
+    private void consume(Iterator<Optional<Page>> output)
+    {
+        Iterators.getOnlyElement(output);
     }
 
     private long getRetainedSizeOfCachedInstance(PageProjection projection)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BaseStrictSymbolsMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BaseStrictSymbolsMatcher.java
@@ -36,6 +36,7 @@ public abstract class BaseStrictSymbolsMatcher
     }
 
     @Override
+    @SuppressWarnings("CheckReturnValue") // only checks if the transformation completes without throwing
     public boolean shapeMatches(PlanNode node)
     {
         try {

--- a/core/trino-main/src/test/java/io/trino/type/TestBigintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBigintOperators.java
@@ -66,6 +66,7 @@ public class TestBigintOperators
     }
 
     @Test
+    @SuppressWarnings("PointlessArithmeticExpression")
     public void testSubtract()
     {
         assertFunction("100000000037 - 37", BIGINT, 100000000037L - 37L);
@@ -84,6 +85,7 @@ public class TestBigintOperators
     }
 
     @Test
+    @SuppressWarnings("PointlessArithmeticExpression")
     public void testDivide()
     {
         assertFunction("100000000037 / 37", BIGINT, 100000000037L / 37L);
@@ -93,6 +95,7 @@ public class TestBigintOperators
     }
 
     @Test
+    @SuppressWarnings({"IdentityBinaryExpression", "PointlessArithmeticExpression"})
     public void testModulus()
     {
         assertFunction("100000000037 % 37", BIGINT, 100000000037L % 37L);

--- a/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
@@ -73,6 +73,7 @@ public class TestDoubleOperators
     }
 
     @Test
+    @SuppressWarnings("PointlessArithmeticExpression")
     public void testSubtract()
     {
         assertFunction("37.7E0 - 37.7E0", DOUBLE, 37.7 - 37.7);
@@ -97,6 +98,7 @@ public class TestDoubleOperators
     }
 
     @Test
+    @SuppressWarnings("PointlessArithmeticExpression")
     public void testDivide()
     {
         assertFunction("37.7E0 / 37.7E0", DOUBLE, 37.7 / 37.7);
@@ -109,6 +111,7 @@ public class TestDoubleOperators
     }
 
     @Test
+    @SuppressWarnings({"IdentityBinaryExpression", "PointlessArithmeticExpression"})
     public void testModulus()
     {
         assertFunction("37.7E0 % 37.7E0", DOUBLE, 37.7 % 37.7);

--- a/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/function/ScalarFunctionAdapter.java
@@ -190,7 +190,7 @@ public final class ScalarFunctionAdapter
         requireNonNull(methodHandle, "methodHandle is null");
         requireNonNull(actualConvention, "actualConvention is null");
         requireNonNull(expectedConvention, "expectedConvention is null");
-        if (expectedConvention.getArgumentConventions().size() != expectedConvention.getArgumentConventions().size()) {
+        if (actualConvention.getArgumentConventions().size() != expectedConvention.getArgumentConventions().size()) {
             throw new IllegalArgumentException("Actual and expected conventions have different number of arguments");
         }
 

--- a/core/trino-spi/src/test/java/io/trino/spi/block/BenchmarkComputePosition.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/BenchmarkComputePosition.java
@@ -78,7 +78,7 @@ public class BenchmarkComputePosition
     @Benchmark
     public long computePositionWithDivision()
     {
-        return (int) ((Integer.toUnsignedLong(Long.hashCode(hashcode)) * hashTableSize) / (1 << 32));
+        return (int) ((Integer.toUnsignedLong(Long.hashCode(hashcode)) * hashTableSize) / (1L << 32));
     }
 
     public static void main(String[] args)

--- a/lib/trino-matching/src/test/java/io/trino/matching/TestMatcher.java
+++ b/lib/trino-matching/src/test/java/io/trino/matching/TestMatcher.java
@@ -194,7 +194,8 @@ public class TestMatcher
                         }).equalTo(true));
 
         AtomicBoolean wasContextUsed = new AtomicBoolean();
-        pattern.match("object", wasContextUsed)
+        @SuppressWarnings("unused")
+        Match match = pattern.match("object", wasContextUsed)
                 .collect(onlyElement());
         assertEquals(wasContextUsed.get(), true);
     }
@@ -209,7 +210,8 @@ public class TestMatcher
                 });
 
         AtomicBoolean wasContextUsed = new AtomicBoolean();
-        pattern.match("object", wasContextUsed)
+        @SuppressWarnings("unused")
+        Match match = pattern.match("object", wasContextUsed)
                 .collect(onlyElement());
         assertEquals(wasContextUsed.get(), true);
     }

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcReaderOptions.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcReaderOptions.java
@@ -66,7 +66,7 @@ public class OrcReaderOptions
         this.tinyStripeThreshold = requireNonNull(tinyStripeThreshold, "tinyStripeThreshold is null");
         this.streamBufferSize = requireNonNull(streamBufferSize, "streamBufferSize is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
-        this.lazyReadSmallRanges = requireNonNull(lazyReadSmallRanges, "lazyReadSmallRanges is null");
+        this.lazyReadSmallRanges = lazyReadSmallRanges;
         this.bloomFiltersEnabled = bloomFiltersEnabled;
         this.nestedLazy = nestedLazy;
     }

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStreamV1.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/LongInputStreamV1.java
@@ -64,7 +64,9 @@ public class LongInputStreamV1
             }
 
             // convert from 0 to 255 to -128 to 127 by converting to a signed byte
-            delta = (byte) delta;
+            @SuppressWarnings("UnnecessaryLocalVariable")
+            byte deltaSigned = (byte) this.delta;
+            delta = deltaSigned;
             literals[0] = LongDecode.readVInt(signed, input);
         }
         else {

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopProcessFactory.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopProcessFactory.java
@@ -45,7 +45,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class AtopProcessFactory
         implements AtopFactory
 {
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("YYYYMMdd");
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
     private final String executablePath;
     private final ZoneId timeZone;
     private final Duration readTimeout;

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TimestampDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TimestampDecoder.java
@@ -35,7 +35,7 @@ import static java.util.Objects.requireNonNull;
 public class TimestampDecoder
         implements Decoder
 {
-    private static final ZoneId ZULU = ZoneId.of("Z");
+    private static final ZoneId ZULU = ZoneOffset.UTC;
     private final String path;
 
     public TimestampDecoder(String path)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
@@ -458,7 +458,7 @@ public final class MetastoreUtil
         Long count = Longs.tryParse(existingRowCount);
         requireNonNull(count, format("For %s, the existing row count (%s) is not a digit string", description, existingRowCount));
         long newRowCount = count + rowCountAdjustment;
-        checkArgument(newRowCount >= 0, "For %s, the subtracted row count (%s) is less than zero, existing count %s, rows deleted %d", description, newRowCount, existingRowCount, rowCountAdjustment);
+        checkArgument(newRowCount >= 0, "For %s, the subtracted row count (%s) is less than zero, existing count %s, rows deleted %s", description, newRowCount, existingRowCount, rowCountAdjustment);
         Map<String, String> copiedParameters = new HashMap<>(parameters);
         copiedParameters.put(NUM_ROWS, String.valueOf(newRowCount));
         return ImmutableMap.copyOf(copiedParameters);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -1006,8 +1006,8 @@ public final class HiveUtil
 
     public static OrcWriterOptions getOrcWriterOptions(Properties schema, OrcWriterOptions orcWriterOptions)
     {
-        if (schema.contains(ORC_BLOOM_FILTER_COLUMNS)) {
-            if (!schema.contains(ORC_BLOOM_FILTER_FPP)) {
+        if (schema.containsValue(ORC_BLOOM_FILTER_COLUMNS)) {
+            if (!schema.containsValue(ORC_BLOOM_FILTER_FPP)) {
                 throw new TrinoException(HIVE_INVALID_METADATA, format("FPP for bloom filter is missing"));
             }
             try {

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisShardCheckpointer.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisShardCheckpointer.java
@@ -22,8 +22,6 @@ import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
 import com.amazonaws.services.kinesis.leases.impl.KinesisClientLeaseManager;
 import io.airlift.log.Logger;
 
-import static com.google.common.base.Throwables.throwIfUnchecked;
-
 public class KinesisShardCheckpointer
 {
     private static final Logger log = Logger.get(KinesisShardCheckpointer.class);
@@ -82,7 +80,6 @@ public class KinesisShardCheckpointer
             }
         }
         catch (ProvisionedThroughputException | InvalidStateException | DependencyException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
         resetNextCheckpointTime();
@@ -118,7 +115,6 @@ public class KinesisShardCheckpointer
             }
         }
         catch (DependencyException | InvalidStateException | ProvisionedThroughputException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
         resetNextCheckpointTime();
@@ -134,7 +130,6 @@ public class KinesisShardCheckpointer
                 oldLease = leaseManager.getLease(createCheckpointKey(currentIterationNumber - 1));
             }
             catch (DependencyException | InvalidStateException | ProvisionedThroughputException e) {
-                throwIfUnchecked(e);
                 throw new RuntimeException(e);
             }
             if (oldLease != null) {

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableDescriptionSupplier.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableDescriptionSupplier.java
@@ -91,7 +91,6 @@ public class KinesisTableDescriptionSupplier
             return tableDefinitions;
         }
         catch (IOException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/s3config/S3TableConfigClient.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/s3config/S3TableConfigClient.java
@@ -48,7 +48,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
@@ -199,7 +198,6 @@ public class S3TableConfigClient
                 }
                 catch (IOException iox) {
                     log.error("Problem reading input stream from object.", iox);
-                    throwIfUnchecked(iox);
                     throw new RuntimeException(iox);
                 }
             }

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryInsertTableHandle.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryInsertTableHandle.java
@@ -33,7 +33,7 @@ public class MemoryInsertTableHandle
             @JsonProperty("table") long table,
             @JsonProperty("activeTableIds") Set<Long> activeTableIds)
     {
-        this.table = requireNonNull(table, "table is null");
+        this.table = table;
         this.activeTableIds = requireNonNull(activeTableIds, "activeTableIds is null");
     }
 

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryOutputTableHandle.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryOutputTableHandle.java
@@ -33,7 +33,7 @@ public final class MemoryOutputTableHandle
             @JsonProperty("table") long table,
             @JsonProperty("activeTableIds") Set<Long> activeTableIds)
     {
-        this.table = requireNonNull(table, "table is null");
+        this.table = table;
         this.activeTableIds = requireNonNull(activeTableIds, "activeTableIds is null");
     }
 

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemorySplit.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemorySplit.java
@@ -50,7 +50,7 @@ public class MemorySplit
         checkState(totalPartsPerWorker >= 1, "totalPartsPerWorker must be >= 1");
         checkState(totalPartsPerWorker > partNumber, "totalPartsPerWorker must be > partNumber");
 
-        this.table = requireNonNull(table, "table is null");
+        this.table = table;
         this.partNumber = partNumber;
         this.totalPartsPerWorker = totalPartsPerWorker;
         this.address = requireNonNull(address, "address is null");

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/TableInfo.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/TableInfo.java
@@ -36,7 +36,7 @@ public class TableInfo
 
     public TableInfo(long id, String schemaName, String tableName, List<ColumnInfo> columns, Map<HostAddress, MemoryDataFragment> dataFragments)
     {
-        this.id = requireNonNull(id, "handle is null");
+        this.id = id;
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.columns = ImmutableList.copyOf(columns);

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -487,7 +487,7 @@ public class PinotClient
     public static <T> T doWithRetries(int retries, Function<Integer, T> caller)
     {
         PinotException firstError = null;
-        checkState(retries > 0, "Invalid num of retries %d", retries);
+        checkState(retries > 0, "Invalid num of retries %s", retries);
         for (int i = 0; i < retries; ++i) {
             try {
                 return caller.apply(i);

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -750,7 +750,7 @@ public class PostgreSqlClient
     private static ColumnMapping timestampWithTimeZoneColumnMapping(int precision)
     {
         // PostgreSQL supports timestamptz precision up to microseconds
-        checkArgument(precision <= POSTGRESQL_MAX_SUPPORTED_TIMESTAMP_PRECISION, "unsupported precision value %d", precision);
+        checkArgument(precision <= POSTGRESQL_MAX_SUPPORTED_TIMESTAMP_PRECISION, "unsupported precision value %s", precision);
         TimestampWithTimeZoneType prestoType = createTimestampWithTimeZoneType(precision);
         if (precision <= TimestampWithTimeZoneType.MAX_SHORT_PRECISION) {
             return ColumnMapping.longMapping(

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -1365,6 +1365,7 @@ public class TestPostgreSqlTypeMapping
      * @see #testTimestampWithTimeZoneCoercion
      */
     @Test(dataProvider = "trueFalse", dataProviderClass = DataProviders.class)
+    @SuppressWarnings("ZoneIdOfZ")
     public void testTimestampWithTimeZone(boolean insertWithTrino)
     {
         DataTypeTest tests = DataTypeTest.create(true);
@@ -1387,6 +1388,7 @@ public class TestPostgreSqlTypeMapping
             tests.addRoundTrip(dataType, afterEpoch.atZone(ZoneId.of("GMT")));
             tests.addRoundTrip(dataType, afterEpoch.atZone(ZoneId.of("UTC")));
             tests.addRoundTrip(dataType, afterEpoch.atZone(ZoneId.of("Z")));
+            tests.addRoundTrip(dataType, afterEpoch.atZone(ZoneOffset.UTC));
             tests.addRoundTrip(dataType, afterEpoch.atZone(ZoneId.of("UTC+00:00")));
             tests.addRoundTrip(dataType, timeDoubledInJvmZone.atZone(UTC));
             tests.addRoundTrip(dataType, timeDoubledInJvmZone.atZone(jvmZone));

--- a/pom.xml
+++ b/pom.xml
@@ -1746,6 +1746,7 @@
                                     -Xep:InjectOnConstructorOfAbstractClass:ERROR
                                     -Xep:MissingCasesInEnumSwitch:ERROR
                                     -Xep:MissingOverride:ERROR
+                                    -Xep:MisusedWeekYear:ERROR <!-- Use of "YYYY" (week year) in a date pattern without "ww" (week in year). You probably meant to use "yyyy" (year) instead. -->
                                     -Xep:NullOptional:ERROR
                                     -Xep:ObjectToString:ERROR
                                     -Xep:OptionalEquality:ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -1755,6 +1755,7 @@
                                     -Xep:OptionalMapUnusedValue:ERROR
                                     -Xep:PreconditionsInvalidPlaceholder:ERROR <!-- Preconditions only accepts the %s placeholder in error message strings -->
                                     -Xep:ReturnValueIgnored:ERROR
+                                    -Xep:SelfAssignment:ERROR
                                     -Xep:StaticQualifiedUsingExpression:ERROR
                                     -Xep:ThrowIfUncheckedKnownChecked:ERROR
                                     -Xep:UnnecessaryCheckNotNull:ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -1750,6 +1750,7 @@
                                     -Xep:ObjectToString:ERROR
                                     -Xep:OptionalEquality:ERROR
                                     -Xep:OptionalMapUnusedValue:ERROR
+                                    -Xep:ReturnValueIgnored:ERROR
                                     -Xep:StaticQualifiedUsingExpression:ERROR
                                     -Xep:UnnecessaryMethodReference:ERROR
                                     -Xep:UnnecessaryOptionalGet:ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -1741,6 +1741,7 @@
                                     -Xep:EqualsIncompatibleType:ERROR
                                     -Xep:FallThrough:ERROR
                                     -Xep:FormatString:ERROR
+                                    -Xep:GetClassOnAnnotation:ERROR
                                     -Xep:GetClassOnClass:ERROR
                                     -Xep:HashtableContains:ERROR
                                     -Xep:IdentityBinaryExpression:ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -1750,6 +1750,7 @@
                                     -Xep:ObjectToString:ERROR
                                     -Xep:OptionalEquality:ERROR
                                     -Xep:OptionalMapUnusedValue:ERROR
+                                    -Xep:PreconditionsInvalidPlaceholder:ERROR <!-- Preconditions only accepts the %s placeholder in error message strings -->
                                     -Xep:ReturnValueIgnored:ERROR
                                     -Xep:StaticQualifiedUsingExpression:ERROR
                                     -Xep:UnnecessaryMethodReference:ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -1754,6 +1754,7 @@
                                     -Xep:ReturnValueIgnored:ERROR
                                     -Xep:StaticQualifiedUsingExpression:ERROR
                                     -Xep:ThrowIfUncheckedKnownChecked:ERROR
+                                    -Xep:UnnecessaryCheckNotNull:ERROR
                                     -Xep:UnnecessaryMethodReference:ERROR
                                     -Xep:UnnecessaryOptionalGet:ERROR
                                     -Xep:UnusedVariable:ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -1733,6 +1733,7 @@
                                     -Xep:ArrayToString:ERROR
                                     -Xep:ArraysAsListPrimitiveArray:ERROR
                                     -Xep:BadInstanceof:ERROR
+                                    -Xep:BadShiftAmount:ERROR
                                     -Xep:BoxedPrimitiveConstructor:ERROR
                                     -Xep:ClassCanBeStatic:ERROR
                                     -Xep:CompareToZero:ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -1764,6 +1764,7 @@
                                     -Xep:UnnecessaryOptionalGet:ERROR
                                     -Xep:UnusedVariable:ERROR
                                     -Xep:UseEnumSwitch:ERROR
+                                    -Xep:ZoneIdOfZ:ERROR
                                 </arg>
                             </compilerArgs>
                             <annotationProcessorPaths>

--- a/pom.xml
+++ b/pom.xml
@@ -1741,6 +1741,7 @@
                                     -Xep:FallThrough:ERROR
                                     -Xep:FormatString:ERROR
                                     -Xep:GetClassOnClass:ERROR
+                                    -Xep:IdentityBinaryExpression:ERROR
                                     -Xep:ImmutableSetForContains:ERROR
                                     -Xep:InconsistentHashCode:ERROR
                                     -Xep:InjectOnConstructorOfAbstractClass:ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -1753,6 +1753,7 @@
                                     -Xep:PreconditionsInvalidPlaceholder:ERROR <!-- Preconditions only accepts the %s placeholder in error message strings -->
                                     -Xep:ReturnValueIgnored:ERROR
                                     -Xep:StaticQualifiedUsingExpression:ERROR
+                                    -Xep:ThrowIfUncheckedKnownChecked:ERROR
                                     -Xep:UnnecessaryMethodReference:ERROR
                                     -Xep:UnnecessaryOptionalGet:ERROR
                                     -Xep:UnusedVariable:ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -1742,6 +1742,7 @@
                                     -Xep:FallThrough:ERROR
                                     -Xep:FormatString:ERROR
                                     -Xep:GetClassOnClass:ERROR
+                                    -Xep:HashtableContains:ERROR
                                     -Xep:IdentityBinaryExpression:ERROR
                                     -Xep:ImmutableSetForContains:ERROR
                                     -Xep:InconsistentHashCode:ERROR

--- a/pom.xml
+++ b/pom.xml
@@ -1723,49 +1723,31 @@
                         <configuration combine.children="merge">
                             <compilerArgs>
                                 <arg>-XDcompilePolicy=simple</arg>
-                                <!-- TODO enable more checks, i.e. remove "-XepDisableAllChecks" -->
                                 <arg>
                                     -Xplugin:ErrorProne
                                     -XepExcludedPaths:.*/target/generated-(|test-)sources/.*
-                                    -XepDisableAllChecks
-                                    -Xep:ArrayEquals:ERROR
-                                    -Xep:ArrayHashCode:ERROR
-                                    -Xep:ArrayToString:ERROR
-                                    -Xep:ArraysAsListPrimitiveArray:ERROR
+
+                                    <!-- -Xep:ReferenceEquality:OFF fails in IDEA -->
+                                    <!-- -Xep:BoxedPrimitiveEquality:OFF fails in IDEA -->
+                                    -Xep:GuardedBy:OFF <!-- needs some careful inspection -->
+
                                     -Xep:BadInstanceof:ERROR
-                                    -Xep:BadShiftAmount:ERROR
                                     -Xep:BoxedPrimitiveConstructor:ERROR
                                     -Xep:ClassCanBeStatic:ERROR
                                     -Xep:CompareToZero:ERROR
-                                    -Xep:ComparingThisWithNull:ERROR
                                     -Xep:EqualsIncompatibleType:ERROR
                                     -Xep:FallThrough:ERROR
-                                    -Xep:FormatString:ERROR
-                                    -Xep:GetClassOnAnnotation:ERROR
-                                    -Xep:GetClassOnClass:ERROR
-                                    -Xep:HashtableContains:ERROR
-                                    -Xep:IdentityBinaryExpression:ERROR
                                     -Xep:ImmutableSetForContains:ERROR
                                     -Xep:InconsistentHashCode:ERROR
                                     -Xep:InjectOnConstructorOfAbstractClass:ERROR
                                     -Xep:MissingCasesInEnumSwitch:ERROR
                                     -Xep:MissingOverride:ERROR
-                                    -Xep:MisusedWeekYear:ERROR <!-- Use of "YYYY" (week year) in a date pattern without "ww" (week in year). You probably meant to use "yyyy" (year) instead. -->
                                     -Xep:NullOptional:ERROR
                                     -Xep:ObjectToString:ERROR
-                                    -Xep:OptionalEquality:ERROR
                                     -Xep:OptionalMapUnusedValue:ERROR
-                                    -Xep:PreconditionsInvalidPlaceholder:ERROR <!-- Preconditions only accepts the %s placeholder in error message strings -->
-                                    -Xep:ReturnValueIgnored:ERROR
-                                    -Xep:SelfAssignment:ERROR
-                                    -Xep:StaticQualifiedUsingExpression:ERROR
-                                    -Xep:ThrowIfUncheckedKnownChecked:ERROR
-                                    -Xep:UnnecessaryCheckNotNull:ERROR
-                                    -Xep:UnnecessaryMethodReference:ERROR
                                     -Xep:UnnecessaryOptionalGet:ERROR
                                     -Xep:UnusedVariable:ERROR
                                     -Xep:UseEnumSwitch:ERROR
-                                    -Xep:ZoneIdOfZ:ERROR
                                 </arg>
                             </compilerArgs>
                             <annotationProcessorPaths>

--- a/service/trino-verifier/src/main/java/io/trino/verifier/VerifyCommand.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/VerifyCommand.java
@@ -181,7 +181,6 @@ public class VerifyCommand
             System.exit((numFailedQueries > 0) ? 1 : 0);
         }
         catch (InterruptedException | MalformedURLException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
         finally {

--- a/testing/trino-testing/src/main/java/io/trino/testing/PlanDeterminismChecker.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/PlanDeterminismChecker.java
@@ -47,6 +47,7 @@ public class PlanDeterminismChecker
         checkPlanIsDeterministic(localQueryRunner.getDefaultSession(), sql);
     }
 
+    @SuppressWarnings("ReturnValueIgnored") // Stream#reduce called for side effects (assertions)
     public void checkPlanIsDeterministic(Session session, String sql)
     {
         IntStream.range(1, MINIMUM_SUBSEQUENT_SAME_PLANS)


### PR DESCRIPTION
This changeset removes a TODO in the `pom.xml` section which configures Error Prone; the TODO asks to enable "more checks" so that the blanket disablement of all checks can be removed - and I oblige, as I'm a sucker for static code analysis.

This is a sequence of commits, each of which enables one more check and contains the associated fixes (or suppressions), followed by a final commit which replaces an allowlist of checks with a denylist. After this is done there is still one check disabled, as it's related to concurrency and requires much closer inspection.

I recommend looking at each commit individually, so that each check's changes are separated.