### PR TITLE
Disable split buffering by default

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 public class QueryManagerConfig
 {
     private int scheduleSplitBatchSize = 1000;
-    private int minScheduleSplitBatchSize = 100;
+    private int minScheduleSplitBatchSize = 1;
     private int maxConcurrentQueries = 1000;
     private int maxQueuedQueries = 5000;
 
@@ -81,6 +81,7 @@ public class QueryManagerConfig
     }
 
     @Min(1)
+    @Deprecated
     public int getMinScheduleSplitBatchSize()
     {
         return minScheduleSplitBatchSize;

--- a/core/trino-main/src/main/java/io/trino/split/BufferingSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/BufferingSplitSource.java
@@ -22,7 +22,6 @@ import io.trino.spi.connector.ConnectorPartitionHandle;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
@@ -64,12 +63,6 @@ public class BufferingSplitSource
     public boolean isFinished()
     {
         return source.isFinished();
-    }
-
-    @Override
-    public Optional<Integer> getMinScheduleSplitBatchSize()
-    {
-        return source.getMinScheduleSplitBatchSize();
     }
 
     private static class GetNextBatch

--- a/core/trino-main/src/main/java/io/trino/split/BufferingSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/BufferingSplitSource.java
@@ -28,6 +28,7 @@ import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
 
+@Deprecated
 public class BufferingSplitSource
         implements SplitSource
 {

--- a/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
@@ -24,8 +24,6 @@ import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorSplitSource.ConnectorSplitBatch;
 
-import java.util.Optional;
-
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static java.util.Objects.requireNonNull;
@@ -71,12 +69,6 @@ public class ConnectorAwareSplitSource
     public boolean isFinished()
     {
         return source.isFinished();
-    }
-
-    @Override
-    public Optional<Integer> getMinScheduleSplitBatchSize()
-    {
-        return source.getMinScheduleSplitBatchSize();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/split/SampledSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/SampledSplitSource.java
@@ -21,7 +21,6 @@ import io.trino.spi.connector.ConnectorPartitionHandle;
 
 import javax.annotation.Nullable;
 
-import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -68,11 +67,5 @@ public class SampledSplitSource
     public boolean isFinished()
     {
         return splitSource.isFinished();
-    }
-
-    @Override
-    public Optional<Integer> getMinScheduleSplitBatchSize()
-    {
-        return splitSource.getMinScheduleSplitBatchSize();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/split/SplitManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/SplitManager.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public class SplitManager
@@ -93,10 +92,6 @@ public class SplitManager
         }
 
         SplitSource splitSource = new ConnectorAwareSplitSource(catalogName, source);
-        int minScheduleSplitBatchSize = this.minScheduleSplitBatchSize;
-        if (splitSource.getMinScheduleSplitBatchSize().isPresent()) {
-            minScheduleSplitBatchSize = min(minScheduleSplitBatchSize, splitSource.getMinScheduleSplitBatchSize().get());
-        }
         if (minScheduleSplitBatchSize > 1) {
             splitSource = new BufferingSplitSource(splitSource, minScheduleSplitBatchSize);
         }

--- a/core/trino-main/src/main/java/io/trino/split/SplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/SplitSource.java
@@ -21,7 +21,6 @@ import io.trino.spi.connector.ConnectorPartitionHandle;
 
 import java.io.Closeable;
 import java.util.List;
-import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -63,6 +62,4 @@ public interface SplitSource
             return lastBatch;
         }
     }
-
-    Optional<Integer> getMinScheduleSplitBatchSize();
 }

--- a/core/trino-main/src/test/java/io/trino/split/MockSplitSource.java
+++ b/core/trino-main/src/test/java/io/trino/split/MockSplitSource.java
@@ -28,7 +28,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -140,12 +139,6 @@ public class MockSplitSource
     public boolean isFinished()
     {
         return splitsProduced == totalSplits && atSplitDepletion == FINISH;
-    }
-
-    @Override
-    public Optional<Integer> getMinScheduleSplitBatchSize()
-    {
-        return Optional.empty();
     }
 
     public int getNextBatchInvocationCount()

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitSource.java
@@ -15,7 +15,6 @@ package io.trino.spi.connector;
 
 import java.io.Closeable;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Objects.requireNonNull;
@@ -58,10 +57,5 @@ public interface ConnectorSplitSource
         {
             return noMoreSplits;
         }
-    }
-
-    default Optional<Integer> getMinScheduleSplitBatchSize()
-    {
-        return Optional.empty();
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorSplitSource.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorSplitSource.java
@@ -19,7 +19,6 @@ import io.trino.spi.connector.ConnectorSplitSource;
 
 import javax.inject.Inject;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Objects.requireNonNull;
@@ -58,14 +57,6 @@ public class ClassLoaderSafeConnectorSplitSource
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.isFinished();
-        }
-    }
-
-    @Override
-    public Optional<Integer> getMinScheduleSplitBatchSize()
-    {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getMinScheduleSplitBatchSize();
         }
     }
 }


### PR DESCRIPTION

Connectors that return multiple spits should return them in batches, per
`io.trino.spi.connector.ConnectorSplitSource#getNextBatch` contract. The
batch size (and whether to batch at all) should be connector's
responsibility.

Previously the batching on the engine was enabled by default and it did
not work well with things like `hive.max-splits-per-second`.