### PR TITLE
Avoid reading JDBC connector table properties

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -115,7 +115,18 @@ public interface Metadata
     Optional<Object> getInfo(Session session, TableHandle handle);
 
     /**
+     * Return table schema definition for the specified table handle.
+     * Table schema definition is a set of information
+     * required by semantic analyzer to analyze the query.
+     * @see {@link #getTableMetadata(Session, TableHandle)}
+     *
+     * @throws RuntimeException if table handle is no longer valid
+     */
+    TableSchema getTableSchema(Session session, TableHandle tableHandle);
+
+    /**
      * Return the metadata for the specified table handle.
+     * @see {@link #getTableSchema(Session, TableHandle)} which is less expsensive.
      *
      * @throws RuntimeException if table handle is no longer valid
      */

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -69,6 +69,7 @@ import io.trino.spi.connector.ConnectorTableLayoutHandle;
 import io.trino.spi.connector.ConnectorTableLayoutResult;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableProperties;
+import io.trino.spi.connector.ConnectorTableSchema;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.Constraint;
@@ -506,6 +507,16 @@ public final class MetadataManager
         }
 
         return metadata.getInfo(handle.getConnectorHandle());
+    }
+
+    @Override
+    public TableSchema getTableSchema(Session session, TableHandle tableHandle)
+    {
+        CatalogName catalogName = tableHandle.getCatalogName();
+        ConnectorMetadata metadata = getMetadata(session, catalogName);
+        ConnectorTableSchema tableSchema = metadata.getTableSchema(session.toConnectorSession(catalogName), tableHandle.getConnectorHandle());
+
+        return new TableSchema(catalogName, tableSchema);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/metadata/TableSchema.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableSchema.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import io.trino.connector.CatalogName;
+import io.trino.spi.connector.ColumnSchema;
+import io.trino.spi.connector.ConnectorTableSchema;
+import io.trino.spi.connector.SchemaTableName;
+
+import java.util.List;
+
+import static com.google.common.collect.MoreCollectors.toOptional;
+import static java.util.Objects.requireNonNull;
+
+public final class TableSchema
+{
+    private final CatalogName catalogName;
+    private final ConnectorTableSchema tableSchema;
+
+    public TableSchema(CatalogName catalogName, ConnectorTableSchema tableSchema)
+    {
+        requireNonNull(catalogName, "catalog is null");
+        requireNonNull(tableSchema, "metadata is null");
+
+        this.catalogName = catalogName;
+        this.tableSchema = tableSchema;
+    }
+
+    public QualifiedObjectName getQualifiedName()
+    {
+        return new QualifiedObjectName(catalogName.getCatalogName(), tableSchema.getTable().getSchemaName(), tableSchema.getTable().getTableName());
+    }
+
+    public CatalogName getCatalogName()
+    {
+        return catalogName;
+    }
+
+    public ConnectorTableSchema getTableSchema()
+    {
+        return tableSchema;
+    }
+
+    public SchemaTableName getTable()
+    {
+        return tableSchema.getTable();
+    }
+
+    public List<ColumnSchema> getColumns()
+    {
+        return tableSchema.getColumns();
+    }
+
+    public ColumnSchema getColumn(String name)
+    {
+        return tableSchema.getColumns().stream()
+                .filter(columnMetadata -> columnMetadata.getName().equals(name))
+                .collect(toOptional())
+                .orElseThrow(() -> new IllegalArgumentException("Invalid column name: " + name));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1149,7 +1149,7 @@ class StatementAnalyzer
         @Override
         protected Scope visitUnnest(Unnest node, Optional<Scope> scope)
         {
-            ImmutableMap.Builder<NodeRef<Expression>, List<Field>> mappings = ImmutableMap.<NodeRef<Expression>, List<Field>>builder();
+            ImmutableMap.Builder<NodeRef<Expression>, List<Field>> mappings = ImmutableMap.builder();
 
             ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
             for (Expression expression : node.getExpressions()) {
@@ -2786,7 +2786,7 @@ class StatementAnalyzer
             }
         }
 
-        public void analyzeWhere(Node node, Scope scope, Expression predicate)
+        private void analyzeWhere(Node node, Scope scope, Expression predicate)
         {
             verifyNoAggregateWindowOrGroupingFunctions(metadata, predicate, "WHERE clause");
 
@@ -3207,7 +3207,7 @@ class StatementAnalyzer
             }
             Relation from = ((QuerySpecification) specification).getFrom().get();
             List<Node> fromReferences = findReferences(from, withQuery.getName());
-            if (fromReferences.size() == 0) {
+            if (fromReferences.isEmpty()) {
                 throw semanticException(INVALID_RECURSIVE_REFERENCE, stepReferences.get(0), "recursive reference outside of FROM clause of the step relation of recursion");
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DistributedExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DistributedExecutionPlanner.java
@@ -19,8 +19,8 @@ import io.airlift.log.Logger;
 import io.trino.Session;
 import io.trino.execution.TableInfo;
 import io.trino.metadata.Metadata;
-import io.trino.metadata.TableMetadata;
 import io.trino.metadata.TableProperties;
+import io.trino.metadata.TableSchema;
 import io.trino.operator.StageExecutionDescriptor;
 import io.trino.server.DynamicFilterService;
 import io.trino.spi.connector.DynamicFilter;
@@ -149,9 +149,9 @@ public class DistributedExecutionPlanner
 
     private TableInfo getTableInfo(TableScanNode node, Session session)
     {
-        TableMetadata tableMetadata = metadata.getTableMetadata(session, node.getTable());
+        TableSchema tableSchema = metadata.getTableSchema(session, node.getTable());
         TableProperties tableProperties = metadata.getTableProperties(session, node.getTable());
-        return new TableInfo(tableMetadata.getQualifiedName(), tableProperties.getPredicate());
+        return new TableInfo(tableSchema.getQualifiedName(), tableProperties.getPredicate());
     }
 
     private final class Visitor

--- a/core/trino-main/src/main/java/io/trino/sql/planner/InputExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/InputExtractor.java
@@ -63,7 +63,7 @@ public class InputExtractor
 
     private Input createInput(Session session, TableHandle table, Set<Column> columns, PlanFragmentId fragmentId, PlanNodeId planNodeId)
     {
-        SchemaTableName schemaTable = metadata.getTableMetadata(session, table).getTable();
+        SchemaTableName schemaTable = metadata.getTableSchema(session, table).getTable();
         Optional<Object> inputMetadata = metadata.getInfo(session, table);
         return new Input(table.getCatalogName().getCatalogName(), schemaTable.getSchemaName(), schemaTable.getTableName(), inputMetadata, ImmutableList.copyOf(columns), fragmentId, planNodeId);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TableInfoSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TableInfoSupplier.java
@@ -16,8 +16,8 @@ package io.trino.sql.planner.planprinter;
 import io.trino.Session;
 import io.trino.execution.TableInfo;
 import io.trino.metadata.Metadata;
-import io.trino.metadata.TableMetadata;
 import io.trino.metadata.TableProperties;
+import io.trino.metadata.TableSchema;
 import io.trino.sql.planner.plan.TableScanNode;
 
 import java.util.function.Function;
@@ -39,8 +39,8 @@ public class TableInfoSupplier
     @Override
     public TableInfo apply(TableScanNode node)
     {
-        TableMetadata tableMetadata = metadata.getTableMetadata(session, node.getTable());
+        TableSchema tableSchema = metadata.getTableSchema(session, node.getTable());
         TableProperties tableProperties = metadata.getTableProperties(session, node.getTable());
-        return new TableInfo(tableMetadata.getQualifiedName(), tableProperties.getPredicate());
+        return new TableInfo(tableSchema.getQualifiedName(), tableProperties.getPredicate());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -164,6 +164,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public TableSchema getTableSchema(Session session, TableHandle tableHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
     {
         throw new UnsupportedOperationException();

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnMetadata.java
@@ -135,6 +135,12 @@ public class ColumnMetadata
         return properties;
     }
 
+    public ColumnSchema getColumnSchema()
+    {
+        return ColumnSchema.builder(this)
+                .build();
+    }
+
     @Override
     public String toString()
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnSchema.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ColumnSchema.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+import io.trino.spi.type.Type;
+
+import java.util.Objects;
+
+import static io.trino.spi.connector.SchemaUtil.checkNotEmpty;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public final class ColumnSchema
+{
+    private final String name;
+    private final Type type;
+    private final boolean hidden;
+
+    private ColumnSchema(String name, Type type, boolean hidden)
+    {
+        checkNotEmpty(name, "name");
+        requireNonNull(type, "type is null");
+
+        this.name = name.toLowerCase(ENGLISH);
+        this.type = type;
+        this.hidden = hidden;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    public boolean isHidden()
+    {
+        return hidden;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ColumnSchema that = (ColumnSchema) o;
+        return hidden == that.hidden
+                && name.equals(that.name)
+                && type.equals(that.type);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, type, hidden);
+    }
+
+    @Override
+    public String toString()
+    {
+        return new StringBuilder("ColumnBasicMetadata{")
+                .append("name='").append(name).append('\'')
+                .append(", type=").append(type)
+                .append(", hidden=").append(hidden)
+                .append('}')
+                .toString();
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static Builder builder(ColumnMetadata columnMetadata)
+    {
+        return new Builder(columnMetadata);
+    }
+
+    public static class Builder
+    {
+        private String name;
+        private Type type;
+        private boolean hidden;
+
+        private Builder() {}
+
+        private Builder(ColumnMetadata columnMetadata)
+        {
+            this.name = columnMetadata.getName();
+            this.type = columnMetadata.getType();
+            this.hidden = columnMetadata.isHidden();
+        }
+
+        public Builder setName(String name)
+        {
+            this.name = requireNonNull(name, "name is null");
+            return this;
+        }
+
+        public Builder setType(Type type)
+        {
+            this.type = requireNonNull(type, "type is null");
+            return this;
+        }
+
+        public Builder setHidden(boolean hidden)
+        {
+            this.hidden = hidden;
+            return this;
+        }
+
+        public ColumnSchema build()
+        {
+            return new ColumnSchema(name, type, hidden);
+        }
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -162,6 +162,17 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Return table schema definition for the specified table handle.
+     * This method is useful when getting full table metadata is expensive.
+     *
+     * @throws RuntimeException if table handle is no longer valid
+     */
+    default ConnectorTableSchema getTableSchema(ConnectorSession session, ConnectorTableHandle table)
+    {
+        return getTableMetadata(session, table).getTableSchema();
+    }
+
+    /**
      * Return the metadata for the specified table handle.
      *
      * @throws RuntimeException if table handle is no longer valid

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableMetadata.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 public class ConnectorTableMetadata
 {
@@ -69,6 +70,15 @@ public class ConnectorTableMetadata
     public Optional<String> getComment()
     {
         return comment;
+    }
+
+    public ConnectorTableSchema getTableSchema()
+    {
+        return new ConnectorTableSchema(
+                table,
+                columns.stream()
+                        .map(ColumnMetadata::getColumnSchema)
+                        .collect(toUnmodifiableList()));
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableSchema.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableSchema.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class ConnectorTableSchema
+{
+    private final SchemaTableName table;
+    private final List<ColumnSchema> columns;
+
+    public ConnectorTableSchema(SchemaTableName table, List<ColumnSchema> columns)
+    {
+        requireNonNull(table, "table is null");
+        requireNonNull(columns, "columns is null");
+
+        this.table = table;
+        this.columns = List.copyOf(columns);
+    }
+
+    public SchemaTableName getTable()
+    {
+        return table;
+    }
+
+    public List<ColumnSchema> getColumns()
+    {
+        return columns;
+    }
+
+    @Override
+    public String toString()
+    {
+        return new StringBuilder("ConnectorTableSchema{")
+                .append("table=").append(table)
+                .append(", columns=").append(columns)
+                .append('}')
+                .toString();
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -35,6 +35,7 @@ import io.trino.spi.connector.ConnectorTableLayoutHandle;
 import io.trino.spi.connector.ConnectorTableLayoutResult;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableProperties;
+import io.trino.spi.connector.ConnectorTableSchema;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
@@ -215,6 +216,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getSystemTable(session, tableName);
+        }
+    }
+
+    @Override
+    public ConnectorTableSchema getTableSchema(ConnectorSession session, ConnectorTableHandle table)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableSchema(session, table);
         }
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcColumnHandle.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Joiner;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ColumnSchema;
 import io.trino.spi.type.Type;
 
 import java.util.Objects;
@@ -105,6 +106,14 @@ public final class JdbcColumnHandle
                 .setType(columnType)
                 .setNullable(nullable)
                 .setComment(comment)
+                .build();
+    }
+
+    public ColumnSchema getColumnSchema()
+    {
+        return ColumnSchema.builder()
+                .setName(columnName)
+                .setType(columnType)
                 .build();
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
@@ -518,6 +518,18 @@ public class JdbcMetadata
     }
 
     @Override
+    public ConnectorTableSchema getTableSchema(ConnectorSession session, ConnectorTableHandle table)
+    {
+        JdbcTableHandle handle = (JdbcTableHandle) table;
+
+        return new ConnectorTableSchema(
+                getSchemaTableName(handle),
+                jdbcClient.getColumns(session, handle).stream()
+                        .map(JdbcColumnHandle::getColumnSchema)
+                        .collect(toImmutableList()));
+    }
+
+    @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
         JdbcTableHandle handle = (JdbcTableHandle) table;

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/H2QueryRunner.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/H2QueryRunner.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -44,12 +45,17 @@ public final class H2QueryRunner
 
     public static DistributedQueryRunner createH2QueryRunner(Iterable<TpchTable<?>> tables)
             throws Exception
-
     {
         return createH2QueryRunner(tables, TestingH2JdbcModule.createProperties());
     }
 
     public static DistributedQueryRunner createH2QueryRunner(Iterable<TpchTable<?>> tables, Map<String, String> properties)
+            throws Exception
+    {
+        return createH2QueryRunner(tables, properties, new TestingH2JdbcModule());
+    }
+
+    public static DistributedQueryRunner createH2QueryRunner(Iterable<TpchTable<?>> tables, Map<String, String> properties, Module module)
             throws Exception
     {
         DistributedQueryRunner queryRunner = null;
@@ -61,7 +67,7 @@ public final class H2QueryRunner
 
             createSchema(properties, "tpch");
 
-            queryRunner.installPlugin(new JdbcPlugin("base-jdbc", new TestingH2JdbcModule()));
+            queryRunner.installPlugin(new JdbcPlugin("base-jdbc", module));
             queryRunner.createCatalog("jdbc", "base-jdbc", properties);
 
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableProperties.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcTableProperties.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.trino.plugin.jdbc.H2QueryRunner.createH2QueryRunner;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
+// Single-threaded because of shared mutable state, e.g. onGetTableProperties
+@Test(singleThreaded = true)
+public class TestJdbcTableProperties
+        extends AbstractTestQueryFramework
+{
+    private final Map<String, String> properties = TestingH2JdbcModule.createProperties();
+    private Runnable onGetTableProperties = () -> {};
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingH2JdbcModule module = new TestingH2JdbcModule((config, connectionFactory) -> new TestingH2JdbcClient(config, connectionFactory)
+        {
+            @Override
+            public Map<String, Object> getTableProperties(ConnectorSession session, JdbcTableHandle tableHandle)
+            {
+                onGetTableProperties.run();
+                return ImmutableMap.of();
+            }
+        });
+        return createH2QueryRunner(ImmutableList.copyOf(TpchTable.getTables()), properties, module);
+    }
+
+    @BeforeTest
+    public void reset()
+    {
+        onGetTableProperties = () -> {};
+    }
+
+    @Test
+    public void testGetTablePropertiesIsNotCalledForSelect()
+    {
+        onGetTableProperties = () -> { fail("Unexpected call of: getTableProperties"); };
+        assertUpdate("CREATE TABLE copy_of_nation AS SELECT * FROM nation", 25);
+        assertQuerySucceeds("SELECT * FROM copy_of_nation");
+        assertQuerySucceeds("SELECT nationkey FROM copy_of_nation");
+    }
+
+    @Test
+    public void testGetTablePropertiesIsCalled()
+    {
+        AtomicInteger counter = new AtomicInteger();
+        onGetTableProperties = () -> { counter.incrementAndGet(); };
+        assertQuerySucceeds("SHOW CREATE TABLE nation");
+        assertThat(counter.get()).isOne();
+    }
+}

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
@@ -85,17 +85,14 @@ public class PhoenixMetadata
     @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
-        return getTableMetadata(session, table, false);
-    }
-
-    private ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table, boolean rowkeyRequired)
-    {
         JdbcTableHandle handle = (JdbcTableHandle) table;
-        List<ColumnMetadata> columnMetadata = phoenixClient.getColumns(session, handle).stream()
-                .filter(column -> rowkeyRequired || !ROWKEY.equalsIgnoreCase(column.getColumnName()))
-                .map(JdbcColumnHandle::getColumnMetadata)
-                .collect(toImmutableList());
-        return new ConnectorTableMetadata(handle.getRequiredNamedRelation().getSchemaTableName(), columnMetadata, phoenixClient.getTableProperties(session, handle));
+        return new ConnectorTableMetadata(
+                getSchemaTableName(handle),
+                phoenixClient.getColumns(session, handle).stream()
+                        .filter(column -> !ROWKEY.equalsIgnoreCase(column.getColumnName()))
+                        .map(JdbcColumnHandle::getColumnMetadata)
+                        .collect(toImmutableList()),
+                phoenixClient.getTableProperties(session, handle));
     }
 
     @Override

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
@@ -30,6 +30,7 @@ import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTableSchema;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ComputedStatistics;
@@ -83,16 +84,32 @@ public class PhoenixMetadata
     }
 
     @Override
+    public ConnectorTableSchema getTableSchema(ConnectorSession session, ConnectorTableHandle table)
+    {
+        JdbcTableHandle handle = (JdbcTableHandle) table;
+        return new ConnectorTableSchema(
+                getSchemaTableName(handle),
+                getColumnMetadata(session, handle).stream()
+                        .map(ColumnMetadata::getColumnSchema)
+                        .collect(toImmutableList()));
+    }
+
+    @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
         JdbcTableHandle handle = (JdbcTableHandle) table;
         return new ConnectorTableMetadata(
                 getSchemaTableName(handle),
-                phoenixClient.getColumns(session, handle).stream()
-                        .filter(column -> !ROWKEY.equalsIgnoreCase(column.getColumnName()))
-                        .map(JdbcColumnHandle::getColumnMetadata)
-                        .collect(toImmutableList()),
+                getColumnMetadata(session, handle),
                 phoenixClient.getTableProperties(session, handle));
+    }
+
+    private List<ColumnMetadata> getColumnMetadata(ConnectorSession session, JdbcTableHandle handle)
+    {
+        return phoenixClient.getColumns(session, handle).stream()
+                .filter(column -> !ROWKEY.equalsIgnoreCase(column.getColumnName()))
+                .map(JdbcColumnHandle::getColumnMetadata)
+                .collect(toImmutableList());
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -85,17 +85,14 @@ public class PhoenixMetadata
     @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
-        return getTableMetadata(session, table, false);
-    }
-
-    private ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table, boolean rowkeyRequired)
-    {
         JdbcTableHandle handle = (JdbcTableHandle) table;
-        List<ColumnMetadata> columnMetadata = phoenixClient.getColumns(session, handle).stream()
-                .filter(column -> rowkeyRequired || !ROWKEY.equalsIgnoreCase(column.getColumnName()))
-                .map(JdbcColumnHandle::getColumnMetadata)
-                .collect(toImmutableList());
-        return new ConnectorTableMetadata(handle.getRequiredNamedRelation().getSchemaTableName(), columnMetadata, phoenixClient.getTableProperties(session, handle));
+        return new ConnectorTableMetadata(
+                getSchemaTableName(handle),
+                phoenixClient.getColumns(session, handle).stream()
+                        .filter(column -> !ROWKEY.equalsIgnoreCase(column.getColumnName()))
+                        .map(JdbcColumnHandle::getColumnMetadata)
+                        .collect(toImmutableList()),
+                phoenixClient.getTableProperties(session, handle));
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -30,6 +30,7 @@ import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTableSchema;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ComputedStatistics;
@@ -83,16 +84,32 @@ public class PhoenixMetadata
     }
 
     @Override
+    public ConnectorTableSchema getTableSchema(ConnectorSession session, ConnectorTableHandle table)
+    {
+        JdbcTableHandle handle = (JdbcTableHandle) table;
+        return new ConnectorTableSchema(
+                getSchemaTableName(handle),
+                getColumnMetadata(session, handle).stream()
+                        .map(ColumnMetadata::getColumnSchema)
+                        .collect(toImmutableList()));
+    }
+
+    @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
         JdbcTableHandle handle = (JdbcTableHandle) table;
         return new ConnectorTableMetadata(
                 getSchemaTableName(handle),
-                phoenixClient.getColumns(session, handle).stream()
-                        .filter(column -> !ROWKEY.equalsIgnoreCase(column.getColumnName()))
-                        .map(JdbcColumnHandle::getColumnMetadata)
-                        .collect(toImmutableList()),
+                getColumnMetadata(session, handle),
                 phoenixClient.getTableProperties(session, handle));
+    }
+
+    private List<ColumnMetadata> getColumnMetadata(ConnectorSession session, JdbcTableHandle handle)
+    {
+        return phoenixClient.getColumns(session, handle).stream()
+                .filter(column -> !ROWKEY.equalsIgnoreCase(column.getColumnName()))
+                .map(JdbcColumnHandle::getColumnMetadata)
+                .collect(toImmutableList());
     }
 
     @Override


### PR DESCRIPTION
Avoid reading JDBC connector table properties

This is achievied by Implementing
getTableBasicMetadata for JDBC connectors
