### PR TITLE
Fix error in BaseConnectorSmokeTest

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorSmokeTest.java
@@ -148,7 +148,7 @@ public abstract class BaseConnectorSmokeTest
     public void testInsert()
     {
         if (!hasBehavior(SUPPORTS_INSERT)) {
-            assertQueryFails("INSERT INTO region (regionkey) VALUES (42)", "This connector does not support insert");
+            assertQueryFails("INSERT INTO region (regionkey) VALUES (42)", "This connector does not support inserts");
             return;
         }
 


### PR DESCRIPTION
The error message for unsupported `INSERT` ends in "s".

The correct message is used in `BaseConnectorTest` and generated at `ConnectorMetadata.beginInsert`.