### PR TITLE
Add parser support for SQL MERGE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -117,6 +117,7 @@ import io.trino.sql.tree.JoinUsing;
 import io.trino.sql.tree.Lateral;
 import io.trino.sql.tree.Limit;
 import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.Merge;
 import io.trino.sql.tree.NaturalJoin;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NodeRef;
@@ -1928,6 +1929,12 @@ class StatementAnalyzer
             }
 
             return createAndAssignScope(update, scope, Field.newUnqualified("rows", BIGINT));
+        }
+
+        @Override
+        protected Scope visitMerge(Merge merge, Optional<Scope> scope)
+        {
+            throw new TrinoException(NOT_SUPPORTED, "This connector does not support merge");
         }
 
         private Scope analyzeJoinUsing(Join node, List<Identifier> columns, Optional<Scope> scope, Scope left, Scope right)

--- a/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
@@ -18,6 +18,7 @@ import io.trino.sql.tree.AliasedRelation;
 import io.trino.sql.tree.AllColumns;
 import io.trino.sql.tree.CoalesceExpression;
 import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.DereferenceExpression;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.GroupBy;
@@ -64,6 +65,11 @@ public final class QueryUtil
     public static Identifier quotedIdentifier(String name)
     {
         return new Identifier(name, true);
+    }
+
+    public static Expression nameReference(String first, String... rest)
+    {
+        return DereferenceExpression.from(QualifiedName.of(first, rest));
     }
 
     public static SelectItem unaliasedName(String name)
@@ -143,6 +149,11 @@ public final class QueryUtil
     public static Row row(Expression... values)
     {
         return new Row(ImmutableList.copyOf(values));
+    }
+
+    public static Relation aliased(Relation relation, String alias)
+    {
+        return new AliasedRelation(relation, identifier(alias), null);
     }
 
     public static Relation aliased(Relation relation, String alias, List<String> columnAliases)

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -2462,12 +2462,6 @@ class AstBuilder
                 .map(ParseTree::getText);
     }
 
-    private static Optional<String> getTextIfPresent(Token token)
-    {
-        return Optional.ofNullable(token)
-                .map(Token::getText);
-    }
-
     private Optional<Identifier> getIdentifierIfPresent(ParserRuleContext context)
     {
         return Optional.ofNullable(context).map(c -> (Identifier) visit(c));

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -527,6 +527,26 @@ public abstract class AstVisitor<R, C>
         return visitNode(node, context);
     }
 
+    protected R visitMergeCase(MergeCase node, C context)
+    {
+        return visitNode(node, context);
+    }
+
+    protected R visitMergeInsert(MergeInsert node, C context)
+    {
+        return visitMergeCase(node, context);
+    }
+
+    protected R visitMergeUpdate(MergeUpdate node, C context)
+    {
+        return visitMergeCase(node, context);
+    }
+
+    protected R visitMergeDelete(MergeDelete node, C context)
+    {
+        return visitMergeCase(node, context);
+    }
+
     protected R visitTableElement(TableElement node, C context)
     {
         return visitNode(node, context);
@@ -888,6 +908,11 @@ public abstract class AstVisitor<R, C>
     }
 
     protected R visitDropMaterializedView(DropMaterializedView node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
+    protected R visitMerge(Merge node, C context)
     {
         return visitStatement(node, context);
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -637,6 +637,44 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
+    protected Void visitMerge(Merge node, C context)
+    {
+        process(node.getTable(), context);
+        node.getTargetAlias().ifPresent(target -> process(target, context));
+        process(node.getRelation(), context);
+        process(node.getExpression(), context);
+        node.getMergeCases().forEach(mergeCase -> process(mergeCase, context));
+        return null;
+    }
+
+    @Override
+    protected Void visitMergeInsert(MergeInsert node, C context)
+    {
+        node.getExpression().ifPresent(expression -> process(expression, context));
+        node.getColumns().forEach(column -> process(column, context));
+        node.getValues().forEach(expression -> process(expression, context));
+        return null;
+    }
+
+    @Override
+    protected Void visitMergeUpdate(MergeUpdate node, C context)
+    {
+        node.getExpression().ifPresent(expression -> process(expression, context));
+        node.getAssignments().forEach(assignment -> {
+            process(assignment.getTarget(), context);
+            process(assignment.getValue(), context);
+        });
+        return null;
+    }
+
+    @Override
+    protected Void visitMergeDelete(MergeDelete node, C context)
+    {
+        node.getExpression().ifPresent(expression -> process(expression, context));
+        return null;
+    }
+
+    @Override
     protected Void visitCreateTableAsSelect(CreateTableAsSelect node, C context)
     {
         process(node.getQuery(), context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Merge.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Merge.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public final class Merge
+        extends Statement
+{
+    private final Table table;
+    private final Optional<Identifier> targetAlias;
+    private final Relation relation;
+    private final Expression expression;
+    private final List<MergeCase> mergeCases;
+
+    public Merge(
+            Table table,
+            Optional<Identifier> targetAlias,
+            Relation relation,
+            Expression expression,
+            List<MergeCase> mergeCases)
+
+    {
+        this(Optional.empty(), table, targetAlias, relation, expression, mergeCases);
+    }
+
+    public Merge(
+            NodeLocation location,
+            Table table,
+            Optional<Identifier> targetAlias,
+            Relation relation,
+            Expression expression,
+            List<MergeCase> mergeCases)
+    {
+        this(Optional.of(location), table, targetAlias, relation, expression, mergeCases);
+    }
+
+    public Merge(
+            Optional<NodeLocation> location,
+            Table table,
+            Optional<Identifier> targetAlias,
+            Relation relation,
+            Expression expression,
+            List<MergeCase> mergeCases)
+    {
+        super(location);
+        this.table = requireNonNull(table, "table is null");
+        this.targetAlias = requireNonNull(targetAlias, "targetAlias is null");
+        this.relation = requireNonNull(relation, "relation is null");
+        this.expression = requireNonNull(expression, "expression is null");
+        this.mergeCases = ImmutableList.copyOf(requireNonNull(mergeCases, "mergeCases is null"));
+    }
+
+    public Table getTable()
+    {
+        return table;
+    }
+
+    public Optional<Identifier> getTargetAlias()
+    {
+        return targetAlias;
+    }
+
+    public Relation getRelation()
+    {
+        return relation;
+    }
+
+    public Expression getExpression()
+    {
+        return expression;
+    }
+
+    public List<MergeCase> getMergeCases()
+    {
+        return mergeCases;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitMerge(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> builder = ImmutableList.builder();
+        builder.add(table);
+        builder.add(relation);
+        builder.add(expression);
+        builder.addAll(mergeCases);
+        return builder.build();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Merge merge = (Merge) o;
+        return Objects.equals(table, merge.table) &&
+                Objects.equals(targetAlias, merge.targetAlias) &&
+                Objects.equals(relation, merge.relation) &&
+                Objects.equals(expression, merge.expression) &&
+                Objects.equals(mergeCases, merge.mergeCases);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(table, targetAlias, relation, expression, mergeCases);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("table", table)
+                .add("targetAlias", targetAlias.orElse(null))
+                .add("relation", relation)
+                .add("expression", expression)
+                .add("mergeCases", mergeCases)
+                .omitNullValues()
+                .toString();
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/MergeCase.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/MergeCase.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class MergeCase
+        extends Node
+{
+    protected final Optional<Expression> expression;
+
+    protected MergeCase(Optional<NodeLocation> location, Optional<Expression> expression)
+    {
+        super(location);
+        this.expression = requireNonNull(expression, "expression is null");
+    }
+
+    public Optional<Expression> getExpression()
+    {
+        return expression;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitMergeCase(this, context);
+    }
+
+    public abstract List<Identifier> getSetColumns();
+
+    public abstract List<Expression> getSetExpressions();
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/MergeDelete.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/MergeDelete.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public class MergeDelete
+        extends MergeCase
+{
+    public MergeDelete(Optional<Expression> expression)
+    {
+        this(Optional.empty(), expression);
+    }
+
+    public MergeDelete(NodeLocation location, Optional<Expression> expression)
+    {
+        super(Optional.of(location), expression);
+    }
+
+    public MergeDelete(Optional<NodeLocation> location, Optional<Expression> expression)
+    {
+        super(location, expression);
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitMergeDelete(this, context);
+    }
+
+    @Override
+    public List<Identifier> getSetColumns()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<Expression> getSetExpressions()
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return expression.map(ImmutableList::of).orElseGet(ImmutableList::of);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(expression);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        MergeDelete mergeDelete = (MergeDelete) obj;
+        return Objects.equals(expression, mergeDelete.expression);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("expression", expression.orElse(null))
+                .omitNullValues()
+                .toString();
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/MergeInsert.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/MergeInsert.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class MergeInsert
+        extends MergeCase
+{
+    private final List<Identifier> columns;
+    private final List<Expression> values;
+
+    public MergeInsert(Optional<Expression> expression, List<Identifier> columns, List<Expression> values)
+    {
+        this(Optional.empty(), expression, columns, values);
+    }
+
+    public MergeInsert(NodeLocation location, Optional<Expression> expression, List<Identifier> columns, List<Expression> values)
+    {
+        this(Optional.of(location), expression, columns, values);
+    }
+
+    public MergeInsert(Optional<NodeLocation> location, Optional<Expression> expression, List<Identifier> columns, List<Expression> values)
+    {
+        super(location, expression);
+        this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
+        this.values = ImmutableList.copyOf(requireNonNull(values, "values is null"));
+    }
+
+    public List<Identifier> getColumns()
+    {
+        return columns;
+    }
+
+    public List<Expression> getValues()
+    {
+        return values;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitMergeInsert(this, context);
+    }
+
+    @Override
+    public List<Identifier> getSetColumns()
+    {
+        return columns;
+    }
+
+    @Override
+    public List<Expression> getSetExpressions()
+    {
+        return values;
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> builder = ImmutableList.builder();
+        expression.ifPresent(builder::add);
+        builder.addAll(columns);
+        builder.addAll(values);
+        return builder.build();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(expression, columns, values);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        MergeInsert o = (MergeInsert) obj;
+        return Objects.equals(expression, o.expression) &&
+                Objects.equals(columns, o.columns) &&
+                Objects.equals(values, o.values);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("expression", expression.orElse(null))
+                .add("columns", columns)
+                .add("values", values)
+                .omitNullValues()
+                .toString();
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/MergeUpdate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/MergeUpdate.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class MergeUpdate
+        extends MergeCase
+{
+    private final List<Assignment> assignments;
+
+    public MergeUpdate(Optional<Expression> expression, List<Assignment> assignments)
+    {
+        this(Optional.empty(), expression, assignments);
+    }
+
+    public MergeUpdate(NodeLocation location, Optional<Expression> expression, List<Assignment> assignments)
+    {
+        this(Optional.of(location), expression, assignments);
+    }
+
+    public MergeUpdate(Optional<NodeLocation> location, Optional<Expression> expression, List<Assignment> assignments)
+    {
+        super(location, expression);
+        this.assignments = ImmutableList.copyOf(requireNonNull(assignments, "assignments is null"));
+    }
+
+    public List<Assignment> getAssignments()
+    {
+        return assignments;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitMergeUpdate(this, context);
+    }
+
+    @Override
+    public List<Identifier> getSetColumns()
+    {
+        return assignments.stream()
+                .map(Assignment::getTarget)
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public List<Expression> getSetExpressions()
+    {
+        return assignments.stream()
+                .map(Assignment::getValue)
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> builder = ImmutableList.builder();
+        expression.ifPresent(builder::add);
+        assignments.forEach(assignment -> {
+            builder.add(assignment.getTarget());
+            builder.add(assignment.getValue());
+        });
+        return builder.build();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(expression, assignments);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        MergeUpdate o = (MergeUpdate) obj;
+        return Objects.equals(expression, o.expression) &&
+                Objects.equals(assignments, o.assignments);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("expression", expression.orElse(null))
+                .add("assignments", assignments)
+                .omitNullValues()
+                .toString();
+    }
+
+    public static class Assignment
+    {
+        private final Identifier target;
+        private final Expression value;
+
+        public Assignment(Identifier target, Expression value)
+        {
+            this.target = requireNonNull(target, "target is null");
+            this.value = requireNonNull(value, "value is null");
+        }
+
+        public Identifier getTarget()
+        {
+            return target;
+        }
+
+        public Expression getValue()
+        {
+            return value;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(target, value);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            Assignment o = (Assignment) obj;
+            return Objects.equals(target, o.target) &&
+                    Objects.equals(value, o.value);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("target", target)
+                    .add("value", value)
+                    .toString();
+        }
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -128,6 +128,7 @@ import io.trino.sql.tree.RevokeRoles;
 import io.trino.sql.tree.Rollback;
 import io.trino.sql.tree.Rollup;
 import io.trino.sql.tree.Row;
+import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.Select;
 import io.trino.sql.tree.SelectItem;
 import io.trino.sql.tree.SetPath;
@@ -756,6 +757,22 @@ public class TestSqlParser
                                         new BooleanLiteral("true"),
                                         new LongLiteral("2"))),
                         Optional.of(new LongLiteral("3"))));
+    }
+
+    @Test
+    public void testSearchedCase()
+    {
+        assertExpression(
+                "CASE WHEN a > 3 THEN 23 WHEN b = a THEN 33 END",
+                new SearchedCaseExpression(
+                        ImmutableList.of(
+                                new WhenClause(
+                                        new ComparisonExpression(ComparisonExpression.Operator.GREATER_THAN, new Identifier("a"), new LongLiteral("3")),
+                                        new LongLiteral("23")),
+                                new WhenClause(
+                                        new ComparisonExpression(ComparisonExpression.Operator.EQUAL, new Identifier("b"), new Identifier("a")),
+                                        new LongLiteral("33"))),
+                        Optional.empty()));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -41,10 +41,10 @@ public class TestSqlParserErrorHandling
         return new Object[][] {
                 {"",
                         "line 1:1: mismatched input '<EOF>'. Expecting: 'ALTER', 'ANALYZE', 'CALL', 'COMMENT', 'COMMIT', 'CREATE', 'DEALLOCATE', 'DELETE', 'DESC', 'DESCRIBE', 'DROP', 'EXECUTE', 'EXPLAIN', 'GRANT', " +
-                                "'INSERT', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'UPDATE', 'USE', <query>"},
+                                "'INSERT', 'MERGE', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'UPDATE', 'USE', <query>"},
                 {"@select",
                         "line 1:1: mismatched input '@'. Expecting: 'ALTER', 'ANALYZE', 'CALL', 'COMMENT', 'COMMIT', 'CREATE', 'DEALLOCATE', 'DELETE', 'DESC', 'DESCRIBE', 'DROP', 'EXECUTE', 'EXPLAIN', 'GRANT', " +
-                                "'INSERT', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'UPDATE', 'USE', <query>"},
+                                "'INSERT', 'MERGE', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'UPDATE', 'USE', <query>"},
                 {"select * from foo where @what",
                         "line 1:25: mismatched input '@'. Expecting: <expression>"},
                 {"select * from 'oops",

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestStatementBuilder.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestStatementBuilder.java
@@ -291,6 +291,16 @@ public class TestStatementBuilder
         printStatement("SELECT * FROM table1 WHERE a >= ALL (VALUES 2, 3, 4)");
         printStatement("SELECT * FROM table1 WHERE a <> ANY (SELECT 2, 3, 4)");
         printStatement("SELECT * FROM table1 WHERE a = SOME (SELECT id FROM table2)");
+
+        printStatement("" +
+                "merge into inventory as i\n" +
+                "using changes as c\n" +
+                "on i.part = c.part\n" +
+                "when matched and c.action = 'mod' then\n" +
+                "update set qty = qty + c.qty\n" +
+                "when matched and c.action = 'del' then delete\n" +
+                "when not matched and c.action = 'new' then\n" +
+                "insert (part, qty) values (c.part, c.qty)");
     }
 
     @Test

--- a/docs/src/main/sphinx/sql.rst
+++ b/docs/src/main/sphinx/sql.rst
@@ -38,6 +38,7 @@ Trino also provides :doc:`numerous SQL functions and operators<functions>`.
     sql/grant
     sql/grant-roles
     sql/insert
+    sql/merge
     sql/prepare
     sql/reset-session
     sql/revoke

--- a/docs/src/main/sphinx/sql/merge.rst
+++ b/docs/src/main/sphinx/sql/merge.rst
@@ -42,6 +42,9 @@ In ``WHEN`` clauses with ``UPDATE`` operations, the column value expressions can
 target or the source.  In the ``NOT MATCHED`` case, the ``INSERT`` expressions can depend only
 on the source.
 
+Each row in the source must match at most one row in the target table.  If more than one target table
+row is matched by a source row, a ``CONSTRAINT_VIOLATION`` exception is raised.
+
 
 Examples
 --------

--- a/docs/src/main/sphinx/sql/merge.rst
+++ b/docs/src/main/sphinx/sql/merge.rst
@@ -1,0 +1,83 @@
+=====
+MERGE
+=====
+
+Synopsis
+--------
+
+.. code-block:: text
+
+    MERGE INTO target_table [ [ AS ]  target_alias ]
+    USING { source_table | query } [ [ AS ] source_alias ]
+    ON search_condition
+    when_clause [...]
+
+where ``when_clause`` is one of
+
+.. code-block:: text
+
+    WHEN MATCHED [ AND condition ]
+        THEN DELETE
+
+.. code-block:: text
+
+    WHEN MATCHED [ AND condition ]
+        THEN UPDATE SET ( column = expression [, ...] )
+
+.. code-block:: text
+
+    WHEN NOT MATCHED [ AND condition ]
+        THEN INSERT [ column_list ] VALUES (expression, ...)
+
+Description
+-----------
+
+Conditionally update and/or delete rows of a table and/or insert new rows into a table.
+
+``MERGE`` supports an arbitrary number of ``WHEN`` clauses with different ``MATCHED`` conditions,
+executing the ``DELETE``, ``UPDATE`` or ``INSERT`` operation in the first ``WHEN`` clause selected
+by the ``MATCHED`` state and the match condition.
+
+In ``WHEN`` clauses with ``UPDATE`` operations, the column value expressions can depend on any field of the
+target or the source.  In the ``NOT MATCHED`` case, the ``INSERT`` expressions can depend only
+on the source.
+
+
+Examples
+--------
+
+Delete all customers mentioned in the source table::
+
+    MERGE INTO target_table t USING source_table s ON (t.customer = s.customer)
+        WHEN MATCHED
+            THEN DELETE
+
+For matching customer rows, increment the purchases, and if there is no match, insert the row
+from the source table::
+
+    MERGE INTO target_table t USING source_table s ON (t.customer = s.customer)
+        WHEN MATCHED
+            THEN UPDATE SET purchases = s.purchases + t.purchases
+        WHEN NOT MATCHED
+            THEN INSERT (customer, purchases, address)
+                  VALUES(s.customer, s.purchases, s.address)
+
+``MERGE`` into the target table from the source table, deleting any matching target row for which
+the source address is Centreville.  For all other matching rows, add the source purchases and
+set the address to the source address, if there is no match in the target table, insert the source
+table row::
+
+    MERGE INTO target_table t USING source_table s ON (t.customer = s.customer)
+        WHEN MATCHED AND s.address = 'Centreville'
+            THEN DELETE
+        WHEN MATCHED
+            THEN UPDATE SET purchases = s.purchases + t.purchases, address = s.address
+        WHEN NOT MATCHED
+            THEN INSERT (customer, purchases, address)
+                  VALUES(s.customer, s.purchases, s.address)
+
+Limitations
+-----------
+
+Some connectors have limited or no support for ``MERGE``.
+See connector documentation for more details.

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -137,7 +137,7 @@ public class TestEventListenerBasic
     public void testParseError()
             throws Exception
     {
-        assertFailedQuery("You shall not parse!", "line 1:1: mismatched input 'You'. Expecting: 'ALTER', 'ANALYZE', 'CALL', 'COMMENT', 'COMMIT', 'CREATE', 'DEALLOCATE', 'DELETE', 'DESC', 'DESCRIBE', 'DROP', 'EXECUTE', 'EXPLAIN', 'GRANT', 'INSERT', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'UPDATE', 'USE', <query>");
+        assertFailedQuery("You shall not parse!", "line 1:1: mismatched input 'You'. Expecting: 'ALTER', 'ANALYZE', 'CALL', 'COMMENT', 'COMMIT', 'CREATE', 'DEALLOCATE', 'DELETE', 'DESC', 'DESCRIBE', 'DROP', 'EXECUTE', 'EXPLAIN', 'GRANT', 'INSERT', 'MERGE', 'PREPARE', 'REFRESH', 'RESET', 'REVOKE', 'ROLLBACK', 'SET', 'SHOW', 'START', 'UPDATE', 'USE', <query>");
     }
 
     @Test


### PR DESCRIPTION
Since complete support for SQL MERGE in Trino and the Hive connector is 5,700 lines of code, @electrum suggested that the parser changes be submitted as this separate PR.

This single commit adds the syntax rules and tree classes needed to parse and represent SQL MERGE syntax, accompanied by parser tests.  

