### PR TITLE
Rename BaseConnectorTest implementation classes

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnector.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnector.java
@@ -26,7 +26,7 @@ import java.util.Properties;
 
 import static io.trino.plugin.jdbc.H2QueryRunner.createH2QueryRunner;
 
-public class TestJdbcConnectorTest
+public class TestJdbcConnector
         extends BaseConnectorTest
 {
     private Map<String, String> properties;

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestGlobalTransactionMySqlConnector.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestGlobalTransactionMySqlConnector.java
@@ -19,7 +19,7 @@ import io.trino.testing.sql.SqlExecutor;
 
 import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 
-public class TestGlobalTransactionMySqlConnectorTest
+public class TestGlobalTransactionMySqlConnector
         // TODO(https://github.com/trinodb/trino/issues/7019) define shorter tests set that exercises various read and write scenarios (a.k.a. "a smoke test")
         extends BaseMySqlConnectorTest
 {

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlConnector.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlConnector.java
@@ -22,7 +22,7 @@ import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
 
-public class TestMySqlConnectorTest
+public class TestMySqlConnector
         extends BaseMySqlConnectorTest
 {
     private TestingMySqlServer mysqlServer;

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnector.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnector.java
@@ -47,7 +47,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-public class TestPostgreSqlConnectorTest
+public class TestPostgreSqlConnector
         extends BaseConnectorTest
 {
     protected TestingPostgreSqlServer postgreSqlServer;

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnector.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnector.java
@@ -21,7 +21,7 @@ import org.testng.annotations.AfterClass;
 
 import static io.trino.plugin.redis.RedisQueryRunner.createRedisQueryRunner;
 
-public class TestRedisConnectorTest
+public class TestRedisConnector
         extends BaseConnectorTest
 {
     private RedisServer redisServer;


### PR DESCRIPTION
Rename BaseConnectorTest implementation classes

The `Test` at the end of was pointless and a bit of misleading as we
do not test the test (we partially do it, but it is not the point),
but it is a test of the connector.
