### PR TITLE
Remove obsolete -XX:+UseGCOverheadLimit JVM flag

### DIFF
--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -5,7 +5,6 @@
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+HeapDumpOnOutOfMemoryError
--XX:+UseGCOverheadLimit
 -XX:+ExitOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=256M
 -XX:PerMethodRecompilationCutoff=10000

--- a/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
@@ -5,7 +5,6 @@
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+ExitOnOutOfMemoryError
--XX:+UseGCOverheadLimit
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=512M
 -XX:PerMethodRecompilationCutoff=10000

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
@@ -5,7 +5,6 @@
 -XX:G1HeapRegionSize=32M
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+ExitOnOutOfMemoryError
--XX:+UseGCOverheadLimit
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M
 -XX:PerMethodRecompilationCutoff=10000


### PR DESCRIPTION
`-XX:+UseGCOverheadLimit` is not used by G1 GC.