### PR TITLE
Fix union of two low-unbounded Domains

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -620,7 +620,7 @@ public final class SortedRangeSet
             }
 
             if (current != null) {
-                Optional<RangeView> merged = current.tryOverlapWithNext(next);
+                Optional<RangeView> merged = current.tryMergeWithNext(next);
                 if (merged.isPresent()) {
                     current = merged.get();
                 }
@@ -1043,7 +1043,7 @@ public final class SortedRangeSet
          * Returns unioned range if {@code this} and {@code next} overlap or are adjacent.
          * The {@code next} lower bound must not be before {@code this} lower bound.
          */
-        public Optional<RangeView> tryOverlapWithNext(RangeView next)
+        public Optional<RangeView> tryMergeWithNext(RangeView next)
         {
             if (this.compareTo(next) > 0) {
                 throw new IllegalArgumentException("next before this");
@@ -1053,13 +1053,17 @@ public final class SortedRangeSet
                 return Optional.of(this);
             }
 
+            boolean merge;
             if (next.isLowUnbounded()) {
-                return Optional.of(next);
+                // both are low-unbounded
+                merge = true;
             }
-
-            int compare = compareValues(comparisonOperator, this.highValueBlock, this.highValuePosition, next.lowValueBlock, next.lowValuePosition);
-            if (compare > 0  // overlap
-                    || (compare == 0 && (this.highInclusive || next.lowInclusive))) { // adjacent
+            else {
+                int compare = compareValues(comparisonOperator, this.highValueBlock, this.highValuePosition, next.lowValueBlock, next.lowValuePosition);
+                merge = compare > 0  // overlap
+                        || compare == 0 && (this.highInclusive || next.lowInclusive); // adjacent
+            }
+            if (merge) {
                 int compareHighBound = compareHighBound(next);
                 return Optional.of(new RangeView(
                         this.type,

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
@@ -160,6 +160,34 @@ public class TestSortedRangeSet
     }
 
     @Test
+    public void testCreateWithRanges()
+    {
+        // two low-unbounded, first shorter
+        assertThat(SortedRangeSet.of(Range.lessThan(BIGINT, 5L), Range.lessThan(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.lessThan(BIGINT, 10L));
+        assertThat(SortedRangeSet.of(Range.lessThan(BIGINT, 10L), Range.lessThanOrEqual(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.lessThanOrEqual(BIGINT, 10L));
+
+        // two low-unbounded, second shorter
+        assertThat(SortedRangeSet.of(Range.lessThan(BIGINT, 10L), Range.lessThan(BIGINT, 5L)).getOrderedRanges())
+                .containsExactly(Range.lessThan(BIGINT, 10L));
+        assertThat(SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 10L), Range.lessThan(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.lessThanOrEqual(BIGINT, 10L));
+
+        // two high-unbounded, first shorter
+        assertThat(SortedRangeSet.of(Range.greaterThan(BIGINT, 10L), Range.greaterThan(BIGINT, 5L)).getOrderedRanges())
+                .containsExactly(Range.greaterThan(BIGINT, 5L));
+        assertThat(SortedRangeSet.of(Range.greaterThan(BIGINT, 10L), Range.greaterThanOrEqual(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.greaterThanOrEqual(BIGINT, 10L));
+
+        // two high-unbounded, second shorter
+        assertThat(SortedRangeSet.of(Range.greaterThan(BIGINT, 5L), Range.greaterThan(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.greaterThan(BIGINT, 5L));
+        assertThat(SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 10L), Range.greaterThan(BIGINT, 10L)).getOrderedRanges())
+                .containsExactly(Range.greaterThanOrEqual(BIGINT, 10L));
+    }
+
+    @Test
     public void testGetSingleValue()
     {
         assertEquals(SortedRangeSet.of(BIGINT, 0L).getSingleValue(), 0L);
@@ -402,6 +430,46 @@ public class TestSortedRangeSet
                 SortedRangeSet.of(Range.range(BIGINT, 0L, true, 10L, false)),
                 SortedRangeSet.of(Range.equal(BIGINT, 9L)),
                 SortedRangeSet.of(Range.range(BIGINT, 0L, true, 10L, false)));
+
+        // two low-unbounded, first shorter
+        assertUnion(
+                SortedRangeSet.of(Range.lessThan(BIGINT, 5L)),
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)));
+        assertUnion(
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 10L)));
+
+        // two low-unbounded, second shorter
+        assertUnion(
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThan(BIGINT, 5L)),
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)));
+        assertUnion(
+                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.lessThanOrEqual(BIGINT, 10L)));
+
+        // two high-unbounded, first shorter
+        assertUnion(
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 5L)),
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 5L)));
+        assertUnion(
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 10L)));
+
+        // two high-unbounded, second shorter
+        assertUnion(
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 5L)),
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 5L)));
+        assertUnion(
+                SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThan(BIGINT, 10L)),
+                SortedRangeSet.of(Range.greaterThanOrEqual(BIGINT, 10L)));
 
         assertUnion(
                 SortedRangeSet.of(Range.range(createVarcharType(25), utf8Slice("LARGE PLATED "), true, utf8Slice("LARGE PLATED!"), false)),


### PR DESCRIPTION
Before the change, union of `(-∞, 10)` and `(-∞, 5)` would incorrectly
return `(-∞m 5)` as the result.

Fixes https://github.com/trinodb/trino/issues/6896 