### PR TITLE
Clean connection uwnrap in Phoenix

### DIFF
--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -201,10 +201,10 @@ public class PhoenixClient
         getConnectionProperties(config).forEach((k, v) -> configuration.set((String) k, (String) v));
     }
 
-    public PhoenixConnection getConnection(ConnectorSession session)
+    public Connection getConnection(ConnectorSession session)
             throws SQLException
     {
-        return connectionFactory.openConnection(session).unwrap(PhoenixConnection.class);
+        return connectionFactory.openConnection(session);
     }
 
     public org.apache.hadoop.hbase.client.Connection getHConnection()
@@ -570,8 +570,8 @@ public class PhoenixClient
     {
         ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
 
-        try (PhoenixConnection connection = (PhoenixConnection) connectionFactory.openConnection(session);
-                HBaseAdmin admin = connection.getQueryServices().getAdmin()) {
+        try (Connection connection = connectionFactory.openConnection(session);
+                HBaseAdmin admin = connection.unwrap(PhoenixConnection.class).getQueryServices().getAdmin()) {
             String schemaName = toPhoenixSchemaName(Optional.ofNullable(handle.getSchemaName())).orElse(null);
             PTable table = getTable(connection, SchemaUtil.getTableName(schemaName, handle.getTableName()));
 

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.phoenix.compile.QueryPlan;
-import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
 import org.apache.phoenix.mapreduce.PhoenixInputSplit;
 import org.apache.phoenix.query.KeyRange;
@@ -45,6 +44,7 @@ import org.apache.phoenix.query.KeyRange;
 import javax.inject.Inject;
 
 import java.io.IOException;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,7 +79,7 @@ public class PhoenixSplitManager
             DynamicFilter dynamicFilter)
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
-        try (PhoenixConnection connection = phoenixClient.getConnection(session)) {
+        try (Connection connection = phoenixClient.getConnection(session)) {
             List<JdbcColumnHandle> columns = tableHandle.getColumns()
                     .map(columnSet -> columnSet.stream().map(JdbcColumnHandle.class::cast).collect(toList()))
                     .orElseGet(() -> phoenixClient.getColumns(session, tableHandle));

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -202,10 +202,10 @@ public class PhoenixClient
         getConnectionProperties(config).forEach((k, v) -> configuration.set((String) k, (String) v));
     }
 
-    public PhoenixConnection getConnection(ConnectorSession session)
+    public Connection getConnection(ConnectorSession session)
             throws SQLException
     {
-        return connectionFactory.openConnection(session).unwrap(PhoenixConnection.class);
+        return connectionFactory.openConnection(session);
     }
 
     public org.apache.hadoop.hbase.client.Connection getHConnection()
@@ -571,8 +571,8 @@ public class PhoenixClient
     {
         ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
 
-        try (PhoenixConnection connection = (PhoenixConnection) connectionFactory.openConnection(session);
-                Admin admin = connection.getQueryServices().getAdmin()) {
+        try (Connection connection = connectionFactory.openConnection(session);
+                Admin admin = connection.unwrap(PhoenixConnection.class).getQueryServices().getAdmin()) {
             String schemaName = toPhoenixSchemaName(Optional.ofNullable(handle.getSchemaName())).orElse(null);
             PTable table = getTable(connection, SchemaUtil.getTableName(schemaName, handle.getTableName()));
 

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.phoenix.compile.QueryPlan;
-import org.apache.phoenix.jdbc.PhoenixConnection;
 import org.apache.phoenix.jdbc.PhoenixPreparedStatement;
 import org.apache.phoenix.mapreduce.PhoenixInputSplit;
 import org.apache.phoenix.query.KeyRange;
@@ -45,6 +44,7 @@ import org.apache.phoenix.query.KeyRange;
 import javax.inject.Inject;
 
 import java.io.IOException;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,7 +79,7 @@ public class PhoenixSplitManager
             DynamicFilter dynamicFilter)
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
-        try (PhoenixConnection connection = phoenixClient.getConnection(session)) {
+        try (Connection connection = phoenixClient.getConnection(session)) {
             List<JdbcColumnHandle> columns = tableHandle.getColumns()
                     .map(columnSet -> columnSet.stream().map(JdbcColumnHandle.class::cast).collect(toList()))
                     .orElseGet(() -> phoenixClient.getColumns(session, tableHandle));


### PR DESCRIPTION
Should the `ConnectionFactory` return a wrapper around
`PhoenixConnection`, it would be important to close that wrapper, not
the unwrapped connection (think: pooling). Fix Phoenix connector to use
correct idioms.