### PR TITLE
Random cleanup and comments

### DIFF
--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
@@ -29,6 +29,8 @@ import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
+// With case-insensitive-name-matching enabled colliding schema/table names are considered as errors.
+// Some tests here create colliding names which can cause any other concurrent test to fail.
 @Test(singleThreaded = true)
 public class TestBigQueryCaseInsensitiveMapping
         extends AbstractTestQueryFramework

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlCaseInsensitiveMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlCaseInsensitiveMapping.java
@@ -30,6 +30,8 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 
+// With case-insensitive-name-matching enabled colliding schema/table names are considered as errors.
+// Some tests here create colliding names which can cause any other concurrent test to fail.
 @Test(singleThreaded = true)
 public class TestMemSqlCaseInsensitiveMapping
         extends AbstractTestQueryFramework

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlCaseInsensitiveMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlCaseInsensitiveMapping.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class TestMemSqlCaseInsensitiveMapping
         extends AbstractTestQueryFramework
 {
-    private TestingMemSqlServer memSqlServer;
+    protected TestingMemSqlServer memSqlServer;
 
     @Override
     protected QueryRunner createQueryRunner()

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlCaseInsensitiveMapping.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlCaseInsensitiveMapping.java
@@ -29,6 +29,8 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 
+// With case-insensitive-name-matching enabled colliding schema/table names are considered as errors.
+// Some tests here create colliding names which can cause any other concurrent test to fail.
 @Test(singleThreaded = true)
 public class TestMySqlCaseInsensitiveMapping
         extends AbstractTestQueryFramework

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleCaseInsensitiveMapping.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOracleCaseInsensitiveMapping.java
@@ -29,6 +29,9 @@ import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
+// With case-insensitive-name-matching enabled colliding schema/table names are considered as errors.
+// Some tests here create colliding names which can cause any other concurrent test to fail.
+@Test(singleThreaded = true)
 public class TestOracleCaseInsensitiveMapping
         extends AbstractTestQueryFramework
 {

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
@@ -30,6 +30,8 @@ import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 
+// With case-insensitive-name-matching enabled colliding schema/table names are considered as errors.
+// Some tests here create colliding names which can cause any other concurrent test to fail.
 @Test(singleThreaded = true)
 public class TestPostgreSqlCaseInsensitiveMapping
         extends AbstractTestQueryFramework


### PR DESCRIPTION
Adds comments about why case-insensitive-name-matching tests are marked single-threaded so we can avoid mistakenly removing them.