### PR TITLE
Rename JdbcRelationHandle to JdbcRelation

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
@@ -165,7 +165,7 @@ public class JdbcMetadata
         List<JdbcColumnHandle> columns = jdbcClient.getColumns(session, handle);
         PreparedQuery preparedQuery = jdbcClient.prepareQuery(session, handle, Optional.empty(), columns, ImmutableMap.of());
         return new JdbcTableHandle(
-                new JdbcQueryRelationHandle(preparedQuery),
+                new JdbcQueryRelation(preparedQuery),
                 TupleDomain.all(),
                 OptionalLong.empty(),
                 Optional.of(columns),
@@ -279,7 +279,7 @@ public class JdbcMetadata
                         .build(),
                 expressions.build());
         handle = new JdbcTableHandle(
-                new JdbcQueryRelationHandle(preparedQuery),
+                new JdbcQueryRelation(preparedQuery),
                 TupleDomain.all(),
                 OptionalLong.empty(),
                 Optional.of(newColumnsList),

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcNamedRelation.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcNamedRelation.java
@@ -22,14 +22,14 @@ import java.util.Objects;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
-public class JdbcNamedRelationHandle
-        extends JdbcRelationHandle
+public class JdbcNamedRelation
+        extends JdbcRelation
 {
     private final SchemaTableName schemaTableName;
     private final RemoteTableName remoteTableName;
 
     @JsonCreator
-    public JdbcNamedRelationHandle(
+    public JdbcNamedRelation(
             @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName)
     {
@@ -58,7 +58,7 @@ public class JdbcNamedRelationHandle
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        JdbcNamedRelationHandle that = (JdbcNamedRelationHandle) o;
+        JdbcNamedRelation that = (JdbcNamedRelation) o;
         return Objects.equals(schemaTableName, that.schemaTableName)
                 // remoteTableName is not compared here, as required by TestJdbcTableHandle#testEquivalence TODO document why this is important
                 /**/;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcQueryRelation.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcQueryRelation.java
@@ -18,13 +18,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static java.lang.String.format;
 
-public class JdbcQueryRelationHandle
-        extends JdbcRelationHandle
+public class JdbcQueryRelation
+        extends JdbcRelation
 {
     private final PreparedQuery preparedQuery;
 
     @JsonCreator
-    public JdbcQueryRelationHandle(PreparedQuery preparedQuery)
+    public JdbcQueryRelation(PreparedQuery preparedQuery)
     {
         this.preparedQuery = preparedQuery;
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRelation.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRelation.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         use = JsonTypeInfo.Id.NAME,
         property = "@type")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = JdbcNamedRelationHandle.class, name = "named"),
-        @JsonSubTypes.Type(value = JdbcQueryRelationHandle.class, name = "query"),
+        @JsonSubTypes.Type(value = JdbcNamedRelation.class, name = "named"),
+        @JsonSubTypes.Type(value = JdbcQueryRelation.class, name = "query"),
 })
-public abstract class JdbcRelationHandle
+public abstract class JdbcRelation
 {
     @Override
     public abstract String toString();

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcTableHandle.java
@@ -35,7 +35,7 @@ import static java.util.Objects.requireNonNull;
 public final class JdbcTableHandle
         implements ConnectorTableHandle
 {
-    private final JdbcRelationHandle relationHandle;
+    private final JdbcRelation relationHandle;
 
     private final TupleDomain<ColumnHandle> constraint;
 
@@ -56,7 +56,7 @@ public final class JdbcTableHandle
     public JdbcTableHandle(SchemaTableName schemaTableName, RemoteTableName remoteTableName)
     {
         this(
-                new JdbcNamedRelationHandle(schemaTableName, remoteTableName),
+                new JdbcNamedRelation(schemaTableName, remoteTableName),
                 TupleDomain.all(),
                 OptionalLong.empty(),
                 Optional.empty(),
@@ -65,7 +65,7 @@ public final class JdbcTableHandle
 
     @JsonCreator
     public JdbcTableHandle(
-            @JsonProperty("relationHandle") JdbcRelationHandle relationHandle,
+            @JsonProperty("relationHandle") JdbcRelation relationHandle,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint,
             @JsonProperty("limit") OptionalLong limit,
             @JsonProperty("columns") Optional<List<JdbcColumnHandle>> columns,
@@ -103,21 +103,21 @@ public final class JdbcTableHandle
         return getRequiredNamedRelation().getRemoteTableName();
     }
 
-    public JdbcNamedRelationHandle asPlainTable()
+    public JdbcNamedRelation asPlainTable()
     {
         checkState(!isSynthetic(), "The table handle does not represent a plain table: %s", this);
         return getRequiredNamedRelation();
     }
 
     @JsonIgnore
-    public JdbcNamedRelationHandle getRequiredNamedRelation()
+    public JdbcNamedRelation getRequiredNamedRelation()
     {
         checkState(isNamedRelation(), "The table handle does not represent a named relation: %s", this);
-        return (JdbcNamedRelationHandle) relationHandle;
+        return (JdbcNamedRelation) relationHandle;
     }
 
     @JsonProperty
-    public JdbcRelationHandle getRelationHandle()
+    public JdbcRelation getRelationHandle()
     {
         return relationHandle;
     }
@@ -190,7 +190,7 @@ public final class JdbcTableHandle
     @JsonIgnore
     public boolean isNamedRelation()
     {
-        return relationHandle instanceof JdbcNamedRelationHandle;
+        return relationHandle instanceof JdbcNamedRelation;
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
@@ -62,7 +62,7 @@ public class QueryBuilder
     public PreparedQuery prepareQuery(
             ConnectorSession session,
             Connection connection,
-            JdbcRelationHandle baseRelation,
+            JdbcRelation baseRelation,
             Optional<List<List<JdbcColumnHandle>>> groupingSets,
             List<JdbcColumnHandle> columns,
             Map<String, String> columnExpressions,
@@ -160,13 +160,13 @@ public class QueryBuilder
                 .collect(joining(", "));
     }
 
-    private String getFrom(JdbcRelationHandle baseRelation, Consumer<QueryParameter> accumulator)
+    private String getFrom(JdbcRelation baseRelation, Consumer<QueryParameter> accumulator)
     {
-        if (baseRelation instanceof JdbcNamedRelationHandle) {
-            return " FROM " + getRelation(((JdbcNamedRelationHandle) baseRelation).getRemoteTableName());
+        if (baseRelation instanceof JdbcNamedRelation) {
+            return " FROM " + getRelation(((JdbcNamedRelation) baseRelation).getRemoteTableName());
         }
-        if (baseRelation instanceof JdbcQueryRelationHandle) {
-            PreparedQuery preparedQuery = ((JdbcQueryRelationHandle) baseRelation).getPreparedQuery();
+        if (baseRelation instanceof JdbcQueryRelation) {
+            PreparedQuery preparedQuery = ((JdbcQueryRelation) baseRelation).getPreparedQuery();
             preparedQuery.getParameters().forEach(accumulator);
             return " FROM (" + preparedQuery.getQuery() + ") o";
         }

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadata.java
@@ -311,7 +311,7 @@ public class TestJdbcMetadata
                 // as firstDomain has been converted into a PreparedQuery
                 Optional.of(ImmutableMap.of(groupByColumn, secondDomain)));
         assertEquals(
-                ((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
+                ((JdbcQueryRelation) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
                 "SELECT \"TEXT\", count(*) AS \"_pfgnrtd_0\" " +
                         "FROM \"" + database.getDatabaseName() + "\".\"EXAMPLE\".\"NUMBERS\" " +
                         "WHERE \"TEXT\" IN (?,?) " +
@@ -340,7 +340,7 @@ public class TestJdbcMetadata
                 tableHandleWithFilter.getConstraint().getDomains(),
                 Optional.of(ImmutableMap.of(nonGroupByColumn, domain)));
         assertEquals(
-                ((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
+                ((JdbcQueryRelation) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
                 "SELECT \"TEXT\", count(*) AS \"_pfgnrtd_0\" " +
                         "FROM \"" + database.getDatabaseName() + "\".\"EXAMPLE\".\"NUMBERS\" " +
                         "GROUP BY \"TEXT\"");
@@ -369,7 +369,7 @@ public class TestJdbcMetadata
                 tableHandleWithFilter.getConstraint().getDomains(),
                 Optional.of(ImmutableMap.of(valueColumn, domain)));
         assertEquals(
-                ((JdbcQueryRelationHandle) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
+                ((JdbcQueryRelation) tableHandleWithFilter.getRelationHandle()).getPreparedQuery().getQuery(),
                 "SELECT \"TEXT\", \"VALUE\", count(*) AS \"_pfgnrtd_0\" " +
                         "FROM \"" + database.getDatabaseName() + "\".\"EXAMPLE\".\"NUMBERS\" " +
                         "GROUP BY GROUPING SETS ((\"TEXT\", \"VALUE\"), (\"TEXT\"))");

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -89,7 +89,7 @@ import static org.testng.Assert.assertEquals;
 @Test(singleThreaded = true)
 public class TestJdbcQueryBuilder
 {
-    private static final JdbcNamedRelationHandle TEST_TABLE = new JdbcNamedRelationHandle(new SchemaTableName(
+    private static final JdbcNamedRelation TEST_TABLE = new JdbcNamedRelation(new SchemaTableName(
             "some_test_schema", "test_table"),
             new RemoteTableName(Optional.empty(), Optional.empty(), "test_table"));
     private static final ConnectorSession SESSION = TestingConnectorSession.builder()

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -19,7 +19,7 @@ import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ColumnMapping;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
-import io.trino.plugin.jdbc.JdbcNamedRelationHandle;
+import io.trino.plugin.jdbc.JdbcNamedRelation;
 import io.trino.plugin.jdbc.JdbcOutputTableHandle;
 import io.trino.plugin.jdbc.JdbcSplit;
 import io.trino.plugin.jdbc.JdbcTableHandle;
@@ -178,7 +178,7 @@ public class DruidJdbcClient
             checkArgument("druid".equals(schemaName), "Only \"druid\" schema is supported");
 
             table = new JdbcTableHandle(
-                    new JdbcNamedRelationHandle(
+                    new JdbcNamedRelation(
                             table.getRequiredNamedRelation().getSchemaTableName(),
                             // Druid doesn't like table names to be qualified with catalog names in the SQL query, hence we null out the catalog.
                             new RemoteTableName(


### PR DESCRIPTION
Rename JdbcRelationHandle to JdbcRelation

We typically use a term `Handle` for things that belongs to connector
and engine use it to communicate with the connector like:
 - to get column metadata you need a column handle
 - to read data you need column handles

Also a term expresses things that do exists at the given time. So you
can access their details or use them. If you cannot get a handle then
you know that the object does not exists.

JdbcRelationHandle is an engine thing (no much relation to connector)
and it is also a complete object (you don't use to get any more
details).
