### PR TITLE
Add Iceberg configuration properties in docs

### DIFF
--- a/docs/src/main/sphinx/connector/iceberg.rst
+++ b/docs/src/main/sphinx/connector/iceberg.rst
@@ -40,6 +40,22 @@ At a minimum, ``hive.metastore.uri`` must be configured:
     connector.name=iceberg
     hive.metastore.uri=thrift://localhost:9083
 
+Iceberg configuration properties
+--------------------------------
+
+================================================== ============================================================ ============
+Property Name                                      Description                                                  Default
+================================================== ============================================================ ============
+``iceberg.file-format``                            Data storage file format for Iceberg tables.                 ``ORC``
+                                                   Possible values are ``PARQUET``, or ``ORC``.
+
+``iceberg.compression-codec``                      The compression codec to use when writing files.             ``GZIP``
+                                                   Possible values are ``NONE``, ``SNAPPY``, ``LZ4``,
+                                                   ``ZSTD``, or ``GZIP``.
+
+``iceberg.max-partitions-per-writer``              Maximum number of partitions per writer.                     100
+================================================== ============================================================ ============
+
 Partitioned tables
 ------------------
 


### PR DESCRIPTION
Added configurable properties for Iceberg connector. Have purposefully left out `iceberg.use-file-size-from-metadata` since it has been marked deprecated.