### PR TITLE
Avoid loading JDBC table properties

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnMetadata.java
@@ -17,7 +17,6 @@ import io.trino.spi.type.Type;
 
 import javax.annotation.Nullable;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -94,7 +93,8 @@ public class ColumnMetadata
         this.comment = comment;
         this.extraInfo = extraInfo;
         this.hidden = hidden;
-        this.properties = properties.isEmpty() ? emptyMap() : unmodifiableMap(new LinkedHashMap<>(properties));
+        // Avoiding doing a copy as properties can be lazy
+        this.properties = properties.isEmpty() ? emptyMap() : unmodifiableMap(properties);
         this.nullable = nullable;
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableMetadata.java
@@ -14,7 +14,6 @@
 package io.trino.spi.connector;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,7 +46,8 @@ public class ConnectorTableMetadata
 
         this.table = table;
         this.columns = List.copyOf(columns);
-        this.properties = Collections.unmodifiableMap(new LinkedHashMap<>(properties));
+        // Avoiding doing a copy as properties can be lazy
+        this.properties = Collections.unmodifiableMap(properties);
         this.comment = comment;
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyMaps.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyMaps.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Suppliers.memoize;
+
+public final class LazyMaps
+{
+    private LazyMaps() {}
+
+    public static <K, V> Map<K, V> of(Supplier<Set<Map.Entry<K, V>>> supplier)
+    {
+        Supplier<Set<Map.Entry<K, V>>> cachedSupplier = memoize(supplier::get);
+        return new AbstractMap<>()
+        {
+            @Override
+            public Set<Entry<K, V>> entrySet()
+            {
+                return cachedSupplier.get();
+            }
+        };
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/H2QueryRunner.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/H2QueryRunner.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -44,12 +45,17 @@ public final class H2QueryRunner
 
     public static DistributedQueryRunner createH2QueryRunner(Iterable<TpchTable<?>> tables)
             throws Exception
-
     {
         return createH2QueryRunner(tables, TestingH2JdbcModule.createProperties());
     }
 
     public static DistributedQueryRunner createH2QueryRunner(Iterable<TpchTable<?>> tables, Map<String, String> properties)
+            throws Exception
+    {
+        return createH2QueryRunner(tables, properties, new TestingH2JdbcModule());
+    }
+
+    public static DistributedQueryRunner createH2QueryRunner(Iterable<TpchTable<?>> tables, Map<String, String> properties, Module module)
             throws Exception
     {
         DistributedQueryRunner queryRunner = null;
@@ -61,7 +67,7 @@ public final class H2QueryRunner
 
             createSchema(properties, "tpch");
 
-            queryRunner.installPlugin(new JdbcPlugin("base-jdbc", new TestingH2JdbcModule()));
+            queryRunner.installPlugin(new JdbcPlugin("base-jdbc", module));
             queryRunner.createCatalog("jdbc", "base-jdbc", properties);
 
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableProperties.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableProperties.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static io.trino.plugin.jdbc.H2QueryRunner.createH2QueryRunner;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
+@Test(singleThreaded = true)
+public class TestJdbcTableProperties
+        extends AbstractTestQueryFramework
+{
+    private final Map<String, String> properties = TestingH2JdbcModule.createProperties();
+    private Runnable onGetTableProperties = () -> {};
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingH2JdbcModule module = new TestingH2JdbcModule((config, connectionFactory) -> new TestingH2JdbcClient(config, connectionFactory)
+        {
+            @Override
+            public Map<String, Object> getTableProperties(ConnectorSession session, JdbcTableHandle tableHandle)
+            {
+                onGetTableProperties.run();
+                return ImmutableMap.of();
+            }
+        });
+        return createH2QueryRunner(ImmutableList.copyOf(TpchTable.getTables()), properties, module);
+    }
+
+    @BeforeTest
+    public void reset()
+    {
+        onGetTableProperties = () -> {};
+    }
+
+    @Test
+    public void testGetTablePropertiesIsNotCalled()
+    {
+        onGetTableProperties = () -> { fail("Unexpected call of: getTableProperties"); };
+        assertUpdate("CREATE TABLE copy_of_nation AS SELECT * FROM nation", 25);
+        assertQuerySucceeds("SELECT * FROM copy_of_nation");
+        assertQuerySucceeds("SELECT nationkey FROM copy_of_nation");
+        assertUpdate("INSERT INTO copy_of_nation SELECT * FROM nation", 25);
+    }
+
+    @Test
+    public void testGetTablePropertiesIsCalled()
+    {
+        AtomicBoolean getTablePropertiesIsCalled = new AtomicBoolean();
+        onGetTableProperties = () -> { getTablePropertiesIsCalled.set(true); };
+        assertQuerySucceeds("SHOW CREATE TABLE nation");
+        assertThat(getTablePropertiesIsCalled.get()).isTrue();
+    }
+}


### PR DESCRIPTION
Avoid loading JDBC table properties

To load table properties additional call to remote data source is
required to capture properties related metadata.

Till this commit such calls were needed per each table scan from JDBC
table times table property. That can impact the Trino query execution
wall time significantly.

This is not the ideal solution, because it introduces lazy map. However
alternative solutions were worse, consider:
 - removing table properties from ConnectorTableMetadata and add another
 SPI method to retrieve table properties. This also requires to pass
 table properties to methods like `ConnectorMetatadata::createTable`
 where table does not exists yet.
 - introducing lightweight object like ConnectorBasicTableMetadata
without table properties. Massive change in the engine.

This solution is nice as it solves the problem in the place of problem
origin. Engine or SPI does not need to be changed.
The bad consequence is that it expects engine and SPI to behave in
certain manner, so it cause some issues with future changes.
