### PR TITLE
Add Error Prone check: ReturnValueIgnored

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -52,7 +52,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -97,7 +97,7 @@ public class SqlTask
             QueryContext queryContext,
             SqlTaskExecutionFactory sqlTaskExecutionFactory,
             ExecutorService taskNotificationExecutor,
-            Function<SqlTask, ?> onDone,
+            Consumer<SqlTask> onDone,
             DataSize maxBufferSize,
             DataSize maxBroadcastBufferSize,
             CounterStat failedTasks)
@@ -140,7 +140,7 @@ public class SqlTask
     }
 
     // this is a separate method to ensure that the `this` reference is not leaked during construction
-    private void initialize(Function<SqlTask, ?> onDone, CounterStat failedTasks)
+    private void initialize(Consumer<SqlTask> onDone, CounterStat failedTasks)
     {
         requireNonNull(onDone, "onDone is null");
         requireNonNull(failedTasks, "failedTasks is null");
@@ -182,7 +182,7 @@ public class SqlTask
             }
 
             try {
-                onDone.apply(SqlTask.this);
+                onDone.accept(this);
             }
             catch (Exception e) {
                 log.warn(e, "Error running task cleanup callback %s", SqlTask.this.taskId);

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -169,10 +169,7 @@ public class SqlTaskManager
                         queryContexts.getUnchecked(taskId.getQueryId()),
                         sqlTaskExecutionFactory,
                         taskNotificationExecutor,
-                        sqlTask -> {
-                            finishedTaskStats.merge(sqlTask.getIoStats());
-                            return null;
-                        },
+                        sqlTask -> finishedTaskStats.merge(sqlTask.getIoStats()),
                         maxBufferSize,
                         maxBroadcastBufferSize,
                         failedTasks)));

--- a/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunctionBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/PolymorphicScalarFunctionBuilder.java
@@ -102,7 +102,7 @@ public final class PolymorphicScalarFunctionBuilder
             argumentDefinitions = nCopies(signature.getArgumentTypes().size(), new FunctionArgumentDefinition(false));
         }
         ChoiceBuilder choiceBuilder = new ChoiceBuilder(clazz, signature);
-        choiceSpecification.apply(choiceBuilder);
+        choiceBuilder = choiceSpecification.apply(choiceBuilder);
         choices.add(choiceBuilder.build());
         return this;
     }
@@ -278,7 +278,7 @@ public final class PolymorphicScalarFunctionBuilder
                 argumentConventions = nCopies(signature.getArgumentTypes().size(), NEVER_NULL);
             }
             MethodsGroupBuilder methodsGroupBuilder = new MethodsGroupBuilder(clazz, signature, argumentConventions);
-            methodsGroupSpecification.apply(methodsGroupBuilder);
+            methodsGroupBuilder = methodsGroupSpecification.apply(methodsGroupBuilder);
             methodsGroups.add(methodsGroupBuilder.build());
             return this;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/ValuesOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ValuesOperator.java
@@ -84,7 +84,7 @@ public class ValuesOperator
     @Override
     public void finish()
     {
-        Iterators.size(pages);
+        int ignored = Iterators.size(pages);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestMemoryRevokingScheduler.java
@@ -14,7 +14,6 @@
 
 package io.trino.execution;
 
-import com.google.common.base.Functions;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -304,7 +303,7 @@ public class TestMemoryRevokingScheduler
                 queryContext,
                 sqlTaskExecutionFactory,
                 executor,
-                Functions.identity(),
+                sqlTask -> {},
                 DataSize.of(32, MEGABYTE),
                 DataSize.of(200, MEGABYTE),
                 new CounterStat());

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTask.java
@@ -13,7 +13,6 @@
  */
 package io.trino.execution;
 
-import com.google.common.base.Functions;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -367,7 +366,7 @@ public class TestSqlTask
                 queryContext,
                 sqlTaskExecutionFactory,
                 taskNotificationExecutor,
-                Functions.identity(),
+                sqlTask -> {},
                 DataSize.of(32, MEGABYTE),
                 DataSize.of(200, MEGABYTE),
                 new CounterStat());

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestAggregationFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AbstractTestAggregationFunction.java
@@ -41,6 +41,7 @@ import static io.trino.operator.aggregation.AggregationTestUtils.makeValidityAss
 import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public abstract class AbstractTestAggregationFunction
 {
@@ -185,9 +186,10 @@ public abstract class AbstractTestAggregationFunction
             oldStart = start;
             oldWidth = width;
             Block block = getFinalBlock(aggregation);
-            makeValidityAssertion(expectedValues[start]).apply(
+            assertThat(makeValidityAssertion(expectedValues[start]).apply(
                     BlockAssertions.getOnlyValue(aggregation.getFinalType(), block),
-                    expectedValues[start]);
+                    expectedValues[start]))
+                    .isTrue();
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
@@ -389,7 +389,7 @@ public final class FunctionAssertions
                     newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
                     SOURCE_PAGE);
             // consume the iterator
-            Iterators.getOnlyElement(output);
+            Optional<Page> ignored = Iterators.getOnlyElement(output);
 
             long retainedSize = processor.getProjections().stream()
                     .mapToLong(this::getRetainedSizeOfCachedInstance)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BaseStrictSymbolsMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/BaseStrictSymbolsMatcher.java
@@ -39,7 +39,7 @@ public abstract class BaseStrictSymbolsMatcher
     public boolean shapeMatches(PlanNode node)
     {
         try {
-            getActual.apply(node);
+            Set<Symbol> ignored = getActual.apply(node);
             return true;
         }
         catch (ClassCastException e) {

--- a/lib/trino-matching/src/test/java/io/trino/matching/TestMatcher.java
+++ b/lib/trino-matching/src/test/java/io/trino/matching/TestMatcher.java
@@ -38,6 +38,7 @@ import static io.trino.matching.example.rel.Patterns.source;
 import static io.trino.matching.example.rel.Patterns.tableName;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
@@ -194,8 +195,8 @@ public class TestMatcher
                         }).equalTo(true));
 
         AtomicBoolean wasContextUsed = new AtomicBoolean();
-        pattern.match("object", wasContextUsed)
-                .collect(onlyElement());
+        assertNotNull(pattern.match("object", wasContextUsed)
+                .collect(onlyElement()));
         assertEquals(wasContextUsed.get(), true);
     }
 
@@ -209,8 +210,8 @@ public class TestMatcher
                 });
 
         AtomicBoolean wasContextUsed = new AtomicBoolean();
-        pattern.match("object", wasContextUsed)
-                .collect(onlyElement());
+        assertNotNull(pattern.match("object", wasContextUsed)
+                .collect(onlyElement()));
         assertEquals(wasContextUsed.get(), true);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1713,6 +1713,7 @@
                                     -Xep:OptionalEquality:ERROR
                                     -Xep:OptionalMapUnusedValue:ERROR
                                     -Xep:PreconditionsInvalidPlaceholder:ERROR
+                                    -Xep:ReturnValueIgnored:ERROR
                                     -Xep:StaticQualifiedUsingExpression:ERROR
                                     -Xep:ThrowIfUncheckedKnownChecked:ERROR
                                     -Xep:UnnecessaryCheckNotNull:ERROR

--- a/testing/trino-testing/src/main/java/io/trino/testing/PlanDeterminismChecker.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/PlanDeterminismChecker.java
@@ -19,7 +19,6 @@ import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.planprinter.PlanPrinter;
 
 import java.util.function.Function;
-import java.util.stream.IntStream;
 
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
 import static org.testng.Assert.assertEquals;
@@ -49,13 +48,11 @@ public class PlanDeterminismChecker
 
     public void checkPlanIsDeterministic(Session session, String sql)
     {
-        IntStream.range(1, MINIMUM_SUBSEQUENT_SAME_PLANS)
-                .mapToObj(attempt -> getPlanText(session, sql))
-                .map(planEquivalenceFunction)
-                .reduce((previous, current) -> {
-                    assertEquals(previous, current);
-                    return current;
-                });
+        String previous = planEquivalenceFunction.apply(getPlanText(session, sql));
+        for (int attempt = 1; attempt < MINIMUM_SUBSEQUENT_SAME_PLANS; attempt++) {
+            String current = planEquivalenceFunction.apply(getPlanText(session, sql));
+            assertEquals(previous, current);
+        }
     }
 
     private String getPlanText(Session session, String sql)


### PR DESCRIPTION
The individual instances of where the check reports errors are mostly suppressed, as there's a couple of places where we rely on side effects, instead of the return value. In one of these there is a parameter passed as a `Function`, where a `Consumer` would be a better interface to use, as the result of the function is ignored. Another interesting case is where there is a `Function` provided as a customizer in the builder pattern, but the ways it's invoked it only relies on side effects (modifying the builder in-place) and the result is ignored; in this case it's prudent to actually use the result as the builder object to continue with, even if in practice it's exactly the same as the input object.