### PR TITLE
Postpone statement execute until the first read

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
@@ -21,6 +21,8 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.type.Type;
 
+import javax.annotation.Nullable;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -50,7 +52,8 @@ public class JdbcRecordCursor
     private final JdbcClient jdbcClient;
     private final Connection connection;
     private final PreparedStatement statement;
-    private final ResultSet resultSet;
+    @Nullable
+    private ResultSet resultSet;
     private boolean closed;
 
     public JdbcRecordCursor(JdbcClient jdbcClient, ConnectorSession session, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
@@ -99,8 +102,6 @@ public class JdbcRecordCursor
             }
 
             statement = jdbcClient.buildSql(session, connection, split, table, columnHandles);
-            log.debug("Executing: %s", statement.toString());
-            resultSet = statement.executeQuery();
         }
         catch (SQLException | RuntimeException e) {
             throw handleSqlException(e);
@@ -133,6 +134,10 @@ public class JdbcRecordCursor
         }
 
         try {
+            if (resultSet == null) {
+                log.debug("Executing: %s", statement.toString());
+                resultSet = statement.executeQuery();
+            }
             return resultSet.next();
         }
         catch (SQLException | RuntimeException e) {
@@ -144,6 +149,7 @@ public class JdbcRecordCursor
     public boolean getBoolean(int field)
     {
         checkState(!closed, "cursor is closed");
+        requireNonNull(resultSet, "resultSet is null");
         try {
             return booleanReadFunctions[field].readBoolean(resultSet, field + 1);
         }
@@ -156,6 +162,7 @@ public class JdbcRecordCursor
     public long getLong(int field)
     {
         checkState(!closed, "cursor is closed");
+        requireNonNull(resultSet, "resultSet is null");
         try {
             return longReadFunctions[field].readLong(resultSet, field + 1);
         }
@@ -168,6 +175,7 @@ public class JdbcRecordCursor
     public double getDouble(int field)
     {
         checkState(!closed, "cursor is closed");
+        requireNonNull(resultSet, "resultSet is null");
         try {
             return doubleReadFunctions[field].readDouble(resultSet, field + 1);
         }
@@ -180,6 +188,7 @@ public class JdbcRecordCursor
     public Slice getSlice(int field)
     {
         checkState(!closed, "cursor is closed");
+        requireNonNull(resultSet, "resultSet is null");
         try {
             return sliceReadFunctions[field].readSlice(resultSet, field + 1);
         }
@@ -192,6 +201,7 @@ public class JdbcRecordCursor
     public Object getObject(int field)
     {
         checkState(!closed, "cursor is closed");
+        requireNonNull(resultSet, "resultSet is null");
         try {
             return objectReadFunctions[field].readObject(resultSet, field + 1);
         }
@@ -205,6 +215,7 @@ public class JdbcRecordCursor
     {
         checkState(!closed, "cursor is closed");
         checkArgument(field < columnHandles.length, "Invalid field index");
+        requireNonNull(resultSet, "resultSet is null");
 
         try {
             return readFunctions[field].isNull(resultSet, field + 1);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordCursor.java
@@ -227,6 +227,15 @@ public class JdbcRecordCursor
         try (Connection connection = this.connection;
                 Statement statement = this.statement;
                 ResultSet resultSet = this.resultSet) {
+            if (statement != null) {
+                try {
+                    // Trying to cancel running statement as close() may not do it
+                    statement.cancel();
+                }
+                catch (SQLException ignored) {
+                    // statement already closed or cancel is not supported
+                }
+            }
             if (connection != null) {
                 jdbcClient.abortReadConnection(connection);
             }


### PR DESCRIPTION
Postpone statement execute until the first read

java.sql.PreparedStatement#executeQuery method could be blocking
and so it could block the construction of JdbcRecordCursor.
Because of that Trino may not be able to close JdbcRecordCursor as it
does not exists yet.
