### PR TITLE
Adding docs for migration config property

### DIFF
--- a/docs/src/main/sphinx/admin/properties-general.rst
+++ b/docs/src/main/sphinx/admin/properties-general.rst
@@ -36,3 +36,21 @@ across nodes in the cluster. It can be disabled, when it is known that the
 output data set is not skewed, in order to avoid the overhead of hashing and
 redistributing all the data across the network. This can be specified
 on a per-query basis using the ``redistribute_writes`` session property.
+
+``protocol.v1.alternate-header-name``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Type:** ``string``
+
+The 351 release of Trino changes the HTTP client protocol headers to start with
+``X-Trino-``. Clients for versions 350 and lower expect the HTTP headers to 
+start with ``X-Presto-``, while newer clients expect ``X-Trino-``. You can support these
+older clients by setting this property to ``Presto``.
+
+The preferred approach to migrating from versions earlier than 351 is to update
+all clients together with the release, or immediately afterwards, and then
+remove usage of this property.
+
+Ensure to use this only as a temporary measure to assist in your migration
+efforts.
+


### PR DESCRIPTION
Blended blog post info with other available info for this. The concern here is that users will forget about this and not clean up in the near-term. Then, it will not be documented for them to know it is ok to be removed when they eventually do clean up. This replaces PR#7232, and includes all changes made there.