### PR TITLE
Add Error Prone check: ThrowIfUncheckedKnownChecked

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToJsonCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayToJsonCast.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandle;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.trino.metadata.Signature.castableToTypeParameter;
 import static io.trino.operator.scalar.JsonOperators.JSON_FACTORY;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
@@ -90,7 +89,6 @@ public class ArrayToJsonCast
             return output.slice();
         }
         catch (IOException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MapToJsonCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MapToJsonCast.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.TreeMap;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.trino.metadata.Signature.castableToTypeParameter;
 import static io.trino.operator.scalar.JsonOperators.JSON_FACTORY;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
@@ -108,7 +107,6 @@ public class MapToJsonCast
             return output.slice();
         }
         catch (IOException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/RowToJsonCast.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/RowToJsonCast.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.trino.operator.scalar.JsonOperators.JSON_FACTORY;
 import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
@@ -101,7 +100,6 @@ public class RowToJsonCast
             return output.slice();
         }
         catch (IOException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/LambdaCapture.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/LambdaCapture.java
@@ -21,8 +21,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 
-import static com.google.common.base.Throwables.throwIfUnchecked;
-
 public final class LambdaCapture
 {
     public static final Method LAMBDA_CAPTURE_METHOD;
@@ -59,7 +57,6 @@ public final class LambdaCapture
                     instantiatedMethodType);
         }
         catch (LambdaConversionException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisShardCheckpointer.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisShardCheckpointer.java
@@ -22,8 +22,6 @@ import com.amazonaws.services.kinesis.leases.impl.KinesisClientLease;
 import com.amazonaws.services.kinesis.leases.impl.KinesisClientLeaseManager;
 import io.airlift.log.Logger;
 
-import static com.google.common.base.Throwables.throwIfUnchecked;
-
 public class KinesisShardCheckpointer
 {
     private static final Logger log = Logger.get(KinesisShardCheckpointer.class);
@@ -82,7 +80,6 @@ public class KinesisShardCheckpointer
             }
         }
         catch (ProvisionedThroughputException | InvalidStateException | DependencyException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
         resetNextCheckpointTime();
@@ -118,7 +115,6 @@ public class KinesisShardCheckpointer
             }
         }
         catch (DependencyException | InvalidStateException | ProvisionedThroughputException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
         resetNextCheckpointTime();
@@ -134,7 +130,6 @@ public class KinesisShardCheckpointer
                 oldLease = leaseManager.getLease(createCheckpointKey(currentIterationNumber - 1));
             }
             catch (DependencyException | InvalidStateException | ProvisionedThroughputException e) {
-                throwIfUnchecked(e);
                 throw new RuntimeException(e);
             }
             if (oldLease != null) {

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableDescriptionSupplier.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableDescriptionSupplier.java
@@ -91,7 +91,6 @@ public class KinesisTableDescriptionSupplier
             return tableDefinitions;
         }
         catch (IOException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
     }

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/s3config/S3TableConfigClient.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/s3config/S3TableConfigClient.java
@@ -48,7 +48,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
@@ -199,7 +198,6 @@ public class S3TableConfigClient
                 }
                 catch (IOException iox) {
                     log.error("Problem reading input stream from object.", iox);
-                    throwIfUnchecked(iox);
                     throw new RuntimeException(iox);
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -1711,6 +1711,7 @@
                                     -Xep:OptionalMapUnusedValue:ERROR
                                     -Xep:PreconditionsInvalidPlaceholder:ERROR
                                     -Xep:StaticQualifiedUsingExpression:ERROR
+                                    -Xep:ThrowIfUncheckedKnownChecked:ERROR
                                     -Xep:UnnecessaryCheckNotNull:ERROR
                                     -Xep:UnnecessaryMethodReference:ERROR
                                     -Xep:UnnecessaryOptionalGet:ERROR

--- a/service/trino-verifier/src/main/java/io/trino/verifier/VerifyCommand.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/VerifyCommand.java
@@ -181,7 +181,6 @@ public class VerifyCommand
             System.exit((numFailedQueries > 0) ? 1 : 0);
         }
         catch (InterruptedException | MalformedURLException e) {
-            throwIfUnchecked(e);
             throw new RuntimeException(e);
         }
         finally {


### PR DESCRIPTION
The method `Throwables.throwIfUnchecked` re-throws a given `Throwable` if it's unchecked (`RuntimeException` or `Error`). This only makes sense when the static type is too general to be known if the actual exception is checked or unchecked. Wherever the static type is known to be checked, this is a no-op and the invocation can be removed.