### PR TITLE
Add Error Prone check: BadShiftAmount

### DIFF
--- a/core/trino-spi/src/test/java/io/trino/spi/block/BenchmarkComputePosition.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/BenchmarkComputePosition.java
@@ -78,7 +78,7 @@ public class BenchmarkComputePosition
     @Benchmark
     public long computePositionWithDivision()
     {
-        return (int) ((Integer.toUnsignedLong(Long.hashCode(hashcode)) * hashTableSize) / (1 << 32));
+        return (int) ((Integer.toUnsignedLong(Long.hashCode(hashcode)) * hashTableSize) / (1L << 32));
     }
 
     public static void main(String[] args)

--- a/pom.xml
+++ b/pom.xml
@@ -1692,6 +1692,7 @@
                                     -Xep:ArrayToString:ERROR
                                     -Xep:ArraysAsListPrimitiveArray:ERROR
                                     -Xep:BadInstanceof:ERROR
+                                    -Xep:BadShiftAmount:ERROR
                                     -Xep:BoxedPrimitiveConstructor:ERROR
                                     -Xep:ClassCanBeStatic:ERROR
                                     -Xep:CompareToZero:ERROR


### PR DESCRIPTION
The expression `1 << 32` is a no-op on int, which I don't think was intended here.