### PR TITLE
Update Phoenix5 connector to 5.1.1

### DIFF
--- a/plugin/trino-phoenix5/pom.xml
+++ b/plugin/trino-phoenix5/pom.xml
@@ -92,14 +92,7 @@
         <dependency>
             <groupId>org.apache.phoenix</groupId>
             <artifactId>phoenix-client-embedded-hbase-2.2</artifactId>
-            <version>5.1.0</version>
-            <exclusions>
-	        <!-- exlude all transitive dependencies -->
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>5.1.1</version>
         </dependency>
 
         <dependency>
@@ -349,10 +342,6 @@
                         <dependency>
                             <groupId>com.clearspring.analytics</groupId>
                             <artifactId>stream</artifactId>
-                        </dependency>
-                        <dependency>
-                            <groupId>javax.activation</groupId>
-                            <artifactId>javax.activation-api</artifactId>
                         </dependency>
                         <dependency>
                             <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
Phoenix 5.1.1 has been released. It fixes some of the dependency issues as well as some bug fixes. It is forward and backward compatible with 5.1.0.

Fixes #6965
