### PR TITLE
Execute TestSemiTransactionalHiveMetastore in a single thread

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestSemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestSemiTransactionalHiveMetastore.java
@@ -42,6 +42,8 @@ import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.testng.Assert.assertTrue;
 
+// countDownLatch field is shared between tests
+@Test(singleThreaded = true)
 public class TestSemiTransactionalHiveMetastore
 {
     private static final Column TABLE_COLUMN = new Column(
@@ -54,7 +56,8 @@ public class TestSemiTransactionalHiveMetastore
             Optional.of(new HiveBucketProperty(ImmutableList.of("column"), BUCKETING_V1, 10, ImmutableList.of(new SortingColumn("column", SortingColumn.Order.ASCENDING)))),
             true,
             ImmutableMap.of("param", "value2"));
-    private static CountDownLatch countDownLatch;
+
+    private CountDownLatch countDownLatch;
 
     @Test
     public void testParallelPartitionDrops()
@@ -123,7 +126,7 @@ public class TestSemiTransactionalHiveMetastore
                 newScheduledThreadPool(1));
     }
 
-    private static class TestingHiveMetastore
+    private class TestingHiveMetastore
             extends UnimplementedHiveMetastore
     {
         @Override
@@ -164,7 +167,7 @@ public class TestSemiTransactionalHiveMetastore
             assertCountDownLatch();
         }
 
-        private static void assertCountDownLatch()
+        private void assertCountDownLatch()
         {
             try {
                 countDownLatch.countDown();


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/7176