### PR TITLE
Allow numeric types with scale 0 as frame offset

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/window/WindowPartition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/WindowPartition.java
@@ -624,13 +624,13 @@ public final class WindowPartition
                 start = peerGroupStart - partitionStart;
                 break;
             case PRECEDING: {
-                PositionAndGroup frameStart = seek(toIntExact(currentGroupIndex - getStartValue(frameInfo)), recentFrame.getStart(), recentFrame.getStartGroupIndex(), seekGroupStart, lastGroup -> new PositionAndGroup(0, 0));
+                PositionAndGroup frameStart = seek(-getStartValue(frameInfo), recentFrame.getStart(), recentFrame.getStartGroupIndex(), seekGroupStart, lastGroup -> new PositionAndGroup(0, 0));
                 start = frameStart.getPosition();
                 startGroupIndex = frameStart.getGroup();
                 break;
             }
             case FOLLOWING: {
-                PositionAndGroup frameStart = seek(toIntExact(currentGroupIndex + getStartValue(frameInfo)), recentFrame.getStart(), recentFrame.getStartGroupIndex(), seekGroupStart, lastGroup -> new PositionAndGroup(partitionEnd - partitionStart, GroupsFrame.ignoreIndex()));
+                PositionAndGroup frameStart = seek(getStartValue(frameInfo), recentFrame.getStart(), recentFrame.getStartGroupIndex(), seekGroupStart, lastGroup -> new PositionAndGroup(partitionEnd - partitionStart, GroupsFrame.ignoreIndex()));
                 start = frameStart.getPosition();
                 startGroupIndex = frameStart.getGroup();
                 break;
@@ -647,13 +647,13 @@ public final class WindowPartition
                 end = peerGroupEnd - partitionStart - 1;
                 break;
             case PRECEDING: {
-                PositionAndGroup frameEnd = seek(toIntExact(currentGroupIndex - getEndValue(frameInfo)), recentFrame.getEnd(), recentFrame.getEndGroupIndex(), seekGroupEnd, lastGroup -> new PositionAndGroup(-1, GroupsFrame.ignoreIndex()));
+                PositionAndGroup frameEnd = seek(-getEndValue(frameInfo), recentFrame.getEnd(), recentFrame.getEndGroupIndex(), seekGroupEnd, lastGroup -> new PositionAndGroup(-1, GroupsFrame.ignoreIndex()));
                 end = frameEnd.getPosition();
                 endGroupIndex = frameEnd.getGroup();
                 break;
             }
             case FOLLOWING: {
-                PositionAndGroup frameEnd = seek(toIntExact(currentGroupIndex + getEndValue(frameInfo)), recentFrame.getEnd(), recentFrame.getEndGroupIndex(), seekGroupEnd, lastGroup -> new PositionAndGroup(partitionEnd - partitionStart - 1, lastPeerGroup));
+                PositionAndGroup frameEnd = seek(getEndValue(frameInfo), recentFrame.getEnd(), recentFrame.getEndGroupIndex(), seekGroupEnd, lastGroup -> new PositionAndGroup(partitionEnd - partitionStart - 1, lastPeerGroup));
                 end = frameEnd.getPosition();
                 endGroupIndex = frameEnd.getGroup();
                 break;
@@ -665,11 +665,13 @@ public final class WindowPartition
         return new GroupsFrame(start, startGroupIndex, end, endGroupIndex);
     }
 
-    private PositionAndGroup seek(int groupIndex, int recentPosition, int recentGroupIndex, Function<Integer, Integer> seekPositionWithinGroup, EdgeResultProvider edgeResult)
+    private PositionAndGroup seek(long offset, int recentPosition, int recentGroupIndex, Function<Integer, Integer> seekPositionWithinGroup, EdgeResultProvider edgeResult)
     {
-        if (groupIndex < 0 || groupIndex > lastPeerGroup) {
+        long searchedIndex = currentGroupIndex + offset;
+        if (searchedIndex < 0 || searchedIndex > lastPeerGroup) {
             return edgeResult.get(lastPeerGroup);
         }
+        int groupIndex = toIntExact(searchedIndex);
         while (recentGroupIndex > groupIndex) {
             recentPosition = seekGroupStart.apply(recentPosition);
             recentPosition--;

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -1006,7 +1006,7 @@ public class TestAnalyzer
 
         assertFails("SELECT * FROM (VALUES 'x') t(a) WINDOW w AS (ROWS a PRECEDING)")
                 .hasErrorCode(TYPE_MISMATCH)
-                .hasMessage("line 1:51: Window frame ROWS start value type must be INTEGER or BIGINT (actual varchar(1))");
+                .hasMessage("line 1:51: Window frame ROWS start value type must be exact numeric type with scale 0 (actual varchar(1))");
 
         assertFails("SELECT * FROM (VALUES 'x') t(a) WINDOW w AS (RANGE a PRECEDING)")
                 .hasErrorCode(MISSING_ORDER_BY)
@@ -1022,7 +1022,7 @@ public class TestAnalyzer
 
         assertFails("SELECT * FROM (VALUES 'x') t(a) WINDOW w AS (ROWS a PRECEDING)")
                 .hasErrorCode(TYPE_MISMATCH)
-                .hasMessage("line 1:51: Window frame ROWS start value type must be INTEGER or BIGINT (actual varchar(1))");
+                .hasMessage("line 1:51: Window frame ROWS start value type must be exact numeric type with scale 0 (actual varchar(1))");
 
         // nested window
         assertFails("SELECT * FROM (VALUES 1) t(a) WINDOW w AS (PARTITION BY count(a) OVER ())")
@@ -1155,7 +1155,7 @@ public class TestAnalyzer
     }
 
     @Test
-    public void testInvalidWindowFrameTypeRows()
+    public void testWindowFrameTypeRows()
     {
         assertFails("SELECT rank() OVER (ROWS UNBOUNDED FOLLOWING)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
@@ -1180,6 +1180,14 @@ public class TestAnalyzer
                 .hasErrorCode(TYPE_MISMATCH);
         assertFails("SELECT rank() OVER (ROWS BETWEEN CURRENT ROW AND 'foo' FOLLOWING)")
                 .hasErrorCode(TYPE_MISMATCH);
+
+        analyze("SELECT rank() OVER (ROWS BETWEEN SMALLINT '1' PRECEDING AND SMALLINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT rank() OVER (ROWS BETWEEN TINYINT '1' PRECEDING AND TINYINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT rank() OVER (ROWS BETWEEN INTEGER '1' PRECEDING AND INTEGER '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT rank() OVER (ROWS BETWEEN BIGINT '1' PRECEDING AND BIGINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT rank() OVER (ROWS BETWEEN DECIMAL '1' PRECEDING AND DECIMAL '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        assertFails("SELECT rank() OVER (ROWS BETWEEN CAST(1 AS decimal(38, 0)) PRECEDING AND CAST(2 AS decimal(38, 0)) FOLLOWING) FROM (VALUES 1) t(x)")
+                .hasErrorCode(NOT_SUPPORTED);
     }
 
     @Test
@@ -1263,7 +1271,7 @@ public class TestAnalyzer
     }
 
     @Test
-    public void testInvalidWindowFrameTypeGroups()
+    public void testWindowFrameTypeGroups()
     {
         assertFails("SELECT rank() OVER (ORDER BY x GROUPS UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
@@ -1291,6 +1299,14 @@ public class TestAnalyzer
                 .hasErrorCode(TYPE_MISMATCH);
         assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 'foo' FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
+
+        analyze("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN SMALLINT '1' PRECEDING AND SMALLINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN TINYINT '1' PRECEDING AND TINYINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN INTEGER '1' PRECEDING AND INTEGER '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN BIGINT '1' PRECEDING AND BIGINT '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN DECIMAL '1' PRECEDING AND DECIMAL '2' FOLLOWING) FROM (VALUES 1) t(x)");
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CAST(1 AS decimal(38, 0)) PRECEDING AND CAST(2 AS decimal(38, 0)) FOLLOWING) FROM (VALUES 1) t(x)")
+                .hasErrorCode(NOT_SUPPORTED);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -1185,111 +1185,111 @@ public class TestAnalyzer
     @Test
     public void testWindowFrameTypeRange()
     {
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE UNBOUNDED FOLLOWING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED FOLLOWING AND 2 FOLLOWING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED FOLLOWING AND 2 FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED FOLLOWING AND CURRENT ROW) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED FOLLOWING AND CURRENT ROW) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED FOLLOWING AND 5 PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED FOLLOWING AND 5 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED FOLLOWING AND UNBOUNDED PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED FOLLOWING AND UNBOUNDED PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED FOLLOWING AND UNBOUNDED FOLLOWING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED FOLLOWING AND UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE 2 FOLLOWING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE 2 FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND CURRENT ROW) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND CURRENT ROW) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND 5 PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND 5 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND UNBOUNDED PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND UNBOUNDED PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND 5 PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND 5 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND UNBOUNDED PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND UNBOUNDED PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND UNBOUNDED PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND UNBOUNDED PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
 
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE UNBOUNDED PRECEDING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING AND 5 PRECEDING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING AND 2 FOLLOWING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE 5 PRECEDING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND 10 PRECEDING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND 3 PRECEDING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND 2 FOLLOWING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND UNBOUNDED FOLLOWING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE CURRENT ROW) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND CURRENT ROW) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND 2 FOLLOWING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND 1 FOLLOWING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND 10 FOLLOWING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND UNBOUNDED FOLLOWING) FROM (VALUES 1) T(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE UNBOUNDED PRECEDING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING AND 5 PRECEDING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING AND 2 FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE 5 PRECEDING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND 10 PRECEDING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND 3 PRECEDING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND 2 FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 5 PRECEDING AND UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE CURRENT ROW) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND CURRENT ROW) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND 2 FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND 1 FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND 10 FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 2 FOLLOWING AND UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)");
 
         // this should pass the analysis but fail during execution
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN -x PRECEDING AND 0 * x FOLLOWING) FROM (VALUES 1) T(x)");
-        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CAST(null AS BIGINT) PRECEDING AND CAST(null AS BIGINT) FOLLOWING) FROM (VALUES 1) T(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN -x PRECEDING AND 0 * x FOLLOWING) FROM (VALUES 1) t(x)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN CAST(null AS BIGINT) PRECEDING AND CAST(null AS BIGINT) FOLLOWING) FROM (VALUES 1) t(x)");
 
-        assertFails("SELECT array_agg(x) OVER (RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(MISSING_ORDER_BY)
                 .hasMessage("line 1:27: Window frame of type RANGE PRECEDING or FOLLOWING requires ORDER BY");
 
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x DESC, x ASC RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x DESC, x ASC RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_ORDER_BY)
                 .hasMessage("line 1:27: Window frame of type RANGE PRECEDING or FOLLOWING requires single sort item in ORDER BY (actual: 2)");
 
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 'a') T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM (VALUES 'a') t(x)")
                 .hasErrorCode(TYPE_MISMATCH)
                 .hasMessage("line 1:36: Window frame of type RANGE PRECEDING or FOLLOWING requires that sort item type be numeric, datetime or interval (actual: varchar(1))");
 
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 'a' PRECEDING AND 'z' FOLLOWING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE BETWEEN 'a' PRECEDING AND 'z' FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH)
                 .hasMessage("line 1:52: Window frame RANGE value type (varchar(1)) not compatible with sort item type (integer)");
 
-        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE INTERVAL '1' day PRECEDING) FROM (VALUES INTERVAL '1' year) T(x)")
+        assertFails("SELECT array_agg(x) OVER (ORDER BY x RANGE INTERVAL '1' day PRECEDING) FROM (VALUES INTERVAL '1' year) t(x)")
                 .hasErrorCode(TYPE_MISMATCH)
                 .hasMessage("line 1:44: Window frame RANGE value type (interval day to second) not compatible with sort item type (interval year to month)");
 
         // window frame other than <expression> PRECEDING or <expression> FOLLOWING has no requirements regarding window ORDER BY clause
         // ORDER BY is not required
-        analyze("SELECT array_agg(x) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM (VALUES 1) T(x)");
+        analyze("SELECT array_agg(x) OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)");
         // multiple sort keys and sort keys of types other than numeric or datetime are allowed
-        analyze("SELECT array_agg(x) OVER (ORDER BY y, z RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM (VALUES (1, 'text', true)) T(x, y, z)");
+        analyze("SELECT array_agg(x) OVER (ORDER BY y, z RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM (VALUES (1, 'text', true)) t(x, y, z)");
     }
 
     @Test
     public void testInvalidWindowFrameTypeGroups()
     {
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS UNBOUNDED FOLLOWING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS UNBOUNDED FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS 2 FOLLOWING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS 2 FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN UNBOUNDED FOLLOWING AND CURRENT ROW) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN UNBOUNDED FOLLOWING AND CURRENT ROW) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND UNBOUNDED PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND UNBOUNDED PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 5 PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 5 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN 2 FOLLOWING AND 5 PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN 2 FOLLOWING AND 5 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN 2 FOLLOWING AND CURRENT ROW) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN 2 FOLLOWING AND CURRENT ROW) FROM (VALUES 1) t(x)")
                 .hasErrorCode(INVALID_WINDOW_FRAME);
 
-        assertFails("SELECT rank() OVER (GROUPS 2 PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (GROUPS 2 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(MISSING_ORDER_BY);
 
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS 5e-1 PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS 5e-1 PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS 'foo' PRECEDING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS 'foo' PRECEDING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 5e-1 FOLLOWING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 5e-1 FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
-        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 'foo' FOLLOWING) FROM (VALUES 1) T(x)")
+        assertFails("SELECT rank() OVER (ORDER BY x GROUPS BETWEEN CURRENT ROW AND 'foo' FOLLOWING) FROM (VALUES 1) t(x)")
                 .hasErrorCode(TYPE_MISMATCH);
     }
 
@@ -1604,7 +1604,7 @@ public class TestAnalyzer
 
         // base relation aliased same as WITH query resulting table
         analyze("WITH RECURSIVE t(n, m) AS (" +
-                "          SELECT * FROM (VALUES(1, 2), (4, 100)) AS T(n, m)" +
+                "          SELECT * FROM (VALUES(1, 2), (4, 100)) AS t(n, m)" +
                 "          UNION ALL" +
                 "          SELECT n + 1, m - 1 FROM t WHERE n < 5" +
                 "          )" +
@@ -1612,7 +1612,7 @@ public class TestAnalyzer
 
         // base relation aliased different than WITH query resulting table
         analyze("WITH RECURSIVE t(n, m) AS (" +
-                "          SELECT * FROM (VALUES(1, 2), (4, 100)) AS T1(x1, y1)" +
+                "          SELECT * FROM (VALUES(1, 2), (4, 100)) AS t1(x1, y1)" +
                 "          UNION ALL" +
                 "          SELECT n + 1, m - 1 FROM t WHERE n < 5" +
                 "          )" +
@@ -1620,7 +1620,7 @@ public class TestAnalyzer
 
         // same aliases for base relation and WITH query resulting table, different order
         analyze("WITH RECURSIVE t(n, m) AS (" +
-                "          SELECT * FROM (VALUES(1, 2), (4, 100)) AS T(m, n)" +
+                "          SELECT * FROM (VALUES(1, 2), (4, 100)) AS t(m, n)" +
                 "          UNION ALL" +
                 "          SELECT n + 1, m - 1 FROM t WHERE n < 5" +
                 "          )" +
@@ -1972,7 +1972,7 @@ public class TestAnalyzer
                 .hasMessage("line 1:82: recursion step relation output type (decimal(2,1)) is not coercible to recursion base relation output type (decimal(1,0)) at column 1");
 
         assertFails("WITH RECURSIVE t(n) AS (" +
-                "          SELECT * FROM (VALUES('a'), ('b')) AS T(n)" +
+                "          SELECT * FROM (VALUES('a'), ('b')) AS t(n)" +
                 "          UNION ALL" +
                 "          SELECT n || 'x' FROM t WHERE n < 'axxxx'" +
                 "          )" +
@@ -2069,7 +2069,7 @@ public class TestAnalyzer
                 .hasErrorCode(TYPE_MISMATCH);
 
         // extract
-        assertFails("SELECT EXTRACT(DAY FROM 'a') FROM t1")
+        assertFails("SELECT EXTRACt(DAY FROM 'a') FROM t1")
                 .hasErrorCode(TYPE_MISMATCH);
 
         // between

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestWindowFrameRange.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestWindowFrameRange.java
@@ -54,7 +54,7 @@ public class TestWindowFrameRange
     public void testFramePrecedingWithSortKeyCoercions()
     {
         @Language("SQL") String sql = "SELECT array_agg(key) OVER(ORDER BY key RANGE x PRECEDING) " +
-                "FROM (VALUES (1, 1.1), (2, 2.2)) T(key, x)";
+                "FROM (VALUES (1, 1.1), (2, 2.2)) t(key, x)";
 
         PlanMatchPattern pattern =
                 anyTree(
@@ -100,7 +100,7 @@ public class TestWindowFrameRange
     public void testFrameFollowingWithOffsetCoercion()
     {
         @Language("SQL") String sql = "SELECT array_agg(key) OVER(ORDER BY key RANGE BETWEEN CURRENT ROW AND x FOLLOWING) " +
-                "FROM (VALUES (1.1, 1), (2.2, 2)) T(key, x)";
+                "FROM (VALUES (1.1, 1), (2.2, 2)) t(key, x)";
 
         PlanMatchPattern pattern =
                 anyTree(
@@ -146,7 +146,7 @@ public class TestWindowFrameRange
     public void testFramePrecedingFollowingNoCoercions()
     {
         @Language("SQL") String sql = "SELECT array_agg(key) OVER(ORDER BY key RANGE BETWEEN x PRECEDING AND y FOLLOWING) " +
-                "FROM (VALUES (1, 1, 1), (2, 2, 2)) T(key, x, y)";
+                "FROM (VALUES (1, 1, 1), (2, 2, 2)) t(key, x, y)";
 
         PlanMatchPattern pattern =
                 anyTree(

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameGroups.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameGroups.java
@@ -41,7 +41,7 @@ public class TestWindowFrameGroups
     public void testConstantOffset()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN 1 PRECEDING AND 2 FOLLOWING) " +
-                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, 1, 2, 2], " +
                         "ARRAY[null, null, 1, 2, 2], " +
@@ -53,7 +53,7 @@ public class TestWindowFrameGroups
                         "ARRAY[2, 2, 3, 3, 3]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS CURRENT ROW) " +
-                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -65,7 +65,7 @@ public class TestWindowFrameGroups
                         "ARRAY[3, 3, 3]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN 0 PRECEDING AND 0 FOLLOWING) " +
-                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -77,7 +77,7 @@ public class TestWindowFrameGroups
                         "ARRAY[3, 3, 3]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
-                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 2, 2], " +
                         "ARRAY[1, 2, 2], " +
@@ -89,7 +89,7 @@ public class TestWindowFrameGroups
                         "null");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
-                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "null, " +
                         "null, " +
@@ -101,7 +101,7 @@ public class TestWindowFrameGroups
                         "ARRAY[1, 2, 2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN 2 FOLLOWING AND 1 FOLLOWING) " +
-                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(integer)), " +
                         "null, " +
@@ -117,7 +117,7 @@ public class TestWindowFrameGroups
     public void testNoValueFrameBounds()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, 1, 1, 2], " +
                         "ARRAY[null, null, 1, 1, 2], " +
@@ -126,7 +126,7 @@ public class TestWindowFrameGroups
                         "ARRAY[null, null, 1, 1, 2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -135,7 +135,7 @@ public class TestWindowFrameGroups
                         "ARRAY[null, null, 1, 1, 2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, 1, 1, 2], " +
                         "ARRAY[null, null, 1, 1, 2], " +
@@ -144,7 +144,7 @@ public class TestWindowFrameGroups
                         "ARRAY[2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN CURRENT ROW AND CURRENT ROW) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -157,7 +157,7 @@ public class TestWindowFrameGroups
     public void testMixedTypeFrameBounds()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST GROUPS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "null, " +
                         "null, " +
@@ -166,7 +166,7 @@ public class TestWindowFrameGroups
                         "ARRAY[1, 1, 2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST GROUPS BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 1, 2], " +
                         "ARRAY[1, 1, 2], " +
@@ -175,7 +175,7 @@ public class TestWindowFrameGroups
                         "ARRAY[1, 1, 2, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST GROUPS BETWEEN CURRENT ROW AND 1 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 1, 2], " +
                         "ARRAY[1, 1, 2], " +
@@ -184,7 +184,7 @@ public class TestWindowFrameGroups
                         "ARRAY[null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 1], " +
                         "ARRAY[1, 1], " +
@@ -193,7 +193,7 @@ public class TestWindowFrameGroups
                         "ARRAY[2, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST GROUPS BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 1, 2, null, null], " +
                         "ARRAY[1, 1, 2, null, null], " +
@@ -202,7 +202,7 @@ public class TestWindowFrameGroups
                         "ARRAY[2, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST GROUPS BETWEEN 1 FOLLOWING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[2, null, null], " +
                         "ARRAY[2, null, null], " +
@@ -215,7 +215,7 @@ public class TestWindowFrameGroups
     public void testEmptyFrame()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST GROUPS BETWEEN 90 PRECEDING AND 100 PRECEDING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(integer)), " +
                         "null, " +
@@ -224,7 +224,7 @@ public class TestWindowFrameGroups
                         "null");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST GROUPS BETWEEN 100 FOLLOWING AND 90 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(integer)), " +
                         "null, " +
@@ -237,14 +237,14 @@ public class TestWindowFrameGroups
     public void testNonConstantOffset()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN x PRECEDING AND y FOLLOWING) " +
-                "FROM (VALUES ('a', 1, 1), ('b', 2, 0), ('c', 0, 3)) T(a, x, y)"))
+                "FROM (VALUES ('a', 1, 1), ('b', 2, 0), ('c', 0, 3)) t(a, x, y)"))
                 .matches("VALUES " +
                         "ARRAY['a', 'b'], " +
                         "ARRAY['a', 'b'], " +
                         "ARRAY['c']");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN x FOLLOWING AND y FOLLOWING) " +
-                "FROM (VALUES ('a', 1, 1), ('b', 2, 0), ('c', 3, 3), ('d', 0, 0)) T(a, x, y)"))
+                "FROM (VALUES ('a', 1, 1), ('b', 2, 0), ('c', 3, 3), ('d', 0, 0)) t(a, x, y)"))
                 .matches("VALUES " +
                         "ARRAY['b'], " +
                         "null, " +
@@ -252,7 +252,7 @@ public class TestWindowFrameGroups
                         "ARRAY['d']");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN x PRECEDING AND y PRECEDING) " +
-                "FROM (VALUES ('a', 1, 1), ('b', 0, 2), ('c', 2, 1), ('d', 0, 2)) T(a, x, y)"))
+                "FROM (VALUES ('a', 1, 1), ('b', 0, 2), ('c', 2, 1), ('d', 0, 2)) t(a, x, y)"))
                 .matches("VALUES " +
                         "null, " +
                         "null, " +
@@ -264,10 +264,10 @@ public class TestWindowFrameGroups
     public void testEmptyInput()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (SELECT 1 WHERE false) T(a)"))
+                "FROM (SELECT 1 WHERE false) t(a)"))
                 .returnsEmptyResult();
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS UNBOUNDED PRECEDING) " +
-                "FROM (SELECT 1 WHERE false) T(a)"))
+                "FROM (SELECT 1 WHERE false) t(a)"))
                 .returnsEmptyResult();
     }
 
@@ -275,21 +275,21 @@ public class TestWindowFrameGroups
     public void testOnlyNulls()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 1 PRECEDING AND 2 FOLLOWING) " +
-                "FROM (VALUES CAST(null AS integer), null, null) T(a)"))
+                "FROM (VALUES CAST(null AS integer), null, null) t(a)"))
                 .matches("VALUES " +
                         "CAST(ARRAY[null, null, null] AS array(integer)), " +
                         "ARRAY[null, null, null], " +
                         "ARRAY[null, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
-                "FROM (VALUES CAST(null AS integer), null, null) T(a)"))
+                "FROM (VALUES CAST(null AS integer), null, null) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(integer)), " +
                         "null, " +
                         "null");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
-                "FROM (VALUES CAST(null AS integer), null, null) T(a)"))
+                "FROM (VALUES CAST(null AS integer), null, null) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(integer)), " +
                         "null, " +
@@ -300,21 +300,21 @@ public class TestWindowFrameGroups
     public void testAllPartitionSameValues()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
-                "FROM (VALUES 'a', 'a', 'a') T(a)"))
+                "FROM (VALUES 'a', 'a', 'a') t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(varchar(1))), " +
                         "null, " +
                         "null");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
-                "FROM (VALUES 'a', 'a', 'a') T(a)"))
+                "FROM (VALUES 'a', 'a', 'a') t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(varchar(1))), " +
                         "null, " +
                         "null");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES 'a', 'a', 'a') T(a)"))
+                "FROM (VALUES 'a', 'a', 'a') t(a)"))
                 .matches("VALUES " +
                         "ARRAY['a', 'a', 'a'], " +
                         "ARRAY['a', 'a', 'a'], " +
@@ -322,7 +322,7 @@ public class TestWindowFrameGroups
 
         // test frame bounds at partition bounds
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS BETWEEN 10 PRECEDING AND 10 FOLLOWING) " +
-                "FROM (VALUES 'a', 'a', 'a') T(a)"))
+                "FROM (VALUES 'a', 'a', 'a') t(a)"))
                 .matches("VALUES " +
                         "ARRAY['a', 'a', 'a'], " +
                         "ARRAY['a', 'a', 'a'], " +
@@ -333,45 +333,45 @@ public class TestWindowFrameGroups
     public void testInvalidOffset()
     {
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC GROUPS x PRECEDING) " +
-                "FROM (VALUES (1, 1), (2, -2)) T(a, x)"))
+                "FROM (VALUES (1, 1), (2, -2)) t(a, x)"))
                 .hasMessage("Window frame -2 offset must not be negative");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC GROUPS BETWEEN 1 PRECEDING AND x FOLLOWING) " +
-                "FROM (VALUES (1, 1), (2, -2)) T(a, x)"))
+                "FROM (VALUES (1, 1), (2, -2)) t(a, x)"))
                 .hasMessage("Window frame -2 offset must not be negative");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS x PRECEDING) " +
-                "FROM (VALUES (1, 1), (2, -2)) T(a, x)"))
+                "FROM (VALUES (1, 1), (2, -2)) t(a, x)"))
                 .hasMessage("Window frame -2 offset must not be negative");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS BETWEEN 1 PRECEDING AND x FOLLOWING) " +
-                "FROM (VALUES (1, 1), (2, -2)) T(a, x)"))
+                "FROM (VALUES (1, 1), (2, -2)) t(a, x)"))
                 .hasMessage("Window frame -2 offset must not be negative");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS x PRECEDING) " +
-                "FROM (VALUES (1, 1), (2, null)) T(a, x)"))
+                "FROM (VALUES (1, 1), (2, null)) t(a, x)"))
                 .hasMessage("Window frame starting offset must not be null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS BETWEEN 1 PRECEDING AND x FOLLOWING) " +
-                "FROM (VALUES (1, 1), (2, null)) T(a, x)"))
+                "FROM (VALUES (1, 1), (2, null)) t(a, x)"))
                 .hasMessage("Window frame ending offset must not be null");
 
         // fail if offset is invalid for null sort key
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS BETWEEN 1 PRECEDING AND x FOLLOWING) " +
-                "FROM (VALUES (1, 1), (null, null)) T(a, x)"))
+                "FROM (VALUES (1, 1), (null, null)) t(a, x)"))
                 .hasMessage("Window frame ending offset must not be null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC GROUPS BETWEEN 1 PRECEDING AND x FOLLOWING) " +
-                "FROM (VALUES (1, 1), (null, -1)) T(a, x)"))
+                "FROM (VALUES (1, 1), (null, -1)) t(a, x)"))
                 .hasMessage("Window frame -1 offset must not be negative");
 
         // test invalid offset of different types
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS x PRECEDING) " +
-                "FROM (VALUES (1, BIGINT '-1')) T(a, x)"))
+                "FROM (VALUES (1, BIGINT '-1')) t(a, x)"))
                 .hasMessage("Window frame -1 offset must not be negative");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a GROUPS x PRECEDING) " +
-                "FROM (VALUES (1, INTEGER '-1')) T(a, x)"))
+                "FROM (VALUES (1, INTEGER '-1')) t(a, x)"))
                 .hasMessage("Window frame -1 offset must not be negative");
     }
 
@@ -379,7 +379,7 @@ public class TestWindowFrameGroups
     public void testWindowPartitioning()
     {
         assertThat(assertions.query("SELECT a, p, array_agg(a) OVER(PARTITION BY p ORDER BY a ASC NULLS FIRST GROUPS BETWEEN 1 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES (1, 'x'), (2, 'x'), (null, 'x'), (null, 'y'), (2, 'y')) T(a, p)"))
+                "FROM (VALUES (1, 'x'), (2, 'x'), (null, 'x'), (null, 'y'), (2, 'y')) t(a, p)"))
                 .matches("VALUES " +
                         "(null, 'x', ARRAY[null, 1]), " +
                         "(1,    'x', ARRAY[null, 1, 2]), " +
@@ -388,7 +388,7 @@ public class TestWindowFrameGroups
                         "(2,    'y', ARRAY[null, 2])");
 
         assertThat(assertions.query("SELECT a, p, array_agg(a) OVER(PARTITION BY p ORDER BY a ASC NULLS FIRST GROUPS BETWEEN 0 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES (1, 'x'), (2, 'x'), (null, 'x'), (null, 'y'), (2, 'y'), (null, null), (null, null), (1, null)) T(a, p)"))
+                "FROM (VALUES (1, 'x'), (2, 'x'), (null, 'x'), (null, 'y'), (2, 'y'), (null, null), (null, null), (1, null)) t(a, p)"))
                 .matches("VALUES " +
                         "(null, null, ARRAY[null, null, 1]), " +
                         "(null, null, ARRAY[null, null, 1]), " +
@@ -408,7 +408,7 @@ public class TestWindowFrameGroups
                 "FROM (VALUES " +
                 "(2, DATE '2222-01-01', 4.4), " +
                 "(1, DATE '1111-01-01', 2.2), " +
-                "(3, DATE '3333-01-01', 6.6)) T(x, date, number)"))
+                "(3, DATE '3333-01-01', 6.6)) t(x, date, number)"))
                 .matches("VALUES " +
                         "(1, null, 4.4), " +
                         "(2, ARRAY[DATE '1111-01-01'], 6.6), " +
@@ -426,7 +426,7 @@ public class TestWindowFrameGroups
                 "(3.0, 3), " +
                 "(4.0, 4), " +
                 "(5.0, 5), " +
-                "(6.0, 6)) T(x, a)"))
+                "(6.0, 6)) t(x, a)"))
                 .matches("VALUES " +
                         "(1.0, ARRAY[1], ARRAY[2, 3], ARRAY[1]), " +
                         "(2.0, ARRAY[1, 2], ARRAY[3, 4], ARRAY[1, 2]), " +

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameGroups.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameGroups.java
@@ -435,4 +435,32 @@ public class TestWindowFrameGroups
                         "(5.0, ARRAY[3, 4, 5], ARRAY[6], ARRAY[4, 5]), " +
                         "(6.0, ARRAY[4, 5, 6], null, ARRAY[5, 6])");
     }
+
+    @Test
+    public void testOffsetOverflowsInteger()
+    {
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN 0 PRECEDING AND 1234567890123456789 FOLLOWING) " +
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
+                .matches("VALUES " +
+                        "ARRAY[null, null, 1, 2, 2, 3, 3, 3], " +
+                        "ARRAY[null, null, 1, 2, 2, 3, 3, 3], " +
+                        "ARRAY[1, 2, 2, 3, 3, 3], " +
+                        "ARRAY[2, 2, 3, 3, 3], " +
+                        "ARRAY[2, 2, 3, 3, 3], " +
+                        "ARRAY[3, 3, 3], " +
+                        "ARRAY[3, 3, 3], " +
+                        "ARRAY[3, 3, 3]");
+
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN 1234567890123456789 PRECEDING AND 0 FOLLOWING) " +
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
+                .matches("VALUES " +
+                        "ARRAY[null, null], " +
+                        "ARRAY[null, null], " +
+                        "ARRAY[null, null, 1], " +
+                        "ARRAY[null, null, 1, 2, 2], " +
+                        "ARRAY[null, null, 1, 2, 2], " +
+                        "ARRAY[null, null, 1, 2, 2, 3, 3, 3], " +
+                        "ARRAY[null, null, 1, 2, 2, 3, 3, 3], " +
+                        "ARRAY[null, null, 1, 2, 2, 3, 3, 3]");
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameGroups.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameGroups.java
@@ -114,6 +114,54 @@ public class TestWindowFrameGroups
     }
 
     @Test
+    public void testOffsetTypes()
+    {
+        String expected = "VALUES " +
+                "ARRAY[null, null, 1, 2, 2], " +
+                "ARRAY[null, null, 1, 2, 2], " +
+                "ARRAY[null, null, 1, 2, 2, 3, 3, 3], " +
+                "ARRAY[1, 2, 2, 3, 3, 3], " +
+                "ARRAY[1, 2, 2, 3, 3, 3], " +
+                "ARRAY[2, 2, 3, 3, 3], " +
+                "ARRAY[2, 2, 3, 3, 3], " +
+                "ARRAY[2, 2, 3, 3, 3]";
+
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN TINYINT '1' PRECEDING AND TINYINT '2' FOLLOWING) " +
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
+                .matches(expected);
+
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN SMALLINT '1' PRECEDING AND SMALLINT '2' FOLLOWING) " +
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
+                .matches(expected);
+
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN INTEGER '1' PRECEDING AND INTEGER '2' FOLLOWING) " +
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
+                .matches(expected);
+
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN BIGINT '1' PRECEDING AND BIGINT '2' FOLLOWING) " +
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
+                .matches(expected);
+
+        // short decimal
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN DECIMAL '1' PRECEDING AND DECIMAL '2' FOLLOWING) " +
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
+                .matches(expected);
+
+        // no integer overflow when frame offset exceeds integer
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN 1 PRECEDING AND DECIMAL '12345678901234567' FOLLOWING) " +
+                "FROM (VALUES 3, 3, 3, 2, 2, 1, null, null) t(a)"))
+                .matches("VALUES " +
+                        "ARRAY[null, null, 1, 2, 2, 3, 3, 3], " +
+                        "ARRAY[null, null, 1, 2, 2, 3, 3, 3], " +
+                        "ARRAY[null, null, 1, 2, 2, 3, 3, 3], " +
+                        "ARRAY[1, 2, 2, 3, 3, 3], " +
+                        "ARRAY[1, 2, 2, 3, 3, 3], " +
+                        "ARRAY[2, 2, 3, 3, 3], " +
+                        "ARRAY[2, 2, 3, 3, 3], " +
+                        "ARRAY[2, 2, 3, 3, 3]");
+    }
+
+    @Test
     public void testNoValueFrameBounds()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST GROUPS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) " +

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameRange.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameRange.java
@@ -41,7 +41,7 @@ public class TestWindowFrameRange
     public void testNullsSortKey()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, null, null], " +
                         "ARRAY[null, null, null, null], " +
@@ -54,7 +54,7 @@ public class TestWindowFrameRange
                         "ARRAY[2, 2, 3]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 1, 2, 2], " +
                         "ARRAY[1, 1, 2, 2], " +
@@ -67,7 +67,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS FIRST RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, null, null], " +
                         "ARRAY[null, null, null, null], " +
@@ -80,7 +80,7 @@ public class TestWindowFrameRange
                         "ARRAY[2, 2, 1, 1]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[3, 2, 2], " +
                         "ARRAY[3, 2, 2, 1, 1], " +
@@ -93,7 +93,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2) T(a)"))
+                "FROM (VALUES 1, null, null, 2) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 2, null, null], " +
                         "ARRAY[1, 2, null, null], " +
@@ -101,7 +101,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2) T(a)"))
+                "FROM (VALUES 1, null, null, 2) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 2], " +
                         "ARRAY[1, 2], " +
@@ -109,7 +109,7 @@ public class TestWindowFrameRange
                         "ARRAY[1, 2, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2) T(a)"))
+                "FROM (VALUES 1, null, null, 2) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -117,7 +117,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null, 1, 2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN 1 PRECEDING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2) T(a)"))
+                "FROM (VALUES 1, null, null, 2) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, 1, 2], " +
                         "ARRAY[null, null, 1, 2], " +
@@ -129,7 +129,7 @@ public class TestWindowFrameRange
     public void testNoValueFrameBounds()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, 1, 1, 2], " +
                         "ARRAY[null, null, 1, 1, 2], " +
@@ -138,7 +138,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null, 1, 1, 2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -147,7 +147,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null, 1, 1, 2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, 1, 1, 2], " +
                         "ARRAY[null, null, 1, 1, 2], " +
@@ -156,7 +156,7 @@ public class TestWindowFrameRange
                         "ARRAY[2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN CURRENT ROW AND CURRENT ROW) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -169,7 +169,7 @@ public class TestWindowFrameRange
     public void testMixedTypeFrameBoundsAscendingNullsFirst()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND 0.5 PRECEDING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -178,7 +178,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null, 1, 1]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND 1.5 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -187,7 +187,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null, 1, 1, 2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN CURRENT ROW AND 1.5 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -196,7 +196,7 @@ public class TestWindowFrameRange
                         "ARRAY[2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN 1.5 PRECEDING AND CURRENT ROW) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -205,7 +205,7 @@ public class TestWindowFrameRange
                         "ARRAY[1, 1, 2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN 0.5 PRECEDING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, 1, 1, 2], " +
                         "ARRAY[null, null, 1, 1, 2], " +
@@ -214,7 +214,7 @@ public class TestWindowFrameRange
                         "ARRAY[2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST RANGE BETWEEN 0.5 FOLLOWING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, 1, 1, 2], " +
                         "ARRAY[null, null, 1, 1, 2], " +
@@ -227,7 +227,7 @@ public class TestWindowFrameRange
     public void testMixedTypeFrameBoundsAscendingNullsLast()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND 0.5 PRECEDING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "null, " +
                         "null, " +
@@ -236,7 +236,7 @@ public class TestWindowFrameRange
                         "ARRAY[1, 1, 2, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND 1.5 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 1, 2], " +
                         "ARRAY[1, 1, 2], " +
@@ -245,7 +245,7 @@ public class TestWindowFrameRange
                         "ARRAY[1, 1, 2, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN CURRENT ROW AND 1.5 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 1, 2], " +
                         "ARRAY[1, 1, 2], " +
@@ -254,7 +254,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN 1.5 PRECEDING AND CURRENT ROW) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 1], " +
                         "ARRAY[1, 1], " +
@@ -263,7 +263,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN 0.5 PRECEDING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 1, 2, null, null], " +
                         "ARRAY[1, 1, 2, null, null], " +
@@ -272,7 +272,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN 0.5 FOLLOWING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[2, null, null], " +
                         "ARRAY[2, null, null], " +
@@ -285,7 +285,7 @@ public class TestWindowFrameRange
     public void testMixedTypeFrameBoundsDescendingNullsFirst()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND 0.5 PRECEDING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -294,7 +294,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null, 2]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS FIRST RANGE BETWEEN UNBOUNDED PRECEDING AND 0.5 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -303,7 +303,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null, 2, 1, 1]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS FIRST RANGE BETWEEN CURRENT ROW AND 1.5 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -312,7 +312,7 @@ public class TestWindowFrameRange
                         "ARRAY[1, 1]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS FIRST RANGE BETWEEN 1.5 PRECEDING AND CURRENT ROW) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null], " +
                         "ARRAY[null, null], " +
@@ -321,7 +321,7 @@ public class TestWindowFrameRange
                         "ARRAY[2, 1, 1]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS FIRST RANGE BETWEEN 1.5 PRECEDING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, 2, 1, 1], " +
                         "ARRAY[null, null, 2, 1, 1], " +
@@ -330,7 +330,7 @@ public class TestWindowFrameRange
                         "ARRAY[2, 1, 1]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS FIRST RANGE BETWEEN 1.5 FOLLOWING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null, null, 2, 1, 1], " +
                         "ARRAY[null, null, 2, 1, 1], " +
@@ -343,7 +343,7 @@ public class TestWindowFrameRange
     public void testMixedTypeFrameBoundsDescendingNullsLast()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND 0.5 PRECEDING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "null, " +
                         "ARRAY[2], " +
@@ -352,7 +352,7 @@ public class TestWindowFrameRange
                         "ARRAY[2, 1, 1, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN UNBOUNDED PRECEDING AND 1.5 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[2, 1, 1], " +
                         "ARRAY[2, 1, 1], " +
@@ -361,7 +361,7 @@ public class TestWindowFrameRange
                         "ARRAY[2, 1, 1, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN CURRENT ROW AND 1.5 FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[2, 1, 1], " +
                         "ARRAY[1, 1], " +
@@ -370,7 +370,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN 0.5 PRECEDING AND CURRENT ROW) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[2], " +
                         "ARRAY[1, 1], " +
@@ -379,7 +379,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN 0.5 PRECEDING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[2, 1, 1, null, null], " +
                         "ARRAY[1, 1, null, null], " +
@@ -388,7 +388,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN 1.5 FOLLOWING AND UNBOUNDED FOLLOWING) " +
-                "FROM (VALUES 1, null, null, 2, 1) T(a)"))
+                "FROM (VALUES 1, null, null, 2, 1) t(a)"))
                 .matches("VALUES " +
                         "CAST(ARRAY[null, null] AS array(integer)), " +
                         "ARRAY[null, null], " +
@@ -401,10 +401,10 @@ public class TestWindowFrameRange
     public void testEmptyInput()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (SELECT 1 WHERE false) T(a)"))
+                "FROM (SELECT 1 WHERE false) t(a)"))
                 .returnsEmptyResult();
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE UNBOUNDED PRECEDING) " +
-                "FROM (SELECT 1 WHERE false) T(a)"))
+                "FROM (SELECT 1 WHERE false) t(a)"))
                 .returnsEmptyResult();
     }
 
@@ -412,7 +412,7 @@ public class TestWindowFrameRange
     public void testEmptyFrame()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN 1 PRECEDING AND 10 PRECEDING) " +
-                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(integer)), " +
                         "null, " +
@@ -425,7 +425,7 @@ public class TestWindowFrameRange
                         "ARRAY[null, null, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC NULLS LAST RANGE BETWEEN 10 FOLLOWING AND 1 FOLLOWING) " +
-                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) T(a)"))
+                "FROM (VALUES 1, 2, 3, null, null, 2, 1, null, null) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(integer)), " +
                         "null, " +
@@ -438,53 +438,53 @@ public class TestWindowFrameRange
                         "ARRAY[null, null, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 0.5 FOLLOWING AND 1.5 FOLLOWING) " +
-                "FROM (VALUES 1, 2, 4) T(a)"))
+                "FROM (VALUES 1, 2, 4) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[2], " +
                         "null, " +
                         "null");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
-                "FROM (VALUES 1.0, 1.1) T(a)"))
+                "FROM (VALUES 1.0, 1.1) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(decimal(2, 1))), " +
                         "null");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a NULLS LAST RANGE BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
-                "FROM (VALUES 1.0, 1.1, null) T(a)"))
+                "FROM (VALUES 1.0, 1.1, null) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(decimal(2, 1))), " +
                         "null, " +
                         "ARRAY[null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
-                "FROM (VALUES 1.0, 1.1) T(a)"))
+                "FROM (VALUES 1.0, 1.1) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(decimal(2, 1))), " +
                         "null");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a NULLS FIRST RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
-                "FROM (VALUES null, 1.0, 1.1) T(a)"))
+                "FROM (VALUES null, 1.0, 1.1) t(a)"))
                 .matches("VALUES " +
                         "CAST(ARRAY[null] AS array(decimal(2,1))), " +
                         "null, " +
                         "null");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
-                "FROM (VALUES 1, 2) T(a)"))
+                "FROM (VALUES 1, 2) t(a)"))
                 .matches("VALUES " +
                         "null, " +
                         "ARRAY[1]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a NULLS FIRST RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
-                "FROM (VALUES null, 1, 2) T(a)"))
+                "FROM (VALUES null, 1, 2) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[null], " +
                         "null, " +
                         "ARRAY[1]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a NULLS FIRST RANGE BETWEEN 2 PRECEDING AND 1.5 PRECEDING) " +
-                "FROM (VALUES null, 1, 2) T(a)"))
+                "FROM (VALUES null, 1, 2) t(a)"))
                 .matches("VALUES " +
                         "CAST(ARRAY[null] AS array(integer)), " +
                         "null, " +
@@ -495,14 +495,14 @@ public class TestWindowFrameRange
     public void testOnlyNulls()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
-                "FROM (VALUES CAST(null AS integer), null, null) T(a)"))
+                "FROM (VALUES CAST(null AS integer), null, null) t(a)"))
                 .matches("VALUES " +
                         "CAST(ARRAY[null, null, null] AS array(integer)), " +
                         "ARRAY[null, null, null], " +
                         "ARRAY[null, null, null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
-                "FROM (VALUES CAST(null AS integer), null, null) T(a)"))
+                "FROM (VALUES CAST(null AS integer), null, null) t(a)"))
                 .matches("VALUES " +
                         "CAST(ARRAY[null, null, null] AS array(integer)), " +
                         "ARRAY[null, null, null], " +
@@ -513,21 +513,21 @@ public class TestWindowFrameRange
     public void testAllPartitionSameValues()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 1 FOLLOWING AND 2 FOLLOWING) " +
-                "FROM (VALUES 1, 1, 1) T(a)"))
+                "FROM (VALUES 1, 1, 1) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(integer)), " +
                         "null, " +
                         "null");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 2 PRECEDING AND 1 PRECEDING) " +
-                "FROM (VALUES 1, 1, 1) T(a)"))
+                "FROM (VALUES 1, 1, 1) t(a)"))
                 .matches("VALUES " +
                         "CAST(null AS array(integer)), " +
                         "null, " +
                         "null");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 1 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES 1, 1, 1) T(a)"))
+                "FROM (VALUES 1, 1, 1) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 1, 1], " +
                         "ARRAY[1, 1, 1], " +
@@ -538,7 +538,7 @@ public class TestWindowFrameRange
     public void testZeroOffset()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS LAST RANGE BETWEEN 0 PRECEDING AND 0 FOLLOWING) " +
-                "FROM (VALUES 1, 2, 1, null) T(a)"))
+                "FROM (VALUES 1, 2, 1, null) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 1], " +
                         "ARRAY[1, 1], " +
@@ -550,14 +550,14 @@ public class TestWindowFrameRange
     public void testNonConstantOffset()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN x * 10 PRECEDING AND y / 10.0 FOLLOWING) " +
-                "FROM (VALUES (1, 0.1, 10), (2, 0.2, 20), (4, 0.4, 40)) T(a, x, y)"))
+                "FROM (VALUES (1, 0.1, 10), (2, 0.2, 20), (4, 0.4, 40)) t(a, x, y)"))
                 .matches("VALUES " +
                         "ARRAY[1, 2], " +
                         "ARRAY[1, 2, 4], " +
                         "ARRAY[1, 2, 4]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN x * 10 PRECEDING AND y / 10.0 FOLLOWING) " +
-                "FROM (VALUES (1, 0.1, 10), (2, 0.2, 20), (4, 0.4, 40), (null, 0.5, 50)) T(a, x, y)"))
+                "FROM (VALUES (1, 0.1, 10), (2, 0.2, 20), (4, 0.4, 40), (null, 0.5, 50)) t(a, x, y)"))
                 .matches("VALUES " +
                         "ARRAY[1, 2], " +
                         "ARRAY[1, 2, 4], " +
@@ -569,89 +569,89 @@ public class TestWindowFrameRange
     public void testInvalidOffset()
     {
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC RANGE x PRECEDING) " +
-                "FROM (VALUES (1, 0.1), (2, -0.2)) T(a, x)"))
+                "FROM (VALUES (1, 0.1), (2, -0.2)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC RANGE BETWEEN 1 PRECEDING AND x FOLLOWING) " +
-                "FROM (VALUES (1, 0.1), (2, -0.2)) T(a, x)"))
+                "FROM (VALUES (1, 0.1), (2, -0.2)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE x PRECEDING) " +
-                "FROM (VALUES (1, 0.1), (2, -0.2)) T(a, x)"))
+                "FROM (VALUES (1, 0.1), (2, -0.2)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE BETWEEN 1 PRECEDING AND x FOLLOWING) " +
-                "FROM (VALUES (1, 0.1), (2, -0.2)) T(a, x)"))
+                "FROM (VALUES (1, 0.1), (2, -0.2)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE x PRECEDING) " +
-                "FROM (VALUES (1, 0.1), (2, null)) T(a, x)"))
+                "FROM (VALUES (1, 0.1), (2, null)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE BETWEEN 1 PRECEDING AND x FOLLOWING) " +
-                "FROM (VALUES (1, 0.1), (2, null)) T(a, x)"))
+                "FROM (VALUES (1, 0.1), (2, null)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         // fail if offset is invalid for null sort key
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE BETWEEN 1 PRECEDING AND x FOLLOWING) " +
-                "FROM (VALUES (1, 0.1), (null, null)) T(a, x)"))
+                "FROM (VALUES (1, 0.1), (null, null)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a DESC RANGE BETWEEN 1 PRECEDING AND x FOLLOWING) " +
-                "FROM (VALUES (1, 0.1), (null, -0.1)) T(a, x)"))
+                "FROM (VALUES (1, 0.1), (null, -0.1)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         // test invalid offset of different types
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (1, BIGINT '-1')) T(a, x)"))
+                "FROM (VALUES (1, BIGINT '-1')) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (1, INTEGER '-1')) T(a, x)"))
+                "FROM (VALUES (1, INTEGER '-1')) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (SMALLINT '1', SMALLINT '-1')) T(a, x)"))
+                "FROM (VALUES (SMALLINT '1', SMALLINT '-1')) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (TINYINT '1', TINYINT '-1')) T(a, x)"))
+                "FROM (VALUES (TINYINT '1', TINYINT '-1')) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (1, -1.1e0)) T(a, x)"))
+                "FROM (VALUES (1, -1.1e0)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (1, REAL '-1.1')) T(a, x)"))
+                "FROM (VALUES (1, REAL '-1.1')) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (1, -1.0001)) T(a, x)"))
+                "FROM (VALUES (1, -1.0001)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' YEAR)) T(a, x)"))
+                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' YEAR)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' MONTH)) T(a, x)"))
+                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' MONTH)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' DAY)) T(a, x)"))
+                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' DAY)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' HOUR)) T(a, x)"))
+                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' HOUR)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' MINUTE)) T(a, x)"))
+                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' MINUTE)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
 
         assertThatThrownBy(() -> assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE x PRECEDING) " +
-                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' SECOND)) T(a, x)"))
+                "FROM (VALUES (DATE '2001-01-31', INTERVAL '-1' SECOND)) t(a, x)"))
                 .hasMessage("Window frame offset value must not be negative or null");
     }
 
@@ -659,7 +659,7 @@ public class TestWindowFrameRange
     public void testWindowPartitioning()
     {
         assertThat(assertions.query("SELECT a, p, array_agg(a) OVER(PARTITION BY p ORDER BY a ASC NULLS FIRST RANGE BETWEEN 0.5 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES (1, 'x'), (2, 'x'), (null, 'x'), (null, 'y'), (2, 'y')) T(a, p)"))
+                "FROM (VALUES (1, 'x'), (2, 'x'), (null, 'x'), (null, 'y'), (2, 'y')) t(a, p)"))
                 .matches("VALUES " +
                         "(null, 'x', ARRAY[null]), " +
                         "(1,    'x', ARRAY[1, 2]), " +
@@ -668,7 +668,7 @@ public class TestWindowFrameRange
                         "(2,    'y', ARRAY[2])");
 
         assertThat(assertions.query("SELECT a, p, array_agg(a) OVER(PARTITION BY p ORDER BY a ASC NULLS FIRST RANGE BETWEEN 0.5 PRECEDING AND 1 FOLLOWING) " +
-                "FROM (VALUES (1, 'x'), (2, 'x'), (null, 'x'), (null, 'y'), (2, 'y'), (null, null), (null, null), (1, null)) T(a, p)"))
+                "FROM (VALUES (1, 'x'), (2, 'x'), (null, 'x'), (null, 'y'), (2, 'y'), (null, null), (null, null), (1, null)) t(a, p)"))
                 .matches("VALUES " +
                         "(null, null, ARRAY[null, null]), " +
                         "(null, null, ARRAY[null, null]), " +
@@ -684,21 +684,21 @@ public class TestWindowFrameRange
     public void testTypes()
     {
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN DOUBLE '0.5' PRECEDING AND TINYINT '1' FOLLOWING) " +
-                "FROM (VALUES 1, null, 2) T(a)"))
+                "FROM (VALUES 1, null, 2) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[1, 2], " +
                         "ARRAY[2], " +
                         "ARRAY[null]");
 
         assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a RANGE BETWEEN 0.5 PRECEDING AND 1.000 FOLLOWING) " +
-                "FROM (VALUES REAL '1', null, 2) T(a)"))
+                "FROM (VALUES REAL '1', null, 2) t(a)"))
                 .matches("VALUES " +
                         "ARRAY[REAL '1', REAL '2'], " +
                         "ARRAY[REAL '2'], " +
                         "ARRAY[null]");
 
         assertThat(assertions.query("SELECT x, array_agg(x) OVER(ORDER BY x DESC RANGE BETWEEN interval '1' month PRECEDING AND interval '1' month FOLLOWING) " +
-                "FROM (VALUES DATE '2001-01-31', DATE '2001-08-25', DATE '2001-09-25', DATE '2001-09-26') T(x)"))
+                "FROM (VALUES DATE '2001-01-31', DATE '2001-08-25', DATE '2001-09-25', DATE '2001-09-26') t(x)"))
                 .matches("VALUES " +
                         "(DATE '2001-09-26', ARRAY[DATE '2001-09-26', DATE '2001-09-25']), " +
                         "(DATE '2001-09-25', ARRAY[DATE '2001-09-26', DATE '2001-09-25', DATE '2001-08-25']), " +
@@ -707,7 +707,7 @@ public class TestWindowFrameRange
 
         // January 31 + 1 month sets the frame bound to the last day of February. March 1 is out of range.
         assertThat(assertions.query("SELECT x, array_agg(x) OVER(ORDER BY x RANGE BETWEEN CURRENT ROW AND interval '1' month FOLLOWING) " +
-                "FROM (VALUES DATE '2001-01-31', DATE '2001-02-28', DATE '2001-03-01') T(x)"))
+                "FROM (VALUES DATE '2001-01-31', DATE '2001-02-28', DATE '2001-03-01') t(x)"))
                 .matches("VALUES " +
                         "(DATE '2001-01-31', ARRAY[DATE '2001-01-31', DATE '2001-02-28']), " +
                         "(DATE '2001-02-28', ARRAY[DATE '2001-02-28', DATE '2001-03-01']), " +
@@ -717,7 +717,7 @@ public class TestWindowFrameRange
                 "FROM (VALUES " +
                 "INTERVAL '1' month, " +
                 "INTERVAL '2' month, " +
-                "INTERVAL '5' year) T(x)"))
+                "INTERVAL '5' year) t(x)"))
                 .matches("VALUES " +
                         "(INTERVAL '1' month, ARRAY[INTERVAL '1' month, INTERVAL '2' month]), " +
                         "(INTERVAL '2' month, ARRAY[INTERVAL '1' month, INTERVAL '2' month]), " +
@@ -731,7 +731,7 @@ public class TestWindowFrameRange
                 "FROM (VALUES " +
                 "(2, DATE '2222-01-01', 4.4), " +
                 "(1, DATE '1111-01-01', 2.2), " +
-                "(3, DATE '3333-01-01', 6.6)) T(x, date, number)"))
+                "(3, DATE '3333-01-01', 6.6)) t(x, date, number)"))
                 .matches("VALUES " +
                         "(1, ARRAY[DATE '1111-01-01', DATE '2222-01-01'], 3.3), " +
                         "(2, ARRAY[DATE '1111-01-01', DATE '2222-01-01', DATE '3333-01-01'], 4.4), " +
@@ -744,7 +744,7 @@ public class TestWindowFrameRange
                 "(3.0, 3), " +
                 "(4.0, 4), " +
                 "(5.0, 5), " +
-                "(6.0, 6)) T(x, a)"))
+                "(6.0, 6)) t(x, a)"))
                 .matches("VALUES " +
                         "(1.0, ARRAY[1], ARRAY[1, 2, 3]), " +
                         "(2.0, ARRAY[1, 2], ARRAY[2, 3, 4]), " +

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameRows.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestWindowFrameRows.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestWindowFrameRows
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testOffsetTypes()
+    {
+        String expected = "VALUES " +
+                "ARRAY[null, null, 1], " +
+                "ARRAY[null, null, 1, 2], " +
+                "ARRAY[null, 1, 2, 2], " +
+                "ARRAY[1, 2, 2], " +
+                "ARRAY[2, 2]";
+
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST ROWS BETWEEN TINYINT '1' PRECEDING AND TINYINT '2' FOLLOWING) " +
+                "FROM (VALUES 2, 2, 1, null, null) t(a)"))
+                .matches(expected);
+
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST ROWS BETWEEN SMALLINT '1' PRECEDING AND SMALLINT '2' FOLLOWING) " +
+                "FROM (VALUES 2, 2, 1, null, null) t(a)"))
+                .matches(expected);
+
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST ROWS BETWEEN INTEGER '1' PRECEDING AND INTEGER '2' FOLLOWING) " +
+                "FROM (VALUES 2, 2, 1, null, null) t(a)"))
+                .matches(expected);
+
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST ROWS BETWEEN BIGINT '1' PRECEDING AND BIGINT '2' FOLLOWING) " +
+                "FROM (VALUES 2, 2, 1, null, null) t(a)"))
+                .matches(expected);
+
+        // short decimal
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST ROWS BETWEEN DECIMAL '1' PRECEDING AND DECIMAL '2' FOLLOWING) " +
+                "FROM (VALUES 2, 2, 1, null, null) t(a)"))
+                .matches(expected);
+
+        // no integer overflow when frame offset exceeds integer
+        assertThat(assertions.query("SELECT array_agg(a) OVER(ORDER BY a ASC NULLS FIRST ROWS BETWEEN 1 PRECEDING AND DECIMAL '12345678901234567' FOLLOWING) " +
+                "FROM (VALUES 2, 2, 1, null, null) t(a)"))
+                .matches("VALUES " +
+                        "ARRAY[null, null, 1, 2, 2], " +
+                        "ARRAY[null, null, 1, 2, 2], " +
+                        "ARRAY[null, 1, 2, 2], " +
+                        "ARRAY[1, 2, 2], " +
+                        "ARRAY[2, 2]");
+    }
+}


### PR DESCRIPTION
This is covered by a more complete solution in https://github.com/trinodb/trino/pull/6897.