### PR TITLE
Verify if join pushdown is not supported with proper session

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -291,13 +291,13 @@ public abstract class BaseJdbcConnectorTest
                                 exchange(ExchangeNode.Scope.REMOTE, ExchangeNode.Type.REPLICATE,
                                         node(TableScanNode.class))));
 
+        Session session = joinPushdownEnabled(getSession());
+
         if (!hasBehavior(SUPPORTS_JOIN_PUSHDOWN)) {
-            assertThat(query("SELECT r.name, n.name FROM nation n JOIN region r ON n.regionkey = r.regionkey"))
+            assertThat(query(session, "SELECT r.name, n.name FROM nation n JOIN region r ON n.regionkey = r.regionkey"))
                     .isNotFullyPushedDown(joinOverTableScans);
             return;
         }
-
-        Session session = joinPushdownEnabled(getSession());
 
         // Disable DF here for the sake of negative test cases' expected plan. With DF enabled, some operators return in DF's FilterNode and some do not.
         Session withoutDynamicFiltering = Session.builder(session)


### PR DESCRIPTION
With default session assertion would pass even for connectors which
actually support join pushdown. Join pushdown would not happen because
it is disabled by default.