### PR TITLE
Remove duplication between prepareQuery and buildSql

### DIFF
--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -38,7 +38,6 @@ import javax.inject.Inject;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
@@ -159,16 +158,9 @@ public class DruidJdbcClient
     }
 
     @Override
-    public PreparedQuery prepareQuery(ConnectorSession session, JdbcTableHandle table, Optional<List<List<JdbcColumnHandle>>> groupingSets, List<JdbcColumnHandle> columns, Map<String, String> columnExpressions)
+    protected PreparedQuery prepareQuery(ConnectorSession session, Connection connection, JdbcTableHandle table, Optional<List<List<JdbcColumnHandle>>> groupingSets, List<JdbcColumnHandle> columns, Map<String, String> columnExpressions, Optional<JdbcSplit> split)
     {
-        return super.prepareQuery(session, prepareTableHandleForQuery(table), groupingSets, columns, columnExpressions);
-    }
-
-    @Override
-    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns)
-            throws SQLException
-    {
-        return super.buildSql(session, connection, split, prepareTableHandleForQuery(table), columns);
+        return super.prepareQuery(session, connection, prepareTableHandleForQuery(table), groupingSets, columns, columnExpressions, split);
     }
 
     private JdbcTableHandle prepareTableHandleForQuery(JdbcTableHandle table)

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -243,21 +243,17 @@ public class PhoenixClient
     public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
             throws SQLException
     {
-        PhoenixSplit phoenixSplit = (PhoenixSplit) split;
-        QueryBuilder queryBuilder = new QueryBuilder(this);
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+        PreparedQuery preparedQuery = prepareQuery(
                 session,
                 connection,
-                table.getRelationHandle(),
+                table,
                 Optional.empty(),
                 columnHandles,
                 ImmutableMap.of(),
-                table.getConstraint(),
-                split.getAdditionalPredicate());
-        preparedQuery = applyQueryTransformations(table, preparedQuery);
-        PreparedStatement query = queryBuilder.prepareStatement(session, connection, preparedQuery);
+                Optional.of(split));
+        PreparedStatement query = new QueryBuilder(this).prepareStatement(session, connection, preparedQuery);
         QueryPlan queryPlan = getQueryPlan((PhoenixPreparedStatement) query);
-        ResultSet resultSet = getResultSet(phoenixSplit.getPhoenixInputSplit(), queryPlan);
+        ResultSet resultSet = getResultSet(((PhoenixSplit) split).getPhoenixInputSplit(), queryPlan);
         return new DelegatePreparedStatement(query)
         {
             @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -244,21 +244,17 @@ public class PhoenixClient
     public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
             throws SQLException
     {
-        PhoenixSplit phoenixSplit = (PhoenixSplit) split;
-        QueryBuilder queryBuilder = new QueryBuilder(this);
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+        PreparedQuery preparedQuery = prepareQuery(
                 session,
                 connection,
-                table.getRelationHandle(),
+                table,
                 Optional.empty(),
                 columnHandles,
                 ImmutableMap.of(),
-                table.getConstraint(),
-                split.getAdditionalPredicate());
-        preparedQuery = applyQueryTransformations(table, preparedQuery);
-        PreparedStatement query = queryBuilder.prepareStatement(session, connection, preparedQuery);
+                Optional.of(split));
+        PreparedStatement query = new QueryBuilder(this).prepareStatement(session, connection, preparedQuery);
         QueryPlan queryPlan = getQueryPlan((PhoenixPreparedStatement) query);
-        ResultSet resultSet = getResultSet(phoenixSplit.getPhoenixInputSplit(), queryPlan);
+        ResultSet resultSet = getResultSet(((PhoenixSplit) split).getPhoenixInputSplit(), queryPlan);
         return new DelegatePreparedStatement(query)
         {
             @Override


### PR DESCRIPTION
`prepareQuery` and `buildSql` had largely duplicated responsibilities.
This commit introduces common `BaseJdbcClient.prepareQuery` to remove
logic duplication.

Alternative to https://github.com/trinodb/trino/pull/7132