### PR TITLE
Remove PhoenixSplit.constraint field

### DIFF
--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -252,7 +252,7 @@ public class PhoenixClient
                 Optional.empty(),
                 columnHandles,
                 ImmutableMap.of(),
-                phoenixSplit.getConstraint(),
+                table.getConstraint(),
                 split.getAdditionalPredicate());
         preparedQuery = applyQueryTransformations(table, preparedQuery);
         PreparedStatement query = queryBuilder.prepareStatement(session, connection, preparedQuery);

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplit.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplit.java
@@ -18,8 +18,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.plugin.jdbc.JdbcSplit;
 import io.trino.spi.HostAddress;
-import io.trino.spi.connector.ColumnHandle;
-import io.trino.spi.predicate.TupleDomain;
 import org.apache.phoenix.mapreduce.PhoenixInputSplit;
 
 import java.util.List;
@@ -32,18 +30,15 @@ public class PhoenixSplit
 {
     private final List<HostAddress> addresses;
     private final WrappedPhoenixInputSplit phoenixInputSplit;
-    private final TupleDomain<ColumnHandle> constraint;
 
     @JsonCreator
     public PhoenixSplit(
             @JsonProperty("addresses") List<HostAddress> addresses,
-            @JsonProperty("phoenixInputSplit") WrappedPhoenixInputSplit wrappedPhoenixInputSplit,
-            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
+            @JsonProperty("phoenixInputSplit") WrappedPhoenixInputSplit wrappedPhoenixInputSplit)
     {
         super(Optional.empty());
         this.addresses = requireNonNull(addresses, "addresses is null");
         this.phoenixInputSplit = requireNonNull(wrappedPhoenixInputSplit, "wrappedPhoenixInputSplit is null");
-        this.constraint = requireNonNull(constraint, "constraint is null");
     }
 
     @JsonProperty
@@ -63,11 +58,5 @@ public class PhoenixSplit
     public PhoenixInputSplit getPhoenixInputSplit()
     {
         return phoenixInputSplit.getPhoenixInputSplit();
-    }
-
-    @JsonProperty
-    public TupleDomain<ColumnHandle> getConstraint()
-    {
-        return constraint;
     }
 }

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
@@ -99,8 +99,7 @@ public class PhoenixSplitManager
                     .map(PhoenixInputSplit.class::cast)
                     .map(split -> new PhoenixSplit(
                             getSplitAddresses(split),
-                            new WrappedPhoenixInputSplit(split),
-                            tableHandle.getConstraint()))
+                            new WrappedPhoenixInputSplit(split)))
                     .collect(toImmutableList());
             return new FixedSplitSource(splits);
         }

--- a/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixSplit.java
+++ b/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixSplit.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.spi.HostAddress;
-import io.trino.spi.predicate.TupleDomain;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.mapreduce.PhoenixInputSplit;
@@ -41,8 +40,7 @@ public class TestPhoenixSplit
         PhoenixInputSplit phoenixInputSplit = new PhoenixInputSplit(scans);
         PhoenixSplit expected = new PhoenixSplit(
                 addresses,
-                new WrappedPhoenixInputSplit(phoenixInputSplit),
-                TupleDomain.all());
+                new WrappedPhoenixInputSplit(phoenixInputSplit));
 
         assertTrue(objectMapper.canSerialize(PhoenixSplit.class));
 
@@ -50,6 +48,5 @@ public class TestPhoenixSplit
         PhoenixSplit actual = objectMapper.readValue(json, PhoenixSplit.class);
         assertEquals(actual.getPhoenixInputSplit(), expected.getPhoenixInputSplit());
         assertEquals(actual.getAddresses(), expected.getAddresses());
-        assertEquals(actual.getConstraint(), expected.getConstraint());
     }
 }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -253,7 +253,7 @@ public class PhoenixClient
                 Optional.empty(),
                 columnHandles,
                 ImmutableMap.of(),
-                phoenixSplit.getConstraint(),
+                table.getConstraint(),
                 split.getAdditionalPredicate());
         preparedQuery = applyQueryTransformations(table, preparedQuery);
         PreparedStatement query = queryBuilder.prepareStatement(session, connection, preparedQuery);

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplit.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplit.java
@@ -18,8 +18,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.plugin.jdbc.JdbcSplit;
 import io.trino.spi.HostAddress;
-import io.trino.spi.connector.ColumnHandle;
-import io.trino.spi.predicate.TupleDomain;
 import org.apache.phoenix.mapreduce.PhoenixInputSplit;
 
 import java.util.List;
@@ -32,18 +30,15 @@ public class PhoenixSplit
 {
     private final List<HostAddress> addresses;
     private final WrappedPhoenixInputSplit phoenixInputSplit;
-    private final TupleDomain<ColumnHandle> constraint;
 
     @JsonCreator
     public PhoenixSplit(
             @JsonProperty("addresses") List<HostAddress> addresses,
-            @JsonProperty("phoenixInputSplit") WrappedPhoenixInputSplit wrappedPhoenixInputSplit,
-            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
+            @JsonProperty("phoenixInputSplit") WrappedPhoenixInputSplit wrappedPhoenixInputSplit)
     {
         super(Optional.empty());
         this.addresses = requireNonNull(addresses, "addresses is null");
         this.phoenixInputSplit = requireNonNull(wrappedPhoenixInputSplit, "wrappedPhoenixInputSplit is null");
-        this.constraint = requireNonNull(constraint, "constraint is null");
     }
 
     @JsonProperty
@@ -63,11 +58,5 @@ public class PhoenixSplit
     public PhoenixInputSplit getPhoenixInputSplit()
     {
         return phoenixInputSplit.getPhoenixInputSplit();
-    }
-
-    @JsonProperty
-    public TupleDomain<ColumnHandle> getConstraint()
-    {
-        return constraint;
     }
 }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
@@ -99,8 +99,7 @@ public class PhoenixSplitManager
                     .map(PhoenixInputSplit.class::cast)
                     .map(split -> new PhoenixSplit(
                             getSplitAddresses(split),
-                            new WrappedPhoenixInputSplit(split),
-                            tableHandle.getConstraint()))
+                            new WrappedPhoenixInputSplit(split)))
                     .collect(toImmutableList());
             return new FixedSplitSource(splits);
         }

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixSplit.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixSplit.java
@@ -17,7 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.spi.HostAddress;
-import io.trino.spi.predicate.TupleDomain;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.phoenix.mapreduce.PhoenixInputSplit;
@@ -41,8 +40,7 @@ public class TestPhoenixSplit
         PhoenixInputSplit phoenixInputSplit = new PhoenixInputSplit(scans);
         PhoenixSplit expected = new PhoenixSplit(
                 addresses,
-                new WrappedPhoenixInputSplit(phoenixInputSplit),
-                TupleDomain.all());
+                new WrappedPhoenixInputSplit(phoenixInputSplit));
 
         assertTrue(objectMapper.canSerialize(PhoenixSplit.class));
 
@@ -50,6 +48,5 @@ public class TestPhoenixSplit
         PhoenixSplit actual = objectMapper.readValue(json, PhoenixSplit.class);
         assertEquals(actual.getPhoenixInputSplit(), expected.getPhoenixInputSplit());
         assertEquals(actual.getAddresses(), expected.getAddresses());
-        assertEquals(actual.getConstraint(), expected.getConstraint());
     }
 }


### PR DESCRIPTION
It contains the same information as `JdbcTableHandle.constraint`.

Extracted from https://github.com/trinodb/trino/pull/7132 / https://github.com/trinodb/trino/pull/7173 to get @vincentpoon eyes on this to make sure i am not missing anything here.

