### PR TITLE
Update sphinx-material theme

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -17,7 +17,7 @@ PyYAML==5.3.1
 requests==2.23.0
 six==1.14.0
 soupsieve==2.0.1
-sphinx-material==0.0.30
+sphinx-material==0.0.32
 sphinx-copybutton==0.3.1
 text-unidecode==1.3
 Unidecode==1.1.1


### PR DESCRIPTION
Looking at some customizations for the theme, we would like to use the latest version of it before we do any fixes.

This change needs to be followed by a new container build and deployment. 

If desired I can also pull in other updates of packages into this PR.

For reference - https://github.com/bashtage/sphinx-material

cc @kylefraser 