### PR TITLE
Fix misleading 'Table not found' message for PostgreSQL

### DIFF
--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -191,20 +191,20 @@ public class TestPostgreSqlConnectorTest
                 AutoCloseable ignore3 = withTable("no_columns", "()")) {
             assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet()).contains("orders", "no_supported_columns", "supported_columns", "no_columns");
 
-            assertQueryFails("SELECT c FROM no_supported_columns", "Table 'tpch.no_supported_columns' not found");
-            assertQueryFails("SELECT * FROM no_supported_columns", "Table 'tpch.no_supported_columns' not found");
-            assertQueryFails("SELECT 'a' FROM no_supported_columns", "Table 'tpch.no_supported_columns' not found");
+            assertQueryFails("SELECT c FROM no_supported_columns", "\\QTable 'tpch.no_supported_columns' has no supported columns (all 1 columns are not supported)");
+            assertQueryFails("SELECT * FROM no_supported_columns", "\\QTable 'tpch.no_supported_columns' has no supported columns (all 1 columns are not supported)");
+            assertQueryFails("SELECT 'a' FROM no_supported_columns", "\\QTable 'tpch.no_supported_columns' has no supported columns (all 1 columns are not supported)");
 
-            assertQueryFails("SELECT c FROM no_columns", "Table 'tpch.no_columns' not found");
-            assertQueryFails("SELECT * FROM no_columns", "Table 'tpch.no_columns' not found");
-            assertQueryFails("SELECT 'a' FROM no_columns", "Table 'tpch.no_columns' not found");
+            assertQueryFails("SELECT c FROM no_columns", "\\QTable 'tpch.no_columns' has no supported columns (all 0 columns are not supported)");
+            assertQueryFails("SELECT * FROM no_columns", "\\QTable 'tpch.no_columns' has no supported columns (all 0 columns are not supported)");
+            assertQueryFails("SELECT 'a' FROM no_columns", "\\QTable 'tpch.no_columns' has no supported columns (all 0 columns are not supported)");
 
             assertQueryFails("SELECT c FROM non_existent", ".* Table .*tpch.non_existent.* does not exist");
             assertQueryFails("SELECT * FROM non_existent", ".* Table .*tpch.non_existent.* does not exist");
             assertQueryFails("SELECT 'a' FROM non_existent", ".* Table .*tpch.non_existent.* does not exist");
 
-            assertQueryFails("SHOW COLUMNS FROM no_supported_columns", "Table 'tpch.no_supported_columns' not found");
-            assertQueryFails("SHOW COLUMNS FROM no_columns", "Table 'tpch.no_columns' not found");
+            assertQueryFails("SHOW COLUMNS FROM no_supported_columns", "\\QTable 'tpch.no_supported_columns' has no supported columns (all 1 columns are not supported)");
+            assertQueryFails("SHOW COLUMNS FROM no_columns", "\\QTable 'tpch.no_columns' has no supported columns (all 0 columns are not supported)");
 
             // Other tables should be visible in SHOW TABLES (the no_supported_columns might be included or might be not) and information_schema.tables
             assertThat(computeActual("SHOW TABLES").getOnlyColumn())


### PR DESCRIPTION
Same as c6c1feb85f87701d07b04e334e8e99fb0306d41e, but for PostgreSQL
connector.