### PR TITLE
Test updates in AC tests with row filtering and column masking

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -541,6 +541,23 @@ public class TestColumnMask
     }
 
     @Test
+    public void testUpdateWithColumnMasking()
+    {
+        accessControl.reset();
+        accessControl.columnMask(
+                new QualifiedObjectName(CATALOG, "tiny", "orders"),
+                "clerk",
+                USER,
+                new ViewExpression(USER, Optional.empty(), Optional.empty(), "clerk"));
+        assertThatThrownBy(() -> assertions.query("UPDATE orders SET clerk = 'X'"))
+                .hasMessage("line 1:1: Updating a table with column masks is not supported");
+        assertThatThrownBy(() -> assertions.query("UPDATE orders SET orderkey = -orderkey"))
+                .hasMessage("line 1:1: Updating a table with column masks is not supported");
+        assertThatThrownBy(() -> assertions.query("UPDATE orders SET clerk = 'X', orderkey = -orderkey"))
+                .hasMessage("line 1:1: Updating a table with column masks is not supported");
+    }
+
+    @Test
     public void testNotReferencedAndDeniedColumnMasking()
     {
         // mask on not used varchar column

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -359,7 +359,7 @@ public class TestColumnMask
                 new ViewExpression(USER, Optional.of(CATALOG), Optional.of("tiny"), "orderkey"));
         assertThatThrownBy(() -> assertions.query(
                 "SELECT (SELECT min(custkey) FROM customer WHERE customer.custkey = orders.custkey) FROM orders"))
-                .hasMessageMatching("\\Qline 1:34: Invalid column mask for 'local.tiny.customer.custkey': Column 'orderkey' cannot be resolved\\E");
+                .hasMessage("line 1:34: Invalid column mask for 'local.tiny.customer.custkey': Column 'orderkey' cannot be resolved");
     }
 
     @Test
@@ -389,7 +389,7 @@ public class TestColumnMask
                 new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "$$$"));
 
         assertThatThrownBy(() -> assertions.query("SELECT orderkey FROM orders"))
-                .hasMessageMatching("\\Qline 1:22: Invalid column mask for 'local.tiny.orders.orderkey': mismatched input '$'. Expecting: <expression>\\E");
+                .hasMessage("line 1:22: Invalid column mask for 'local.tiny.orders.orderkey': mismatched input '$'. Expecting: <expression>");
 
         // unknown column
         accessControl.reset();
@@ -400,7 +400,7 @@ public class TestColumnMask
                 new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "unknown_column"));
 
         assertThatThrownBy(() -> assertions.query("SELECT orderkey FROM orders"))
-                .hasMessageMatching("\\Qline 1:22: Invalid column mask for 'local.tiny.orders.orderkey': Column 'unknown_column' cannot be resolved\\E");
+                .hasMessage("line 1:22: Invalid column mask for 'local.tiny.orders.orderkey': Column 'unknown_column' cannot be resolved");
 
         // invalid type
         accessControl.reset();
@@ -411,7 +411,7 @@ public class TestColumnMask
                 new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "'foo'"));
 
         assertThatThrownBy(() -> assertions.query("SELECT orderkey FROM orders"))
-                .hasMessageMatching("\\Qline 1:22: Expected column mask for 'local.tiny.orders.orderkey' to be of type bigint, but was varchar(3)\\E");
+                .hasMessage("line 1:22: Expected column mask for 'local.tiny.orders.orderkey' to be of type bigint, but was varchar(3)");
 
         // aggregation
         accessControl.reset();
@@ -422,7 +422,7 @@ public class TestColumnMask
                 new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "count(*) > 0"));
 
         assertThatThrownBy(() -> assertions.query("SELECT orderkey FROM orders"))
-                .hasMessageMatching("\\Qline 1:10: Column mask for 'orders.orderkey' cannot contain aggregations, window functions or grouping operations: [count(*)]\\E");
+                .hasMessage("line 1:10: Column mask for 'orders.orderkey' cannot contain aggregations, window functions or grouping operations: [count(*)]");
 
         // window function
         accessControl.reset();
@@ -433,7 +433,7 @@ public class TestColumnMask
                 new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "row_number() OVER () > 0"));
 
         assertThatThrownBy(() -> assertions.query("SELECT orderkey FROM orders"))
-                .hasMessageMatching("\\Qline 1:22: Column mask for 'orders.orderkey' cannot contain aggregations, window functions or grouping operations: [row_number() OVER ()]\\E");
+                .hasMessage("line 1:22: Column mask for 'orders.orderkey' cannot contain aggregations, window functions or grouping operations: [row_number() OVER ()]");
 
         // grouping function
         accessControl.reset();
@@ -444,7 +444,7 @@ public class TestColumnMask
                 new ViewExpression(USER, Optional.of(CATALOG), Optional.of("tiny"), "grouping(orderkey) = 0"));
 
         assertThatThrownBy(() -> assertions.query("SELECT orderkey FROM orders"))
-                .hasMessageMatching("\\Qline 1:20: Column mask for 'orders.orderkey' cannot contain aggregations, window functions or grouping operations: [GROUPING (orderkey)]\\E");
+                .hasMessage("line 1:20: Column mask for 'orders.orderkey' cannot contain aggregations, window functions or grouping operations: [GROUPING (orderkey)]");
     }
 
     @Test
@@ -511,7 +511,7 @@ public class TestColumnMask
                 USER,
                 new ViewExpression(USER, Optional.empty(), Optional.empty(), "custkey"));
         assertThatThrownBy(() -> assertions.query("SELECT orderkey FROM orders"))
-                .hasMessageMatching("\\QAccess Denied: Cannot select from columns [orderkey, custkey] in table or view local.tiny.orders");
+                .hasMessage("Access Denied: Cannot select from columns [orderkey, custkey] in table or view local.tiny.orders");
     }
 
     @Test
@@ -524,7 +524,7 @@ public class TestColumnMask
                 USER,
                 new ViewExpression(USER, Optional.empty(), Optional.empty(), "clerk"));
         assertThatThrownBy(() -> assertions.query("INSERT INTO orders SELECT * FROM orders"))
-                .hasMessageMatching("\\QInsert into table with column masks");
+                .hasMessage("Insert into table with column masks");
     }
 
     @Test
@@ -537,7 +537,7 @@ public class TestColumnMask
                 USER,
                 new ViewExpression(USER, Optional.empty(), Optional.empty(), "clerk"));
         assertThatThrownBy(() -> assertions.query("DELETE FROM orders"))
-                .hasMessageMatching("\\Qline 1:1: Delete from table with column mask");
+                .hasMessage("line 1:1: Delete from table with column mask");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
@@ -276,7 +276,7 @@ public class TestRowFilter
                 new ViewExpression(USER, Optional.of(CATALOG), Optional.of("tiny"), "orderkey = 1"));
         assertThatThrownBy(() -> assertions.query(
                 "SELECT (SELECT min(name) FROM customer WHERE customer.custkey = orders.custkey) FROM orders"))
-                .hasMessageMatching("\\Qline 1:31: Invalid row filter for 'local.tiny.customer': Column 'orderkey' cannot be resolved\\E");
+                .hasMessage("line 1:31: Invalid row filter for 'local.tiny.customer': Column 'orderkey' cannot be resolved");
     }
 
     @Test
@@ -304,7 +304,7 @@ public class TestRowFilter
                 new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "$$$"));
 
         assertThatThrownBy(() -> assertions.query("SELECT count(*) FROM orders"))
-                .hasMessageMatching("\\Qline 1:22: Invalid row filter for 'local.tiny.orders': mismatched input '$'. Expecting: <expression>\\E");
+                .hasMessage("line 1:22: Invalid row filter for 'local.tiny.orders': mismatched input '$'. Expecting: <expression>");
 
         // unknown column
         accessControl.reset();
@@ -314,7 +314,7 @@ public class TestRowFilter
                 new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "unknown_column"));
 
         assertThatThrownBy(() -> assertions.query("SELECT count(*) FROM orders"))
-                .hasMessageMatching("\\Qline 1:22: Invalid row filter for 'local.tiny.orders': Column 'unknown_column' cannot be resolved\\E");
+                .hasMessage("line 1:22: Invalid row filter for 'local.tiny.orders': Column 'unknown_column' cannot be resolved");
 
         // invalid type
         accessControl.reset();
@@ -324,7 +324,7 @@ public class TestRowFilter
                 new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "1"));
 
         assertThatThrownBy(() -> assertions.query("SELECT count(*) FROM orders"))
-                .hasMessageMatching("\\Qline 1:22: Expected row filter for 'local.tiny.orders' to be of type BOOLEAN, but was integer\\E");
+                .hasMessage("line 1:22: Expected row filter for 'local.tiny.orders' to be of type BOOLEAN, but was integer");
 
         // aggregation
         accessControl.reset();
@@ -334,7 +334,7 @@ public class TestRowFilter
                 new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "count(*) > 0"));
 
         assertThatThrownBy(() -> assertions.query("SELECT count(*) FROM orders"))
-                .hasMessageMatching("\\Qline 1:10: Row filter for 'local.tiny.orders' cannot contain aggregations, window functions or grouping operations: [count(*)]\\E");
+                .hasMessage("line 1:10: Row filter for 'local.tiny.orders' cannot contain aggregations, window functions or grouping operations: [count(*)]");
 
         // window function
         accessControl.reset();
@@ -344,7 +344,7 @@ public class TestRowFilter
                 new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "row_number() OVER () > 0"));
 
         assertThatThrownBy(() -> assertions.query("SELECT count(*) FROM orders"))
-                .hasMessageMatching("\\Qline 1:22: Row filter for 'local.tiny.orders' cannot contain aggregations, window functions or grouping operations: [row_number() OVER ()]\\E");
+                .hasMessage("line 1:22: Row filter for 'local.tiny.orders' cannot contain aggregations, window functions or grouping operations: [row_number() OVER ()]");
 
         // window function
         accessControl.reset();
@@ -354,7 +354,7 @@ public class TestRowFilter
                 new ViewExpression(RUN_AS_USER, Optional.of(CATALOG), Optional.of("tiny"), "grouping(orderkey) = 0"));
 
         assertThatThrownBy(() -> assertions.query("SELECT count(*) FROM orders"))
-                .hasMessageMatching("\\Qline 1:20: Row filter for 'local.tiny.orders' cannot contain aggregations, window functions or grouping operations: [GROUPING (orderkey)]\\E");
+                .hasMessage("line 1:20: Row filter for 'local.tiny.orders' cannot contain aggregations, window functions or grouping operations: [GROUPING (orderkey)]");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
@@ -373,4 +373,20 @@ public class TestRowFilter
                                 "(CAST('custkey' AS varchar), 0e1, 0e1, 1e0, CAST(NULL AS double), CAST(NULL AS varchar), CAST(NULL AS varchar))," +
                                 "(NULL, NULL, NULL, NULL, 0e1, NULL, NULL)");
     }
+
+    @Test
+    public void testDelete()
+    {
+        accessControl.reset();
+        accessControl.rowFilter(
+                new QualifiedObjectName(CATALOG, "tiny", "orders"),
+                USER,
+                new ViewExpression(USER, Optional.empty(), Optional.empty(), "orderkey < 10"));
+        assertThatThrownBy(() -> assertions.query("DELETE FROM orders"))
+                .hasMessage("line 1:1: Delete from table with row filter");
+        assertThatThrownBy(() -> assertions.query("DELETE FROM orders WHERE orderkey IN (1, 2, 3)"))
+                .hasMessage("line 1:1: Delete from table with row filter");
+        assertThatThrownBy(() -> assertions.query("DELETE FROM orders WHERE orderkey IN (10, 20, 30)"))
+                .hasMessage("line 1:1: Delete from table with row filter");
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowFilter.java
@@ -389,4 +389,20 @@ public class TestRowFilter
         assertThatThrownBy(() -> assertions.query("DELETE FROM orders WHERE orderkey IN (10, 20, 30)"))
                 .hasMessage("line 1:1: Delete from table with row filter");
     }
+
+    @Test
+    public void testUpdate()
+    {
+        accessControl.reset();
+        accessControl.rowFilter(
+                new QualifiedObjectName(CATALOG, "tiny", "orders"),
+                USER,
+                new ViewExpression(USER, Optional.empty(), Optional.empty(), "orderkey < 10"));
+        assertThatThrownBy(() -> assertions.query("UPDATE orders SET totalprice = totalprice * 2"))
+                .hasMessage("line 1:1: Updating a table with a row filter is not supported");
+        assertThatThrownBy(() -> assertions.query("UPDATE orders SET totalprice = totalprice * 2 WHERE orderkey IN (1, 2, 3)"))
+                .hasMessage("line 1:1: Updating a table with a row filter is not supported");
+        assertThatThrownBy(() -> assertions.query("UPDATE orders SET totalprice = totalprice * 2 WHERE orderkey IN (10, 20, 30)"))
+                .hasMessage("line 1:1: Updating a table with a row filter is not supported");
+    }
 }


### PR DESCRIPTION
The tests for access control with row filtering and column masking were incomplete with regards to update statements: the `TestColumnMask` already had tests for `INSERT` and `DELETE`, but `TestRowFilter` missed them, and both missed tests for `UPDATE`. This PR adds the missing pieces.

Includes a side-refactoring of exception message asserts.