### PR TITLE
Make Range representation lightweight

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/Marker.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/Marker.java
@@ -40,6 +40,7 @@ import static java.util.Objects.requireNonNull;
  * A point on the continuous space defined by the specified type.
  * Each point may be just below, exact, or just above the specified value according to the Bound.
  */
+@Deprecated
 public final class Marker
         implements Comparable<Marker>
 {

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/Range.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/Range.java
@@ -16,9 +16,21 @@ package io.trino.spi.predicate;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.Type;
 
+import java.lang.invoke.MethodHandle;
 import java.util.Objects;
 import java.util.Optional;
 
+import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
+import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
+import static io.trino.spi.function.InvocationConvention.simpleConvention;
+import static io.trino.spi.predicate.Marker.Bound.ABOVE;
+import static io.trino.spi.predicate.Marker.Bound.BELOW;
+import static io.trino.spi.predicate.Marker.Bound.EXACTLY;
+import static io.trino.spi.predicate.Utils.TUPLE_DOMAIN_TYPE_OPERATORS;
+import static io.trino.spi.predicate.Utils.handleThrowable;
+import static io.trino.spi.predicate.Utils.nativeValueToBlock;
+import static io.trino.spi.type.TypeUtils.isFloatingPointNaN;
+import static io.trino.spi.type.TypeUtils.readNativeValue;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -27,125 +39,198 @@ import static java.util.Objects.requireNonNull;
  */
 public final class Range
 {
-    private final Marker low;
-    private final Marker high;
+    private final Type type;
+    private final boolean lowInclusive;
+    private final Optional<Object> lowValue;
+    private final boolean highInclusive;
+    private final Optional<Object> highValue;
 
+    private final MethodHandle comparisonOperator;
+    private final boolean isSingleValue;
+
+    @Deprecated
     public Range(Marker low, Marker high)
+    {
+        this(
+                verifyMarkersAndGetType(low, high),
+                low.getBound() == EXACTLY,
+                low.getValueBlock().map(block -> readNativeValue(low.getType(), block, 0)),
+                high.getBound() == EXACTLY,
+                high.getValueBlock().map(block -> readNativeValue(high.getType(), block, 0)));
+    }
+
+    private static Type verifyMarkersAndGetType(Marker low, Marker high)
     {
         requireNonNull(low, "value is null");
         requireNonNull(high, "value is null");
         if (!low.getType().equals(high.getType())) {
             throw new IllegalArgumentException(format("Marker types do not match: %s vs %s", low.getType(), high.getType()));
         }
-        if (low.getBound() == Marker.Bound.BELOW) {
+        if (low.getBound() == BELOW) {
             throw new IllegalArgumentException("low bound must be EXACTLY or ABOVE");
         }
-        if (high.getBound() == Marker.Bound.ABOVE) {
+        if (high.getBound() == ABOVE) {
             throw new IllegalArgumentException("high bound must be EXACTLY or BELOW");
         }
-        if (low.compareTo(high) > 0) {
-            throw new IllegalArgumentException("low must be less than or equal to high");
+        return low.getType();
+    }
+
+    private Range(Type type, boolean lowInclusive, Optional<Object> lowValue, boolean highInclusive, Optional<Object> highValue)
+    {
+        requireNonNull(type, "type is null");
+        this.type = type;
+        MethodHandle comparisonOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getComparisonOperator(type, simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL));
+
+        requireNonNull(lowValue, "lowValue is null");
+        requireNonNull(highValue, "highValue is null");
+
+        if (lowValue.isEmpty() && lowInclusive) {
+            throw new IllegalArgumentException("low bound must be exclusive for low unbounded range");
         }
-        this.low = low;
-        this.high = high;
+        if (highValue.isEmpty() && highInclusive) {
+            throw new IllegalArgumentException("high bound must be exclusive for high unbounded range");
+        }
+        boolean isSingleValue = false;
+        if (lowValue.isPresent() && highValue.isPresent()) {
+            int compare = compareValues(comparisonOperator, lowValue.get(), highValue.get());
+            if (compare > 0) {
+                throw new IllegalArgumentException("low must be less than or equal to high");
+            }
+            if (compare == 0) {
+                if (!highInclusive || !lowInclusive) {
+                    throw new IllegalArgumentException("invalid bounds for single value range");
+                }
+                isSingleValue = true;
+            }
+        }
+        lowValue.ifPresent(value -> verifyNotNan(type, value));
+        highValue.ifPresent(value -> verifyNotNan(type, value));
+
+        this.lowInclusive = lowInclusive;
+        this.lowValue = lowValue;
+        this.highInclusive = highInclusive;
+        this.highValue = highValue;
+
+        this.comparisonOperator = comparisonOperator;
+        this.isSingleValue = isSingleValue;
+    }
+
+    private static void verifyNotNan(Type type, Object value)
+    {
+        if (isFloatingPointNaN(type, value)) {
+            throw new IllegalArgumentException("cannot use NaN as range bound");
+        }
     }
 
     public static Range all(Type type)
     {
-        return new Range(Marker.lowerUnbounded(type), Marker.upperUnbounded(type));
+        return new Range(type, false, Optional.empty(), false, Optional.empty());
     }
 
     public static Range greaterThan(Type type, Object low)
     {
-        return new Range(Marker.above(type, low), Marker.upperUnbounded(type));
+        requireNonNull(low, "low is null");
+        return new Range(type, false, Optional.of(low), false, Optional.empty());
     }
 
     public static Range greaterThanOrEqual(Type type, Object low)
     {
-        return new Range(Marker.exactly(type, low), Marker.upperUnbounded(type));
+        requireNonNull(low, "low is null");
+        return new Range(type, true, Optional.of(low), false, Optional.empty());
     }
 
     public static Range lessThan(Type type, Object high)
     {
-        return new Range(Marker.lowerUnbounded(type), Marker.below(type, high));
+        requireNonNull(high, "high is null");
+        return new Range(type, false, Optional.empty(), false, Optional.of(high));
     }
 
     public static Range lessThanOrEqual(Type type, Object high)
     {
-        return new Range(Marker.lowerUnbounded(type), Marker.exactly(type, high));
+        requireNonNull(high, "high is null");
+        return new Range(type, false, Optional.empty(), true, Optional.of(high));
     }
 
     public static Range equal(Type type, Object value)
     {
-        Marker marker = Marker.exactly(type, value);
-        return new Range(marker, marker);
+        requireNonNull(value, "value is null");
+        Optional<Object> valueAsOptional = Optional.of(value);
+        return new Range(type, true, valueAsOptional, true, valueAsOptional);
     }
 
     public static Range range(Type type, Object low, boolean lowInclusive, Object high, boolean highInclusive)
     {
-        Marker lowMarker = lowInclusive ? Marker.exactly(type, low) : Marker.above(type, low);
-        Marker highMarker = highInclusive ? Marker.exactly(type, high) : Marker.below(type, high);
-        return new Range(lowMarker, highMarker);
+        requireNonNull(low, "low is null");
+        requireNonNull(high, "high is null");
+        return new Range(type, lowInclusive, Optional.of(low), highInclusive, Optional.of(high));
     }
 
     public Type getType()
     {
-        return low.getType();
+        return type;
     }
 
+    /**
+     * @deprecated Use {@link #isLowInclusive()} and {@link #getLowValue()}.
+     */
+    @Deprecated
     public Marker getLow()
     {
-        return low;
+        return new Marker(type, lowValue.map(value -> nativeValueToBlock(type, value)), lowInclusive ? EXACTLY : ABOVE);
     }
 
     public boolean isLowInclusive()
     {
-        return low.getBound() == Marker.Bound.EXACTLY;
+        return lowInclusive;
     }
 
     public boolean isLowUnbounded()
     {
-        return low.isLowerUnbounded();
+        return lowValue.isEmpty();
     }
 
     public Object getLowBoundedValue()
     {
-        return low.getValue();
+        return lowValue.orElseThrow(() -> new IllegalStateException("The range is low-unbounded"));
     }
 
     public Optional<Object> getLowValue()
     {
-        return low.getValueBlock().isPresent() ? Optional.of(low.getValue()) : Optional.empty();
+        return lowValue;
     }
 
+    /**
+     * @deprecated Use {@link #isHighInclusive()} and {@link #getHighValue()}.
+     */
+    @Deprecated
     public Marker getHigh()
     {
-        return high;
+        return new Marker(type, highValue.map(value -> nativeValueToBlock(type, value)), highInclusive ? EXACTLY : BELOW);
     }
 
     public boolean isHighInclusive()
     {
-        return high.getBound() == Marker.Bound.EXACTLY;
+        return highInclusive;
     }
 
     public boolean isHighUnbounded()
     {
-        return high.isUpperUnbounded();
+        return highValue.isEmpty();
     }
 
     public Object getHighBoundedValue()
     {
-        return high.getValue();
+        return highValue.orElseThrow(() -> new IllegalStateException("The range is high-unbounded"));
     }
 
     public Optional<Object> getHighValue()
     {
-        return high.getValueBlock().isPresent() ? Optional.of(high.getValue()) : Optional.empty();
+        return highValue;
     }
 
     public boolean isSingleValue()
     {
-        return low.getBound() == Marker.Bound.EXACTLY && low.equals(high);
+        return isSingleValue;
     }
 
     public Object getSingleValue()
@@ -153,41 +238,41 @@ public final class Range
         if (!isSingleValue()) {
             throw new IllegalStateException("Range does not have just a single value");
         }
-        return low.getValue();
+        return lowValue.orElseThrow();
     }
 
     public boolean isAll()
     {
-        return low.isLowerUnbounded() && high.isUpperUnbounded();
+        return lowValue.isEmpty() && highValue.isEmpty();
     }
 
+    @Deprecated
     public boolean includes(Marker marker)
     {
         requireNonNull(marker, "marker is null");
         checkTypeCompatibility(marker);
-        return low.compareTo(marker) <= 0 && high.compareTo(marker) >= 0;
+        return getLow().compareTo(marker) <= 0 && getHigh().compareTo(marker) >= 0;
     }
 
     public boolean contains(Range other)
     {
         checkTypeCompatibility(other);
-        return this.getLow().compareTo(other.getLow()) <= 0 &&
-                this.getHigh().compareTo(other.getHigh()) >= 0;
+
+        return compareLowBound(other) <= 0 &&
+                compareHighBound(other) >= 0;
     }
 
     public Range span(Range other)
     {
         checkTypeCompatibility(other);
-        Marker lowMarker = Marker.min(low, other.getLow());
-        Marker highMarker = Marker.max(high, other.getHigh());
-        return new Range(lowMarker, highMarker);
-    }
-
-    public boolean overlaps(Range other)
-    {
-        checkTypeCompatibility(other);
-        return this.getLow().compareTo(other.getHigh()) <= 0 &&
-                other.getLow().compareTo(this.getHigh()) <= 0;
+        int compareLowBound = compareLowBound(other);
+        int compareHighBound = compareHighBound(other);
+        return new Range(
+                type,
+                compareLowBound <= 0 ? this.lowInclusive : other.lowInclusive,
+                compareLowBound <= 0 ? this.lowValue : other.lowValue,
+                compareHighBound >= 0 ? this.highInclusive : other.highInclusive,
+                compareHighBound >= 0 ? this.highValue : other.highValue);
     }
 
     public Range intersect(Range other)
@@ -196,9 +281,79 @@ public final class Range
         if (!this.overlaps(other)) {
             throw new IllegalArgumentException("Cannot intersect non-overlapping ranges");
         }
-        Marker lowMarker = Marker.max(low, other.getLow());
-        Marker highMarker = Marker.min(high, other.getHigh());
-        return new Range(lowMarker, highMarker);
+
+        int compareLowBound = compareLowBound(other);
+        int compareHighBound = compareHighBound(other);
+        return new Range(
+                type,
+                compareLowBound >= 0 ? this.lowInclusive : other.lowInclusive,
+                compareLowBound >= 0 ? this.lowValue : other.lowValue,
+                compareHighBound <= 0 ? this.highInclusive : other.highInclusive,
+                compareHighBound <= 0 ? this.highValue : other.highValue);
+    }
+
+    public boolean overlaps(Range other)
+    {
+        checkTypeCompatibility(other);
+        return !this.isFullyBefore(other) && !other.isFullyBefore(this);
+    }
+
+    /**
+     * Returns unioned range if {@code this} and {@code next} overlap or are adjacent.
+     * The {@code next} lower bound must not be before {@code this} lower bound.
+     */
+    Optional<Range> tryMergeWithNext(Range next)
+    {
+        if (this.compareLowBound(next) > 0) {
+            throw new IllegalArgumentException("next before this");
+        }
+
+        if (this.isHighUnbounded()) {
+            return Optional.of(this);
+        }
+
+        boolean merge;
+        if (next.isLowUnbounded()) {
+            // both are low-unbounded
+            merge = true;
+        }
+        else {
+            int compare = compareValues(comparisonOperator, this.highValue.orElseThrow(), next.lowValue.orElseThrow());
+            merge = compare > 0  // overlap
+                    || compare == 0 && (this.highInclusive || next.lowInclusive); // adjacent
+        }
+        if (merge) {
+            int compareHighBound = compareHighBound(next);
+            return Optional.of(new Range(
+                    this.type,
+                    this.lowInclusive,
+                    this.lowValue,
+                    // max of high bounds
+                    compareHighBound <= 0 ? next.highInclusive : this.highInclusive,
+                    compareHighBound <= 0 ? next.highValue : this.highValue));
+        }
+
+        return Optional.empty();
+    }
+
+    private boolean isFullyBefore(Range other)
+    {
+        if (this.isHighUnbounded()) {
+            return false;
+        }
+        if (other.isLowUnbounded()) {
+            return false;
+        }
+
+        int compare = compareValues(comparisonOperator, this.highValue.orElseThrow(), other.lowValue.orElseThrow());
+        if (compare < 0) {
+            return true;
+        }
+        if (compare == 0) {
+            return !(this.highInclusive && other.lowInclusive);
+        }
+
+        return false;
     }
 
     private void checkTypeCompatibility(Range range)
@@ -215,24 +370,69 @@ public final class Range
         }
     }
 
-    @Override
-    public int hashCode()
+    int compareLowBound(Range other)
     {
-        return Objects.hash(low, high);
+        if (this.isLowUnbounded() || other.isLowUnbounded()) {
+            return Boolean.compare(!this.isLowUnbounded(), !other.isLowUnbounded());
+        }
+        int compare = compareValues(comparisonOperator, this.lowValue.orElseThrow(), other.lowValue.orElseThrow());
+        if (compare != 0) {
+            return compare;
+        }
+        return Boolean.compare(!this.lowInclusive, !other.lowInclusive);
+    }
+
+    private int compareHighBound(Range other)
+    {
+        if (this.isHighUnbounded() || other.isHighUnbounded()) {
+            return Boolean.compare(this.isHighUnbounded(), other.isHighUnbounded());
+        }
+        int compare = compareValues(comparisonOperator, this.highValue.orElseThrow(), other.highValue.orElseThrow());
+        if (compare != 0) {
+            return compare;
+        }
+        return Boolean.compare(this.highInclusive, other.highInclusive);
     }
 
     @Override
-    public boolean equals(Object obj)
+    public boolean equals(Object o)
     {
-        if (this == obj) {
+        if (this == o) {
             return true;
         }
-        if (obj == null || getClass() != obj.getClass()) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        Range other = (Range) obj;
-        return Objects.equals(this.low, other.low) &&
-                Objects.equals(this.high, other.high);
+        Range range = (Range) o;
+        return lowInclusive == range.lowInclusive &&
+                highInclusive == range.highInclusive &&
+                type.equals(range.type) &&
+                valuesEqual(lowValue, range.lowValue) &&
+                valuesEqual(highValue, range.highValue);
+    }
+
+    private boolean valuesEqual(Optional<Object> a, Optional<Object> b)
+    {
+        if (a.isEmpty() || b.isEmpty()) {
+            return a.isEmpty() == b.isEmpty();
+        }
+        return compareValues(comparisonOperator, a.get(), b.get()) == 0;
+    }
+
+    private static int compareValues(MethodHandle comparisonOperator, Object left, Object right)
+    {
+        try {
+            return (int) (long) comparisonOperator.invoke(left, right);
+        }
+        catch (Throwable throwable) {
+            throw handleThrowable(throwable);
+        }
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(type, lowInclusive, lowValue, highInclusive, highValue);
     }
 
     @Override
@@ -243,15 +443,21 @@ public final class Range
 
     public String toString(ConnectorSession session)
     {
+        Object lowObject = lowValue
+                .map(value -> type.getObjectValue(session, nativeValueToBlock(type, value), 0))
+                .orElse("<min>");
+
         if (isSingleValue()) {
-            return "[" + low.getPrintableValue(session) + "]";
+            return format("[%s]", lowObject);
         }
-        StringBuilder buffer = new StringBuilder();
-        buffer.append((low.getBound() == Marker.Bound.EXACTLY) ? '[' : '(');
-        buffer.append(low.isLowerUnbounded() ? "<min>" : low.getPrintableValue(session));
-        buffer.append(", ");
-        buffer.append(high.isUpperUnbounded() ? "<max>" : high.getPrintableValue(session));
-        buffer.append((high.getBound() == Marker.Bound.EXACTLY) ? ']' : ')');
-        return buffer.toString();
+        Object highObject = highValue
+                .map(value -> type.getObjectValue(session, nativeValueToBlock(type, value), 0))
+                .orElse("<max>");
+        return format(
+                "%s%s, %s%s",
+                lowInclusive ? "[" : "(",
+                lowObject,
+                highObject,
+                highInclusive ? "]" : ")");
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -620,7 +620,7 @@ public final class SortedRangeSet
             }
 
             if (current != null) {
-                Optional<RangeView> merged = current.tryOverlapWithNext(next);
+                Optional<RangeView> merged = current.tryMergeWithNext(next);
                 if (merged.isPresent()) {
                     current = merged.get();
                 }
@@ -1043,7 +1043,7 @@ public final class SortedRangeSet
          * Returns unioned range if {@code this} and {@code next} overlap or are adjacent.
          * The {@code next} lower bound must not be before {@code this} lower bound.
          */
-        public Optional<RangeView> tryOverlapWithNext(RangeView next)
+        public Optional<RangeView> tryMergeWithNext(RangeView next)
         {
             if (this.compareTo(next) > 0) {
                 throw new IllegalArgumentException("next before this");
@@ -1053,13 +1053,17 @@ public final class SortedRangeSet
                 return Optional.of(this);
             }
 
+            boolean merge;
             if (next.isLowUnbounded()) {
-                return Optional.of(next);
+                // both are low-unbounded
+                merge = true;
             }
-
-            int compare = compareValues(comparisonOperator, this.highValueBlock, this.highValuePosition, next.lowValueBlock, next.lowValuePosition);
-            if (compare > 0  // overlap
-                    || (compare == 0 && (this.highInclusive || next.lowInclusive))) { // adjacent
+            else {
+                int compare = compareValues(comparisonOperator, this.highValueBlock, this.highValuePosition, next.lowValueBlock, next.lowValuePosition);
+                merge = compare > 0  // overlap
+                        || compare == 0 && (this.highInclusive || next.lowInclusive); // adjacent
+            }
+            if (merge) {
                 int compareHighBound = compareHighBound(next);
                 return Optional.of(new RangeView(
                         this.type,

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -26,7 +26,6 @@ import java.lang.invoke.MethodHandle;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -873,7 +872,7 @@ public final class SortedRangeSet
 
         SortedRangeSet build()
         {
-            ranges.sort(Comparator.comparing(Range::getLow));
+            ranges.sort(Range::compareLowBound);
 
             List<Range> result = new ArrayList<>(ranges.size());
 
@@ -884,8 +883,9 @@ public final class SortedRangeSet
                     continue;
                 }
 
-                if (current.overlaps(next) || current.getHigh().isAdjacent(next.getLow())) {
-                    current = current.span(next);
+                Optional<Range> merged = current.tryMergeWithNext(next);
+                if (merged.isPresent()) {
+                    current = merged.get();
                 }
                 else {
                     result.add(current);
@@ -910,20 +910,10 @@ public final class SortedRangeSet
 
     private static void writeRange(Type type, BlockBuilder blockBuilder, boolean[] inclusive, int rangeIndex, Range range)
     {
-        inclusive[2 * rangeIndex] = range.getLow().getBound() == Marker.Bound.EXACTLY;
-        inclusive[2 * rangeIndex + 1] = range.getHigh().getBound() == Marker.Bound.EXACTLY;
-        if (range.getLow().getValueBlock().isEmpty()) {
-            blockBuilder.appendNull();
-        }
-        else {
-            type.appendTo(range.getLow().getValueBlock().get(), 0, blockBuilder);
-        }
-        if (range.getHigh().getValueBlock().isEmpty()) {
-            blockBuilder.appendNull();
-        }
-        else {
-            type.appendTo(range.getHigh().getValueBlock().get(), 0, blockBuilder);
-        }
+        inclusive[2 * rangeIndex] = range.isLowInclusive();
+        inclusive[2 * rangeIndex + 1] = range.isHighInclusive();
+        writeNativeValue(type, blockBuilder, range.getLowValue().orElse(null));
+        writeNativeValue(type, blockBuilder, range.getHighValue().orElse(null));
     }
 
     private static void writeRange(Type type, BlockBuilder blockBuilder, boolean[] inclusive, int rangeIndex, RangeView range)

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
@@ -160,6 +160,34 @@ public class TestSortedRangeSet
     }
 
     @Test
+    public void testCreateWithRanges()
+    {
+        // two low-unbounded, first shorter
+        assertThat(SortedRangeSet.of(Range.lessThan(BIGINT, 5L), Range.lessThan(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.lessThan(BIGINT, 10L));
+        assertThat(SortedRangeSet.of(Range.lessThan(BIGINT, 10L), Range.lessThanOrEqual(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.lessThanOrEqual(BIGINT, 10L));
+
+        // two low-unbounded, second shorter
+        assertThat(SortedRangeSet.of(Range.lessThan(BIGINT, 10L), Range.lessThan(BIGINT, 5L)).getOrderedRanges())
+                .containsExactly(Range.lessThan(BIGINT, 10L));
+        assertThat(SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 10L), Range.lessThan(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.lessThanOrEqual(BIGINT, 10L));
+
+        // two high-unbounded, first shorter
+        assertThat(SortedRangeSet.of(Range.greaterThan(BIGINT, 10L), Range.greaterThan(BIGINT, 5L)).getOrderedRanges())
+                .containsExactly(Range.greaterThan(BIGINT, 5L));
+        assertThat(SortedRangeSet.of(Range.greaterThan(BIGINT, 10L), Range.greaterThanOrEqual(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.greaterThanOrEqual(BIGINT, 10L));
+
+        // two high-unbounded, second shorter
+        assertThat(SortedRangeSet.of(Range.greaterThan(BIGINT, 5L), Range.greaterThan(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.greaterThan(BIGINT, 5L));
+        assertThat(SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 10L), Range.greaterThan(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.greaterThanOrEqual(BIGINT, 10L));
+    }
+
+    @Test
     public void testGetSingleValue()
     {
         assertEquals(SortedRangeSet.of(BIGINT, 0L).getSingleValue(), 0L);
@@ -402,6 +430,46 @@ public class TestSortedRangeSet
                 SortedRangeSet.of(Range.range(BIGINT, 0L, true, 10L, false)),
                 SortedRangeSet.of(Range.equal(BIGINT, 9L)),
                 SortedRangeSet.of(Range.range(BIGINT, 0L, true, 10L, false)));
+
+        // two low-unbounded, first shorter
+        assertUnion(
+                SortedRangeSet.of(Range.lessThan(BIGINT, 5L)),
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)));
+        assertUnion(
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 10L)));
+
+        // two low-unbounded, second shorter
+        assertUnion(
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThan(BIGINT, 5L)),
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)));
+        assertUnion(
+                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 10L)));
+
+        // two high-unbounded, first shorter
+        assertUnion(
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 5L)),
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 5L)));
+        assertUnion(
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 10L)));
+
+        // two high-unbounded, second shorter
+        assertUnion(
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 5L)),
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 5L)));
+        assertUnion(
+                SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 10L)));
 
         assertUnion(
                 SortedRangeSet.of(Range.range(createVarcharType(25), utf8Slice("LARGE PLATED "), true, utf8Slice("LARGE PLATED!"), false)),


### PR DESCRIPTION
Previously `Range` consisted of low and high `Marker` objects, each
containing a single-row `Block`. This was useful from serialization
perspective, but caused:

1. memory overhead when dealing with many `Range` instances at once
2. API overhead, where consumer of `Range` had to translate `Marker`
   bounds to infer low-unboundedness and high-unboundedness of a range.

Now that `Range` is no longer serialized, we can simplify the
representation.


https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/findepi/b082f654a9be4378a4403688eed2504e/raw/51e198fee3058d8c925898d48e075048eecd13b6/JMH%2520BenchmarkSortedRangeSet%2520A1%2520master.json,https://gist.githubusercontent.com/findepi/b082f654a9be4378a4403688eed2504e/raw/51e198fee3058d8c925898d48e075048eecd13b6/JMH%2520BenchmarkSortedRangeSet%2520A2%2520branch.json

#### before

```
Benchmark                                      Mode  Cnt     Score     Error  Units
BenchmarkSortedRangeSet.benchmarkBuilder       avgt   10     0.986 ±   0.447  ms/op
BenchmarkSortedRangeSet.complementLarge        avgt   10    36.320 ±   1.351  ms/op
BenchmarkSortedRangeSet.complementSmall        avgt   10   238.683 ±  26.884  ms/op
BenchmarkSortedRangeSet.containsValueLarge     avgt   10  1115.749 ± 130.025  ms/op
BenchmarkSortedRangeSet.containsValueSmall     avgt   10   550.078 ±  40.958  ms/op
BenchmarkSortedRangeSet.equalsLarge            avgt   10     0.057 ±   0.003  ms/op
BenchmarkSortedRangeSet.equalsSmall            avgt   10    14.319 ±   3.276  ms/op
BenchmarkSortedRangeSet.getOrderedRangesLarge  avgt   10   927.169 ±   8.283  ms/op
BenchmarkSortedRangeSet.getOrderedRangesSmall  avgt   10   715.147 ±  30.282  ms/op
BenchmarkSortedRangeSet.overlapsLarge          avgt   10     8.690 ±   0.249  ms/op
BenchmarkSortedRangeSet.overlapsSmall          avgt   10   123.784 ±  13.068  ms/op
BenchmarkSortedRangeSet.unionLarge             avgt   10   269.696 ±  31.384  ms/op
BenchmarkSortedRangeSet.unionSmall             avgt   10   417.966 ± 111.192  ms/op
```


#### after

```
Benchmark                                      Mode  Cnt     Score     Error  Units
BenchmarkSortedRangeSet.benchmarkBuilder       avgt   10     1.112 ±   0.233  ms/op
BenchmarkSortedRangeSet.complementLarge        avgt   10    36.034 ±   1.859  ms/op
BenchmarkSortedRangeSet.complementSmall        avgt   10   226.923 ±  19.067  ms/op
BenchmarkSortedRangeSet.containsValueLarge     avgt   10  1064.851 ±  35.166  ms/op
BenchmarkSortedRangeSet.containsValueSmall     avgt   10   555.789 ±  43.273  ms/op
BenchmarkSortedRangeSet.equalsLarge            avgt   10     0.058 ±   0.005  ms/op
BenchmarkSortedRangeSet.equalsSmall            avgt   10    14.006 ±   4.968  ms/op
BenchmarkSortedRangeSet.getOrderedRangesLarge  avgt   10   187.961 ±   7.599  ms/op
BenchmarkSortedRangeSet.getOrderedRangesSmall  avgt   10   206.972 ±  88.700  ms/op
BenchmarkSortedRangeSet.overlapsLarge          avgt   10     5.255 ±   0.156  ms/op
BenchmarkSortedRangeSet.overlapsSmall          avgt   10    78.558 ±  32.456  ms/op
BenchmarkSortedRangeSet.unionLarge             avgt   10   204.506 ±  50.603  ms/op
BenchmarkSortedRangeSet.unionSmall             avgt   10   360.224 ± 133.375  ms/op
```