### PR TITLE
Keep only one special value for preferred-write-partitioning-min-number-of-partitions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -217,6 +217,11 @@ public final class SystemSessionProperties
                         PREFERRED_WRITE_PARTITIONING_MIN_NUMBER_OF_PARTITIONS,
                         "Use preferred write partitioning when the number of written partitions exceeds the configured threshold",
                         featuresConfig.getPreferredWritePartitioningMinNumberOfPartitions(),
+                        value -> {
+                            if (value < 1) {
+                                throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s must be greater than or equal to 1: %s", PREFERRED_WRITE_PARTITIONING_MIN_NUMBER_OF_PARTITIONS, value));
+                            }
+                        },
                         false),
                 booleanProperty(
                         SCALE_WRITERS,

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/FeaturesConfig.java
@@ -374,7 +374,7 @@ public class FeaturesConfig
         return this;
     }
 
-    @Min(0)
+    @Min(1)
     public int getPreferredWritePartitioningMinNumberOfPartitions()
     {
         return preferredWritePartitioningMinNumberOfPartitions;

--- a/docs/src/main/sphinx/admin/properties-writer-scaling.rst
+++ b/docs/src/main/sphinx/admin/properties-writer-scaling.rst
@@ -53,5 +53,5 @@ nodes for parallel processing.
 The minimum number of written partitions that is required to use connector
 ``preferred write partitioning``. If the number of partitions cannot be
 estimated from the statistics, then preferred write partitioning is not used.
-If the threshold value is less than or equal to ``1`` then ``preferred write
-partitioning`` is always used.
+If the threshold value is ``1`` then ``preferred write partitioning`` is always
+used.


### PR DESCRIPTION


Before the change, config allowed 0 and 1, but both meant the same.
Session property allowed any integer number.

Now both are validated to be [1, +∞).