### PR TITLE
Add list of ColumnHandles to applyTableScanRedirect

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -622,9 +622,9 @@ public interface Metadata
     MaterializedViewFreshness getMaterializedViewFreshness(Session session, QualifiedObjectName name);
 
     /**
-     * Returns the result of redirecting the table scan on a given table to a different table.
+     * Returns the result of redirecting the table scan on the specified columns of a given table to a different table.
      * This method is used by the engine during the plan optimization phase to allow a connector to offload table scans to any other connector.
      * This method is called after security checks against the original table.
      */
-    Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(Session session, TableHandle tableHandle);
+    Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(Session session, TableHandle tableHandle, List<ColumnHandle> columns);
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1233,13 +1233,13 @@ public final class MetadataManager
     }
 
     @Override
-    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(Session session, TableHandle tableHandle)
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(Session session, TableHandle tableHandle, List<ColumnHandle> columns)
     {
         CatalogName catalogName = tableHandle.getCatalogName();
         CatalogMetadata catalogMetadata = getCatalogMetadata(session, catalogName);
         ConnectorMetadata metadata = catalogMetadata.getMetadataFor(catalogName);
         ConnectorSession connectorSession = session.toConnectorSession(catalogName);
-        return metadata.applyTableScanRedirect(connectorSession, tableHandle.getConnectorHandle());
+        return metadata.applyTableScanRedirect(connectorSession, tableHandle.getConnectorHandle(), columns);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyTableScanRedirection.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyTableScanRedirection.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.metadata.QualifiedObjectName.convertFromSchemaTableName;
@@ -74,7 +75,10 @@ public class ApplyTableScanRedirection
     @Override
     public Result apply(TableScanNode scanNode, Captures captures, Context context)
     {
-        Optional<TableScanRedirectApplicationResult> tableScanRedirectApplicationResult = metadata.applyTableScanRedirect(context.getSession(), scanNode.getTable());
+        Optional<TableScanRedirectApplicationResult> tableScanRedirectApplicationResult = metadata.applyTableScanRedirect(
+                context.getSession(),
+                scanNode.getTable(),
+                scanNode.getAssignments().values().stream().collect(toImmutableList()));
         if (tableScanRedirectApplicationResult.isEmpty()) {
             return Result.empty();
         }

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -211,9 +211,9 @@ public class MockConnector
         }
 
         @Override
-        public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle tableHandle)
+        public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns)
         {
-            return applyTableScanRedirect.apply(session, tableHandle);
+            return applyTableScanRedirect.apply(session, tableHandle, columns);
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -207,7 +207,7 @@ public class MockConnectorFactory
     @FunctionalInterface
     public interface ApplyTableScanRedirect
     {
-        Optional<TableScanRedirectApplicationResult> apply(ConnectorSession session, ConnectorTableHandle handle);
+        Optional<TableScanRedirectApplicationResult> apply(ConnectorSession session, ConnectorTableHandle handle, List<ColumnHandle> columns);
     }
 
     @FunctionalInterface
@@ -234,7 +234,7 @@ public class MockConnectorFactory
         private Grants<String> schemaGrants = new AllowAllGrants<>();
         private Grants<SchemaTableName> tableGrants = new AllowAllGrants<>();
         private ApplyFilter applyFilter = (session, handle, constraint) -> Optional.empty();
-        private ApplyTableScanRedirect applyTableScanRedirect = (session, handle) -> Optional.empty();
+        private ApplyTableScanRedirect applyTableScanRedirect = (session, handle, columns) -> Optional.empty();
 
         public Builder withListSchemaNames(Function<ConnectorSession, List<String>> listSchemaNames)
         {

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -850,7 +850,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(Session session, TableHandle tableHandle)
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(Session session, TableHandle tableHandle, List<ColumnHandle> columns)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanRedirectionWithPushdown.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestTableScanRedirectionWithPushdown.java
@@ -292,14 +292,14 @@ public class TestTableScanRedirectionWithPushdown
 
     private Optional<TableScanRedirectApplicationResult> mockApplyRedirectAfterProjectionPushdown(
             ConnectorSession session,
-            ConnectorTableHandle handle)
+            ConnectorTableHandle handle,
+            List<ColumnHandle> columns)
     {
         MockConnectorTableHandle mockConnectorTable = (MockConnectorTableHandle) handle;
-        Optional<List<ColumnHandle>> projectedColumns = mockConnectorTable.getColumns();
-        if (projectedColumns.isEmpty()) {
+        if (columns.isEmpty()) {
             return Optional.empty();
         }
-        List<String> projectedColumnNames = projectedColumns.get().stream()
+        List<String> projectedColumnNames = columns.stream()
                 .map(MockConnectorColumnHandle.class::cast)
                 .map(MockConnectorColumnHandle::getName)
                 .collect(toImmutableList());
@@ -340,15 +340,14 @@ public class TestTableScanRedirectionWithPushdown
             Map<ColumnHandle, String> redirectionMapping,
             Optional<Set<ColumnHandle>> requiredProjections)
     {
-        return (session, handle) -> {
+        return (session, handle, columns) -> {
             MockConnectorTableHandle mockConnectorTable = (MockConnectorTableHandle) handle;
             // make sure we do redirection after predicate is pushed down
             if (mockConnectorTable.getConstraint().isAll()) {
                 return Optional.empty();
             }
-            Optional<List<ColumnHandle>> projectedColumns = mockConnectorTable.getColumns();
             if (requiredProjections.isPresent()
-                    && (projectedColumns.isEmpty() || !requiredProjections.get().equals(ImmutableSet.copyOf(projectedColumns.get())))) {
+                    && (columns.isEmpty() || !requiredProjections.get().equals(ImmutableSet.copyOf(columns)))) {
                 return Optional.empty();
             }
             return Optional.of(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestApplyTableScanRedirection.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestApplyTableScanRedirection.java
@@ -37,6 +37,7 @@ import io.trino.testing.LocalQueryRunner;
 import io.trino.testing.TestingTransactionHandle;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -254,7 +255,7 @@ public class TestApplyTableScanRedirection
 
     private ApplyTableScanRedirect getMockApplyRedirect(Map<ColumnHandle, String> redirectionMapping)
     {
-        return (ConnectorSession session, ConnectorTableHandle handle) -> Optional.of(
+        return (ConnectorSession session, ConnectorTableHandle handle, List<ColumnHandle> columns) -> Optional.of(
                 new TableScanRedirectApplicationResult(
                         new CatalogSchemaTableName(MOCK_CATALOG, DESTINATION_TABLE),
                         redirectionMapping,

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1130,7 +1130,7 @@ public interface ConnectorMetadata
         return new MaterializedViewFreshness(false);
     }
 
-    default Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle tableHandle)
+    default Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns)
     {
         return Optional.empty();
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -859,10 +859,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle tableHandle)
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applyTableScanRedirect(session, tableHandle);
+            return delegate.applyTableScanRedirect(session, tableHandle, columns);
         }
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -425,9 +425,9 @@ public class CachingJdbcClient
     }
 
     @Override
-    public Optional<TableScanRedirectApplicationResult> getTableScanRedirection(ConnectorSession session, JdbcTableHandle tableHandle)
+    public Optional<TableScanRedirectApplicationResult> getTableScanRedirection(ConnectorSession session, JdbcTableHandle tableHandle, List<ColumnHandle> columns)
     {
-        return delegate.getTableScanRedirection(session, tableHandle);
+        return delegate.getTableScanRedirection(session, tableHandle, columns);
     }
 
     private Map<String, Object> getSessionProperties(ConnectorSession session)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -329,8 +329,8 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public Optional<TableScanRedirectApplicationResult> getTableScanRedirection(ConnectorSession session, JdbcTableHandle tableHandle)
+    public Optional<TableScanRedirectApplicationResult> getTableScanRedirection(ConnectorSession session, JdbcTableHandle tableHandle, List<ColumnHandle> columns)
     {
-        return delegate().getTableScanRedirection(session, tableHandle);
+        return delegate().getTableScanRedirection(session, tableHandle, columns);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -165,7 +165,7 @@ public interface JdbcClient
 
     Map<String, Object> getTableProperties(ConnectorSession session, JdbcTableHandle tableHandle);
 
-    default Optional<TableScanRedirectApplicationResult> getTableScanRedirection(ConnectorSession session, JdbcTableHandle tableHandle)
+    default Optional<TableScanRedirectApplicationResult> getTableScanRedirection(ConnectorSession session, JdbcTableHandle tableHandle, List<ColumnHandle> columns)
     {
         return Optional.empty();
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
@@ -487,10 +487,10 @@ public class JdbcMetadata
     }
 
     @Override
-    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle table)
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle table, List<ColumnHandle> columns)
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
-        return jdbcClient.getTableScanRedirection(session, tableHandle);
+        return jdbcClient.getTableScanRedirection(session, tableHandle, columns);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -347,8 +347,8 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public Optional<TableScanRedirectApplicationResult> getTableScanRedirection(ConnectorSession session, JdbcTableHandle tableHandle)
+    public Optional<TableScanRedirectApplicationResult> getTableScanRedirection(ConnectorSession session, JdbcTableHandle tableHandle, List<ColumnHandle> columns)
     {
-        return stats.getGetTableScanRedirection().wrap(() -> delegate().getTableScanRedirection(session, tableHandle));
+        return stats.getGetTableScanRedirection().wrap(() -> delegate().getTableScanRedirection(session, tableHandle, columns));
     }
 }

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
@@ -517,7 +517,7 @@ public class TpchMetadata
     }
 
     @Override
-    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle table)
+    public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle table, List<ColumnHandle> columns)
     {
         TpchTableHandle handle = (TpchTableHandle) table;
         if (destinationCatalog.isEmpty()) {


### PR DESCRIPTION
Some connectors don't record projected column handles in
ConnectorTableHandle. Adding listing of scanned columns
to applyTableScanRedirect API to pass this information
explicitly from the optimizer rule to the connector.