### PR TITLE
Mark a table if it is directly referenced by query

### DIFF
--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -26,6 +26,7 @@ import io.trino.spi.connector.ConnectorNewTableLayout;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableProperties;
@@ -33,6 +34,8 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
+import io.trino.spi.connector.DynamicFilter;
+import io.trino.spi.connector.FixedSplitSource;
 import io.trino.spi.connector.JoinApplicationResult;
 import io.trino.spi.connector.JoinCondition;
 import io.trino.spi.connector.JoinStatistics;
@@ -134,7 +137,13 @@ public class MockConnector
     @Override
     public ConnectorSplitManager getSplitManager()
     {
-        return new ConnectorSplitManager() {};
+        return new ConnectorSplitManager() {
+            @Override
+            public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableHandle table, SplitSchedulingStrategy splitSchedulingStrategy, DynamicFilter dynamicFilter)
+            {
+                return new FixedSplitSource(ImmutableList.of());
+            }
+        };
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableInfo.java
@@ -28,8 +28,9 @@ public class TableInfo
 
     private final List<String> filters;
     private final List<ColumnInfo> columns;
+    private final boolean directlyReferenced;
 
-    public TableInfo(String catalog, String schema, String table, String authorization, List<String> filters, List<ColumnInfo> columns)
+    public TableInfo(String catalog, String schema, String table, String authorization, List<String> filters, List<ColumnInfo> columns, boolean directlyReferenced)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
@@ -37,6 +38,7 @@ public class TableInfo
         this.authorization = requireNonNull(authorization, "authorization is null");
         this.filters = List.copyOf(requireNonNull(filters, "filters is null"));
         this.columns = List.copyOf(requireNonNull(columns, "columns is null"));
+        this.directlyReferenced = directlyReferenced;
     }
 
     @JsonProperty
@@ -73,5 +75,11 @@ public class TableInfo
     public List<ColumnInfo> getColumns()
     {
         return columns;
+    }
+
+    @JsonProperty
+    public boolean isDirectlyReferenced()
+    {
+        return directlyReferenced;
     }
 }


### PR DESCRIPTION
This allows us to identify the tables which are added as a part of query and which are referenced by views.