### PR TITLE
Add Error Prone check: PreconditionsInvalidPlaceholder

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/MergePages.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/MergePages.java
@@ -101,7 +101,7 @@ public final class MergePages
             checkArgument(minRowCount >= 0, "minRowCount must be greater or equal than zero");
             checkArgument(maxPageSizeInBytes > 0, "maxPageSizeInBytes must be greater than zero");
             checkArgument(maxPageSizeInBytes >= minPageSizeInBytes, "maxPageSizeInBytes must be greater or equal than minPageSizeInBytes");
-            checkArgument(minPageSizeInBytes <= MAX_MIN_PAGE_SIZE, "minPageSizeInBytes must be less or equal than %d", MAX_MIN_PAGE_SIZE);
+            checkArgument(minPageSizeInBytes <= MAX_MIN_PAGE_SIZE, "minPageSizeInBytes must be less or equal than %s", MAX_MIN_PAGE_SIZE);
             this.minPageSizeInBytes = minPageSizeInBytes;
             this.minRowCount = minRowCount;
             this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/Util.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/Util.java
@@ -96,7 +96,7 @@ final class Util
 
         checkArgument(
                 (node.getSources().size() == permittedChildOutputs.size()),
-                "Mismatched child (%d) and permitted outputs (%d) sizes",
+                "Mismatched child (%s) and permitted outputs (%s) sizes",
                 node.getSources().size(),
                 permittedChildOutputs.size());
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
@@ -458,7 +458,7 @@ public final class MetastoreUtil
         Long count = Longs.tryParse(existingRowCount);
         requireNonNull(count, format("For %s, the existing row count (%s) is not a digit string", description, existingRowCount));
         long newRowCount = count + rowCountAdjustment;
-        checkArgument(newRowCount >= 0, "For %s, the subtracted row count (%s) is less than zero, existing count %s, rows deleted %d", description, newRowCount, existingRowCount, rowCountAdjustment);
+        checkArgument(newRowCount >= 0, "For %s, the subtracted row count (%s) is less than zero, existing count %s, rows deleted %s", description, newRowCount, existingRowCount, rowCountAdjustment);
         Map<String, String> copiedParameters = new HashMap<>(parameters);
         copiedParameters.put(NUM_ROWS, String.valueOf(newRowCount));
         return ImmutableMap.copyOf(copiedParameters);

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -487,7 +487,7 @@ public class PinotClient
     public static <T> T doWithRetries(int retries, Function<Integer, T> caller)
     {
         PinotException firstError = null;
-        checkState(retries > 0, "Invalid num of retries %d", retries);
+        checkState(retries > 0, "Invalid num of retries %s", retries);
         for (int i = 0; i < retries; ++i) {
             try {
                 return caller.apply(i);

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -750,7 +750,7 @@ public class PostgreSqlClient
     private static ColumnMapping timestampWithTimeZoneColumnMapping(int precision)
     {
         // PostgreSQL supports timestamptz precision up to microseconds
-        checkArgument(precision <= POSTGRESQL_MAX_SUPPORTED_TIMESTAMP_PRECISION, "unsupported precision value %d", precision);
+        checkArgument(precision <= POSTGRESQL_MAX_SUPPORTED_TIMESTAMP_PRECISION, "unsupported precision value %s", precision);
         TimestampWithTimeZoneType prestoType = createTimestampWithTimeZoneType(precision);
         if (precision <= TimestampWithTimeZoneType.MAX_SHORT_PRECISION) {
             return ColumnMapping.longMapping(

--- a/pom.xml
+++ b/pom.xml
@@ -1709,6 +1709,7 @@
                                     -Xep:ObjectToString:ERROR
                                     -Xep:OptionalEquality:ERROR
                                     -Xep:OptionalMapUnusedValue:ERROR
+                                    -Xep:PreconditionsInvalidPlaceholder:ERROR
                                     -Xep:StaticQualifiedUsingExpression:ERROR
                                     -Xep:UnnecessaryMethodReference:ERROR
                                     -Xep:UnnecessaryOptionalGet:ERROR


### PR DESCRIPTION
The format strings in preconditions only suport the `%s` placeholder.