### PR TITLE
Update session-property-managers.rst

### DIFF
--- a/docs/src/main/sphinx/admin/session-property-managers.rst
+++ b/docs/src/main/sphinx/admin/session-property-managers.rst
@@ -69,20 +69,20 @@ These requirements can be expressed with the following rules:
     [
       {
         "group": "global.*",
-        "session_properties": {
-          "query_max_execution_time": "8h",
+        "sessionProperties": {
+          "query_max_execution_time": "8h"
         }
       },
       {
         "group": "global.interactive.*",
-        "session_properties": {
+        "sessionProperties": {
           "query_max_execution_time": "1h"
         }
       },
       {
         "group": "global.pipeline.*",
         "clientTags": ["etl"],
-        "session_properties": {
+        "sessionProperties": {
           "scale_writers": "true",
           "writer_min_size": "1GB",
           "hive.insert_existing_partitions_behavior": "overwrite"


### PR DESCRIPTION
The example here is not working.

 - There’s an extra `,` on L5.
- `session_properties`  results in
```
2021-03-11T10:10:35.436Z	INFO	main	Bootstrap	session-property-manager.config-file  ----     /etc/presto/session-property-config.json
2021-03-11T10:10:35.944Z	ERROR	main	io.prestosql.server.Server	Unable to create injector, see the following errors:

1) Error injecting constructor, java.lang.IllegalArgumentException: sessionProperties is null
  at io.prestosql.plugin.session.file.FileSessionPropertyManager.<init>(FileSessionPropertyManager.java:48)
  at io.prestosql.plugin.session.file.FileSessionPropertyManagerModule.configure(FileSessionPropertyManagerModule.java:29)
  while locating io.prestosql.plugin.session.file.FileSessionPropertyManager 
```

Can be fixed if `session_properties` is changed to `sessionProperties`.