### PR TITLE
Recommend using -XX:+UseGCOverheadLimit

### DIFF
--- a/docs/src/main/sphinx/installation/deployment.rst
+++ b/docs/src/main/sphinx/installation/deployment.rst
@@ -121,6 +121,7 @@ The following provides a good starting point for creating ``etc/jvm.config``:
     -XX:G1HeapRegionSize=32M
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+ExitOnOutOfMemoryError
+    -XX:+UseGCOverheadLimit
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:ReservedCodeCacheSize=512M
     -XX:PerMethodRecompilationCutoff=10000


### PR DESCRIPTION
The flag is currently ignored with G1, but may become observed in future
JVM versions.

This also makes the docs in sync with the defaults actually provided in
RPM and docker-based installations.