### PR TITLE
Simplify ValueSet creation from collection of values

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -149,8 +149,6 @@ public final class SortedRangeSet
             return of(type, first);
         }
 
-        MethodHandle comparisonOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getComparisonOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION));
-
         BlockBuilder blockBuilder = type.createBlockBuilder(null, 1 + rest.length);
         checkNotNaN(type, first);
         writeNativeValue(type, blockBuilder, first);
@@ -159,6 +157,29 @@ public final class SortedRangeSet
             writeNativeValue(type, blockBuilder, value);
         }
         Block block = blockBuilder.build();
+
+        return fromUnorderedValuesBlock(type, block);
+    }
+
+    static SortedRangeSet of(Type type, Collection<?> values)
+    {
+        if (values.isEmpty()) {
+            return none(type);
+        }
+
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, values.size());
+        for (Object value : values) {
+            checkNotNaN(type, value);
+            writeNativeValue(type, blockBuilder, value);
+        }
+        Block block = blockBuilder.build();
+
+        return fromUnorderedValuesBlock(type, block);
+    }
+
+    private static SortedRangeSet fromUnorderedValuesBlock(Type type, Block block)
+    {
+        MethodHandle comparisonOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getComparisonOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION));
 
         List<Integer> indexes = new ArrayList<>(block.getPositionCount());
         for (int position = 0; position < block.getPositionCount(); position++) {

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -223,14 +223,14 @@ public final class SortedRangeSet
                 new RunLengthEncodedBlock(block, 2));
     }
 
-    /**
-     * Provided Ranges are unioned together to form the SortedRangeSet
-     */
     static SortedRangeSet copyOf(Type type, Iterable<Range> ranges)
     {
         return new Builder(type).addAll(ranges).build();
     }
 
+    /**
+     * Provided Ranges are unioned together to form the SortedRangeSet
+     */
     public static SortedRangeSet copyOf(Type type, List<Range> ranges)
     {
         return copyOf(type, (Iterable<Range>) ranges);

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/ValueSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/ValueSet.java
@@ -21,8 +21,6 @@ import io.trino.spi.type.Type;
 import java.util.Collection;
 import java.util.List;
 
-import static java.util.stream.Collectors.toList;
-
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         property = "@type")
@@ -68,9 +66,7 @@ public interface ValueSet
     static ValueSet copyOf(Type type, Collection<Object> values)
     {
         if (type.isOrderable()) {
-            return SortedRangeSet.copyOf(type, values.stream()
-                    .map(value -> Range.equal(type, value))
-                    .collect(toList()));
+            return SortedRangeSet.of(type, values);
         }
         if (type.isComparable()) {
             return EquatableValueSet.copyOf(type, values);


### PR DESCRIPTION

Make `ValueSet.copyOf(Type, Collection)` utilize the same code path as
`ValueSet.of(Type, Object, Object...)`.