### PR TITLE
Validate that none of the partitioning arguments are constants

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -551,6 +551,9 @@ public class AddLocalExchanges
 
             // connector provided hash function
             verify(!(partitioningScheme.getPartitioning().getHandle().getConnectorHandle() instanceof SystemPartitioningHandle));
+            verify(
+                    partitioningScheme.getPartitioning().getArguments().stream().noneMatch(Partitioning.ArgumentBinding::isConstant),
+                    "Table writer partitioning has constant arguments");
             PlanWithProperties source = node.getSource().accept(this, parentPreferences);
             PlanWithProperties exchange = deriveProperties(
                     partitionedExchange(


### PR DESCRIPTION

    Partitioning created in LogicalPlanner#createTableWriterPlan
    should not have any constant arguments