### PR TITLE
Including legacy kill switch for parallelizing inserts

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -391,6 +391,10 @@ Property Name                                      Description                  
 ``hive.parallel-partitioned-bucketed-writes``      Improve parallelism of partitioned and bucketed table        ``true``
                                                    writes. When disabled, the number of writing threads
                                                    is limited to number of buckets.
+
+``hive.parallel-partitioned-bucketed-inserts``     DEPRECATED. Improves parallelism of partitioned and bucketed ``true``
+                                                   table inserts. Please use 
+                                                   ``hive.parallel-partitioned-bucketed-writes`` instead.
 ================================================== ============================================================ ============
 
 Metastore configuration properties


### PR DESCRIPTION
I've marked this as deprecated as the only use I can find of it is marked as a legacy config for parallelizing writes:

From HiveConfig.java:

    @Config("hive.parallel-partitioned-bucketed-writes")
    @LegacyConfig("hive.parallel-partitioned-bucketed-inserts")
    @ConfigDescription("Improve parallelism of partitioned and bucketed table writes")

Please let me know if this is not the case.