### PR TITLE
Remove API for unconditional port exposure

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/TestRun.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/TestRun.java
@@ -47,11 +47,11 @@ import java.util.concurrent.Callable;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.tests.product.launcher.cli.Commands.runCommand;
-import static io.trino.tests.product.launcher.docker.ContainerUtil.exposePort;
 import static io.trino.tests.product.launcher.env.DockerContainer.cleanOrCreateHostPath;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static io.trino.tests.product.launcher.env.EnvironmentListener.getStandardListeners;
 import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_TEMPTO_PROFILE_CONFIG;
+import static io.trino.tests.product.launcher.testcontainers.PortBinder.unsafelyExposePort;
 import static java.lang.StrictMath.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.containers.BindMode.READ_ONLY;
@@ -252,7 +252,7 @@ public final class TestRun
                 if (debug) {
                     temptoJavaOptions = new ArrayList<>(temptoJavaOptions);
                     temptoJavaOptions.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5007");
-                    exposePort(container, 5007); // debug port
+                    unsafelyExposePort(container, 5007); // debug port
                 }
 
                 if (System.getenv("CONTINUOUS_INTEGRATION") != null) {

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/docker/ContainerUtil.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/docker/ContainerUtil.java
@@ -20,7 +20,6 @@ import com.github.dockerjava.api.exception.ConflictException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.Network;
-import io.trino.tests.product.launcher.env.DockerContainer;
 import io.trino.tests.product.launcher.testcontainers.SelectedPortWaitStrategy;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
@@ -74,12 +73,6 @@ public final class ContainerUtil
         dockerClient.removeContainerCmd("testcontainers-ryuk-" + DockerClientFactory.SESSION_ID)
                 .withForce(true)
                 .exec();
-    }
-
-    public static void exposePort(DockerContainer container, int port)
-    {
-        container.addExposedPort(port);
-        container.withFixedExposedPort(port, port);
     }
 
     public static WaitStrategy forSelectedPorts(int... ports)

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
@@ -38,11 +38,11 @@ import java.time.Duration;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static io.trino.tests.product.launcher.docker.ContainerUtil.exposePort;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.TESTS;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.WORKER;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.WORKER_NTH;
+import static io.trino.tests.product.launcher.testcontainers.PortBinder.unsafelyExposePort;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -182,7 +182,7 @@ public final class Standard
             container.withCopyFileToContainer(forHostPath(script), "/docker/presto-init.d/enable-java-debugger.sh");
 
             // expose debug port unconditionally when debug is enabled
-            exposePort(container, debugPort);
+            unsafelyExposePort(container, debugPort);
         }
         catch (IOException e) {
             throw new UncheckedIOException(e);


### PR DESCRIPTION
This removes the possibility to misuse this API.

Unconditional port exposure is used only for opening debugging ports.