### PR TITLE
WIP: add config for defaulting to INVOKER for hive views

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -146,6 +146,8 @@ public class HiveConfig
 
     private boolean legacyHiveViewTranslation;
 
+    private boolean runViewsAsInvoker;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1041,4 +1043,18 @@ public class HiveConfig
     {
         return this.legacyHiveViewTranslation;
     }
+
+    @Config("hive.run-views-as-invoker")
+    @ConfigDescription("")
+    public HiveConfig setRunViewsAsInvoker(boolean runViewsAsInvoker)
+    {
+        this.runViewsAsInvoker = runViewsAsInvoker;
+        return this;
+    }
+
+    public boolean runViewsAsInvoker()
+    {
+        return runViewsAsInvoker;
+    }
+
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -317,6 +317,7 @@ public class HiveMetadata
     private final boolean writesToNonManagedTablesEnabled;
     private final boolean createsOfNonManagedTablesEnabled;
     private final boolean translateHiveViews;
+    private final boolean runViewsAsInvoker;
     private final boolean hideDeltaLakeTables;
     private final String prestoVersion;
     private final HiveStatisticsProvider hiveStatisticsProvider;
@@ -330,6 +331,7 @@ public class HiveMetadata
             boolean writesToNonManagedTablesEnabled,
             boolean createsOfNonManagedTablesEnabled,
             boolean translateHiveViews,
+            boolean runViewsAsInvoker,
             boolean hideDeltaLakeTables,
             TypeManager typeManager,
             LocationService locationService,
@@ -348,6 +350,7 @@ public class HiveMetadata
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
         this.createsOfNonManagedTablesEnabled = createsOfNonManagedTablesEnabled;
         this.translateHiveViews = translateHiveViews;
+        this.runViewsAsInvoker = runViewsAsInvoker;
         this.hideDeltaLakeTables = hideDeltaLakeTables;
         this.prestoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
         this.hiveStatisticsProvider = requireNonNull(hiveStatisticsProvider, "hiveStatisticsProvider is null");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
@@ -44,6 +44,7 @@ public class HiveMetadataFactory
     private final boolean writesToNonManagedTablesEnabled;
     private final boolean createsOfNonManagedTablesEnabled;
     private final boolean translateHiveViews;
+    private final boolean runViewsAsInvoker;
     private final boolean hideDeltaLakeTables;
     private final long perTransactionCacheMaximumSize;
     private final HiveMetastore metastore;
@@ -90,6 +91,7 @@ public class HiveMetadataFactory
                 hiveConfig.getWritesToNonManagedTablesEnabled(),
                 hiveConfig.getCreatesOfNonManagedTablesEnabled(),
                 hiveConfig.isTranslateHiveViews(),
+                hiveConfig.runViewsAsInvoker(),
                 hiveConfig.getPerTransactionMetastoreCacheMaximumSize(),
                 hiveConfig.getHiveTransactionHeartbeatInterval(),
                 metastoreConfig.isHideDeltaLakeTables(),
@@ -115,6 +117,7 @@ public class HiveMetadataFactory
             boolean writesToNonManagedTablesEnabled,
             boolean createsOfNonManagedTablesEnabled,
             boolean translateHiveViews,
+            boolean runViewsAsInvoker,
             long perTransactionCacheMaximumSize,
             Optional<Duration> hiveTransactionHeartbeatInterval,
             boolean hideDeltaLakeTables,
@@ -132,6 +135,7 @@ public class HiveMetadataFactory
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
         this.createsOfNonManagedTablesEnabled = createsOfNonManagedTablesEnabled;
         this.translateHiveViews = translateHiveViews;
+        this.runViewsAsInvoker = runViewsAsInvoker;
         this.hideDeltaLakeTables = hideDeltaLakeTables;
         this.perTransactionCacheMaximumSize = perTransactionCacheMaximumSize;
 
@@ -179,6 +183,7 @@ public class HiveMetadataFactory
                 writesToNonManagedTablesEnabled,
                 createsOfNonManagedTablesEnabled,
                 translateHiveViews,
+                runViewsAsInvoker,
                 hideDeltaLakeTables,
                 typeManager,
                 locationService,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -158,7 +158,7 @@ public final class ViewReaderUtil
         }
 
         @Override
-        public ConnectorViewDefinition decodeViewData(String viewSql, Table table, CatalogName catalogName)
+        public ConnectorViewDefinition decodeViewData(String viewSql, Table table, CatalogName catalogName, boolean runViewsAsInvoker)
         {
             try {
                 HiveToRelConverter hiveToRelConverter = HiveToRelConverter.create(metastoreClient);
@@ -177,7 +177,7 @@ public final class ViewReaderUtil
                         columns,
                         Optional.ofNullable(table.getParameters().get(TABLE_COMMENT)),
                         Optional.empty(),
-                        false);
+                        runViewsAsInvoker);
             }
             catch (RuntimeException e) {
                 throw new TrinoException(HIVE_VIEW_TRANSLATION_ERROR,


### PR DESCRIPTION
```
In the INVOKER security mode, tables referenced in the view are accessed using the permissions of the query user (the invoker of the view). A view created in this mode is simply a stored query.
```
This is often the desired behavior when migrating to trino from hive where this is the default. So adding a config property to set view security mode to `INVOKER`.