### PR TITLE
Introduce LazyConnectionFactory

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingConnection.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingConnection.java
@@ -1,0 +1,476 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.jdbc;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.ShardingKey;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+public abstract class ForwardingConnection
+        implements Connection
+{
+    protected abstract Connection getDelegate()
+            throws SQLException;
+
+    @Override
+    public Statement createStatement()
+            throws SQLException
+    {
+        return getDelegate().createStatement();
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql)
+            throws SQLException
+    {
+        return getDelegate().prepareStatement(sql);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql)
+            throws SQLException
+    {
+        return getDelegate().prepareCall(sql);
+    }
+
+    @Override
+    public String nativeSQL(String sql)
+            throws SQLException
+    {
+        return getDelegate().nativeSQL(sql);
+    }
+
+    @Override
+    public void setAutoCommit(boolean autoCommit)
+            throws SQLException
+    {
+        getDelegate().setAutoCommit(autoCommit);
+    }
+
+    @Override
+    public boolean getAutoCommit()
+            throws SQLException
+    {
+        return getDelegate().getAutoCommit();
+    }
+
+    @Override
+    public void commit()
+            throws SQLException
+    {
+        getDelegate().commit();
+    }
+
+    @Override
+    public void rollback()
+            throws SQLException
+    {
+        getDelegate().rollback();
+    }
+
+    @Override
+    public void close()
+            throws SQLException
+    {
+        getDelegate().close();
+    }
+
+    @Override
+    public boolean isClosed()
+            throws SQLException
+    {
+        return getDelegate().isClosed();
+    }
+
+    @Override
+    public DatabaseMetaData getMetaData()
+            throws SQLException
+    {
+        return getDelegate().getMetaData();
+    }
+
+    @Override
+    public void setReadOnly(boolean readOnly)
+            throws SQLException
+    {
+        getDelegate().setReadOnly(readOnly);
+    }
+
+    @Override
+    public boolean isReadOnly()
+            throws SQLException
+    {
+        return getDelegate().isReadOnly();
+    }
+
+    @Override
+    public void setCatalog(String catalog)
+            throws SQLException
+    {
+        getDelegate().setCatalog(catalog);
+    }
+
+    @Override
+    public String getCatalog()
+            throws SQLException
+    {
+        return getDelegate().getCatalog();
+    }
+
+    @Override
+    public void setTransactionIsolation(int level)
+            throws SQLException
+    {
+        getDelegate().setTransactionIsolation(level);
+    }
+
+    @Override
+    public int getTransactionIsolation()
+            throws SQLException
+    {
+        return getDelegate().getTransactionIsolation();
+    }
+
+    @Override
+    public SQLWarning getWarnings()
+            throws SQLException
+    {
+        return getDelegate().getWarnings();
+    }
+
+    @Override
+    public void clearWarnings()
+            throws SQLException
+    {
+        getDelegate().clearWarnings();
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency)
+            throws SQLException
+    {
+        return getDelegate().createStatement(resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency)
+            throws SQLException
+    {
+        return getDelegate().prepareStatement(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency)
+            throws SQLException
+    {
+        return getDelegate().prepareCall(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public Map<String, Class<?>> getTypeMap()
+            throws SQLException
+    {
+        return getDelegate().getTypeMap();
+    }
+
+    @Override
+    public void setTypeMap(Map<String, Class<?>> map)
+            throws SQLException
+    {
+        getDelegate().setTypeMap(map);
+    }
+
+    @Override
+    public void setHoldability(int holdability)
+            throws SQLException
+    {
+        getDelegate().setHoldability(holdability);
+    }
+
+    @Override
+    public int getHoldability()
+            throws SQLException
+    {
+        return getDelegate().getHoldability();
+    }
+
+    @Override
+    public Savepoint setSavepoint()
+            throws SQLException
+    {
+        return getDelegate().setSavepoint();
+    }
+
+    @Override
+    public Savepoint setSavepoint(String name)
+            throws SQLException
+    {
+        return getDelegate().setSavepoint(name);
+    }
+
+    @Override
+    public void rollback(Savepoint savepoint)
+            throws SQLException
+    {
+        getDelegate().rollback();
+    }
+
+    @Override
+    public void releaseSavepoint(Savepoint savepoint)
+            throws SQLException
+    {
+        getDelegate().releaseSavepoint(savepoint);
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+            throws SQLException
+    {
+        return getDelegate().createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+            throws SQLException
+    {
+        return getDelegate().prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+            throws SQLException
+    {
+        return getDelegate().prepareCall(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys)
+            throws SQLException
+    {
+        return getDelegate().prepareStatement(sql, autoGeneratedKeys);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int[] columnIndexes)
+            throws SQLException
+    {
+        return getDelegate().prepareStatement(sql, columnIndexes);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, String[] columnNames)
+            throws SQLException
+    {
+        return getDelegate().prepareStatement(sql, columnNames);
+    }
+
+    @Override
+    public Clob createClob()
+            throws SQLException
+    {
+        return getDelegate().createClob();
+    }
+
+    @Override
+    public Blob createBlob()
+            throws SQLException
+    {
+        return getDelegate().createBlob();
+    }
+
+    @Override
+    public NClob createNClob()
+            throws SQLException
+    {
+        return getDelegate().createNClob();
+    }
+
+    @Override
+    public SQLXML createSQLXML()
+            throws SQLException
+    {
+        return getDelegate().createSQLXML();
+    }
+
+    @Override
+    public boolean isValid(int timeout)
+            throws SQLException
+    {
+        return getDelegate().isValid(timeout);
+    }
+
+    @Override
+    public void setClientInfo(String name, String value)
+            throws SQLClientInfoException
+    {
+        Connection delegate;
+        try {
+            delegate = getDelegate();
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        delegate.setClientInfo(name, value);
+    }
+
+    @Override
+    public void setClientInfo(Properties properties)
+            throws SQLClientInfoException
+    {
+        Connection delegate;
+        try {
+            delegate = getDelegate();
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        delegate.setClientInfo(properties);
+    }
+
+    @Override
+    public String getClientInfo(String name)
+            throws SQLException
+    {
+        return getDelegate().getClientInfo(name);
+    }
+
+    @Override
+    public Properties getClientInfo()
+            throws SQLException
+    {
+        return getDelegate().getClientInfo();
+    }
+
+    @Override
+    public Array createArrayOf(String typeName, Object[] elements)
+            throws SQLException
+    {
+        return getDelegate().createArrayOf(typeName, elements);
+    }
+
+    @Override
+    public Struct createStruct(String typeName, Object[] attributes)
+            throws SQLException
+    {
+        return getDelegate().createStruct(typeName, attributes);
+    }
+
+    @Override
+    public void setSchema(String schema)
+            throws SQLException
+    {
+        getDelegate().setSchema(schema);
+    }
+
+    @Override
+    public String getSchema()
+            throws SQLException
+    {
+        return getDelegate().getSchema();
+    }
+
+    @Override
+    public void abort(Executor executor)
+            throws SQLException
+    {
+        getDelegate().abort(executor);
+    }
+
+    @Override
+    public void setNetworkTimeout(Executor executor, int milliseconds)
+            throws SQLException
+    {
+        getDelegate().setNetworkTimeout(executor, milliseconds);
+    }
+
+    @Override
+    public int getNetworkTimeout()
+            throws SQLException
+    {
+        return getDelegate().getNetworkTimeout();
+    }
+
+    @Override
+    public void beginRequest()
+            throws SQLException
+    {
+        getDelegate().beginRequest();
+    }
+
+    @Override
+    public void endRequest()
+            throws SQLException
+    {
+        getDelegate().endRequest();
+    }
+
+    @Override
+    public boolean setShardingKeyIfValid(ShardingKey shardingKey, ShardingKey superShardingKey, int timeout)
+            throws SQLException
+    {
+        return getDelegate().setShardingKeyIfValid(shardingKey, superShardingKey, timeout);
+    }
+
+    @Override
+    public boolean setShardingKeyIfValid(ShardingKey shardingKey, int timeout)
+            throws SQLException
+    {
+        return getDelegate().setShardingKeyIfValid(shardingKey, timeout);
+    }
+
+    @Override
+    public void setShardingKey(ShardingKey shardingKey, ShardingKey superShardingKey)
+            throws SQLException
+    {
+        getDelegate().setShardingKey(shardingKey, superShardingKey);
+    }
+
+    @Override
+    public void setShardingKey(ShardingKey shardingKey)
+            throws SQLException
+    {
+        getDelegate().setShardingKey(shardingKey);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface)
+            throws SQLException
+    {
+        return getDelegate().unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface)
+            throws SQLException
+    {
+        return getDelegate().isWrapperFor(iface);
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc;
 import com.google.inject.Binder;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import io.trino.plugin.base.CatalogName;
@@ -26,6 +27,7 @@ import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.procedure.Procedure;
 
 import javax.inject.Provider;
+import javax.inject.Singleton;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
@@ -66,9 +68,15 @@ public class JdbcModule
         bindSessionPropertiesProvider(binder, JdbcMetadataSessionProperties.class);
 
         binder.bind(JdbcClient.class).to(CachingJdbcClient.class).in(Scopes.SINGLETON);
-        binder.bind(ConnectionFactory.class).to(Key.get(ConnectionFactory.class, StatsCollecting.class));
 
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class));
+    }
+
+    @Provides
+    @Singleton
+    public ConnectionFactory createConnectionFactory(@StatsCollecting ConnectionFactory connectionFactory)
+    {
+        return new LazyConnectionFactory(connectionFactory);
     }
 
     public static Multibinder<SessionPropertiesProvider> sessionPropertiesProviderBinder(Binder binder)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyConnectionFactory.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import io.trino.spi.connector.ConnectorSession;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public final class LazyConnectionFactory
+        implements ConnectionFactory
+{
+    private final ConnectionFactory delegate;
+
+    public LazyConnectionFactory(ConnectionFactory delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public Connection openConnection(ConnectorSession session)
+            throws SQLException
+    {
+        return new LazyConnection(() -> delegate.openConnection(session));
+    }
+
+    @Override
+    public void close()
+            throws SQLException
+    {
+        delegate.close();
+    }
+
+    private static final class LazyConnection
+            extends ForwardingConnection
+    {
+        private final SqlSupplier<Connection> connectionSupplier;
+        @Nullable
+        @GuardedBy("this")
+        private Connection connection;
+        @GuardedBy("this")
+        private boolean closed;
+
+        public LazyConnection(SqlSupplier<Connection> connectionSupplier)
+        {
+            this.connectionSupplier = requireNonNull(connectionSupplier, "connectionSupplier is null");
+        }
+
+        @Override
+        protected synchronized Connection getDelegate()
+                throws SQLException
+        {
+            checkState(!closed, "Connection is already closed");
+            if (connection == null) {
+                connection = requireNonNull(connectionSupplier.get(), "connectionSupplier.get() is null");
+            }
+            return connection;
+        }
+
+        @Override
+        public synchronized void close()
+                throws SQLException
+        {
+            closed = true;
+            if (connection != null) {
+                connection.close();
+            }
+        }
+    }
+
+    @FunctionalInterface
+    private interface SqlSupplier<T>
+    {
+        T get()
+                throws SQLException;
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestForwardingConnection.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestForwardingConnection.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.jdbc;
+
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+
+import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+
+public class TestForwardingConnection
+{
+    @Test
+    public void testEverythingImplemented()
+    {
+        assertAllMethodsOverridden(Connection.class, ForwardingConnection.class);
+    }
+
+    // TODO implement testEverythingForwarded - it requires to mock java.sql complex structures
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestLazyConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestLazyConnectionFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import io.trino.plugin.jdbc.credential.EmptyCredentialProvider;
+import org.h2.Driver;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static io.trino.testing.TestingConnectorSession.SESSION;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestLazyConnectionFactory
+{
+    @Test
+    public void testNoConnectionIsCreated()
+            throws Exception
+    {
+        ConnectionFactory failingConnectionFactory = session -> {
+            throw new AssertionError("Expected no connection creation");
+        };
+
+        try (LazyConnectionFactory lazyConnectionFactory = new LazyConnectionFactory(failingConnectionFactory);
+                Connection ignored = lazyConnectionFactory.openConnection(SESSION)) {
+            // no-op
+        }
+    }
+
+    @Test
+    public void testConnectionCannotBeReusedAfterClose()
+            throws Exception
+    {
+        BaseJdbcConfig config = new BaseJdbcConfig()
+                .setConnectionUrl(format("jdbc:h2:mem:test%s;DB_CLOSE_DELAY=-1", System.nanoTime() + ThreadLocalRandom.current().nextLong()));
+
+        try (DriverConnectionFactory h2ConnectionFactory = new DriverConnectionFactory(new Driver(), config, new EmptyCredentialProvider());
+                LazyConnectionFactory lazyConnectionFactory = new LazyConnectionFactory(h2ConnectionFactory)) {
+            Connection connection = lazyConnectionFactory.openConnection(SESSION);
+            connection.close();
+            assertThatThrownBy(() -> connection.createStatement())
+                    .hasMessage("Connection is already closed");
+        }
+    }
+}

--- a/plugin/trino-postgresql/pom.xml
+++ b/plugin/trino-postgresql/pom.xml
@@ -114,6 +114,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-jmx</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/PostgreSqlQueryRunner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
 import io.trino.Session;
+import io.trino.plugin.jmx.JmxPlugin;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
@@ -91,6 +92,9 @@ public final class PostgreSqlQueryRunner
                 ImmutableMap.of("http-server.http.port", "8080"),
                 ImmutableMap.of(),
                 TpchTable.getTables());
+
+        queryRunner.installPlugin(new JmxPlugin());
+        queryRunner.createCatalog("jmx", "jmx");
 
         Logger log = Logger.get(PostgreSqlQueryRunner.class);
         log.info("======== SERVER STARTED ========");

--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,12 @@
 
             <dependency>
                 <groupId>io.trino</groupId>
+                <artifactId>trino-jmx</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.trino</groupId>
                 <artifactId>trino-local-file</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Introduce LazyConnectionFactory

This reduces number of connections made to RDBMS during planning by
skipping no-op connections.

Fixes https://github.com/trinodb/trino/issues/6719