### PR TITLE
Support tables with non-lowercase names in Druid

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RemoteTableNameCacheKey.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RemoteTableNameCacheKey.java
@@ -18,12 +18,12 @@ import java.util.Objects;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
-final class RemoteTableNameCacheKey
+public final class RemoteTableNameCacheKey
 {
     private final JdbcIdentity identity;
     private final String schema;
 
-    RemoteTableNameCacheKey(JdbcIdentity identity, String schema)
+    public RemoteTableNameCacheKey(JdbcIdentity identity, String schema)
     {
         this.identity = requireNonNull(identity, "identity is null");
         this.schema = requireNonNull(schema, "schema is null");

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidCaseInsensitiveMatch.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidCaseInsensitiveMatch.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.druid;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.MaterializedResult;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.assertions.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static io.trino.plugin.druid.BaseDruidIntegrationSmokeTest.SELECT_FROM_ORDERS;
+import static io.trino.plugin.druid.BaseDruidIntegrationSmokeTest.SELECT_FROM_REGION;
+import static io.trino.plugin.druid.DruidQueryRunner.copyAndIngestTpchData;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestDruidCaseInsensitiveMatch
+        extends AbstractTestQueryFramework
+{
+    private TestingDruidServer druidServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        druidServer = new TestingDruidServer();
+        closeAfterClass(() -> {
+            druidServer.close();
+            druidServer = null;
+        });
+        DistributedQueryRunner queryRunner = DruidQueryRunner.createDruidQueryRunnerTpch(
+                druidServer, ImmutableMap.of(), ImmutableMap.of("case-insensitive-name-matching", "true"));
+        copyAndIngestTpchData(queryRunner.execute(SELECT_FROM_ORDERS + " LIMIT 10"), this.druidServer, "orders", "CamelCase");
+        return queryRunner;
+    }
+
+    @Test
+    public void testNonLowerCaseTableName()
+    {
+        MaterializedResult expectedColumns = MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
+                .row("__time", "timestamp(3)", "", "")
+                .row("clerk", "varchar", "", "") // String columns are reported only as varchar
+                .row("comment", "varchar", "", "")
+                .row("custkey", "bigint", "", "") // Long columns are reported as bigint
+                .row("orderdate", "varchar", "", "")
+                .row("orderkey", "bigint", "", "")
+                .row("orderpriority", "varchar", "", "")
+                .row("orderstatus", "varchar", "", "")
+                .row("shippriority", "bigint", "", "") // Druid doesn't support int type
+                .row("totalprice", "double", "", "")
+                .build();
+        MaterializedResult actualColumns = computeActual("DESCRIBE " + "CamelCase");
+        Assert.assertEquals(actualColumns, expectedColumns);
+        MaterializedResult materializedRows = computeActual("SELECT * FROM druid.druid.CAMELCASE");
+        Assert.assertEquals(materializedRows.getRowCount(), 10);
+        MaterializedResult materializedRows1 = computeActual("SELECT * FROM druid.CamelCase");
+        MaterializedResult materializedRows2 = computeActual("SELECT * FROM druid.camelcase");
+        assertThat(materializedRows.equals(materializedRows1));
+        assertThat(materializedRows.equals(materializedRows2));
+    }
+
+    @Test
+    public void testTableNameClash()
+            throws IOException, InterruptedException
+    {
+        try {
+            //ingesting data with already existing table name in lowercase which should fail
+            copyAndIngestTpchData(getQueryRunner().execute(SELECT_FROM_REGION + " LIMIT 10"), this.druidServer, "region", "camelcase");
+        }
+        catch (AssertionError e) {
+            Assert.assertEquals(e.getMessage(), "Datasource camelcase not loaded expected [true] but found [false]");
+        }
+    }
+}

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidIntegrationSmokeTest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidIntegrationSmokeTest.java
@@ -32,7 +32,7 @@ public class TestDruidIntegrationSmokeTest
             throws Exception
     {
         this.druidServer = new TestingDruidServer();
-        QueryRunner runner = DruidQueryRunner.createDruidQueryRunnerTpch(druidServer, ImmutableMap.of());
+        QueryRunner runner = DruidQueryRunner.createDruidQueryRunnerTpch(druidServer, ImmutableMap.of(), ImmutableMap.of());
         copyAndIngestTpchData(runner.execute(SELECT_FROM_ORDERS), this.druidServer, ORDERS.getTableName());
         copyAndIngestTpchData(runner.execute(SELECT_FROM_LINEITEM), this.druidServer, LINE_ITEM.getTableName());
         copyAndIngestTpchData(runner.execute(SELECT_FROM_NATION), this.druidServer, NATION.getTableName());

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidIntegrationSmokeTestLatest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestDruidIntegrationSmokeTestLatest.java
@@ -34,7 +34,7 @@ public class TestDruidIntegrationSmokeTestLatest
             throws Exception
     {
         this.druidServer = new TestingDruidServer(LATEST_DRUID_DOCKER_IMAGE);
-        QueryRunner runner = DruidQueryRunner.createDruidQueryRunnerTpch(druidServer, ImmutableMap.of());
+        QueryRunner runner = DruidQueryRunner.createDruidQueryRunnerTpch(druidServer, ImmutableMap.of(), ImmutableMap.of());
         copyAndIngestTpchData(runner.execute(SELECT_FROM_ORDERS), this.druidServer, ORDERS.getTableName());
         copyAndIngestTpchData(runner.execute(SELECT_FROM_LINEITEM), this.druidServer, LINE_ITEM.getTableName());
         copyAndIngestTpchData(runner.execute(SELECT_FROM_NATION), this.druidServer, NATION.getTableName());

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/TestingDruidServer.java
@@ -223,7 +223,7 @@ public class TestingDruidServer
         middleManager.withCopyFileToContainer(forHostPath(dataFilePath),
                 getMiddleManagerContainerPathForDataFile(dataFilePath));
         String indexTask = Resources.toString(getResource(indexTaskFile), Charset.defaultCharset());
-
+        indexTask = getReplacedIndexTask(datasource, indexTask);
         Request.Builder requestBuilder = new Request.Builder();
         requestBuilder.addHeader("content-type", "application/json;charset=utf-8")
                 .url("http://localhost:" + getCoordinatorOverlordPort() + "/druid/indexer/v1/task")
@@ -232,6 +232,13 @@ public class TestingDruidServer
         try (Response ignored = httpClient.newCall(ingestionRequest).execute()) {
             Assert.assertTrue(checkDatasourceAvailable(datasource), "Datasource " + datasource + " not loaded");
         }
+    }
+
+    private String getReplacedIndexTask(String targetDataSource, String indexTask)
+    {
+        indexTask = indexTask.replaceAll("dataSource\":.*,", "dataSource\": \"" + targetDataSource + "\",");
+        indexTask = indexTask.replaceAll("filter\":.*", "filter\": \"" + targetDataSource + ".tsv\"");
+        return indexTask;
     }
 
     private boolean checkDatasourceAvailable(String datasource)


### PR DESCRIPTION
This PR addresses https://github.com/trinodb/trino/issues/6850

 Changes in this PR
1. calling getRemoteTable & getRemoteSchema before filtering in `getTableHandle(ConnectorSession session, SchemaTableName schemaTableName)` 
2. Added test cases for the same "TestCaseInSensitiveMapping"
3. Added a copyandIngestTpch function to copy any existing dataSource with a different dataSource name.