### PR TITLE
Support limiting the number of unacknowledged splits per task

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/RemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RemoteTask.java
@@ -64,4 +64,6 @@ public interface RemoteTask
     int getPartitionedSplitCount();
 
     int getQueuedPartitionedSplitCount();
+
+    int getUnacknowledgedPartitionedSplitCount();
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeAssignmentStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeAssignmentStats.java
@@ -39,12 +39,12 @@ public final class NodeAssignmentStats
         this.stageQueuedSplitInfo = new HashMap<>(nodeMapSize);
 
         for (RemoteTask task : existingTasks) {
-            checkArgument(stageQueuedSplitInfo.put(task.getNodeId(), new PendingSplitInfo(task.getQueuedPartitionedSplitCount())) == null, "A single stage may not have multiple tasks running on the same node");
+            checkArgument(stageQueuedSplitInfo.put(task.getNodeId(), new PendingSplitInfo(task.getQueuedPartitionedSplitCount(), task.getUnacknowledgedPartitionedSplitCount())) == null, "A single stage may not have multiple tasks running on the same node");
         }
 
         // pre-populate the assignment counts with zeros
         if (existingTasks.size() < nodeMapSize) {
-            Function<String, PendingSplitInfo> createEmptySplitInfo = (ignored) -> new PendingSplitInfo(0);
+            Function<String, PendingSplitInfo> createEmptySplitInfo = (ignored) -> new PendingSplitInfo(0, 0);
             for (InternalNode node : nodeMap.getNodesByHostAndPort().values()) {
                 stageQueuedSplitInfo.computeIfAbsent(node.getNodeIdentifier(), createEmptySplitInfo);
             }
@@ -64,6 +64,12 @@ public final class NodeAssignmentStats
         return stageInfo == null ? 0 : stageInfo.getQueuedSplitCount();
     }
 
+    public int getUnacknowledgedSplitCountForStage(InternalNode node)
+    {
+        PendingSplitInfo stageInfo = stageQueuedSplitInfo.get(node.getNodeIdentifier());
+        return stageInfo == null ? 0 : stageInfo.getUnacknowledgedSplitCount();
+    }
+
     public void addAssignedSplit(InternalNode node)
     {
         getOrCreateStageSplitInfo(node).addAssignedSplit();
@@ -80,7 +86,7 @@ public final class NodeAssignmentStats
         // Avoids the extra per-invocation lambda allocation of computeIfAbsent since assigning a split to an existing task more common than creating a new task
         PendingSplitInfo stageInfo = stageQueuedSplitInfo.get(nodeId);
         if (stageInfo == null) {
-            stageInfo = new PendingSplitInfo(0);
+            stageInfo = new PendingSplitInfo(0, 0);
             stageQueuedSplitInfo.put(nodeId, stageInfo);
         }
         return stageInfo;
@@ -89,11 +95,13 @@ public final class NodeAssignmentStats
     private static final class PendingSplitInfo
     {
         private final int queuedSplitCount;
+        private final int unacknowledgedSplitCount;
         private int assignedSplits;
 
-        private PendingSplitInfo(int queuedSplitCount)
+        private PendingSplitInfo(int queuedSplitCount, int unacknowledgedSplitCount)
         {
             this.queuedSplitCount = queuedSplitCount;
+            this.unacknowledgedSplitCount = unacknowledgedSplitCount;
         }
 
         public int getAssignedSplitCount()
@@ -104,6 +112,11 @@ public final class NodeAssignmentStats
         public int getQueuedSplitCount()
         {
             return queuedSplitCount + assignedSplits;
+        }
+
+        public int getUnacknowledgedSplitCount()
+        {
+            return unacknowledgedSplitCount + assignedSplits;
         }
 
         public void addAssignedSplit()

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeAssignmentStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeAssignmentStats.java
@@ -20,6 +20,7 @@ import io.trino.metadata.InternalNode;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -27,41 +28,92 @@ import static java.util.Objects.requireNonNull;
 public final class NodeAssignmentStats
 {
     private final NodeTaskMap nodeTaskMap;
-    private final Map<InternalNode, Integer> assignmentCount = new HashMap<>();
-    private final Map<InternalNode, Integer> splitCountByNode = new HashMap<>();
-    private final Map<String, Integer> queuedSplitCountByNode = new HashMap<>();
+    private final Map<InternalNode, Integer> nodeTotalSplitCount;
+    private final Map<String, PendingSplitInfo> stageQueuedSplitInfo;
 
     public NodeAssignmentStats(NodeTaskMap nodeTaskMap, NodeMap nodeMap, List<RemoteTask> existingTasks)
     {
         this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
-
-        // pre-populate the assignment counts with zeros. This makes getOrDefault() faster
-        for (InternalNode node : nodeMap.getNodesByHostAndPort().values()) {
-            assignmentCount.put(node, 0);
-        }
+        int nodeMapSize = requireNonNull(nodeMap, "nodeMap is null").getNodesByHostAndPort().size();
+        this.nodeTotalSplitCount = new HashMap<>(nodeMapSize);
+        this.stageQueuedSplitInfo = new HashMap<>(nodeMapSize);
 
         for (RemoteTask task : existingTasks) {
-            checkArgument(queuedSplitCountByNode.put(task.getNodeId(), task.getQueuedPartitionedSplitCount()) == null, "A single stage may not have multiple tasks running on the same node");
+            checkArgument(stageQueuedSplitInfo.put(task.getNodeId(), new PendingSplitInfo(task.getQueuedPartitionedSplitCount())) == null, "A single stage may not have multiple tasks running on the same node");
+        }
+
+        // pre-populate the assignment counts with zeros
+        if (existingTasks.size() < nodeMapSize) {
+            Function<String, PendingSplitInfo> createEmptySplitInfo = (ignored) -> new PendingSplitInfo(0);
+            for (InternalNode node : nodeMap.getNodesByHostAndPort().values()) {
+                stageQueuedSplitInfo.computeIfAbsent(node.getNodeIdentifier(), createEmptySplitInfo);
+            }
         }
     }
 
     public int getTotalSplitCount(InternalNode node)
     {
-        return assignmentCount.getOrDefault(node, 0) + splitCountByNode.computeIfAbsent(node, nodeTaskMap::getPartitionedSplitsOnNode);
+        int nodeTotalSplits = nodeTotalSplitCount.computeIfAbsent(node, nodeTaskMap::getPartitionedSplitsOnNode);
+        PendingSplitInfo stageInfo = stageQueuedSplitInfo.get(node.getNodeIdentifier());
+        return nodeTotalSplits + (stageInfo == null ? 0 : stageInfo.getAssignedSplitCount());
     }
 
     public int getQueuedSplitCountForStage(InternalNode node)
     {
-        return queuedSplitCountByNode.getOrDefault(node.getNodeIdentifier(), 0) + assignmentCount.getOrDefault(node, 0);
+        PendingSplitInfo stageInfo = stageQueuedSplitInfo.get(node.getNodeIdentifier());
+        return stageInfo == null ? 0 : stageInfo.getQueuedSplitCount();
     }
 
     public void addAssignedSplit(InternalNode node)
     {
-        assignmentCount.merge(node, 1, Integer::sum);
+        getOrCreateStageSplitInfo(node).addAssignedSplit();
     }
 
     public void removeAssignedSplit(InternalNode node)
     {
-        assignmentCount.merge(node, 1, (x, y) -> x - y);
+        getOrCreateStageSplitInfo(node).removeAssignedSplit();
+    }
+
+    private PendingSplitInfo getOrCreateStageSplitInfo(InternalNode node)
+    {
+        String nodeId = node.getNodeIdentifier();
+        // Avoids the extra per-invocation lambda allocation of computeIfAbsent since assigning a split to an existing task more common than creating a new task
+        PendingSplitInfo stageInfo = stageQueuedSplitInfo.get(nodeId);
+        if (stageInfo == null) {
+            stageInfo = new PendingSplitInfo(0);
+            stageQueuedSplitInfo.put(nodeId, stageInfo);
+        }
+        return stageInfo;
+    }
+
+    private static final class PendingSplitInfo
+    {
+        private final int queuedSplitCount;
+        private int assignedSplits;
+
+        private PendingSplitInfo(int queuedSplitCount)
+        {
+            this.queuedSplitCount = queuedSplitCount;
+        }
+
+        public int getAssignedSplitCount()
+        {
+            return assignedSplits;
+        }
+
+        public int getQueuedSplitCount()
+        {
+            return queuedSplitCount + assignedSplits;
+        }
+
+        public void addAssignedSplit()
+        {
+            assignedSplits++;
+        }
+
+        public void removeAssignedSplit()
+        {
+            assignedSplits--;
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.Session;
 import io.trino.connector.CatalogName;
 import io.trino.execution.NodeTaskMap;
 import io.trino.execution.RemoteTask;
@@ -56,9 +57,9 @@ public class NodeScheduler
         this.nodeSelectorFactory = requireNonNull(nodeSelectorFactory, "nodeSelectorFactory is null");
     }
 
-    public NodeSelector createNodeSelector(Optional<CatalogName> catalogName)
+    public NodeSelector createNodeSelector(Session session, Optional<CatalogName> catalogName)
     {
-        return nodeSelectorFactory.createNodeSelector(requireNonNull(catalogName, "catalogName is null"));
+        return nodeSelectorFactory.createNodeSelector(requireNonNull(session, "session is null"), requireNonNull(catalogName, "catalogName is null"));
     }
 
     public static List<InternalNode> getAllNodes(NodeMap nodeMap, boolean includeCoordinator)
@@ -149,6 +150,7 @@ public class NodeScheduler
             NodeTaskMap nodeTaskMap,
             int maxSplitsPerNode,
             int maxPendingSplitsPerTask,
+            int maxUnacknowledgedSplitsPerTask,
             Set<Split> splits,
             List<RemoteTask> existingTasks,
             BucketNodeMap bucketNodeMap)
@@ -162,8 +164,8 @@ public class NodeScheduler
             InternalNode node = bucketNodeMap.getAssignedNode(split).get();
 
             // if node is full, don't schedule now, which will push back on the scheduling of splits
-            if (assignmentStats.getTotalSplitCount(node) < maxSplitsPerNode ||
-                    assignmentStats.getQueuedSplitCountForStage(node) < maxPendingSplitsPerTask) {
+            if (assignmentStats.getUnacknowledgedSplitCountForStage(node) < maxUnacknowledgedSplitsPerTask &&
+                    (assignmentStats.getTotalSplitCount(node) < maxSplitsPerNode || assignmentStats.getQueuedSplitCountForStage(node) < maxPendingSplitsPerTask)) {
                 assignments.put(node, split);
                 assignmentStats.addAssignedSplit(node);
             }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSchedulerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSchedulerConfig.java
@@ -14,6 +14,7 @@
 package io.trino.execution.scheduler;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.DefunctConfig;
 import io.airlift.configuration.LegacyConfig;
 
@@ -36,6 +37,7 @@ public class NodeSchedulerConfig
     private int maxPendingSplitsPerTask = 10;
     private NodeSchedulerPolicy nodeSchedulerPolicy = NodeSchedulerPolicy.UNIFORM;
     private boolean optimizedLocalScheduling = true;
+    private int maxUnacknowledgedSplitsPerTask = 500;
 
     @NotNull
     public NodeSchedulerPolicy getNodeSchedulerPolicy()
@@ -113,6 +115,20 @@ public class NodeSchedulerConfig
     public NodeSchedulerConfig setMaxSplitsPerNode(int maxSplitsPerNode)
     {
         this.maxSplitsPerNode = maxSplitsPerNode;
+        return this;
+    }
+
+    @Min(1)
+    public int getMaxUnacknowledgedSplitsPerTask()
+    {
+        return maxUnacknowledgedSplitsPerTask;
+    }
+
+    @Config("node-scheduler.max-unacknowledged-splits-per-task")
+    @ConfigDescription("Maximum number of leaf splits not yet delivered to a given task")
+    public NodeSchedulerConfig setMaxUnacknowledgedSplitsPerTask(int maxUnacknowledgedSplitsPerTask)
+    {
+        this.maxUnacknowledgedSplitsPerTask = maxUnacknowledgedSplitsPerTask;
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSelectorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeSelectorFactory.java
@@ -13,11 +13,12 @@
  */
 package io.trino.execution.scheduler;
 
+import io.trino.Session;
 import io.trino.connector.CatalogName;
 
 import java.util.Optional;
 
 public interface NodeSelectorFactory
 {
-    NodeSelector createNodeSelector(Optional<CatalogName> catalogName);
+    NodeSelector createNodeSelector(Session session, Optional<CatalogName> catalogName);
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
@@ -350,7 +350,7 @@ public class SqlQueryScheduler
             SplitSource splitSource = entry.getValue();
             Optional<CatalogName> catalogName = Optional.of(splitSource.getCatalogName())
                     .filter(catalog -> !isInternalSystemConnector(catalog));
-            NodeSelector nodeSelector = nodeScheduler.createNodeSelector(catalogName);
+            NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, catalogName);
             SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeSelector, stage::getAllTasks);
 
             checkArgument(!plan.getFragment().getStageExecutionDescriptor().isStageGroupedExecution());
@@ -377,7 +377,7 @@ public class SqlQueryScheduler
                     stage,
                     sourceTasksProvider,
                     writerTasksProvider,
-                    nodeScheduler.createNodeSelector(Optional.empty()),
+                    nodeScheduler.createNodeSelector(session, Optional.empty()),
                     schedulerExecutor,
                     getWriterMinSize(session));
             whenAllStages(childStages, StageState::isDone)
@@ -412,7 +412,7 @@ public class SqlQueryScheduler
                     // verify execution is consistent with planner's decision on dynamic lifespan schedule
                     verify(bucketNodeMap.isDynamic() == dynamicLifespanSchedule);
 
-                    stageNodeList = new ArrayList<>(nodeScheduler.createNodeSelector(catalogName).allNodes());
+                    stageNodeList = new ArrayList<>(nodeScheduler.createNodeSelector(session, catalogName).allNodes());
                     Collections.shuffle(stageNodeList);
                     bucketToPartition = Optional.empty();
                 }
@@ -439,7 +439,7 @@ public class SqlQueryScheduler
                         bucketNodeMap,
                         splitBatchSize,
                         getConcurrentLifespansPerNode(session),
-                        nodeScheduler.createNodeSelector(catalogName),
+                        nodeScheduler.createNodeSelector(session, catalogName),
                         connectorPartitionHandles,
                         dynamicFilterService));
             }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorFactory.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import io.airlift.log.Logger;
 import io.airlift.stats.CounterStat;
+import io.trino.Session;
 import io.trino.connector.CatalogName;
 import io.trino.execution.NodeTaskMap;
 import io.trino.metadata.InternalNode;
@@ -41,6 +42,7 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
 import static io.trino.metadata.NodeState.ACTIVE;
 import static java.util.Objects.requireNonNull;
 
@@ -111,7 +113,7 @@ public class TopologyAwareNodeSelectorFactory
     }
 
     @Override
-    public NodeSelector createNodeSelector(Optional<CatalogName> catalogName)
+    public NodeSelector createNodeSelector(Session session, Optional<CatalogName> catalogName)
     {
         requireNonNull(catalogName, "catalogName is null");
 
@@ -129,6 +131,7 @@ public class TopologyAwareNodeSelectorFactory
                 minCandidates,
                 maxSplitsPerNode,
                 maxPendingSplitsPerTask,
+                getMaxUnacknowledgedSplitsPerTask(session),
                 placementCounters,
                 networkTopology);
     }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
@@ -41,6 +41,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.execution.scheduler.NodeScheduler.calculateLowWatermark;
 import static io.trino.execution.scheduler.NodeScheduler.getAllNodes;
@@ -65,6 +66,7 @@ public class UniformNodeSelector
     private final int minCandidates;
     private final int maxSplitsPerNode;
     private final int maxPendingSplitsPerTask;
+    private final int maxUnacknowledgedSplitsPerTask;
     private final boolean optimizedLocalScheduling;
 
     public UniformNodeSelector(
@@ -75,6 +77,7 @@ public class UniformNodeSelector
             int minCandidates,
             int maxSplitsPerNode,
             int maxPendingSplitsPerTask,
+            int maxUnacknowledgedSplitsPerTask,
             boolean optimizedLocalScheduling)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
@@ -84,6 +87,8 @@ public class UniformNodeSelector
         this.minCandidates = minCandidates;
         this.maxSplitsPerNode = maxSplitsPerNode;
         this.maxPendingSplitsPerTask = maxPendingSplitsPerTask;
+        this.maxUnacknowledgedSplitsPerTask = maxUnacknowledgedSplitsPerTask;
+        checkArgument(maxUnacknowledgedSplitsPerTask > 0, "maxUnacknowledgedSplitsPerTask must be > 0, found: %s", maxUnacknowledgedSplitsPerTask);
         this.optimizedLocalScheduling = optimizedLocalScheduling;
     }
 
@@ -133,7 +138,7 @@ public class UniformNodeSelector
                     List<InternalNode> candidateNodes = selectExactNodes(nodeMap, split.getAddresses(), includeCoordinator);
 
                     Optional<InternalNode> chosenNode = candidateNodes.stream()
-                            .filter(ownerNode -> assignmentStats.getTotalSplitCount(ownerNode) < maxSplitsPerNode)
+                            .filter(ownerNode -> assignmentStats.getTotalSplitCount(ownerNode) < maxSplitsPerNode && assignmentStats.getUnacknowledgedSplitCountForStage(ownerNode) < maxUnacknowledgedSplitsPerTask)
                             .min(comparingInt(assignmentStats::getTotalSplitCount));
 
                     if (chosenNode.isPresent()) {
@@ -170,7 +175,7 @@ public class UniformNodeSelector
 
             for (InternalNode node : candidateNodes) {
                 int totalSplitCount = assignmentStats.getTotalSplitCount(node);
-                if (totalSplitCount < min && totalSplitCount < maxSplitsPerNode) {
+                if (totalSplitCount < min && totalSplitCount < maxSplitsPerNode && assignmentStats.getUnacknowledgedSplitCountForStage(node) < maxUnacknowledgedSplitsPerTask) {
                     chosenNode = node;
                     min = totalSplitCount;
                 }
@@ -179,7 +184,7 @@ public class UniformNodeSelector
                 // min is guaranteed to be MAX_VALUE at this line
                 for (InternalNode node : candidateNodes) {
                     int totalSplitCount = assignmentStats.getQueuedSplitCountForStage(node);
-                    if (totalSplitCount < min && totalSplitCount < maxPendingSplitsPerTask) {
+                    if (totalSplitCount < min && totalSplitCount < maxPendingSplitsPerTask && assignmentStats.getUnacknowledgedSplitCountForStage(node) < maxUnacknowledgedSplitsPerTask) {
                         chosenNode = node;
                         min = totalSplitCount;
                     }
@@ -217,7 +222,7 @@ public class UniformNodeSelector
     @Override
     public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
     {
-        return selectDistributionNodes(nodeMap.get().get(), nodeTaskMap, maxSplitsPerNode, maxPendingSplitsPerTask, splits, existingTasks, bucketNodeMap);
+        return selectDistributionNodes(nodeMap.get().get(), nodeTaskMap, maxSplitsPerNode, maxPendingSplitsPerTask, maxUnacknowledgedSplitsPerTask, splits, existingTasks, bucketNodeMap);
     }
 
     /**

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelectorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelectorFactory.java
@@ -20,6 +20,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableSetMultimap;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
+import io.trino.Session;
 import io.trino.connector.CatalogName;
 import io.trino.execution.NodeTaskMap;
 import io.trino.metadata.InternalNode;
@@ -37,6 +38,7 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
 import static io.trino.metadata.NodeState.ACTIVE;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -92,7 +94,7 @@ public class UniformNodeSelectorFactory
     }
 
     @Override
-    public NodeSelector createNodeSelector(Optional<CatalogName> catalogName)
+    public NodeSelector createNodeSelector(Session session, Optional<CatalogName> catalogName)
     {
         requireNonNull(catalogName, "catalogName is null");
 
@@ -116,6 +118,7 @@ public class UniformNodeSelectorFactory
                 minCandidates,
                 maxSplitsPerNode,
                 maxPendingSplitsPerTask,
+                getMaxUnacknowledgedSplitsPerTask(session),
                 optimizedLocalScheduling);
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/NodePartitioningManager.java
@@ -145,7 +145,7 @@ public class NodePartitioningManager
             CatalogName catalogName = partitioningHandle.getConnectorId()
                     .orElseThrow(() -> new IllegalArgumentException("No connector ID for partitioning handle: " + partitioningHandle));
             bucketToNode = createArbitraryBucketToNode(
-                    nodeScheduler.createNodeSelector(Optional.of(catalogName)).allNodes(),
+                    nodeScheduler.createNodeSelector(session, Optional.of(catalogName)).allNodes(),
                     connectorBucketNodeMap.getBucketCount());
         }
 
@@ -186,7 +186,7 @@ public class NodePartitioningManager
         return new FixedBucketNodeMap(
                 getSplitToBucket(session, partitioningHandle),
                 createArbitraryBucketToNode(
-                        new ArrayList<>(nodeScheduler.createNodeSelector(catalogName).allNodes()),
+                        new ArrayList<>(nodeScheduler.createNodeSelector(session, catalogName).allNodes()),
                         connectorBucketNodeMap.getBucketCount()));
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SystemPartitioningHandle.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SystemPartitioningHandle.java
@@ -137,7 +137,7 @@ public final class SystemPartitioningHandle
 
     public NodePartitionMap getNodePartitionMap(Session session, NodeScheduler nodeScheduler)
     {
-        NodeSelector nodeSelector = nodeScheduler.createNodeSelector(Optional.empty());
+        NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, Optional.empty());
         List<InternalNode> nodes;
 
         switch (partitioning) {

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -318,7 +318,7 @@ public class LocalQueryRunner
 
         this.metadata = new MetadataManager(
                 featuresConfig,
-                new SessionPropertyManager(new SystemSessionProperties(new QueryManagerConfig(), taskManagerConfig, new MemoryManagerConfig(), featuresConfig, new NodeMemoryConfig(), new DynamicFilterConfig())),
+                new SessionPropertyManager(new SystemSessionProperties(new QueryManagerConfig(), taskManagerConfig, new MemoryManagerConfig(), featuresConfig, new NodeMemoryConfig(), new DynamicFilterConfig(), new NodeSchedulerConfig())),
                 new SchemaPropertyManager(),
                 new TablePropertyManager(),
                 new ColumnPropertyManager(),

--- a/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BenchmarkNodeScheduler.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Multimap;
+import io.trino.Session;
 import io.trino.client.NodeVersion;
 import io.trino.connector.CatalogName;
 import io.trino.execution.scheduler.FlatNetworkTopology;
@@ -36,6 +37,7 @@ import io.trino.metadata.Split;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.sql.planner.plan.PlanNodeId;
+import io.trino.testing.TestingSession;
 import io.trino.util.FinalizerService;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -69,6 +71,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.SystemSessionProperties.MAX_UNACKNOWLEDGED_SPLITS_PER_TASK;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 
@@ -169,7 +172,10 @@ public class BenchmarkNodeScheduler
             InMemoryNodeManager nodeManager = new InMemoryNodeManager();
             nodeManager.addNode(CONNECTOR_ID, nodes);
             NodeScheduler nodeScheduler = new NodeScheduler(getNodeSelectorFactory(nodeManager, nodeTaskMap));
-            nodeSelector = nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID));
+            Session session = TestingSession.testSessionBuilder()
+                    .setSystemProperty(MAX_UNACKNOWLEDGED_SPLITS_PER_TASK, Integer.toString(Integer.MAX_VALUE))
+                    .build();
+            nodeSelector = nodeScheduler.createNodeSelector(session, Optional.of(CONNECTOR_ID));
         }
 
         @TearDown

--- a/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
@@ -69,6 +69,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -163,6 +164,11 @@ public class MockRemoteTaskFactory
 
         @GuardedBy("this")
         private int runningDrivers;
+
+        @GuardedBy("this")
+        private int maxUnacknowledgedSplits = Integer.MAX_VALUE;
+        @GuardedBy("this")
+        private int unacknowledgedSplits;
 
         @GuardedBy("this")
         private SettableFuture<?> whenSplitQueueHasSpace = SettableFuture.create();
@@ -289,7 +295,7 @@ public class MockRemoteTaskFactory
 
         private synchronized void updateSplitQueueSpace()
         {
-            if (getQueuedPartitionedSplitCount() < 9) {
+            if (unacknowledgedSplits < maxUnacknowledgedSplits && getQueuedPartitionedSplitCount() < 9) {
                 if (!whenSplitQueueHasSpace.isDone()) {
                     whenSplitQueueHasSpace.set(null);
                 }
@@ -316,9 +322,24 @@ public class MockRemoteTaskFactory
 
         public synchronized void clearSplits()
         {
+            unacknowledgedSplits = 0;
             splits.clear();
             partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
             runningDrivers = 0;
+            updateSplitQueueSpace();
+        }
+
+        public synchronized void setMaxUnacknowledgedSplits(int maxUnacknowledgedSplits)
+        {
+            checkArgument(maxUnacknowledgedSplits > 0);
+            this.maxUnacknowledgedSplits = maxUnacknowledgedSplits;
+            updateSplitQueueSpace();
+        }
+
+        public synchronized void setUnacknowledgedSplits(int unacknowledgedSplits)
+        {
+            checkArgument(unacknowledgedSplits >= 0);
+            this.unacknowledgedSplits = unacknowledgedSplits;
             updateSplitQueueSpace();
         }
 
@@ -442,6 +463,12 @@ public class MockRemoteTaskFactory
                 return 0;
             }
             return getPartitionedSplitCount() - runningDrivers;
+        }
+
+        @Override
+        public synchronized int getUnacknowledgedPartitionedSplitCount()
+        {
+            return unacknowledgedSplits;
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeSchedulerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeSchedulerConfig.java
@@ -34,6 +34,7 @@ public class TestNodeSchedulerConfig
                 .setMinCandidates(10)
                 .setMaxSplitsPerNode(100)
                 .setMaxPendingSplitsPerTask(10)
+                .setMaxUnacknowledgedSplitsPerTask(500)
                 .setIncludeCoordinator(true)
                 .setOptimizedLocalScheduling(true));
     }
@@ -47,6 +48,7 @@ public class TestNodeSchedulerConfig
                 .put("node-scheduler.include-coordinator", "false")
                 .put("node-scheduler.max-pending-splits-per-task", "11")
                 .put("node-scheduler.max-splits-per-node", "101")
+                .put("node-scheduler.max-unacknowledged-splits-per-task", "501")
                 .put("node-scheduler.optimized-local-scheduling", "false")
                 .build();
 
@@ -55,6 +57,7 @@ public class TestNodeSchedulerConfig
                 .setIncludeCoordinator(false)
                 .setMaxSplitsPerNode(101)
                 .setMaxPendingSplitsPerTask(11)
+                .setMaxUnacknowledgedSplitsPerTask(501)
                 .setMinCandidates(11)
                 .setOptimizedLocalScheduling(false);
 

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.airlift.units.Duration;
+import io.trino.Session;
 import io.trino.client.NodeVersion;
 import io.trino.connector.CatalogName;
 import io.trino.cost.StatsAndCosts;
@@ -62,6 +63,7 @@ import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.RemoteSourceNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.testing.TestingMetadata.TestingColumnHandle;
+import io.trino.testing.TestingSession;
 import io.trino.testing.TestingSplit;
 import io.trino.util.FinalizerService;
 import org.testng.annotations.AfterClass;
@@ -120,6 +122,7 @@ public class TestSourcePartitionedScheduler
     private final FinalizerService finalizerService = new FinalizerService();
     private final Metadata metadata = createTestMetadataManager();
     private final TypeOperators typeOperators = new TypeOperators();
+    private final Session session = TestingSession.testSessionBuilder().build();
 
     public TestSourcePartitionedScheduler()
     {
@@ -334,7 +337,7 @@ public class TestSourcePartitionedScheduler
                     stage,
                     Iterables.getOnlyElement(plan.getSplitSources().keySet()),
                     Iterables.getOnlyElement(plan.getSplitSources().values()),
-                    new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID)), stage::getAllTasks),
+                    new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session, Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                     2,
                     new DynamicFilterService(metadata, typeOperators, new DynamicFilterConfig()),
                     () -> false);
@@ -408,7 +411,7 @@ public class TestSourcePartitionedScheduler
                 stage,
                 Iterables.getOnlyElement(plan.getSplitSources().keySet()),
                 Iterables.getOnlyElement(plan.getSplitSources().values()),
-                new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID)), stage::getAllTasks),
+                new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session, Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                 500,
                 new DynamicFilterService(metadata, typeOperators, new DynamicFilterConfig()),
                 () -> false);
@@ -447,7 +450,7 @@ public class TestSourcePartitionedScheduler
                 stage,
                 Iterables.getOnlyElement(plan.getSplitSources().keySet()),
                 Iterables.getOnlyElement(plan.getSplitSources().values()),
-                new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID)), stage::getAllTasks),
+                new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session, Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                 400,
                 new DynamicFilterService(metadata, typeOperators, new DynamicFilterConfig()),
                 () -> true);
@@ -484,7 +487,7 @@ public class TestSourcePartitionedScheduler
                 stage,
                 Iterables.getOnlyElement(plan.getSplitSources().keySet()),
                 Iterables.getOnlyElement(plan.getSplitSources().values()),
-                new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(CONNECTOR_ID)), stage::getAllTasks),
+                new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session, Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                 2,
                 dynamicFilterService,
                 () -> true);
@@ -544,7 +547,7 @@ public class TestSourcePartitionedScheduler
 
         PlanNodeId sourceNode = Iterables.getOnlyElement(plan.getSplitSources().keySet());
         SplitSource splitSource = Iterables.getOnlyElement(plan.getSplitSources().values());
-        SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(Optional.of(splitSource.getCatalogName())), stage::getAllTasks);
+        SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session, Optional.of(splitSource.getCatalogName())), stage::getAllTasks);
         return newSourcePartitionedSchedulerAsStageScheduler(
                 stage,
                 sourceNode,

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -24,6 +24,7 @@ import io.trino.connector.system.SystemConnector;
 import io.trino.execution.DynamicFilterConfig;
 import io.trino.execution.QueryManagerConfig;
 import io.trino.execution.TaskManagerConfig;
+import io.trino.execution.scheduler.NodeSchedulerConfig;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.memory.MemoryManagerConfig;
 import io.trino.memory.NodeMemoryConfig;
@@ -792,7 +793,8 @@ public class TestAnalyzer
                 new MemoryManagerConfig(),
                 new FeaturesConfig().setMaxGroupingSets(2048),
                 new NodeMemoryConfig(),
-                new DynamicFilterConfig()))).build();
+                new DynamicFilterConfig(),
+                new NodeSchedulerConfig()))).build();
         analyze(session, "SELECT a, b, c, d, e, f, g, h, i, j, k, SUM(l)" +
                 "FROM (VALUES (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))\n" +
                 "t (a, b, c, d, e, f, g, h, i, j, k, l)\n" +


### PR DESCRIPTION
Extracted changes from https://github.com/prestodb/presto/pull/15761

Adds support for tracking (and optionally limiting) the number of splits that are not yet acknowledged for a given task. Previously, the only two scheduler supported limits were the number of total splits across all tasks on the worker node and the number of splits queued for a given task which included:
- splits received by the worker but not yet running as of the last task status update
- splits queued in the coordinator local `RemoteTask` but not yet sent to the task
- splits assigned in the current scheduling batch but not yet added to the coordinator-local `RemoteTask`

The new `max_unacknowledged_splits_per_task` session property enables setting a limit on the number of splits that are either:
- queued on the coordinator-local `RemoteTask` but not yet sent or at least not confirmed to have been received by the worker
- assigned to the task in the current scheduling batch but not yet added to the coordinator-local `RemoteTask`

This limit enforcement takes precedence over both of the other existing split limit configurations and is designed to prevent large task update requests that might cause a query to fail.