### PR TITLE
CLI external authentication

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -101,6 +101,9 @@ public class ClientOptions
     @Option(names = "--password", paramLabel = "<password>", description = "Prompt for password")
     public boolean password;
 
+    @Option(names = "--external-authentication", paramLabel = "<externalAuthentication>", description = "Enable external authentication")
+    public boolean externalAuthentication;
+
     @Option(names = "--source", paramLabel = "<source>", defaultValue = "trino-cli", description = "Name of source making query " + DEFAULT_VALUE)
     public String source;
 

--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -179,7 +179,8 @@ public class Console
                 clientOptions.krb5ConfigPath,
                 clientOptions.krb5KeytabPath,
                 clientOptions.krb5CredentialCachePath,
-                !clientOptions.krb5DisableRemoteServiceHostnameCanonicalization)) {
+                !clientOptions.krb5DisableRemoteServiceHostnameCanonicalization,
+                clientOptions.externalAuthentication)) {
             if (hasQuery) {
                 return executeCommand(
                         queryRunner,

--- a/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/QueryRunner.java
@@ -18,10 +18,15 @@ import io.airlift.log.Logger;
 import io.trino.client.ClientSession;
 import io.trino.client.OkHttpUtil;
 import io.trino.client.StatementClient;
+import io.trino.client.auth.external.ExternalAuthenticator;
+import io.trino.client.auth.external.HttpTokenPoller;
+import io.trino.client.auth.external.RedirectHandler;
+import io.trino.client.auth.external.TokenPoller;
 import okhttp3.OkHttpClient;
 
 import java.io.Closeable;
 import java.io.File;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -38,6 +43,7 @@ import static io.trino.client.OkHttpUtil.setupSsl;
 import static io.trino.client.OkHttpUtil.setupTimeouts;
 import static io.trino.client.OkHttpUtil.tokenAuth;
 import static io.trino.client.StatementClientFactory.newStatementClient;
+import static java.lang.System.out;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -72,7 +78,8 @@ public class QueryRunner
             Optional<String> kerberosConfigPath,
             Optional<String> kerberosKeytabPath,
             Optional<String> kerberosCredentialCachePath,
-            boolean kerberosUseCanonicalHostname)
+            boolean kerberosUseCanonicalHostname,
+            boolean externalAuthentication)
     {
         this.session = new AtomicReference<>(requireNonNull(session, "session is null"));
         this.debug = debug;
@@ -93,6 +100,7 @@ public class QueryRunner
         setupHttpProxy(builder, httpProxy);
         setupBasicAuth(builder, session, user, password);
         setupTokenAuth(builder, session, accessToken);
+        setupExternalAuth(builder, session, externalAuthentication, sslSetup);
         setupNetworkLogging(builder);
 
         if (kerberosRemoteServiceName.isPresent()) {
@@ -164,6 +172,33 @@ public class QueryRunner
                     "Authentication using username/password requires HTTPS to be enabled");
             clientBuilder.addInterceptor(basicAuth(user.get(), password.get()));
         }
+    }
+
+    private static void setupExternalAuth(
+            OkHttpClient.Builder builder,
+            ClientSession session,
+            boolean enabled,
+            Consumer<OkHttpClient.Builder> sslSetup)
+    {
+        if (!enabled) {
+            return;
+        }
+        checkArgument(session.getServer().getScheme().equalsIgnoreCase("https"),
+                "Authentication using externalAuthentication requires HTTPS to be enabled");
+
+        RedirectHandler redirectHandler = uri -> {
+            out.println("External authentication required. Please go to:");
+            out.println(uri.toString());
+        };
+        TokenPoller poller = new HttpTokenPoller(builder.build(), sslSetup);
+
+        ExternalAuthenticator authenticator = new ExternalAuthenticator(
+                redirectHandler,
+                poller,
+                Duration.ofMinutes(10));
+
+        builder.authenticator(authenticator);
+        builder.addInterceptor(authenticator);
     }
 
     private static void setupTokenAuth(

--- a/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
@@ -164,6 +164,7 @@ public class TestQueryRunner
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                false,
                 false);
     }
 


### PR DESCRIPTION
Added options are as follows:
--external-authentication

After considering comments from @kokosing I've decided to remove option to choose different redirect strategy (so only console one is available) and to increase timeout time to 10m and not exposing it as an option.