### PR TITLE
Move testSetSession, testResetSession to engine-only tests

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/TestingSession.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingSession.java
@@ -39,7 +39,6 @@ import static java.util.Locale.ENGLISH;
 
 public final class TestingSession
 {
-    public static final String TESTING_CATALOG = "testing_catalog";
     private static final QueryIdGenerator queryIdGenerator = new QueryIdGenerator();
 
     /*

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestShowQueries.java
@@ -15,6 +15,7 @@ package io.trino.sql.query;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.trino.connector.CatalogName;
 import io.trino.connector.MockConnectorFactory;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.SchemaTableName;
@@ -23,7 +24,10 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.List;
+
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingSession.createBogusTestingCatalog;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -61,6 +65,8 @@ public class TestShowQueries
                         .withListTables((session, schemaName) -> ImmutableList.of(new SchemaTableName("mockSchema", "mockTable")))
                         .build(),
                 ImmutableMap.of());
+        queryRunner.getCatalogManager().registerCatalog(createBogusTestingCatalog("testing_catalog"));
+        queryRunner.getMetadata().getSessionPropertyManager().addConnectorSessionProperties(new CatalogName("testing_catalog"), List.of());
         assertions = new QueryAssertions(queryRunner);
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/AbstractTestIcebergSmoke.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/AbstractTestIcebergSmoke.java
@@ -112,7 +112,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testShowCreateSchema()
     {
         assertThat(computeActual("SHOW CREATE SCHEMA tpch").getOnlyValue().toString())
@@ -126,7 +126,7 @@ public abstract class AbstractTestIcebergSmoke
     @Override
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testDescribeTable()
     {
         MaterializedResult expectedColumns = resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
@@ -147,7 +147,7 @@ public abstract class AbstractTestIcebergSmoke
     @Override
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testShowCreateTable()
     {
         assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
@@ -169,7 +169,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testDecimal()
     {
         testDecimalWithPrecisionAndScale(1, 0);
@@ -210,7 +210,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testTime()
     {
         testSelectOrPartitionedByTime(false);
@@ -218,7 +218,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testPartitionedByTime()
     {
         testSelectOrPartitionedByTime(true);
@@ -243,7 +243,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testPartitionByTimestamp()
     {
         testSelectOrPartitionedByTimestamp(true);
@@ -251,7 +251,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testSelectByTimestamp()
     {
         testSelectOrPartitionedByTimestamp(false);
@@ -281,7 +281,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testCreatePartitionedTable()
     {
         @Language("SQL") String createTable = "" +
@@ -349,7 +349,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testCreatePartitionedTableWithNestedTypes()
     {
         @Language("SQL") String createTable = "" +
@@ -369,7 +369,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testPartitionedTableWithNullValues()
     {
         @Language("SQL") String createTable = "" +
@@ -424,7 +424,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testCreatePartitionedTableAs()
     {
         @Language("SQL") String createTable = "" +
@@ -463,7 +463,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testColumnComments()
     {
         // TODO add support for setting comments on existing column and replace the test with io.trino.testing.AbstractTestDistributedQueries#testCommentColumn
@@ -477,7 +477,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testTableComments()
     {
         String createTableTemplate = "" +
@@ -519,7 +519,7 @@ public abstract class AbstractTestIcebergSmoke
     // add it and $snapshot_timestamp_ms
     @Test(enabled = false)
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testQueryBySnapshotId()
     {
         assertUpdate("CREATE TABLE test_query_by_snapshot (col0 INTEGER, col1 BIGINT)");
@@ -535,7 +535,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testRollbackSnapshot()
     {
         assertUpdate("CREATE TABLE test_rollback (col0 INTEGER, col1 BIGINT)");
@@ -564,7 +564,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testInsertIntoNotNullColumn()
     {
         assertUpdate("CREATE TABLE test_not_null_table (c1 INTEGER, c2 INTEGER NOT NULL)");
@@ -582,7 +582,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testSchemaEvolution()
     {
         assertUpdate("CREATE TABLE test_schema_evolution_drop_end (col0 INTEGER, col1 INTEGER, col2 INTEGER)");
@@ -609,7 +609,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testLargeInFailureOnPartitionedColumns()
     {
         QualifiedObjectName tableName = new QualifiedObjectName("iceberg", "tpch", "test_large_in_failure");
@@ -633,7 +633,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testCreateTableLike()
     {
         FileFormat otherFormat = format == PARQUET ? ORC : PARQUET;
@@ -690,7 +690,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testPredicating()
     {
         assertUpdate("CREATE TABLE test_predicating_on_real (col REAL)");
@@ -701,7 +701,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testHourTransform()
     {
         assertUpdate("CREATE TABLE test_hour_transform (d TIMESTAMP(6), b BIGINT) WITH (partitioning = ARRAY['hour(d)'])");
@@ -747,7 +747,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testDayTransformDate()
     {
         assertUpdate("CREATE TABLE test_day_transform_date (d DATE, b BIGINT) WITH (partitioning = ARRAY['day(d)'])");
@@ -784,7 +784,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testDayTransformTimestamp()
     {
         assertUpdate("CREATE TABLE test_day_transform_timestamp (d TIMESTAMP(6), b BIGINT) WITH (partitioning = ARRAY['day(d)'])");
@@ -831,7 +831,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testMonthTransformDate()
     {
         assertUpdate("CREATE TABLE test_month_transform_date (d DATE, b BIGINT) WITH (partitioning = ARRAY['month(d)'])");
@@ -872,7 +872,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testMonthTransformTimestamp()
     {
         assertUpdate("CREATE TABLE test_month_transform_timestamp (d TIMESTAMP(6), b BIGINT) WITH (partitioning = ARRAY['month(d)'])");
@@ -917,7 +917,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testYearTransformDate()
     {
         assertUpdate("CREATE TABLE test_year_transform_date (d DATE, b BIGINT) WITH (partitioning = ARRAY['year(d)'])");
@@ -953,7 +953,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testYearTransformTimestamp()
     {
         assertUpdate("CREATE TABLE test_year_transform_timestamp (d TIMESTAMP(6), b BIGINT) WITH (partitioning = ARRAY['year(d)'])");
@@ -996,7 +996,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testTruncateTransform()
     {
         String select = "SELECT d_trunc, row_count, d.min AS d_min, d.max AS d_max, b.min AS b_min, b.max AS b_max FROM \"test_truncate_transform$partitions\"";
@@ -1029,7 +1029,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testBucketTransform()
     {
         String select = "SELECT d_bucket, row_count, d.min AS d_min, d.max AS d_max, b.min AS b_min, b.max AS b_max FROM \"test_bucket_transform$partitions\"";
@@ -1056,7 +1056,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testMetadataDeleteSimple()
     {
         assertUpdate("CREATE TABLE test_metadata_delete_simple (col1 BIGINT, col2 BIGINT) WITH (partitioning = ARRAY['col1'])");
@@ -1074,7 +1074,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testMetadataDelete()
     {
         @Language("SQL") String createTable = "" +
@@ -1112,7 +1112,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testInSet()
     {
         testInSet(31);
@@ -1137,7 +1137,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testBasicTableStatistics()
     {
         String tableName = format("iceberg.tpch.test_basic_%s_table_statistics", format.name().toLowerCase(ENGLISH));
@@ -1171,7 +1171,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testMultipleColumnTableStatistics()
     {
         String tableName = format("iceberg.tpch.test_multiple_%s_table_statistics", format.name().toLowerCase(ENGLISH));
@@ -1226,7 +1226,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testPartitionedTableStatistics()
     {
         assertUpdate("CREATE TABLE iceberg.tpch.test_partitioned_table_statistics (col1 REAL, col2 BIGINT) WITH (partitioning = ARRAY['col2'])");
@@ -1303,7 +1303,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testStatisticsConstraints()
     {
         String tableName = "iceberg.tpch.test_simple_partitioned_table_statistics";
@@ -1336,7 +1336,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testPredicatePushdown()
     {
         QualifiedObjectName tableName = new QualifiedObjectName("iceberg", "tpch", "test_predicate");
@@ -1506,7 +1506,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testCreateNestedPartitionedTable()
     {
         @Language("SQL") String createTable = "" +
@@ -1578,7 +1578,7 @@ public abstract class AbstractTestIcebergSmoke
 
     @Test
     // This particular method may or may not be @Flaky. It is annotated since the problem is generic.
-    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: io.trino.plugin.iceberg.HdfsInputFile")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/5201", match = "Failed to read footer of file: HdfsInputFile")
     public void testSerializableReadIsolation()
     {
         assertUpdate("CREATE TABLE test_read_isolation (x int)");

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java
@@ -14,7 +14,6 @@
 package io.trino.testing;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedTimeoutException;
 import io.airlift.units.Duration;
@@ -46,7 +45,6 @@ import static io.trino.testing.DataProviders.toDataProvider;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static io.trino.testing.QueryAssertions.assertContains;
 import static io.trino.testing.QueryAssertions.getTrinoExceptionCause;
-import static io.trino.testing.TestingSession.TESTING_CATALOG;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static io.trino.testing.assertions.Assert.assertEventually;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
@@ -122,54 +120,6 @@ public abstract class AbstractTestDistributedQueries
     {
         assertThat(getQueryRunner().getNodeCount()).as("query runner node count")
                 .isGreaterThanOrEqualTo(3);
-    }
-
-    @Test
-    public void testSetSession()
-    {
-        MaterializedResult result = computeActual("SET SESSION test_string = 'bar'");
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
-        assertEquals(result.getSetSessionProperties(), ImmutableMap.of("test_string", "bar"));
-
-        result = computeActual(format("SET SESSION %s.connector_long = 999", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
-        assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_long", "999"));
-
-        result = computeActual(format("SET SESSION %s.connector_string = 'baz'", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
-        assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_string", "baz"));
-
-        result = computeActual(format("SET SESSION %s.connector_string = 'ban' || 'ana'", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
-        assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_string", "banana"));
-
-        result = computeActual(format("SET SESSION %s.connector_long = 444", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
-        assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_long", "444"));
-
-        result = computeActual(format("SET SESSION %s.connector_long = 111 + 111", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
-        assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_long", "222"));
-
-        result = computeActual(format("SET SESSION %s.connector_boolean = 111 < 3", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
-        assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_boolean", "false"));
-
-        result = computeActual(format("SET SESSION %s.connector_double = 11.1", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
-        assertEquals(result.getSetSessionProperties(), ImmutableMap.of(TESTING_CATALOG + ".connector_double", "11.1"));
-    }
-
-    @Test
-    public void testResetSession()
-    {
-        MaterializedResult result = computeActual(getSession(), "RESET SESSION test_string");
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
-        assertEquals(result.getResetSessionProperties(), ImmutableSet.of("test_string"));
-
-        result = computeActual(getSession(), format("RESET SESSION %s.connector_string", TESTING_CATALOG));
-        assertTrue((Boolean) getOnlyElement(result).getField(0));
-        assertEquals(result.getResetSessionProperties(), ImmutableSet.of(TESTING_CATALOG + ".connector_string"));
     }
 
     @Test

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.metadata.FunctionListBuilder;
 import io.trino.metadata.SqlFunction;
-import io.trino.spi.session.PropertyMetadata;
 import io.trino.tpch.TpchTable;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.testng.annotations.DataProvider;
@@ -61,39 +60,6 @@ public abstract class AbstractTestQueries
             .scalars(CreateHll.class)
             .functions(APPLY_FUNCTION, INVOKE_FUNCTION, STATEFUL_SLEEPING_SUM)
             .getFunctions();
-
-    public static final List<PropertyMetadata<?>> TEST_SYSTEM_PROPERTIES = ImmutableList.of(
-            PropertyMetadata.stringProperty(
-                    "test_string",
-                    "test string property",
-                    "test default",
-                    false),
-            PropertyMetadata.longProperty(
-                    "test_long",
-                    "test long property",
-                    42L,
-                    false));
-    public static final List<PropertyMetadata<?>> TEST_CATALOG_PROPERTIES = ImmutableList.of(
-            PropertyMetadata.stringProperty(
-                    "connector_string",
-                    "connector string property",
-                    "connector default",
-                    false),
-            PropertyMetadata.longProperty(
-                    "connector_long",
-                    "connector long property",
-                    33L,
-                    false),
-            PropertyMetadata.booleanProperty(
-                    "connector_boolean",
-                    "connector boolean property",
-                    true,
-                    false),
-            PropertyMetadata.doubleProperty(
-                    "connector_double",
-                    "connector double property",
-                    99.0,
-                    false));
 
     @Test
     public void testAggregationOverUnknown()

--- a/testing/trino-testing/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -21,7 +21,6 @@ import io.trino.metadata.AllNodes;
 import io.trino.metadata.InternalNode;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
-import io.trino.metadata.SessionPropertyManager;
 import io.trino.metadata.SqlFunction;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.Plugin;
@@ -40,8 +39,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static io.airlift.testing.Closeables.closeAll;
-import static io.trino.testing.AbstractTestQueries.TEST_CATALOG_PROPERTIES;
-import static io.trino.testing.AbstractTestQueries.TEST_SYSTEM_PROPERTIES;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -64,10 +61,6 @@ public final class StandaloneQueryRunner
         refreshNodes();
 
         server.getMetadata().addFunctions(AbstractTestQueries.CUSTOM_FUNCTIONS);
-
-        SessionPropertyManager sessionPropertyManager = server.getMetadata().getSessionPropertyManager();
-        sessionPropertyManager.addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
-        sessionPropertyManager.addConnectorSessionProperties(new CatalogName("catalog"), TEST_CATALOG_PROPERTIES);
     }
 
     @Override

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestLocalEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestLocalEngineOnlyQueries.java
@@ -13,7 +13,13 @@
  */
 package io.trino.tests;
 
+import io.trino.connector.CatalogName;
+import io.trino.testing.LocalQueryRunner;
 import io.trino.testing.QueryRunner;
+import org.testng.SkipException;
+
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.testing.TestingSession.createBogusTestingCatalog;
 
 public class TestLocalEngineOnlyQueries
         extends AbstractTestEngineOnlyQueries
@@ -21,6 +27,28 @@ public class TestLocalEngineOnlyQueries
     @Override
     protected QueryRunner createQueryRunner()
     {
-        return TestLocalQueries.createLocalQueryRunner();
+        LocalQueryRunner queryRunner = TestLocalQueries.createLocalQueryRunner();
+        try {
+            // for testing session properties
+            queryRunner.getMetadata().getSessionPropertyManager().addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
+            queryRunner.getCatalogManager().registerCatalog(createBogusTestingCatalog(TESTING_CATALOG));
+            queryRunner.getMetadata().getSessionPropertyManager().addConnectorSessionProperties(new CatalogName(TESTING_CATALOG), TEST_CATALOG_PROPERTIES);
+        }
+        catch (RuntimeException e) {
+            throw closeAllSuppress(e, queryRunner);
+        }
+        return queryRunner;
+    }
+
+    @Override
+    public void testSetSession()
+    {
+        throw new SkipException("SET SESSION is not supported by LocalQueryRunner");
+    }
+
+    @Override
+    public void testResetSession()
+    {
+        throw new SkipException("RESET SESSION is not supported by LocalQueryRunner");
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestLocalQueries.java
@@ -15,7 +15,6 @@ package io.trino.tests;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
-import io.trino.metadata.SessionPropertyManager;
 import io.trino.plugin.tpch.TpchConnectorFactory;
 import io.trino.testing.AbstractTestQueries;
 import io.trino.testing.LocalQueryRunner;
@@ -28,7 +27,6 @@ import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.testing.MaterializedResult.resultBuilder;
-import static io.trino.testing.TestingSession.TESTING_CATALOG;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static io.trino.testing.assertions.Assert.assertEquals;
 
@@ -50,7 +48,6 @@ public class TestLocalQueries
                 .build();
 
         LocalQueryRunner localQueryRunner = LocalQueryRunner.builder(defaultSession)
-                .withDefaultSessionProperties(ImmutableMap.of(TESTING_CATALOG, TEST_CATALOG_PROPERTIES))
                 .build();
 
         // add the tpch catalog
@@ -61,9 +58,6 @@ public class TestLocalQueries
                 ImmutableMap.of());
 
         localQueryRunner.getMetadata().addFunctions(CUSTOM_FUNCTIONS);
-
-        SessionPropertyManager sessionPropertyManager = localQueryRunner.getMetadata().getSessionPropertyManager();
-        sessionPropertyManager.addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
 
         return localQueryRunner;
     }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestProcedureCall.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestProcedureCall.java
@@ -29,8 +29,9 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
-import static io.trino.testing.TestingSession.TESTING_CATALOG;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.tests.AbstractTestEngineOnlyQueries.TESTING_CATALOG;
+import static io.trino.tests.TestDistributedEngineOnlyQueries.addTestingCatalog;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -59,6 +60,7 @@ public class TestProcedureCall
         tester = coordinator.getProcedureTester();
 
         // register procedures in the bogus testing catalog
+        addTestingCatalog(getDistributedQueryRunner());
         ProcedureRegistry procedureRegistry = coordinator.getMetadata().getProcedureRegistry();
         TestingProcedures procedures = new TestingProcedures(coordinator.getProcedureTester());
         procedureRegistry.addProcedures(

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestQueryPlanDeterminism.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestQueryPlanDeterminism.java
@@ -15,7 +15,6 @@ package io.trino.tests;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
-import io.trino.metadata.SessionPropertyManager;
 import io.trino.plugin.tpch.TpchConnectorFactory;
 import io.trino.spi.type.Type;
 import io.trino.testing.AbstractTestQueries;
@@ -33,7 +32,6 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
-import static io.trino.testing.TestingSession.TESTING_CATALOG;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 
 public class TestQueryPlanDeterminism
@@ -62,7 +60,6 @@ public class TestQueryPlanDeterminism
                 .build();
 
         LocalQueryRunner localQueryRunner = LocalQueryRunner.builder(defaultSession)
-                .withDefaultSessionProperties(ImmutableMap.of(TESTING_CATALOG, TEST_CATALOG_PROPERTIES))
                 .build();
 
         // add the tpch catalog
@@ -73,9 +70,6 @@ public class TestQueryPlanDeterminism
                 ImmutableMap.of());
 
         localQueryRunner.getMetadata().addFunctions(CUSTOM_FUNCTIONS);
-
-        SessionPropertyManager sessionPropertyManager = localQueryRunner.getMetadata().getSessionPropertyManager();
-        sessionPropertyManager.addSystemSessionProperties(TEST_SYSTEM_PROPERTIES);
 
         return localQueryRunner;
     }


### PR DESCRIPTION
This also removes global registration of `testing_catalog`.