### PR TITLE
Minor cleanups

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/index/PageRecordSet.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/PageRecordSet.java
@@ -87,10 +87,7 @@ public class PageRecordSet
         public boolean advanceNextPosition()
         {
             position++;
-            if (position >= page.getPositionCount()) {
-                return false;
-            }
-            return true;
+            return position < page.getPositionCount();
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeUtils.java
@@ -292,14 +292,14 @@ public final class BytecodeUtils
         Class<?> unboxedReturnType = Primitives.unwrap(returnType);
 
         List<Class<?>> stackTypes = new ArrayList<>();
-        boolean boundInstance = false;
+        boolean instanceIsBound = false;
         while (currentParameterIndex < methodType.parameterArray().length) {
             Class<?> type = methodType.parameterArray()[currentParameterIndex];
             stackTypes.add(type);
-            if (instance.isPresent() && !boundInstance) {
+            if (instance.isPresent() && !instanceIsBound) {
                 checkState(type.equals(functionInvoker.getInstanceFactory().get().type().returnType()), "Mismatched type for instance parameter");
                 block.append(instance.get());
-                boundInstance = true;
+                instanceIsBound = true;
             }
             else if (type == ConnectorSession.class) {
                 block.append(scope.getVariable("session"));

--- a/core/trino-spi/src/main/java/io/trino/spi/type/FixedWidthType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/FixedWidthType.java
@@ -22,7 +22,7 @@ public interface FixedWidthType
         extends Type
 {
     /**
-     * Gets the size of a value of this type is bytes. All values
+     * Gets the size of a value of this type in bytes. All values
      * of a FixedWidthType are the same size.
      */
     int getFixedSize();

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -202,10 +202,7 @@ public abstract class BaseJdbcClient
 
     protected boolean filterSchema(String schemaName)
     {
-        if (schemaName.equalsIgnoreCase("information_schema")) {
-            return false;
-        }
-        return true;
+        return !schemaName.equalsIgnoreCase("information_schema");
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/StandardColumnMappings.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/StandardColumnMappings.java
@@ -518,12 +518,12 @@ public final class StandardColumnMappings
     {
         long precision = timestampType.getPrecision();
         checkArgument(precision <= TimestampType.MAX_SHORT_PRECISION, "Precision is out of range: %s", precision);
-        Instant instant = localDateTime.atZone(UTC).toInstant();
-        long epochMicros = instant.getEpochSecond() * MICROSECONDS_PER_SECOND + roundDiv(instant.getNano(), NANOSECONDS_PER_MICROSECOND);
+        long epochMicros = localDateTime.toEpochSecond(UTC) * MICROSECONDS_PER_SECOND
+                + localDateTime.getNano() / NANOSECONDS_PER_MICROSECOND;
         verify(
                 epochMicros == round(epochMicros, TimestampType.MAX_SHORT_PRECISION - timestampType.getPrecision()),
                 "Invalid value of epochMicros for precision %s: %s",
-                timestampType.getPrecision(),
+                precision,
                 epochMicros);
         return epochMicros;
     }
@@ -532,13 +532,13 @@ public final class StandardColumnMappings
     {
         long precision = timestampType.getPrecision();
         checkArgument(precision > TimestampType.MAX_SHORT_PRECISION, "Precision is out of range: %s", precision);
-        Instant instant = localDateTime.atZone(UTC).toInstant();
-        long epochMicros = instant.getEpochSecond() * MICROSECONDS_PER_SECOND + floorDiv(instant.getNano(), NANOSECONDS_PER_MICROSECOND);
-        int picosOfMicro = (instant.getNano() % NANOSECONDS_PER_MICROSECOND) * PICOSECONDS_PER_NANOSECOND;
+        long epochMicros = localDateTime.toEpochSecond(UTC) * MICROSECONDS_PER_SECOND
+                + localDateTime.getNano() / NANOSECONDS_PER_MICROSECOND;
+        int picosOfMicro = (localDateTime.getNano() % NANOSECONDS_PER_MICROSECOND) * PICOSECONDS_PER_NANOSECOND;
         verify(
                 picosOfMicro == round(picosOfMicro, TimestampType.MAX_PRECISION - timestampType.getPrecision()),
                 "Invalid value of picosOfMicro for precision %s: %s",
-                timestampType.getPrecision(),
+                precision,
                 picosOfMicro);
         return new LongTimestamp(epochMicros, picosOfMicro);
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderPageSource.java
@@ -21,9 +21,10 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * A wrapper class for
- * - delegate reader page source and
- * - columns to be read by the delegate (present only if different from the columns desired by the connector pagesource)
- * <p>
+ * <ul>
+ * <li> delegate reader page source and
+ * <li> columns to be read by the delegate (present only if different from the columns desired by the connector pagesource)
+ * </ul>
  */
 public class ReaderPageSource
 {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -965,12 +965,9 @@ public class IcebergMetadata
 
     private boolean isMaterializedView(Table table)
     {
-        if (table.getTableType().equals(VIRTUAL_VIEW.name()) &&
-                "true".equals(table.getParameters().get(PRESTO_VIEW_FLAG)) &&
-                table.getParameters().containsKey(STORAGE_TABLE)) {
-            return true;
-        }
-        return false;
+        return table.getTableType().equals(VIRTUAL_VIEW.name())
+                && "true".equals(table.getParameters().get(PRESTO_VIEW_FLAG))
+                && table.getParameters().containsKey(STORAGE_TABLE);
     }
 
     private boolean isMaterializedView(ConnectorSession session, SchemaTableName schemaTableName)

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordCursor.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordCursor.java
@@ -173,10 +173,7 @@ public class PrometheusRecordCursor
     public boolean isNull(int field)
     {
         checkArgument(field < columnHandles.size(), "Invalid field index");
-        if (getFieldValue(field) == null) {
-            return true;
-        }
-        return false;
+        return getFieldValue(field) == null;
     }
 
     private void checkFieldType(int field, Type expected)

--- a/testing/trino-testng-services/src/main/java/io/trino/testng/services/ReportUnannotatedMethods.java
+++ b/testing/trino-testng-services/src/main/java/io/trino/testng/services/ReportUnannotatedMethods.java
@@ -101,10 +101,7 @@ public class ReportUnannotatedMethods
         }
 
         if (method.getDeclaringClass().isInterface()) {
-            if (isTemptoClass(method.getDeclaringClass())) {
-                return true;
-            }
-            return false;
+            return isTemptoClass(method.getDeclaringClass());
         }
 
         for (Class<?> interfaceClass : method.getDeclaringClass().getInterfaces()) {


### PR DESCRIPTION
- Use `LocalDateTime` without converting to `Instant` in
  `StandardColumnMappings.to(Presto|Long)Timestamp`
- Fix a typo
- Rename one variable to be more explicit
- Use HTML list instead of markdown-like plain text list in a Javadoc
