### PR TITLE
Future-proof code leveraging MissingCasesInEnumSwitch

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -94,6 +94,13 @@ non-native english speaker to understand the code. Very well known
 abbreviations like `max` or `min` and ones already very commonly used across
 the code base like `ttl` are allowed and encouraged.
 
+## Avoid default clause in exhaustive enum-based switch statements
+
+Avoid using the `default` clause when the switch statement is meant to cover all the
+enum values. Handling the unknown option case after the switch statement allows static code
+analysis tools (e.g. Error Prone's `MissingCasesInEnumSwitch` check) report a problem
+when the enum definition is updated but the code using it is not.
+
 ## Additional IDE configuration
 
 When using IntelliJ to develop Trino, we recommend starting with all of the default inspections,

--- a/core/trino-main/src/main/java/io/trino/cost/ComparisonStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ComparisonStatsCalculator.java
@@ -53,9 +53,8 @@ public final class ComparisonStatsCalculator
                 return estimateExpressionGreaterThanLiteral(inputStatistics, expressionStatistics, expressionSymbol, literalValue);
             case IS_DISTINCT_FROM:
                 return PlanNodeStatsEstimate.unknown();
-            default:
-                throw new IllegalArgumentException("Unexpected comparison operator: " + operator);
         }
+        throw new IllegalArgumentException("Unexpected comparison operator: " + operator);
     }
 
     private static PlanNodeStatsEstimate estimateExpressionEqualToLiteral(
@@ -167,9 +166,8 @@ public final class ComparisonStatsCalculator
             case GREATER_THAN_OR_EQUAL:
             case IS_DISTINCT_FROM:
                 return PlanNodeStatsEstimate.unknown();
-            default:
-                throw new IllegalArgumentException("Unexpected comparison operator: " + operator);
         }
+        throw new IllegalArgumentException("Unexpected comparison operator: " + operator);
     }
 
     private static PlanNodeStatsEstimate estimateExpressionEqualToExpression(

--- a/core/trino-main/src/main/java/io/trino/cost/CostCalculatorUsingExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/cost/CostCalculatorUsingExchanges.java
@@ -228,9 +228,8 @@ public class CostCalculatorUsingExchanges
                             return calculateLocalRepartitionCost(inputSizeInBytes);
                         case REPLICATE:
                             return LocalCostEstimate.zero();
-                        default:
-                            throw new IllegalArgumentException("Unexpected type: " + node.getType());
                     }
+                    throw new IllegalArgumentException("Unexpected type: " + node.getType());
                 case REMOTE:
                     switch (node.getType()) {
                         case GATHER:
@@ -242,12 +241,10 @@ public class CostCalculatorUsingExchanges
                             // it is true as now replicated exchange is used for joins only
                             // for replicated join probe side is usually source distributed
                             return calculateRemoteReplicateCost(inputSizeInBytes, taskCountEstimator.estimateSourceDistributedTaskCount(session));
-                        default:
-                            throw new IllegalArgumentException("Unexpected type: " + node.getType());
                     }
-                default:
-                    throw new IllegalArgumentException("Unexpected scope: " + node.getScope());
+                    throw new IllegalArgumentException("Unexpected type: " + node.getType());
             }
+            throw new IllegalArgumentException("Unexpected scope: " + node.getScope());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/cost/FilterStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/FilterStatsCalculator.java
@@ -175,9 +175,8 @@ public class FilterStatsCalculator
                     return estimateLogicalAnd(node.getLeft(), node.getRight());
                 case OR:
                     return estimateLogicalOr(node.getLeft(), node.getRight());
-                default:
-                    throw new IllegalArgumentException("Unexpected binary operator: " + node.getOperator());
             }
+            throw new IllegalArgumentException("Unexpected binary operator: " + node.getOperator());
         }
 
         private PlanNodeStatsEstimate estimateLogicalAnd(Expression left, Expression right)

--- a/core/trino-main/src/main/java/io/trino/cost/JoinStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/JoinStatsRule.java
@@ -91,9 +91,8 @@ public class JoinStatsRule
                 return Optional.of(computeRightJoinStats(node, leftStats, rightStats, crossJoinStats, session, types));
             case FULL:
                 return Optional.of(computeFullJoinStats(node, leftStats, rightStats, crossJoinStats, session, types));
-            default:
-                throw new IllegalStateException("Unknown join type: " + node.getType());
         }
+        throw new IllegalStateException("Unknown join type: " + node.getType());
     }
 
     private PlanNodeStatsEstimate computeFullJoinStats(

--- a/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
+++ b/core/trino-main/src/main/java/io/trino/cost/ScalarStatsCalculator.java
@@ -226,9 +226,8 @@ public class ScalarStatsCalculator
                             .setLowValue(-stats.getHighValue())
                             .setHighValue(-stats.getLowValue())
                             .build();
-                default:
-                    throw new IllegalStateException("Unexpected sign: " + node.getSign());
             }
+            throw new IllegalStateException("Unexpected sign: " + node.getSign());
         }
 
         @Override
@@ -298,9 +297,8 @@ public class ScalarStatsCalculator
                     return left / right;
                 case MODULUS:
                     return left % right;
-                default:
-                    throw new IllegalStateException("Unsupported ArithmeticBinaryExpression.Operator: " + operator);
             }
+            throw new IllegalStateException("Unsupported ArithmeticBinaryExpression.Operator: " + operator);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/cost/SpatialJoinStatsRule.java
+++ b/core/trino-main/src/main/java/io/trino/cost/SpatialJoinStatsRule.java
@@ -49,9 +49,8 @@ public class SpatialJoinStatsRule
                 return Optional.of(statsCalculator.filterStats(crossJoinStats, node.getFilter(), session, types));
             case LEFT:
                 return Optional.of(PlanNodeStatsEstimate.unknown());
-            default:
-                throw new IllegalArgumentException("Unknown spatial join type: " + node.getType());
         }
+        throw new IllegalArgumentException("Unknown spatial join type: " + node.getType());
     }
 
     private PlanNodeStatsEstimate crossJoinStats(SpatialJoinNode node, PlanNodeStatsEstimate leftStats, PlanNodeStatsEstimate rightStats)

--- a/core/trino-main/src/main/java/io/trino/execution/SetRoleTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetRoleTask.java
@@ -49,21 +49,21 @@ public class SetRoleTask
                     statement.getRole().map(c -> c.getValue().toLowerCase(ENGLISH)).get(),
                     catalog);
         }
-        SelectedRole.Type type;
-        switch (statement.getType()) {
-            case ROLE:
-                type = SelectedRole.Type.ROLE;
-                break;
-            case ALL:
-                type = SelectedRole.Type.ALL;
-                break;
-            case NONE:
-                type = SelectedRole.Type.NONE;
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported type: " + statement.getType());
-        }
+        SelectedRole.Type type = toSelectedRoleType(statement.getType());
         stateMachine.addSetRole(catalog, new SelectedRole(type, statement.getRole().map(c -> c.getValue().toLowerCase(ENGLISH))));
         return immediateFuture(null);
+    }
+
+    private static SelectedRole.Type toSelectedRoleType(SetRole.Type statementRoleType)
+    {
+        switch (statementRoleType) {
+            case ROLE:
+                return SelectedRole.Type.ROLE;
+            case ALL:
+                return SelectedRole.Type.ALL;
+            case NONE:
+                return SelectedRole.Type.NONE;
+        }
+        throw new IllegalArgumentException("Unsupported type: " + statementRoleType);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
@@ -664,13 +664,12 @@ public class SqlTaskExecution
         switch (executionStrategy) {
             case GROUPED_EXECUTION:
                 checkArgument(!lifespan.isTaskWide(), "Expect driver-group life cycle for grouped ExecutionStrategy. Got task-wide life cycle.");
-                break;
+                return;
             case UNGROUPED_EXECUTION:
                 checkArgument(lifespan.isTaskWide(), "Expect task-wide life cycle for ungrouped ExecutionStrategy. Got driver-group life cycle.");
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown executionStrategy: " + executionStrategy);
+                return;
         }
+        throw new IllegalArgumentException("Unknown executionStrategy: " + executionStrategy);
     }
 
     private void checkHoldsLock()

--- a/core/trino-main/src/main/java/io/trino/execution/StartTransactionTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StartTransactionTask.java
@@ -113,8 +113,7 @@ public class StartTransactionTask
                 return IsolationLevel.READ_COMMITTED;
             case READ_UNCOMMITTED:
                 return IsolationLevel.READ_UNCOMMITTED;
-            default:
-                throw new AssertionError("Unhandled isolation level: " + level);
         }
+        throw new AssertionError("Unhandled isolation level: " + level);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ScheduleResult.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ScheduleResult.java
@@ -48,9 +48,8 @@ public class ScheduleResult
                     return other == WAITING_FOR_SOURCE || other == NO_ACTIVE_DRIVER_GROUP ? WAITING_FOR_SOURCE : MIXED_SPLIT_QUEUES_FULL_AND_WAITING_FOR_SOURCE;
                 case MIXED_SPLIT_QUEUES_FULL_AND_WAITING_FOR_SOURCE:
                     return MIXED_SPLIT_QUEUES_FULL_AND_WAITING_FOR_SOURCE;
-                default:
-                    throw new IllegalArgumentException("Unknown blocked reason: " + other);
             }
+            throw new IllegalArgumentException("Unknown blocked reason: " + other);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
@@ -366,9 +366,8 @@ public class SourcePartitionedScheduler
                             true,
                             overallNewTasks.build(),
                             overallSplitAssignmentCount);
-                default:
-                    throw new IllegalStateException("Unknown state");
             }
+            throw new IllegalStateException("Unknown state");
         }
 
         if (anyNotBlocked) {

--- a/core/trino-main/src/main/java/io/trino/metadata/DiscoveryNodeManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DiscoveryNodeManager.java
@@ -329,9 +329,8 @@ public final class DiscoveryNodeManager
                 return getAllNodes().getInactiveNodes();
             case SHUTTING_DOWN:
                 return getAllNodes().getShuttingDownNodes();
-            default:
-                throw new IllegalArgumentException("Unknown node state " + state);
         }
+        throw new IllegalArgumentException("Unknown node state " + state);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/metadata/InMemoryNodeManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/InMemoryNodeManager.java
@@ -84,9 +84,8 @@ public class InMemoryNodeManager
                 return getAllNodes().getInactiveNodes();
             case SHUTTING_DOWN:
                 return getAllNodes().getShuttingDownNodes();
-            default:
-                throw new IllegalArgumentException("Unknown node state " + state);
         }
+        throw new IllegalArgumentException("Unknown node state " + state);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataUtil.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataUtil.java
@@ -167,9 +167,8 @@ public final class MetadataUtil
             case CURRENT_ROLE:
                 // TODO: will be implemented once the "SET ROLE" statement is introduced
                 throw new UnsupportedOperationException("CURRENT_ROLE is not yet supported");
-            default:
-                throw new IllegalArgumentException("Unsupported type: " + type);
         }
+        throw new IllegalArgumentException("Unsupported type: " + type);
     }
 
     public static TrinoPrincipal createPrincipal(PrincipalSpecification specification)
@@ -181,9 +180,8 @@ public final class MetadataUtil
                 return new TrinoPrincipal(USER, specification.getName().getValue());
             case ROLE:
                 return new TrinoPrincipal(ROLE, specification.getName().getValue());
-            default:
-                throw new IllegalArgumentException("Unsupported type: " + type);
         }
+        throw new IllegalArgumentException("Unsupported type: " + type);
     }
 
     public static PrincipalSpecification createPrincipal(TrinoPrincipal principal)
@@ -194,9 +192,8 @@ public final class MetadataUtil
                 return new PrincipalSpecification(PrincipalSpecification.Type.USER, new Identifier(principal.getName()));
             case ROLE:
                 return new PrincipalSpecification(PrincipalSpecification.Type.ROLE, new Identifier(principal.getName()));
-            default:
-                throw new IllegalArgumentException("Unsupported type: " + type);
         }
+        throw new IllegalArgumentException("Unsupported type: " + type);
     }
 
     public static boolean tableExists(Metadata metadata, Session session, String table)

--- a/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunction.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunction.java
@@ -169,9 +169,8 @@ class PolymorphicScalarFunction
                 return Primitives.wrap(clazz);
             case FAIL_ON_NULL:
                 return clazz;
-            default:
-                throw new UnsupportedOperationException("Unknown return convention: " + returnConvention);
         }
+        throw new UnsupportedOperationException("Unknown return convention: " + returnConvention);
     }
 
     static final class PolymorphicScalarFunctionChoice

--- a/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
@@ -503,7 +503,7 @@ public class SignatureBinder
                 case VARIABLE:
                     break;
                 default:
-                    throw new UnsupportedOperationException();
+                    throw new UnsupportedOperationException("Unknown parameter kind: " + parameter.getKind());
             }
         }
 
@@ -527,7 +527,7 @@ public class SignatureBinder
                     variables.add(parameter.getVariable());
                     break;
                 default:
-                    throw new UnsupportedOperationException();
+                    throw new UnsupportedOperationException("Unknown parameter kind: " + parameter.getKind());
             }
         }
 
@@ -625,9 +625,8 @@ public class SignatureBinder
             case LONG: {
                 return parameter;
             }
-            default:
-                throw new IllegalStateException("Unknown parameter kind: " + parameter.getKind());
         }
+        throw new IllegalStateException("Unknown parameter kind: " + parameter.getKind());
     }
 
     private static List<TypeSignature> expandVarargFormalTypeSignature(List<TypeSignature> formalTypeSignatures, int actualArity)
@@ -661,9 +660,8 @@ public class SignatureBinder
                 return canCast(actualType, metadata.getType(constraintTypeSignature));
             case EXPLICIT_COERCION_FROM:
                 return canCast(metadata.getType(constraintTypeSignature), actualType);
-            default:
-                throw new IllegalArgumentException("Unsupported relationshipType " + relationshipType);
         }
+        throw new IllegalArgumentException("Unsupported relationshipType " + relationshipType);
     }
 
     private boolean canCast(Type fromType, Type toType)

--- a/core/trino-main/src/main/java/io/trino/operator/JoinBridgeManager.java
+++ b/core/trino-main/src/main/java/io/trino/operator/JoinBridgeManager.java
@@ -177,21 +177,19 @@ public class JoinBridgeManager<T extends JoinBridge>
                         return new TaskWideInternalJoinBridgeDataManager<>(joinBridgeProvider, probeFactoryCount, outerFactoryCount);
                     case GROUPED_EXECUTION:
                         throw new UnsupportedOperationException("Invalid combination. Lookup source should not be grouped if probe is not going to take advantage of it.");
-                    default:
-                        throw new IllegalArgumentException("Unknown buildExecutionStrategy: " + buildExecutionStrategy);
                 }
+                throw new UnsupportedOperationException("Unknown buildExecutionStrategy: " + buildExecutionStrategy);
+
             case GROUPED_EXECUTION:
                 switch (buildExecutionStrategy) {
                     case UNGROUPED_EXECUTION:
                         return new SharedInternalJoinBridgeDataManager<>(joinBridgeProvider, probeFactoryCount, outerFactoryCount);
                     case GROUPED_EXECUTION:
                         return new OneToOneInternalJoinBridgeDataManager<>(joinBridgeProvider, probeFactoryCount, outerFactoryCount);
-                    default:
-                        throw new IllegalArgumentException("Unknown buildExecutionStrategy: " + buildExecutionStrategy);
                 }
-            default:
-                throw new UnsupportedOperationException();
+                throw new UnsupportedOperationException("Unknown buildExecutionStrategy: " + buildExecutionStrategy);
         }
+        throw new UnsupportedOperationException("Unknown probeExecutionStrategy: " + probeExecutionStrategy);
     }
 
     private interface InternalJoinBridgeDataManager<T extends JoinBridge>

--- a/core/trino-main/src/main/java/io/trino/operator/window/ReflectionWindowFunctionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/ReflectionWindowFunctionSupplier.java
@@ -93,9 +93,8 @@ public class ReflectionWindowFunctionSupplier<T extends WindowFunction>
                     return constructor.newInstance(inputs);
                 case INPUTS_IGNORE_NULLS:
                     return constructor.newInstance(inputs, ignoreNulls);
-                default:
-                    throw new VerifyException("Unhandled constructor type: " + constructorType);
             }
+            throw new VerifyException("Unhandled constructor type: " + constructorType);
         }
         catch (ReflectiveOperationException e) {
             throw new RuntimeException(e);

--- a/core/trino-main/src/main/java/io/trino/operator/window/WindowPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/WindowPartition.java
@@ -273,9 +273,8 @@ public final class WindowPartition
                 }
                 recentGroupsFrames.put(functionIndex, frame);
                 return frame.getRange();
-            default:
-                throw new IllegalArgumentException("Unsupported frame type: " + frameInfo.getType());
         }
+        throw new IllegalArgumentException("Unsupported frame type: " + frameInfo.getType());
     }
 
     private Range getFrameRange(FrameInfo frameInfo)

--- a/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContext.java
+++ b/core/trino-main/src/main/java/io/trino/server/HttpRequestSessionContext.java
@@ -428,16 +428,15 @@ public final class HttpRequestSessionContext
                 switch (name.toUpperCase(ENGLISH)) {
                     case ResourceEstimates.EXECUTION_TIME:
                         builder.setExecutionTime(Duration.valueOf(value));
-                        break;
+                        return;
                     case ResourceEstimates.CPU_TIME:
                         builder.setCpuTime(Duration.valueOf(value));
-                        break;
+                        return;
                     case ResourceEstimates.PEAK_MEMORY:
                         builder.setPeakMemory(DataSize.valueOf(value));
-                        break;
-                    default:
-                        throw badRequest(format("Unsupported resource name %s", name));
+                        return;
                 }
+                throw badRequest(format("Unsupported resource name %s", name));
             }
             catch (IllegalArgumentException e) {
                 throw badRequest(format("Unsupported format for resource estimate '%s': %s", value, e));

--- a/core/trino-main/src/main/java/io/trino/server/security/ResourceSecurityDynamicFeature.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/ResourceSecurityDynamicFeature.java
@@ -88,27 +88,26 @@ public class ResourceSecurityDynamicFeature
         switch (accessType) {
             case PUBLIC:
                 // no authentication or authorization
-                break;
+                return;
             case WEB_UI:
                 context.register(webUiAuthenticationFilter);
                 context.register(new DisposeIdentityResponseFilter());
-                break;
+                return;
             case AUTHENTICATED_USER:
                 context.register(authenticationFilter);
                 context.register(new DisposeIdentityResponseFilter());
-                break;
+                return;
             case MANAGEMENT_READ:
             case MANAGEMENT_WRITE:
                 context.register(new ManagementAuthenticationFilter(fixedManagementUser, fixedManagementUserForHttps, authenticationFilter));
                 context.register(new ManagementAuthorizationFilter(accessControl, groupProvider, accessType == MANAGEMENT_READ, alternateHeaderName));
                 context.register(new DisposeIdentityResponseFilter());
-                break;
+                return;
             case INTERNAL_ONLY:
                 context.register(new InternalOnlyRequestFilter(internalAuthenticationManager));
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown mode: " + accessType);
+                return;
         }
+        throw new IllegalArgumentException("Unknown mode: " + accessType);
     }
 
     @Priority(Priorities.AUTHENTICATION)

--- a/core/trino-main/src/main/java/io/trino/sql/ExpressionUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ExpressionUtils.java
@@ -117,9 +117,8 @@ public final class ExpressionUtils
                     return TRUE_LITERAL;
                 case OR:
                     return FALSE_LITERAL;
-                default:
-                    throw new IllegalArgumentException("Unsupported LogicalBinaryExpression operator");
             }
+            throw new IllegalArgumentException("Unsupported LogicalBinaryExpression operator");
         }
 
         // Build balanced tree for efficient recursive processing that

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -441,44 +441,29 @@ public class ExpressionAnalyzer
         @Override
         protected Type visitCurrentTime(CurrentTime node, StackableAstVisitorContext<Context> context)
         {
-            Type type;
             switch (node.getFunction()) {
                 case DATE:
                     checkArgument(node.getPrecision() == null);
-                    type = DATE;
-                    break;
+                    return setExpressionType(node, DATE);
                 case TIME:
                     if (node.getPrecision() != null) {
-                        type = createTimeWithTimeZoneType(node.getPrecision());
+                        return setExpressionType(node, createTimeWithTimeZoneType(node.getPrecision()));
                     }
-                    else {
-                        type = TIME_WITH_TIME_ZONE;
-                    }
-                    break;
+                    return setExpressionType(node, TIME_WITH_TIME_ZONE);
                 case LOCALTIME:
                     if (node.getPrecision() != null) {
-                        type = createTimeType(node.getPrecision());
+                        return setExpressionType(node, createTimeType(node.getPrecision()));
                     }
-                    else {
-                        type = TIME;
-                    }
-                    break;
+                    return setExpressionType(node, TIME);
                 case TIMESTAMP:
-                    type = createTimestampWithTimeZoneType(firstNonNull(node.getPrecision(), TimestampWithTimeZoneType.DEFAULT_PRECISION));
-                    break;
+                    return setExpressionType(node, createTimestampWithTimeZoneType(firstNonNull(node.getPrecision(), TimestampWithTimeZoneType.DEFAULT_PRECISION)));
                 case LOCALTIMESTAMP:
                     if (node.getPrecision() != null) {
-                        type = createTimestampType(node.getPrecision());
+                        return setExpressionType(node, createTimestampType(node.getPrecision()));
                     }
-                    else {
-                        type = TIMESTAMP_MILLIS;
-                    }
-                    break;
-                default:
-                    throw semanticException(NOT_SUPPORTED, node, "%s not yet supported", node.getFunction().getName());
+                    return setExpressionType(node, TIMESTAMP_MILLIS);
             }
-
-            return setExpressionType(node, type);
+            throw semanticException(NOT_SUPPORTED, node, "%s not yet supported", node.getFunction().getName());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DistributedExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DistributedExecutionPlanner.java
@@ -292,10 +292,8 @@ public class DistributedExecutionPlanner
                     }
                     // table sampling on a sub query without splits is meaningless
                     return nodeSplits;
-
-                default:
-                    throw new UnsupportedOperationException("Sampling is not supported for type " + node.getSampleType());
             }
+            throw new UnsupportedOperationException("Sampling is not supported for type " + node.getSampleType());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -430,10 +430,8 @@ public final class DomainTranslator
                     }
 
                     return new ExtractionResult(columnUnionedTupleDomain, remainingExpression);
-
-                default:
-                    throw new AssertionError("Unknown operator: " + node.getOperator());
             }
+            throw new AssertionError("Unknown operator: " + node.getOperator());
         }
 
         @Override
@@ -566,10 +564,8 @@ public final class DomainTranslator
                         return Optional.of(new ExtractionResult(
                                 TupleDomain.withColumnDomains(ImmutableMap.of(column, domain)),
                                 TRUE_LITERAL));
-
-                    default:
-                        throw new AssertionError("Unhandled operator: " + comparisonOperator);
                 }
+                throw new AssertionError("Unhandled operator: " + comparisonOperator);
             }
             if (type.isOrderable()) {
                 return extractOrderableDomain(comparisonOperator, type, value, complement)
@@ -606,9 +602,8 @@ public final class DomainTranslator
                     case IS_DISTINCT_FROM:
                         // Need to potential complement the whole domain for IS_DISTINCT_FROM since it is null-aware
                         return Optional.of(complementIfNecessary(Domain.create(ValueSet.ofRanges(Range.lessThan(type, value), Range.greaterThan(type, value)), true), complement));
-                    default:
-                        throw new AssertionError("Unhandled operator: " + comparisonOperator);
                 }
+                throw new AssertionError("Unhandled operator: " + comparisonOperator);
             }
 
             // Handle comparisons against NaN
@@ -627,10 +622,8 @@ public final class DomainTranslator
                     case IS_DISTINCT_FROM:
                         // The Domain should be "all but NaN". It is currently not supported.
                         return Optional.empty();
-
-                    default:
-                        throw new AssertionError("Unhandled operator: " + comparisonOperator);
                 }
+                throw new AssertionError("Unhandled operator: " + comparisonOperator);
             }
 
             // Handle comparisons against a non-NaN value when the compared value might be NaN
@@ -693,9 +686,8 @@ public final class DomainTranslator
                     else {
                         return Optional.empty();
                     }
-                default:
-                    throw new AssertionError("Unhandled operator: " + comparisonOperator);
             }
+            throw new AssertionError("Unhandled operator: " + comparisonOperator);
         }
 
         private static Domain extractEquatableDomain(ComparisonExpression.Operator comparisonOperator, Type type, Object value, boolean complement)
@@ -706,12 +698,19 @@ public final class DomainTranslator
                     return Domain.create(complementIfNecessary(ValueSet.of(type, value), complement), false);
                 case NOT_EQUAL:
                     return Domain.create(complementIfNecessary(ValueSet.of(type, value).complement(), complement), false);
+
                 case IS_DISTINCT_FROM:
                     // Need to potential complement the whole domain for IS_DISTINCT_FROM since it is null-aware
                     return complementIfNecessary(Domain.create(ValueSet.of(type, value).complement(), true), complement);
-                default:
-                    throw new AssertionError("Unhandled operator: " + comparisonOperator);
+
+                case LESS_THAN:
+                case LESS_THAN_OR_EQUAL:
+                case GREATER_THAN:
+                case GREATER_THAN_OR_EQUAL:
+                    // not applicable to equatable types
+                    break;
             }
+            throw new AssertionError("Unhandled operator: " + comparisonOperator);
         }
 
         private Optional<Expression> coerceComparisonWithRounding(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
@@ -287,9 +287,8 @@ public class EffectivePredicateExtractor
                 case RIGHT:
                 case FULL:
                     return TRUE_LITERAL;
-                default:
-                    throw new UnsupportedOperationException("Unknown UNNEST join type: " + node.getJoinType());
             }
+            throw new UnsupportedOperationException("Unknown UNNEST join type: " + node.getJoinType());
         }
 
         @Override
@@ -328,9 +327,8 @@ public class EffectivePredicateExtractor
                             .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(rightPredicate), node.getOutputSymbols(), node.getRight().getOutputSymbols()::contains))
                             .addAll(pullNullableConjunctsThroughOuterJoin(joinConjuncts, node.getOutputSymbols(), node.getLeft().getOutputSymbols()::contains, node.getRight().getOutputSymbols()::contains))
                             .build());
-                default:
-                    throw new UnsupportedOperationException("Unknown join type: " + node.getType());
             }
+            throw new UnsupportedOperationException("Unknown join type: " + node.getType());
         }
 
         @Override
@@ -485,9 +483,8 @@ public class EffectivePredicateExtractor
                             .add(pullExpressionThroughSymbols(leftPredicate, node.getOutputSymbols()))
                             .addAll(pullNullableConjunctsThroughOuterJoin(extractConjuncts(rightPredicate), node.getOutputSymbols(), node.getRight().getOutputSymbols()::contains))
                             .build());
-                default:
-                    throw new IllegalArgumentException("Unsupported spatial join type: " + node.getType());
             }
+            throw new IllegalArgumentException("Unsupported spatial join type: " + node.getType());
         }
 
         private Expression deriveCommonPredicates(PlanNode node, Function<Integer, Collection<Map.Entry<Symbol, SymbolReference>>> mapping)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -800,6 +800,7 @@ public class ExpressionInterpreter
             return invokeOperator(OperatorType.valueOf(operator.name()), types(leftExpression, rightExpression), ImmutableList.of(left, right));
         }
 
+        // TODO define method contract or split into separate methods, as flip(EQUAL) is a negation, while flip(LESS_THAN) is just flipping sides
         private ComparisonExpression flipComparison(ComparisonExpression comparisonExpression)
         {
             switch (comparisonExpression.getOperator()) {
@@ -815,9 +816,10 @@ public class ExpressionInterpreter
                     return new ComparisonExpression(Operator.LESS_THAN, comparisonExpression.getRight(), comparisonExpression.getLeft());
                 case GREATER_THAN_OR_EQUAL:
                     return new ComparisonExpression(Operator.LESS_THAN_OR_EQUAL, comparisonExpression.getRight(), comparisonExpression.getLeft());
-                default:
-                    throw new IllegalArgumentException("Unsupported comparison type: " + comparisonExpression.getOperator());
+                case IS_DISTINCT_FROM:
+                    // not expected here
             }
+            throw new IllegalArgumentException("Unsupported comparison type: " + comparisonExpression.getOperator());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1788,9 +1788,8 @@ public class LocalExecutionPlanner
                 case RIGHT:
                 case FULL:
                     return createLookupJoin(node, node.getLeft(), leftSymbols, node.getLeftHashSymbol(), node.getRight(), rightSymbols, node.getRightHashSymbol(), localDynamicFilters, context);
-                default:
-                    throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
             }
+            throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
         }
 
         @Override
@@ -2363,9 +2362,8 @@ public class LocalExecutionPlanner
                     return lookupJoinOperators.lookupOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactoryManager, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels), totalOperatorsCount, partitioningSpillerFactory, blockTypeOperators);
                 case FULL:
                     return lookupJoinOperators.fullOuterJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactoryManager, probeTypes, probeJoinChannels, probeHashChannel, Optional.of(probeOutputChannels), totalOperatorsCount, partitioningSpillerFactory, blockTypeOperators);
-                default:
-                    throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
             }
+            throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
         }
 
         private Map<Symbol, Integer> createJoinSourcesLayout(Map<Symbol, Integer> lookupSourceLayout, Map<Symbol, Integer> probeSourceLayout)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanFragmenter.java
@@ -616,9 +616,8 @@ public class PlanFragmenter
                     //   As a result, there is no reason to change currentNodeCapable or subTreeUseful to false.
                     //
                     return left;
-                default:
-                    throw new UnsupportedOperationException("Unknown distribution type: " + node.getDistributionType());
             }
+            throw new UnsupportedOperationException("Unknown distribution type: " + node.getDistributionType());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/StatisticsAggregationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/StatisticsAggregationPlanner.java
@@ -121,9 +121,8 @@ public class StatisticsAggregationPlanner
                 return createAggregation(QualifiedName.of(SumDataSizeForStats.NAME), input.toSymbolReference(), inputType, BIGINT);
             case MAX_VALUE_SIZE_IN_BYTES:
                 return createAggregation(QualifiedName.of(MaxDataSizeForStats.NAME), input.toSymbolReference(), inputType, BIGINT);
-            default:
-                throw new IllegalArgumentException("Unsupported statistic type: " + statisticType);
         }
+        throw new IllegalArgumentException("Unsupported statistic type: " + statisticType);
     }
 
     private ColumnStatisticsAggregation createAggregation(QualifiedName functionName, SymbolReference input, Type inputType, Type outputType)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CanonicalizeExpressionRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CanonicalizeExpressionRewriter.java
@@ -162,9 +162,8 @@ public final class CanonicalizeExpressionRewriter
                             .setName(QualifiedName.of("$localtimestamp"))
                             .setArguments(ImmutableList.of(expressionTypes.get(NodeRef.of(node))), ImmutableList.of(new NullLiteral()))
                             .build();
-                default:
-                    throw new UnsupportedOperationException("not yet implemented: " + node.getFunction());
             }
+            throw new UnsupportedOperationException("not yet implemented: " + node.getFunction());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
@@ -76,9 +76,8 @@ public class DetermineSemiJoinDistributionType
                 return Result.ofPlanNode(semiJoinNode.withDistributionType(PARTITIONED));
             case BROADCAST:
                 return Result.ofPlanNode(semiJoinNode.withDistributionType(REPLICATED));
-            default:
-                throw new IllegalArgumentException("Unknown join_distribution_type: " + joinDistributionType);
         }
+        throw new IllegalArgumentException("Unknown join_distribution_type: " + joinDistributionType);
     }
 
     private PlanNode getCostBasedDistributionType(SemiJoinNode node, Context context)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushJoinIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushJoinIntoTableScan.java
@@ -291,9 +291,8 @@ public class PushJoinIntoTableScan
                 return JoinCondition.Operator.GREATER_THAN_OR_EQUAL;
             case IS_DISTINCT_FROM:
                 return JoinCondition.Operator.IS_DISTINCT_FROM;
-            default:
-                throw new IllegalArgumentException("Unknown operator: " + operator);
         }
+        throw new IllegalArgumentException("Unknown operator: " + operator);
     }
 
     private JoinType getJoinType(JoinNode joinNode)
@@ -307,8 +306,7 @@ public class PushJoinIntoTableScan
                 return JoinType.RIGHT_OUTER;
             case FULL:
                 return JoinType.FULL_OUTER;
-            default:
-                throw new IllegalArgumentException("Unknown join type: " + joinNode.getType());
         }
+        throw new IllegalArgumentException("Unknown join type: " + joinNode.getType());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushSampleIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushSampleIntoTableScan.java
@@ -81,8 +81,7 @@ public class PushSampleIntoTableScan
                 return SampleType.SYSTEM;
             case BERNOULLI:
                 return SampleType.BERNOULLI;
-            default:
-                throw new UnsupportedOperationException("Not yet implemented for " + sampleNodeType);
         }
+        throw new UnsupportedOperationException("Not yet implemented for " + sampleNodeType);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReorderJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReorderJoins.java
@@ -435,9 +435,8 @@ public class ReorderJoins
                     result.addAll(getPossibleJoinNodes(joinNode, PARTITIONED));
                     result.addAll(getPossibleJoinNodes(joinNode, REPLICATED, node -> canReplicate(node, context)));
                     return result.build();
-                default:
-                    throw new IllegalArgumentException("unexpected join distribution type: " + distributionType);
             }
+            throw new IllegalArgumentException("unexpected join distribution type: " + distributionType);
         }
 
         private List<JoinEnumerationResult> getPossibleJoinNodes(JoinNode joinNode, DistributionType distributionType)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapCastInComparison.java
@@ -198,9 +198,8 @@ public class UnwrapCastInComparison
                         return new Cast(new NullLiteral(), toSqlType(BOOLEAN));
                     case IS_DISTINCT_FROM:
                         return new IsNotNullPredicate(cast);
-                    default:
-                        throw new UnsupportedOperationException("Not yet implemented");
                 }
+                throw new UnsupportedOperationException("Not yet implemented");
             }
 
             if (right instanceof Expression) {
@@ -267,9 +266,8 @@ public class UnwrapCastInComparison
                             return trueIfNotNull(cast.getExpression());
                         case IS_DISTINCT_FROM:
                             return TRUE_LITERAL;
-                        default:
-                            throw new UnsupportedOperationException("Not yet implemented: " + operator);
                     }
+                    throw new UnsupportedOperationException("Not yet implemented: " + operator);
                 }
 
                 if (upperBoundComparison == 0) {
@@ -287,9 +285,8 @@ public class UnwrapCastInComparison
                         case NOT_EQUAL:
                         case IS_DISTINCT_FROM:
                             return new ComparisonExpression(operator, cast.getExpression(), literalEncoder.toExpression(max, sourceType));
-                        default:
-                            throw new UnsupportedOperationException("Not yet implemented: " + operator);
                     }
+                    throw new UnsupportedOperationException("Not yet implemented: " + operator);
                 }
 
                 Object min = sourceRange.get().getMin();
@@ -309,9 +306,8 @@ public class UnwrapCastInComparison
                             return falseIfNotNull(cast.getExpression());
                         case IS_DISTINCT_FROM:
                             return TRUE_LITERAL;
-                        default:
-                            throw new UnsupportedOperationException("Not yet implemented: " + operator);
                     }
+                    throw new UnsupportedOperationException("Not yet implemented: " + operator);
                 }
 
                 if (lowerBoundComparison == 0) {
@@ -329,9 +325,8 @@ public class UnwrapCastInComparison
                         case NOT_EQUAL:
                         case IS_DISTINCT_FROM:
                             return new ComparisonExpression(operator, cast.getExpression(), literalEncoder.toExpression(min, sourceType));
-                        default:
-                            throw new UnsupportedOperationException("Not yet implemented: " + operator);
                     }
+                    throw new UnsupportedOperationException("Not yet implemented: " + operator);
                 }
             }
 
@@ -382,9 +377,8 @@ public class UnwrapCastInComparison
                         // We expect implicit coercions to be order-preserving, so the result of converting back from target -> source cannot produce a value
                         // larger than the next value in the source type
                         return new ComparisonExpression(GREATER_THAN, cast.getExpression(), literalEncoder.toExpression(literalInSourceType, sourceType));
-                    default:
-                        throw new UnsupportedOperationException("Not yet implemented: " + operator);
                 }
+                throw new UnsupportedOperationException("Not yet implemented: " + operator);
             }
 
             if (literalVsRoundtripped < 0) {
@@ -407,9 +401,8 @@ public class UnwrapCastInComparison
                             return new ComparisonExpression(EQUAL, cast.getExpression(), literalEncoder.toExpression(literalInSourceType, sourceType));
                         }
                         return new ComparisonExpression(GREATER_THAN_OR_EQUAL, cast.getExpression(), literalEncoder.toExpression(literalInSourceType, sourceType));
-                    default:
-                        throw new UnsupportedOperationException("Not yet implemented: " + operator);
                 }
+                throw new UnsupportedOperationException("Not yet implemented: " + operator);
             }
 
             return new ComparisonExpression(operator, cast.getExpression(), literalEncoder.toExpression(literalInSourceType, sourceType));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -411,14 +411,12 @@ public class AddExchanges
                                 gatheringExchange(idAllocator.getNextId(), REMOTE, child.getNode()),
                                 child.getProperties());
                     }
-                    break;
+                    return rebaseAndDeriveProperties(node, child);
                 case PARTIAL:
                     child = planChild(node, PreferredProperties.any());
-                    break;
-                default:
-                    throw new UnsupportedOperationException(format("Unsupported step for TopN [%s]", node.getStep()));
+                    return rebaseAndDeriveProperties(node, child);
             }
-            return rebaseAndDeriveProperties(node, child);
+            throw new UnsupportedOperationException(format("Unsupported step for TopN [%s]", node.getStep()));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -473,9 +473,8 @@ public final class PropertyDerivations
                     return ActualProperties.builder()
                             .global(probeProperties.isSingleNode() ? singleStreamPartition() : arbitraryPartition())
                             .build();
-                default:
-                    throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
             }
+            throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
         }
 
         @Override
@@ -505,9 +504,8 @@ public final class PropertyDerivations
                 case LEFT:
                     return ActualProperties.builderFrom(probeProperties.translate(column -> filterIfMissing(node.getOutputSymbols(), column)))
                             .build();
-                default:
-                    throw new IllegalArgumentException("Unsupported spatial join type: " + node.getType());
             }
+            throw new IllegalArgumentException("Unsupported spatial join type: " + node.getType());
         }
 
         @Override
@@ -529,9 +527,8 @@ public final class PropertyDerivations
                     return ActualProperties.builderFrom(probeProperties)
                             .constants(probeProperties.getConstants())
                             .build();
-                default:
-                    throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
             }
+            throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
         }
 
         @Override
@@ -729,9 +726,8 @@ public final class PropertyDerivations
                     return ActualProperties.builderFrom(translatedProperties)
                             .local(ImmutableList.of())
                             .build();
-                default:
-                    throw new UnsupportedOperationException("Unknown UNNEST join type: " + node.getJoinType());
             }
+            throw new UnsupportedOperationException("Unknown UNNEST join type: " + node.getJoinType());
         }
 
         @Override
@@ -848,9 +844,8 @@ public final class PropertyDerivations
             case FULL:
                 // Currently there is no spill support for outer on the build side.
                 return false;
-            default:
-                throw new IllegalStateException("Unknown join type: " + joinType);
         }
+        throw new IllegalStateException("Unknown join type: " + joinType);
     }
 
     public static Optional<Symbol> filterIfMissing(Collection<Symbol> columns, Symbol column)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -223,9 +223,8 @@ public final class StreamPropertyDerivations
                     // partitioning, and nulls from the right are produced from a extra new stream
                     // so we will always have multiple streams.
                     return new StreamProperties(MULTIPLE, Optional.empty(), false);
-                default:
-                    throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
             }
+            throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
         }
 
         private static boolean spillPossible(Session session, JoinNode node)
@@ -242,9 +241,8 @@ public final class StreamPropertyDerivations
                 case INNER:
                 case LEFT:
                     return leftProperties.translate(column -> PropertyDerivations.filterIfMissing(node.getOutputSymbols(), column));
-                default:
-                    throw new IllegalArgumentException("Unsupported spatial join type: " + node.getType());
             }
+            throw new IllegalArgumentException("Unsupported spatial join type: " + node.getType());
         }
 
         @Override
@@ -259,9 +257,8 @@ public final class StreamPropertyDerivations
                     // the probe can contain nulls in any stream so we can't say anything about the
                     // partitioning but the other properties of the probe will be maintained.
                     return probeProperties.withUnspecifiedPartitioning();
-                default:
-                    throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
             }
+            throw new UnsupportedOperationException("Unsupported join type: " + node.getType());
         }
 
         //
@@ -474,9 +471,8 @@ public final class StreamPropertyDerivations
                 case RIGHT:
                 case FULL:
                     return translatedProperties.unordered(true);
-                default:
-                    throw new UnsupportedOperationException("Unknown UNNEST join type: " + node.getJoinType());
             }
+            throw new UnsupportedOperationException("Unknown UNNEST join type: " + node.getJoinType());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/CorrelatedJoinNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/CorrelatedJoinNode.java
@@ -71,9 +71,8 @@ public class CorrelatedJoinNode
                     return Type.RIGHT;
                 case FULL:
                     return Type.FULL;
-                default:
-                    throw new UnsupportedOperationException("Unsupported join type: " + joinType);
             }
+            throw new UnsupportedOperationException("Unsupported join type: " + joinType);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/JoinNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/JoinNode.java
@@ -169,9 +169,8 @@ public class JoinNode
                 return RIGHT;
             case RIGHT:
                 return LEFT;
-            default:
-                throw new IllegalStateException("No inverse defined for join type: " + type);
         }
+        throw new IllegalStateException("No inverse defined for join type: " + type);
     }
 
     private static List<EquiJoinClause> flipJoinCriteria(List<EquiJoinClause> joinCriteria)
@@ -219,9 +218,8 @@ public class JoinNode
                     return Type.RIGHT;
                 case FULL:
                     return Type.FULL;
-                default:
-                    throw new UnsupportedOperationException("Unsupported join type: " + joinType);
             }
+            throw new UnsupportedOperationException("Unsupported join type: " + joinType);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/SampleNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/SampleNode.java
@@ -47,9 +47,8 @@ public class SampleNode
                     return Type.BERNOULLI;
                 case SYSTEM:
                     return Type.SYSTEM;
-                default:
-                    throw new UnsupportedOperationException("Unsupported sample type: " + sampleType);
             }
+            throw new UnsupportedOperationException("Unsupported sample type: " + sampleType);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/SpatialJoinNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/SpatialJoinNode.java
@@ -57,9 +57,12 @@ public class SpatialJoinNode
                     return Type.INNER;
                 case LEFT:
                     return Type.LEFT;
-                default:
-                    throw new IllegalArgumentException("Unsupported spatial join type: " + joinNodeType);
+                case RIGHT:
+                case FULL:
+                    // unsupported
+                    break;
             }
+            throw new IllegalArgumentException("Unsupported spatial join type: " + joinNodeType);
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/relational/optimizer/ExpressionOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/optimizer/ExpressionOptimizer.java
@@ -172,9 +172,8 @@ public class ExpressionOptimizer
                             .collect(toImmutableList());
                     return new SpecialForm(specialForm.getForm(), specialForm.getType(), arguments, specialForm.getFunctionDependencies());
                 }
-                default:
-                    throw new IllegalArgumentException("Unsupported special form " + specialForm.getForm());
             }
+            throw new IllegalArgumentException("Unsupported special form " + specialForm.getForm());
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
+++ b/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
@@ -570,15 +570,14 @@ public class TestLocalExchange
         switch (pipelineExecutionStrategy) {
             case UNGROUPED_EXECUTION:
                 test.accept(localExchangeFactory.getLocalExchange(Lifespan.taskWide()));
-                break;
+                return;
             case GROUPED_EXECUTION:
                 test.accept(localExchangeFactory.getLocalExchange(Lifespan.driverGroup(1)));
                 test.accept(localExchangeFactory.getLocalExchange(Lifespan.driverGroup(12)));
                 test.accept(localExchangeFactory.getLocalExchange(Lifespan.driverGroup(23)));
-                break;
-            default:
-                throw new IllegalArgumentException("Unknown pipelineExecutionStrategy");
+                return;
         }
+        throw new IllegalArgumentException("Unknown pipelineExecutionStrategy");
     }
 
     private static void assertSource(LocalExchangeSource source, int pageCount)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushJoinIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushJoinIntoTableScan.java
@@ -625,9 +625,8 @@ public class TestPushJoinIntoTableScan
                 return JoinType.RIGHT_OUTER;
             case FULL:
                 return JoinType.FULL_OUTER;
-            default:
-                throw new IllegalArgumentException("Unknown join type: " + joinType);
         }
+        throw new IllegalArgumentException("Unknown join type: " + joinType);
     }
 
     private JoinCondition.Operator getConditionOperator(ComparisonExpression.Operator operator)
@@ -647,8 +646,7 @@ public class TestPushJoinIntoTableScan
                 return JoinCondition.Operator.GREATER_THAN_OR_EQUAL;
             case IS_DISTINCT_FROM:
                 return JoinCondition.Operator.IS_DISTINCT_FROM;
-            default:
-                throw new IllegalArgumentException("Unknown operator: " + operator);
         }
+        throw new IllegalArgumentException("Unknown operator: " + operator);
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -505,9 +505,8 @@ public final class ExpressionFormatter
                     return "-(" + value + ")";
                 case PLUS:
                     return "+" + value;
-                default:
-                    throw new UnsupportedOperationException("Unsupported sign: " + node.getSign());
             }
+            throw new UnsupportedOperationException("Unsupported sign: " + node.getSign());
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -1099,9 +1099,8 @@ public final class SqlFormatter
                     return type.name();
                 case PRINCIPAL:
                     return formatPrincipal(grantor.getPrincipal().get());
-                default:
-                    throw new IllegalArgumentException("Unsupported principal type: " + type);
             }
+            throw new IllegalArgumentException("Unsupported principal type: " + type);
         }
 
         private static String formatPrincipal(PrincipalSpecification principal)
@@ -1113,9 +1112,8 @@ public final class SqlFormatter
                 case USER:
                 case ROLE:
                     return format("%s %s", type.name(), principal.getName().toString());
-                default:
-                    throw new IllegalArgumentException("Unsupported principal type: " + type);
             }
+            throw new IllegalArgumentException("Unsupported principal type: " + type);
         }
 
         @Override
@@ -1463,14 +1461,12 @@ public final class SqlFormatter
                 case ALL:
                 case NONE:
                     builder.append(type.toString());
-                    break;
+                    return null;
                 case ROLE:
                     builder.append(node.getRole().get());
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unsupported type: " + type);
+                    return null;
             }
-            return null;
+            throw new IllegalArgumentException("Unsupported type: " + type);
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ComparisonExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ComparisonExpression.java
@@ -138,9 +138,8 @@ public class ComparisonExpression
                     return LESS_THAN_OR_EQUAL;
                 case IS_DISTINCT_FROM:
                     return IS_DISTINCT_FROM;
-                default:
-                    throw new IllegalArgumentException("Unsupported comparison: " + this);
             }
+            throw new IllegalArgumentException("Unsupported comparison: " + this);
         }
 
         public Operator negate()
@@ -158,9 +157,11 @@ public class ComparisonExpression
                     return LESS_THAN_OR_EQUAL;
                 case GREATER_THAN_OR_EQUAL:
                     return LESS_THAN;
-                default:
-                    throw new IllegalArgumentException("Unsupported comparison: " + this);
+                case IS_DISTINCT_FROM:
+                    // Cannot negate
+                    break;
             }
+            throw new IllegalArgumentException("Unsupported comparison: " + this);
         }
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/LogicalBinaryExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/LogicalBinaryExpression.java
@@ -35,9 +35,8 @@ public class LogicalBinaryExpression
                     return OR;
                 case OR:
                     return AND;
-                default:
-                    throw new IllegalArgumentException("Unsupported logical expression type: " + this);
             }
+            throw new IllegalArgumentException("Unsupported logical expression type: " + this);
         }
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/Marker.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/Marker.java
@@ -202,9 +202,8 @@ public final class Marker
                 return new Marker(type, valueBlock, Bound.ABOVE);
             case ABOVE:
                 throw new IllegalStateException("No greater marker adjacent to an ABOVE bound");
-            default:
-                throw new AssertionError("Unsupported type: " + bound);
         }
+        throw new AssertionError("Unsupported type: " + bound);
     }
 
     public Marker lesserAdjacent()
@@ -219,9 +218,8 @@ public final class Marker
                 return new Marker(type, valueBlock, Bound.BELOW);
             case ABOVE:
                 return new Marker(type, valueBlock, Bound.EXACTLY);
-            default:
-                throw new AssertionError("Unsupported type: " + bound);
         }
+        throw new AssertionError("Unsupported type: " + bound);
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeParameter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeParameter.java
@@ -65,9 +65,8 @@ public class TypeParameter
             }
             case VARIABLE:
                 return of(parameter.getVariable());
-            default:
-                throw new UnsupportedOperationException(format("Unsupported parameter [%s]", parameter));
         }
+        throw new UnsupportedOperationException(format("Unsupported parameter [%s]", parameter));
     }
 
     public ParameterKind getKind()

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeSignatureParameter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeSignatureParameter.java
@@ -163,9 +163,8 @@ public final class TypeSignatureParameter
                 return false;
             case VARIABLE:
                 return true;
-            default:
-                throw new IllegalArgumentException("Unexpected parameter kind: " + kind);
         }
+        throw new IllegalArgumentException("Unexpected parameter kind: " + kind);
     }
 
     @Override

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/serde/GeometrySerde.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/serde/GeometrySerde.java
@@ -84,30 +84,29 @@ public final class GeometrySerde
         switch (type) {
             case POINT:
                 writePoint(output, geometry);
-                break;
+                return;
             case MULTI_POINT:
                 writeSimpleGeometry(output, GeometrySerializationType.MULTI_POINT, geometry);
-                break;
+                return;
             case LINE_STRING:
                 writeSimpleGeometry(output, GeometrySerializationType.LINE_STRING, geometry);
-                break;
+                return;
             case MULTI_LINE_STRING:
                 writeSimpleGeometry(output, GeometrySerializationType.MULTI_LINE_STRING, geometry);
-                break;
+                return;
             case POLYGON:
                 writeSimpleGeometry(output, GeometrySerializationType.POLYGON, geometry);
-                break;
+                return;
             case MULTI_POLYGON:
                 writeSimpleGeometry(output, GeometrySerializationType.MULTI_POLYGON, geometry);
-                break;
+                return;
             case GEOMETRY_COLLECTION: {
                 verify(geometry instanceof OGCConcreteGeometryCollection);
                 writeGeometryCollection(output, (OGCConcreteGeometryCollection) geometry);
-                break;
+                return;
             }
-            default:
-                throw new IllegalArgumentException("Unexpected type: " + type);
         }
+        throw new IllegalArgumentException("Unexpected type: " + type);
     }
 
     private static void writeGeometryCollection(DynamicSliceOutput output, OGCGeometryCollection collection)
@@ -189,9 +188,8 @@ public final class GeometrySerde
                 return readGeometryCollection(input, inputSlice);
             case ENVELOPE:
                 return createFromEsriGeometry(readEnvelope(input), false);
-            default:
-                throw new IllegalArgumentException("Unexpected type: " + type);
         }
+        throw new IllegalArgumentException("Unexpected type: " + type);
     }
 
     private static OGCConcreteGeometryCollection readGeometryCollection(BasicSliceInput input, Slice inputSlice)
@@ -251,9 +249,13 @@ public final class GeometrySerde
                 polygon.addEnvelope((Envelope) geometry, false);
                 return new OGCPolygon(polygon, null);
             }
-            default:
-                throw new IllegalArgumentException("Unexpected geometry type: " + type);
+            case Line:
+                // TODO unsupported
+                break;
+            case Unknown:
+                break;
         }
+        throw new IllegalArgumentException("Unexpected geometry type: " + type);
     }
 
     private static OGCPoint readPoint(BasicSliceInput input)
@@ -297,9 +299,8 @@ public final class GeometrySerde
                 return getGeometryCollectionOverallEnvelope(input);
             case ENVELOPE:
                 return readEnvelope(input);
-            default:
-                throw new IllegalArgumentException("Unexpected type: " + type);
         }
+        throw new IllegalArgumentException("Unexpected type: " + type);
     }
 
     private static Envelope getGeometryCollectionOverallEnvelope(BasicSliceInput input)

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/serde/JtsGeometrySerde.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/serde/JtsGeometrySerde.java
@@ -75,9 +75,8 @@ public final class JtsGeometrySerde
                 return readGeometryCollection(input);
             case ENVELOPE:
                 return readEnvelope(input);
-            default:
-                throw new UnsupportedOperationException("Unexpected type: " + type);
         }
+        throw new UnsupportedOperationException("Unexpected type: " + type);
     }
 
     private static Point readPoint(SliceInput input)
@@ -271,28 +270,27 @@ public final class JtsGeometrySerde
         switch (geometry.getGeometryType()) {
             case "Point":
                 writePoint((Point) geometry, output);
-                break;
+                return;
             case "MultiPoint":
                 writeMultiPoint((MultiPoint) geometry, output);
-                break;
+                return;
             case "LineString":
                 writePolyline(geometry, output, false);
-                break;
+                return;
             case "MultiLineString":
                 writePolyline(geometry, output, true);
-                break;
+                return;
             case "Polygon":
                 writePolygon(geometry, output, false);
-                break;
+                return;
             case "MultiPolygon":
                 writePolygon(geometry, output, true);
-                break;
+                return;
             case "GeometryCollection":
                 writeGeometryCollection(geometry, output);
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported geometry type : " + geometry.getGeometryType());
+                return;
         }
+        throw new IllegalArgumentException("Unsupported geometry type : " + geometry.getGeometryType());
     }
 
     private static void writePoint(Point point, SliceOutput output)

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcDecompressor.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcDecompressor.java
@@ -43,9 +43,8 @@ public interface OrcDecompressor
                 return Optional.of(new OrcLz4Decompressor(orcDataSourceId, bufferSize));
             case ZSTD:
                 return Optional.of(new OrcZstdDecompressor(orcDataSourceId, bufferSize));
-            default:
-                throw new OrcCorruptionException(orcDataSourceId, "Unknown compression type: " + compression);
         }
+        throw new OrcCorruptionException(orcDataSourceId, "Unknown compression type: " + compression);
     }
 
     int decompress(byte[] input, int offset, int length, OutputBuffer output)

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcOutputBuffer.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcOutputBuffer.java
@@ -84,26 +84,25 @@ public class OrcOutputBuffer
         this.slice = wrappedBuffer(buffer);
 
         compressedOutputStream = new ChunkedSliceOutput(MINIMUM_OUTPUT_BUFFER_CHUNK_SIZE, MAXIMUM_OUTPUT_BUFFER_CHUNK_SIZE);
+        this.compressor = getCompressor(compression);
+    }
 
+    @Nullable
+    private static Compressor getCompressor(CompressionKind compression)
+    {
         switch (compression) {
             case NONE:
-                this.compressor = null;
-                break;
+                return null;
             case SNAPPY:
-                this.compressor = new SnappyCompressor();
-                break;
+                return new SnappyCompressor();
             case ZLIB:
-                this.compressor = new DeflateCompressor();
-                break;
+                return new DeflateCompressor();
             case LZ4:
-                this.compressor = new Lz4Compressor();
-                break;
+                return new Lz4Compressor();
             case ZSTD:
-                this.compressor = new ZstdCompressor();
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported compression " + compression);
+                return new ZstdCompressor();
         }
+        throw new IllegalArgumentException("Unsupported compression " + compression);
     }
 
     public long getOutputDataSize()

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriterStats.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriterStats.java
@@ -101,9 +101,8 @@ public class OrcWriterStats
                 return dictionaryFullFlush;
             case CLOSED:
                 return closedFlush;
-            default:
-                throw new IllegalArgumentException("unknown flush reason " + flushReason);
         }
+        throw new IllegalArgumentException("unknown flush reason " + flushReason);
     }
 
     @Override

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/OrcMetadataReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/OrcMetadataReader.java
@@ -577,9 +577,8 @@ public class OrcMetadataReader
                 return OrcTypeKind.VARCHAR;
             case CHAR:
                 return OrcTypeKind.CHAR;
-            default:
-                throw new IllegalStateException(typeKind + " stream type not implemented yet");
         }
+        throw new IllegalStateException(typeKind + " stream type not implemented yet");
     }
 
     // This method assumes type attributes have no duplicate key
@@ -617,9 +616,14 @@ public class OrcMetadataReader
                 return StreamKind.BLOOM_FILTER;
             case BLOOM_FILTER_UTF8:
                 return StreamKind.BLOOM_FILTER_UTF8;
-            default:
-                throw new IllegalStateException(streamKind + " stream type not implemented yet");
+            case ENCRYPTED_INDEX:
+            case ENCRYPTED_DATA:
+            case STRIPE_STATISTICS:
+            case FILE_STATISTICS:
+                // unsupported
+                break;
         }
+        throw new IllegalStateException(streamKind + " stream type not implemented yet");
     }
 
     private static ColumnEncodingKind toColumnEncodingKind(OrcProto.ColumnEncoding.Kind columnEncodingKind)
@@ -633,9 +637,8 @@ public class OrcMetadataReader
                 return ColumnEncodingKind.DICTIONARY;
             case DICTIONARY_V2:
                 return ColumnEncodingKind.DICTIONARY_V2;
-            default:
-                throw new IllegalStateException(columnEncodingKind + " stream encoding not implemented yet");
         }
+        throw new IllegalStateException(columnEncodingKind + " stream encoding not implemented yet");
     }
 
     private static CompressionKind toCompression(OrcProto.CompressionKind compression)
@@ -647,12 +650,14 @@ public class OrcMetadataReader
                 return ZLIB;
             case SNAPPY:
                 return SNAPPY;
+            case LZO:
+                // TODO unsupported
+                break;
             case LZ4:
                 return LZ4;
             case ZSTD:
                 return ZSTD;
-            default:
-                throw new IllegalStateException(compression + " compression not implemented yet");
         }
+        throw new IllegalStateException(compression + " compression not implemented yet");
     }
 }

--- a/lib/trino-orc/src/main/java/io/trino/orc/reader/ColumnReaders.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/reader/ColumnReaders.java
@@ -79,8 +79,7 @@ public final class ColumnReaders
                 return new DecimalColumnReader(type, column, systemMemoryContext.newLocalMemoryContext(ColumnReaders.class.getSimpleName()));
             case UNION:
                 return new UnionColumnReader(type, column, systemMemoryContext, blockFactory, fieldMapperFactory);
-            default:
-                throw new IllegalArgumentException("Unsupported type: " + column.getColumnType());
         }
+        throw new IllegalArgumentException("Unsupported type: " + column.getColumnType());
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetCompressionUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetCompressionUtils.java
@@ -62,9 +62,11 @@ public final class ParquetCompressionUtils
                 return decompressLz4(input, uncompressedSize);
             case ZSTD:
                 return decompressZstd(input, uncompressedSize);
-            default:
-                throw new ParquetCorruptionException("Codec not supported in Parquet: " + codec);
+            case BROTLI:
+                // unsupported
+                break;
         }
+        throw new ParquetCorruptionException("Codec not supported in Parquet: " + codec);
     }
 
     private static Slice decompressSnappy(Slice input, int uncompressedSize)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetEncoding.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetEncoding.java
@@ -72,9 +72,8 @@ public enum ParquetEncoding
                     return new FixedLenByteArrayPlainValuesReader(INT96_TYPE_LENGTH);
                 case FIXED_LEN_BYTE_ARRAY:
                     return new FixedLenByteArrayPlainValuesReader(descriptor.getPrimitiveType().getTypeLength());
-                default:
-                    throw new ParquetDecodingException("Plain values reader does not support: " + descriptor.getPrimitiveType().getPrimitiveTypeName());
             }
+            throw new ParquetDecodingException("Plain values reader does not support: " + descriptor.getPrimitiveType().getPrimitiveTypeName());
         }
 
         @Override
@@ -82,6 +81,9 @@ public enum ParquetEncoding
                 throws IOException
         {
             switch (descriptor.getPrimitiveType().getPrimitiveTypeName()) {
+                case BOOLEAN:
+                    // No dictionary encoding for boolean
+                    break;
                 case BINARY:
                     return new BinaryDictionary(dictionaryPage);
                 case FIXED_LEN_BYTE_ARRAY:
@@ -96,9 +98,8 @@ public enum ParquetEncoding
                     return new IntegerDictionary(dictionaryPage);
                 case FLOAT:
                     return new FloatDictionary(dictionaryPage);
-                default:
-                    throw new ParquetDecodingException("Dictionary encoding does not support: " + descriptor.getPrimitiveType().getPrimitiveTypeName());
             }
+            throw new ParquetDecodingException("Dictionary encoding does not support: " + descriptor.getPrimitiveType().getPrimitiveTypeName());
         }
     },
 
@@ -206,10 +207,8 @@ public enum ParquetEncoding
                 if (descriptor.getPrimitiveType().getPrimitiveTypeName() == BOOLEAN) {
                     return 1;
                 }
-                // fall-through
-            default:
-                throw new ParquetDecodingException("Unsupported values type: " + valuesType);
         }
+        throw new ParquetDecodingException("Unsupported values type: " + valuesType);
     }
 
     public boolean usesDictionary()

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -161,9 +161,8 @@ public final class ParquetTypeUtils
                 return ParquetEncoding.DELTA_BYTE_ARRAY;
             case RLE_DICTIONARY:
                 return ParquetEncoding.RLE_DICTIONARY;
-            default:
-                throw new ParquetDecodingException("Unsupported Parquet encoding: " + encoding);
         }
+        throw new ParquetDecodingException("Unsupported Parquet encoding: " + encoding);
     }
 
     public static org.apache.parquet.schema.Type getParquetTypeByName(String columnName, GroupType groupType)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
@@ -325,8 +325,7 @@ public final class MetadataReader
                 return PrimitiveTypeName.INT96;
             case FIXED_LEN_BYTE_ARRAY:
                 return PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
-            default:
-                throw new IllegalArgumentException("Unknown type " + type);
         }
+        throw new IllegalArgumentException("Unknown type " + type);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
@@ -107,9 +107,8 @@ public abstract class PrimitiveColumnReader
             case FIXED_LEN_BYTE_ARRAY:
                 return createDecimalColumnReader(descriptor)
                         .orElseThrow(() -> new TrinoException(NOT_SUPPORTED, " type FIXED_LEN_BYTE_ARRAY supported as DECIMAL; got " + descriptor.getPrimitiveType().getOriginalType()));
-            default:
-                throw new TrinoException(NOT_SUPPORTED, "Unsupported parquet type: " + descriptor.getPrimitiveType().getPrimitiveTypeName());
         }
+        throw new TrinoException(NOT_SUPPORTED, "Unsupported parquet type: " + descriptor.getPrimitiveType().getPrimitiveTypeName());
     }
 
     private static Optional<PrimitiveColumnReader> createDecimalColumnReader(RichColumnDescriptor descriptor)

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/MessageTypeConverter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/MessageTypeConverter.java
@@ -123,9 +123,8 @@ class MessageTypeConverter
                 return Type.INT96;
             case FIXED_LEN_BYTE_ARRAY:
                 return Type.FIXED_LEN_BYTE_ARRAY;
-            default:
-                throw new RuntimeException("Unknown primitive type " + type);
         }
+        throw new RuntimeException("Unknown primitive type " + type);
     }
 
     private static ConvertedType getConvertedType(OriginalType type)
@@ -175,8 +174,7 @@ class MessageTypeConverter
                 return ConvertedType.JSON;
             case BSON:
                 return ConvertedType.BSON;
-            default:
-                throw new RuntimeException("Unknown original type " + type);
         }
+        throw new RuntimeException("Unknown original type " + type);
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetTypeConverter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetTypeConverter.java
@@ -40,8 +40,7 @@ public class ParquetTypeConverter
                 return Type.INT96;
             case FIXED_LEN_BYTE_ARRAY:
                 return Type.FIXED_LEN_BYTE_ARRAY;
-            default:
-                throw new RuntimeException("Unknown primitive type " + type);
         }
+        throw new RuntimeException("Unknown primitive type " + type);
     }
 }

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraType.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraType.java
@@ -215,9 +215,8 @@ public enum CassandraType
                 return NullableValue.of(trinoType, utf8Slice(buildArrayValue(row, position)));
             case MAP:
                 return NullableValue.of(trinoType, utf8Slice(buildMapValue(row, position)));
-            default:
-                throw new IllegalStateException("Handling of type " + this + " is not implemented");
         }
+        throw new IllegalStateException("Handling of type " + this + " is not implemented");
     }
 
     private static String buildMapValue(Row row, int position)
@@ -310,9 +309,14 @@ public enum CassandraType
             case BLOB:
             case CUSTOM:
                 return Bytes.toHexString(row.getBytesUnsafe(position));
-            default:
-                throw new IllegalStateException("Handling of type " + this + " is not implemented");
+
+            case LIST:
+            case SET:
+            case MAP:
+                // unsupported
+                break;
         }
+        throw new IllegalStateException("Handling of type " + this + " is not implemented");
     }
 
     // TODO unify with getColumnValueForCql
@@ -379,9 +383,8 @@ public enum CassandraType
                 return buildArrayValue((Collection<?>) cassandraValue, getOnlyElement(dataType.getTypeArguments()));
             case MAP:
                 return buildMapValue((Map<?, ?>) cassandraValue, dataType.getTypeArguments().get(0), dataType.getTypeArguments().get(1));
-            default:
-                throw new IllegalStateException("Unsupported type: " + cassandraType);
         }
+        throw new IllegalStateException("Unsupported type: " + cassandraType);
     }
 
     public Object getJavaValue(Object trinoNativeValue)
@@ -425,9 +428,8 @@ public enum CassandraType
             case SET:
             case LIST:
             case MAP:
-            default:
-                throw new IllegalStateException("Back conversion not implemented for " + this);
         }
+        throw new IllegalStateException("Back conversion not implemented for " + this);
     }
 
     public boolean isSupportedPartitionKey()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveLocationService.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveLocationService.java
@@ -121,20 +121,7 @@ public class HiveLocationService
             // existing partition
             WriteMode writeMode = locationHandle.getWriteMode();
             Path targetPath = new Path(partition.get().getStorage().getLocation());
-
-            Path writePath;
-            switch (writeMode) {
-                case STAGE_AND_MOVE_TO_TARGET_DIRECTORY:
-                    writePath = new Path(locationHandle.getWritePath(), partitionName);
-                    break;
-                case DIRECT_TO_TARGET_EXISTING_DIRECTORY:
-                    writePath = targetPath;
-                    break;
-                case DIRECT_TO_TARGET_NEW_DIRECTORY:
-                default:
-                    throw new UnsupportedOperationException(format("inserting into existing partition is not supported for %s", writeMode));
-            }
-
+            Path writePath = getPartitionWritePath(locationHandle, partitionName, writeMode, targetPath);
             return new WriteInfo(targetPath, writePath, writeMode);
         }
         else {
@@ -144,5 +131,18 @@ public class HiveLocationService
                     new Path(locationHandle.getWritePath(), partitionName),
                     locationHandle.getWriteMode());
         }
+    }
+
+    private Path getPartitionWritePath(LocationHandle locationHandle, String partitionName, WriteMode writeMode, Path targetPath)
+    {
+        switch (writeMode) {
+            case STAGE_AND_MOVE_TO_TARGET_DIRECTORY:
+                return new Path(locationHandle.getWritePath(), partitionName);
+            case DIRECT_TO_TARGET_EXISTING_DIRECTORY:
+                return targetPath;
+            case DIRECT_TO_TARGET_NEW_DIRECTORY:
+                throw new UnsupportedOperationException(format("inserting into existing partition is not supported for %s", writeMode));
+        }
+        throw new UnsupportedOperationException("Unexpected write mode: " + writeMode);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HivePrincipal.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HivePrincipal.java
@@ -72,19 +72,21 @@ public class HivePrincipal
     public HivePrincipal(@JsonProperty("type") PrincipalType type, @JsonProperty("name") String name)
     {
         this.type = requireNonNull(type, "type is null");
+        this.name = canonicalName(type, name);
+    }
+
+    private static String canonicalName(PrincipalType type, String name)
+    {
         requireNonNull(name, "name is null");
         switch (type) {
             case USER:
                 // In Hive user names are case sensitive
-                this.name = name;
-                break;
+                return name;
             case ROLE:
                 // In Hive role names are case insensitive
-                this.name = name.toLowerCase(ENGLISH);
-                break;
-            default:
-                throw new IllegalArgumentException("Unsupported type: " + type);
+                return name.toLowerCase(ENGLISH);
         }
+        throw new IllegalArgumentException("Unsupported type: " + type);
     }
 
     @JsonProperty

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HivePrivilegeInfo.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HivePrivilegeInfo.java
@@ -92,9 +92,8 @@ public class HivePrivilegeInfo
                 return DELETE;
             case UPDATE:
                 return UPDATE;
-            default:
-                throw new IllegalArgumentException("Unexpected privilege: " + privilege);
         }
+        throw new IllegalArgumentException("Unexpected privilege: " + privilege);
     }
 
     public boolean isContainedIn(HivePrivilegeInfo hivePrivilegeInfo)
@@ -117,9 +116,8 @@ public class HivePrivilegeInfo
                 return ImmutableSet.of(new PrivilegeInfo(Privilege.UPDATE, isGrantOption()));
             case OWNERSHIP:
                 return ImmutableSet.of();
-            default:
-                throw new IllegalArgumentException("Unsupported hivePrivilege: " + hivePrivilege);
         }
+        throw new IllegalArgumentException("Unsupported hivePrivilege: " + hivePrivilege);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -648,9 +648,8 @@ public final class ThriftMetastoreUtil
                 return org.apache.hadoop.hive.metastore.api.PrincipalType.USER;
             case ROLE:
                 return org.apache.hadoop.hive.metastore.api.PrincipalType.ROLE;
-            default:
-                throw new IllegalArgumentException("Unsupported principal type: " + principalType);
         }
+        throw new IllegalArgumentException("Unsupported principal type: " + principalType);
     }
 
     public static PrincipalType fromMetastoreApiPrincipalType(org.apache.hadoop.hive.metastore.api.PrincipalType principalType)
@@ -661,9 +660,11 @@ public final class ThriftMetastoreUtil
                 return USER;
             case ROLE:
                 return ROLE;
-            default:
-                throw new IllegalArgumentException("Unsupported principal type: " + principalType);
+            case GROUP:
+                // TODO
+                break;
         }
+        throw new IllegalArgumentException("Unsupported principal type: " + principalType);
     }
 
     public static FieldSchema toMetastoreApiFieldSchema(Column column)
@@ -823,9 +824,16 @@ public final class ThriftMetastoreUtil
                 return createBinaryStatistics(columnName, columnType, statistics, rowCount);
             case DECIMAL:
                 return createDecimalStatistics(columnName, columnType, statistics);
-            default:
-                throw new IllegalArgumentException(format("unsupported type: %s", columnType));
+
+            case TIMESTAMPLOCALTZ:
+            case INTERVAL_YEAR_MONTH:
+            case INTERVAL_DAY_TIME:
+                // TODO support these, when we add support for these Hive types
+            case VOID:
+            case UNKNOWN:
+                break;
         }
+        throw new IllegalArgumentException(format("unsupported type: %s", columnType));
     }
 
     private static ColumnStatisticsObj createBooleanStatistics(String columnName, HiveType columnType, HiveColumnStatistics statistics)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -159,7 +159,8 @@ public final class ThriftMetastoreUtil
         result.setName(database.getDatabaseName());
         database.getLocation().ifPresent(result::setLocationUri);
         result.setOwnerName(database.getOwnerName());
-        result.setOwnerType(toMetastoreApiPrincipalType(database.getOwnerType()));
+
+        result.setOwnerType(fromTrinoPrincipalType(database.getOwnerType()));
         database.getComment().ifPresent(result::setDescription);
         result.setParameters(database.getParameters());
         return result;
@@ -215,18 +216,6 @@ public final class ThriftMetastoreUtil
                 privilegeInfo.getGrantor().getName(),
                 fromTrinoPrincipalType(privilegeInfo.getGrantor().getType()),
                 privilegeInfo.isGrantOption());
-    }
-
-    private static org.apache.hadoop.hive.metastore.api.PrincipalType toMetastoreApiPrincipalType(PrincipalType principalType)
-    {
-        switch (principalType) {
-            case USER:
-                return org.apache.hadoop.hive.metastore.api.PrincipalType.USER;
-            case ROLE:
-                return org.apache.hadoop.hive.metastore.api.PrincipalType.ROLE;
-            default:
-                throw new IllegalArgumentException("Unsupported principal type: " + principalType);
-        }
     }
 
     public static Stream<RoleGrant> listApplicableRoles(HivePrincipal principal, Function<HivePrincipal, Set<RoleGrant>> listRoleGrants)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeToHiveTypeTranslator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcTypeToHiveTypeTranslator.java
@@ -104,9 +104,12 @@ public final class OrcTypeToHiveTypeTranslator
                 return toHiveType(getStructTypeInfo(orcType.getFieldNames(), fieldTypeInfo.build()));
             }
 
-            default:
-                throw new VerifyException("Unhandled ORC type: " + orcType.getOrcTypeKind());
+            case TIMESTAMP_INSTANT:
+            case UNION:
+                // unsupported
+                break;
         }
+        throw new VerifyException("Unhandled ORC type: " + orcType.getOrcTypeKind());
     }
 
     private static HiveType getHiveType(OrcType orcType, int index, ColumnMetadata<OrcType> columnMetadata)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Module.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Module.java
@@ -47,17 +47,16 @@ public class HiveS3Module
                 binder.bind(TrinoS3FileSystemStats.class).toInstance(TrinoS3FileSystem.getFileSystemStats());
                 newExporter(binder).export(TrinoS3FileSystemStats.class)
                         .as(generator -> generator.generatedNameOf(TrinoS3FileSystem.class));
-                break;
+                return;
             case EMRFS:
                 validateEmrFsClass();
                 newSetBinder(binder, ConfigurationInitializer.class).addBinding().to(EmrFsS3ConfigurationInitializer.class).in(Scopes.SINGLETON);
-                break;
+                return;
             case HADOOP_DEFAULT:
                 // configuration is done using Hadoop configuration files
-                break;
-            default:
-                throw new RuntimeException("Unknown file system type: " + type);
+                return;
         }
+        throw new RuntimeException("Unknown file system type: " + type);
     }
 
     private void bindSecurityMapping(Binder binder)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV1.java
@@ -100,17 +100,31 @@ final class HiveBucketingV1
                     case DATE:
                         // day offset from 1970-01-01
                         return toIntExact(trinoType.getLong(block, position));
-                    default:
-                        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
+                    case TIMESTAMP:
+                        // We do not support bucketing on timestamp
+                        break;
+                    case DECIMAL:
+                    case CHAR:
+                    case BINARY:
+                    case TIMESTAMPLOCALTZ:
+                    case INTERVAL_YEAR_MONTH:
+                    case INTERVAL_DAY_TIME:
+                        // TODO
+                        break;
+                    case VOID:
+                    case UNKNOWN:
+                        break;
                 }
+                throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
             case LIST:
                 return hashOfList((ListTypeInfo) type, block.getObject(position, Block.class));
             case MAP:
                 return hashOfMap((MapTypeInfo) type, block.getObject(position, Block.class));
-            default:
+            case STRUCT:
+            case UNION:
                 // TODO: support more types, e.g. ROW
-                throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory());
         }
+        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory());
     }
 
     private static int hash(TypeInfo type, Object value)
@@ -148,17 +162,31 @@ final class HiveBucketingV1
                     case DATE:
                         // day offset from 1970-01-01
                         return toIntExact((long) value);
-                    default:
-                        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
+                    case TIMESTAMP:
+                        // We do not support bucketing on timestamp
+                        break;
+                    case DECIMAL:
+                    case CHAR:
+                    case BINARY:
+                    case TIMESTAMPLOCALTZ:
+                    case INTERVAL_YEAR_MONTH:
+                    case INTERVAL_DAY_TIME:
+                        // TODO
+                        break;
+                    case VOID:
+                    case UNKNOWN:
+                        break;
                 }
+                throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
             case LIST:
                 return hashOfList((ListTypeInfo) type, (Block) value);
             case MAP:
                 return hashOfMap((MapTypeInfo) type, (Block) value);
-            default:
+            case STRUCT:
+            case UNION:
                 // TODO: support more types, e.g. ROW
-                throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory());
         }
+        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory());
     }
 
     private static int hashOfMap(MapTypeInfo type, Block singleMapBlock)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketingV2.java
@@ -105,17 +105,31 @@ final class HiveBucketingV2
                     case DATE:
                         // day offset from 1970-01-01
                         return Murmur3.hash32(bytes(toIntExact(trinoType.getLong(block, position))));
-                    default:
-                        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
+                    case TIMESTAMP:
+                        // We do not support bucketing on timestamp
+                        break;
+                    case DECIMAL:
+                    case CHAR:
+                    case BINARY:
+                    case TIMESTAMPLOCALTZ:
+                    case INTERVAL_YEAR_MONTH:
+                    case INTERVAL_DAY_TIME:
+                        // TODO
+                        break;
+                    case VOID:
+                    case UNKNOWN:
+                        break;
                 }
+                throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
             case LIST:
                 return hashOfList((ListTypeInfo) type, block.getObject(position, Block.class));
             case MAP:
                 return hashOfMap((MapTypeInfo) type, block.getObject(position, Block.class));
-            default:
+            case STRUCT:
+            case UNION:
                 // TODO: support more types, e.g. ROW
-                throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory());
         }
+        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory());
     }
 
     private static int hash(TypeInfo type, Object value)
@@ -156,17 +170,31 @@ final class HiveBucketingV2
                     case DATE:
                         // day offset from 1970-01-01
                         return Murmur3.hash32(bytes(toIntExact((long) value)));
-                    default:
-                        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
+                    case TIMESTAMP:
+                        // We do not support bucketing on timestamp
+                        break;
+                    case DECIMAL:
+                    case CHAR:
+                    case BINARY:
+                    case TIMESTAMPLOCALTZ:
+                    case INTERVAL_YEAR_MONTH:
+                    case INTERVAL_DAY_TIME:
+                        // TODO
+                        break;
+                    case VOID:
+                    case UNKNOWN:
+                        break;
                 }
+                throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive primitive category: " + primitiveCategory);
             case LIST:
                 return hashOfList((ListTypeInfo) type, (Block) value);
             case MAP:
                 return hashOfMap((MapTypeInfo) type, (Block) value);
-            default:
+            case STRUCT:
+            case UNION:
                 // TODO: support more types, e.g. ROW
-                throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory());
         }
+        throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory());
     }
 
     private static int hashOfMap(MapTypeInfo type, Block singleMapBlock)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -326,8 +326,7 @@ public class TestHivePageSink
                 return HIVE_DOUBLE;
             case VARCHAR:
                 return HIVE_STRING;
-            default:
-                throw new UnsupportedOperationException();
         }
+        throw new UnsupportedOperationException();
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveBucketing.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestHiveBucketing.java
@@ -361,9 +361,8 @@ public class TestHiveBucketing
                 return hashCodeOld;
             case BUCKETING_V2:
                 return ObjectInspectorUtils.getBucketHashCode(objects, objectInspectors);
-            default:
-                throw new IllegalArgumentException("Unsupported bucketing version: " + bucketingVersion);
         }
+        throw new IllegalArgumentException("Unsupported bucketing version: " + bucketingVersion);
     }
 
     private static Object toNativeContainerValue(Type type, Object hiveValue)

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/AvroSchemaConverter.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/AvroSchemaConverter.java
@@ -139,9 +139,11 @@ public class AvroSchemaConverter
                 return convertMap(schema);
             case RECORD:
                 return convertRecord(schema);
-            default:
-                throw new UnsupportedOperationException(format("Type %s not supported", schema.getType()));
+            case NULL:
+                // unsupported
+                break;
         }
+        throw new UnsupportedOperationException(format("Type %s not supported", schema.getType()));
     }
 
     private Optional<Type> convertUnion(Schema schema)
@@ -209,9 +211,8 @@ public class AvroSchemaConverter
                     return Optional.of(RowType.from(ImmutableList.of(new RowType.Field(Optional.of(DUMMY_FIELD_NAME), BooleanType.BOOLEAN))));
                 case FAIL:
                     throw new IllegalStateException(format("Struct type has no valid fields for schema: '%s'", schema));
-                default:
-                    throw new IllegalStateException(format("Unknown emptyFieldStrategy '%s'", emptyFieldStrategy));
             }
+            throw new IllegalStateException(format("Unknown emptyFieldStrategy '%s'", emptyFieldStrategy));
         }
         return Optional.of(RowType.from(fields));
     }

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplitManager.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplitManager.java
@@ -77,9 +77,8 @@ public class KuduSplitManager
                 return new FixedSplitSource(splits);
             case GROUPED_SCHEDULING:
                 return new KuduBucketedSplitSource(splits);
-            default:
-                throw new IllegalArgumentException("Unknown splitSchedulingStrategy: " + splitSchedulingStrategy);
         }
+        throw new IllegalArgumentException("Unknown splitSchedulingStrategy: " + splitSchedulingStrategy);
     }
 
     private static CompletableFuture<?> whenCompleted(DynamicFilter dynamicFilter)

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
@@ -122,9 +122,8 @@ public final class TypeHelper
                 return VarbinaryType.VARBINARY;
             case DECIMAL:
                 return DecimalType.createDecimalType(attributes.getPrecision(), attributes.getScale());
-            default:
-                throw new IllegalStateException("Kudu type not implemented for " + ktype);
         }
+        throw new IllegalStateException("Kudu type not implemented for " + ktype);
     }
 
     public static Object getJavaValue(Type type, Object nativeValue)

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/KuduTableProperties.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/KuduTableProperties.java
@@ -399,13 +399,17 @@ public final class KuduTableProperties
                 return bound.getShort(idx);
             case INT8:
                 return (short) bound.getByte(idx);
+            case FLOAT:
+            case DOUBLE:
+            case DECIMAL:
+                // TODO unsupported
+                break;
             case BOOL:
                 return bound.getBoolean(idx);
             case BINARY:
                 return bound.getBinaryCopy(idx);
-            default:
-                throw new IllegalStateException("Unhandled type " + type + " for range partition");
         }
+        throw new IllegalStateException("Unhandled type " + type + " for range partition");
     }
 
     public static PartitionDesign getPartitionDesign(KuduTable table)

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/KuduTableProperties.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/properties/KuduTableProperties.java
@@ -40,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -407,21 +406,6 @@ public final class KuduTableProperties
             default:
                 throw new IllegalStateException("Unhandled type " + type + " for range partition");
         }
-    }
-
-    private static LinkedHashMap<String, ColumnDesign> getColumns(KuduTable table)
-    {
-        Schema schema = table.getSchema();
-        LinkedHashMap<String, ColumnDesign> columns = new LinkedHashMap<>();
-        for (ColumnSchema columnSchema : schema.getColumns()) {
-            ColumnDesign design = new ColumnDesign();
-            design.setNullable(columnSchema.isNullable());
-            design.setPrimaryKey(columnSchema.isKey());
-            design.setCompression(lookupCompressionString(columnSchema.getCompressionAlgorithm()));
-            design.setEncoding(lookupEncodingString(columnSchema.getEncoding()));
-            columns.put(columnSchema.getName(), design);
-        }
-        return columns;
     }
 
     public static PartitionDesign getPartitionDesign(KuduTable table)

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotPageSourceProvider.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotPageSourceProvider.java
@@ -103,8 +103,7 @@ public class PinotPageSourceProvider
                         pinotQuery,
                         handles,
                         clusterInfoFetcher);
-            default:
-                throw new UnsupportedOperationException("Unknown Pinot split type: " + pinotSplit.getSplitType());
         }
+        throw new UnsupportedOperationException("Unknown Pinot split type: " + pinotSplit.getSplitType());
     }
 }

--- a/plugin/trino-thrift-api/src/main/java/io/trino/plugin/thrift/api/valuesets/TrinoThriftRangeValueSet.java
+++ b/plugin/trino-thrift-api/src/main/java/io/trino/plugin/thrift/api/valuesets/TrinoThriftRangeValueSet.java
@@ -124,9 +124,8 @@ public final class TrinoThriftRangeValueSet
                     return EXACTLY;
                 case ABOVE:
                     return ABOVE;
-                default:
-                    throw new IllegalArgumentException("Unknown bound: " + bound);
             }
+            throw new IllegalArgumentException("Unknown bound: " + bound);
         }
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveCoercion.java
@@ -851,8 +851,7 @@ public class TestHiveCoercion
                 return onHive();
             case PRESTO:
                 return onPresto();
-            default:
-                throw new IllegalStateException("Unknown enum value " + engine);
         }
+        throw new IllegalStateException("Unknown enum value " + engine);
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveTransactionalTable.java
@@ -1290,9 +1290,8 @@ public class TestHiveTransactionalTable
                 return onHive();
             case PRESTO:
                 return onPresto();
-            default:
-                throw new IllegalStateException("Unknown enum value " + hiveOrPresto);
         }
+        throw new IllegalStateException("Unknown enum value " + hiveOrPresto);
     }
 
     @DataProvider


### PR DESCRIPTION
Remove the `default` branch from enum-based `switch` statements that are
meant to be exhaustive. This, combined with `MissingCasesInEnumSwitch`
errorprone check already enabled, ensures the code gets updated when a
new enum option is added.

Some places were not updated. Specifically, since the `default` branch
gets converted to a `throw` right after  the `switch`, the statements
within larger method flows were kept intact. It does not mean they
should not be refactored, just that it was considered out of scope for
this commit.

Follows https://github.com/trinodb/trino/pull/6876