### PR TITLE
Remove test case in TestSubnetTopology

### DIFF
--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSubnetTopology.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSubnetTopology.java
@@ -32,7 +32,6 @@ public class TestSubnetTopology
         assertEquals(
                 topology.locate(HostAddress.fromString("192.168.0.172")),
                 new NetworkLocation("192.168.0.0", "192.168.0.128", "192.168.0.160", "192.168.0.172"));
-        assertEquals(topology.locate(HostAddress.fromString("localhost")), new NetworkLocation("127.0.0.0", "127.0.0.0", "127.0.0.0", "127.0.0.1"));
 
         SubnetBasedTopology noTopology = new SubnetBasedTopology(ImmutableList.of(), IPv4);
         assertEquals(noTopology.locate(HostAddress.fromString("192.168.0.172")), new NetworkLocation("192.168.0.172"));
@@ -54,10 +53,6 @@ public class TestSubnetTopology
                         "2001:db8::ff00:42:0",
                         "2001:db8::ff00:42:8300",
                         "2001:db8::ff00:42:8329"));
-
-        assertEquals(
-                topology.locate(HostAddress.fromString("localhost")),
-                new NetworkLocation("::", "::", "::", "::", "::1"));
 
         SubnetBasedTopology noTopology = new SubnetBasedTopology(ImmutableList.of(), IPv6);
         assertEquals(noTopology.locate(HostAddress.fromString("2001:db8::ff00:42:8329")), new NetworkLocation("2001:db8::ff00:42:8329"));


### PR DESCRIPTION
Ref: https://trinodb.slack.com/archives/CGB0QHWSW/p1613068842339700?thread_ts=1612492914.246000&cid=CGB0QHWSW

The test seems to fail with the following error on centos with adoptjdk. It looks like `InetAddress.getAllByName(localhost)` returns just IPv4 address on that setup. The OS network library being used there seems to only return IPv4 address but not IPv6. 

```
[ERROR] Tests run: 6868, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 576.23 s <<< FAILURE! - in TestSuite
[ERROR] testSubnetTopologyIpv6(io.trino.execution.scheduler.TestSubnetTopology)  Time elapsed: 0.001 s  <<< FAILURE!
java.lang.AssertionError: expected [NetworkLocation{location=/::/::/::/::/::1}] but found [NetworkLocation{location=/}]
        at org.testng.Assert.fail(Assert.java:94)
        at org.testng.Assert.failNotEquals(Assert.java:513)
        at org.testng.Assert.assertEqualsImpl(Assert.java:135)
        at org.testng.Assert.assertEquals(Assert.java:116)
        at org.testng.Assert.assertEquals(Assert.java:179)
        at io.trino.execution.scheduler.TestSubnetTopology.testSubnetTopologyIpv6(TestSubnetTopology.java:58)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
        at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
        at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
        at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
        at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
        at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

we can remove this test to correct out-of-the-box behavior. IMO the test coverage for this feature is not compromised because we're still testing with other IPv6 addresses. (Also removing the corresponding testcase from IPv4 tests which succeeds.)