### PR TITLE
Do case insensitive comparison between dereferenced fields and internal ORC field names

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -298,16 +298,14 @@ public class OrcPageSourceFactory
                         .collect(Collectors.groupingBy(
                                 HiveColumnHandle::getBaseColumnName,
                                 mapping(
-                                        column -> column.getHiveColumnProjectionInfo().map(HiveColumnProjectionInfo::getDereferenceNames).orElse(ImmutableList.<String>of()),
-                                        toList())));
+                                        OrcPageSourceFactory::getDereferencesAsList, toList())));
             }
             else {
                 projectionsByColumnIndex = projections.stream()
                         .collect(Collectors.groupingBy(
                                 HiveColumnHandle::getBaseHiveColumnIndex,
                                 mapping(
-                                        column -> column.getHiveColumnProjectionInfo().map(HiveColumnProjectionInfo::getDereferenceNames).orElse(ImmutableList.<String>of()),
-                                        toList())));
+                                        OrcPageSourceFactory::getDereferencesAsList, toList())));
             }
 
             TupleDomainOrcPredicateBuilder predicateBuilder = TupleDomainOrcPredicate.builder()
@@ -539,5 +537,14 @@ public class OrcPageSourceFactory
             current = orcColumn.get();
         }
         return current;
+    }
+
+    private static List<String> getDereferencesAsList(HiveColumnHandle column)
+    {
+        return column.getHiveColumnProjectionInfo()
+                .map(info -> info.getDereferenceNames().stream()
+                        .map(dereference -> dereference.toLowerCase(ENGLISH))
+                        .collect(toList()))
+                .orElse(ImmutableList.<String>of());
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -544,7 +544,7 @@ public class OrcPageSourceFactory
         return column.getHiveColumnProjectionInfo()
                 .map(info -> info.getDereferenceNames().stream()
                         .map(dereference -> dereference.toLowerCase(ENGLISH))
-                        .collect(toList()))
-                .orElse(ImmutableList.<String>of());
+                        .collect(toImmutableList()))
+                .orElse(ImmutableList.of());
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/hive/TestHiveStorageFormats.java
@@ -480,7 +480,7 @@ public class TestHiveStorageFormats
         onHive().executeQuery("DROP TABLE " + tableName);
     }
 
-    @Test(groups = STORAGE_FORMATS)
+    @Test
     public void testOrcStructsWithNonLowercaseFields()
             throws SQLException
     {


### PR DESCRIPTION
Trino will currently return NULLs if table metadata contains a struct that uses caps, e.g. `entryId struct<custId:string,acctGuid:string,requestDate:string>` and the ORC internal field definition does not. Reading the code, I actually suspect that NULL would be returned even if the internal field name did match the casing in the table def'n, but I have not tested this scenario. 