### PR TITLE
Rename Launcher --without-presto to --without-trino

### DIFF
--- a/core/trino-server-main/etc/catalog/hive.properties
+++ b/core/trino-server-main/etc/catalog/hive.properties
@@ -8,7 +8,7 @@
 connector.name=hive-hadoop2
 
 # Configuration appropriate for Hive as started by product test environment, e.g.
-#   trino-product-tests-launcher/bin/run-launcher env up --environment singlenode --without-presto
+#   trino-product-tests-launcher/bin/run-launcher env up --environment singlenode --without-trino
 # On Mac, this additionally requires that you add "<your external IP> hadoop-master" to /etc/hosts
 hive.metastore.uri=thrift://localhost:9083
 hive.hdfs.socks-proxy=localhost:1180

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentOptions.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentOptions.java
@@ -28,7 +28,7 @@ public final class EnvironmentOptions
     @Option(names = "--server-package", paramLabel = "<package>", description = "Path to Trino server package " + DEFAULT_VALUE, defaultValue = "${server.module}/target/${server.name}-${project.version}.tar.gz")
     public File serverPackage;
 
-    @Option(names = "--without-presto", description = "Do not start " + COORDINATOR)
+    @Option(names = "--without-trino", description = "Do not start " + COORDINATOR)
     public boolean withoutPrestoMaster;
 
     @Option(names = "--no-bind", description = "Bind ports on localhost", negatable = true)


### PR DESCRIPTION
More complete update to product tests is due, but this fixes
Launcher's client interface.

I already updated https://gist.github.com/findepi/04c96f0f60dcc95329f569bb0c44a0cd and want to roll forward if no-one objects. 