### PR TITLE
Convert TestMemSqlTypeMapping to use SqlDataTypeTest

### DIFF
--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
@@ -62,7 +62,6 @@ import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.testing.datatype.DataType.bigintDataType;
-import static io.trino.testing.datatype.DataType.charDataType;
 import static io.trino.testing.datatype.DataType.dataType;
 import static io.trino.testing.datatype.DataType.dateDataType;
 import static io.trino.testing.datatype.DataType.doubleDataType;
@@ -392,29 +391,29 @@ public class TestMemSqlTypeMapping
     @Test
     public void testMemSqlCreatedParameterizedCharUnicode()
     {
-        DataTypeTest.create()
-                .addRoundTrip(charDataType(1, CHARACTER_SET_UTF8), "\u653b")
-                .addRoundTrip(charDataType(5, CHARACTER_SET_UTF8), "\u653b\u6bbb")
-                .addRoundTrip(charDataType(5, CHARACTER_SET_UTF8), "\u653b\u6bbb\u6a5f\u52d5\u968a")
+        SqlDataTypeTest.create()
+                .addRoundTrip("char(1)", "'攻'", createCharType(1), "CAST('攻' AS char(1))")
+                .addRoundTrip("char(5)", "'攻殻'", createCharType(5), "CAST('攻殻' AS char(5))")
+                .addRoundTrip("char(5)", "'攻殻機動隊'", createCharType(5), "CAST('攻殻機動隊' AS char(5))")
                 .execute(getQueryRunner(), memSqlCreateAndInsert("tpch.memsql_test_parameterized_varchar"));
     }
 
     @Test
     public void testTrinoCreatedParameterizedVarchar()
     {
-        DataTypeTest.create()
-                .addRoundTrip(stringDataType("varchar(10)", createVarcharType(10)), "text_a")
-                .addRoundTrip(stringDataType("varchar(255)", createVarcharType(255)), "text_b")
-                .addRoundTrip(stringDataType("varchar(256)", createVarcharType(256)), "text_c")
-                .addRoundTrip(stringDataType("varchar(" + MEMSQL_VARCHAR_MAX_LENGTH + ")", createVarcharType(MEMSQL_VARCHAR_MAX_LENGTH)), "text_memsql_max")
+        SqlDataTypeTest.create()
+                .addRoundTrip("varchar(10)", "'text_a'", createVarcharType(10), "CAST('text_a' AS varchar(10))")
+                .addRoundTrip("varchar(255)", "'text_b'", createVarcharType(255), "CAST('text_b' AS varchar(255))")
+                .addRoundTrip("varchar(256)", "'text_c'", createVarcharType(256), "CAST('text_c' AS varchar(256))")
+                .addRoundTrip("varchar(" + MEMSQL_VARCHAR_MAX_LENGTH + ")", "'text_memsql_max'", createVarcharType(MEMSQL_VARCHAR_MAX_LENGTH), "CAST('text_memsql_max' AS varchar(" + MEMSQL_VARCHAR_MAX_LENGTH + "))")
                 // types larger than max VARCHAR(n) for MemSQL get mapped to one of TEXT/MEDIUMTEXT/LONGTEXT
-                .addRoundTrip(stringDataType("varchar(" + (MEMSQL_VARCHAR_MAX_LENGTH + 1) + ")", createVarcharType(65535)), "text_memsql_larger_than_max")
-                .addRoundTrip(stringDataType("varchar(65535)", createVarcharType(65535)), "text_d")
-                .addRoundTrip(stringDataType("varchar(65536)", createVarcharType(16777215)), "text_e")
-                .addRoundTrip(stringDataType("varchar(16777215)", createVarcharType(16777215)), "text_f")
-                .addRoundTrip(stringDataType("varchar(16777216)", createUnboundedVarcharType()), "text_g")
-                .addRoundTrip(stringDataType("varchar(" + VarcharType.MAX_LENGTH + ")", createUnboundedVarcharType()), "text_h")
-                .addRoundTrip(varcharDataType(), "unbounded")
+                .addRoundTrip("varchar(" + (MEMSQL_VARCHAR_MAX_LENGTH + 1) + ")", "'text_memsql_larger_than_max'", createVarcharType(65535), "CAST('text_memsql_larger_than_max' AS varchar(65535))")
+                .addRoundTrip("varchar(65535)", "'text_d'", createVarcharType(65535), "CAST('text_d' AS varchar(65535))")
+                .addRoundTrip("varchar(65536)", "'text_e'", createVarcharType(16777215), "CAST('text_e' AS varchar(16777215))")
+                .addRoundTrip("varchar(16777215)", "'text_f'", createVarcharType(16777215), "CAST('text_f' AS varchar(16777215))")
+                .addRoundTrip("varchar(16777216)", "'text_g'", createUnboundedVarcharType(), "CAST('text_g' AS varchar)")
+                .addRoundTrip("varchar(" + VarcharType.MAX_LENGTH + ")", "'text_h'", createUnboundedVarcharType(), "CAST('text_h' AS varchar)")
+                .addRoundTrip("varchar", "'unbounded'", createUnboundedVarcharType(), "CAST('unbounded' AS varchar)")
                 .execute(getQueryRunner(), trinoCreateAsSelect("trino_test_parameterized_varchar"));
     }
 

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
@@ -58,15 +58,11 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
+import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
-import static io.trino.testing.datatype.DataType.bigintDataType;
 import static io.trino.testing.datatype.DataType.dataType;
-import static io.trino.testing.datatype.DataType.doubleDataType;
-import static io.trino.testing.datatype.DataType.integerDataType;
 import static io.trino.testing.datatype.DataType.realDataType;
-import static io.trino.testing.datatype.DataType.smallintDataType;
-import static io.trino.testing.datatype.DataType.tinyintDataType;
 import static io.trino.type.JsonType.JSON;
 import static java.lang.String.format;
 import static java.math.RoundingMode.HALF_UP;
@@ -97,50 +93,65 @@ public class TestMemSqlTypeMapping
     @Test
     public void testBasicTypes()
     {
-        DataTypeTest.create()
-                .addRoundTrip(bigintDataType(), 123_456_789_012L)
-                .addRoundTrip(integerDataType(), 1_234_567_890)
-                .addRoundTrip(smallintDataType(), (short) 32_456)
-                .addRoundTrip(tinyintDataType(), (byte) 125)
-                .addRoundTrip(doubleDataType(), 123.45d)
-                .addRoundTrip(realDataType(), 123.45f)
+        SqlDataTypeTest.create()
+                .addRoundTrip("bigint", "123456789012", BIGINT, "123456789012")
+                .addRoundTrip("integer", "1234567890", INTEGER, "1234567890")
+                .addRoundTrip("smallint", "32456", SMALLINT, "SMALLINT '32456'")
+                .addRoundTrip("tinyint", "125", TINYINT, "TINYINT '125'")
+                .addRoundTrip("double", "123.45", DOUBLE, "DOUBLE '123.45'")
+                // TODO: Real doesn't work with SqlDataTypeTest (see below)
+                // .addRoundTrip("real", "123.45", REAL, "REAL '123.45'")
                 .execute(getQueryRunner(), trinoCreateAsSelect("test_basic_types"));
     }
 
     @Test
     public void testFloat()
     {
-        singlePrecisionFloatingPointTests(realDataType())
-                .execute(getQueryRunner(), trinoCreateAsSelect("trino_test_float"));
-        singlePrecisionFloatingPointTests(memSqlFloatDataType())
-                .execute(getQueryRunner(), memSqlCreateAndInsert("tpch.memsql_test_float"));
-    }
-
-    private static DataTypeTest singlePrecisionFloatingPointTests(DataType<Float> floatType)
-    {
         // we are not testing Nan/-Infinity/+Infinity as those are not supported by MemSQL
-        return DataTypeTest.create()
-                .addRoundTrip(floatType, 3.14f)
+        DataTypeTest.create()
+                .addRoundTrip(realDataType(), 3.14f)
+                // TODO Overeagerly rounded by MemSQL to 3.14159
+                // .addRoundTrip(realDataType(), 3.1415927f)
+                .addRoundTrip(realDataType(), null)
+                .execute(getQueryRunner(), trinoCreateAsSelect("trino_test_float"));
+
+        DataTypeTest.create()
+                .addRoundTrip(memSqlFloatDataType(), 3.14f)
                 // TODO Overeagerly rounded by MemSQL to 3.14159
                 // .addRoundTrip(floatType, 3.1415927f)
-                .addRoundTrip(floatType, null);
+                .addRoundTrip(memSqlFloatDataType(), null)
+                .execute(getQueryRunner(), memSqlCreateAndInsert("tpch.memsql_test_float"));
+
+        // TODO: Changing to SqlDataTypeTest with Real does not work: assertion in SqlDataTypeTest.verifyPredicate() fails
+
+        // SqlDataTypeTest.create()
+        //         .addRoundTrip("real", "3.14", REAL, "REAL '3.14'")
+        //         // TODO Overeagerly rounded by MemSQL to 3.14159
+        //         // .addRoundTrip("real", "3.1415927", REAL, "REAL '3.14159'")
+        //         .addRoundTrip("real", "NULL", REAL, "CAST(NULL AS real)")
+        //         .execute(getQueryRunner(), trinoCreateAsSelect("trino_test_float"));
+
+        // SqlDataTypeTest.create()
+        //         .addRoundTrip("float", "3.14", REAL, "REAL '3.14'")
+        //         // TODO Overeagerly rounded by MemSQL to 3.14159
+        //         // .addRoundTrip("float", "3.1415927", REAL, "REAL '3.14159'")
+        //         .addRoundTrip("float", "NULL", REAL, "CAST(NULL AS real)")
+        //         .execute(getQueryRunner(), memSqlCreateAndInsert("tpch.memsql_test_float"));
     }
 
     @Test
     public void testDouble()
     {
-        doublePrecisionFloatingPointTests(doubleDataType())
-                .execute(getQueryRunner(), trinoCreateAsSelect("trino_test_double"));
-        doublePrecisionFloatingPointTests(memSqlDoubleDataType())
-                .execute(getQueryRunner(), memSqlCreateAndInsert("tpch.memsql_test_double"));
-    }
-
-    private static DataTypeTest doublePrecisionFloatingPointTests(DataType<Double> doubleType)
-    {
         // we are not testing Nan/-Infinity/+Infinity as those are not supported by MemSQL
-        return DataTypeTest.create()
-                .addRoundTrip(doubleType, 1.0e100d)
-                .addRoundTrip(doubleType, null);
+        SqlDataTypeTest.create()
+                .addRoundTrip("double", "1.0E100", DOUBLE, "DOUBLE '1.0E100'")
+                .addRoundTrip("double", "NULL", DOUBLE, "CAST(NULL AS double)")
+                .execute(getQueryRunner(), trinoCreateAsSelect("trino_test_double"));
+
+        SqlDataTypeTest.create()
+                .addRoundTrip("double precision", "1.0E100", DOUBLE, "DOUBLE '1.0E100'")
+                .addRoundTrip("double precision", "NULL", DOUBLE, "CAST(NULL AS double)")
+                .execute(getQueryRunner(), memSqlCreateAndInsert("tpch.memsql_test_double"));
     }
 
     @Test
@@ -562,10 +573,5 @@ public class TestMemSqlTypeMapping
     private static DataType<Float> memSqlFloatDataType()
     {
         return dataType("float", REAL, Object::toString);
-    }
-
-    private static DataType<Double> memSqlDoubleDataType()
-    {
-        return dataType("double precision", DOUBLE, Object::toString);
     }
 }

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
@@ -69,9 +69,7 @@ import static io.trino.testing.datatype.DataType.formatStringLiteral;
 import static io.trino.testing.datatype.DataType.integerDataType;
 import static io.trino.testing.datatype.DataType.realDataType;
 import static io.trino.testing.datatype.DataType.smallintDataType;
-import static io.trino.testing.datatype.DataType.stringDataType;
 import static io.trino.testing.datatype.DataType.tinyintDataType;
-import static io.trino.testing.datatype.DataType.varcharDataType;
 import static io.trino.type.JsonType.JSON;
 import static java.lang.String.format;
 import static java.math.RoundingMode.HALF_UP;
@@ -420,28 +418,29 @@ public class TestMemSqlTypeMapping
     @Test
     public void testMemSqlCreatedParameterizedVarchar()
     {
-        DataTypeTest.create()
-                .addRoundTrip(stringDataType("tinytext", createVarcharType(255)), "a")
-                .addRoundTrip(stringDataType("text", createVarcharType(65535)), "b")
-                .addRoundTrip(stringDataType("mediumtext", createVarcharType(16777215)), "c")
-                .addRoundTrip(stringDataType("longtext", createUnboundedVarcharType()), "d")
-                .addRoundTrip(varcharDataType(32), "e")
-                .addRoundTrip(varcharDataType(15000), "f")
+        SqlDataTypeTest.create()
+                .addRoundTrip("tinytext", "'a'", createVarcharType(255), "CAST('a' AS varchar(255))")
+                .addRoundTrip("text", "'b'", createVarcharType(65535), "CAST('b' AS varchar(65535))")
+                .addRoundTrip("mediumtext", "'c'", createVarcharType(16777215), "CAST('c' AS varchar(16777215))")
+                .addRoundTrip("longtext", "'unbounded'", createUnboundedVarcharType(), "CAST('unbounded' AS varchar)")
+                .addRoundTrip("varchar(32)", "'e'", createVarcharType(32), "CAST('e' AS varchar(32))")
+                .addRoundTrip("varchar(15000)", "'f'", createVarcharType(15000), "CAST('f' AS varchar(15000))")
                 .execute(getQueryRunner(), memSqlCreateAndInsert("tpch.memsql_test_parameterized_varchar"));
     }
 
     @Test
     public void testMemSqlCreatedParameterizedVarcharUnicode()
     {
-        String sampleUnicodeText = "\u653b\u6bbb\u6a5f\u52d5\u968a";
-        DataTypeTest.create()
-                .addRoundTrip(stringDataType("tinytext " + CHARACTER_SET_UTF8, createVarcharType(255)), sampleUnicodeText)
-                .addRoundTrip(stringDataType("text " + CHARACTER_SET_UTF8, createVarcharType(65535)), sampleUnicodeText)
-                .addRoundTrip(stringDataType("mediumtext " + CHARACTER_SET_UTF8, createVarcharType(16777215)), sampleUnicodeText)
-                .addRoundTrip(stringDataType("longtext " + CHARACTER_SET_UTF8, createUnboundedVarcharType()), sampleUnicodeText)
-                .addRoundTrip(varcharDataType(sampleUnicodeText.length(), CHARACTER_SET_UTF8), sampleUnicodeText)
-                .addRoundTrip(varcharDataType(32, CHARACTER_SET_UTF8), sampleUnicodeText)
-                .addRoundTrip(varcharDataType(20000, CHARACTER_SET_UTF8), sampleUnicodeText)
+        String sampleUnicodeText = "'\u653b\u6bbb\u6a5f\u52d5\u968a'";
+        SqlDataTypeTest.create()
+                .addRoundTrip("tinytext " + CHARACTER_SET_UTF8, sampleUnicodeText, createVarcharType(255), "CAST(" + sampleUnicodeText + "AS varchar(255))")
+                .addRoundTrip("text " + CHARACTER_SET_UTF8, sampleUnicodeText, createVarcharType(65535), "CAST(" + sampleUnicodeText + "AS varchar(65535))")
+                .addRoundTrip("mediumtext " + CHARACTER_SET_UTF8, sampleUnicodeText, createVarcharType(16777215), "CAST(" + sampleUnicodeText + "AS varchar(16777215))")
+                .addRoundTrip("longtext " + CHARACTER_SET_UTF8, sampleUnicodeText, createUnboundedVarcharType(), "CAST(" + sampleUnicodeText + "AS varchar)")
+                .addRoundTrip("varchar(" + sampleUnicodeText.length() + ") " + CHARACTER_SET_UTF8, sampleUnicodeText,
+                        createVarcharType(sampleUnicodeText.length()), "CAST(" + sampleUnicodeText + "AS varchar(" + sampleUnicodeText.length() + "))")
+                .addRoundTrip("varchar(32) " + CHARACTER_SET_UTF8, sampleUnicodeText, createVarcharType(32), "CAST(" + sampleUnicodeText + "AS varchar(32))")
+                .addRoundTrip("varchar(20000) " + CHARACTER_SET_UTF8, sampleUnicodeText, createVarcharType(20000), "CAST(" + sampleUnicodeText + "AS varchar(20000))")
                 .execute(getQueryRunner(), memSqlCreateAndInsert("tpch.memsql_test_parameterized_varchar_unicode"));
     }
 

--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlTypeMapping.java
@@ -427,16 +427,16 @@ public class TestMemSqlTypeMapping
     @Test
     public void testMemSqlCreatedParameterizedVarcharUnicode()
     {
-        String sampleUnicodeText = "'\u653b\u6bbb\u6a5f\u52d5\u968a'";
+        String sampleUnicodeLiteral = "'\u653b\u6bbb\u6a5f\u52d5\u968a'";
         SqlDataTypeTest.create()
-                .addRoundTrip("tinytext " + CHARACTER_SET_UTF8, sampleUnicodeText, createVarcharType(255), "CAST(" + sampleUnicodeText + " AS varchar(255))")
-                .addRoundTrip("text " + CHARACTER_SET_UTF8, sampleUnicodeText, createVarcharType(65535), "CAST(" + sampleUnicodeText + " AS varchar(65535))")
-                .addRoundTrip("mediumtext " + CHARACTER_SET_UTF8, sampleUnicodeText, createVarcharType(16777215), "CAST(" + sampleUnicodeText + " AS varchar(16777215))")
-                .addRoundTrip("longtext " + CHARACTER_SET_UTF8, sampleUnicodeText, createUnboundedVarcharType(), "CAST(" + sampleUnicodeText + " AS varchar)")
-                .addRoundTrip("varchar(" + sampleUnicodeText.length() + ") " + CHARACTER_SET_UTF8, sampleUnicodeText,
-                        createVarcharType(sampleUnicodeText.length()), "CAST(" + sampleUnicodeText + " AS varchar(" + sampleUnicodeText.length() + "))")
-                .addRoundTrip("varchar(32) " + CHARACTER_SET_UTF8, sampleUnicodeText, createVarcharType(32), "CAST(" + sampleUnicodeText + " AS varchar(32))")
-                .addRoundTrip("varchar(20000) " + CHARACTER_SET_UTF8, sampleUnicodeText, createVarcharType(20000), "CAST(" + sampleUnicodeText + " AS varchar(20000))")
+                .addRoundTrip("tinytext " + CHARACTER_SET_UTF8, sampleUnicodeLiteral, createVarcharType(255), "CAST(" + sampleUnicodeLiteral + " AS varchar(255))")
+                .addRoundTrip("text " + CHARACTER_SET_UTF8, sampleUnicodeLiteral, createVarcharType(65535), "CAST(" + sampleUnicodeLiteral + " AS varchar(65535))")
+                .addRoundTrip("mediumtext " + CHARACTER_SET_UTF8, sampleUnicodeLiteral, createVarcharType(16777215), "CAST(" + sampleUnicodeLiteral + " AS varchar(16777215))")
+                .addRoundTrip("longtext " + CHARACTER_SET_UTF8, sampleUnicodeLiteral, createUnboundedVarcharType(), "CAST(" + sampleUnicodeLiteral + " AS varchar)")
+                .addRoundTrip("varchar(" + sampleUnicodeLiteral.length() + ") " + CHARACTER_SET_UTF8, sampleUnicodeLiteral,
+                        createVarcharType(sampleUnicodeLiteral.length()), "CAST(" + sampleUnicodeLiteral + " AS varchar(" + sampleUnicodeLiteral.length() + "))")
+                .addRoundTrip("varchar(32) " + CHARACTER_SET_UTF8, sampleUnicodeLiteral, createVarcharType(32), "CAST(" + sampleUnicodeLiteral + " AS varchar(32))")
+                .addRoundTrip("varchar(20000) " + CHARACTER_SET_UTF8, sampleUnicodeLiteral, createVarcharType(20000), "CAST(" + sampleUnicodeLiteral + " AS varchar(20000))")
                 .execute(getQueryRunner(), memSqlCreateAndInsert("tpch.memsql_test_parameterized_varchar_unicode"));
     }
 


### PR DESCRIPTION
Hej, we* did our best to resolve issue #6393 by converting the test in class `testMemSqlTypeMapping` to use `SqlDataTypeTest` instead of `DataTypeTest`.

We have succeeded on most methods, with one exception being the Real type (both in `testBasicType()` and `testFloat()`, which resulted in the exception below. I don't know where exactly it stems from, but I believe it may be worth further investigation.

```
[ERROR]   TestMemSqlTypeMapping.testBasicTypes:112 [Rows]
Expecting:
  <>
to contain exactly in any order:
  <[(found)]>
but could not find the following elements:
  <(found)>

[ERROR]   TestMemSqlTypeMapping.testFloat:119 [Rows]
Expecting:
  <>
to contain exactly in any order:
  <[(found)]>
but could not find the following elements:
  <(found)>
```

Let me know if you have any questions/comments.

\* We are a group of five students (me, @caillouc, @hallon-heyman, @linnea-bonnevier, and @aoutir) who worked on this issue as a university assignment. All of us have sent in the CLA, and the ownership of the contributed code is personal.

Fixes #6393 