### PR TITLE
Remove default schema from testing PostgreSQL server URL

### DIFF
--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlTypeMapping.java
@@ -172,7 +172,7 @@ public class TestPostgreSqlTypeMapping
         checkIsGap(kathmandu, timeGapInKathmandu);
 
         JdbcSqlExecutor executor = new JdbcSqlExecutor(postgreSqlServer.getJdbcUrl(), postgreSqlServer.getProperties());
-        executor.execute("CREATE EXTENSION hstore");
+        executor.execute("CREATE EXTENSION hstore WITH SCHEMA public");
     }
 
     @Test

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestingPostgreSqlServer.java
@@ -77,12 +77,13 @@ public class TestingPostgreSqlServer
         Properties properties = new Properties();
         properties.setProperty("user", USER);
         properties.setProperty("password", PASSWORD);
+        properties.setProperty("currentSchema", "tpch,public");
         return properties;
     }
 
     public String getJdbcUrl()
     {
-        return format("jdbc:postgresql://%s:%s/%s?currentSchema=tpch", dockerContainer.getContainerIpAddress(), dockerContainer.getMappedPort(POSTGRESQL_PORT), DATABASE);
+        return format("jdbc:postgresql://%s:%s/%s", dockerContainer.getContainerIpAddress(), dockerContainer.getMappedPort(POSTGRESQL_PORT), DATABASE);
     }
 
     @Override


### PR DESCRIPTION


The URL is used to configure the connector and should not contain
`currentSchema=xxx`. The default schema should be applied only when executing
queries on PostgreSQL server directly.