### PR TITLE
Indicate constraint in JdbcTableHandle.toString

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -235,6 +236,16 @@ public final class JdbcTableHandle
     {
         StringBuilder builder = new StringBuilder();
         builder.append(relationHandle);
+        if (constraint.isNone()) {
+            builder.append(" constraint=FALSE");
+        }
+        else if (!constraint.isAll()) {
+            builder.append(" constraint on ");
+            builder.append(constraint.getDomains().orElseThrow().keySet().stream()
+                    // TODO constraint should be defined on JdbcTableHandle
+                    .map(columnHandle -> ((JdbcColumnHandle) columnHandle).getColumnName())
+                    .collect(Collectors.joining(", ", "[", "]")));
+        }
         sortOrder.ifPresent(value -> builder.append(" sortOrder=").append(value));
         limit.ifPresent(value -> builder.append(" limit=").append(value));
         columns.ifPresent(value -> builder.append(" columns=").append(value));

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -169,6 +169,15 @@ public abstract class BaseConnectorTest
     }
 
     @Test
+    public void testPredicateReflectedInExplain()
+    {
+        // Even if the predicate is pushed down into the table scan, it should still be reflected in EXPLAIN (via ConnectorTableHandle.toString)
+        assertExplain(
+                "EXPLAIN SELECT name FROM nation WHERE nationkey = 42",
+                "(predicate|filterPredicate|constraint).{0,10}(nationkey|NATIONKEY)");
+    }
+
+    @Test
     public void testConcurrentScans()
     {
         String unionMultipleTimes = join(" UNION ALL ", nCopies(25, "SELECT * FROM orders"));


### PR DESCRIPTION
The `toString` is used by `EXPLAIN` to provide information for the user.

Fixes https://github.com/trinodb/trino/issues/5548
Refs https://github.com/trinodb/trino/issues/6953 cc @2DKot 