### PR TITLE
Add Error Prone check: GetClassOnAnnotation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/annotations/ImplementationDependency.java
+++ b/core/trino-main/src/main/java/io/trino/operator/annotations/ImplementationDependency.java
@@ -139,7 +139,7 @@ public interface ImplementationDependency
                         type);
             }
 
-            throw new IllegalArgumentException("Unsupported annotation " + annotation.getClass().getSimpleName());
+            throw new IllegalArgumentException("Unsupported annotation " + annotation);
         }
 
         private static InvocationConvention toInvocationConvention(Convention convention)

--- a/pom.xml
+++ b/pom.xml
@@ -1700,6 +1700,7 @@
                                     -Xep:EqualsIncompatibleType:ERROR
                                     -Xep:FallThrough:ERROR
                                     -Xep:FormatString:ERROR
+                                    -Xep:GetClassOnAnnotation:ERROR
                                     -Xep:GetClassOnClass:ERROR
                                     -Xep:IdentityBinaryExpression:ERROR
                                     -Xep:ImmutableSetForContains:ERROR


### PR DESCRIPTION
The problem here is that the `Annotation` object can be a dynamic proxy, in which case we won't get meaningful output. The fix for the only instance is assuming that the eventual proxy will have a meaningful `toString` implementation, which we can verify thusly:

```
$ jshell
|  Welcome to JShell -- Version 11.0.10
|  For an introduction type: /help intro

jshell> var obj = new Object() {@java.beans.BeanProperty public int getProperty() { return 0; }};
obj ==> $0@20e2cbe0

jshell> obj.getClass().getMethod("getProperty").getAnnotations()[0].toString();
$2 ==> @java.beans.BeanProperty(expert=false, hidden=false, visualUpdate=false, bound=true, description="", enumerationValues={}, required=false, preferred=false)

jshell> obj.getClass().getMethod("getProperty").getAnnotations()[0].getClass();
$3 ==> class com.sun.proxy.$Proxy1
```