### PR TITLE
Add reusable connector smoke test

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/QueryAssertions.java
@@ -250,6 +250,7 @@ public class QueryAssertions
         private final Session session;
         private final String query;
         private boolean ordered;
+        private boolean skipTypesCheck;
 
         static AssertProvider<QueryAssert> newQueryAssert(String query, QueryRunner runner, Session session)
         {
@@ -277,6 +278,12 @@ public class QueryAssertions
             return this;
         }
 
+        public QueryAssert skippingTypesCheck()
+        {
+            skipTypesCheck = true;
+            return this;
+        }
+
         public QueryAssert matches(@Language("SQL") String query)
         {
             MaterializedResult expected = runner.execute(session, query);
@@ -286,7 +293,9 @@ public class QueryAssertions
         public QueryAssert matches(MaterializedResult expected)
         {
             return satisfies(actual -> {
-                assertTypes(actual, expected.getTypes());
+                if (!skipTypesCheck) {
+                    assertTypes(actual, expected.getTypes());
+                }
 
                 ListAssert<MaterializedRow> assertion = assertThat(actual.getMaterializedRows())
                         .as("Rows")
@@ -310,7 +319,9 @@ public class QueryAssertions
         public QueryAssert containsAll(MaterializedResult expected)
         {
             return satisfies(actual -> {
-                assertTypes(actual, expected.getTypes());
+                if (!skipTypesCheck) {
+                    assertTypes(actual, expected.getTypes());
+                }
 
                 assertThat(actual.getMaterializedRows())
                         .as("Rows")

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorSmokeTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorSmokeTest.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import io.trino.testing.BaseConnectorSmokeTest;
+
+public abstract class BaseJdbcConnectorSmokeTest
+        extends BaseConnectorSmokeTest {}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcCachingQueries.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcCachingQueries.java
@@ -14,118 +14,25 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.testing.AbstractTestDistributedQueries;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.sql.JdbcSqlExecutor;
-import io.trino.testing.sql.TestTable;
-import org.testng.SkipException;
 
 import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
 
 import static io.trino.plugin.jdbc.H2QueryRunner.createH2QueryRunner;
 
 public class TestJdbcCachingQueries
-        // TODO define shorter tests set that exercises various read and write scenarios (a.k.a. "a smoke test")
-        extends AbstractTestDistributedQueries
+        extends BaseJdbcConnectorSmokeTest
 {
-    private Map<String, String> properties;
-
     @Override
     protected QueryRunner createQueryRunner()
             throws Exception
     {
-        properties = ImmutableMap.<String, String>builder()
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .putAll(TestingH2JdbcModule.createProperties())
                 .put("metadata.cache-ttl", "10m")
                 .put("metadata.cache-missing", "true")
                 .put("allow-drop-table", "true")
                 .build();
         return createH2QueryRunner(REQUIRED_TPCH_TABLES, properties);
-    }
-
-    @Override
-    protected boolean supportsDelete()
-    {
-        return false;
-    }
-
-    @Override
-    protected boolean supportsViews()
-    {
-        return false;
-    }
-
-    @Override
-    protected boolean supportsArrays()
-    {
-        return false;
-    }
-
-    @Override
-    protected boolean supportsCommentOnTable()
-    {
-        return false;
-    }
-
-    @Override
-    protected boolean supportsCommentOnColumn()
-    {
-        return false;
-    }
-
-    @Override
-    public void testLargeIn(int valuesCount)
-    {
-        throw new SkipException("This test should pass with H2, but takes too long (currently over a mninute) and is not that important");
-    }
-
-    @Override
-    protected TestTable createTableWithDefaultColumns()
-    {
-        return new TestTable(
-                getSqlExecutor(),
-                "tpch.table",
-                "(col_required BIGINT NOT NULL," +
-                        "col_nullable BIGINT," +
-                        "col_default BIGINT DEFAULT 43," +
-                        "col_nonnull_default BIGINT NOT NULL DEFAULT 42," +
-                        "col_required2 BIGINT NOT NULL)");
-    }
-
-    @Override
-    protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
-    {
-        String typeBaseName = dataMappingTestSetup.getTrinoTypeName().replaceAll("\\([^()]*\\)", "");
-        switch (typeBaseName) {
-            case "boolean":
-            case "decimal":
-            case "char":
-            case "varbinary":
-            case "time":
-            case "timestamp":
-            case "timestamp with time zone":
-                return Optional.of(dataMappingTestSetup.asUnsupported());
-        }
-
-        return Optional.of(dataMappingTestSetup);
-    }
-
-    @Override
-    protected Optional<DataMappingTestSetup> filterCaseSensitiveDataMappingTestData(DataMappingTestSetup dataMappingTestSetup)
-    {
-        String typeBaseName = dataMappingTestSetup.getTrinoTypeName().replaceAll("\\([^()]*\\)", "");
-        switch (typeBaseName) {
-            case "char":
-                return Optional.of(dataMappingTestSetup.asUnsupported());
-        }
-
-        return Optional.of(dataMappingTestSetup);
-    }
-
-    private JdbcSqlExecutor getSqlExecutor()
-    {
-        return new JdbcSqlExecutor(properties.get("connection-url"), new Properties());
     }
 }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlGlobalTransactionMyConnectorSmokeTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlGlobalTransactionMyConnectorSmokeTest.java
@@ -14,14 +14,13 @@
 package io.trino.plugin.mysql;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.jdbc.BaseJdbcConnectorSmokeTest;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.sql.SqlExecutor;
 
 import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 
-public class TestGlobalTransactionMySqlConnectorTest
-        // TODO(https://github.com/trinodb/trino/issues/7019) define shorter tests set that exercises various read and write scenarios (a.k.a. "a smoke test")
-        extends BaseMySqlConnectorTest
+public class TestMySqlGlobalTransactionMyConnectorSmokeTest
+        extends BaseJdbcConnectorSmokeTest
 {
     private TestingMySqlServer mysqlServer;
 
@@ -31,11 +30,5 @@ public class TestGlobalTransactionMySqlConnectorTest
     {
         mysqlServer = closeAfterClass(new TestingMySqlServer(true));
         return createMySqlQueryRunner(mysqlServer, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
-    }
-
-    @Override
-    protected SqlExecutor getMySqlExecutor()
-    {
-        return mysqlServer::execute;
     }
 }

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorSmokeTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorSmokeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.oracle;
+
+import io.trino.plugin.jdbc.BaseJdbcConnectorSmokeTest;
+import io.trino.testing.TestingConnectorBehavior;
+import org.testng.annotations.Test;
+
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public abstract class BaseOracleConnectorSmokeTest
+        extends BaseJdbcConnectorSmokeTest
+{
+    @Override
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        switch (connectorBehavior) {
+            case SUPPORTS_CREATE_SCHEMA:
+                return false;
+
+            default:
+                return super.hasBehavior(connectorBehavior);
+        }
+    }
+
+    @Test
+    public void testCommentColumn()
+    {
+        String tableName = "test_comment_column_" + randomTableSuffix();
+
+        assertUpdate("CREATE TABLE " + tableName + "(a integer)");
+
+        // comment set
+        assertUpdate("COMMENT ON COLUMN " + tableName + ".a IS 'new comment'");
+        // without remarksReporting (default) Oracle does not return comments set
+        assertThat((String) computeActual("SHOW CREATE TABLE " + tableName).getOnlyValue()).doesNotContain("COMMENT 'new comment'");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+}

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOraclePoolConnectorSmokeTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestOraclePoolConnectorSmokeTest.java
@@ -16,7 +16,6 @@ package io.trino.plugin.oracle;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.testing.Closeables;
 import io.trino.testing.QueryRunner;
-import io.trino.testing.sql.SqlExecutor;
 import org.testng.annotations.AfterClass;
 
 import java.io.IOException;
@@ -24,8 +23,8 @@ import java.io.IOException;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_PASS;
 import static io.trino.plugin.oracle.TestingOracleServer.TEST_USER;
 
-public class TestRemarksReportingOraclePoolConnectorTest
-        extends BaseOracleConnectorTest
+public class TestOraclePoolConnectorSmokeTest
+        extends BaseOracleConnectorSmokeTest
 {
     private TestingOracleServer oracleServer;
 
@@ -43,7 +42,7 @@ public class TestRemarksReportingOraclePoolConnectorTest
                         .put("connection-password", TEST_PASS)
                         .put("allow-drop-table", "true")
                         .put("oracle.connection-pool.enabled", "true")
-                        .put("oracle.remarks-reporting.enabled", "true")
+                        .put("oracle.remarks-reporting.enabled", "false")
                         .build(),
                 REQUIRED_TPCH_TABLES);
     }
@@ -54,11 +53,5 @@ public class TestRemarksReportingOraclePoolConnectorTest
     {
         Closeables.closeAll(oracleServer);
         oracleServer = null;
-    }
-
-    @Override
-    protected SqlExecutor onOracle()
-    {
-        return oracleServer::execute;
     }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.tpch.TpchTable;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_CREATE_SCHEMA;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_CREATE_TABLE;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_CREATE_TABLE_WITH_DATA;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_INSERT;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_ROW_LEVEL_DELETE;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static io.trino.tpch.TpchTable.NATION;
+import static io.trino.tpch.TpchTable.REGION;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A connector smoke test exercising various connector functionalities without going in depth on any of them.
+ * A connector should implement {@link BaseConnectorTest} and use this class to exercise some configuration variants.
+ */
+public abstract class BaseConnectorSmokeTest
+        extends AbstractTestQueryFramework
+{
+    protected static final List<TpchTable<?>> REQUIRED_TPCH_TABLES = ImmutableList.of(NATION, REGION);
+
+    protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
+    {
+        return connectorBehavior.hasBehaviorByDefault(this::hasBehavior);
+    }
+
+    /**
+     * Ensure the tests are run with {@link DistributedQueryRunner}. E.g. {@link LocalQueryRunner} takes some
+     * shortcuts, not exercising certain aspects.
+     */
+    @Test
+    public void ensureDistributedQueryRunner()
+    {
+        assertThat(getQueryRunner().getNodeCount()).as("query runner node count")
+                .isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    public void testSelect()
+    {
+        assertQuery("SELECT name FROM region");
+    }
+
+    @Test
+    public void testPredicate()
+    {
+        assertQuery("SELECT name, regionkey FROM nation WHERE nationkey = 10");
+        assertQuery("SELECT name, regionkey FROM nation WHERE nationkey BETWEEN 5 AND 15");
+        assertQuery("SELECT name, regionkey FROM nation WHERE name = 'EGYPT'");
+    }
+
+    @Test
+    public void testLimit()
+    {
+        assertQuery("SELECT name FROM region LIMIT 5");
+    }
+
+    @Test
+    public void testTopN()
+    {
+        assertQuery("SELECT regionkey FROM nation ORDER BY name LIMIT 3");
+    }
+
+    @Test
+    public void testAggregation()
+    {
+        assertQuery("SELECT sum(regionkey) FROM nation");
+        assertQuery("SELECT sum(nationkey) FROM nation GROUP BY regionkey");
+    }
+
+    @Test
+    public void testHaving()
+    {
+        assertQuery("SELECT regionkey, sum(nationkey) FROM nation GROUP BY regionkey HAVING sum(nationkey) = 58", "VALUES (4, 58)");
+    }
+
+    @Test
+    public void testJoin()
+    {
+        assertQuery("SELECT n.name, r.name FROM nation n JOIN region r on n.regionkey = r.regionkey");
+    }
+
+    @Test
+    public void testCreateTable()
+    {
+        if (!hasBehavior(SUPPORTS_CREATE_TABLE)) {
+            assertQueryFails("CREATE TABLE xxxx (a bigint, b double)", "This connector does not support create");
+            return;
+        }
+
+        String tableName = "test_create_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (a bigint, b double)");
+        assertThat(query("SELECT a, b FROM " + tableName))
+                .returnsEmptyResult();
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testCreateTableAsSelect()
+    {
+        if (!hasBehavior(SUPPORTS_CREATE_TABLE_WITH_DATA)) {
+            assertQueryFails("CREATE TABLE xxxx (a bigint, b double) AS VALUES (42, -38.5)", "This connector does not support create");
+            return;
+        }
+
+        String tableName = "test_create_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT BIGINT '42' a, DOUBLE '-38.5' b", 1);
+        assertThat(query("SELECT CAST(a AS bigint), b FROM " + tableName))
+                .matches("VALUES (BIGINT '42', -385e-1)");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testInsert()
+    {
+        if (!hasBehavior(SUPPORTS_INSERT)) {
+            assertQueryFails("INSERT INTO region (regionkey) VALUES (42)", "This connector does not support insert");
+            return;
+        }
+
+        String tableName = "test_create_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " (a bigint, b double)");
+        assertUpdate("INSERT INTO " + tableName + " (a, b) VALUES (42, -38.5)", 1);
+        assertThat(query("SELECT CAST(a AS bigint), b FROM " + tableName))
+                .matches("VALUES (BIGINT '42', -385e-1)");
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testDelete()
+    {
+        if (!hasBehavior(SUPPORTS_ROW_LEVEL_DELETE)) {
+            assertQueryFails("DELETE FROM region", "This connector does not support deletes");
+            return;
+        }
+
+        String tableName = "test_delete_" + randomTableSuffix();
+        assertUpdate("CREATE TABLE " + tableName + " AS SELECT * FROM region", 5);
+
+        // delete half the table, then delete the rest
+        assertUpdate("DELETE FROM " + tableName + " WHERE regionkey = 2", 1);
+        assertThat(query("SELECT regionkey FROM " + tableName))
+                .skippingTypesCheck()
+                .matches("VALUES 1, 3, 4, 5");
+
+        assertUpdate("DROP TABLE " + tableName);
+    }
+
+    @Test
+    public void testCreateSchema()
+    {
+        if (!hasBehavior(SUPPORTS_CREATE_SCHEMA)) {
+            assertQueryFails("CREATE SCHEMA xxxxxx", "This connector does not support creating schemas");
+            return;
+        }
+
+        String schemaName = "test_schema_create_" + randomTableSuffix();
+        assertUpdate("CREATE SCHEMA " + schemaName);
+        assertThat(query("SHOW SCHEMAS"))
+                .skippingTypesCheck()
+                .containsAll(format("VALUES '%s', '%s'", getSession().getSchema().orElseThrow(), schemaName));
+        assertUpdate("DROP SCHEMA " + schemaName);
+    }
+
+    @Test
+    public void testSelectInformationSchemaTables()
+    {
+        assertThat(query(format("SELECT table_name FROM information_schema.tables WHERE table_schema = '%s'", getSession().getSchema().orElseThrow())))
+                .skippingTypesCheck()
+                .containsAll("VALUES 'nation', 'region'");
+    }
+
+    @Test
+    public void testSelectInformationSchemaColumns()
+    {
+        assertThat(query(format("SELECT column_name FROM information_schema.columns WHERE table_schema = '%s' AND table_name = 'region'", getSession().getSchema().orElseThrow())))
+                .skippingTypesCheck()
+                .matches("VALUES 'regionkey', 'name', 'comment'");
+    }
+
+    @Test
+    public void testShowCreateTable()
+    {
+        // SHOW CREATE TABLE exercises table properties and comments, which may be skipped during regular SELECT execution
+        assertThat((String) computeActual("SHOW CREATE TABLE region").getOnlyValue())
+                .matches(format(
+                        "CREATE TABLE %s.%s.region \\(\n" +
+                                "   regionkey (bigint|decimal\\(19, 0\\)),\n" +
+                                "   name varchar(\\(\\d+\\))?,\n" +
+                                "   comment varchar(\\(\\d+\\))?\n" +
+                                "\\)",
+                        Pattern.quote(getSession().getCatalog().orElseThrow()),
+                        Pattern.quote(getSession().getSchema().orElseThrow())));
+    }
+}

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -25,8 +25,6 @@ import static io.trino.SystemSessionProperties.IGNORE_STATS_CALCULATOR_FAILURES;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.DataProviders.toDataProvider;
 import static io.trino.testing.QueryAssertions.assertContains;
-import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_JOIN_PUSHDOWN;
-import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_PREDICATE_PUSHDOWN;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static java.lang.String.join;
 import static java.util.Collections.nCopies;
@@ -43,23 +41,7 @@ public abstract class BaseConnectorTest
 {
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
-        switch (connectorBehavior) {
-            case SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_EQUALITY:
-            case SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY:
-                return hasBehavior(SUPPORTS_PREDICATE_PUSHDOWN);
-
-            case SUPPORTS_JOIN_PUSHDOWN:
-                // Currently no connector supports Join pushdown by default. JDBC connectors may support Join pushdown and BaseJdbcConnectorTest
-                // verifies truthfulness of SUPPORTS_JOIN_PUSHDOWN declaration, so it is a safe default.
-                return false;
-
-            case SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN:
-            case SUPPORTS_JOIN_PUSHDOWN_WITH_DISTINCT_FROM:
-                return hasBehavior(SUPPORTS_JOIN_PUSHDOWN);
-
-            default:
-                return true;
-        }
+        return connectorBehavior.hasBehaviorByDefault(this::hasBehavior);
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
@@ -13,16 +13,57 @@
  */
 package io.trino.testing;
 
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+
 public enum TestingConnectorBehavior
 {
     SUPPORTS_PREDICATE_PUSHDOWN,
-    SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_EQUALITY,
-    SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY,
+    SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_EQUALITY(SUPPORTS_PREDICATE_PUSHDOWN),
+    SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY(SUPPORTS_PREDICATE_PUSHDOWN),
     SUPPORTS_LIMIT_PUSHDOWN,
     SUPPORTS_TOPN_PUSHDOWN,
     SUPPORTS_AGGREGATION_PUSHDOWN,
-    SUPPORTS_JOIN_PUSHDOWN,
-    SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN,
-    SUPPORTS_JOIN_PUSHDOWN_WITH_DISTINCT_FROM,
+    SUPPORTS_JOIN_PUSHDOWN(
+            // Currently no connector supports Join pushdown by default. JDBC connectors may support Join pushdown and BaseJdbcConnectorTest
+            // verifies truthfulness of SUPPORTS_JOIN_PUSHDOWN declaration, so it is a safe default.
+            false),
+    SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN(SUPPORTS_JOIN_PUSHDOWN),
+    SUPPORTS_JOIN_PUSHDOWN_WITH_DISTINCT_FROM(SUPPORTS_JOIN_PUSHDOWN),
     /**/;
+
+    private final Predicate<Predicate<TestingConnectorBehavior>> hasBehaviorByDefault;
+
+    TestingConnectorBehavior()
+    {
+        this(true);
+    }
+
+    TestingConnectorBehavior(boolean hasBehaviorByDefault)
+    {
+        this(fallback -> hasBehaviorByDefault);
+    }
+
+    TestingConnectorBehavior(TestingConnectorBehavior defaultBehaviorSource)
+    {
+        this(fallback -> fallback.test(defaultBehaviorSource));
+    }
+
+    TestingConnectorBehavior(Predicate<Predicate<TestingConnectorBehavior>> hasBehaviorByDefault)
+    {
+        this.hasBehaviorByDefault = requireNonNull(hasBehaviorByDefault, "hasBehaviorByDefault is null");
+    }
+
+    /**
+     * Determines whether a connector should be assumed to have this behavior.
+     *
+     * @param fallback callback to be used to inspect connector behaviors, if this behavior is assumed to be had conditionally
+     */
+    // Intentionally package private. This is just a convenience method for sharing behavior between reusable test base classes.
+    // If it was to be public, a different API would need to be provided.
+    boolean hasBehaviorByDefault(Predicate<TestingConnectorBehavior> fallback)
+    {
+        return hasBehaviorByDefault.test(fallback);
+    }
 }

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
@@ -22,15 +22,30 @@ public enum TestingConnectorBehavior
     SUPPORTS_PREDICATE_PUSHDOWN,
     SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_EQUALITY(SUPPORTS_PREDICATE_PUSHDOWN),
     SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY(SUPPORTS_PREDICATE_PUSHDOWN),
+
     SUPPORTS_LIMIT_PUSHDOWN,
+
     SUPPORTS_TOPN_PUSHDOWN,
+
     SUPPORTS_AGGREGATION_PUSHDOWN,
+
     SUPPORTS_JOIN_PUSHDOWN(
             // Currently no connector supports Join pushdown by default. JDBC connectors may support Join pushdown and BaseJdbcConnectorTest
             // verifies truthfulness of SUPPORTS_JOIN_PUSHDOWN declaration, so it is a safe default.
             false),
     SUPPORTS_JOIN_PUSHDOWN_WITH_FULL_JOIN(SUPPORTS_JOIN_PUSHDOWN),
     SUPPORTS_JOIN_PUSHDOWN_WITH_DISTINCT_FROM(SUPPORTS_JOIN_PUSHDOWN),
+
+    SUPPORTS_CREATE_TABLE,
+    SUPPORTS_CREATE_TABLE_WITH_DATA(SUPPORTS_CREATE_TABLE),
+
+    SUPPORTS_INSERT,
+
+    SUPPORTS_DELETE(false),
+    SUPPORTS_ROW_LEVEL_DELETE(SUPPORTS_DELETE),
+
+    SUPPORTS_CREATE_SCHEMA,
+
     /**/;
 
     private final Predicate<Predicate<TestingConnectorBehavior>> hasBehaviorByDefault;


### PR DESCRIPTION
Add `BaseConnectorSmokeTest`, a reusable, slim, fast connector smoke test everyone always wanted, but never dared to ask for one.