### PR TITLE
Add Error Prone check: MisusedWeekYear

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/CompilerUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/CompilerUtils.java
@@ -35,7 +35,7 @@ public final class CompilerUtils
     private static final Logger log = Logger.get(CompilerUtils.class);
 
     private static final AtomicLong CLASS_ID = new AtomicLong();
-    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("YYYYMMdd_HHmmss");
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss");
 
     private CompilerUtils() {}
 

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopProcessFactory.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopProcessFactory.java
@@ -45,7 +45,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class AtopProcessFactory
         implements AtopFactory
 {
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("YYYYMMdd");
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
     private final String executablePath;
     private final ZoneId timeZone;
     private final Duration readTimeout;

--- a/pom.xml
+++ b/pom.xml
@@ -1705,6 +1705,7 @@
                                     -Xep:InjectOnConstructorOfAbstractClass:ERROR
                                     -Xep:MissingCasesInEnumSwitch:ERROR
                                     -Xep:MissingOverride:ERROR
+                                    -Xep:MisusedWeekYear:ERROR
                                     -Xep:NullOptional:ERROR
                                     -Xep:ObjectToString:ERROR
                                     -Xep:OptionalEquality:ERROR


### PR DESCRIPTION
The `YYYY` date format pattern is a week year, whereas supposedly a year was intended.

The javadocs say this:

```
A week year is in sync with a WEEK_OF_YEAR cycle. All weeks between the first and last weeks (inclusive) have the same week year value. Therefore, the first and last days of a week year may have different calendar year values.

For example, January 1, 1998 is a Thursday. If getFirstDayOfWeek() is MONDAY and getMinimalDaysInFirstWeek() is 4 (ISO 8601 standard compatible setting), then week 1 of 1998 starts on December 29, 1997, and ends on January 4, 1998. The week year is 1998 for the last three days of calendar year 1997. If, however, getFirstDayOfWeek() is SUNDAY, then week 1 of 1998 starts on January 4, 1998, and ends on January 10, 1998; the first three days of 1998 then are part of week 53 of 1997 and their week year is 1997.
```

So the difference is visible - sometimes - only during the last couple of days of the year. The Error Prone check description says:

```
Use of "YYYY" (week year) in a date pattern without "ww" (week in year). You probably meant to use "yyyy" (year) instead.
```

So this is reported when the YYYY pattern is used but ww is not.

The two instances reported by this check both seem to be harmless - one is in a generator of class names for the bytecode compiler, which are inherently transient, and the other is in the component which invokes `atop`, and the pattern is used to generate a file name for `atop`'s raw data.