### PR TITLE
Fix MemSQL test failure: testRenameTableAcrossSchema

### DIFF
--- a/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlConnectorTest.java
+++ b/plugin/trino-memsql/src/test/java/io/trino/plugin/memsql/TestMemSqlConnectorTest.java
@@ -89,6 +89,9 @@ public class TestMemSqlConnectorTest
             case SUPPORTS_ARRAY:
                 return false;
 
+            case SUPPORTS_RENAME_TABLE_ACROSS_SCHEMAS:
+                return false;
+
             default:
                 return super.hasBehavior(connectorBehavior);
         }


### PR DESCRIPTION
This was overlooked in #7239. Tests failed on master after merging it.