### PR TITLE
Update JDBC driver for MemSQL

### DIFF
--- a/plugin/trino-memsql/pom.xml
+++ b/plugin/trino-memsql/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>2.4.0</version>
+            <version>2.7.2</version>
         </dependency>
 
         <!-- Trino SPI -->

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlConnectorSmokeTestLatest.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlConnectorSmokeTestLatest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.memsql;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.jdbc.BaseJdbcConnectorSmokeTest;
+import io.trino.testing.QueryRunner;
+
+import static io.trino.plugin.memsql.MemSqlQueryRunner.createMemSqlQueryRunner;
+
+public class TestMemSqlConnectorSmokeTestLatest
+        extends BaseJdbcConnectorSmokeTest
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingMemSqlServer memSqlServer = closeAfterClass(new TestingMemSqlServer(TestingMemSqlServer.LATEST_TESTED_TAG));
+        return createMemSqlQueryRunner(memSqlServer, ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+    }
+}

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestingMemSqlServer.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestingMemSqlServer.java
@@ -31,6 +31,7 @@ public class TestingMemSqlServer
     private static final String MEM_SQL_LICENSE = requireNonNull(System.getProperty("memsql.license"), "memsql.license is not set");
 
     public static final String DEFAULT_TAG = "memsql/cluster-in-a-box:centos-7.1.13-11ddea2a3a-3.0.0-1.9.0";
+    public static final String LATEST_TESTED_TAG = "memsql/cluster-in-a-box:centos-7.3.4-d596a2867a-3.2.4-1.10.1";
 
     public static final Integer MEMSQL_PORT = 3306;
 
@@ -42,6 +43,7 @@ public class TestingMemSqlServer
     public TestingMemSqlServer(String dockerImageName)
     {
         super(DockerImageName.parse(dockerImageName));
+        addEnv("ROOT_PASSWORD", "memsql_root_password");
         start();
     }
 
@@ -75,7 +77,7 @@ public class TestingMemSqlServer
     @Override
     public String getPassword()
     {
-        return "";
+        return "memsql_root_password";
     }
 
     @Override


### PR DESCRIPTION
This fixes compatibility issue with recent MemSQL versions.

The driver previously used would fail to authenticate, with following
being printed in MemSQL logs

    ERROR: ProcessHandshakeResponsePacket() failed. Sending back 1045: Access denied for user 'root'@'172.17.0.1' (using password: YES)