### PR TITLE
Added a new JDBC driver parameter - 'TimeZoneID'

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -71,6 +71,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<File> KERBEROS_KEYTAB_PATH = new KerberosKeytabPath();
     public static final ConnectionProperty<File> KERBEROS_CREDENTIAL_CACHE_PATH = new KerberosCredentialCachePath();
     public static final ConnectionProperty<String> ACCESS_TOKEN = new AccessToken();
+    public static final ConnectionProperty<String> TIMEZONE_ID = new TimeZoneID();
     public static final ConnectionProperty<Boolean> EXTERNAL_AUTHENTICATION = new ExternalAuthentication();
     public static final ConnectionProperty<Duration> EXTERNAL_AUTHENTICATION_TIMEOUT = new ExternalAuthenticationTimeout();
     public static final ConnectionProperty<Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
@@ -105,6 +106,7 @@ final class ConnectionProperties
             .add(KERBEROS_KEYTAB_PATH)
             .add(KERBEROS_CREDENTIAL_CACHE_PATH)
             .add(ACCESS_TOKEN)
+            .add(TIMEZONE_ID)
             .add(EXTRA_CREDENTIALS)
             .add(CLIENT_INFO)
             .add(CLIENT_TAGS)
@@ -437,6 +439,15 @@ final class ConnectionProperties
         public AccessToken()
         {
             super("accessToken", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class TimeZoneID
+            extends AbstractConnectionProperty<String>
+    {
+        public TimeZoneID()
+        {
+            super("TimeZoneID", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -121,7 +121,8 @@ public class TrinoConnection
         uri.getTraceToken().ifPresent(tags -> clientInfo.put(TRACE_TOKEN, tags));
 
         roles.putAll(uri.getRoles());
-        timeZoneId.set(ZoneId.systemDefault());
+        timeZoneId.set(uri.getTimeZoneID().isPresent() ?
+                ZoneId.of(uri.getTimeZoneID().get()) : ZoneId.systemDefault());
         locale.set(Locale.getDefault());
         sessionProperties.putAll(uri.getSessionProperties());
     }

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -32,6 +32,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,6 +85,7 @@ import static io.trino.jdbc.ConnectionProperties.SslVerificationMode;
 import static io.trino.jdbc.ConnectionProperties.SslVerificationMode.CA;
 import static io.trino.jdbc.ConnectionProperties.SslVerificationMode.FULL;
 import static io.trino.jdbc.ConnectionProperties.SslVerificationMode.NONE;
+import static io.trino.jdbc.ConnectionProperties.TIMEZONE_ID;
 import static io.trino.jdbc.ConnectionProperties.TRACE_TOKEN;
 import static io.trino.jdbc.ConnectionProperties.USER;
 import static java.lang.String.format;
@@ -191,6 +193,21 @@ public final class TrinoDriverUri
     public Properties getProperties()
     {
         return properties;
+    }
+
+    public Optional<String> getTimeZoneID()
+            throws SQLException
+    {
+        Optional<String> tzId = TIMEZONE_ID.getValue(properties);
+
+        if (tzId.isPresent()) {
+            List<String> ids = Arrays.asList(java.util.TimeZone.getAvailableIDs());
+            if (ids.contains(tzId.get())) {
+                return tzId;
+            }
+            throw new SQLException("Specified TimeZoneID is not supported");
+        }
+        return tzId;
     }
 
     public Map<String, String> getExtraCredentials()


### PR DESCRIPTION
Hello Team, 
I have added a new JDBC driver parameter: **TimeZoneID**.  This parameter may be specified as part of URI 
or as part of properties passed to DriverManager. Both of the following examples are equivalent:

```
// URL parameter
String url = "jdbc:trino://example.net:8080/hive/sales?TimeZoneID=US/Eastern";
Connection connection = DriverManager.getConnection(url);

// Properties
String url = "jdbc:trino://example.net:8080/hive/sales";
Properties properties = new Properties();
properties.setProperty("TimeZoneID", "US/Eastern");
Connection connection = DriverManager.getConnection(url, properties);
```
Could you please let me know where can I write tests for this change? And if there is anything else needed for this pull request to be merged?

Fixes https://github.com/trinodb/trino/issues/7158 