### PR TITLE
Handle mixed array fields in ES

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
@@ -324,7 +324,7 @@ public class ScanQueryPageSource
         if (type instanceof ArrayType) {
             Type elementType = ((ArrayType) type).getElementType();
 
-            return new ArrayDecoder(path, createDecoder(path, elementType));
+            return new ArrayDecoder(createDecoder(path, elementType));
         }
 
         throw new UnsupportedOperationException("Type not supported: " + type);

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/ArrayDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/ArrayDecoder.java
@@ -13,26 +13,19 @@
  */
 package io.trino.plugin.elasticsearch.decoders;
 
-import io.trino.spi.TrinoException;
 import io.trino.spi.block.BlockBuilder;
 import org.elasticsearch.search.SearchHit;
 
 import java.util.List;
 import java.util.function.Supplier;
 
-import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
-import static java.lang.String.format;
-import static java.util.Objects.requireNonNull;
-
 public class ArrayDecoder
         implements Decoder
 {
-    private final String path;
     private final Decoder elementDecoder;
 
-    public ArrayDecoder(String path, Decoder elementDecoder)
+    public ArrayDecoder(Decoder elementDecoder)
     {
-        this.path = requireNonNull(path, "path is null");
         this.elementDecoder = elementDecoder;
     }
 
@@ -50,7 +43,9 @@ public class ArrayDecoder
             output.closeEntry();
         }
         else {
-            throw new TrinoException(TYPE_MISMATCH, format("Expected list of elements for field '%s' of type ARRAY: %s [%s]", path, data, data.getClass().getSimpleName()));
+            BlockBuilder array = output.beginBlockEntry();
+            elementDecoder.decode(hit, () -> data, array);
+            output.closeEntry();
         }
     }
 }

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchSmokeTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchSmokeTest.java
@@ -284,6 +284,47 @@ public abstract class BaseElasticsearchSmokeTest
     }
 
     @Test
+    public void testMixedArray()
+            throws IOException
+    {
+        String indexName = "test_mixed_arrays";
+
+        @Language("JSON")
+        String mapping = "" +
+                "{" +
+                "      \"_meta\": {" +
+                "        \"presto\": {" +
+                "          \"a\": {" +
+                "                \"isArray\": true" +
+                "          }" +
+                "        }" +
+                "      }," +
+                "      \"properties\": {" +
+                "        \"a\": {" +
+                "          \"type\": \"keyword\"" +
+                "        }" +
+                "      }" +
+                "}";
+
+        createIndex(indexName, mapping);
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .build());
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("a", "hello")
+                .build());
+
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("a", ImmutableList.of("foo", "bar"))
+                .build());
+
+        assertQuery(
+                "SELECT a FROM test_mixed_arrays",
+                "VALUES NULL, ARRAY['hello'], ARRAY['foo', 'bar']");
+    }
+
+    @Test
     public void testEmptyObjectFields()
             throws IOException
     {


### PR DESCRIPTION
Allow interpreting scalar values as single-element arrays if a field
was tagged as an array field in the index mapping

Fixes https://github.com/trinodb/trino/issues/7012