### PR TITLE
Disallow bucketing or sorting on hive partitioning columns

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveIntegrationSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveIntegrationSmokeTest.java
@@ -2214,6 +2214,45 @@ public class TestHiveIntegrationSmokeTest
                 .hasMessage("Bucketing columns [c] not present in schema");
 
         assertThatThrownBy(() -> computeActual("" +
+                "CREATE TABLE " + tableName + " (" +
+                "  a BIGINT," +
+                "  b DOUBLE," +
+                "  p VARCHAR" +
+                ") WITH (" +
+                "format = '" + storageFormat + "', " +
+                "partitioned_by = ARRAY[ 'p' ], " +
+                "bucketed_by = ARRAY[ 'a' ], " +
+                "bucket_count = 11, " +
+                "sorted_by = ARRAY[ 'c' ] " +
+                ")"))
+                .hasMessage("Sorting columns [c] not present in schema");
+
+        assertThatThrownBy(() -> computeActual("" +
+                "CREATE TABLE " + tableName + " (" +
+                "  a BIGINT," +
+                "  p VARCHAR" +
+                ") WITH (" +
+                "format = '" + storageFormat + "', " +
+                "partitioned_by = ARRAY[ 'p' ], " +
+                "bucketed_by = ARRAY[ 'p' ], " +
+                "bucket_count = 11 " +
+                ")"))
+                .hasMessage("Bucketing columns [p] are also used as partitioning columns");
+
+        assertThatThrownBy(() -> computeActual("" +
+                "CREATE TABLE " + tableName + " (" +
+                "  a BIGINT," +
+                "  p VARCHAR" +
+                ") WITH (" +
+                "format = '" + storageFormat + "', " +
+                "partitioned_by = ARRAY[ 'p' ], " +
+                "bucketed_by = ARRAY[ 'a' ], " +
+                "bucket_count = 11, " +
+                "sorted_by = ARRAY[ 'p' ] " +
+                ")"))
+                .hasMessage("Sorting columns [p] are also used as partitioning columns");
+
+        assertThatThrownBy(() -> computeActual("" +
                 "CREATE TABLE " + tableName + " " +
                 "WITH (" +
                 "format = '" + storageFormat + "', " +
@@ -2225,6 +2264,20 @@ public class TestHiveIntegrationSmokeTest
                 "SELECT custkey, custkey AS custkey2, comment, orderstatus " +
                 "FROM tpch.tiny.orders"))
                 .hasMessage("Bucketing columns [custkey3] not present in schema");
+
+        assertThatThrownBy(() -> computeActual("" +
+                "CREATE TABLE " + tableName + " " +
+                "WITH (" +
+                "format = '" + storageFormat + "', " +
+                "partitioned_by = ARRAY[ 'orderstatus' ], " +
+                "bucketed_by = ARRAY[ 'custkey' ], " +
+                "bucket_count = 11, " +
+                "sorted_by = ARRAY[ 'custkey3' ] " +
+                ") " +
+                "AS " +
+                "SELECT custkey, custkey AS custkey2, comment, orderstatus " +
+                "FROM tpch.tiny.orders"))
+                .hasMessage("Sorting columns [custkey3] not present in schema");
 
         assertFalse(getQueryRunner().tableExists(getSession(), tableName));
     }


### PR DESCRIPTION
Currently a query like ```create table test with (bucketed_by=array['orderkey'], bucket_count=1, partitioned_by=array['orderkey']) as select partkey, orderkey from tpch.tiny.lineitem;``` 
fails with exception
```
2021-02-16T16:25:14.519+0530	ERROR	remote-task-callback-1	io.trino.execution.StageStateMachine	Stage 20210216_105428_00000_5nkuw.1 failed
java.lang.NullPointerException
	at java.base/java.util.stream.ReferencePipeline$4$1.accept(ReferencePipeline.java:212)
	at java.base/java.util.Collections$2.tryAdvance(Collections.java:4747)
	at java.base/java.util.Collections$2.forEachRemaining(Collections.java:4755)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:550)
	at java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)
	at java.base/java.util.stream.IntPipeline.toArray(IntPipeline.java:538)
	at io.trino.plugin.hive.HivePageSink.<init>(HivePageSink.java:144)
	at io.trino.plugin.hive.HivePageSinkProvider.createPageSink(HivePageSinkProvider.java:168)
	at io.trino.plugin.hive.HivePageSinkProvider.createPageSink(HivePageSinkProvider.java:114)
```
because we assume bucketing columns are not partitioning columns.
Explicitly adding validation for this case as this is not allowed by Hive either.