### PR TITLE
Allow matching values disregarding types

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -283,11 +283,27 @@ public class QueryAssertions
             return matches(expected);
         }
 
+        /**
+         * {@link #matches(String)} disregarding types.
+         */
+        public QueryAssert matchesValues(@Language("SQL") String query)
+        {
+            MaterializedResult expected = runner.execute(session, query);
+            return matchesValues(expected);
+        }
+
         public QueryAssert matches(MaterializedResult expected)
         {
-            return satisfies(actual -> {
-                assertTypes(actual, expected.getTypes());
+            return satisfies(actual -> assertTypes(actual, expected.getTypes()))
+                    .matchesValues(expected);
+        }
 
+        /**
+         * {@link #matches(MaterializedResult)} disregarding types.
+         */
+        public QueryAssert matchesValues(MaterializedResult expected)
+        {
+            return satisfies(actual -> {
                 ListAssert<MaterializedRow> assertion = assertThat(actual.getMaterializedRows())
                         .as("Rows")
                         .withRepresentation(ROWS_REPRESENTATION);


### PR DESCRIPTION
In some reusable tests we do not want to discern between value being
e.g. `varchar` or `varchar(25)` and the actual type may vary between
connectors.