### PR TITLE
Verify table metadata in SHOW COLUMNS

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
@@ -150,8 +150,14 @@ public class TestJdbcIntegrationSmokeTest
                     session,
                     "SHOW CREATE TABLE " + table.getName(),
                     unsupportedTableErrorMessage);
-            assertQueryReturnsEmptyResult(session, "SHOW COLUMNS FROM " + table.getName());
-            assertQueryReturnsEmptyResult(session, "DESCRIBE " + table.getName());
+            assertQueryFails(
+                    session,
+                    "SHOW COLUMNS FROM " + table.getName(),
+                    unsupportedTableErrorMessage);
+            assertQueryFails(
+                    session,
+                    "DESCRIBE " + table.getName(),
+                    unsupportedTableErrorMessage);
         }
     }
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcIntegrationSmokeTest.java
@@ -30,6 +30,7 @@ import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.UNSUPPORTED
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.IGNORE;
 import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestJdbcIntegrationSmokeTest
         // TODO extend BaseConnectorTest
@@ -117,6 +118,40 @@ public class TestJdbcIntegrationSmokeTest
                     convertToVarcharUnsupportedTypes,
                     "SELECT * FROM " + table.getName(),
                     "VALUES (1, NULL), (2, 'POINT (7 52)'), (3, NULL)");
+        }
+    }
+
+    @Test
+    public void testTableWithOnlyUnsupportedColumns()
+    {
+        Session session = Session.builder(getSession())
+                .setSchema("public")
+                .build();
+        try (TestTable table = new TestTable(getSqlExecutor(), "unsupported_table", "(geometry_column GEOMETRY)", ImmutableList.of("NULL", "'POINT(7 52)'"))) {
+            // SELECT all tables to avoid any optimizations that could skip the table listing
+            assertThat(getQueryRunner().execute("SELECT table_name FROM information_schema.tables").getOnlyColumn())
+                    .contains(table.getName());
+            assertQuery(
+                    format("SELECT count(*) FROM information_schema.tables WHERE table_name = '%s'", table.getName()),
+                    "SELECT 1");
+            assertQuery(
+                    format("SELECT count(*) FROM information_schema.columns WHERE table_name = '%s'", table.getName()),
+                    "SELECT 0");
+            assertQuery(
+                    session,
+                    format("SHOW TABLES LIKE '%s'", table.getName()),
+                    format("SELECT '%s'", table.getName()));
+            String unsupportedTableErrorMessage = "Table 'public.*' has no supported columns.*";
+            assertQueryFails(
+                    session,
+                    "SELECT * FROM " + table.getName(),
+                    unsupportedTableErrorMessage);
+            assertQueryFails(
+                    session,
+                    "SHOW CREATE TABLE " + table.getName(),
+                    unsupportedTableErrorMessage);
+            assertQueryReturnsEmptyResult(session, "SHOW COLUMNS FROM " + table.getName());
+            assertQueryReturnsEmptyResult(session, "DESCRIBE " + table.getName());
         }
     }
 

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -200,8 +200,8 @@ public class TestPostgreSqlConnectorTest
             assertQueryFails("SELECT * FROM non_existent", ".* Table .*tpch.non_existent.* does not exist");
             assertQueryFails("SELECT 'a' FROM non_existent", ".* Table .*tpch.non_existent.* does not exist");
 
-            assertQuery("SHOW COLUMNS FROM no_supported_columns", "SELECT 'nothing' WHERE false");
-            assertQuery("SHOW COLUMNS FROM no_columns", "SELECT 'nothing' WHERE false");
+            assertQueryFails("SHOW COLUMNS FROM no_supported_columns", "Table 'tpch.no_supported_columns' not found");
+            assertQueryFails("SHOW COLUMNS FROM no_columns", "Table 'tpch.no_columns' not found");
 
             // Other tables should be visible in SHOW TABLES (the no_supported_columns might be included or might be not) and information_schema.tables
             assertThat(computeActual("SHOW TABLES").getOnlyColumn())


### PR DESCRIPTION
Verify table metadata in SHOW COLUMNS

We are using information_schema which may ignore
errors when getting the list of columns for a table,
since listing columns is a requirement for some tools,
and thus failing due to a single bad table would make the system unusable.

However, when showing columns for a single table,
it is important to fail if the columns are not available,
rather than erroneously returning an empty list.
We thus ask for table metadata, which will hopefully
fail for the same reasons that would cause an empty list of
columns.

We still go through information_schema, even though we appear
to have all the needed information in the table metadata,
so that we use the same code path for all column listing.
Connectors may have different listing logic than for metadata,
and we need to perform security filtering of the returned columns.