### PR TITLE
Increase notes font size

### DIFF
--- a/docs/src/main/sphinx/static/trino.css
+++ b/docs/src/main/sphinx/static/trino.css
@@ -43,7 +43,7 @@ pre.literal-block {
 }
 
 .md-typeset .admonition, .md-typeset .admonition-title {
-    font-size: 0.64rem
+    font-size: 0.8rem
 }
 
 @media only screen and (min-width: 88.25em) {


### PR DESCRIPTION
This PR increases the font size for Notes in the documentation. It sets the font-size to `0.8rem` to maintain consistency with surrounding text styles. 

Related issue: https://github.com/trinodb/trino/issues/6996


| Before | After |
| ------------- | ------------- |
| ![Screen Shot 2021-03-12 at 2 01 45 PM](https://user-images.githubusercontent.com/1330423/110986308-80ac0b80-833b-11eb-9330-b436020fb0b1.png)  | ![Screen Shot 2021-03-12 at 2 00 52 PM](https://user-images.githubusercontent.com/1330423/110986249-70942c00-833b-11eb-95e7-f65d0f9d21c9.png)  |
