### PR TITLE
Update 352 release notes

### DIFF
--- a/docs/src/main/sphinx/release/release-352.md
+++ b/docs/src/main/sphinx/release/release-352.md
@@ -109,6 +109,7 @@
 * Honor precision of SQL Server's `datetime2` type . ({issue}`6654`)
 * Add support for Trino `timestamp` type in `CREATE TABLE` statement, by mapping it to SQL Server's `datetime2` type.
   Previously, it was incorrectly mapped to SQL Server's `timestamp` type. ({issue}`6654`)
+* Add support for the `time` type. ({issue}`6654`)
 * Improve performance for certain complex queries involving aggregation and predicates (e.g. `HAVING` clause)
   by pushing the aggregation and predicates computation into the remote database. ({issue}`6667`)
 * Fix failure when querying tables having indexes and constraints. ({issue}`6464`)


### PR DESCRIPTION
Add a missing item in 352 release notes. It was missed since it wasn't obvious that updating the mssql jdbc driver added support for reading `LocalTime` and thus using the `TIME` SQL data type.

Follow up on #6751