### PR TITLE
Add Error Prone check: UnnecessaryCheckNotNull

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/IoPlanPrinter.java
@@ -356,11 +356,11 @@ public class IoPlanPrinter
                 @JsonProperty("maxMemory") double maxMemory,
                 @JsonProperty("networkCost") double networkCost)
         {
-            this.outputRowCount = requireNonNull(outputRowCount, "outputRowCount is null");
-            this.outputSizeInBytes = requireNonNull(outputSizeInBytes, "outputSizeInBytes is null");
-            this.cpuCost = requireNonNull(cpuCost, "cpuCost is null");
-            this.maxMemory = requireNonNull(maxMemory, "maxMemory is null");
-            this.networkCost = requireNonNull(networkCost, "networkCost is null");
+            this.outputRowCount = outputRowCount;
+            this.outputSizeInBytes = outputSizeInBytes;
+            this.cpuCost = cpuCost;
+            this.maxMemory = maxMemory;
+            this.networkCost = networkCost;
         }
 
         @JsonProperty

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcReaderOptions.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcReaderOptions.java
@@ -66,7 +66,7 @@ public class OrcReaderOptions
         this.tinyStripeThreshold = requireNonNull(tinyStripeThreshold, "tinyStripeThreshold is null");
         this.streamBufferSize = requireNonNull(streamBufferSize, "streamBufferSize is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
-        this.lazyReadSmallRanges = requireNonNull(lazyReadSmallRanges, "lazyReadSmallRanges is null");
+        this.lazyReadSmallRanges = lazyReadSmallRanges;
         this.bloomFiltersEnabled = bloomFiltersEnabled;
         this.nestedLazy = nestedLazy;
     }

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryInsertTableHandle.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryInsertTableHandle.java
@@ -33,7 +33,7 @@ public class MemoryInsertTableHandle
             @JsonProperty("table") long table,
             @JsonProperty("activeTableIds") Set<Long> activeTableIds)
     {
-        this.table = requireNonNull(table, "table is null");
+        this.table = table;
         this.activeTableIds = requireNonNull(activeTableIds, "activeTableIds is null");
     }
 

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryOutputTableHandle.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryOutputTableHandle.java
@@ -33,7 +33,7 @@ public final class MemoryOutputTableHandle
             @JsonProperty("table") long table,
             @JsonProperty("activeTableIds") Set<Long> activeTableIds)
     {
-        this.table = requireNonNull(table, "table is null");
+        this.table = table;
         this.activeTableIds = requireNonNull(activeTableIds, "activeTableIds is null");
     }
 

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemorySplit.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemorySplit.java
@@ -50,7 +50,7 @@ public class MemorySplit
         checkState(totalPartsPerWorker >= 1, "totalPartsPerWorker must be >= 1");
         checkState(totalPartsPerWorker > partNumber, "totalPartsPerWorker must be > partNumber");
 
-        this.table = requireNonNull(table, "table is null");
+        this.table = table;
         this.partNumber = partNumber;
         this.totalPartsPerWorker = totalPartsPerWorker;
         this.address = requireNonNull(address, "address is null");

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/TableInfo.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/TableInfo.java
@@ -36,7 +36,7 @@ public class TableInfo
 
     public TableInfo(long id, String schemaName, String tableName, List<ColumnInfo> columns, Map<HostAddress, MemoryDataFragment> dataFragments)
     {
-        this.id = requireNonNull(id, "handle is null");
+        this.id = id;
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.columns = ImmutableList.copyOf(columns);

--- a/pom.xml
+++ b/pom.xml
@@ -1710,6 +1710,7 @@
                                     -Xep:OptionalEquality:ERROR
                                     -Xep:OptionalMapUnusedValue:ERROR
                                     -Xep:StaticQualifiedUsingExpression:ERROR
+                                    -Xep:UnnecessaryCheckNotNull:ERROR
                                     -Xep:UnnecessaryMethodReference:ERROR
                                     -Xep:UnnecessaryOptionalGet:ERROR
                                     -Xep:UnusedVariable:ERROR


### PR DESCRIPTION
This removes the null checks on parameters of primitive type, in which case no null is possible, so the call never fails (and in addition incurs boxing overhead).