### PR TITLE
Fix timezone output in API results

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SessionRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/SessionRepresentation.java
@@ -290,6 +290,12 @@ public final class SessionRepresentation
         return protocolName;
     }
 
+    @JsonProperty
+    public String getTimeZone()
+    {
+        return timeZoneKey.getId();
+    }
+
     public Session toSession(SessionPropertyManager sessionPropertyManager)
     {
         return toSession(sessionPropertyManager, emptyMap());

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestTimeZoneKey.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestTimeZoneKey.java
@@ -13,11 +13,13 @@
  */
 package io.trino.spi.type;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.SortedSet;
 
@@ -219,6 +221,19 @@ public class TestTimeZoneKey
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
         assertEquals(hasher.hash().asLong(), 6334606028834602490L, "zone-index.properties file contents changed!");
+    }
+
+    @Test
+    public void testRoundTripSerialization()
+            throws IOException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+
+        for (TimeZoneKey zoneKey : TimeZoneKey.getTimeZoneKeys()) {
+            String json = mapper.writeValueAsString(zoneKey);
+            Object value = mapper.readValue(json, zoneKey.getClass());
+            assertEquals(value, zoneKey);
+        }
     }
 
     public void assertTimeZoneNotSupported(String zoneId)


### PR DESCRIPTION
Trino API, right now, only exposes the session timezone information via an internal zone representation number (`timeZoneKey`). This requires anyone needing timezone information to know the internal representation of zone. 

This PR added an additional field `timeZone` which provides the timezone information correctly. The changes are based on this [Slack discussion thread](https://trinodb.slack.com/archives/CP1MUNEUX/p1614796005120700).