### PR TITLE
Add HTTPS, PEM, JKS pages; fix cross-refs thereto

### DIFF
--- a/docs/src/main/sphinx/security.rst
+++ b/docs/src/main/sphinx/security.rst
@@ -9,6 +9,8 @@ Cluster access security
   :maxdepth: 1
 
   security/tls
+  security/inspect-pem
+  security/inspect-jks
   security/ldap
   security/password-file
   security/salesforce

--- a/docs/src/main/sphinx/security/cli.rst
+++ b/docs/src/main/sphinx/security/cli.rst
@@ -33,13 +33,12 @@ principal.
 
 .. include:: ktadd-note.fragment
 
-Java keystore file for TLS
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Configuration for TLS
+^^^^^^^^^^^^^^^^^^^^^
 
-Access to the Trino coordinator must be through HTTPS when using Kerberos
-authentication. The Trino coordinator uses a :ref:`Java Keystore
-<server_java_keystore>` file for its TLS configuration. This file can be
-copied to the client machine and used for its configuration.
+When using Kerberos authentication, access to the Trino coordinator must be
+through HTTPS. If you have not yet configured HTTPS/TLS for your coordinator,
+refer to :doc:`HTTPS and TLS </security/tls>`.
 
 Trino CLI execution
 --------------------

--- a/docs/src/main/sphinx/security/inspect-jks.rst
+++ b/docs/src/main/sphinx/security/inspect-jks.rst
@@ -1,0 +1,132 @@
+=========
+JKS files
+=========
+
+This topic describes how to validate a :ref:`Java keystore (JKS) <glossJKS>`
+file used to configure :doc:`/security/tls`.
+
+The Java KeyStore (JKS) system is provided as part of your Java installation.
+Private keys and certificates for your server are stored in a *keystore* file.
+The JKS system supports both PKCS #12 ``.p12`` files as well as legacy
+keystore ``.jks`` files.
+
+The keystore file itself is always password-protected. The keystore file can
+have more than one key in the the same file, each addressed by its **alias**
+name.
+
+If you receive a keystore file from your site's network admin group, verify that
+it shows the correct information for your Trino cluster, as described next.
+
+.. _troubleshooting_keystore:
+
+Inspect and validate keystore
+-----------------------------
+
+Inspect the keystore file to make sure it contains the correct information for
+your Trino server. Use the ``keytool`` command, which is installed as part of
+your Java installation, to retrieve information from your keystore file:
+
+.. code-block:: text
+
+  keytool -list -v -keystore yourKeystore.jks
+
+Keystores always require a password. If not provided on the ``keytool`` command
+line, ``keytool`` prompts for the password.
+
+Independent of the keystore's password, it is possible that an individual key
+has its own password. It is easiest to make sure these passwords are the same.
+If the JKS key inside the keystore has a different password, you are prompted
+twice.
+
+In the output of the ``keytool -list`` command, look for:
+
+* The keystore may contain either a private key (``Entry type:
+  PrivateKeyEntry``) or certificate (``Entry type: trustedCertEntry``) or both.
+*  Modern browsers now enforce 398 days as the maximum validity period for a
+   certificate. Look for the ``Valid from ... until`` entry, and make sure the
+   time span does not exceed 398 days.
+*  Modern browsers and clients require the **SubjectAlternativeName** (SAN)
+   field. Make sure this shows the DNS name of your server, such as
+   ``DNS:cluster.example.com``. Certificates without SANs are not
+   supported.
+
+   Example:
+
+.. code-block:: text
+
+  SubjectAlternativeName [
+      DNSName:  cluster.example.com
+  ]
+
+If your keystore shows valid information for your cluster, proceed to configure
+the Trino server, as described in :ref:`cert-placement` and
+:ref:`configure-https`.
+
+The rest of this page describes additional steps that may apply in certain
+circumstances.
+
+.. _import_to_keystore:
+
+Extra: add PEM to keystore
+--------------------------
+
+Your site may have standardized on using JKS semantics for all servers. If a
+vendor sends you a PEM-encoded certificate file for your Trino server, you can
+import it into a keystore with a command like the following. Consult ``keytool``
+references for different options.
+
+.. code-block:: shell
+
+  keytool -trustcacerts -import -alias cluster -file localhost.pem -keystore localkeys.jks
+
+If the specified keystore file exists, ``keytool`` prompts for its password. If
+you are creating a new keystore, ``keytool`` prompts for a new password, then
+prompts you to confirm the same password. ``keytool`` shows you the
+contents of the key being added, similar to the ``keytool -list`` format, then
+prompts:
+
+.. code-block:: text
+
+  Trust this certificate? [no]:
+
+Type ``yes`` to add the PEM certificate to the keystore.
+
+The ``alias`` name is an arbitrary string used as a handle for the certificate
+you are adding. A keystore can contain multiple keys and certs, so ``keytool``
+uses the alias to address individual entries.
+
+.. _cli_java_truststore:
+
+Extra: Java truststores
+-----------------------
+
+.. note::
+
+    Remember that there may be no need to identify a local truststore when
+    directly using a signed PEM-encoded certificate, independent of a keystore.
+    PEM certs can contain the server's private key and the certificate chain all
+    the way back to a recognzied CA.
+
+Truststore files contain a list of :ref:`Certificate Authorities <glossCA>`
+trusted by Java to validate the private keys of servers, plus a list of the
+certificates of trusted TLS servers. The standard Java-provided truststore file,
+``cacerts``, is part of your Java installation in a standard location.
+
+Keystores normally rely on the default location of the system truststore, which
+therefore does not need to be configured.
+
+However, there are cases in which you need to use an alternate truststore. For
+example, if your site relies on the JKS system, your network managers may have
+appended site-specific, local CAs to the standard list, to validate locally
+signed keys.
+
+If your server must use a custom truststore, identify its location in the
+server's config properties file. For example:
+
+.. code-block:: text
+
+   http-server.https.truststore.path=/mnt/shared/certs/localcacerts
+   http-server.https.truststore.key=<truststore-password>
+
+If connecting clients such as browsers or the Trino CLI must be separately
+configured, contact your site's network administrators for assistance.

--- a/docs/src/main/sphinx/security/inspect-pem.rst
+++ b/docs/src/main/sphinx/security/inspect-pem.rst
@@ -1,0 +1,130 @@
+=========
+PEM files
+=========
+
+PEM (Privacy Enhanced Mail) is a standard for public key and certificate
+information, and an encoding standard used to transmit keys and certificates.
+
+Trino supports PEM-encoded certificates. If you want to use other supported
+formats, see:
+
+*  :doc:`JKS keystores </security/inspect-jks>`
+*  :ref:`PKCS 12 <glossPKCS12>` stores. (Look up alternate commands for these in
+   ``openssl`` references.)
+
+A single PEM-encoded file can contain either certificate or key pair
+information, or both in the same file. Certified keys can contain a chain of
+certificates from successive certificate authorities.
+
+Follow the steps in this topic to inspect and validate PEM-encoded key and
+certificate files. See :ref:`troubleshooting_keystore` to validate JKS
+keystores.
+
+.. _inspect_pems:
+
+Inspect PEM file
+----------------
+
+The file name extensions shown on this page are examples only; there is no
+extension naming standard.
+
+You may receive a single file that includes a private key and its certificate,
+or separate files. If you received separate files, concatenate them into one,
+typically in order from key to certificate. For example:
+
+.. code-block:: shell
+
+  cat clustercoord.key clustercoord.cert > clustercoord.pem
+
+Next, use the ``cat`` command to view this plain text file. For example:
+
+.. code-block:: shell
+
+    cat clustercoord.pem | less
+
+Make sure the PEM file shows at least one ``KEY`` and one ``CERTIFICATE``
+section. A key section looks something like the following:
+
+.. code-block:: text
+
+  -----BEGIN PRIVATE KEY-----
+  MIIEowIBAAKCAQEAwJL8CLeDFAHhZe3QOOF1vWt4Vuk9vyO38Y1y9SgBfB02b2jW
+  ....
+  -----END PRIVATE KEY-----
+
+If your key section reports ``BEGIN ENCRYPTED PRIVATE KEY`` instead, this means
+the key is encrypted and you must use the password to open or inspect the key.
+You may have specified the password when requesting the key, or the password
+could be assigned by your site's network managers.
+
+If your key section reports ``BEGIN EC PRIVATE KEY`` or ``BEGIN DSA PRIVATE
+KEY``, this designates a key using Elliptical Curve or DSA alternatives to RSA.
+
+The certificate section looks like the following example:
+
+.. code-block:: text
+
+  -----BEGIN CERTIFICATE-----
+  MIIDujCCAqICAQEwDQYJKoZIhvcNAQEFBQAwgaIxCzAJBgNVBAYTAlVTMRYwFAYD
+  ....
+  -----END CERTIFICATE-----
+  -----BEGIN CERTIFICATE-----
+  MIIDwjCCAqoCCQCxyqwZ9GK50jANBgkqhkiG9w0BAQsFADCBojELMAkGA1UEBhMC
+  ....
+  -----END CERTIFICATE-----
+
+The file can show a single certificate section, or more than one to express a
+chain of authorities, each certifying the previous.
+
+.. _validate_pems:
+
+Validate PEM key section
+------------------------
+
+This page presumes your system provides the ``openssl`` command from OpenSSL 1.1
+or later.
+
+Test an RSA private key's validity with the following command:
+
+.. code-block:: text
+
+  openssl rsa -in clustercoord.pem -check -noout
+
+Look for the following confirmation message:
+
+.. code-block:: text
+
+  RSA key ok
+
+.. note::
+
+  Consult ``openssl`` references for the appropriate versions of the
+  verification commands for EC or DSA keys.
+
+Validate PEM certificate section
+--------------------------------
+
+Analyze the certificate section of your PEM file with the following ``openssl``
+command:
+
+.. code-block:: text
+
+  openssl x509 -in clustercoord.pem -text -noout
+
+If your certificate was generated with a password, ``openssl`` prompts for it.
+
+In the output of the ``openssl`` command, look for the following
+characteristics:
+
+*  Modern browsers now enforce 398 days as the maximum validity period for a
+   certificate. Look for ``Not Before`` and ``Not After`` dates in the
+   ``Validity`` section of the output, and make sure the time span does not
+   exceed 398 days.
+*  Modern browsers and clients require the **Subject Alternative Name** (SAN)
+   field. Make sure this shows the DNS name of your server, such as
+   ``DNS:clustercoord.example.com``. Certificates without SANs are not
+   supported.
+
+If your PEM certificate shows valid information for your cluster, proceed to
+configure the server, as described in :ref:`cert-placement` and
+:ref:`configure-https`.

--- a/docs/src/main/sphinx/security/ldap.rst
+++ b/docs/src/main/sphinx/security/ldap.rst
@@ -21,8 +21,8 @@ Trino server configuration
 Trino coordinator node configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Access to the Trino coordinator should be through HTTPS. You can do that
-by creating a :ref:`server_java_keystore` on the coordinator.
+Access to the Trino coordinator should be through HTTPS, configured as described
+on :doc:`HTTPS and TLS </security/tls>`.
 
 You also need to make changes to the Trino configuration files.
 LDAP authentication is configured on the coordinator in two parts.
@@ -55,10 +55,11 @@ Property                                                      Description
                                                               Should be set to ``true``. Default value is
                                                               ``false``.
 ``http-server.https.port``                                    HTTPS server port.
-``http-server.https.keystore.path``                           The location of the Java Keystore file that will be
-                                                              used to secure TLS.
-``http-server.https.keystore.key``                            The password for the keystore. This must match the
-                                                              password you specified when creating the keystore.
+``http-server.https.keystore.path``                           The location of the PEM or Java keystore file
+                                                              is used to enable TLS.
+``http-server.https.keystore.key``                            The password for the PEM or Java keystore. This
+                                                              must match the password you specified when creating
+                                                              the PEM or keystore.
 ``http-server.process-forwarded``                             Enable treating forwarded HTTPS requests over HTTP
                                                               as secure.  Requires the ``X-Forwarded-Proto`` header
                                                               to be set to ``https`` on forwarded requests.
@@ -88,11 +89,11 @@ Property                           Description
 ================================== ======================================================
 ``ldap.url``                       The URL to the LDAP server. The URL scheme must be
                                    ``ldap://`` or ``ldaps://``. Connecting to the LDAP
-                                   server without SSL enabled requires
+                                   server without TLS enabled requires
                                    ``ldap.allow-insecure=true``.
 ``ldap.allow-insecure``            Allow using an LDAP connection that is not secured with
                                    TLS.
-``ldap.ssl-trust-certificate``     The path to the PEM encoded trust certificate  for the
+``ldap.ssl-trust-certificate``     The path to the PEM encoded trust certificate for the
                                    LDAP server. This file should contain the LDAP
                                    server's certificate or its certificate authority.
 ``ldap.user-bind-pattern``         This property can be used to specify the LDAP user
@@ -243,15 +244,8 @@ Environment configuration
 TLS configuration
 ~~~~~~~~~~~~~~~~~
 
-Access to the Trino coordinator should be through HTTPS when using LDAP
-authentication. The Trino CLI can use either a :ref:`Java Keystore
-<server_java_keystore>` file or :ref:`Java Truststore <cli_java_truststore>`
-for its TLS configuration.
-
-If you are using a keystore file, it can be copied to the client machine and used
-for its TLS configuration. If you are using truststore, you can either use
-default Java truststores or create a custom truststore on the CLI. We do not
-recommend using self-signed certificates in production.
+When using LDAP authentication, access to the Trino coordinator must be through
+:doc:`HTTPS/TLS </security/tls>`.
 
 Trino CLI execution
 ^^^^^^^^^^^^^^^^^^^^
@@ -289,7 +283,7 @@ Option                          Description
                                 to secure TLS.
 ``--keystore-password``         The password for the keystore. This must match the
                                 password you specified when creating the keystore.
-``--truststore-path``           The location of the Java Truststore file that will be used
+``--truststore-path``           The location of the Java truststore file that will be used
                                 to secure TLS.
 ``--truststore-password``       The password for the truststore. This must match the
                                 password you specified when creating the truststore.
@@ -319,10 +313,10 @@ you can change the :ref:`log level <log-levels>` for the LDAP authenticator:
 
     io.trino.plugin.password=DEBUG
 
-SSL debugging for Trino CLI
+TLS debugging for Trino CLI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you encounter any SSL related errors when running the Trino CLI, you can run
+If you encounter any TLS related errors when running the Trino CLI, you can run
 the CLI using the ``-Djavax.net.debug=ssl`` parameter for debugging. Use the
 Trino CLI executable JAR to enable this. For example:
 
@@ -334,30 +328,30 @@ Trino CLI executable JAR to enable this. For example:
     --server https://coordinator:8443 \
     <other_cli_arguments>
 
-Common SSL errors
-~~~~~~~~~~~~~~~~~
+Common TLS/SSL errors
+~~~~~~~~~~~~~~~~~~~~~
 
 java.security.cert.CertificateException: No subject alternative names present
 *****************************************************************************
 
 This error is seen when the Trino coordinator’s certificate is invalid, and does not have the IP you provide
-in the ``--server`` argument of the CLI. You have to regenerate the coordinator's SSL certificate
+in the ``--server`` argument of the CLI. You have to regenerate the coordinator's TLS certificate
 with the appropriate :abbr:`SAN (Subject Alternative Name)` added.
 
 Adding a SAN to this certificate is required in cases where ``https://`` uses IP address in the URL, rather
 than the domain contained in the coordinator's certificate, and the certificate does not contain the
 :abbr:`SAN (Subject Alternative Name)` parameter with the matching IP address as an alternative attribute.
 
-Authentication or SSL errors with JDK upgrade
+Authentication or TLS errors with JDK upgrade
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Starting with the JDK 8u181 release, to improve the robustness of LDAPS
-(secure LDAP over TLS) connections, endpoint identification algorithms have
-been enabled by default. See release notes
+(secure LDAP over TLS) connections, endpoint identification algorithms were
+enabled by default. See release notes
 `from Oracle <https://www.oracle.com/technetwork/java/javase/8u181-relnotes-4479407.html#JDK-8200666.>`_.
 The same LDAP server certificate on the Trino coordinator, running on JDK
 version >= 8u181, that was previously able to successfully connect to an
-LDAPS server, may now fail with the below error:
+LDAPS server, may now fail with the following error:
 
 .. code-block:: text
 

--- a/docs/src/main/sphinx/security/server.rst
+++ b/docs/src/main/sphinx/security/server.rst
@@ -46,12 +46,11 @@ In addition, the Trino coordinator needs a `keytab file
 
 .. include:: ktadd-note.fragment
 
-Java keystore file for TLS
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Configuration for TLS
+^^^^^^^^^^^^^^^^^^^^^
 
-When using Kerberos authentication, access to the Trino coordinator should be
-through HTTPS. You can do it by creating a :ref:`server_java_keystore` on the
-coordinator.
+When using Kerberos authentication, access to the Trino coordinator must be
+through :doc:`HTTPS and TLS </security/tls>`.
 
 System access control plugin
 ----------------------------
@@ -68,10 +67,10 @@ Trino coordinator to use Kerberos authentication and HTTPS. After making the
 following environment changes, you can make the changes to the Trino
 configuration files.
 
+* :doc:`/security/tls`
 * :ref:`server_kerberos_services`
 * :ref:`server_kerberos_configuration`
 * :ref:`server_kerberos_principals`
-* :ref:`server_java_keystore`
 * :doc:`System Access Control Plugin </develop/system-access-control>`
 
 config.properties

--- a/docs/src/main/sphinx/security/tls.rst
+++ b/docs/src/main/sphinx/security/tls.rst
@@ -1,84 +1,322 @@
-==============================
-Java keystores and truststores
-==============================
+=============
+HTTPS and TLS
+=============
 
-.. _server_java_keystore:
+Trino runs with no security by default. This allows you to connect to the server
+using URLs that specify the HTTP protocol when using the Trino :doc:`CLI
+</installation/cli>`, the :doc:`Web UI </admin/web-interface>`, or other
+clients.
 
-Java keystore file for TLS
---------------------------
+This topic describes how to configure your Trino server to use :ref:`TLS
+<glossTLS>` to require clients to use the HTTPS connection protocol. All
+authentication technologies supported by Trino require configuring TLS as the
+foundational layer.
 
-Access to the Trino coordinator must be through HTTPS when using Kerberos
-and LDAP authentication. The Trino coordinator uses a :ref:`Java Keystore
-<server_java_keystore>` file for its TLS configuration. These keys are
-generated using :command:`keytool` and stored in a Java Keystore file for the
-Trino coordinator.
+When configured to use TLS, a Trino server responds to client connections using
+TLS 1.2 and TLS 1.3 certificates. The server rejects TLS 1.1, TLS 1.0, and all
+SSL format certificates.
 
-The alias in the :command:`keytool` command line should match the principal that the
-Trino coordinator uses.
+.. important::
 
-You'll be prompted for the first and last name. Use the Common Name that will
-be used in the certificate. In this case, it should be the unqualified hostname
-of the Trino coordinator. In the following example, you can see this in the prompt
-that confirms the information is correct:
+    This page discusses only how to prepare the Trino server for secure client
+    connections from outside of the Trino cluster to its coordinator.
 
-.. code-block:: text
+See the :ref:`TLS Glossary <tlsglossary>` to clarify unfamiliar terms.
 
-    keytool -genkeypair -alias trino -keyalg RSA -keystore keystore.jks
-    Enter keystore password:
-    Re-enter new password:
-    What is your first and last name?
-      [Unknown]:  trino-coordinator.example.com
-    What is the name of your organizational unit?
-      [Unknown]:
-    What is the name of your organization?
-      [Unknown]:
-    What is the name of your City or Locality?
-      [Unknown]:
-    What is the name of your State or Province?
-      [Unknown]:
-    What is the two-letter country code for this unit?
-      [Unknown]:
-    Is CN=trino-coordinator.example.com, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown correct?
-      [no]:  yes
+Approaches
+----------
 
-    Enter key password for <trino>
-            (RETURN if same as keystore password):
+To configure Trino with TLS support, consider two alternative paths:
 
-.. _cli_java_truststore:
+* Use the :ref:`load balancer or proxy <https-load-balancer>` at your site
+  or cloud environment to terminate HTTPS/TLS. This approach is the simplest and
+  strongly preferred solution.
 
-Java truststore file for TLS
-----------------------------
+* Secure the Trino :ref:`server directly <https-secure-directly>`. This
+  requires you to obtain a valid certificate, and add it to the Trino
+  coordinator's configuration.
 
-Truststore files contain certificates of trusted TLS/SSL servers, or of
-Certificate Authorities trusted to identify servers. For securing access
-to the Trino coordinator through HTTPS, the clients can configure truststores.
-For the Trino CLI to trust the Trino coordinator, the coordinator's certificate
-must be imported to the CLI's truststore.
+.. _https-load-balancer:
 
-You can either import the certificate to the default Java truststore, or to a
-custom truststore. You should be careful, if you choose to use the default
-one, since you may need to remove the certificates of CAs you do not deem trustworthy.
+Use a load balancer to terminate HTTPS/TLS
+------------------------------------------
 
-You can use :command:`keytool` to import the certificate to the truststore.
-In the example, we are going to import ``trino_certificate.cer`` to a custom
-truststore ``trino_trust.jks``, and you get a prompt asking if the certificate
-can be trusted or not.
+Your site or cloud environment may already have a :ref:`load balancer <glossLB>`
+or proxy server configured and running with a valid, globally trusted TLS
+certificate. In this case, you can work with your network administrators to set
+up your Trino server behind the load balancer. The load balancer or proxy server
+accepts TLS connections and forwards them to the Trino coordinator, which
+typically runs with default HTTP configuration on the default port, 8080.
+
+When a load balancer accepts a TLS encrypted connection, it adds a
+`forwarded
+<https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling#forwarding_client_information_through_proxies>`_
+HTTP header to the request, such as:
 
 .. code-block:: text
 
-    $ keytool -import -v -trustcacerts -alias trino_trust -file trino_certificate.cer -keystore trino_trust.jks -keypass <truststore_pass>
+    X-Forwarded-Proto: https
 
-Troubleshooting
----------------
+This tells the Trino coordinator to process the connection as if a TLS
+connection has already been successfully negotiated for it. This is why you do
+not need to configure ``http-server.https.enabled=true`` for a coordinator
+behind a load balancer.
 
-.. _troubleshooting_keystore:
-
-Java keystore file verification
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Verify the password for a keystore file and view its contents using `keytool
-<https://docs.oracle.com/en/java/javase/11/tools/keytool.html>`_.
+However, to enable processing of such forwarded headers, the server's
+:ref:`config properties file <config_properties>` *must* include the following:
 
 .. code-block:: text
 
-    $ keytool -list -v -keystore /etc/trino/trino.jks
+  http-server.process-forwarded=true
+
+This completes any necessary configuration for using HTTPS with a load balancer.
+Client tools can access Trino with the URL exposed by the load balancer.
+
+.. _https-secure-directly:
+
+Secure Trino directly
+----------------------
+
+Instead of the preferred mechanism of using an :ref:`external load balancer
+<https-load-balancer>`, you can secure the Trino coordinator itself. This
+requires you to obtain and install a TLS :ref:`certificate <glossCert>`, and
+configure Trino to use it for client connections.
+
+Add a TLS certificate
+^^^^^^^^^^^^^^^^^^^^^
+
+Obtain a TLS certificate file for use with your Trino server. Consider the
+following types of certificates:
+
+* **Globally trusted certificates** — A certificate that is automatically
+  trusted by all browsers and clients. This is the easiest type to use because
+  you do not need to configure clients. Obtain a certificate of this type from:
+
+  *  A commercial certificate vendor
+  *  Your cloud infrastructure provider
+  *  A domain name registrar, such as Verisign or GoDaddy
+  *  A free certificate generator, such as
+     `letsencrypt.org <https://letsencrypt.org/>`_ or
+     `sslforfree.com <https://www.sslforfree.com/>`_
+
+* **Corporate trusted certificates** — A certificate trusted by browsers and
+  clients in your organization. Typically, a site's IT department runs a local
+  :ref:`certificate authority <glossCA>` and preconfigures clients and servers
+  to trust this CA.
+
+* **Generated self-signed certificates** — A certificate generated just for
+  Trino that is not automatically trusted by any client. Before using, make sure
+  you understand the :ref:`limitations of self-signed certificates
+  <self_signed_limits>`.
+
+The most convenient option and strongly recommended option is a globally trusted
+certificate. It may require a little more work up front, but it is worth it to
+not have to configure every single client.
+
+Keys and certificates
+^^^^^^^^^^^^^^^^^^^^^
+
+Trino can read certificates and private keys encoded in PEM encoded PKCS #1, PEM
+encoded PKCS #8, PKCS #12, and the legacy Java KeyStore (JKS) format.
+
+Make sure you obtain a certificate that is validated by a recognized
+:ref:`certificate authority <glossCA>`.
+
+Inspect received certificates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Before installing your certificate, inspect and validate the received key and
+certificate files to make sure they reference the correct information to access
+your Trino server. Much unnecessary debugging time is saved by taking the time
+to validate your certificates before proceeding to configure the server.
+
+Inspect PEM-encoded files as described in :doc:`Inspect PEM files
+</security/inspect-pem>`.
+
+Inspect PKCS # 12 and JKS keystores as described in :doc:`Inspect JKS files
+</security/inspect-jks>`.
+
+Invalid certificates
+^^^^^^^^^^^^^^^^^^^^^
+
+If your certificate does not pass validation, or does not show the expected
+information on inspection, contact the group or vendor who provided it for a
+replacement.
+
+.. _cert-placement:
+
+Place the certificate file
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are no location requirements for a certificate file as long as:
+
+* The file can be read by the Trino coordinator server process.
+* The location is secure from copying or tampering by malicious actors.
+
+You can place your file in the Trino coordinator's ``etc`` directory, which
+allows you to use a relative path reference in configuration files. However,
+this location can require you to keep track of the certificate file, and move it
+to a new ``etc`` directory when you upgrade your Trino version.
+
+.. _configure-https:
+
+Configure the coordinator
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On the coordinator, add the following lines to the :ref:`config properties file
+<config_properties>` to enable TLS/HTTPS support for the server.
+
+.. note::
+
+  Legacy ``keystore`` and ``truststore`` wording is used in property names, even
+  when directly using PEM-encoded certificates.
+
+.. code-block:: text
+
+  http-server.https.enabled=true
+  http-server.https.port=8443
+  http-server.https.keystore.path=etc/clustercoord.pem
+
+Possible alternatives for the third line include:
+
+.. code-block:: text
+
+  http-server.https.keystore.path=etc/clustercoord.jks
+  http-server.https.keystore.path=/usr/local/certs/clustercoord.p12
+
+Relative paths are relative to the Trino server's root directory. In a
+``tar.gz`` installation, the root directory is one level above ``etc``.
+
+JKS keystores always require a password, while PEM format certificates can
+optionally require a password. For cases where you need a password, add the
+following line to the configuration.
+
+.. code-block:: text
+
+  http-server.https.keystore.key=<keystore-password>
+
+It is possible for a key inside a keystore to have its own password,
+independent of the keystore's password. In this case, specify the key's password
+with the following property:
+
+.. code-block:: text
+
+  http-server.https.keymanager.password=<key-password>
+
+When your Trino coordinator has an authenticator enabled along with HTTPS
+enabled, HTTP access is automatically disabled for all clients, including the
+:doc:`Web UI </admin/web-interface>`. Although not recommended, you can
+re-enable it by setting:
+
+.. code-block:: text
+
+  http-server.authentication.allow-insecure-over-http=true
+
+Test configuration
+^^^^^^^^^^^^^^^^^^
+
+To test your configuration settings, restart the server and try to connect to it
+with the Trino :doc:`CLI </installation/cli>` or :doc:`Web UI
+</admin/web-interface>`, using a URL that begins with ``https://``.
+
+Now that TLS is configured, go back and :doc:`configure the authentication
+</security>` method for your server.
+
+.. _self_signed_limits:
+
+Limitations of self-signed certificates
+---------------------------------------
+
+It is possible to generate a self-signed certificate with the ``openssl``,
+``keytool``, or on Linux, ``certtool`` commands. Self-signed certificates can be
+useful during development of a cluster for internal use only. We recommend never
+using a self-signed certificate for a production Trino server.
+
+Self-signed certificates are not trusted by anyone. They are typically created
+by an administrator for expediency, because they do not require getting trust
+signoff from anyone.
+
+To use a self-signed certificate while developing your cluster requires:
+
+* distributing to every client a local truststore that validates the certificate
+* configuring every client to use this certificate
+
+However, even with this client configuration, modern browsers reject these
+certificates, which makes self-signed servers difficult to work with.
+
+There is a difference between self-signed and unsigned certificates. Both types
+are created with the same tools, but unsigned certificates are meant to be
+forwarded to a CA with a Certificate Signing Request (CSR). The CA returns the
+certificate signed by the CA and now globally trusted.
+
+.. _tlsglossary:
+
+TLS Glossary
+------------
+
+.. _glossCA:
+
+CA
+    Certificate Authority, a trusted organization that examines and validates
+    organizations and their proposed server URIs, and issues digital
+    certificates verified as valid for the requesting organization.
+
+.. _glossCert:
+
+Certificate
+    A public key `certificate
+    <https://en.wikipedia.org/wiki/Public_key_certificate>`_ issued by a CA,
+    sometimes abbreviated as *cert*, that verifies the ownership of a server's
+    keys. Certificate format is specified in the `X.509
+    <https://en.wikipedia.org/wiki/X.509>`_ standard.
+
+.. _glossJKS:
+
+JKS
+    Java KeyStore, the system of public key cryptography supported as one part
+    of the Java security APIs. The legacy JKS system recognizes keys and
+    certificates stored in *keystore* files, typically with the ``.jks``
+    extension, and relies on a system-level list of CAs in *truststore* files
+    installed as part of the current Java installation.
+
+.. _glossKey:
+
+Key
+    A cryptographic key specified as a pair of public and private keys.
+
+.. _glossLB:
+
+Load Balancer (LB)
+    Software or a hardware device that sits on a network's outer edge or
+    firewall and accepts network connections on behalf of servers behind that
+    wall. Load balancers carefully manage network traffic, and can accept TLS
+    connections from incoming clients and pass those connections transparently
+    to servers behind the wall.
+
+.. _glossPEM:
+
+PEM
+    Privacy-Enhanced Mail, a syntax for private key information, and a content
+    type used to store and send cryptographic keys and certificates. PEM format
+    can contain both a key and its certificate, plus the chain of certificates
+    from authorities back to the root :ref:`CA <glossCA>`, or back to a CA
+    vendor's intermediate CA.
+
+.. _glossPKCS12:
+
+PKCS #12
+    A binary archive used to store keys and certificates or certificate chains
+    that validate a key. `PKCS #12 <https://en.wikipedia.org/wiki/PKCS_12>`_
+    files have ``.p12`` or ``.pfx`` extensions.
+
+SSL
+    Secure Sockets Layer, now superceded by TLS, but still recognized as the
+    term for what TLS does now.
+
+.. _glossTLS:
+
+TLS
+    `Transport Layer Security
+    <https://en.wikipedia.org/wiki/Transport_Layer_Security>`_ is the successor
+    to SSL. These security topics use the term TLS to refer to both TLS and SSL.
+


### PR DESCRIPTION
This is the second attempt to add a new HTTPS page, this time incorporating the comments and wishlist from a previous attempt's review.

Notice that links in the body of the new pages generally go to terms in the Glossary of https.rst, whereas links in the Glossary itself generally point to outside pages. This saves much jumping around between domains, and also make the pages usable in situations of no Internet access. 