### PR TITLE
Upgrade MySQL driver to 8.x

### DIFF
--- a/plugin/trino-mysql/pom.xml
+++ b/plugin/trino-mysql/pom.xml
@@ -160,6 +160,20 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- org.testcontainers:mariadb depends on the MariaDB driver -->
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>2.4.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mariadb</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -14,7 +14,7 @@
 package io.trino.plugin.mysql;
 
 import com.google.common.collect.ImmutableSet;
-import com.mysql.jdbc.Statement;
+import com.mysql.cj.jdbc.JdbcStatement;
 import io.trino.plugin.jdbc.BaseJdbcClient;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ColumnMapping;
@@ -73,8 +73,8 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static com.mysql.jdbc.SQLError.SQL_STATE_ER_TABLE_EXISTS_ERROR;
-import static com.mysql.jdbc.SQLError.SQL_STATE_SYNTAX_ERROR;
+import static com.mysql.cj.exceptions.MysqlErrorNumbers.SQL_STATE_ER_TABLE_EXISTS_ERROR;
+import static com.mysql.cj.exceptions.MysqlErrorNumbers.SQL_STATE_SYNTAX_ERROR;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.base.util.JsonTypeUtil.jsonParse;
 import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
@@ -212,8 +212,8 @@ public class MySqlClient
             throws SQLException
     {
         PreparedStatement statement = connection.prepareStatement(sql);
-        if (statement.isWrapperFor(Statement.class)) {
-            statement.unwrap(Statement.class).enableStreamingResults();
+        if (statement.isWrapperFor(JdbcStatement.class)) {
+            statement.unwrap(JdbcStatement.class).enableStreamingResults();
         }
         return statement;
     }

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClientModule.java
@@ -52,7 +52,6 @@ public class MySqlClientModule
     {
         Properties connectionProperties = new Properties();
         connectionProperties.setProperty("useInformationSchema", Boolean.toString(mySqlConfig.isDriverUseInformationSchema()));
-        connectionProperties.setProperty("nullCatalogMeansCurrent", "false");
         connectionProperties.setProperty("useUnicode", "true");
         connectionProperties.setProperty("characterEncoding", "utf8");
         connectionProperties.setProperty("tinyInt1isBit", "false");

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlJdbcConfig.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlJdbcConfig.java
@@ -13,13 +13,14 @@
  */
 package io.trino.plugin.mysql;
 
-import com.mysql.jdbc.Driver;
+import com.mysql.cj.conf.ConnectionUrlParser;
+import com.mysql.cj.exceptions.CJException;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 
 import javax.validation.constraints.AssertTrue;
 
-import java.sql.SQLException;
-import java.util.Properties;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.mysql.cj.conf.ConnectionUrlParser.parseConnectionString;
 
 public class MySqlJdbcConfig
         extends BaseJdbcConfig
@@ -28,12 +29,11 @@ public class MySqlJdbcConfig
     public boolean isUrlValid()
     {
         try {
-            Driver driver = new Driver();
-            Properties properties = driver.parseURL(getConnectionUrl(), null);
-            return properties != null;
+            parseConnectionString(getConnectionUrl());
+            return true;
         }
-        catch (SQLException e) {
-            throw new RuntimeException(e);
+        catch (CJException ignored) {
+            return false;
         }
     }
 
@@ -41,12 +41,11 @@ public class MySqlJdbcConfig
     public boolean isUrlWithoutDatabase()
     {
         try {
-            Driver driver = new Driver();
-            Properties properties = driver.parseURL(getConnectionUrl(), null);
-            return (properties == null) || (driver.database(properties) == null);
+            ConnectionUrlParser parser = parseConnectionString(getConnectionUrl());
+            return isNullOrEmpty(parser.getPath());
         }
-        catch (SQLException e) {
-            throw new RuntimeException(e);
+        catch (CJException ignored) {
+            return false;
         }
     }
 }

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MariaDBQueryRunner.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/MariaDBQueryRunner.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mysql;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.airlift.log.Logging;
+import io.trino.Session;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.QueryAssertions.copyTpchTables;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public class MariaDBQueryRunner
+{
+    private MariaDBQueryRunner() {}
+
+    private static final String TPCH_SCHEMA = "tpch";
+
+    public static QueryRunner createMariaDBQueryRunner(TestingMariaDBServer server, TpchTable<?>... tables)
+            throws Exception
+    {
+        return createMariaDBQueryRunner(server, ImmutableMap.of(), ImmutableMap.of(), ImmutableList.copyOf(tables));
+    }
+
+    public static DistributedQueryRunner createMariaDBQueryRunner(
+            TestingMariaDBServer server,
+            Map<String, String> extraProperties,
+            Map<String, String> connectorProperties,
+            Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
+                .setExtraProperties(extraProperties)
+                .build();
+        try {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+
+            connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
+            connectorProperties.putIfAbsent("connection-url", server.getJdbcUrl());
+            connectorProperties.putIfAbsent("connection-user", server.getUsername());
+            connectorProperties.putIfAbsent("connection-password", server.getPassword());
+            connectorProperties.putIfAbsent("allow-drop-table", "true");
+
+            queryRunner.installPlugin(new MySqlPlugin());
+            queryRunner.createCatalog("mysql", "mysql", connectorProperties);
+
+            copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(), tables);
+
+            return queryRunner;
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    private static Session createSession()
+    {
+        return testSessionBuilder()
+                .setCatalog("mysql")
+                .setSchema(TPCH_SCHEMA)
+                .build();
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Logging.initialize();
+
+        DistributedQueryRunner queryRunner = createMariaDBQueryRunner(
+                new TestingMariaDBServer(),
+                ImmutableMap.of("http-server.http.port", "8080"),
+                ImmutableMap.of(),
+                TpchTable.getTables());
+
+        Logger log = Logger.get(MariaDBQueryRunner.class);
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+    }
+}

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMariaDbCompatibilityTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMariaDbCompatibilityTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mysql;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.sql.SqlExecutor;
+
+import static io.trino.plugin.mysql.MariaDBQueryRunner.createMariaDBQueryRunner;
+
+public class TestMariaDbCompatibilityTest
+        extends BaseMySqlConnectorTest
+{
+    private TestingMariaDBServer mariaDBServer;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        mariaDBServer = closeAfterClass(new TestingMariaDBServer());
+        return createMariaDBQueryRunner(mariaDBServer, ImmutableMap.of(), ImmutableMap.of(), REQUIRED_TPCH_TABLES);
+    }
+
+    @Override
+    protected SqlExecutor getMySqlExecutor()
+    {
+        return mariaDBServer::execute;
+    }
+}

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMariaDBServer.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestingMariaDBServer.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.mysql;
+
+import org.testcontainers.containers.MariaDBContainer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static io.trino.testing.containers.TestContainers.startOrReuse;
+import static java.lang.String.format;
+
+public class TestingMariaDBServer
+        implements AutoCloseable
+{
+    private final MariaDBContainer<?> container;
+    private final Closeable cleanup;
+
+    public TestingMariaDBServer()
+    {
+        this("mariadb:10.5.4");
+    }
+
+    public TestingMariaDBServer(String dockerImageName)
+    {
+        MariaDBContainer<?> container = new MariaDBContainer<>(dockerImageName);
+        container = container.withDatabaseName("tpch");
+        this.container = container;
+        configureContainer(container);
+        cleanup = startOrReuse(container);
+        execute(format("GRANT ALL PRIVILEGES ON *.* TO '%s'", container.getUsername()), "root", container.getPassword());
+    }
+
+    protected void configureContainer(MariaDBContainer<?> container) {}
+
+    public Connection createConnection()
+            throws SQLException
+    {
+        return container.createConnection("");
+    }
+
+    public void execute(String sql)
+    {
+        execute(sql, getUsername(), getPassword());
+    }
+
+    public void execute(String sql, String user, String password)
+    {
+        try (Connection connection = DriverManager.getConnection(getJdbcUrl(), user, password);
+                Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getUsername()
+    {
+        return container.getUsername();
+    }
+
+    public String getPassword()
+    {
+        return container.getPassword();
+    }
+
+    public String getDatabaseName()
+    {
+        return container.getDatabaseName();
+    }
+
+    public String getJdbcUrl()
+    {
+        // The connection URL is still using mysql to ensure we test MariaDB compatibility with the MySQL connector
+        return format("jdbc:mysql://%s:%s?useSSL=false&allowPublicKeyRetrieval=true", container.getContainerIpAddress(), container.getMappedPort(3306));
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            cleanup.close();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/plugin/trino-raptor-legacy/pom.xml
+++ b/plugin/trino-raptor-legacy/pom.xml
@@ -147,6 +147,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>${dep.mysql5.version}</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-resource-group-managers/pom.xml
+++ b/plugin/trino-resource-group-managers/pom.xml
@@ -102,6 +102,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>${dep.mysql5.version}</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-session-property-managers/pom.xml
+++ b/plugin/trino-session-property-managers/pom.xml
@@ -102,6 +102,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>${dep.mysql5.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <dep.docker-java.version>3.2.7</dep.docker-java.version>
         <dep.coral.version>1.0.25</dep.coral.version>
         <dep.confluent.version>5.5.2</dep.confluent.version>
+        <dep.mysql5.version>5.1.48</dep.mysql5.version>
 
         <!--
           America/Bahia_Banderas has:
@@ -1250,7 +1251,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.48</version>
+                <version>8.0.23</version>
             </dependency>
 
             <dependency>

--- a/service/trino-verifier/pom.xml
+++ b/service/trino-verifier/pom.xml
@@ -122,6 +122,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>${dep.mysql5.version}</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
Based on https://github.com/trinodb/trino/pull/7198 to preserve MariaDB compat.

This change migrates `trino-mysql` to Connector/J 8.0.22 from 5.1.48 while keeping other modules at 5.1.48 for now.

This should unblock https://github.com/trinodb/trino/issues/6910.

Fixes https://github.com/trinodb/trino/issues/443