### PR TITLE
Test metadata queries are cancelled

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/H2QueryRunner.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/H2QueryRunner.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
 import io.trino.Session;
 import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
@@ -52,6 +53,12 @@ public final class H2QueryRunner
     public static DistributedQueryRunner createH2QueryRunner(Iterable<TpchTable<?>> tables, Map<String, String> properties)
             throws Exception
     {
+        return createH2QueryRunner(tables, properties, new TestingH2JdbcModule());
+    }
+
+    public static DistributedQueryRunner createH2QueryRunner(Iterable<TpchTable<?>> tables, Map<String, String> properties, Module module)
+            throws Exception
+    {
         DistributedQueryRunner queryRunner = null;
         try {
             queryRunner = DistributedQueryRunner.builder(createSession()).build();
@@ -61,7 +68,7 @@ public final class H2QueryRunner
 
             createSchema(properties, "tpch");
 
-            queryRunner.installPlugin(new JdbcPlugin("base-jdbc", new TestingH2JdbcModule()));
+            queryRunner.installPlugin(new JdbcPlugin("base-jdbc", module));
             queryRunner.createCatalog("jdbc", "base-jdbc", properties);
 
             copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
@@ -62,7 +62,7 @@ import static io.trino.spi.type.TimeType.TIME_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
 
-class TestingH2JdbcClient
+public class TestingH2JdbcClient
         extends BaseJdbcClient
 {
     private static final JdbcTypeHandle BIGINT_TYPE_HANDLE = new JdbcTypeHandle(Types.BIGINT, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcModule.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcModule.java
@@ -25,10 +25,23 @@ import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public class TestingH2JdbcModule
         implements Module
 {
+    private final TestingH2JdbcClientFactory testingH2JdbcClientFactory;
+
+    public TestingH2JdbcModule()
+    {
+        this(TestingH2JdbcClient::new);
+    }
+
+    public TestingH2JdbcModule(TestingH2JdbcClientFactory testingH2JdbcClientFactory)
+    {
+        this.testingH2JdbcClientFactory = requireNonNull(testingH2JdbcClientFactory, "testingH2JdbcClientFactory is null");
+    }
+
     @Override
     public void configure(Binder binder) {}
 
@@ -36,7 +49,7 @@ public class TestingH2JdbcModule
     @ForBaseJdbc
     public JdbcClient provideJdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory)
     {
-        return new TestingH2JdbcClient(config, connectionFactory);
+        return testingH2JdbcClientFactory.create(config, connectionFactory);
     }
 
     @Provides
@@ -52,5 +65,10 @@ public class TestingH2JdbcModule
         return ImmutableMap.<String, String>builder()
                 .put("connection-url", format("jdbc:h2:mem:test%s;DB_CLOSE_DELAY=-1", System.nanoTime() + ThreadLocalRandom.current().nextLong()))
                 .build();
+    }
+
+    public interface TestingH2JdbcClientFactory
+    {
+        TestingH2JdbcClient create(BaseJdbcConfig config, ConnectionFactory connectionFactory);
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataQueriesCancelled.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataQueriesCancelled.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.Duration;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.plugin.jdbc.TestingH2JdbcClient;
+import io.trino.plugin.jdbc.TestingH2JdbcModule;
+import io.trino.spi.ErrorCode;
+import io.trino.spi.QueryId;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.trino.plugin.jdbc.H2QueryRunner.createH2QueryRunner;
+import static io.trino.spi.ErrorType.INTERNAL_ERROR;
+import static io.trino.testing.assertions.Assert.assertEventually;
+import static java.lang.String.format;
+import static java.lang.Thread.sleep;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestMetadataQueriesCancelled
+        extends AbstractTestQueryFramework
+{
+    private final Map<String, String> properties = TestingH2JdbcModule.createProperties();
+    private final ExecutorService threadPool = newCachedThreadPool(daemonThreadsNamed("cancel-query-test"));
+    private boolean test;
+
+    @AfterClass(alwaysRun = true)
+    public void afterClass()
+    {
+        assertThat(threadPool.shutdownNow()).isEmpty();
+    }
+
+    @BeforeMethod
+    public void reset()
+    {
+        test = true;
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingH2JdbcModule module = new TestingH2JdbcModule((config, connectionFactory) -> new TestingH2JdbcClient(config, connectionFactory)
+        {
+            @Override
+            public Map<String, Object> getTableProperties(ConnectorSession session, JdbcTableHandle tableHandle)
+            {
+                if (!test) {
+                    return super.getTableProperties(session, tableHandle);
+                }
+                try {
+                    sleep(10_000);
+                }
+                catch (InterruptedException e) {
+                    // this is expected situation for this test, so test should not fail
+                    return super.getTableProperties(session, tableHandle);
+                }
+                throw new TrinoException(() -> new ErrorCode(1, "Test exception", INTERNAL_ERROR),
+                        "Thread with metadata query was not interrupted when query cancelled.");
+            }
+        });
+        DistributedQueryRunner queryRunner = createH2QueryRunner(ImmutableList.copyOf(TpchTable.getTables()), properties, module);
+        queryRunner.execute("CREATE TABLE copy_of_nation AS SELECT * FROM nation");
+        return queryRunner;
+    }
+
+    @Test
+    public void testOverrideTestMethodIsImplementedCorrectly()
+    {
+        assertQueryFails("SELECT nationkey FROM copy_of_nation", "Thread with metadata query was not interrupted when query cancelled.");
+    }
+
+    @Test
+    public void testMetadataQueryWasCancelled()
+            throws InterruptedException, ExecutionException
+    {
+        Future<?> future = threadPool.submit(() -> assertQueryFails("SELECT nationkey FROM copy_of_nation", "Query killed. Message: Killed by test"));
+//        sleep(5_000); // to make sure datasource is queried
+        QueryId queryId = getQueryId("SELECT nationkey");
+        assertUpdate(format("CALL system.runtime.kill_query(query_id => '%s', message => '%s')", queryId, "Killed by test"));
+        future.get();
+    }
+
+    private QueryId getQueryId(String sqlPattern)
+    {
+        AtomicReference<QueryId> queryId = new AtomicReference<>();
+        assertEventually(Duration.valueOf("10s"), () -> {
+            MaterializedResult queriesResult = getQueryRunner().execute(format(
+                    ""
+                            + "SELECT query_id "
+                            + "FROM system.runtime.queries "
+                            + "WHERE state = 'WAITING_FOR_RESOURCES' "
+                            + "AND query LIKE '%%%s%%' "
+                            + "AND query NOT LIKE '%%system.runtime.queries%%'",
+                    sqlPattern));
+            assertThat(queriesResult.getRowCount()).isEqualTo(1);
+
+            queryId.set(new QueryId((String) queriesResult.getOnlyValue()));
+        });
+        return queryId.get();
+    }
+}


### PR DESCRIPTION
When user cancels target query metadata queries should be cancelled too.
This change ensures that metadata queries cancellation takes place. 

@kokosing I currently don't know why during manual debug in intellij i didn't see such cancellation.