### PR TITLE
Always show `SECURITY` clause in `SHOW CREATE VIEW`

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -135,6 +135,8 @@ import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
+import static io.trino.sql.tree.CreateView.Security.DEFINER;
+import static io.trino.sql.tree.CreateView.Security.INVOKER;
 import static io.trino.sql.tree.LogicalBinaryExpression.and;
 import static io.trino.sql.tree.ShowCreate.Type.MATERIALIZED_VIEW;
 import static io.trino.sql.tree.ShowCreate.Type.SCHEMA;
@@ -479,7 +481,8 @@ final class ShowQueriesRewrite
 
                 accessControl.checkCanShowCreateTable(session.toSecurityContext(), new QualifiedObjectName(catalogName.getValue(), schemaName.getValue(), tableName.getValue()));
 
-                String sql = formatSql(new CreateView(QualifiedName.of(ImmutableList.of(catalogName, schemaName, tableName)), query, false, viewDefinition.get().getComment(), Optional.empty())).trim();
+                CreateView.Security security = viewDefinition.get().isRunAsInvoker() ? INVOKER : DEFINER;
+                String sql = formatSql(new CreateView(QualifiedName.of(ImmutableList.of(catalogName, schemaName, tableName)), query, false, viewDefinition.get().getComment(), Optional.of(security))).trim();
                 return singleValueQuery("Create View", sql);
             }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/hive/AbstractTestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/hive/AbstractTestHiveViews.java
@@ -126,7 +126,7 @@ public abstract class AbstractTestHiveViews
         onHive().executeQuery("CREATE VIEW hive_show_view AS SELECT * FROM nation");
 
         String showCreateViewSql = "SHOW CREATE VIEW %s.default.hive_show_view";
-        String expectedResult = "CREATE VIEW %s.default.hive_show_view AS\n" +
+        String expectedResult = "CREATE VIEW %s.default.hive_show_view SECURITY DEFINER AS\n" +
                 "SELECT\n" +
                 "  \"n_nationkey\"\n" +
                 ", \"n_name\"\n" +


### PR DESCRIPTION
The issue was that the `SHOW CREATE VIEW` was not reconstructing the `SECURITY <X>` clause from the CREATE VIEW command, as `ShowQueriesRewrite` was always passing `Optional.empty()` to the `security` parameter of `CreateView`. This is fixed here, but with one caveat. We don't have enough information to reconstruct the `SECURITY` clause completely - the security mode is determined from presence (`DEFINER`) or absence (`INVOKER`) of the owner of the view, as stored in the metadata, alone, and this is not enough to determine whether the clause was given explicitly or not. So in the result of `SHOW CREATE VIEW` we always include the `SECURITY` clause.

Fixes #6792