### PR TITLE
Fix docs rendering

### DIFF
--- a/docs/src/main/sphinx/connector/hive-azure.rst
+++ b/docs/src/main/sphinx/connector/hive-azure.rst
@@ -173,7 +173,7 @@ need to execute a query::
          shippriority integer,
          comment varchar(79)
     ) WITH (
-         external_location = 'abfs[s]://file_system@account_name.dfs.core.windows.net/<path>/<path>/<file_name>`',
+         external_location = 'abfs[s]://file_system@account_name.dfs.core.windows.net/<path>/<path>/<file_name>',
          format = 'ORC' -- or 'PARQUET'
     );
 

--- a/docs/src/main/sphinx/connector/kudu.rst
+++ b/docs/src/main/sphinx/connector/kudu.rst
@@ -37,8 +37,8 @@ replacing the properties as appropriate:
    ## For more details see connector documentation.
    #kudu.schema-emulation.enabled=false
 
-   ## Prefix to use for schema emulation (only relevant if `kudu.schema-emulation.enabled=true`)
-   ## The standard prefix is `presto::`. Empty prefix is also supported.
+   ## Prefix to use for schema emulation (only relevant if kudu.schema-emulation.enabled=true)
+   ## The standard prefix is presto::. Empty prefix is also supported.
    ## For more details see connector documentation.
    #kudu.schema-emulation.prefix=
 

--- a/docs/src/main/sphinx/sql/show-role-grants.rst
+++ b/docs/src/main/sphinx/sql/show-role-grants.rst
@@ -12,5 +12,5 @@ Synopsis
 Description
 -----------
 
-List non-recursively the ``ROLE``s that have been granted to the session user
-in ``catalog``, or the current catalog if ``catalog`` is not specified.
+List non-recursively the roles that have been granted to the current user in the specified catalog,
+or in the current catalog if catalog is not specified.

--- a/docs/src/main/sphinx/sql/show-roles.rst
+++ b/docs/src/main/sphinx/sql/show-roles.rst
@@ -16,5 +16,5 @@ Description
 current catalog if ``catalog`` is not specified.
 
 ``SHOW CURRENT ROLES`` lists the enabled roles for the session
-in ``catalog, or in the current catalog if ``catalog`` is not
+in ``catalog``, or in the current catalog if ``catalog`` is not
 specified.


### PR DESCRIPTION
Fixes following rendering problems:

![Screenshot 2021-03-03 at 10 55 16](https://user-images.githubusercontent.com/66972/109787869-f95dea00-7c0e-11eb-9a6b-ea7b85ba1841.png)
![Screenshot 2021-03-03 at 10 53 49](https://user-images.githubusercontent.com/66972/109787882-fb27ad80-7c0e-11eb-977e-b7bea9ebda7c.png)
![Screenshot 2021-03-03 at 10 54 28](https://user-images.githubusercontent.com/66972/109787879-fa8f1700-7c0e-11eb-95c2-9f7f3d2681c2.png)
![Screenshot 2021-03-03 at 10 54 49](https://user-images.githubusercontent.com/66972/109787874-fa8f1700-7c0e-11eb-9a6c-28c9e033ed23.png)

Idk why ``ROLE``s does not render properly so I reworded that section to match the structure in the other `show-.rst` files.

