### PR TITLE
Upgrade PostgreSQL driver to 42.2.19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1434,7 +1434,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.2.10</version>
+                <version>42.2.19</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This mitigates CVE-2020-13692 (https://jdbc.postgresql.org/documentation/changelog.html#version_42.2.13)

