### PR TITLE
Document safe apparently unsynchronized access

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/DiscoveryNodeManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DiscoveryNodeManager.java
@@ -336,6 +336,7 @@ public final class DiscoveryNodeManager
     @Override
     public synchronized Set<InternalNode> getActiveConnectorNodes(CatalogName catalogName)
     {
+        // activeNodesByCatalogName is immutable
         return activeNodesByCatalogName.get(catalogName);
     }
 


### PR DESCRIPTION
`activeNodesByCatalogName` is multimap guarded by `this`.
`Multimap.get` returns a view, not a copy.