### PR TITLE
Enforce connector tests naming convention

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcCachingConnectorSmokeTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcCachingConnectorSmokeTest.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import static io.trino.plugin.jdbc.H2QueryRunner.createH2QueryRunner;
 
-public class TestJdbcCachingQueries
+public class TestJdbcCachingConnectorSmokeTest
         extends BaseJdbcConnectorSmokeTest
 {
     @Override

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -56,6 +56,7 @@ import org.intellij.lang.annotations.Language;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.testing.TestingMBeanServer;
 
@@ -107,6 +108,15 @@ public abstract class AbstractTestQueryFramework
         h2QueryRunner = null;
         sqlParser = null;
         queryAssertions = null;
+    }
+
+    @Test
+    public void ensureTestNamingConvention()
+    {
+        // Enforce a naming convention to make code navigation easier.
+        assertThat(getClass().getName())
+                .doesNotEndWith("ConnectorTest")
+                .doesNotEndWith("ConnectorSmokeTest");
     }
 
     protected Session getSession()

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -58,6 +58,15 @@ public abstract class BaseConnectorSmokeTest
     }
 
     @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        // Enforce a naming convention to make code navigation easier.
+        assertThat(getClass().getName())
+                .endsWith("ConnectorSmokeTest");
+    }
+
+    @Test
     public void testSelect()
     {
         assertQuery("SELECT name FROM region");

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -45,6 +45,15 @@ public abstract class BaseConnectorTest
     }
 
     @Test
+    @Override
+    public void ensureTestNamingConvention()
+    {
+        // Enforce a naming convention to make code navigation easier.
+        assertThat(getClass().getName())
+                .endsWith("ConnectorTest");
+    }
+
+    @Test
     public void testColumnsInReverseOrder()
     {
         assertQuery("SELECT shippriority, clerk, totalprice FROM orders");


### PR DESCRIPTION
Enforce a naming convention to make code navigation easier.