### PR TITLE
Use full commit SHA for third-party cleanup action

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -8,7 +8,7 @@ jobs:
   cancel:
     runs-on: ubuntu-latest
     steps:
-      - uses: n1hility/cancel-previous-runs@2e3c189
+      - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
         with:
           token: ${{ github.token }}
           workflow: ci.yml


### PR DESCRIPTION
Recent change in GitHub requires all third-party action calls
use full SHA commit of the third-party action to ensure code immutability
For more details, see:
https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions