### PR TITLE
Fix test flakiness due to query cancellation race

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -550,7 +550,13 @@ public class DistributedQueryRunner
         QueryManager queryManager = coordinator.getQueryManager();
         for (BasicQueryInfo queryInfo : queryManager.getQueries()) {
             if (!queryInfo.getState().isDone()) {
-                queryManager.cancelQuery(queryInfo.getQueryId());
+                try {
+                    queryManager.cancelQuery(queryInfo.getQueryId());
+                }
+                catch (RuntimeException e) {
+                    // TODO (https://github.com/trinodb/trino/issues/6723) query cancellation can sometimes fail
+                    log.warn(e, "Failed to cancel query");
+                }
             }
         }
     }


### PR DESCRIPTION
`TestUserImpersonationAccessControl.close` sometimes fails.
The problem is general, but the `DistributedQueryRunner.close` could be
more robust anyway.

For https://github.com/trinodb/trino/issues/6723 