### PR TITLE
Fix queries on tables without snapshot id

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -287,6 +287,12 @@ public class IcebergMetadata
 
         TupleDomain<IcebergColumnHandle> enforcedPredicate = table.getEnforcedPredicate();
 
+        if (table.getSnapshotId().isEmpty()) {
+            // A table with missing snapshot id produces no splits, so we optimize here by returning
+            // TupleDomain.none() as the predicate
+            return new ConnectorTableProperties(TupleDomain.none(), Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of());
+        }
+
         TableScan tableScan = icebergTable.newScan()
                 .useSnapshot(table.getSnapshotId().get())
                 .filter(toIcebergExpression(enforcedPredicate))

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/iceberg/TestSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/iceberg/TestSparkCompatibility.java
@@ -62,6 +62,12 @@ public class TestSparkCompatibility
                         ") USING ICEBERG";
         onSpark().executeQuery(format(sparkTableDefinition, sparkTableName));
 
+        // Validate queries on an empty table created by Spark
+        String snapshotsTable = prestoTableName("\"" + baseTableName + "$snapshots\"");
+        assertThat(onPresto().executeQuery(format("SELECT * FROM %s", snapshotsTable))).hasNoRows();
+        QueryResult emptyResult = onPresto().executeQuery(format("SELECT * FROM %s", prestoTableName(baseTableName)));
+        assertThat(emptyResult).hasNoRows();
+
         String values = "VALUES (" +
                 "'a_string'" +
                 ", 1000000000000000" +


### PR DESCRIPTION
Tables created by Spark can have empty snapshot id, and needs to be handled while getting table properties.

Didn't find any Iceberg documentation on whether empty snapshot _always_ means an empty table, but this is consistent with `IcebergSplitManager#getSplits` implementation. We could instead maintain the `predicate`, but `tupledomain.none()` seems like a valid interpretation from the table handle state.