### PR TITLE
Add Error Prone check: ZoneIdOfZ

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TimestampDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TimestampDecoder.java
@@ -20,8 +20,6 @@ import org.elasticsearch.search.SearchHit;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.function.Supplier;
 
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -29,13 +27,13 @@ import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.String.format;
+import static java.time.ZoneOffset.UTC;
 import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 import static java.util.Objects.requireNonNull;
 
 public class TimestampDecoder
         implements Decoder
 {
-    private static final ZoneId ZULU = ZoneId.of("Z");
     private final String path;
 
     public TimestampDecoder(String path)
@@ -68,7 +66,7 @@ public class TimestampDecoder
                 timestamp = ISO_DATE_TIME.parse((String) value, LocalDateTime::from);
             }
             else if (value instanceof Number) {
-                timestamp = LocalDateTime.ofInstant(Instant.ofEpochMilli(((Number) value).longValue()), ZULU);
+                timestamp = LocalDateTime.ofInstant(Instant.ofEpochMilli(((Number) value).longValue()), UTC);
             }
             else {
                 throw new TrinoException(NOT_SUPPORTED, format(
@@ -78,7 +76,7 @@ public class TimestampDecoder
                         value.getClass().getSimpleName()));
             }
 
-            long epochMicros = timestamp.atOffset(ZoneOffset.UTC).toInstant().toEpochMilli() * MICROSECONDS_PER_MILLISECOND;
+            long epochMicros = timestamp.atOffset(UTC).toInstant().toEpochMilli() * MICROSECONDS_PER_MILLISECOND;
 
             TIMESTAMP_MILLIS.writeLong(output, epochMicros);
         }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -1386,7 +1386,6 @@ public class TestPostgreSqlTypeMapping
             tests.addRoundTrip(dataType, afterEpoch.atZone(fixedOffsetWest));
             tests.addRoundTrip(dataType, afterEpoch.atZone(ZoneId.of("GMT")));
             tests.addRoundTrip(dataType, afterEpoch.atZone(ZoneId.of("UTC")));
-            tests.addRoundTrip(dataType, afterEpoch.atZone(ZoneId.of("Z")));
             tests.addRoundTrip(dataType, afterEpoch.atZone(ZoneId.of("UTC+00:00")));
             tests.addRoundTrip(dataType, timeDoubledInJvmZone.atZone(UTC));
             tests.addRoundTrip(dataType, timeDoubledInJvmZone.atZone(jvmZone));

--- a/pom.xml
+++ b/pom.xml
@@ -1721,6 +1721,7 @@
                                     -Xep:UnnecessaryOptionalGet:ERROR
                                     -Xep:UnusedVariable:ERROR
                                     -Xep:UseEnumSwitch:ERROR
+                                    -Xep:ZoneIdOfZ:ERROR
                                 </arg>
                             </compilerArgs>
                             <annotationProcessorPaths>


### PR DESCRIPTION
There is a convenient static field which can replace use of a magic String constant of "Z". In fact, at least in the JDK I'm using, these objects are exactly the same:

```
$ jshell
|  Welcome to JShell -- Version 11.0.10
|  For an introduction type: /help intro

jshell> var z = java.time.ZoneId.of("Z");
z ==> Z

jshell> var utc = java.time.ZoneOffset.UTC;
utc ==> Z

jshell> z == utc;
$3 ==> true
```