### PR TITLE
Use distinct package name for phoenix5 plugin

### DIFF
--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/MetadataUtil.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/MetadataUtil.java
@@ -11,13 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import org.apache.phoenix.util.SchemaUtil;
 
 import java.util.Optional;
 
-import static io.trino.plugin.phoenix.PhoenixMetadata.DEFAULT_SCHEMA;
+import static io.trino.plugin.phoenix5.PhoenixMetadata.DEFAULT_SCHEMA;
 
 public final class MetadataUtil
 {

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -134,17 +134,17 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.varcharColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.getUnsupportedTypeHandling;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
-import static io.trino.plugin.phoenix.MetadataUtil.getEscapedTableName;
-import static io.trino.plugin.phoenix.MetadataUtil.toPhoenixSchemaName;
-import static io.trino.plugin.phoenix.PhoenixClientModule.getConnectionProperties;
-import static io.trino.plugin.phoenix.PhoenixColumnProperties.isPrimaryKey;
-import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_METADATA_ERROR;
-import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_QUERY_ERROR;
-import static io.trino.plugin.phoenix.PhoenixMetadata.DEFAULT_SCHEMA;
-import static io.trino.plugin.phoenix.TypeUtils.getArrayElementPhoenixTypeName;
-import static io.trino.plugin.phoenix.TypeUtils.getJdbcObjectArray;
-import static io.trino.plugin.phoenix.TypeUtils.jdbcObjectArrayToBlock;
-import static io.trino.plugin.phoenix.TypeUtils.toBoxedArray;
+import static io.trino.plugin.phoenix5.MetadataUtil.getEscapedTableName;
+import static io.trino.plugin.phoenix5.MetadataUtil.toPhoenixSchemaName;
+import static io.trino.plugin.phoenix5.PhoenixClientModule.getConnectionProperties;
+import static io.trino.plugin.phoenix5.PhoenixColumnProperties.isPrimaryKey;
+import static io.trino.plugin.phoenix5.PhoenixErrorCode.PHOENIX_METADATA_ERROR;
+import static io.trino.plugin.phoenix5.PhoenixErrorCode.PHOENIX_QUERY_ERROR;
+import static io.trino.plugin.phoenix5.PhoenixMetadata.DEFAULT_SCHEMA;
+import static io.trino.plugin.phoenix5.TypeUtils.getArrayElementPhoenixTypeName;
+import static io.trino.plugin.phoenix5.TypeUtils.getJdbcObjectArray;
+import static io.trino.plugin.phoenix5.TypeUtils.jdbcObjectArrayToBlock;
+import static io.trino.plugin.phoenix5.TypeUtils.toBoxedArray;
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.inject.Binder;
 import com.google.inject.Key;
@@ -60,7 +60,7 @@ import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
 import static io.trino.plugin.jdbc.JdbcModule.bindTablePropertiesProvider;
-import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_CONFIG_ERROR;
+import static io.trino.plugin.phoenix5.PhoenixErrorCode.PHOENIX_CONFIG_ERROR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixColumnProperties.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixColumnProperties.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.connector.ColumnMetadata;
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.trino.plugin.phoenix.PhoenixTableProperties.getRowkeys;
+import static io.trino.plugin.phoenix5.PhoenixTableProperties.getRowkeys;
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 
 public class PhoenixColumnProperties

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConfig.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConfig.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnector.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnector.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.inject.Inject;
 import io.airlift.bootstrap.LifeCycleManager;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnectorFactory.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnectorFactory.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixErrorCode.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixErrorCode.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import io.trino.spi.ErrorCode;
 import io.trino.spi.ErrorCodeSupplier;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixHandleResolver.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixHandleResolver.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import io.airlift.slice.Slice;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
@@ -45,9 +45,9 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.plugin.phoenix.MetadataUtil.getEscapedTableName;
-import static io.trino.plugin.phoenix.MetadataUtil.toPrestoSchemaName;
-import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_METADATA_ERROR;
+import static io.trino.plugin.phoenix5.MetadataUtil.getEscapedTableName;
+import static io.trino.plugin.phoenix5.MetadataUtil.toPrestoSchemaName;
+import static io.trino.plugin.phoenix5.PhoenixErrorCode.PHOENIX_METADATA_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixOutputTableHandle.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixOutputTableHandle.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixPlugin.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixPlugin.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.spi.Plugin;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplit.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplit.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -51,8 +51,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_INTERNAL_ERROR;
-import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_SPLIT_ERROR;
+import static io.trino.plugin.phoenix5.PhoenixErrorCode.PHOENIX_INTERNAL_ERROR;
+import static io.trino.plugin.phoenix5.PhoenixErrorCode.PHOENIX_SPLIT_ERROR;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.phoenix.coprocessor.BaseScannerRegionObserver.EXPECTED_UPPER_REGION_KEY;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixTableProperties.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixTableProperties.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.jdbc.TablePropertiesProvider;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/TypeUtils.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/TypeUtils.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.base.CharMatcher;
 import com.google.common.primitives.Shorts;

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/WrappedPhoenixInputSplit.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/WrappedPhoenixInputSplit.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixQueryRunner.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixQueryRunner.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixSqlExecutor.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/PhoenixSqlExecutor.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import io.trino.testing.sql.SqlExecutor;
 

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConfig.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConfig.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixDistributedQueries.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixDistributedQueries.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.AbstractTestDistributedQueries;
@@ -20,7 +20,7 @@ import io.trino.testing.sql.TestTable;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 
-import static io.trino.plugin.phoenix.PhoenixQueryRunner.createPhoenixQueryRunner;
+import static io.trino.plugin.phoenix5.PhoenixQueryRunner.createPhoenixQueryRunner;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestPhoenixDistributedQueries

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixIntegrationSmokeTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixIntegrationSmokeTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
@@ -28,7 +28,7 @@ import java.sql.Statement;
 
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.UNSUPPORTED_TYPE_HANDLING;
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
-import static io.trino.plugin.phoenix.PhoenixQueryRunner.createPhoenixQueryRunner;
+import static io.trino.plugin.phoenix5.PhoenixQueryRunner.createPhoenixQueryRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixSplit.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixSplit.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixTypeMapping.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixTypeMapping.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -41,7 +41,7 @@ import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
-import static io.trino.plugin.phoenix.PhoenixQueryRunner.createPhoenixQueryRunner;
+import static io.trino.plugin.phoenix5.PhoenixQueryRunner.createPhoenixQueryRunner;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.IntegerType.INTEGER;

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestingPhoenixServer.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestingPhoenixServer.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.phoenix;
+package io.trino.plugin.phoenix5;
 
 import io.airlift.log.Logger;
 import org.apache.hadoop.conf.Configuration;


### PR DESCRIPTION
`phoenix5` plugin is a copy of the `phoenix` plugin. Two plugins have
thus classes with same qualified names and this apparently may confuse
IDEs.  For example, when asked about overrides of an `BaseJdbcClient`
method my IntelliJ 2020.2.4 shows implementation in `phoenix` plugin but
no the other one in the `phoenix5` plugin.

See also https://github.com/trinodb/trino/pull/6865#issuecomment-791336067 