### PR TITLE
Upgrade Iceberg to 0.11.0

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.iceberg.version>0.9.0</dep.iceberg.version>
+        <dep.iceberg.version>0.11.0</dep.iceberg.version>
     </properties>
 
     <dependencies>
@@ -146,7 +146,7 @@
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-hive</artifactId>
+            <artifactId>iceberg-hive-metastore</artifactId>
             <version>${dep.iceberg.version}</version>
         </dependency>
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
@@ -16,7 +16,6 @@ package io.trino.plugin.iceberg;
 import io.airlift.log.Logger;
 import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
-import io.trino.plugin.hive.HiveType;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.HiveMetastore;
@@ -36,7 +35,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.CommitFailedException;
-import org.apache.iceberg.hive.HiveTypeConverter;
+import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
@@ -54,6 +53,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
+import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergUtil.isIcebergTable;
@@ -350,7 +350,7 @@ public class HiveTableOperations
         return columns.stream()
                 .map(column -> new Column(
                         column.name(),
-                        HiveType.valueOf(HiveTypeConverter.convert(column.type())),
+                        toHiveType(HiveSchemaUtil.convert(column.type())),
                         Optional.empty()))
                 .collect(toImmutableList());
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
@@ -168,8 +168,9 @@ public class PartitionTable
 
             for (FileScanTask fileScanTask : fileScanTasks) {
                 DataFile dataFile = fileScanTask.file();
+                Types.StructType structType = fileScanTask.spec().partitionType();
                 StructLike partitionStruct = dataFile.partition();
-                StructLikeWrapper partitionWrapper = StructLikeWrapper.wrap(partitionStruct);
+                StructLikeWrapper partitionWrapper = StructLikeWrapper.forType(structType).set(partitionStruct);
 
                 if (!partitions.containsKey(partitionWrapper)) {
                     Partition partition = new Partition(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
@@ -66,8 +66,6 @@ public final class PartitionTransforms
 
     private static final DateTimeField YEAR_FIELD = ISOChronology.getInstanceUTC().year();
     private static final DateTimeField MONTH_FIELD = ISOChronology.getInstanceUTC().monthOfYear();
-    private static final DateTimeField DAY_OF_YEAR_FIELD = ISOChronology.getInstanceUTC().dayOfYear();
-    private static final DateTimeField DAY_OF_MONTH_FIELD = ISOChronology.getInstanceUTC().dayOfMonth();
 
     private PartitionTransforms() {}
 
@@ -497,48 +495,27 @@ public final class PartitionTransforms
     @VisibleForTesting
     static long epochYear(long epochMilli)
     {
-        int epochYear = YEAR_FIELD.get(epochMilli) - 1970;
-        // Iceberg incorrectly handles negative epoch values
-        if ((epochMilli < 0) && ((DAY_OF_YEAR_FIELD.get(epochMilli) > 1) || !isMidnight(epochMilli))) {
-            epochYear++;
-        }
-        return epochYear;
+        return YEAR_FIELD.get(epochMilli) - 1970;
     }
 
     @VisibleForTesting
     static long epochMonth(long epochMilli)
     {
-        long year = YEAR_FIELD.get(epochMilli) - 1970;
+        long year = epochYear(epochMilli);
         int month = MONTH_FIELD.get(epochMilli) - 1;
-        long epochMonth = (year * 12) + month;
-        // Iceberg incorrectly handles negative epoch values
-        if ((epochMilli < 0) && ((DAY_OF_MONTH_FIELD.get(epochMilli) > 1) || !isMidnight(epochMilli))) {
-            epochMonth++;
-        }
-        return epochMonth;
+        return (year * 12) + month;
     }
 
     @VisibleForTesting
     static long epochDay(long epochMilli)
     {
-        long epochDay = floorDiv(epochMilli, MILLISECONDS_PER_DAY);
-        // Iceberg incorrectly handles negative epoch values
-        if ((epochMilli < 0) && !isMidnight(epochMilli)) {
-            epochDay++;
-        }
-        return epochDay;
+        return floorDiv(epochMilli, MILLISECONDS_PER_DAY);
     }
 
     @VisibleForTesting
     static long epochHour(long epochMilli)
     {
-        // Iceberg incorrectly handles negative epoch values
-        return epochMilli / MILLISECONDS_PER_HOUR;
-    }
-
-    private static boolean isMidnight(long epochMilli)
-    {
-        return (epochMilli % MILLISECONDS_PER_DAY) == 0;
+        return floorDiv(epochMilli, MILLISECONDS_PER_HOUR);
     }
 
     public static class ColumnTransform

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/AbstractTestIcebergSmoke.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/AbstractTestIcebergSmoke.java
@@ -722,15 +722,17 @@ public abstract class AbstractTestIcebergSmoke
         assertQuery("SELECT * FROM test_hour_transform", values);
 
         @Language("SQL") String expected = "VALUES " +
-                "(-1, 1, TIMESTAMP '1969-12-31 22:22:22.222222', TIMESTAMP '1969-12-31 22:22:22.222222', 8, 8), " +
-                "(0, 3, TIMESTAMP '1969-12-31 23:33:11.456789', TIMESTAMP '1970-01-01 00:55:44.765432', 9, 11), " +
+                "(-2, 1, TIMESTAMP '1969-12-31 22:22:22.222222', TIMESTAMP '1969-12-31 22:22:22.222222', 8, 8), " +
+                "(-1, 2, TIMESTAMP '1969-12-31 23:33:11.456789', TIMESTAMP '1969-12-31 23:44:55.567890', 9, 10), " +
+                "(0, 1, TIMESTAMP '1970-01-01 00:55:44.765432', TIMESTAMP '1970-01-01 00:55:44.765432', 11, 11), " +
                 "(394474, 3, TIMESTAMP '2015-01-01 10:01:23.123456', TIMESTAMP '2015-01-01 10:55:00.456789', 1, 3), " +
                 "(397692, 2, TIMESTAMP '2015-05-15 12:05:01.234567', TIMESTAMP '2015-05-15 12:21:02.345678', 4, 5), " +
                 "(439525, 2, TIMESTAMP '2020-02-21 13:11:11.876543', TIMESTAMP '2020-02-21 13:12:12.654321', 6, 7)";
         if (format == ORC) {
             expected = "VALUES " +
-                    "(-1, 1, NULL, NULL, 8, 8), " +
-                    "(0, 3, NULL, NULL, 9, 11), " +
+                    "(-2, 1, NULL, NULL, 8, 8), " +
+                    "(-1, 2, NULL, NULL, 9, 10), " +
+                    "(0, 1, NULL, NULL, 11, 11), " +
                     "(394474, 3, NULL, NULL, 1, 3), " +
                     "(397692, 2, NULL, NULL, 4, 5), " +
                     "(439525, 2, NULL, NULL, 6, 7)";
@@ -804,17 +806,19 @@ public abstract class AbstractTestIcebergSmoke
         assertQuery("SELECT * FROM test_day_transform_timestamp", values);
 
         @Language("SQL") String expected = "VALUES " +
-                "(DATE '1969-12-26', 1, TIMESTAMP '1969-12-25 15:13:12.876543', TIMESTAMP '1969-12-25 15:13:12.876543', 8, 8), " +
-                "(DATE '1969-12-31', 2, TIMESTAMP '1969-12-30 18:47:33.345678', TIMESTAMP '1969-12-31 00:00:00.000000', 9, 10), " +
-                "(DATE '1970-01-01', 2, TIMESTAMP '1969-12-31 05:06:07.234567', TIMESTAMP '1970-01-01 12:03:08.456789', 11, 12), " +
+                "(DATE '1969-12-25', 1, TIMESTAMP '1969-12-25 15:13:12.876543', TIMESTAMP '1969-12-25 15:13:12.876543', 8, 8), " +
+                "(DATE '1969-12-30', 1, TIMESTAMP '1969-12-30 18:47:33.345678', TIMESTAMP '1969-12-30 18:47:33.345678', 9, 9), " +
+                "(DATE '1969-12-31', 2, TIMESTAMP '1969-12-31 00:00:00.000000', TIMESTAMP '1969-12-31 05:06:07.234567', 10, 11), " +
+                "(DATE '1970-01-01', 1, TIMESTAMP '1970-01-01 12:03:08.456789', TIMESTAMP '1970-01-01 12:03:08.456789', 12, 12), " +
                 "(DATE '2015-01-01', 3, TIMESTAMP '2015-01-01 10:01:23.123456', TIMESTAMP '2015-01-01 12:55:00.456789', 1, 3), " +
                 "(DATE '2015-05-15', 2, TIMESTAMP '2015-05-15 13:05:01.234567', TIMESTAMP '2015-05-15 14:21:02.345678', 4, 5), " +
                 "(DATE '2020-02-21', 2, TIMESTAMP '2020-02-21 15:11:11.876543', TIMESTAMP '2020-02-21 16:12:12.654321', 6, 7)";
         if (format == ORC) {
             expected = "VALUES " +
-                    "(DATE '1969-12-26', 1, NULL, NULL, 8, 8), " +
-                    "(DATE '1969-12-31', 2, NULL, NULL, 9, 10), " +
-                    "(DATE '1970-01-01', 2, NULL, NULL, 11, 12), " +
+                    "(DATE '1969-12-25', 1, NULL, NULL, 8, 8), " +
+                    "(DATE '1969-12-30', 1, NULL, NULL, 9, 9), " +
+                    "(DATE '1969-12-31', 2, NULL, NULL, 10, 11), " +
+                    "(DATE '1970-01-01', 1, NULL, NULL, 12, 12), " +
                     "(DATE '2015-01-01', 3, NULL, NULL, 1, 3), " +
                     "(DATE '2015-05-15', 2, NULL, NULL, 4, 5), " +
                     "(DATE '2020-02-21', 2, NULL, NULL, 6, 7)";
@@ -853,8 +857,9 @@ public abstract class AbstractTestIcebergSmoke
         assertQuery(
                 "SELECT d_month, row_count, d.min, d.max, b.min, b.max FROM \"test_month_transform_date$partitions\"",
                 "VALUES " +
-                        "(-1, 2, DATE '1969-11-13', DATE '1969-12-01', 1, 2), " +
-                        "(0, 3, DATE '1969-12-02', DATE '1970-01-01', 3, 5), " +
+                        "(-2, 1, DATE '1969-11-13', DATE '1969-11-13', 1, 1), " +
+                        "(-1, 3, DATE '1969-12-01', DATE '1969-12-31', 2, 4), " +
+                        "(0, 1, DATE '1970-01-01', DATE '1970-01-01', 5, 5), " +
                         "(4, 1, DATE '1970-05-13', DATE '1970-05-13', 6, 6), " +
                         "(11, 1, DATE '1970-12-31', DATE '1970-12-31', 7, 7), " +
                         "(600, 1, DATE '2020-01-01', DATE '2020-01-01', 8, 8), " +
@@ -889,15 +894,17 @@ public abstract class AbstractTestIcebergSmoke
         assertQuery("SELECT * FROM test_month_transform_timestamp", values);
 
         @Language("SQL") String expected = "VALUES " +
-                "(-1, 3, TIMESTAMP '1969-11-15 15:13:12.876543', TIMESTAMP '1969-12-01 00:00:00.000000', 8, 10), " +
-                "(0, 2, TIMESTAMP '1969-12-01 05:06:07.234567', TIMESTAMP '1970-01-01 12:03:08.456789', 11, 12), " +
+                "(-2, 2, TIMESTAMP '1969-11-15 15:13:12.876543', TIMESTAMP '1969-11-19 18:47:33.345678', 8, 9), " +
+                "(-1, 2, TIMESTAMP '1969-12-01 00:00:00.000000', TIMESTAMP '1969-12-01 05:06:07.234567', 10, 11), " +
+                "(0, 1, TIMESTAMP '1970-01-01 12:03:08.456789', TIMESTAMP '1970-01-01 12:03:08.456789', 12, 12), " +
                 "(540, 3, TIMESTAMP '2015-01-01 10:01:23.123456', TIMESTAMP '2015-01-01 12:55:00.456789', 1, 3), " +
                 "(544, 2, TIMESTAMP '2015-05-15 13:05:01.234567', TIMESTAMP '2015-05-15 14:21:02.345678', 4, 5), " +
                 "(601, 2, TIMESTAMP '2020-02-21 15:11:11.876543', TIMESTAMP '2020-02-21 16:12:12.654321', 6, 7)";
         if (format == ORC) {
             expected = "VALUES " +
-                    "(-1, 3, NULL, NULL, 8, 10), " +
-                    "(0, 2, NULL, NULL, 11, 12), " +
+                    "(-2, 2, NULL, NULL, 8, 9), " +
+                    "(-1, 2, NULL, NULL, 10, 11), " +
+                    "(0, 1, NULL, NULL, 12, 12), " +
                     "(540, 3, NULL, NULL, 1, 3), " +
                     "(544, 2, NULL, NULL, 4, 5), " +
                     "(601, 2, NULL, NULL, 6, 7)";
@@ -934,8 +941,9 @@ public abstract class AbstractTestIcebergSmoke
         assertQuery(
                 "SELECT d_year, row_count, d.min, d.max, b.min, b.max FROM \"test_year_transform_date$partitions\"",
                 "VALUES " +
-                        "(-1, 2, DATE '1968-10-13', DATE '1969-01-01', 1, 2), " +
-                        "(0, 3, DATE '1969-03-15', DATE '1970-03-05', 3, 5), " +
+                        "(-2, 1, DATE '1968-10-13', DATE '1968-10-13', 1, 1), " +
+                        "(-1, 2, DATE '1969-01-01', DATE '1969-03-15', 2, 3), " +
+                        "(0, 2, DATE '1970-01-01', DATE '1970-03-05', 4, 5), " +
                         "(45, 3, DATE '2015-01-01', DATE '2015-07-28', 6, 8), " +
                         "(46, 2, DATE '2016-05-15', DATE '2016-06-06', 9, 10), " +
                         "(50, 2, DATE '2020-02-21', DATE '2020-11-10', 11, 12)");
@@ -967,14 +975,16 @@ public abstract class AbstractTestIcebergSmoke
         assertQuery("SELECT * FROM test_year_transform_timestamp", values);
 
         @Language("SQL") String expected = "VALUES " +
-                "(-1, 3, TIMESTAMP '1968-03-15 15:13:12.876543', TIMESTAMP '1969-01-01 00:00:00.000000', 1, 3), " +
-                "(0, 5, TIMESTAMP '1969-01-01 05:06:07.234567', TIMESTAMP '1970-12-31 12:55:00.456789', 4, 8), " +
+                "(-2, 2, TIMESTAMP '1968-03-15 15:13:12.876543', TIMESTAMP '1968-11-19 18:47:33.345678', 1, 2), " +
+                "(-1, 2, TIMESTAMP '1969-01-01 00:00:00.000000', TIMESTAMP '1969-01-01 05:06:07.234567', 3, 4), " +
+                "(0, 4, TIMESTAMP '1970-01-18 12:03:08.456789', TIMESTAMP '1970-12-31 12:55:00.456789', 5, 8), " +
                 "(45, 2, TIMESTAMP '2015-05-15 13:05:01.234567', TIMESTAMP '2015-09-15 14:21:02.345678', 9, 10), " +
                 "(50, 2, TIMESTAMP '2020-02-21 15:11:11.876543', TIMESTAMP '2020-08-21 16:12:12.654321', 11, 12)";
         if (format == ORC) {
             expected = "VALUES " +
-                    "(-1, 3, NULL, NULL, 1, 3), " +
-                    "(0, 5, NULL, NULL, 4, 8), " +
+                    "(-2, 2, NULL, NULL, 1, 2), " +
+                    "(-1, 2, NULL, NULL, 3, 4), " +
+                    "(0, 4, NULL, NULL, 5, 8), " +
                     "(45, 2, NULL, NULL, 9, 10), " +
                     "(50, 2, NULL, NULL, 11, 12)";
         }


### PR DESCRIPTION
Iceberg fixed error with negative epoch values in 0.11.0. We should upgrade to this version to remove former workaround code.
Information from [Iceberg release notes](https://iceberg.apache.org/releases/#0110-release-notes):
> #1981 fixes bug that date and timestamp transforms were producing incorrect values for dates and times before 1970. Before the fix, negative values were incorrectly transformed by date and timestamp transforms to 1 larger than the correct value. For example, day(1969-12-31 10:00:00) produced 0 instead of -1. The fix is backwards compatible, which means predicate projection can still work with the incorrectly transformed partitions written using older versions.