### PR TITLE
Add Error Prone check: HashtableContains

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -1006,8 +1006,8 @@ public final class HiveUtil
 
     public static OrcWriterOptions getOrcWriterOptions(Properties schema, OrcWriterOptions orcWriterOptions)
     {
-        if (schema.contains(ORC_BLOOM_FILTER_COLUMNS)) {
-            if (!schema.contains(ORC_BLOOM_FILTER_FPP)) {
+        if (schema.containsValue(ORC_BLOOM_FILTER_COLUMNS)) {
+            if (!schema.containsValue(ORC_BLOOM_FILTER_FPP)) {
                 throw new TrinoException(HIVE_INVALID_METADATA, format("FPP for bloom filter is missing"));
             }
             try {

--- a/pom.xml
+++ b/pom.xml
@@ -1701,6 +1701,7 @@
                                     -Xep:FallThrough:ERROR
                                     -Xep:FormatString:ERROR
                                     -Xep:GetClassOnClass:ERROR
+                                    -Xep:HashtableContains:ERROR
                                     -Xep:IdentityBinaryExpression:ERROR
                                     -Xep:ImmutableSetForContains:ERROR
                                     -Xep:InconsistentHashCode:ERROR


### PR DESCRIPTION
The `Properties#contains` method (inherited from `Hashtable`) is a legacy equivalent to `Map#containsValue`; not sure why this is an ERROR, not a WARN, but there you have it.