### PR TITLE
Allow connector to limit LIMIT support

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -1040,7 +1040,7 @@ public abstract class BaseJdbcClient
     }
 
     @Override
-    public boolean supportsLimit()
+    public boolean supportsLimit(long limit)
     {
         return limitFunction().isPresent();
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -234,9 +234,9 @@ public class CachingJdbcClient
     }
 
     @Override
-    public boolean supportsLimit()
+    public boolean supportsLimit(long limit)
     {
-        return delegate.supportsLimit();
+        return delegate.supportsLimit(limit);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -245,9 +245,9 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public boolean supportsLimit()
+    public boolean supportsLimit(long limit)
     {
-        return delegate().supportsLimit();
+        return delegate().supportsLimit(limit);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -109,7 +109,7 @@ public interface JdbcClient
 
     boolean isTopNLimitGuaranteed(ConnectorSession session);
 
-    boolean supportsLimit();
+    boolean supportsLimit(long limit);
 
     boolean isLimitGuaranteed(ConnectorSession session);
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
@@ -415,7 +415,7 @@ public class JdbcMetadata
     {
         JdbcTableHandle handle = (JdbcTableHandle) table;
 
-        if (!jdbcClient.supportsLimit()) {
+        if (!jdbcClient.supportsLimit(limit)) {
             return Optional.empty();
         }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -299,9 +299,9 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public boolean supportsLimit()
+    public boolean supportsLimit(long limit)
     {
-        return delegate().supportsLimit();
+        return delegate().supportsLimit(limit);
     }
 
     @Override

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -269,14 +269,15 @@ public class PhoenixClient
     }
 
     @Override
+    public boolean supportsLimit(long limit)
+    {
+        return limit <= Integer.MAX_VALUE;
+    }
+
+    @Override
     protected Optional<BiFunction<String, Long, String>> limitFunction()
     {
-        return Optional.of((sql, limit) -> {
-            if (limit > Integer.MAX_VALUE) {
-                return sql;
-            }
-            return sql + " LIMIT " + limit;
-        });
+        return Optional.of((sql, limit) -> sql + " LIMIT " + limit);
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -270,14 +270,15 @@ public class PhoenixClient
     }
 
     @Override
+    public boolean supportsLimit(long limit)
+    {
+        return limit <= Integer.MAX_VALUE;
+    }
+
+    @Override
     protected Optional<BiFunction<String, Long, String>> limitFunction()
     {
-        return Optional.of((sql, limit) -> {
-            if (limit > Integer.MAX_VALUE) {
-                return sql;
-            }
-            return sql + " LIMIT " + limit;
-        });
+        return Optional.of((sql, limit) -> sql + " LIMIT " + limit);
     }
 
     @Override

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
@@ -85,6 +85,12 @@ public class RedshiftClient
     }
 
     @Override
+    public boolean supportsLimit(long limit)
+    {
+        return limit <= Integer.MAX_VALUE;
+    }
+
+    @Override
     protected Optional<BiFunction<String, Long, String>> limitFunction()
     {
         return Optional.of((sql, limit) -> sql + " LIMIT " + limit);


### PR DESCRIPTION
Some databases, like Phoenix and Redshift, support LIMIT up to
Integer.MAX_VALUE.

Previously we handled such cases with `isLimitGuaranteed = false`, but
this prevents further pushdowns for a case when LIMIT value is more
typical (relatively small).