### PR TITLE
Fix statistics update in ANALYZE table for Hive transactional tables

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -1123,5 +1123,6 @@ Hive 3 related limitations
       )
       AS <query>
 
-  Trino does not support gathering table statistics for Hive transactional tables.
-  You need to use Hive to gather table statistics with ``ANALYZE TABLE COMPUTE STATISTICS`` after table creation.
+* For transactional tables, Trino does not support gathering table statistics while processing
+  ``INSERT`` and ``CREATE TABLE AS`` statements, as well as ``UPDATE`` statements.  However,
+  Trino can gather statistics for transactional tables using the ``ANALYZE`` statement.

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -99,16 +99,16 @@ public class HiveMetastoreClosure
         delegate.updateTableStatistics(identity, databaseName, tableName, transaction, update);
     }
 
-    public void updatePartitionStatistics(HiveIdentity identity, String databaseName, String tableName, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    public void updatePartitionStatistics(HiveIdentity identity, String databaseName, String tableName, String partitionName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update)
     {
         Table table = getExistingTable(identity, databaseName, tableName);
-        delegate.updatePartitionStatistics(identity, table, partitionName, update);
+        delegate.updatePartitionStatistics(identity, table, partitionName, transaction, update);
     }
 
-    public void updatePartitionStatistics(HiveIdentity identity, String databaseName, String tableName, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public void updatePartitionStatistics(HiveIdentity identity, String databaseName, String tableName, AcidTransaction transaction, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         Table table = getExistingTable(identity, databaseName, tableName);
-        delegate.updatePartitionStatistics(identity, table, updates);
+        delegate.updatePartitionStatistics(identity, table, transaction, updates);
     }
 
     public List<String> getAllTables(String databaseName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/acid/AcidOperation.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/acid/AcidOperation.java
@@ -23,11 +23,25 @@ import java.util.Optional;
 public enum AcidOperation
 {
     // UPDATE and MERGE will be added when they are implemented
-    NONE,
-    CREATE_TABLE,
-    DELETE,
-    INSERT,
-    UPDATE;
+    NONE(false),
+    CREATE_TABLE(false),
+    DELETE(true),
+    INSERT(true),
+    UPDATE(true),
+    ANALYZE(true),
+    /**/;
+
+    final boolean acidTransaction;
+
+    AcidOperation(boolean acidTransaction)
+    {
+        this.acidTransaction = acidTransaction;
+    }
+
+    public boolean isAcidTransaction()
+    {
+        return acidTransaction;
+    }
 
     private static final Map<AcidOperation, DataOperationType> DATA_OPERATION_TYPES = ImmutableMap.of(
             DELETE, DataOperationType.DELETE,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/acid/AcidTransaction.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/acid/AcidTransaction.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
+import static io.trino.plugin.hive.acid.AcidOperation.ANALYZE;
 import static io.trino.plugin.hive.acid.AcidOperation.CREATE_TABLE;
 import static io.trino.plugin.hive.acid.AcidOperation.DELETE;
 import static io.trino.plugin.hive.acid.AcidOperation.INSERT;
@@ -80,7 +81,7 @@ public class AcidTransaction
     @JsonIgnore
     public boolean isAcidTransactionRunning()
     {
-        return operation == INSERT || operation == DELETE || operation == UPDATE;
+        return operation.isAcidTransaction();
     }
 
     @JsonIgnore
@@ -131,6 +132,12 @@ public class AcidTransaction
     public boolean isUpdate()
     {
         return operation == UPDATE;
+    }
+
+    @JsonIgnore
+    public boolean isAnalyze()
+    {
+        return operation == ANALYZE;
     }
 
     public boolean isAcidInsertOperation(WriterKind writerKind)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -51,12 +51,12 @@ public interface HiveMetastore
 
     void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update);
 
-    default void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    default void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update)
     {
-        updatePartitionStatistics(identity, table, ImmutableMap.of(partitionName, update));
+        updatePartitionStatistics(identity, table, transaction, ImmutableMap.of(partitionName, update));
     }
 
-    void updatePartitionStatistics(HiveIdentity identity, Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates);
+    void updatePartitionStatistics(HiveIdentity identity, Table table, AcidTransaction transaction, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates);
 
     List<String> getAllTables(String databaseName);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/RecordingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/RecordingHiveMetastore.java
@@ -256,17 +256,17 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    public void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update)
     {
         verifyRecordingMode();
-        delegate.updatePartitionStatistics(identity, table, partitionName, update);
+        delegate.updatePartitionStatistics(identity, table, partitionName, transaction, update);
     }
 
     @Override
-    public void updatePartitionStatistics(HiveIdentity identity, Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public void updatePartitionStatistics(HiveIdentity identity, Table table, AcidTransaction transaction, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         verifyRecordingMode();
-        delegate.updatePartitionStatistics(identity, table, updates);
+        delegate.updatePartitionStatistics(identity, table, transaction, updates);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -198,6 +198,7 @@ public class AlluxioHiveMetastore
     public void updatePartitionStatistics(
             HiveIdentity identity,
             Table table,
+            AcidTransaction transaction,
             Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         throw new TrinoException(NOT_SUPPORTED, "updatePartitionStatistics");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -398,11 +398,11 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    public void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update)
     {
         identity = updateIdentity(identity);
         try {
-            delegate.updatePartitionStatistics(identity, table, partitionName, update);
+            delegate.updatePartitionStatistics(identity, table, partitionName, transaction, update);
         }
         finally {
             HivePartitionName hivePartitionName = hivePartitionName(hiveTableName(table.getDatabaseName(), table.getTableName()), partitionName);
@@ -413,10 +413,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void updatePartitionStatistics(HiveIdentity identity, Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public void updatePartitionStatistics(HiveIdentity identity, Table table, AcidTransaction transaction, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         try {
-            delegate.updatePartitionStatistics(updateIdentity(identity), table, updates);
+            delegate.updatePartitionStatistics(updateIdentity(identity), table, transaction, updates);
         }
         finally {
             HiveIdentity hiveIdentity = updateIdentity(identity);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -435,7 +435,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized void updatePartitionStatistics(HiveIdentity identity, Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public synchronized void updatePartitionStatistics(HiveIdentity identity, Table table, AcidTransaction transaction, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         updates.forEach((partitionName, update) -> {
             PartitionStatistics originalStatistics = getPartitionStatistics(table, extractPartitionValues(partitionName));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -384,7 +384,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public void updatePartitionStatistics(HiveIdentity identity, Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public void updatePartitionStatistics(HiveIdentity identity, Table table, AcidTransaction transaction, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         Iterables.partition(updates.entrySet(), BATCH_CREATE_PARTITION_MAX_PAGE_SIZE).forEach(partitionUpdates ->
                 updatePartitionStatisticsBatch(table, partitionUpdates.stream().collect(toImmutableMap(Entry::getKey, Entry::getValue))));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -134,10 +134,10 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void updatePartitionStatistics(HiveIdentity identity, Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public void updatePartitionStatistics(HiveIdentity identity, Table table, AcidTransaction transaction, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         org.apache.hadoop.hive.metastore.api.Table metastoreTable = toMetastoreApiTable(table);
-        updates.forEach((partitionName, update) -> delegate.updatePartitionStatistics(identity, metastoreTable, partitionName, update));
+        updates.forEach((partitionName, update) -> delegate.updatePartitionStatistics(identity, metastoreTable, partitionName, transaction, update));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/FailureAwareThriftMetastoreClient.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive.metastore.thrift;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.trino.plugin.hive.acid.AcidOperation;
+import io.trino.plugin.hive.acid.AcidTransaction;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
@@ -175,10 +176,10 @@ public class FailureAwareThriftMetastoreClient
     }
 
     @Override
-    public void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics)
+    public void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics, AcidTransaction transaction)
             throws TException
     {
-        runWithHandle(() -> delegate.setTableColumnStatistics(databaseName, tableName, statistics));
+        runWithHandle(() -> delegate.setTableColumnStatistics(databaseName, tableName, statistics, transaction));
     }
 
     @Override
@@ -196,10 +197,10 @@ public class FailureAwareThriftMetastoreClient
     }
 
     @Override
-    public void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics)
+    public void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics, AcidTransaction transaction)
             throws TException
     {
-        runWithHandle(() -> delegate.setPartitionColumnStatistics(databaseName, tableName, partitionName, statistics));
+        runWithHandle(() -> delegate.setPartitionColumnStatistics(databaseName, tableName, partitionName, statistics, transaction));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -130,6 +130,7 @@ import static com.google.common.collect.Sets.difference;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_TABLE_LOCK_NOT_ACQUIRED;
 import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
+import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import static io.trino.plugin.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.partitionKeyFilterToStringList;
@@ -548,14 +549,16 @@ public class ThriftHiveMetastore
                     return Stream.of(createMetastoreColumnStatistics(entry.getKey(), type, entry.getValue(), rowCount));
                 })
                 .collect(toImmutableList());
+        // If the table is a transactional table, the column statistics will be empty for all
+        // operations other than ANALYZE table
         if (!metastoreColumnStatistics.isEmpty()) {
-            setTableColumnStatistics(identity, databaseName, tableName, metastoreColumnStatistics);
+            setTableColumnStatistics(identity, databaseName, tableName, metastoreColumnStatistics, transaction);
         }
         Set<String> removedColumnStatistics = difference(currentStatistics.getColumnStatistics().keySet(), updatedStatistics.getColumnStatistics().keySet());
         removedColumnStatistics.forEach(column -> deleteTableColumnStatistics(identity, databaseName, tableName, column));
     }
 
-    private void setTableColumnStatistics(HiveIdentity identity, String databaseName, String tableName, List<ColumnStatisticsObj> statistics)
+    private void setTableColumnStatistics(HiveIdentity identity, String databaseName, String tableName, List<ColumnStatisticsObj> statistics, AcidTransaction transaction)
     {
         try {
             retry()
@@ -566,7 +569,7 @@ public class ThriftHiveMetastore
                                 identity,
                                 format("table %s.%s", databaseName, tableName),
                                 statistics,
-                                (client, stats) -> client.setTableColumnStatistics(databaseName, tableName, stats));
+                                (client, stats) -> client.setTableColumnStatistics(databaseName, tableName, stats, transaction));
                         return null;
                     }));
         }
@@ -606,7 +609,7 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    public void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update)
     {
         List<Partition> partitions = getPartitionsByNames(identity, table.getDbName(), table.getTableName(), ImmutableList.of(partitionName));
         if (partitions.size() != 1) {
@@ -625,7 +628,7 @@ public class ThriftHiveMetastore
 
         Map<String, HiveType> columns = modifiedPartition.getSd().getCols().stream()
                 .collect(toImmutableMap(FieldSchema::getName, schema -> HiveType.valueOf(schema.getType())));
-        setPartitionColumnStatistics(identity, table.getDbName(), table.getTableName(), partitionName, columns, updatedStatistics.getColumnStatistics(), basicStatistics.getRowCount());
+        setPartitionColumnStatistics(identity, table.getDbName(), table.getTableName(), partitionName, columns, updatedStatistics.getColumnStatistics(), basicStatistics.getRowCount(), transaction);
 
         Set<String> removedStatistics = difference(currentStatistics.getColumnStatistics().keySet(), updatedStatistics.getColumnStatistics().keySet());
         removedStatistics.forEach(column -> deletePartitionColumnStatistics(identity, table.getDbName(), table.getTableName(), partitionName, column));
@@ -638,18 +641,19 @@ public class ThriftHiveMetastore
             String partitionName,
             Map<String, HiveType> columns,
             Map<String, HiveColumnStatistics> columnStatistics,
-            OptionalLong rowCount)
+            OptionalLong rowCount,
+            AcidTransaction transaction)
     {
         List<ColumnStatisticsObj> metastoreColumnStatistics = columnStatistics.entrySet().stream()
                 .filter(entry -> columns.containsKey(entry.getKey()))
                 .map(entry -> createMetastoreColumnStatistics(entry.getKey(), columns.get(entry.getKey()), entry.getValue(), rowCount))
                 .collect(toImmutableList());
         if (!metastoreColumnStatistics.isEmpty()) {
-            setPartitionColumnStatistics(identity, databaseName, tableName, partitionName, metastoreColumnStatistics);
+            setPartitionColumnStatistics(identity, databaseName, tableName, partitionName, metastoreColumnStatistics, transaction);
         }
     }
 
-    private void setPartitionColumnStatistics(HiveIdentity identity, String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics)
+    private void setPartitionColumnStatistics(HiveIdentity identity, String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics, AcidTransaction transaction)
     {
         try {
             retry()
@@ -660,7 +664,7 @@ public class ThriftHiveMetastore
                                 identity,
                                 format("partition of table %s.%s", databaseName, tableName),
                                 statistics,
-                                (client, stats) -> client.setPartitionColumnStatistics(databaseName, tableName, partitionName, stats));
+                                (client, stats) -> client.setPartitionColumnStatistics(databaseName, tableName, partitionName, stats, transaction));
                         return null;
                     }));
         }
@@ -1341,7 +1345,9 @@ public class ThriftHiveMetastore
         }
         Map<String, HiveType> columnTypes = partitionWithStatistics.getPartition().getColumns().stream()
                 .collect(toImmutableMap(Column::getName, Column::getType));
-        setPartitionColumnStatistics(identity, databaseName, tableName, partitionName, columnTypes, columnStatistics, statistics.getBasicStatistics().getRowCount());
+        // Using NO_ACID_TRANSACTION as this code path is currently not used for transactional tables.
+        // TODO (https://github.com/trinodb/trino/issues/7190) support stats in INSERT, DELETE and UPDATE for transactional tables
+        setPartitionColumnStatistics(identity, databaseName, tableName, partitionName, columnTypes, columnStatistics, statistics.getBasicStatistics().getRowCount(), NO_ACID_TRANSACTION);
     }
 
     /*

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -19,6 +19,7 @@ import io.trino.plugin.base.util.LoggingInvocationHandler;
 import io.trino.plugin.base.util.LoggingInvocationHandler.AirliftParameterNamesProvider;
 import io.trino.plugin.base.util.LoggingInvocationHandler.ParameterNamesProvider;
 import io.trino.plugin.hive.acid.AcidOperation;
+import io.trino.plugin.hive.acid.AcidTransaction;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.metastore.api.AbortTxnRequest;
 import org.apache.hadoop.hive.metastore.api.AddDynamicPartitions;
@@ -59,6 +60,7 @@ import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.hive.metastore.api.PrivilegeBag;
 import org.apache.hadoop.hive.metastore.api.Role;
 import org.apache.hadoop.hive.metastore.api.RolePrincipalGrant;
+import org.apache.hadoop.hive.metastore.api.SetPartitionsStatsRequest;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.TableStatsRequest;
 import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
@@ -75,6 +77,7 @@ import java.util.Map;
 import java.util.OptionalLong;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.reflect.Reflection.newProxy;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.adjustRowCount;
 import static java.lang.String.format;
@@ -224,12 +227,29 @@ public class ThriftHiveMetastoreClient
     }
 
     @Override
-    public void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics)
+    public void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics, AcidTransaction transaction)
             throws TException
     {
         ColumnStatisticsDesc statisticsDescription = new ColumnStatisticsDesc(true, databaseName, tableName);
-        ColumnStatistics request = new ColumnStatistics(statisticsDescription, statistics);
-        client.update_table_column_statistics(request);
+        ColumnStatistics columnStatistics = new ColumnStatistics(statisticsDescription, statistics);
+        if (transaction.isTransactional()) {
+            verify(transaction.isAnalyze(), "Stats collection for transactional tables is currently supported with ANALYZE only");
+            SetPartitionsStatsRequest request = new SetPartitionsStatsRequest();
+            request.setColStats(ImmutableList.of(columnStatistics));
+            request.setNeedMerge(false);
+            request.setWriteId(transaction.getWriteId());
+            // Valid writeIds are fetched here rather than at the start of the transaction.
+            // I believe the reason we can't fetch at the start of the transaction is that
+            // Hive metastore insists that the table or partition be locked for exclusive access,
+            // and that only happens when the transaction is being committed.  Moreover, fetching
+            // at this point matches Hive behavior - - Hive always fetches valid writeIds for each
+            // table or partition updated leading up to committing the transaction.
+            request.setValidWriteIdList(getTableWriteIds(databaseName, tableName, transaction.getAcidTransactionId()));
+            client.update_table_column_statistics_req(request);
+        }
+        else {
+            client.update_table_column_statistics(columnStatistics);
+        }
     }
 
     @Override
@@ -248,13 +268,30 @@ public class ThriftHiveMetastoreClient
     }
 
     @Override
-    public void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics)
+    public void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics, AcidTransaction transaction)
             throws TException
     {
         ColumnStatisticsDesc statisticsDescription = new ColumnStatisticsDesc(false, databaseName, tableName);
+        ColumnStatistics columnStatistics = new ColumnStatistics(statisticsDescription, statistics);
         statisticsDescription.setPartName(partitionName);
-        ColumnStatistics request = new ColumnStatistics(statisticsDescription, statistics);
-        client.update_partition_column_statistics(request);
+        if (transaction.isTransactional()) {
+            verify(transaction.isAnalyze(), "Stats collection for transactional tables is currently supported with ANALYZE only");
+            SetPartitionsStatsRequest request = new SetPartitionsStatsRequest();
+            request.setColStats(ImmutableList.of(columnStatistics));
+            request.setNeedMerge(false);
+            request.setWriteId(transaction.getWriteId());
+            // Valid writeIds are fetched here rather than at the start of the transaction.
+            // I believe the reason we can't fetch at the start of the transaction is that
+            // Hive metastore insists that the table or partition be locked for exclusive access,
+            // and that only happens when the transaction is being committed.  Moreover, fetching
+            // at this point matches Hive behavior - - Hive always fetches valid writeIds for each
+            // table or partition updated leading up to committing the transaction.
+            request.setValidWriteIdList(getTableWriteIds(databaseName, tableName, transaction.getAcidTransactionId()));
+            client.update_partition_column_statistics_req(request);
+        }
+        else {
+            client.update_partition_column_statistics(columnStatistics);
+        }
     }
 
     @Override
@@ -590,9 +627,15 @@ public class ThriftHiveMetastoreClient
         table.setWriteId(writeId);
         checkArgument(writeId >= table.getWriteId(), "The writeId supplied %s should be greater than or equal to the table writeId %s", writeId, table.getWriteId());
         AlterTableRequest request = new AlterTableRequest(table.getDbName(), table.getTableName(), table);
-        request.setValidWriteIdList(getValidWriteIds(ImmutableList.of(format("%s.%s", table.getDbName(), table.getTableName())), transactionId));
+        request.setValidWriteIdList(getTableWriteIds(table.getDbName(), table.getTableName(), transactionId));
         request.setWriteId(writeId);
         request.setEnvironmentContext(environmentContext);
         client.alter_table_req(request);
+    }
+
+    private String getTableWriteIds(String databaseName, String tableName, long transactionId)
+            throws TException
+    {
+        return getValidWriteIds(ImmutableList.of(format("%s.%s", databaseName, tableName)), transactionId);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastore.java
@@ -92,7 +92,7 @@ public interface ThriftMetastore
 
     void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update);
 
-    void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update);
+    void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update);
 
     void createRole(String role, String grantor);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreClient.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive.metastore.thrift;
 
 import io.trino.plugin.hive.acid.AcidOperation;
+import io.trino.plugin.hive.acid.AcidTransaction;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
@@ -87,7 +88,7 @@ public interface ThriftMetastoreClient
     List<ColumnStatisticsObj> getTableColumnStatistics(String databaseName, String tableName, List<String> columnNames)
             throws TException;
 
-    void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics)
+    void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics, AcidTransaction transaction)
             throws TException;
 
     void deleteTableColumnStatistics(String databaseName, String tableName, String columnName)
@@ -96,7 +97,7 @@ public interface ThriftMetastoreClient
     Map<String, List<ColumnStatisticsObj>> getPartitionColumnStatistics(String databaseName, String tableName, List<String> partitionNames, List<String> columnNames)
             throws TException;
 
-    void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics)
+    void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics, AcidTransaction transaction)
             throws TException;
 
     void deletePartitionColumnStatistics(String databaseName, String tableName, String partitionName, String columnName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
@@ -96,6 +96,7 @@ public class DropStatsProcedure
         }
     }
 
+    // TODO: Make drop stats work for Hive transactional tables (Issue #7189)
     private void doDropStats(ConnectorSession session, ConnectorAccessControl accessControl, String schema, String table, List<?> partitionValues)
     {
         TransactionalMetadata hiveMetadata = hiveMetadataFactory.create(true);
@@ -125,6 +126,7 @@ public class DropStatsProcedure
                     schema,
                     table,
                     makePartName(partitionColumns, values),
+                    NO_ACID_TRANSACTION,
                     stats -> PartitionStatistics.empty()));
         }
         else {
@@ -146,6 +148,7 @@ public class DropStatsProcedure
                                 schema,
                                 table,
                                 partitionName,
+                                NO_ACID_TRANSACTION,
                                 stats -> PartitionStatistics.empty())));
             }
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -75,7 +75,7 @@ class UnimplementedHiveMetastore
     }
 
     @Override
-    public void updatePartitionStatistics(HiveIdentity identity, Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public void updatePartitionStatistics(HiveIdentity identity, Table table, AcidTransaction transaction, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -56,6 +56,7 @@ import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.trino.plugin.hive.HiveColumnHandle.createBaseColumn;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveType.HIVE_STRING;
+import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.trino.plugin.hive.metastore.HiveColumnStatistics.createIntegerColumnStatistics;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.computePartitionKeyFilter;
 import static io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.cachingHiveMetastore;
@@ -406,7 +407,7 @@ public class TestCachingHiveMetastore
         Table table = hiveMetastoreClosure.getTable(IDENTITY, TEST_DATABASE, TEST_TABLE).get();
         assertEquals(mockClient.getAccessCount(), 1);
 
-        hiveMetastoreClosure.updatePartitionStatistics(IDENTITY, table.getDatabaseName(), table.getTableName(), TEST_PARTITION1, identity());
+        hiveMetastoreClosure.updatePartitionStatistics(IDENTITY, table.getDatabaseName(), table.getTableName(), TEST_PARTITION1, NO_ACID_TRANSACTION, identity());
         assertEquals(mockClient.getAccessCount(), 5);
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -975,7 +975,7 @@ public class TestHiveGlueMetastore
                     .setColumnStatistics(columnStatistics).build();
 
             createDummyPartitionedTable(tableName, columns);
-            metastore.updatePartitionStatistics(HIVE_IDENTITY, tableName.getSchemaName(), tableName.getTableName(), "ds=2016-01-01", actualStatistics -> partitionStatistics);
+            metastore.updatePartitionStatistics(HIVE_IDENTITY, tableName.getSchemaName(), tableName.getTableName(), NO_ACID_TRANSACTION, ImmutableMap.of("ds=2016-01-01", actualStatistics -> partitionStatistics));
 
             PartitionStatistics tableStatistics = new PartitionStatistics(createEmptyStatistics(), Map.of());
             assertThat(metastore.getTableStatistics(HIVE_IDENTITY, tableName.getSchemaName(), tableName.getTableName()))
@@ -1133,7 +1133,7 @@ public class TestHiveGlueMetastore
         metastoreClient.addPartitions(identity, tableName.getSchemaName(), tableName.getTableName(), partitions);
         partitionNames.forEach(
                 partitionName -> metastoreClient.updatePartitionStatistics(
-                        identity, tableName.getSchemaName(), tableName.getTableName(), partitionName, currentStatistics -> EMPTY_TABLE_STATISTICS));
+                        identity, tableName.getSchemaName(), tableName.getTableName(), partitionName, NO_ACID_TRANSACTION, currentStatistics -> EMPTY_TABLE_STATISTICS));
     }
 
     private class CloseableSchamaTableName

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/InMemoryThriftMetastore.java
@@ -487,7 +487,7 @@ public class InMemoryThriftMetastore
     }
 
     @Override
-    public synchronized void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    public synchronized void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update)
     {
         PartitionName partitionKey = PartitionName.partition(table.getDbName(), table.getTableName(), partitionName);
         partitionColumnStatistics.put(partitionKey, update.apply(getPartitionStatistics(table.getDbName(), table.getTableName(), ImmutableSet.of(partitionName)).get(partitionName)));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.trino.plugin.hive.acid.AcidOperation;
+import io.trino.plugin.hive.acid.AcidTransaction;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
@@ -188,7 +189,7 @@ public class MockThriftMetastoreClient
     }
 
     @Override
-    public void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics)
+    public void setTableColumnStatistics(String databaseName, String tableName, List<ColumnStatisticsObj> statistics, AcidTransaction transaction)
     {
         throw new UnsupportedOperationException();
     }
@@ -219,7 +220,7 @@ public class MockThriftMetastoreClient
     }
 
     @Override
-    public void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics)
+    public void setPartitionColumnStatistics(String databaseName, String tableName, String partitionName, List<ColumnStatisticsObj> statistics, AcidTransaction transaction)
     {
         accessCount.incrementAndGet();
         // No-op

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/CountingAccessFileHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/CountingAccessFileHiveMetastore.java
@@ -326,7 +326,7 @@ public class CountingAccessFileHiveMetastore
     }
 
     @Override
-    public void updatePartitionStatistics(HiveIdentity identity, Table table, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
+    public void updatePartitionStatistics(HiveIdentity identity, Table table, AcidTransaction transaction, Map<String, Function<PartitionStatistics, PartitionStatistics>> updates)
     {
         throw new UnsupportedOperationException();
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBasicTableStatistics.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBasicTableStatistics.java
@@ -14,12 +14,13 @@
 package io.trino.tests.product.hive;
 
 import com.google.common.primitives.Longs;
-import io.trino.tempto.ProductTest;
 import io.trino.tempto.Requires;
 import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableNationTable;
 import io.trino.tempto.query.QueryExecutor;
 import io.trino.tempto.query.QueryResult;
 import io.trino.testng.services.Flaky;
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -28,8 +29,6 @@ import java.util.OptionalLong;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.tests.product.TestGroups.SKIP_ON_CDH;
-import static io.trino.tests.product.hive.HiveProductTest.ERROR_COMMITTING_WRITE_TO_HIVE_ISSUE;
-import static io.trino.tests.product.hive.HiveProductTest.ERROR_COMMITTING_WRITE_TO_HIVE_MATCH;
 import static io.trino.tests.product.hive.util.TableLocationUtils.getTableLocation;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
@@ -39,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Requires(ImmutableNationTable.class)
 public class TestHiveBasicTableStatistics
-        extends ProductTest
+        extends HiveProductTest
 {
     @Test
     public void testCreateUnpartitioned()
@@ -176,15 +175,20 @@ public class TestHiveBasicTableStatistics
         }
     }
 
-    @Test(groups = SKIP_ON_CDH /* CDH 5 metastore automatically gathers raw data size statistics on its own */)
-    public void testAnalyzePartitioned()
+    @Test(groups = SKIP_ON_CDH, // CDH 5 metastore automatically gathers raw data size statistics on its own
+            dataProvider = "transactionalNonTransactionalProvider")
+    public void testAnalyzePartitioned(boolean transactional)
     {
+        if (transactional) {
+            ensureTransactionalHive();
+        }
         String tableName = "test_basic_statistics_analyze_partitioned";
 
         onTrino().executeQuery("DROP TABLE IF EXISTS " + tableName);
         onTrino().executeQuery(format("" +
                 "CREATE TABLE %s " +
                 "WITH ( " +
+                "   transactional = %s, " +
                 "   partitioned_by = ARRAY['n_regionkey'], " +
                 "   bucketed_by = ARRAY['n_nationkey'], " +
                 "   bucket_count = 10 " +
@@ -192,7 +196,7 @@ public class TestHiveBasicTableStatistics
                 "AS " +
                 "SELECT n_nationkey, n_name, n_comment, n_regionkey " +
                 "FROM nation " +
-                "WHERE n_regionkey = 1", tableName));
+                "WHERE n_regionkey = 1", tableName, transactional));
 
         try {
             BasicStatistics tableStatistics = getBasicStatisticsForTable(onHive(), tableName);
@@ -220,18 +224,22 @@ public class TestHiveBasicTableStatistics
         }
     }
 
-    @Test
-    public void testAnalyzeUnpartitioned()
+    @Test(dataProvider = "transactionalNonTransactionalProvider")
+    public void testAnalyzeUnpartitioned(boolean transactional)
     {
+        if (transactional) {
+            ensureTransactionalHive();
+        }
         String tableName = "test_basic_statistics_analyze_unpartitioned";
 
         onTrino().executeQuery("DROP TABLE IF EXISTS " + tableName);
         onTrino().executeQuery(format("" +
                 "CREATE TABLE %s " +
+                "WITH (transactional = %s) " +
                 "AS " +
                 "SELECT n_nationkey, n_name, n_comment, n_regionkey " +
                 "FROM nation " +
-                "WHERE n_regionkey = 1", tableName));
+                "WHERE n_regionkey = 1", tableName, transactional));
 
         try {
             BasicStatistics tableStatisticsBefore = getBasicStatisticsForTable(onHive(), tableName);
@@ -251,6 +259,15 @@ public class TestHiveBasicTableStatistics
         finally {
             onTrino().executeQuery(format("DROP TABLE %s", tableName));
         }
+    }
+
+    @DataProvider
+    public Object[][] transactionalNonTransactionalProvider()
+    {
+        return new Object[][] {
+                {false},
+                {true},
+        };
     }
 
     @Test
@@ -517,6 +534,13 @@ public class TestHiveBasicTableStatistics
         public OptionalLong getTotalSize()
         {
             return totalSize;
+        }
+    }
+
+    private void ensureTransactionalHive()
+    {
+        if (getHiveVersionMajor() < 3) {
+            throw new SkipException("Hive transactional tables are supported with Hive version 3 or above");
         }
     }
 }


### PR DESCRIPTION
This commit fixes update of statistics resulting from ANALYZE run on
Hive transactional tables.  This fix adds a new ANALYZE transaction
type, and adds an AcidTransaction object to the metastore APIs that
update/set table and partition statistics, calling into formerly unused
metastore APIs to update statistics for transactional tables.

This commit is drawn narrowly, in that it only uses the new APIs
for the case of ANALYZE on transactional tables.  As of today,
INSERT, DELETE and UPDATE do not update column statistics when
run on Hive transactional tables.  We could enable that behavior
with a small follow-on PR now that the necessary Hive metastore
APIs are accessible.

In this commit, the choice of which statistics update API to use is made
at the lowest level, in `ThriftHiveMetastoreClient`.  An alternative that seemed
slightly less desirable would be to do it at the `SemiTransactionalHiveMetastore`
level.