### PR TITLE
Update docs for hive.write-precision to include writes

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -294,10 +294,10 @@ Property Name                                      Description                  
 ``hive.orc.time-zone``                             Sets the default time zone for legacy ORC files that did     JVM default
                                                    not declare a time zone.
 
-``hive.timestamp-precision``                       Specifies the precision to use for columns of type           ``MILLISECONDS``
+``hive.timestamp-precision``                       Specifies the precision to use for Hive columns of type      ``MILLISECONDS``
                                                    ``timestamp``. Possible values are ``MILLISECONDS``,
-                                                   ``MICROSECONDS`` and ``NANOSECONDS``. Write operations
-                                                   are only supported for ``MILLISECONDS``.
+                                                   ``MICROSECONDS`` and ``NANOSECONDS``. Values with higher
+                                                   precision than configured are rounded.
 
 ``hive.temporary-staging-directory-enabled``       Controls whether the temporary staging directory configured  ``true``
                                                    at ``hive.temporary-staging-directory-path`` should be

--- a/docs/src/main/sphinx/release/release-352.md
+++ b/docs/src/main/sphinx/release/release-352.md
@@ -59,7 +59,7 @@
 * Match columns by name rather than by index by default for Parquet files. ({issue}`6479`)
 * Remove the `hive.partition-use-column-names` configuration property and the
   `partition_use_column_names ` session property. This is now determined automatically. ({issue}`6479`)
-* Support reading timestamp with microsecond or nanosecond precision (as configured with 
+* Support timestamps with microsecond or nanosecond precision (as configured with
   `hive.timestamp-precision` property) nested within `array`, `map` or `struct` data types. ({issue}`5195`)
 * Support reading from table in Sequencefile format that uses LZO compression. ({issue}`6452`)
 * Expose AWS HTTP Client stats via JMX. ({issue}`6503`)


### PR DESCRIPTION
This replaces "write opreations are only supported for `MILLISECONDS`" with "values with higher precision than configured will be rounded," and adds "in Trino" and "Hive" to make the preceding sentence clearer.
