### PR TITLE
Add a flag for HttpRemoteTask to avoid eager but unnecessary sendUpdate

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -159,6 +159,7 @@ public final class HttpRemoteTask
 
     private final PartitionedSplitCountTracker partitionedSplitCountTracker;
 
+    private final AtomicBoolean started = new AtomicBoolean(false);
     private final AtomicBoolean aborting = new AtomicBoolean(false);
 
     public HttpRemoteTask(
@@ -318,6 +319,7 @@ public final class HttpRemoteTask
     {
         try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
             // to start we just need to trigger an update
+            started.set(true);
             scheduleUpdate();
 
             dynamicFiltersFetcher.start();
@@ -513,7 +515,7 @@ public final class HttpRemoteTask
     {
         TaskStatus taskStatus = getTaskStatus();
         // don't update if the task hasn't been started yet or if it is already finished
-        if (!needsUpdate.get() || taskStatus.getState().isDone()) {
+        if (!started.get() || !needsUpdate.get() || taskStatus.getState().isDone()) {
             return;
         }
 


### PR DESCRIPTION
It should not sendUpdate before task been started,
while the needsUpdate flag in RemoteHttpTask is not enough to ensure this,
which case will happen on all non-leaf stage, as 450-470 lines in
SqlStageExecution.java
Although task will start soon after noMoreSplits, but we should avoid
this, which is unnecessary and not strictly accurate in principle.

I have tested it, and found the not started tasks(which is on non-leaf Stage) would sendUpdate requests on Worker node eagerly.
The code lead to above case is as below,
![image](https://user-images.githubusercontent.com/5463066/111726192-6924d380-88a3-11eb-8546-35129dddfcd3.png)
