### PR TITLE
Reduce Iceberg metadata scans

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FileIoProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/FileIoProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
+import org.apache.iceberg.io.FileIO;
+
+public interface FileIoProvider
+{
+    FileIO createFileIo(HdfsContext hdfsContext);
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HdfsFileIoProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HdfsFileIoProvider.java
@@ -33,7 +33,7 @@ public class HdfsFileIoProvider
     }
 
     @Override
-    public FileIO createFileIo(HdfsContext hdfsContext)
+    public FileIO createFileIo(HdfsContext hdfsContext, String queryId)
     {
         return new HdfsFileIo(hdfsEnvironment, hdfsContext);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HdfsFileIoProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HdfsFileIoProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
+import org.apache.iceberg.io.FileIO;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class HdfsFileIoProvider
+        implements FileIoProvider
+{
+    private final HdfsEnvironment hdfsEnvironment;
+
+    @Inject
+    public HdfsFileIoProvider(HdfsEnvironment hdfsEnvironment)
+    {
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+    }
+
+    @Override
+    public FileIO createFileIo(HdfsContext hdfsContext)
+    {
+        return new HdfsFileIo(hdfsEnvironment, hdfsContext);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
@@ -14,8 +14,6 @@
 package io.trino.plugin.iceberg;
 
 import io.airlift.log.Logger;
-import io.trino.plugin.hive.HdfsEnvironment;
-import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.HiveMetastore;
@@ -96,23 +94,7 @@ public class HiveTableOperations
     private boolean shouldRefresh = true;
     private int version = -1;
 
-    public HiveTableOperations(HiveMetastore metastore, HdfsEnvironment hdfsEnvironment, HdfsContext hdfsContext, HiveIdentity identity, String database, String table)
-    {
-        this(new HdfsFileIo(hdfsEnvironment, hdfsContext), metastore, identity, database, table, Optional.empty(), Optional.empty());
-    }
-
-    public HiveTableOperations(HiveMetastore metastore, HdfsEnvironment hdfsEnvironment, HdfsContext hdfsContext, HiveIdentity identity, String database, String table, String owner, String location)
-    {
-        this(new HdfsFileIo(hdfsEnvironment, hdfsContext),
-                metastore,
-                identity,
-                database,
-                table,
-                Optional.of(requireNonNull(owner, "owner is null")),
-                Optional.of(requireNonNull(location, "location is null")));
-    }
-
-    private HiveTableOperations(FileIO fileIo, HiveMetastore metastore, HiveIdentity identity, String database, String table, Optional<String> owner, Optional<String> location)
+    HiveTableOperations(FileIO fileIo, HiveMetastore metastore, HiveIdentity identity, String database, String table, Optional<String> owner, Optional<String> location)
     {
         this.fileIo = requireNonNull(fileIo, "fileIo is null");
         this.metastore = requireNonNull(metastore, "metastore is null");

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
@@ -105,6 +105,15 @@ public class HiveTableOperations
         this.location = requireNonNull(location, "location is null");
     }
 
+    public void initializeFromMetadata(TableMetadata tableMetadata)
+    {
+        checkState(currentMetadata == null, "already initialized");
+        currentMetadata = tableMetadata;
+        currentMetadataLocation = tableMetadata.metadataFileLocation();
+        shouldRefresh = false;
+        version = parseVersion(currentMetadataLocation);
+    }
+
     @Override
     public TableMetadata current()
     {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperationsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperationsProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.trino.plugin.hive.authentication.HiveIdentity;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import org.apache.iceberg.TableOperations;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class HiveTableOperationsProvider
+{
+    private final FileIoProvider fileIoProvider;
+    private final HiveMetastore hiveMetastore;
+
+    @Inject
+    public HiveTableOperationsProvider(FileIoProvider fileIoProvider, HiveMetastore hiveMetastore)
+    {
+        this.fileIoProvider = requireNonNull(fileIoProvider, "fileIoProvider is null");
+        this.hiveMetastore = requireNonNull(hiveMetastore, "hiveMetastore is null");
+    }
+
+    public TableOperations createTableOperations(
+            HdfsContext hdfsContext,
+            HiveIdentity identity,
+            String database,
+            String table,
+            Optional<String> owner,
+            Optional<String> location)
+    {
+        return new HiveTableOperations(
+                fileIoProvider.createFileIo(hdfsContext),
+                hiveMetastore,
+                identity,
+                database,
+                table,
+                owner,
+                location);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperationsProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperationsProvider.java
@@ -38,6 +38,7 @@ public class HiveTableOperationsProvider
 
     public TableOperations createTableOperations(
             HdfsContext hdfsContext,
+            String queryId,
             HiveIdentity identity,
             String database,
             String table,
@@ -45,7 +46,7 @@ public class HiveTableOperationsProvider
             Optional<String> location)
     {
         return new HiveTableOperations(
-                fileIoProvider.createFileIo(hdfsContext),
+                fileIoProvider.createFileIo(hdfsContext, queryId),
                 hiveMetastore,
                 identity,
                 database,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnectorFactory.java
@@ -38,8 +38,8 @@ public class IcebergConnectorFactory
         ClassLoader classLoader = context.duplicatePluginClassLoader();
         try {
             return (Connector) classLoader.loadClass(InternalIcebergConnectorFactory.class.getName())
-                    .getMethod("createConnector", String.class, Map.class, ConnectorContext.class, Optional.class)
-                    .invoke(null, catalogName, config, context, Optional.empty());
+                    .getMethod("createConnector", String.class, Map.class, ConnectorContext.class, Optional.class, boolean.class)
+                    .invoke(null, catalogName, config, context, Optional.empty(), false);
         }
         catch (InvocationTargetException e) {
             Throwable targetException = e.getTargetException();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -526,6 +526,7 @@ public class IcebergMetadata
 
         TableOperations operations = tableOperationsProvider.createTableOperations(
                 hdfsContext,
+                session.getQueryId(),
                 identity,
                 schemaName,
                 tableName,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -173,6 +173,7 @@ public class IcebergMetadata
     private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
     private final JsonCodec<CommitTaskData> commitTaskCodec;
+    private final HiveTableOperationsProvider tableOperationsProvider;
 
     private final Map<String, Optional<Long>> snapshotIds = new ConcurrentHashMap<>();
 
@@ -183,13 +184,15 @@ public class IcebergMetadata
             HiveMetastore metastore,
             HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
-            JsonCodec<CommitTaskData> commitTaskCodec)
+            JsonCodec<CommitTaskData> commitTaskCodec,
+            HiveTableOperationsProvider tableOperationsProvider)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
+        this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
     }
 
     @Override
@@ -234,7 +237,7 @@ public class IcebergMetadata
             throw new UnknownTableTypeException(tableName);
         }
 
-        org.apache.iceberg.Table table = getIcebergTable(metastore, hdfsEnvironment, session, hiveTable.get().getSchemaTableName());
+        org.apache.iceberg.Table table = getIcebergTable(tableOperationsProvider, session, hiveTable.get().getSchemaTableName());
         Optional<Long> snapshotId = getSnapshotId(table, name.getSnapshotId());
 
         return new IcebergTableHandle(
@@ -262,7 +265,7 @@ public class IcebergMetadata
             return Optional.empty();
         }
 
-        org.apache.iceberg.Table table = getIcebergTable(metastore, hdfsEnvironment, session, hiveTable.get().getSchemaTableName());
+        org.apache.iceberg.Table table = getIcebergTable(tableOperationsProvider, session, hiveTable.get().getSchemaTableName());
 
         SchemaTableName systemTableName = new SchemaTableName(tableName.getSchemaName(), name.getTableNameWithType());
         switch (name.getTableType()) {
@@ -292,7 +295,7 @@ public class IcebergMetadata
     public ConnectorTableProperties getTableProperties(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
 
         TupleDomain<IcebergColumnHandle> enforcedPredicate = table.getEnforcedPredicate();
 
@@ -395,7 +398,7 @@ public class IcebergMetadata
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
         return getColumns(icebergTable.schema(), typeManager).stream()
                 .collect(toImmutableMap(IcebergColumnHandle::getName, identity()));
     }
@@ -491,7 +494,7 @@ public class IcebergMetadata
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
         metastore.commentTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), comment);
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, handle.getSchemaTableName());
         if (comment.isEmpty()) {
             icebergTable.updateProperties().remove(TABLE_COMMENT).commit();
         }
@@ -521,7 +524,14 @@ public class IcebergMetadata
             targetPath = getTableDefaultLocation(database, hdfsContext, hdfsEnvironment, schemaName, tableName).toString();
         }
 
-        TableOperations operations = new HiveTableOperations(metastore, hdfsEnvironment, hdfsContext, identity, schemaName, tableName, session.getUser(), targetPath);
+        TableOperations operations = tableOperationsProvider.createTableOperations(
+                hdfsContext,
+                identity,
+                schemaName,
+                tableName,
+                Optional.of(session.getUser()),
+                Optional.of(targetPath));
+
         if (operations.current() != null) {
             throw new TableAlreadyExistsException(schemaTableName);
         }
@@ -557,7 +567,7 @@ public class IcebergMetadata
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
 
         transaction = icebergTable.newTransaction();
 
@@ -643,7 +653,7 @@ public class IcebergMetadata
     public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, handle.getSchemaTableName());
         icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType())).commit();
     }
 
@@ -652,7 +662,7 @@ public class IcebergMetadata
     {
         IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
         IcebergColumnHandle handle = (IcebergColumnHandle) column;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, icebergTableHandle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, icebergTableHandle.getSchemaTableName());
         icebergTable.updateSchema().deleteColumn(handle.getName()).commit();
     }
 
@@ -661,7 +671,7 @@ public class IcebergMetadata
     {
         IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
         IcebergColumnHandle columnHandle = (IcebergColumnHandle) source;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, icebergTableHandle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, icebergTableHandle.getSchemaTableName());
         icebergTable.updateSchema().renameColumn(columnHandle.getName(), target).commit();
     }
 
@@ -671,7 +681,7 @@ public class IcebergMetadata
             throw new TableNotFoundException(table);
         }
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table);
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table);
 
         List<ColumnMetadata> columns = getColumnMetadatas(icebergTable);
 
@@ -734,7 +744,7 @@ public class IcebergMetadata
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, handle.getSchemaTableName());
 
         icebergTable.newDelete()
                 .deleteFromRowFilter(toIcebergExpression(handle.getEnforcedPredicate()))
@@ -764,7 +774,7 @@ public class IcebergMetadata
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
     {
         IcebergTableHandle table = (IcebergTableHandle) handle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
 
         Set<Integer> partitionSourceIds = identityPartitionColumnsInAllSpecs(icebergTable);
         BiPredicate<IcebergColumnHandle, Domain> isIdentityPartition = (column, domain) -> partitionSourceIds.contains(column.getId());
@@ -810,7 +820,7 @@ public class IcebergMetadata
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, handle.getSchemaTableName());
         return TableStatisticsMaker.getTableStatistics(typeManager, constraint, handle, icebergTable);
     }
 
@@ -914,7 +924,7 @@ public class IcebergMetadata
     public ConnectorInsertTableHandle beginRefreshMaterializedView(ConnectorSession session, ConnectorTableHandle tableHandle, List<ConnectorTableHandle> sourceTableHandles)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
         transaction = icebergTable.newTransaction();
 
         return new IcebergWritableTableHandle(
@@ -1028,7 +1038,7 @@ public class IcebergMetadata
     public Optional<TableToken> getTableToken(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
         return Optional.ofNullable(icebergTable.currentSnapshot())
                 .map(snapshot -> new TableToken(snapshot.snapshotId()));
     }
@@ -1083,7 +1093,7 @@ public class IcebergMetadata
                 .map(CatalogSchemaTableName::getSchemaTableName)
                 .orElseThrow(() -> new IllegalStateException("Storage table missing in definition of materialized view " + name));
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, storageTableName);
+        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, storageTableName);
         String dependsOnTables = icebergTable.currentSnapshot().summary().getOrDefault(DEPENDS_ON_TABLES, "");
         if (!dependsOnTables.isEmpty()) {
             Map<String, String> tableToSnapshotIdMap = Splitter.on(',').withKeyValueSeparator('=').split(dependsOnTables);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.base.Splitter;
+import com.google.common.base.Suppliers;
 import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -69,6 +70,7 @@ import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.TypeManager;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
@@ -89,6 +91,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -104,6 +107,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -136,10 +140,11 @@ import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumns;
 import static io.trino.plugin.iceberg.IcebergUtil.getDataPath;
 import static io.trino.plugin.iceberg.IcebergUtil.getFileFormat;
-import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTable;
+import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableWithMetadata;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
 import static io.trino.plugin.iceberg.IcebergUtil.getTableComment;
 import static io.trino.plugin.iceberg.IcebergUtil.isIcebergTable;
+import static io.trino.plugin.iceberg.IcebergUtil.loadIcebergTable;
 import static io.trino.plugin.iceberg.PartitionFields.parsePartitionFields;
 import static io.trino.plugin.iceberg.PartitionFields.toPartitionFields;
 import static io.trino.plugin.iceberg.TableType.DATA;
@@ -176,6 +181,7 @@ public class IcebergMetadata
     private final HiveTableOperationsProvider tableOperationsProvider;
 
     private final Map<String, Optional<Long>> snapshotIds = new ConcurrentHashMap<>();
+    private final Map<SchemaTableName, TableMetadata> tableMetadataCache = new ConcurrentHashMap<>();
 
     private Transaction transaction;
 
@@ -237,7 +243,7 @@ public class IcebergMetadata
             throw new UnknownTableTypeException(tableName);
         }
 
-        org.apache.iceberg.Table table = getIcebergTable(tableOperationsProvider, session, hiveTable.get().getSchemaTableName());
+        org.apache.iceberg.Table table = getIcebergTable(session, hiveTable.get().getSchemaTableName());
         Optional<Long> snapshotId = getSnapshotId(table, name.getSnapshotId());
 
         return new IcebergTableHandle(
@@ -265,7 +271,7 @@ public class IcebergMetadata
             return Optional.empty();
         }
 
-        org.apache.iceberg.Table table = getIcebergTable(tableOperationsProvider, session, hiveTable.get().getSchemaTableName());
+        org.apache.iceberg.Table table = getIcebergTable(session, hiveTable.get().getSchemaTableName());
 
         SchemaTableName systemTableName = new SchemaTableName(tableName.getSchemaName(), name.getTableNameWithType());
         switch (name.getTableType()) {
@@ -295,9 +301,6 @@ public class IcebergMetadata
     public ConnectorTableProperties getTableProperties(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
-
-        TupleDomain<IcebergColumnHandle> enforcedPredicate = table.getEnforcedPredicate();
 
         if (table.getSnapshotId().isEmpty()) {
             // A table with missing snapshot id produces no splits, so we optimize here by returning
@@ -305,15 +308,12 @@ public class IcebergMetadata
             return new ConnectorTableProperties(TupleDomain.none(), Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of());
         }
 
-        TableScan tableScan = icebergTable.newScan()
-                .useSnapshot(table.getSnapshotId().get())
-                .filter(toIcebergExpression(enforcedPredicate))
-                .includeColumnStats();
-
-        CloseableIterable<FileScanTask> files = tableScan.planFiles();
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
 
         // Extract identity partition fields that are present in all partition specs, for creating the discrete predicates.
         Set<Integer> partitionSourceIds = identityPartitionColumnsInAllSpecs(icebergTable);
+
+        TupleDomain<IcebergColumnHandle> enforcedPredicate = table.getEnforcedPredicate();
 
         DiscretePredicates discretePredicates = null;
         if (!partitionSourceIds.isEmpty()) {
@@ -321,6 +321,22 @@ public class IcebergMetadata
             Map<Integer, IcebergColumnHandle> columns = getColumns(icebergTable.schema(), typeManager).stream()
                     .filter(column -> partitionSourceIds.contains(column.getId()))
                     .collect(toImmutableMap(IcebergColumnHandle::getId, Function.identity()));
+
+            Supplier<List<FileScanTask>> lazyFiles = Suppliers.memoize(() -> {
+                TableScan tableScan = icebergTable.newScan()
+                        .useSnapshot(table.getSnapshotId().get())
+                        .filter(toIcebergExpression(enforcedPredicate))
+                        .includeColumnStats();
+
+                try (CloseableIterable<FileScanTask> iterator = tableScan.planFiles()) {
+                    return ImmutableList.copyOf(iterator);
+                }
+                catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+
+            Iterable<FileScanTask> files = () -> lazyFiles.get().iterator();
 
             Iterable<TupleDomain<ColumnHandle>> discreteTupleDomain = Iterables.transform(files, fileScan -> {
                 // Extract partition values in the data file
@@ -398,7 +414,7 @@ public class IcebergMetadata
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
         return getColumns(icebergTable.schema(), typeManager).stream()
                 .collect(toImmutableMap(IcebergColumnHandle::getName, identity()));
     }
@@ -494,7 +510,7 @@ public class IcebergMetadata
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
         metastore.commentTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), comment);
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, handle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
         if (comment.isEmpty()) {
             icebergTable.updateProperties().remove(TABLE_COMMENT).commit();
         }
@@ -568,7 +584,7 @@ public class IcebergMetadata
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
 
         transaction = icebergTable.newTransaction();
 
@@ -654,7 +670,7 @@ public class IcebergMetadata
     public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, handle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
         icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType())).commit();
     }
 
@@ -663,7 +679,7 @@ public class IcebergMetadata
     {
         IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
         IcebergColumnHandle handle = (IcebergColumnHandle) column;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, icebergTableHandle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, icebergTableHandle.getSchemaTableName());
         icebergTable.updateSchema().deleteColumn(handle.getName()).commit();
     }
 
@@ -672,7 +688,7 @@ public class IcebergMetadata
     {
         IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
         IcebergColumnHandle columnHandle = (IcebergColumnHandle) source;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, icebergTableHandle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, icebergTableHandle.getSchemaTableName());
         icebergTable.updateSchema().renameColumn(columnHandle.getName(), target).commit();
     }
 
@@ -682,7 +698,7 @@ public class IcebergMetadata
             throw new TableNotFoundException(table);
         }
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table);
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table);
 
         List<ColumnMetadata> columns = getColumnMetadatas(icebergTable);
 
@@ -745,7 +761,7 @@ public class IcebergMetadata
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, handle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
 
         icebergTable.newDelete()
                 .deleteFromRowFilter(toIcebergExpression(handle.getEnforcedPredicate()))
@@ -775,7 +791,7 @@ public class IcebergMetadata
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
     {
         IcebergTableHandle table = (IcebergTableHandle) handle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
 
         Set<Integer> partitionSourceIds = identityPartitionColumnsInAllSpecs(icebergTable);
         BiPredicate<IcebergColumnHandle, Domain> isIdentityPartition = (column, domain) -> partitionSourceIds.contains(column.getId());
@@ -821,7 +837,7 @@ public class IcebergMetadata
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, handle.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
         return TableStatisticsMaker.getTableStatistics(typeManager, constraint, handle, icebergTable);
     }
 
@@ -830,6 +846,15 @@ public class IcebergMetadata
         return snapshotIds.computeIfAbsent(table.toString(), ignored -> snapshotId
                 .map(id -> IcebergUtil.resolveSnapshotId(table, id))
                 .or(() -> Optional.ofNullable(table.currentSnapshot()).map(Snapshot::snapshotId)));
+    }
+
+    org.apache.iceberg.Table getIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
+    {
+        TableMetadata metadata = tableMetadataCache.computeIfAbsent(
+                schemaTableName,
+                ignore -> ((BaseTable) loadIcebergTable(tableOperationsProvider, session, schemaTableName)).operations().current());
+
+        return getIcebergTableWithMetadata(tableOperationsProvider, session, schemaTableName, metadata);
     }
 
     @Override
@@ -925,7 +950,7 @@ public class IcebergMetadata
     public ConnectorInsertTableHandle beginRefreshMaterializedView(ConnectorSession session, ConnectorTableHandle tableHandle, List<ConnectorTableHandle> sourceTableHandles)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
         transaction = icebergTable.newTransaction();
 
         return new IcebergWritableTableHandle(
@@ -1039,7 +1064,7 @@ public class IcebergMetadata
     public Optional<TableToken> getTableToken(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
         return Optional.ofNullable(icebergTable.currentSnapshot())
                 .map(snapshot -> new TableToken(snapshot.snapshotId()));
     }
@@ -1094,7 +1119,7 @@ public class IcebergMetadata
                 .map(CatalogSchemaTableName::getSchemaTableName)
                 .orElseThrow(() -> new IllegalStateException("Storage table missing in definition of materialized view " + name));
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(tableOperationsProvider, session, storageTableName);
+        org.apache.iceberg.Table icebergTable = getIcebergTable(session, storageTableName);
         String dependsOnTables = icebergTable.currentSnapshot().summary().getOrDefault(DEPENDS_ON_TABLES, "");
         if (!dependsOnTables.isEmpty()) {
             Map<String, String> tableToSnapshotIdMap = Splitter.on(',').withKeyValueSeparator('=').split(dependsOnTables);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
@@ -30,6 +30,7 @@ public class IcebergMetadataFactory
     private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
     private final JsonCodec<CommitTaskData> commitTaskCodec;
+    private final HiveTableOperationsProvider tableOperationsProvider;
 
     @Inject
     public IcebergMetadataFactory(
@@ -38,9 +39,10 @@ public class IcebergMetadataFactory
             HiveMetastore metastore,
             HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
-            JsonCodec<CommitTaskData> commitTaskDataJsonCodec)
+            JsonCodec<CommitTaskData> commitTaskDataJsonCodec,
+            HiveTableOperationsProvider tableOperationsProvider)
     {
-        this(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskDataJsonCodec);
+        this(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskDataJsonCodec, tableOperationsProvider);
     }
 
     public IcebergMetadataFactory(
@@ -48,17 +50,19 @@ public class IcebergMetadataFactory
             HiveMetastore metastore,
             HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
-            JsonCodec<CommitTaskData> commitTaskCodec)
+            JsonCodec<CommitTaskData> commitTaskCodec,
+            HiveTableOperationsProvider tableOperationsProvider)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
+        this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
     }
 
     public IcebergMetadata create()
     {
-        return new IcebergMetadata(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskCodec);
+        return new IcebergMetadata(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskCodec, tableOperationsProvider);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -70,7 +70,6 @@ public class IcebergModule
         newExporter(binder).export(FileFormatDataSourceStats.class).withGeneratedName();
 
         binder.bind(HiveTableOperationsProvider.class).in(Scopes.SINGLETON);
-        binder.bind(FileIoProvider.class).to(HdfsFileIoProvider.class).in(Scopes.SINGLETON);
 
         binder.bind(IcebergFileWriterFactory.class).in(Scopes.SINGLETON);
         newExporter(binder).export(IcebergFileWriterFactory.class).withGeneratedName();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -69,6 +69,9 @@ public class IcebergModule
         binder.bind(FileFormatDataSourceStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(FileFormatDataSourceStats.class).withGeneratedName();
 
+        binder.bind(HiveTableOperationsProvider.class).in(Scopes.SINGLETON);
+        binder.bind(FileIoProvider.class).to(HdfsFileIoProvider.class).in(Scopes.SINGLETON);
+
         binder.bind(IcebergFileWriterFactory.class).in(Scopes.SINGLETON);
         newExporter(binder).export(IcebergFileWriterFactory.class).withGeneratedName();
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -15,8 +15,6 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitSource;
-import io.trino.plugin.hive.HdfsEnvironment;
-import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -39,13 +37,13 @@ public class IcebergSplitManager
     public static final int ICEBERG_DOMAIN_COMPACTION_THRESHOLD = 1000;
 
     private final IcebergTransactionManager transactionManager;
-    private final HdfsEnvironment hdfsEnvironment;
+    private final HiveTableOperationsProvider tableOperationsProvider;
 
     @Inject
-    public IcebergSplitManager(IcebergTransactionManager transactionManager, HdfsEnvironment hdfsEnvironment)
+    public IcebergSplitManager(IcebergTransactionManager transactionManager, HiveTableOperationsProvider tableOperationsProvider)
     {
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
-        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
     }
 
     @Override
@@ -62,8 +60,7 @@ public class IcebergSplitManager
             return new FixedSplitSource(ImmutableList.of());
         }
 
-        HiveMetastore metastore = transactionManager.get(transaction).getMetastore();
-        Table icebergTable = getIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+        Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
 
         TableScan tableScan = icebergTable.newScan()
                 .filter(toIcebergExpression(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -28,7 +28,6 @@ import org.apache.iceberg.TableScan;
 import javax.inject.Inject;
 
 import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
-import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTable;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergSplitManager
@@ -37,13 +36,11 @@ public class IcebergSplitManager
     public static final int ICEBERG_DOMAIN_COMPACTION_THRESHOLD = 1000;
 
     private final IcebergTransactionManager transactionManager;
-    private final HiveTableOperationsProvider tableOperationsProvider;
 
     @Inject
     public IcebergSplitManager(IcebergTransactionManager transactionManager, HiveTableOperationsProvider tableOperationsProvider)
     {
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
-        this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
     }
 
     @Override
@@ -60,7 +57,7 @@ public class IcebergSplitManager
             return new FixedSplitSource(ImmutableList.of());
         }
 
-        Table icebergTable = getIcebergTable(tableOperationsProvider, session, table.getSchemaTableName());
+        Table icebergTable = transactionManager.get(transaction).getIcebergTable(session, table.getSchemaTableName());
 
         TableScan tableScan = icebergTable.newScan()
                 .filter(toIcebergExpression(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 
 import java.math.BigDecimal;
@@ -94,7 +95,7 @@ final class IcebergUtil
         return ICEBERG_TABLE_TYPE_VALUE.equalsIgnoreCase(table.getParameters().get(TABLE_TYPE_PROP));
     }
 
-    public static Table getIcebergTable(HiveTableOperationsProvider tableOperationsProvider, ConnectorSession session, SchemaTableName table)
+    public static Table loadIcebergTable(HiveTableOperationsProvider tableOperationsProvider, ConnectorSession session, SchemaTableName table)
     {
         TableOperations operations = tableOperationsProvider.createTableOperations(
                 new HdfsContext(session),
@@ -104,6 +105,24 @@ final class IcebergUtil
                 table.getTableName(),
                 Optional.empty(),
                 Optional.empty());
+        return new BaseTable(operations, quotedTableName(table));
+    }
+
+    public static Table getIcebergTableWithMetadata(
+            HiveTableOperationsProvider tableOperationsProvider,
+            ConnectorSession session,
+            SchemaTableName table,
+            TableMetadata tableMetadata)
+    {
+        HiveTableOperations operations = (HiveTableOperations) tableOperationsProvider.createTableOperations(
+                new HdfsContext(session),
+                session.getQueryId(),
+                new HiveIdentity(session),
+                table.getSchemaName(),
+                table.getTableName(),
+                Optional.empty(),
+                Optional.empty());
+        operations.initializeFromMetadata(tableMetadata);
         return new BaseTable(operations, quotedTableName(table));
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -96,9 +96,14 @@ final class IcebergUtil
 
     public static Table getIcebergTable(HiveTableOperationsProvider tableOperationsProvider, ConnectorSession session, SchemaTableName table)
     {
-        HdfsContext hdfsContext = new HdfsContext(session);
-        HiveIdentity identity = new HiveIdentity(session);
-        TableOperations operations = tableOperationsProvider.createTableOperations(hdfsContext, identity, table.getSchemaName(), table.getTableName(), Optional.empty(), Optional.empty());
+        TableOperations operations = tableOperationsProvider.createTableOperations(
+                new HdfsContext(session),
+                session.getQueryId(),
+                new HiveIdentity(session),
+                table.getSchemaName(),
+                table.getTableName(),
+                Optional.empty(),
+                Optional.empty());
         return new BaseTable(operations, quotedTableName(table));
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -16,10 +16,8 @@ package io.trino.plugin.iceberg;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceUtf8;
-import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.trino.plugin.hive.authentication.HiveIdentity;
-import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
@@ -96,11 +94,11 @@ final class IcebergUtil
         return ICEBERG_TABLE_TYPE_VALUE.equalsIgnoreCase(table.getParameters().get(TABLE_TYPE_PROP));
     }
 
-    public static Table getIcebergTable(HiveMetastore metastore, HdfsEnvironment hdfsEnvironment, ConnectorSession session, SchemaTableName table)
+    public static Table getIcebergTable(HiveTableOperationsProvider tableOperationsProvider, ConnectorSession session, SchemaTableName table)
     {
         HdfsContext hdfsContext = new HdfsContext(session);
         HiveIdentity identity = new HiveIdentity(session);
-        TableOperations operations = new HiveTableOperations(metastore, hdfsEnvironment, hdfsContext, identity, table.getSchemaName(), table.getTableName());
+        TableOperations operations = tableOperationsProvider.createTableOperations(hdfsContext, identity, table.getSchemaName(), table.getTableName(), Optional.empty(), Optional.empty());
         return new BaseTable(operations, quotedTableName(table));
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RollbackToSnapshotProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RollbackToSnapshotProcedure.java
@@ -24,7 +24,7 @@ import javax.inject.Provider;
 
 import java.lang.invoke.MethodHandle;
 
-import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTable;
+import static io.trino.plugin.iceberg.IcebergUtil.loadIcebergTable;
 import static io.trino.spi.block.MethodHandleUtil.methodHandle;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -65,7 +65,7 @@ public class RollbackToSnapshotProcedure
     public void rollbackToSnapshot(ConnectorSession clientSession, String schema, String table, Long snapshotId)
     {
         SchemaTableName schemaTableName = new SchemaTableName(schema, table);
-        Table icebergTable = getIcebergTable(tableOperationsProvider, clientSession, schemaTableName);
+        Table icebergTable = loadIcebergTable(tableOperationsProvider, clientSession, schemaTableName);
         icebergTable.rollback().toSnapshotId(snapshotId).commit();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/testing/ForTrackingFileIoProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/testing/ForTrackingFileIoProvider.java
@@ -11,12 +11,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.iceberg;
+package io.trino.plugin.iceberg.testing;
 
-import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
-import org.apache.iceberg.io.FileIO;
+import javax.inject.Qualifier;
 
-public interface FileIoProvider
-{
-    FileIO createFileIo(HdfsContext hdfsContext, String queryId);
-}
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForTrackingFileIoProvider {}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/testing/TrackingFileIoModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/testing/TrackingFileIoModule.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.testing;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.trino.plugin.iceberg.FileIoProvider;
+import io.trino.plugin.iceberg.HdfsFileIoProvider;
+
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class TrackingFileIoModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(FileIoProvider.class).to(TrackingFileIoProvider.class).in(Scopes.SINGLETON);
+        binder.bind(FileIoProvider.class)
+                .annotatedWith(ForTrackingFileIoProvider.class)
+                .to(HdfsFileIoProvider.class)
+                .in(Scopes.SINGLETON);
+        binder.bind(TrackingFileIoProvider.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(TrackingFileIoProvider.class).withGeneratedName();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/testing/TrackingFileIoProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/testing/TrackingFileIoProvider.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg.testing;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.trino.plugin.iceberg.FileIoProvider;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.weakref.jmx.Managed;
+
+import javax.annotation.concurrent.Immutable;
+import javax.inject.Inject;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.INPUT_FILE_EXISTS;
+import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.INPUT_FILE_GET_LENGTH;
+import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.INPUT_FILE_NEW_STREAM;
+import static java.util.Objects.requireNonNull;
+
+@VisibleForTesting
+public class TrackingFileIoProvider
+        implements FileIoProvider
+{
+    public enum OperationType
+    {
+        INPUT_FILE_GET_LENGTH,
+        INPUT_FILE_NEW_STREAM,
+        INPUT_FILE_EXISTS,
+    }
+
+    private final AtomicInteger fileId = new AtomicInteger();
+    private final FileIoProvider delegate;
+
+    private final Map<OperationContext, Integer> operationCounts = new ConcurrentHashMap<>();
+
+    @Inject
+    public TrackingFileIoProvider(@ForTrackingFileIoProvider FileIoProvider delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Managed
+    public Map<OperationContext, Integer> getOperationCounts()
+    {
+        return ImmutableMap.copyOf(operationCounts);
+    }
+
+    private void increment(String queryId, String path, int fileId, OperationType operationType)
+    {
+        OperationContext context = new OperationContext(queryId, path, fileId, operationType);
+        operationCounts.merge(context, 1, Math::addExact);    // merge is atomic for ConcurrentHashMap
+    }
+
+    @Override
+    public FileIO createFileIo(HdfsContext hdfsContext, String queryId)
+    {
+        return new TrackingFileIo(
+                delegate.createFileIo(hdfsContext, queryId),
+                (path, fileId, operationType) -> increment(queryId, path, fileId, operationType));
+    }
+
+    private interface Tracker
+    {
+        void track(String path, int fileId, OperationType operationType);
+    }
+
+    private class TrackingFileIo
+            implements FileIO
+    {
+        private final FileIO delegate;
+        private final Tracker tracker;
+
+        public TrackingFileIo(FileIO delegate, Tracker tracker)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+            this.tracker = requireNonNull(tracker, "tracker is null");
+        }
+
+        @Override
+        public InputFile newInputFile(String path)
+        {
+            int nextId = fileId.incrementAndGet();
+            return new TrackingInputFile(
+                    delegate.newInputFile(path),
+                    operation -> tracker.track(path, nextId, operation));
+        }
+
+        @Override
+        public OutputFile newOutputFile(String path)
+        {
+            return delegate.newOutputFile(path);  // TODO: track output file calls
+        }
+
+        @Override
+        public void deleteFile(String path)
+        {
+            delegate.deleteFile(path);  // TODO: track delete files calls
+        }
+    }
+
+    private static class TrackingInputFile
+            implements InputFile
+    {
+        private final InputFile delegate;
+        private final Consumer<OperationType> tracker;
+
+        public TrackingInputFile(InputFile delegate, Consumer<OperationType> tracker)
+        {
+            this.delegate = requireNonNull(delegate, "delegate is null");
+            this.tracker = requireNonNull(tracker, "tracker is null");
+        }
+
+        @Override
+        public long getLength()
+        {
+            tracker.accept(INPUT_FILE_GET_LENGTH);
+            return delegate.getLength();
+        }
+
+        @Override
+        public SeekableInputStream newStream()
+        {
+            tracker.accept(INPUT_FILE_NEW_STREAM);
+            return delegate.newStream();
+        }
+
+        @Override
+        public String location()
+        {
+            return delegate.location();
+        }
+
+        @Override
+        public boolean exists()
+        {
+            tracker.accept(INPUT_FILE_EXISTS);
+            return delegate.exists();
+        }
+    }
+
+    @Immutable
+    public static class OperationContext
+    {
+        private final String queryId;
+        private final String filePath;
+        private final int fileId;
+        private final OperationType operationType;
+
+        public OperationContext(String queryId, String filePath, int fileId, OperationType operationType)
+        {
+            this.queryId = requireNonNull(queryId, "queryId is null");
+            this.filePath = requireNonNull(filePath, "filePath is null");
+            this.fileId = fileId;
+            this.operationType = requireNonNull(operationType, "operationType is null");
+        }
+
+        public String getQueryId()
+        {
+            return queryId;
+        }
+
+        public String getFilePath()
+        {
+            return filePath;
+        }
+
+        public int getFileId()
+        {
+            return fileId;
+        }
+
+        public OperationType getOperationType()
+        {
+            return operationType;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            OperationContext that = (OperationContext) o;
+            return Objects.equals(queryId, that.queryId)
+                && Objects.equals(filePath, that.filePath)
+                && fileId == that.fileId
+                && operationType == that.operationType;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(queryId, filePath, fileId, operationType);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("queryId", queryId)
+                    .add("path", filePath)
+                    .add("fileId", fileId)
+                    .add("operation", operationType)
+                    .toString();
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -87,15 +87,15 @@ public class TestIcebergMetadataFileOperations
         // for assertions.
 
         String metadataFileSuffix = "metadata.json";
-        assertEquals(counts.forPathContaining(metadataFileSuffix).forOperation(INPUT_FILE_NEW_STREAM).sum(), 16);
+        assertEquals(counts.forPathContaining(metadataFileSuffix).forOperation(INPUT_FILE_NEW_STREAM).sum(), 1);
         // getLength is cached, so only assert number of different InputFile instances for a file
         assertEquals(counts.forPathContaining(metadataFileSuffix).forOperation(INPUT_FILE_GET_LENGTH).get().size(), 0);
         assertEquals(counts.forPathContaining(metadataFileSuffix).forOperation(INPUT_FILE_EXISTS).sum(), 0);
 
         String snapshotFilePrefix = "/snap-";
-        assertEquals(counts.forPathContaining(snapshotFilePrefix).forOperation(INPUT_FILE_NEW_STREAM).sum(), 10);
+        assertEquals(counts.forPathContaining(snapshotFilePrefix).forOperation(INPUT_FILE_NEW_STREAM).sum(), 1);
         // getLength is cached, so only assert number of different InputFile instances for a file
-        assertEquals(counts.forPathContaining(snapshotFilePrefix).forOperation(INPUT_FILE_GET_LENGTH).get().size(), 10);
+        assertEquals(counts.forPathContaining(snapshotFilePrefix).forOperation(INPUT_FILE_GET_LENGTH).get().size(), 1);
         assertEquals(counts.forPathContaining(snapshotFilePrefix).forOperation(INPUT_FILE_EXISTS).sum(), 0);
 
         String manifestFileSuffix = "-m0.avro";

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.Session;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.iceberg.testing.TrackingFileIoProvider;
+import io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationContext;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
+import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.INPUT_FILE_EXISTS;
+import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.INPUT_FILE_GET_LENGTH;
+import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.INPUT_FILE_NEW_STREAM;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
+
+public class TestIcebergMetadataFileOperations
+        extends AbstractTestQueryFramework
+{
+    private static final MBeanServer BEAN_SERVER = ManagementFactory.getPlatformMBeanServer();
+    private static final String BEAN_NAME = "trino.plugin.iceberg.testing:type=TrackingFileIoProvider,name=iceberg";
+    private static final String OPERATION_COUNTS_ATTRIBUTE = "OperationCounts";
+    private static final Session TEST_SESSION = testSessionBuilder()
+            .setCatalog("iceberg")
+            .setSchema("test_schema")
+            .build();
+
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("iceberg")
+                .setSchema("test_schema")
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                // Tests that inspect MBean attributes need to run with just one node, otherwise
+                // the attributes may come from the bound class instance in non-coordinator node
+                .setNodeCount(1)
+                .build();
+
+        File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
+        HiveMetastore metastore = createTestingFileHiveMetastore(baseDir);
+        queryRunner.installPlugin(new TestingIcebergPlugin(metastore, true));
+        queryRunner.createCatalog("iceberg", "iceberg");
+
+        queryRunner.execute("CREATE SCHEMA test_schema");
+        return queryRunner;
+    }
+
+    @Test
+    public void testOperations()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_select_from AS SELECT 1 col0", 1);
+        String queryId = runAndGetId("SELECT * FROM test_select_from");
+
+        OperationCounts counts = getCounts().forQueryId(queryId);
+
+        // The table contains exactly one metadata, snapshot and manifest files, so file-naming based filters are sufficient
+        // for assertions.
+
+        String metadataFileSuffix = "metadata.json";
+        assertEquals(counts.forPathContaining(metadataFileSuffix).forOperation(INPUT_FILE_NEW_STREAM).sum(), 16);
+        // getLength is cached, so only assert number of different InputFile instances for a file
+        assertEquals(counts.forPathContaining(metadataFileSuffix).forOperation(INPUT_FILE_GET_LENGTH).get().size(), 0);
+        assertEquals(counts.forPathContaining(metadataFileSuffix).forOperation(INPUT_FILE_EXISTS).sum(), 0);
+
+        String snapshotFilePrefix = "/snap-";
+        assertEquals(counts.forPathContaining(snapshotFilePrefix).forOperation(INPUT_FILE_NEW_STREAM).sum(), 10);
+        // getLength is cached, so only assert number of different InputFile instances for a file
+        assertEquals(counts.forPathContaining(snapshotFilePrefix).forOperation(INPUT_FILE_GET_LENGTH).get().size(), 10);
+        assertEquals(counts.forPathContaining(snapshotFilePrefix).forOperation(INPUT_FILE_EXISTS).sum(), 0);
+
+        String manifestFileSuffix = "-m0.avro";
+        // Iceberg seems to read manifest files twice during Streams.stream(combinedScanIterable) call in IcebergSplitSource
+        assertEquals(counts.forPathContaining(manifestFileSuffix).forOperation(INPUT_FILE_NEW_STREAM).sum(), 2);
+        // getLength is cached, so only assert number of different InputFile instances for a file
+        assertEquals(counts.forPathContaining(manifestFileSuffix).forOperation(INPUT_FILE_GET_LENGTH).get().size(), 1);
+        assertEquals(counts.forPathContaining(manifestFileSuffix).forOperation(INPUT_FILE_EXISTS).sum(), 0);
+    }
+
+    private String runAndGetId(String query)
+    {
+        return getDistributedQueryRunner().executeWithQueryId(TEST_SESSION, query).getQueryId().getId();
+    }
+
+    private static OperationCounts getCounts()
+            throws Exception
+    {
+        return new OperationCounts((Map<OperationContext, Integer>) BEAN_SERVER.getAttribute(new ObjectName(BEAN_NAME), OPERATION_COUNTS_ATTRIBUTE));
+    }
+
+    private static class OperationCounts
+    {
+        private final Map<OperationContext, Integer> allCounts;
+        private Optional<String> queryId = Optional.empty();
+        private Predicate<String> pathPredicate = path -> true;
+        private Optional<TrackingFileIoProvider.OperationType> type = Optional.empty();
+
+        public OperationCounts(Map<OperationContext, Integer> allCounts)
+        {
+            this.allCounts = requireNonNull(allCounts, "allCounts is null");
+        }
+
+        public OperationCounts forQueryId(String queryId)
+        {
+            this.queryId = Optional.of(queryId);
+            return this;
+        }
+
+        public OperationCounts forPathContaining(String value)
+        {
+            this.pathPredicate = path -> path.contains(value);
+            return this;
+        }
+
+        public OperationCounts forOperation(TrackingFileIoProvider.OperationType type)
+        {
+            this.type = Optional.of(type);
+            return this;
+        }
+
+        public Map<OperationContext, Integer> get()
+        {
+            return allCounts.entrySet().stream()
+                    .filter(entry -> queryId.map(id -> entry.getKey().getQueryId().equals(id)).orElse(true))
+                    .filter(entry -> pathPredicate.test(entry.getKey().getFilePath()))
+                    .filter(entry -> type.map(value -> value == entry.getKey().getOperationType()).orElse(true))
+                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+
+        public int sum()
+        {
+            return get().values().stream().mapToInt(Integer::intValue).sum();
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
@@ -73,7 +73,7 @@ public class TestIcebergMetadataListing
                         .setCatalogDirectory(baseDir.toURI().toString())
                         .setMetastoreUser("test"));
 
-        queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
+        queryRunner.installPlugin(new TestingIcebergPlugin(metastore, false));
         queryRunner.createCatalog("iceberg", "iceberg");
         queryRunner.installPlugin(new TestingHivePlugin(metastore));
         queryRunner.createCatalog("hive", "hive", ImmutableMap.of("hive.security", "sql-standard"));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -79,7 +79,7 @@ public class TestIcebergOrcMetricsCollection
                         .setCatalogDirectory(baseDir.toURI().toString())
                         .setMetastoreUser("test"));
 
-        queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
+        queryRunner.installPlugin(new TestingIcebergPlugin(metastore, false));
         queryRunner.createCatalog("iceberg", "iceberg");
 
         queryRunner.installPlugin(new TpchPlugin());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSystemTables.java
@@ -70,7 +70,7 @@ public class TestIcebergSystemTables
                         .setCatalogDirectory(baseDir.toURI().toString())
                         .setMetastoreUser("test"));
 
-        queryRunner.installPlugin(new TestingIcebergPlugin(metastore));
+        queryRunner.installPlugin(new TestingIcebergPlugin(metastore, false));
         queryRunner.createCatalog("iceberg", "iceberg");
 
         return queryRunner;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
@@ -59,7 +59,7 @@ public class TestMetadataQueryOptimization
 
         queryRunner.createCatalog(
                 ICEBERG_CATALOG,
-                new TestingIcebergConnectorFactory(Optional.of(metastore)),
+                new TestingIcebergConnectorFactory(Optional.of(metastore), false),
                 ImmutableMap.of());
 
         Database database = Database.builder()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergConnectorFactory.java
@@ -29,10 +29,12 @@ public class TestingIcebergConnectorFactory
         implements ConnectorFactory
 {
     private final Optional<HiveMetastore> metastore;
+    private final boolean trackMetadataIo;
 
-    public TestingIcebergConnectorFactory(Optional<HiveMetastore> metastore)
+    public TestingIcebergConnectorFactory(Optional<HiveMetastore> metastore, boolean trackMetadataIo)
     {
         this.metastore = requireNonNull(metastore, "metastore is null");
+        this.trackMetadataIo = trackMetadataIo;
     }
 
     @Override
@@ -50,6 +52,6 @@ public class TestingIcebergConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        return createConnector(catalogName, config, context, metastore);
+        return createConnector(catalogName, config, context, metastore, trackMetadataIo);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestingIcebergPlugin.java
@@ -26,15 +26,17 @@ public class TestingIcebergPlugin
         implements Plugin
 {
     private final Optional<HiveMetastore> metastore;
+    private final boolean trackMetadataIo;
 
-    public TestingIcebergPlugin(HiveMetastore metastore)
+    public TestingIcebergPlugin(HiveMetastore metastore, boolean trackMetadataIo)
     {
         this.metastore = Optional.of(requireNonNull(metastore, "metastore is null"));
+        this.trackMetadataIo = trackMetadataIo;
     }
 
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new TestingIcebergConnectorFactory(metastore));
+        return ImmutableList.of(new TestingIcebergConnectorFactory(metastore, trackMetadataIo));
     }
 }


### PR DESCRIPTION
#7336 

This PR 

* reduces scans of `metadata` file on the read path by reusing Iceberg's `TableMetadata`
* reduces scans of `snapshot` file on the read path by lazily initializing file iterator during `IcebergMetadata#getTableProperties` 

some other related things to discuss:

* Iceberg's `TableMetadata` does not provide fully immutable objects (e.g. some lazy loading in BaseSnapshot, Schema etc). On a cursory look, iceberg code seems to have synchronization (or rely on reference assignments being atomic and marking them as volatile), but not sure if it's ideal to trust that as the spec/api-docs don't say anything. Adding a wrapper on Iceberg's `TableMetadata` isn't very useful since we need to use the full `TableMetadata` object in IcebergSplitManager anyway. (It'd require bigger refactoring if we want to create replica of Iceberg objects in trino)

* `getTableStatistics` also invokes `planFiles`, which causes repeated iterations on metadata, snapshot and manifest files. however, invocations of getTableStatistics during planning may also have different predicates. This PR doesn't cache/optimize it. 

* [`Streams.stream(combinedScanIterable)`](https://github.com/trinodb/trino/blob/master/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java#L48) seems to cause manifest files to be read twice, but it shouldn't need to, imo this needs to be fixed in Iceberg.