### PR TITLE
WIP: Use posix tar mode in maven-assembly-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1667,6 +1667,18 @@
                     </excludes>
                 </configuration>
             </plugin>
+
+            <!--
+             TODO: move this to airbase
+             This fixes 'user id is too big' error
+             -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <tarLongFileMode>posix</tarLongFileMode>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 


### PR DESCRIPTION
This is a workaround for "user is too big" when trying to build Trino from the user with high uid number (this ideally should be moved to airbase)