### PR TITLE
Move testInsertInPresenceOfNotSupportedColumn into BaseJdbcConnectorTest

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/TupleDomainParquetPredicate.java
@@ -146,11 +146,11 @@ public class TupleDomainParquetPredicate
             return Domain.all(type);
         }
 
-        if (statistics.getNumNulls() == rowCount) {
+        if (statistics.isNumNullsSet() && statistics.getNumNulls() == rowCount) {
             return Domain.onlyNull(type);
         }
 
-        boolean hasNullValue = statistics.getNumNulls() != 0L;
+        boolean hasNullValue = !statistics.isNumNullsSet() || statistics.getNumNulls() != 0L;
 
         if (!statistics.hasNonNullValue() || statistics.genericGetMin() == null || statistics.genericGetMax() == null) {
             return Domain.create(ValueSet.all(type), hasNullValue);

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestMetadataReader.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/reader/TestMetadataReader.java
@@ -32,6 +32,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
@@ -60,7 +61,11 @@ public class TestMetadataReader
         statistics.setMax(fromHex("3AA40000"));
         assertThat(MetadataReader.readStats(fileCreatedBy, Optional.of(statistics), new PrimitiveType(OPTIONAL, INT32, "Test column")))
                 .isInstanceOfSatisfying(IntStatistics.class, columnStatistics -> {
+                    assertFalse(columnStatistics.isEmpty());
+
+                    assertTrue(columnStatistics.isNumNullsSet());
                     assertEquals(columnStatistics.getNumNulls(), 13);
+
                     assertEquals(columnStatistics.getMin(), -10);
                     assertEquals(columnStatistics.getMax(), 42042);
                     assertEquals(columnStatistics.genericGetMin(), (Integer) (int) -10);
@@ -77,7 +82,31 @@ public class TestMetadataReader
         statistics.setMax(fromHex("3AA4000000000000"));
         assertThat(MetadataReader.readStats(fileCreatedBy, Optional.of(statistics), new PrimitiveType(OPTIONAL, INT64, "Test column")))
                 .isInstanceOfSatisfying(LongStatistics.class, columnStatistics -> {
+                    assertFalse(columnStatistics.isEmpty());
+
+                    assertTrue(columnStatistics.isNumNullsSet());
                     assertEquals(columnStatistics.getNumNulls(), 13);
+
+                    assertEquals(columnStatistics.getMin(), -10);
+                    assertEquals(columnStatistics.getMax(), 42042);
+                    assertEquals(columnStatistics.genericGetMin(), (Long) (long) -10L);
+                    assertEquals(columnStatistics.genericGetMax(), (Long) 42042L);
+                });
+    }
+
+    @Test(dataProvider = "allCreatedBy")
+    public void testReadStatsInt64WithoutNullCount(Optional<String> fileCreatedBy)
+    {
+        Statistics statistics = new Statistics();
+        statistics.setMin(fromHex("F6FFFFFFFFFFFFFF"));
+        statistics.setMax(fromHex("3AA4000000000000"));
+        assertThat(MetadataReader.readStats(fileCreatedBy, Optional.of(statistics), new PrimitiveType(OPTIONAL, INT64, "Test column")))
+                .isInstanceOfSatisfying(LongStatistics.class, columnStatistics -> {
+                    assertFalse(columnStatistics.isEmpty());
+
+                    assertFalse(columnStatistics.isNumNullsSet());
+                    assertEquals(columnStatistics.getNumNulls(), -1);
+
                     assertEquals(columnStatistics.getMin(), -10);
                     assertEquals(columnStatistics.getMax(), 42042);
                     assertEquals(columnStatistics.genericGetMin(), (Long) (long) -10L);
@@ -113,7 +142,11 @@ public class TestMetadataReader
         statistics.setMax_value("é".getBytes(UTF_8));
         assertThat(MetadataReader.readStats(fileCreatedBy, Optional.of(statistics), varbinary))
                 .isInstanceOfSatisfying(BinaryStatistics.class, columnStatistics -> {
+                    assertFalse(columnStatistics.isEmpty());
+
+                    assertTrue(columnStatistics.isNumNullsSet());
                     assertEquals(columnStatistics.getNumNulls(), 13);
+
                     assertEquals(columnStatistics.getMin().getBytes(), new byte[] {'a'});
                     assertEquals(columnStatistics.getMax().getBytes(), new byte[] {(byte) 0xC3, (byte) 0xA9});
                     assertEquals(columnStatistics.getMinBytes(), new byte[] {'a'});
@@ -206,6 +239,9 @@ public class TestMetadataReader
         }
         assertThat(MetadataReader.readStats(fileCreatedBy, Optional.of(statistics), new PrimitiveType(OPTIONAL, BINARY, "Test column", OriginalType.UTF8)))
                 .isInstanceOfSatisfying(BinaryStatistics.class, columnStatistics -> {
+                    assertFalse(columnStatistics.isEmpty());
+
+                    assertTrue(columnStatistics.isNumNullsSet());
                     assertEquals(columnStatistics.getNumNulls(), 13);
 
                     byte[] expectedMinBytes = expectedMin != null ? expectedMin.getBytes(UTF_8) : null;
@@ -245,7 +281,11 @@ public class TestMetadataReader
         statistics.setMax_value("é".getBytes(UTF_8));
         assertThat(MetadataReader.readStats(fileCreatedBy, Optional.of(statistics), varchar))
                 .isInstanceOfSatisfying(BinaryStatistics.class, columnStatistics -> {
+                    assertFalse(columnStatistics.isEmpty());
+
+                    assertTrue(columnStatistics.isNumNullsSet());
                     assertEquals(columnStatistics.getNumNulls(), 13);
+
                     assertEquals(columnStatistics.getMin().getBytes(), new byte[] {'a'});
                     assertEquals(columnStatistics.getMax().getBytes(), new byte[] {(byte) 0xC3, (byte) 0xA9});
                     assertEquals(columnStatistics.getMinBytes(), new byte[] {'a'});

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorTest.java
@@ -79,13 +79,22 @@ public class TestJdbcConnectorTest
     protected TestTable createTableWithDefaultColumns()
     {
         return new TestTable(
-                getSqlExecutor(),
+                onRemoteDatabase(),
                 "tpch.table",
                 "(col_required BIGINT NOT NULL," +
                         "col_nullable BIGINT," +
                         "col_default BIGINT DEFAULT 43," +
                         "col_nonnull_default BIGINT NOT NULL DEFAULT 42," +
                         "col_required2 BIGINT NOT NULL)");
+    }
+
+    @Override
+    protected TestTable createTableWithUnsupportedColumn()
+    {
+        return new TestTable(
+                onRemoteDatabase(),
+                "tpch.test_unsupported_column_present",
+                "(one bigint, two geometry, three varchar(10))");
     }
 
     @Override
@@ -118,7 +127,7 @@ public class TestJdbcConnectorTest
         return Optional.of(dataMappingTestSetup);
     }
 
-    private JdbcSqlExecutor getSqlExecutor()
+    private JdbcSqlExecutor onRemoteDatabase()
     {
         return new JdbcSqlExecutor(properties.get("connection-url"), new Properties());
     }

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -147,6 +147,15 @@ public class TestClickHouseConnectorTest
     }
 
     @Override
+    protected TestTable createTableWithUnsupportedColumn()
+    {
+        return new TestTable(
+                clickhouseServer::execute,
+                "tpch.test_unsupported_column_present",
+                "(one bigint, two Array(UInt8), three String) ENGINE=Log");
+    }
+
+    @Override
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {
         switch (dataMappingTestSetup.getTrinoTypeName()) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSourceProvider.java
@@ -190,7 +190,7 @@ public class HivePageSourceProvider
         if (pageSource.isPresent()) {
             ConnectorPageSource source = pageSource.get();
             if (hiveTable.isAcidDelete() || hiveTable.isAcidUpdate()) {
-                checkArgument(orcFileWriterFactory.isPresent(), "orcFileWriterFactory not supplied but required for DELETEs");
+                checkArgument(orcFileWriterFactory.isPresent(), "orcFileWriterFactory not supplied but required for DELETE and UPDATE");
                 HivePageSource hivePageSource = (HivePageSource) source;
                 OrcPageSource orcPageSource = (OrcPageSource) hivePageSource.getDelegate();
                 ColumnMetadata<OrcType> columnMetadata = orcPageSource.getColumnTypes();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
@@ -39,6 +39,7 @@ import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static io.trino.plugin.hive.PartitionAndStatementId.CODEC;
 import static io.trino.spi.predicate.Utils.nativeValueToBlock;
@@ -140,9 +141,7 @@ public class HiveUpdatablePageSource
     public void updateRows(Page page, List<Integer> columnValueAndRowIdChannels)
     {
         int positionCount = page.getPositionCount();
-        if (positionCount == 0) {
-            return;
-        }
+        verify(positionCount > 0, "Unexpected empty page"); // should be filtered out by engine
 
         HiveUpdateProcessor updateProcessor = transaction.getUpdateProcessor().orElseThrow(() -> new IllegalArgumentException("updateProcessor not present"));
         RowBlock acidRowBlock = updateProcessor.getAcidRowBlock(page, columnValueAndRowIdChannels);

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
@@ -88,6 +88,15 @@ public abstract class BaseMySqlConnectorTest
     }
 
     @Override
+    protected TestTable createTableWithUnsupportedColumn()
+    {
+        return new TestTable(
+                onRemoteDatabase(),
+                "tpch.test_unsupported_column_present",
+                "(one bigint, two decimal(50,0), three varchar(10))");
+    }
+
+    @Override
     public void testShowColumns()
     {
         MaterializedResult actual = computeActual("SHOW COLUMNS FROM orders");
@@ -199,17 +208,6 @@ public abstract class BaseMySqlConnectorTest
         assertUpdate("INSERT INTO test_insert VALUES (123, 'test')", 1);
         assertQuery("SELECT * FROM test_insert", "SELECT 123 x, 'test' y");
         assertUpdate("DROP TABLE test_insert");
-    }
-
-    @Test
-    public void testInsertInPresenceOfNotSupportedColumn()
-    {
-        onRemoteDatabase().execute("CREATE TABLE tpch.test_insert_not_supported_column_present(x bigint, y decimal(50,0), z varchar(10))");
-        // Check that column y is not supported.
-        assertQuery("SELECT column_name FROM information_schema.columns WHERE table_name = 'test_insert_not_supported_column_present'", "VALUES 'x', 'z'");
-        assertUpdate("INSERT INTO test_insert_not_supported_column_present (x, z) VALUES (123, 'test')", 1);
-        assertQuery("SELECT x, z FROM test_insert_not_supported_column_present", "SELECT 123, 'test'");
-        assertUpdate("DROP TABLE test_insert_not_supported_column_present");
     }
 
     @Test

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/BaseOracleConnectorTest.java
@@ -119,6 +119,15 @@ public abstract class BaseOracleConnectorTest
                         "col_required2 decimal(20,0) NOT NULL)");
     }
 
+    @Override
+    protected TestTable createTableWithUnsupportedColumn()
+    {
+        return new TestTable(
+                onRemoteDatabase(),
+                "test_unsupported_col",
+                "(one NUMBER(19), two NUMBER, three VARCHAR2(10 CHAR))");
+    }
+
     @Test
     @Override
     public void testCreateTableAsSelect()

--- a/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixConnectorTest.java
@@ -20,6 +20,7 @@ import io.trino.plugin.jdbc.UnsupportedTypeHandling;
 import io.trino.testing.AbstractTestDistributedQueries;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
+import io.trino.testing.sql.SqlExecutor;
 import io.trino.testing.sql.TestTable;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
@@ -79,6 +80,13 @@ public class TestPhoenixConnectorTest
     protected TestTable createTableWithDefaultColumns()
     {
         throw new SkipException("Phoenix connector does not support column default values");
+    }
+
+    @Override
+    protected TestTable createTableWithUnsupportedColumn()
+    {
+        // Apparently all Phoenix types are supported in the Phoenix connector.
+        throw new SkipException("Cannot find an unsupported data type");
     }
 
     @Override
@@ -304,6 +312,18 @@ public class TestPhoenixConnectorTest
         assertUpdate("INSERT INTO test_col_insert(pk, col1) VALUES('1', 'val1')", 1);
         assertUpdate("INSERT INTO test_col_insert(pk, col2) VALUES('1', 'val2')", 1);
         assertQuery("SELECT * FROM test_col_insert", "SELECT 1, 'val1', 'val2'");
+    }
+
+    protected SqlExecutor onRemoteDatabase()
+    {
+        return sql -> {
+            try {
+                executeInPhoenix(sql);
+            }
+            catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        };
     }
 
     private void executeInPhoenix(String sql)

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -82,6 +82,13 @@ public class TestPhoenixConnectorTest
     }
 
     @Override
+    protected TestTable createTableWithUnsupportedColumn()
+    {
+        // Apparently all Phoenix types are supported in the Phoenix connector.
+        throw new SkipException("Cannot find an unsupported data type");
+    }
+
+    @Override
     public void testRenameTable()
     {
         assertThatThrownBy(super::testRenameTable)

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -87,6 +87,15 @@ public abstract class BaseSqlServerConnectorTest
     }
 
     @Override
+    protected TestTable createTableWithUnsupportedColumn()
+    {
+        return new TestTable(
+                onRemoteDatabase(),
+                "test_unsupported_column_present",
+                "(one bigint, two sql_variant, three varchar(10))");
+    }
+
+    @Override
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {
         String typeName = dataMappingTestSetup.getTrinoTypeName();
@@ -100,17 +109,6 @@ public abstract class BaseSqlServerConnectorTest
         }
 
         return Optional.of(dataMappingTestSetup);
-    }
-
-    @Test
-    public void testInsertInPresenceOfNotSupportedColumn()
-    {
-        onRemoteDatabase().execute("CREATE TABLE test_insert_not_supported_column_present(x bigint, y sql_variant, z varchar(10))");
-        // Check that column y is not supported.
-        assertQuery("SELECT column_name FROM information_schema.columns WHERE table_name = 'test_insert_not_supported_column_present'", "VALUES 'x', 'z'");
-        assertUpdate("INSERT INTO test_insert_not_supported_column_present (x, z) VALUES (123, 'test')", 1);
-        assertQuery("SELECT x, z FROM test_insert_not_supported_column_present", "SELECT 123, 'test'");
-        assertUpdate("DROP TABLE test_insert_not_supported_column_present");
     }
 
     @Test


### PR DESCRIPTION
The test was defined (copied) in several connectors, now it's elevated
to run for all JDBC connectors.