### PR TITLE
Make AbstractTestIntegrationSmokeTest extend AbstractTestQueries

### DIFF
--- a/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloDistributedQueries.java
+++ b/plugin/trino-accumulo/src/test/java/io/trino/plugin/accumulo/TestAccumuloDistributedQueries.java
@@ -13,10 +13,8 @@
  */
 package io.trino.plugin.accumulo;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.AbstractTestDistributedQueries;
-import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
 import org.intellij.lang.annotations.Language;
@@ -26,7 +24,6 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static io.trino.plugin.accumulo.AccumuloQueryRunner.createAccumuloQueryRunner;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -190,122 +187,6 @@ public class TestAccumuloDistributedQueries
         finally {
             assertUpdate("DROP TABLE test_insert_duplicate");
         }
-    }
-
-    @Override
-    public void testScalarSubquery()
-    {
-        // Override because of extra UUID column in lineitem table, cannot SELECT *
-
-        // nested
-        assertQuery("SELECT (SELECT (SELECT (SELECT 1)))");
-
-        // aggregation
-        assertQuery("SELECT "
-                + "orderkey, partkey, suppkey, linenumber, quantity, "
-                + "extendedprice, discount, tax, returnflag, linestatus, "
-                + "shipdate, commitdate, receiptdate, shipinstruct, shipmode, comment "
-                + "FROM lineitem WHERE orderkey = \n"
-                + "(SELECT max(orderkey) FROM orders)");
-
-        // no output
-        assertQuery("SELECT "
-                + "orderkey, partkey, suppkey, linenumber, quantity, "
-                + "extendedprice, discount, tax, returnflag, linestatus, "
-                + "shipdate, commitdate, receiptdate, shipinstruct, shipmode, comment "
-                + "FROM lineitem WHERE orderkey = \n"
-                + "(SELECT orderkey FROM orders WHERE 0=1)");
-
-        // no output matching with null test
-        assertQuery("SELECT "
-                + "orderkey, partkey, suppkey, linenumber, quantity, "
-                + "extendedprice, discount, tax, returnflag, linestatus, "
-                + "shipdate, commitdate, receiptdate, shipinstruct, shipmode, comment "
-                + "FROM lineitem WHERE \n"
-                + "(SELECT orderkey FROM orders WHERE 0=1) "
-                + "is null");
-        assertQuery("SELECT "
-                + "orderkey, partkey, suppkey, linenumber, quantity, "
-                + "extendedprice, discount, tax, returnflag, linestatus, "
-                + "shipdate, commitdate, receiptdate, shipinstruct, shipmode, comment "
-                + "FROM lineitem WHERE \n"
-                + "(SELECT orderkey FROM orders WHERE 0=1) "
-                + "is not null");
-
-        // subquery results and an in-predicate
-        assertQuery("SELECT (SELECT 1) IN (1, 2, 3)");
-        assertQuery("SELECT (SELECT 1) IN (   2, 3)");
-
-        // multiple subqueries
-        assertQuery("SELECT (SELECT 1) = (SELECT 3)");
-        assertQuery("SELECT (SELECT 1) < (SELECT 3)");
-        assertQuery("SELECT COUNT(*) FROM lineitem WHERE " +
-                "(SELECT min(orderkey) FROM orders)" +
-                "<" +
-                "(SELECT max(orderkey) FROM orders)");
-
-        // distinct
-        assertQuery("SELECT DISTINCT orderkey FROM lineitem " +
-                "WHERE orderkey BETWEEN" +
-                "   (SELECT avg(orderkey) FROM orders) - 10 " +
-                "   AND" +
-                "   (SELECT avg(orderkey) FROM orders) + 10");
-
-        // subqueries with joins
-        for (String joinType : ImmutableList.of("INNER", "LEFT OUTER")) {
-            assertQuery("SELECT l.orderkey, COUNT(*) " +
-                    "FROM lineitem l " + joinType + " JOIN orders o ON l.orderkey = o.orderkey " +
-                    "WHERE l.orderkey BETWEEN" +
-                    "   (SELECT avg(orderkey) FROM orders) - 10 " +
-                    "   AND" +
-                    "   (SELECT avg(orderkey) FROM orders) + 10 " +
-                    "GROUP BY l.orderkey");
-        }
-
-        // subqueries with ORDER BY
-        assertQuery("SELECT orderkey, totalprice FROM orders ORDER BY (SELECT 2)");
-
-        // subquery returns multiple rows
-        String multipleRowsErrorMsg = "Scalar sub-query has returned multiple rows";
-        assertQueryFails("SELECT "
-                        + "orderkey, partkey, suppkey, linenumber, quantity, "
-                        + "extendedprice, discount, tax, returnflag, linestatus, "
-                        + "shipdate, commitdate, receiptdate, shipinstruct, shipmode, comment "
-                        + "FROM lineitem WHERE orderkey = (\n"
-                        + "SELECT orderkey FROM orders ORDER BY totalprice)",
-                multipleRowsErrorMsg);
-        assertQueryFails("SELECT orderkey, totalprice FROM orders ORDER BY (VALUES 1, 2)",
-                multipleRowsErrorMsg);
-
-        // exposes a bug in optimize hash generation because EnforceSingleNode does not
-        // support more than one column from the underlying query
-        assertQuery("SELECT custkey, (SELECT DISTINCT custkey FROM orders ORDER BY custkey LIMIT 1) FROM orders");
-    }
-
-    @Override
-    public void testShowColumns()
-    {
-        // Override base class because table descriptions for Accumulo connector include comments
-        MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
-
-        assertEquals(actual.getMaterializedRows().get(0).getField(0), "orderkey");
-        assertEquals(actual.getMaterializedRows().get(0).getField(1), "bigint");
-        assertEquals(actual.getMaterializedRows().get(1).getField(0), "custkey");
-        assertEquals(actual.getMaterializedRows().get(1).getField(1), "bigint");
-        assertEquals(actual.getMaterializedRows().get(2).getField(0), "orderstatus");
-        assertEquals(actual.getMaterializedRows().get(2).getField(1), "varchar(1)");
-        assertEquals(actual.getMaterializedRows().get(3).getField(0), "totalprice");
-        assertEquals(actual.getMaterializedRows().get(3).getField(1), "double");
-        assertEquals(actual.getMaterializedRows().get(4).getField(0), "orderdate");
-        assertEquals(actual.getMaterializedRows().get(4).getField(1), "date");
-        assertEquals(actual.getMaterializedRows().get(5).getField(0), "orderpriority");
-        assertEquals(actual.getMaterializedRows().get(5).getField(1), "varchar(15)");
-        assertEquals(actual.getMaterializedRows().get(6).getField(0), "clerk");
-        assertEquals(actual.getMaterializedRows().get(6).getField(1), "varchar(15)");
-        assertEquals(actual.getMaterializedRows().get(7).getField(0), "shippriority");
-        assertEquals(actual.getMaterializedRows().get(7).getField(1), "integer");
-        assertEquals(actual.getMaterializedRows().get(8).getField(0), "comment");
-        assertEquals(actual.getMaterializedRows().get(8).getField(1), "varchar(79)");
     }
 
     @Test

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/BaseCassandraDistributedQueries.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/BaseCassandraDistributedQueries.java
@@ -14,15 +14,11 @@
 package io.trino.plugin.cassandra;
 
 import io.trino.testing.AbstractTestDistributedQueries;
-import io.trino.testing.MaterializedResult;
 import io.trino.testing.sql.TestTable;
 import org.testng.SkipException;
 
 import java.util.Optional;
 
-import static io.trino.spi.type.VarcharType.VARCHAR;
-import static io.trino.testing.MaterializedResult.resultBuilder;
-import static io.trino.testing.assertions.Assert.assertEquals;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public abstract class BaseCassandraDistributedQueries
@@ -87,26 +83,6 @@ public abstract class BaseCassandraDistributedQueries
     {
         assertThatThrownBy(super::testDelete)
                 .hasStackTraceContaining("This connector only supports delete with primary key or partition key");
-    }
-
-    @Override
-    public void testShowColumns()
-    {
-        MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
-
-        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "bigint", "", "")
-                .row("custkey", "bigint", "", "")
-                .row("orderstatus", "varchar", "", "")
-                .row("totalprice", "double", "", "")
-                .row("orderdate", "date", "", "")
-                .row("orderpriority", "varchar", "", "")
-                .row("clerk", "varchar", "", "")
-                .row("shippriority", "integer", "", "")
-                .row("comment", "varchar", "", "")
-                .build();
-
-        assertEquals(actual, expectedParametrizedVarchar);
     }
 
     @Override

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraIntegrationSmokeTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraIntegrationSmokeTest.java
@@ -135,6 +135,26 @@ public class TestCassandraIntegrationSmokeTest
                         ")");
     }
 
+    @Override
+    public void testShowColumns()
+    {
+        MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
+
+        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "bigint", "", "")
+                .row("custkey", "bigint", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("totalprice", "double", "", "")
+                .row("orderdate", "date", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("clerk", "varchar", "", "")
+                .row("shippriority", "integer", "", "")
+                .row("comment", "varchar", "", "")
+                .build();
+
+        Assert.assertEquals(actual, expectedParametrizedVarchar);
+    }
+
     @Test
     public void testPartitionKeyPredicate()
     {

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduIntegrationSmokeTest.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/AbstractKuduIntegrationSmokeTest.java
@@ -118,6 +118,26 @@ public abstract class AbstractKuduIntegrationSmokeTest
         assertUpdate("DROP TABLE test_show_create_table");
     }
 
+    @Override
+    public void testShowColumns()
+    {
+        MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
+
+        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "bigint", "nullable, encoding=auto, compression=default", "")
+                .row("custkey", "bigint", "nullable, encoding=auto, compression=default", "")
+                .row("orderstatus", "varchar", "nullable, encoding=auto, compression=default", "")
+                .row("totalprice", "double", "nullable, encoding=auto, compression=default", "")
+                .row("orderdate", "varchar", "nullable, encoding=auto, compression=default", "")
+                .row("orderpriority", "varchar", "nullable, encoding=auto, compression=default", "")
+                .row("clerk", "varchar", "nullable, encoding=auto, compression=default", "")
+                .row("shippriority", "integer", "nullable, encoding=auto, compression=default", "")
+                .row("comment", "varchar", "nullable, encoding=auto, compression=default", "")
+                .build();
+
+        assertEquals(actual, expectedParametrizedVarchar);
+    }
+
     @Test
     public void testRowDelete()
     {

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduDistributedQueries.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduDistributedQueries.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.kudu;
 
 import io.trino.testing.AbstractTestDistributedQueries;
-import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
 import io.trino.tpch.TpchTable;
@@ -25,9 +24,6 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static io.trino.plugin.kudu.KuduQueryRunnerFactory.createKuduQueryRunnerTpch;
-import static io.trino.spi.type.VarcharType.VARCHAR;
-import static io.trino.testing.MaterializedResult.resultBuilder;
-import static io.trino.testing.assertions.Assert.assertEquals;
 
 public class TestKuduDistributedQueries
         extends AbstractTestDistributedQueries
@@ -120,26 +116,6 @@ public class TestKuduDistributedQueries
     public void testDelete()
     {
         // TODO Support these test once kudu connector can create tables with default partitions
-    }
-
-    @Override
-    public void testShowColumns()
-    {
-        MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
-
-        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "bigint", "nullable, encoding=auto, compression=default", "")
-                .row("custkey", "bigint", "nullable, encoding=auto, compression=default", "")
-                .row("orderstatus", "varchar", "nullable, encoding=auto, compression=default", "")
-                .row("totalprice", "double", "nullable, encoding=auto, compression=default", "")
-                .row("orderdate", "varchar", "nullable, encoding=auto, compression=default", "")
-                .row("orderpriority", "varchar", "nullable, encoding=auto, compression=default", "")
-                .row("clerk", "varchar", "nullable, encoding=auto, compression=default", "")
-                .row("shippriority", "integer", "nullable, encoding=auto, compression=default", "")
-                .row("comment", "varchar", "nullable, encoding=auto, compression=default", "")
-                .build();
-
-        assertEquals(actual, expectedParametrizedVarchar);
     }
 
     @Override

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlDistributedQueries.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlDistributedQueries.java
@@ -130,15 +130,6 @@ public class TestMemSqlDistributedQueries
     }
 
     @Override
-    public void testLargeIn(int valuesCount)
-    {
-        // Running this tests on MemSQL results in
-        // "Available disk space is below the value of 'minimal_disk_space' global variable (100 MB). This query cannot be executed"
-        // on followup tests
-        throw new SkipException("Running testLargeIn on MemSQL results in out-of-disk space errors");
-    }
-
-    @Override
     public void testInsertUnicode()
     {
         // MemSQL's utf8 encoding is 3 bytes and truncates strings upon encountering a 4 byte sequence

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlIntegrationSmokeTest.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlIntegrationSmokeTest.java
@@ -20,6 +20,7 @@ import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -56,6 +57,15 @@ public class TestMemSqlIntegrationSmokeTest
     public final void destroy()
     {
         memSqlServer.close();
+    }
+
+    @Override
+    public void testLargeIn(int valuesCount)
+    {
+        // Running this tests on MemSQL results in
+        // "Available disk space is below the value of 'minimal_disk_space' global variable (100 MB). This query cannot be executed"
+        // on followup tests
+        throw new SkipException("Running testLargeIn on MemSQL results in out-of-disk space errors");
     }
 
     @Test

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlIntegrationSmokeTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlIntegrationSmokeTest.java
@@ -79,6 +79,26 @@ abstract class BaseMySqlIntegrationSmokeTest
                         ")");
     }
 
+    @Override
+    public void testShowColumns()
+    {
+        MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
+
+        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "bigint", "", "")
+                .row("custkey", "bigint", "", "")
+                .row("orderstatus", "varchar(255)", "", "")
+                .row("totalprice", "double", "", "")
+                .row("orderdate", "date", "", "")
+                .row("orderpriority", "varchar(255)", "", "")
+                .row("clerk", "varchar(255)", "", "")
+                .row("shippriority", "integer", "", "")
+                .row("comment", "varchar(255)", "", "")
+                .build();
+
+        assertEquals(actual, expectedParametrizedVarchar);
+    }
+
     @Test
     public void testDropTable()
     {

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlDistributedQueries.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlDistributedQueries.java
@@ -15,7 +15,6 @@ package io.trino.plugin.mysql;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.AbstractTestDistributedQueries;
-import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
 import io.trino.tpch.TpchTable;
@@ -24,9 +23,6 @@ import java.util.Optional;
 
 import static com.google.common.base.Strings.nullToEmpty;
 import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
-import static io.trino.spi.type.VarcharType.VARCHAR;
-import static io.trino.testing.MaterializedResult.resultBuilder;
-import static io.trino.testing.assertions.Assert.assertEquals;
 
 public class TestMySqlDistributedQueries
         extends AbstractTestDistributedQueries
@@ -90,26 +86,6 @@ public class TestMySqlDistributedQueries
                         "col_default BIGINT DEFAULT 43," +
                         "col_nonnull_default BIGINT NOT NULL DEFAULT 42," +
                         "col_required2 BIGINT NOT NULL)");
-    }
-
-    @Override
-    public void testShowColumns()
-    {
-        MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
-
-        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "bigint", "", "")
-                .row("custkey", "bigint", "", "")
-                .row("orderstatus", "varchar(255)", "", "")
-                .row("totalprice", "double", "", "")
-                .row("orderdate", "date", "", "")
-                .row("orderpriority", "varchar(255)", "", "")
-                .row("clerk", "varchar(255)", "", "")
-                .row("shippriority", "integer", "", "")
-                .row("comment", "varchar(255)", "", "")
-                .build();
-
-        assertEquals(actual, expectedParametrizedVarchar);
     }
 
     @Override

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleIntegrationSmokeTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleIntegrationSmokeTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
@@ -72,6 +73,39 @@ public abstract class BaseOracleIntegrationSmokeTest
                         "   shippriority decimal(10, 0),\n" +
                         "   comment varchar(79)\n" +
                         ")");
+    }
+
+    @Override
+    public void testShowColumns()
+    {
+        MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
+
+        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("orderkey", "decimal(19,0)", "", "")
+                .row("custkey", "decimal(19,0)", "", "")
+                .row("orderstatus", "varchar(1)", "", "")
+                .row("totalprice", "double", "", "")
+                .row("orderdate", "timestamp(3)", "", "")
+                .row("orderpriority", "varchar(15)", "", "")
+                .row("clerk", "varchar(15)", "", "")
+                .row("shippriority", "decimal(10,0)", "", "")
+                .row("comment", "varchar(79)", "", "")
+                .build();
+
+        // Until we migrate all connectors to parametrized varchar we check two options
+        assertTrue(actual.equals(expectedParametrizedVarchar),
+                format("%s does not matches %s", actual, expectedParametrizedVarchar));
+    }
+
+    @Override
+    public void testInformationSchemaFiltering()
+    {
+        assertQuery(
+                "SELECT table_name FROM information_schema.tables WHERE table_name = 'orders' LIMIT 1",
+                "SELECT 'orders' table_name");
+        assertQuery(
+                "SELECT table_name FROM information_schema.columns WHERE data_type = 'decimal(19,0)' AND table_name = 'customer' AND column_name = 'custkey' LIMIT 1",
+                "SELECT 'customer' table_name");
     }
 
     @Test

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseTestOracleDistributedQueries.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseTestOracleDistributedQueries.java
@@ -24,10 +24,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static io.trino.spi.type.VarcharType.VARCHAR;
-import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
-import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -238,40 +235,6 @@ public abstract class BaseTestOracleDistributedQueries
         assertTrue(queryInfo.getQueryStats().getLogicalWrittenDataSize().toBytes() > 0L);
 
         assertUpdate("DROP TABLE " + tableName);
-    }
-
-    @Test
-    @Override
-    public void testShowColumns()
-    {
-        MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
-
-        MaterializedResult expectedParametrizedVarchar = resultBuilder(getSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
-                .row("orderkey", "decimal(19,0)", "", "")
-                .row("custkey", "decimal(19,0)", "", "")
-                .row("orderstatus", "varchar(1)", "", "")
-                .row("totalprice", "double", "", "")
-                .row("orderdate", "timestamp(3)", "", "")
-                .row("orderpriority", "varchar(15)", "", "")
-                .row("clerk", "varchar(15)", "", "")
-                .row("shippriority", "decimal(10,0)", "", "")
-                .row("comment", "varchar(79)", "", "")
-                .build();
-
-        // Until we migrate all connectors to parametrized varchar we check two options
-        assertTrue(actual.equals(expectedParametrizedVarchar),
-                format("%s does not matches %s", actual, expectedParametrizedVarchar));
-    }
-
-    @Override
-    public void testInformationSchemaFiltering()
-    {
-        assertQuery(
-                "SELECT table_name FROM information_schema.tables WHERE table_name = 'orders' LIMIT 1",
-                "SELECT 'orders' table_name");
-        assertQuery(
-                "SELECT table_name FROM information_schema.columns WHERE data_type = 'decimal(19,0)' AND table_name = 'customer' AND column_name = 'custkey' LIMIT 1",
-                "SELECT 'customer' table_name");
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
@@ -69,7 +69,7 @@ import static org.testng.Assert.assertTrue;
  * @see AbstractTestIntegrationSmokeTest
  */
 public abstract class AbstractTestDistributedQueries
-        extends AbstractTestQueries
+        extends AbstractTestQueryFramework
 {
     protected boolean supportsDelete()
     {

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestIntegrationSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestIntegrationSmokeTest.java
@@ -39,7 +39,7 @@ import static org.testng.Assert.assertTrue;
  * @see AbstractTestDistributedQueries
  */
 public abstract class AbstractTestIntegrationSmokeTest
-        extends AbstractTestQueryFramework
+        extends AbstractTestQueries
 {
     /**
      * Ensure the tests are run with {@link DistributedQueryRunner}. E.g. {@link LocalQueryRunner} takes some
@@ -162,12 +162,6 @@ public abstract class AbstractTestIntegrationSmokeTest
     }
 
     @Test
-    public void testLimit()
-    {
-        assertEquals(computeActual("SELECT * FROM orders LIMIT 10").getRowCount(), 10);
-    }
-
-    @Test
     public void testMultipleRangesPredicate()
     {
         // List columns explicitly. Some connectors do not maintain column ordering.
@@ -256,27 +250,6 @@ public abstract class AbstractTestIntegrationSmokeTest
                         "FROM (SELECT name, regionkey, nationkey, count(*) count FROM nation GROUP BY name, regionkey, nationkey) n " +
                         "JOIN customer c ON c.nationkey = n.nationkey " +
                         "JOIN region r ON n.regionkey = r.regionkey");
-    }
-
-    @Test
-    public void testShowSchemas()
-    {
-        MaterializedResult actualSchemas = computeActual("SHOW SCHEMAS").toTestTypes();
-
-        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR)
-                .row(getQueryRunner().getDefaultSession().getSchema().orElse("tpch"));
-
-        assertContains(actualSchemas, resultBuilder.build());
-    }
-
-    @Test
-    public void testShowTables()
-    {
-        MaterializedResult actualTables = computeActual("SHOW TABLES").toTestTypes();
-        MaterializedResult expectedTables = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR)
-                .row("orders")
-                .build();
-        assertContains(actualTables, expectedTables);
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
@@ -902,7 +902,7 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void testPredicatePushdown()
+    public void testPredicate()
     {
         assertQuery("" +
                 "SELECT *\n" +


### PR DESCRIPTION
Make `AbstractTestIntegrationSmokeTest` extend `AbstractTestQueries` instead
of `AbstractTestDistributedQueries`. `AbstractTestIntegrationSmokeTest`
are meant to be run by read-only connectors and
`AbstractTestDistributedQueries` are meant to be run by connectors
supporting read/write, and `AbstractTestQueries` are applicable to
read-only connectors.