### PR TITLE
Fix #7290 partition DELETE and UPDATE bug

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -232,9 +232,9 @@ public class Analysis
         this.target = Optional.empty();
     }
 
-    public boolean isDeleteTarget(Table table)
+    public boolean isModifyTarget(Table table)
     {
-        return "DELETE".equals(updateType) &&
+        return ("DELETE".equals(updateType) || "UPDATE".equals(updateType)) &&
                 target.orElseThrow(() -> new IllegalStateException("Update target not set"))
                         .getTable().orElseThrow(() -> new IllegalStateException("Table reference not set in update target")) == table; // intentional comparison by reference
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -202,8 +202,8 @@ class RelationPlanner
             }
 
             List<Symbol> outputSymbols = outputSymbolsBuilder.build();
-            boolean isDeleteTarget = analysis.isDeleteTarget(node);
-            PlanNode root = TableScanNode.newInstance(idAllocator.getNextId(), handle, outputSymbols, columns.build(), isDeleteTarget);
+            boolean isModifyTarget = analysis.isModifyTarget(node);
+            PlanNode root = TableScanNode.newInstance(idAllocator.getNextId(), handle, outputSymbols, columns.build(), isModifyTarget);
 
             plan = new RelationPlan(root, scope, outputSymbols, outerContext);
         }


### PR DESCRIPTION
PR #7302 fixes the same bugs in a different, perhaps better way.  I didn't know about #7302 when I prepared this PR.  One of the two should be closed.

Issue #7290 describes a bug in which DELETE has a
WHERE clause that can be expressed as a TupleDomain
partition restriction.  That restriction got dropped, causing
too many rows to be deleted.  The root cause of the problem
was that the TableHandle passed to ConnectorMetadata.beginDelete()
was the one stored in the DeleteTarget, but must be the one
gotten from the TableScanNode after plan optimization.  The same
bug exists for UPDATE.

This commit uses the TableScanNode forDelete boolean
to find the appropriate TableScanNode, and extracts the TableHandle
from that node to pass to beginDelete() and beginUpdate().

More can and will be done, but I wanted to get this PR out for review quickly:

- We need more and better tests.  I'll add them throughout the day today.
- Boolean TableScanNode.forDelete is now misnamed - - it should be forModify.
- DeleteTarget and UpdateTarget should turn their TableHandle arg into an Optional, initialized to Optional.empty() until beginDelete()/beginUpdate() is called.

Fixes #7290 