### PR TITLE
Fix requireNonNull call sites

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -347,7 +347,7 @@ public class ClientSession
 
         public Builder withCredentials(Map<String, String> credentials)
         {
-            this.credentials = requireNonNull(credentials, "extraCredentials is null");
+            this.credentials = requireNonNull(credentials, "credentials is null");
             return this;
         }
 

--- a/client/trino-client/src/main/java/io/trino/client/SpnegoHandler.java
+++ b/client/trino-client/src/main/java/io/trino/client/SpnegoHandler.java
@@ -319,7 +319,7 @@ public class SpnegoHandler
         public Session(LoginContext loginContext, GSSCredential clientCredential)
         {
             requireNonNull(loginContext, "loginContext is null");
-            requireNonNull(clientCredential, "gssCredential is null");
+            requireNonNull(clientCredential, "clientCredential is null");
 
             this.loginContext = loginContext;
             this.clientCredential = clientCredential;

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ColumnInfo.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ColumnInfo.java
@@ -70,7 +70,7 @@ class ColumnInfo
     {
         this.columnType = columnType;
         this.columnParameterTypes = ImmutableList.copyOf(requireNonNull(columnParameterTypes, "columnParameterTypes is null"));
-        this.columnTypeSignature = requireNonNull(columnTypeSignature, "columnTypeName is null");
+        this.columnTypeSignature = requireNonNull(columnTypeSignature, "columnTypeSignature is null");
         this.nullable = requireNonNull(nullable, "nullable is null");
         this.currency = currency;
         this.signed = signed;

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoArray.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoArray.java
@@ -34,7 +34,7 @@ public class TrinoArray
 
     TrinoArray(String elementTypeName, int elementType, List<?> array)
     {
-        this.elementTypeName = requireNonNull(elementTypeName, "elementType is null");
+        this.elementTypeName = requireNonNull(elementTypeName, "elementTypeName is null");
         this.elementType = elementType;
         this.array = requireNonNull(array, "array is null").toArray();
     }

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaSplit.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaSplit.java
@@ -33,8 +33,8 @@ public class InformationSchemaSplit
     public InformationSchemaSplit(
             @JsonProperty("addresses") List<HostAddress> addresses)
     {
-        requireNonNull(addresses, "hosts is null");
-        checkArgument(!addresses.isEmpty(), "hosts is empty");
+        requireNonNull(addresses, "addresses is null");
+        checkArgument(!addresses.isEmpty(), "addresses is empty");
         this.addresses = ImmutableList.copyOf(addresses);
     }
 

--- a/core/trino-main/src/main/java/io/trino/connector/system/SystemSplit.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/SystemSplit.java
@@ -43,8 +43,8 @@ public class SystemSplit
             @JsonProperty("addresses") List<HostAddress> addresses,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
     {
-        requireNonNull(addresses, "hosts is null");
-        checkArgument(!addresses.isEmpty(), "hosts is empty");
+        requireNonNull(addresses, "addresses is null");
+        checkArgument(!addresses.isEmpty(), "addresses is empty");
         this.addresses = ImmutableList.copyOf(addresses);
         this.constraint = requireNonNull(constraint, "constraint is null");
     }

--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchInfo.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchInfo.java
@@ -40,7 +40,7 @@ public class DispatchInfo
 
     public static DispatchInfo failed(ExecutionFailureInfo failureInfo, Duration elapsedTime, Duration queuedTime)
     {
-        requireNonNull(failureInfo, "coordinatorLocation is null");
+        requireNonNull(failureInfo, "failureInfo is null");
         return new DispatchInfo(Optional.empty(), Optional.of(failureInfo), elapsedTime, queuedTime);
     }
 

--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQueryFactory.java
@@ -84,7 +84,7 @@ public class LocalDispatchQueryFactory
 
         this.clusterSizeMonitor = requireNonNull(clusterSizeMonitor, "clusterSizeMonitor is null");
 
-        this.executor = requireNonNull(dispatchExecutor, "executorService is null").getExecutor();
+        this.executor = requireNonNull(dispatchExecutor, "dispatchExecutor is null").getExecutor();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -121,8 +121,8 @@ public class QueuedStatementResource
         this.dispatchManager = requireNonNull(dispatchManager, "dispatchManager is null");
 
         requireNonNull(dispatchManager, "dispatchManager is null");
-        this.responseExecutor = requireNonNull(executor, "responseExecutor is null").getExecutor();
-        this.timeoutExecutor = requireNonNull(executor, "timeoutExecutor is null").getScheduledExecutor();
+        this.responseExecutor = requireNonNull(executor, "executor is null").getExecutor();
+        this.timeoutExecutor = requireNonNull(executor, "executor is null").getScheduledExecutor();
         this.compressionEnabled = requireNonNull(serverConfig, "serverConfig is null").isQueryResultsCompressionEnabled();
         this.alternateHeaderName = requireNonNull(protocolConfig, "protocolConfig is null").getAlternateHeaderName();
 

--- a/core/trino-main/src/main/java/io/trino/execution/QueryInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryInfo.java
@@ -128,7 +128,7 @@ public class QueryInfo
         requireNonNull(setPath, "setPath is null");
         requireNonNull(setSessionProperties, "setSessionProperties is null");
         requireNonNull(resetSessionProperties, "resetSessionProperties is null");
-        requireNonNull(addedPreparedStatements, "addedPreparedStatemetns is null");
+        requireNonNull(addedPreparedStatements, "addedPreparedStatements is null");
         requireNonNull(deallocatedPreparedStatements, "deallocatedPreparedStatements is null");
         requireNonNull(startedTransactionId, "startedTransactionId is null");
         requireNonNull(query, "query is null");

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -747,7 +747,7 @@ public class SqlQueryExecution
             this.failureDetector = requireNonNull(failureDetector, "failureDetector is null");
             this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
             this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
-            this.executionPolicies = requireNonNull(executionPolicies, "schedulerPolicies is null");
+            this.executionPolicies = requireNonNull(executionPolicies, "executionPolicies is null");
             this.planOptimizers = requireNonNull(planOptimizers, "planOptimizers is null").get();
             this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
             this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
@@ -182,7 +182,7 @@ public class SqlTaskExecution
         this.taskContext = requireNonNull(taskContext, "taskContext is null");
         this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
 
-        this.taskExecutor = requireNonNull(taskExecutor, "driverExecutor is null");
+        this.taskExecutor = requireNonNull(taskExecutor, "taskExecutor is null");
         this.notificationExecutor = requireNonNull(notificationExecutor, "notificationExecutor is null");
 
         this.splitMonitor = requireNonNull(splitMonitor, "splitMonitor is null");
@@ -1026,7 +1026,7 @@ public class SqlTaskExecution
 
         private DriverSplitRunner(DriverSplitRunnerFactory driverSplitRunnerFactory, DriverContext driverContext, @Nullable ScheduledSplit partitionedSplit, Lifespan lifespan)
         {
-            this.driverSplitRunnerFactory = requireNonNull(driverSplitRunnerFactory, "driverFactory is null");
+            this.driverSplitRunnerFactory = requireNonNull(driverSplitRunnerFactory, "driverSplitRunnerFactory is null");
             this.driverContext = requireNonNull(driverContext, "driverContext is null");
             this.partitionedSplit = partitionedSplit;
             this.lifespan = requireNonNull(lifespan, "lifespan is null");

--- a/core/trino-main/src/main/java/io/trino/execution/StageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStats.java
@@ -198,7 +198,7 @@ public class StageStats
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
 
-        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "writtenDataSize is null");
+        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "physicalWrittenDataSize is null");
 
         this.gcInfo = requireNonNull(gcInfo, "gcInfo is null");
 

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
@@ -210,7 +210,7 @@ public class ArbitraryOutputBuffer
     public void enqueue(List<SerializedPage> pages)
     {
         checkState(!Thread.holdsLock(this), "Cannot enqueue pages while holding a lock on this");
-        requireNonNull(pages, "page is null");
+        requireNonNull(pages, "pages is null");
 
         // ignore pages after "no more pages" is set
         // this can happen with a limit query

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
@@ -215,7 +215,7 @@ public class PartitionedOutputBuffer
     @Override
     public void acknowledge(OutputBufferId outputBufferId, long sequenceId)
     {
-        requireNonNull(outputBufferId, "bufferId is null");
+        requireNonNull(outputBufferId, "outputBufferId is null");
 
         partitions.get(outputBufferId.getId()).acknowledgePages(sequenceId);
     }

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/SerializedPageReference.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/SerializedPageReference.java
@@ -33,7 +33,7 @@ final class SerializedPageReference
 
     public SerializedPageReference(SerializedPage serializedPage, int referenceCount)
     {
-        this.serializedPage = requireNonNull(serializedPage, "page is null");
+        this.serializedPage = requireNonNull(serializedPage, "serializedPage is null");
         checkArgument(referenceCount > 0, "referenceCount must be at least 1");
         this.referenceCount = referenceCount;
     }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ScaledWriterScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ScaledWriterScheduler.java
@@ -63,7 +63,7 @@ public class ScaledWriterScheduler
         this.writerTasksProvider = requireNonNull(writerTasksProvider, "writerTasksProvider is null");
         this.nodeSelector = requireNonNull(nodeSelector, "nodeSelector is null");
         this.executor = requireNonNull(executor, "executor is null");
-        this.writerMinSizeBytes = requireNonNull(writerMinSize, "minWriterSize is null").toBytes();
+        this.writerMinSizeBytes = requireNonNull(writerMinSize, "writerMinSize is null").toBytes();
     }
 
     public void finish()

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
@@ -181,7 +181,7 @@ public class SqlQueryScheduler
             DynamicFilterService dynamicFilterService)
     {
         this.queryStateMachine = requireNonNull(queryStateMachine, "queryStateMachine is null");
-        this.executionPolicy = requireNonNull(executionPolicy, "schedulerPolicyFactory is null");
+        this.executionPolicy = requireNonNull(executionPolicy, "executionPolicy is null");
         this.schedulerStats = requireNonNull(schedulerStats, "schedulerStats is null");
         this.summarizeTaskInfo = summarizeTaskInfo;
         this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");

--- a/core/trino-main/src/main/java/io/trino/failuredetector/HeartbeatFailureDetector.java
+++ b/core/trino-main/src/main/java/io/trino/failuredetector/HeartbeatFailureDetector.java
@@ -110,7 +110,7 @@ public class HeartbeatFailureDetector
         requireNonNull(selector, "selector is null");
         requireNonNull(httpClient, "httpClient is null");
         requireNonNull(nodeInfo, "nodeInfo is null");
-        requireNonNull(failureDetectorConfig, "config is null");
+        requireNonNull(failureDetectorConfig, "failureDetectorConfig is null");
         checkArgument(failureDetectorConfig.getHeartbeatInterval().toMillis() >= 1, "heartbeat interval must be >= 1ms");
 
         this.selector = selector;

--- a/core/trino-main/src/main/java/io/trino/memory/MemoryPool.java
+++ b/core/trino-main/src/main/java/io/trino/memory/MemoryPool.java
@@ -72,7 +72,7 @@ public class MemoryPool
 
     public MemoryPool(MemoryPoolId id, DataSize size)
     {
-        this.id = requireNonNull(id, "name is null");
+        this.id = requireNonNull(id, "id is null");
         requireNonNull(size, "size is null");
         maxBytes = size.toBytes();
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/BoundSignature.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/BoundSignature.java
@@ -37,7 +37,7 @@ public class BoundSignature
             @JsonProperty("returnType") Type returnType,
             @JsonProperty("argumentTypes") List<Type> argumentTypes)
     {
-        this.name = requireNonNull(name, "qualifiedName is null");
+        this.name = requireNonNull(name, "name is null");
         this.returnType = requireNonNull(returnType, "returnType is null");
         this.argumentTypes = ImmutableList.copyOf(requireNonNull(argumentTypes, "argumentTypes is null"));
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Catalog.java
@@ -42,7 +42,7 @@ public class Catalog
             Connector systemTables)
     {
         this.catalogName = checkCatalogName(catalogName);
-        this.connectorCatalogName = requireNonNull(connectorCatalogName, "connectorConnectorId is null");
+        this.connectorCatalogName = requireNonNull(connectorCatalogName, "connectorCatalogName is null");
         this.connector = requireNonNull(connector, "connector is null");
         this.informationSchemaId = requireNonNull(informationSchemaId, "informationSchemaId is null");
         this.informationSchema = requireNonNull(informationSchema, "informationSchema is null");

--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionListBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionListBuilder.java
@@ -67,7 +67,7 @@ public class FunctionListBuilder
 
     public FunctionListBuilder function(SqlFunction sqlFunction)
     {
-        requireNonNull(sqlFunction, "parametricFunction is null");
+        requireNonNull(sqlFunction, "sqlFunction is null");
         functions.add(sqlFunction);
         return this;
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -382,7 +382,7 @@ public final class MetadataManager
     public Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName)
     {
         requireNonNull(session, "session is null");
-        requireNonNull(tableName, "table is null");
+        requireNonNull(tableName, "tableName is null");
 
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, tableName.getCatalogName());
         if (catalog.isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SignatureBinder.java
@@ -91,7 +91,7 @@ public class SignatureBinder
         checkNoLiteralVariableUsageAcrossTypes(declaredSignature);
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.typeCoercion = new TypeCoercion(metadata::getType);
-        this.declaredSignature = requireNonNull(declaredSignature, "parametrizedSignature is null");
+        this.declaredSignature = requireNonNull(declaredSignature, "declaredSignature is null");
         this.allowCoercion = allowCoercion;
 
         this.typeVariableConstraints = declaredSignature.getTypeVariableConstraints().stream()

--- a/core/trino-main/src/main/java/io/trino/metadata/TableMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableMetadata.java
@@ -29,7 +29,7 @@ public class TableMetadata
 
     public TableMetadata(CatalogName catalogName, ConnectorTableMetadata metadata)
     {
-        requireNonNull(catalogName, "catalog is null");
+        requireNonNull(catalogName, "catalogName is null");
         requireNonNull(metadata, "metadata is null");
 
         this.catalogName = catalogName;

--- a/core/trino-main/src/main/java/io/trino/metadata/TableProperties.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableProperties.java
@@ -40,7 +40,7 @@ public class TableProperties
     {
         requireNonNull(catalogName, "catalogName is null");
         requireNonNull(transaction, "transaction is null");
-        requireNonNull(tableProperties, "layout is null");
+        requireNonNull(tableProperties, "tableProperties is null");
 
         this.catalogName = catalogName;
         this.transaction = transaction;

--- a/core/trino-main/src/main/java/io/trino/operator/BasicWorkProcessorOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/BasicWorkProcessorOperatorAdapter.java
@@ -113,7 +113,7 @@ public class BasicWorkProcessorOperatorAdapter
             BasicAdapterWorkProcessorOperatorFactory operatorFactory)
     {
         this.pageBuffer = new PageBuffer();
-        this.operator = requireNonNull(operatorFactory, "operator is null").createAdapterOperator(processorContext, pageBuffer.pages());
+        this.operator = requireNonNull(operatorFactory, "operatorFactory is null").createAdapterOperator(processorContext, pageBuffer.pages());
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
@@ -88,7 +88,7 @@ public class DriverContext
     {
         this.pipelineContext = requireNonNull(pipelineContext, "pipelineContext is null");
         this.notificationExecutor = requireNonNull(notificationExecutor, "notificationExecutor is null");
-        this.yieldExecutor = requireNonNull(yieldExecutor, "scheduler is null");
+        this.yieldExecutor = requireNonNull(yieldExecutor, "yieldExecutor is null");
         this.driverMemoryContext = requireNonNull(driverMemoryContext, "driverMemoryContext is null");
         this.lifespan = requireNonNull(lifespan, "lifespan is null");
         this.yieldSignal = new DriverYieldSignal();

--- a/core/trino-main/src/main/java/io/trino/operator/DriverStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverStats.java
@@ -202,7 +202,7 @@ public class DriverStats
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
 
-        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "writtenDataSize is null");
+        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "physicalWrittenDataSize is null");
 
         this.operatorStats = ImmutableList.copyOf(requireNonNull(operatorStats, "operatorStats is null"));
     }

--- a/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankAccumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupedTopNRankAccumulator.java
@@ -75,7 +75,7 @@ public class GroupedTopNRankAccumulator
 
     public GroupedTopNRankAccumulator(RowIdComparisonHashStrategy strategy, int topN, LongConsumer rowIdEvictionListener)
     {
-        this.strategy = requireNonNull(strategy, "rowComparisonStrategy is null");
+        this.strategy = requireNonNull(strategy, "strategy is null");
         this.peerGroupLookup = new TopNPeerGroupLookup(10_000, strategy, NULL_GROUP_ID, UNKNOWN_INDEX);
         checkArgument(topN > 0, "topN must be greater than zero");
         this.topN = topN;

--- a/core/trino-main/src/main/java/io/trino/operator/HashSemiJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashSemiJoinOperator.java
@@ -156,9 +156,9 @@ public class HashSemiJoinOperator
         {
             checkArgument(probeJoinChannel >= 0, "probeJoinChannel is negative");
 
-            this.channelSetFuture = requireNonNull(channelSetFuture, "hashProvider is null").getChannelSet();
+            this.channelSetFuture = requireNonNull(channelSetFuture, "channelSetFuture is null").getChannelSet();
             this.probeJoinChannel = probeJoinChannel;
-            this.probeHashChannel = requireNonNull(probeHashChannel, "hashChannel is null");
+            this.probeHashChannel = requireNonNull(probeHashChannel, "probeHashChannel is null");
             this.localMemoryContext = requireNonNull(aggregatedMemoryContext, "aggregatedMemoryContext is null").newLocalMemoryContext(SemiJoinPages.class.getSimpleName());
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/JoinBridgeManager.java
+++ b/core/trino-main/src/main/java/io/trino/operator/JoinBridgeManager.java
@@ -67,7 +67,7 @@ public class JoinBridgeManager<T extends JoinBridge>
         this.buildOuter = buildOuter;
         this.probeExecutionStrategy = requireNonNull(probeExecutionStrategy, "probeExecutionStrategy is null");
         this.buildExecutionStrategy = requireNonNull(lookupSourceExecutionStrategy, "lookupSourceExecutionStrategy is null");
-        this.joinBridgeProvider = requireNonNull(lookupSourceFactoryProvider, "joinBridgeProvider is null");
+        this.joinBridgeProvider = requireNonNull(lookupSourceFactoryProvider, "lookupSourceFactoryProvider is null");
         this.buildOutputTypes = requireNonNull(buildOutputTypes, "buildOutputTypes is null");
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/JoinHashSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/JoinHashSupplier.java
@@ -52,7 +52,7 @@ public class JoinHashSupplier
         this.addresses = requireNonNull(addresses, "addresses is null");
         this.filterFunctionFactory = requireNonNull(filterFunctionFactory, "filterFunctionFactory is null");
         this.searchFunctionFactories = ImmutableList.copyOf(searchFunctionFactories);
-        requireNonNull(channels, "pages is null");
+        requireNonNull(channels, "channels is null");
         requireNonNull(pagesHashStrategy, "pagesHashStrategy is null");
 
         PositionLinks.FactoryBuilder positionLinksFactoryBuilder;

--- a/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
@@ -79,7 +79,7 @@ public class MergeOperator
             this.outputTypes = mappedCopy(outputChannels, types::get);
             this.sortChannels = requireNonNull(sortChannels, "sortChannels is null");
             this.sortOrder = requireNonNull(sortOrder, "sortOrder is null");
-            this.orderingCompiler = requireNonNull(orderingCompiler, "mergeSortComparatorFactory is null");
+            this.orderingCompiler = requireNonNull(orderingCompiler, "orderingCompiler is null");
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -443,7 +443,7 @@ public class OperatorContext
 
     public void setInfoSupplier(Supplier<OperatorInfo> infoSupplier)
     {
-        requireNonNull(infoSupplier, "infoProvider is null");
+        requireNonNull(infoSupplier, "infoSupplier is null");
         this.infoSupplier.set(infoSupplier);
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
@@ -170,7 +170,7 @@ public class OperatorStats
 
         this.dynamicFilterSplitsProcessed = dynamicFilterSplitsProcessed;
 
-        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "writtenDataSize is null");
+        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "physicalWrittenDataSize is null");
 
         this.blockedWall = requireNonNull(blockedWall, "blockedWall is null");
 

--- a/core/trino-main/src/main/java/io/trino/operator/PagesRTreeIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesRTreeIndex.java
@@ -114,7 +114,7 @@ public class PagesRTreeIndex
         this.channels = requireNonNull(channels, "channels is null");
         this.rtree = requireNonNull(rtree, "rtree is null");
         this.radiusChannel = radiusChannel.orElse(-1);
-        this.spatialRelationshipTest = requireNonNull(spatialRelationshipTest, "spatial relationship is null");
+        this.spatialRelationshipTest = requireNonNull(spatialRelationshipTest, "spatialRelationshipTest is null");
         this.filterFunction = filterFunctionFactory.map(factory -> factory.create(session.toConnectorSession(), addresses, channelsToPages(channels))).orElse(null);
         this.partitions = requireNonNull(partitions, "partitions is null");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/PipelineStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PipelineStats.java
@@ -197,7 +197,7 @@ public class PipelineStats
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
 
-        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "writtenDataSize is null");
+        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "physicalWrittenDataSize is null");
 
         this.operatorSummaries = ImmutableList.copyOf(requireNonNull(operatorSummaries, "operatorSummaries is null"));
         this.drivers = ImmutableList.copyOf(requireNonNull(drivers, "drivers is null"));

--- a/core/trino-main/src/main/java/io/trino/operator/SetBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SetBuilderOperator.java
@@ -144,7 +144,7 @@ public class SetBuilderOperator
             BlockTypeOperators blockTypeOperators)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.setSupplier = requireNonNull(setSupplier, "setProvider is null");
+        this.setSupplier = requireNonNull(setSupplier, "setSupplier is null");
 
         if (requireNonNull(hashChannel, "hashChannel is null").isPresent()) {
             this.sourceChannels = new int[] {setChannel, hashChannel.get()};

--- a/core/trino-main/src/main/java/io/trino/operator/StageExecutionDescriptor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/StageExecutionDescriptor.java
@@ -97,7 +97,7 @@ public class StageExecutionDescriptor
     {
         return new StageExecutionDescriptor(
                 requireNonNull(strategy, "strategy is null"),
-                ImmutableSet.copyOf(requireNonNull(groupedExecutionCapableScanNodes, "groupedExecutionScanNodes is null")));
+                ImmutableSet.copyOf(requireNonNull(groupedExecutionCapableScanNodes, "groupedExecutionCapableScanNodes is null")));
     }
 
     @JsonProperty("groupedExecutionScanNodes")

--- a/core/trino-main/src/main/java/io/trino/operator/TableFinishOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableFinishOperator.java
@@ -125,7 +125,7 @@ public class TableFinishOperator
             boolean statisticsCpuTimerEnabled)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.tableFinisher = requireNonNull(tableFinisher, "tableCommitter is null");
+        this.tableFinisher = requireNonNull(tableFinisher, "tableFinisher is null");
         this.statisticsAggregationOperator = requireNonNull(statisticsAggregationOperator, "statisticsAggregationOperator is null");
         this.descriptor = requireNonNull(descriptor, "descriptor is null");
         this.statisticsCpuTimerEnabled = statisticsCpuTimerEnabled;

--- a/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
@@ -236,7 +236,7 @@ public class TaskStats
         checkArgument(outputPositions >= 0, "outputPositions is negative");
         this.outputPositions = outputPositions;
 
-        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "writtenDataSize is null");
+        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "physicalWrittenDataSize is null");
 
         checkArgument(fullGcCount >= 0, "fullGcCount is negative");
         this.fullGcCount = fullGcCount;

--- a/core/trino-main/src/main/java/io/trino/operator/WindowFunctionDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowFunctionDefinition.java
@@ -50,7 +50,7 @@ public class WindowFunctionDefinition
         requireNonNull(type, "type is null");
         requireNonNull(frameInfo, "frameInfo is null");
         requireNonNull(lambdaProviders, "lambdaProviders is null");
-        requireNonNull(argumentChannels, "inputs is null");
+        requireNonNull(argumentChannels, "argumentChannels is null");
 
         this.functionSupplier = functionSupplier;
         this.type = type;

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationMetadata.java
@@ -83,7 +83,7 @@ public class AggregationMetadata
             Type outputType,
             List<Class<?>> lambdaInterfaces)
     {
-        this.outputType = requireNonNull(outputType);
+        this.outputType = requireNonNull(outputType, "outputType is null");
         this.valueInputMetadata = ImmutableList.copyOf(requireNonNull(valueInputMetadata, "valueInputMetadata is null"));
         this.name = requireNonNull(name, "name is null");
         this.inputFunction = requireNonNull(inputFunction, "inputFunction is null");

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/QuantileDigestAndPercentileStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/QuantileDigestAndPercentileStateFactory.java
@@ -73,7 +73,7 @@ public class QuantileDigestAndPercentileStateFactory
         @Override
         public void setDigest(QuantileDigest digest)
         {
-            requireNonNull(digest, "value is null");
+            requireNonNull(digest, "digest is null");
             digests.set(getGroupId(), digest);
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestAndPercentileStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/TDigestAndPercentileStateFactory.java
@@ -73,7 +73,7 @@ public class TDigestAndPercentileStateFactory
         @Override
         public void setDigest(TDigest digest)
         {
-            requireNonNull(digest, "value is null");
+            requireNonNull(digest, "digest is null");
             digests.set(getGroupId(), digest);
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchange.java
@@ -382,7 +382,7 @@ public class LocalExchange
             this.nodePartitioningManager = requireNonNull(nodePartitioningManager, "nodePartitioningManager is null");
             this.session = requireNonNull(session, "session is null");
             this.partitioning = requireNonNull(partitioning, "partitioning is null");
-            this.partitionChannels = requireNonNull(partitionChannels, "partitioningChannels is null");
+            this.partitionChannels = requireNonNull(partitionChannels, "partitionChannels is null");
             requireNonNull(types, "types is null");
             this.partitionChannelTypes = partitionChannels.stream()
                     .map(types::get)

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalMergeSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalMergeSourceOperator.java
@@ -62,7 +62,7 @@ public class LocalMergeSourceOperator
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
-            this.localExchangeFactory = requireNonNull(localExchangeFactory, "exchange is null");
+            this.localExchangeFactory = requireNonNull(localExchangeFactory, "localExchangeFactory is null");
             this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
             this.orderingCompiler = requireNonNull(orderingCompiler, "orderingCompiler is null");
             this.sortChannels = ImmutableList.copyOf(requireNonNull(sortChannels, "sortChannels is null"));

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ParametricScalarImplementation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/annotations/ParametricScalarImplementation.java
@@ -117,7 +117,7 @@ public class ParametricScalarImplementation
         this.specializedTypeParameters = ImmutableMap.copyOf(requireNonNull(specializedTypeParameters, "specializedTypeParameters is null"));
         this.choices = requireNonNull(choices, "choices is null");
         checkArgument(!choices.isEmpty(), "choices is empty");
-        this.returnNativeContainerType = requireNonNull(returnContainerType, "return native container type is null");
+        this.returnNativeContainerType = requireNonNull(returnContainerType, "returnContainerType is null");
 
         for (Class<?> specializedJavaType : specializedTypeParameters.values()) {
             checkArgument(!Primitives.isWrapperType(specializedJavaType), "specializedTypeParameter must not contain boxed primitive types");
@@ -321,7 +321,7 @@ public class ParametricScalarImplementation
             this.argumentNativeContainerTypes = ImmutableList.copyOf(requireNonNull(argumentNativeContainerTypes, "argumentNativeContainerTypes is null"));
             this.specializedTypeParameters = ImmutableMap.copyOf(requireNonNull(specializedTypeParameters, "specializedTypeParameters is null"));
             this.choices = new ArrayList<>();
-            this.returnNativeContainerType = requireNonNull(returnNativeContainerType, "return native container type is null");
+            this.returnNativeContainerType = requireNonNull(returnNativeContainerType, "returnNativeContainerType is null");
         }
 
         void addChoice(ParametricScalarImplementationChoice choice)

--- a/core/trino-main/src/main/java/io/trino/operator/window/AbstractWindowFunctionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/AbstractWindowFunctionSupplier.java
@@ -58,7 +58,7 @@ public abstract class AbstractWindowFunctionSupplier
     @Override
     public final WindowFunction createWindowFunction(List<Integer> argumentChannels, boolean ignoreNulls, List<LambdaProvider> lambdaProviders)
     {
-        requireNonNull(argumentChannels, "inputs is null");
+        requireNonNull(argumentChannels, "argumentChannels is null");
 
         long argumentCount = signature.getArgumentTypes().stream()
                 .filter(type -> !type.getBase().equalsIgnoreCase(FunctionType.NAME))

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -658,7 +658,7 @@ public class AccessControlManager
     public void checkCanSetViewAuthorization(SecurityContext securityContext, QualifiedObjectName viewName, TrinoPrincipal principal)
     {
         requireNonNull(securityContext, "securityContext is null");
-        requireNonNull(viewName, "tableName is null");
+        requireNonNull(viewName, "viewName is null");
         requireNonNull(principal, "principal is null");
 
         checkCanAccessCatalog(securityContext, viewName.getCatalogName());
@@ -867,7 +867,7 @@ public class AccessControlManager
     {
         requireNonNull(securityContext, "securityContext is null");
         requireNonNull(role, "role is null");
-        requireNonNull(catalogName, "catalog is null");
+        requireNonNull(catalogName, "catalogName is null");
 
         checkCanAccessCatalog(securityContext, catalogName);
 
@@ -946,8 +946,8 @@ public class AccessControlManager
     @Override
     public List<ViewExpression> getRowFilters(SecurityContext context, QualifiedObjectName tableName)
     {
-        requireNonNull(context, "securityContext is null");
-        requireNonNull(tableName, "catalogName is null");
+        requireNonNull(context, "context is null");
+        requireNonNull(tableName, "tableName is null");
 
         ImmutableList.Builder<ViewExpression> filters = ImmutableList.builder();
         CatalogAccessControlEntry entry = getConnectorAccessControl(context.getTransactionId(), tableName.getCatalogName());
@@ -968,8 +968,8 @@ public class AccessControlManager
     @Override
     public List<ViewExpression> getColumnMasks(SecurityContext context, QualifiedObjectName tableName, String columnName, Type type)
     {
-        requireNonNull(context, "securityContext is null");
-        requireNonNull(tableName, "catalogName is null");
+        requireNonNull(context, "context is null");
+        requireNonNull(tableName, "tableName is null");
 
         ImmutableList.Builder<ViewExpression> masks = ImmutableList.builder();
 

--- a/core/trino-main/src/main/java/io/trino/server/BasicQueryStats.java
+++ b/core/trino-main/src/main/java/io/trino/server/BasicQueryStats.java
@@ -108,7 +108,7 @@ public class BasicQueryStats
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
         this.completedDrivers = completedDrivers;
 
-        this.rawInputDataSize = requireNonNull(rawInputDataSize);
+        this.rawInputDataSize = requireNonNull(rawInputDataSize, "rawInputDataSize is null");
         this.rawInputPositions = rawInputPositions;
         this.physicalInputDataSize = physicalInputDataSize;
 

--- a/core/trino-main/src/main/java/io/trino/server/TaskUpdateRequest.java
+++ b/core/trino-main/src/main/java/io/trino/server/TaskUpdateRequest.java
@@ -49,7 +49,7 @@ public class TaskUpdateRequest
             @JsonProperty("totalPartitions") OptionalInt totalPartitions)
     {
         requireNonNull(session, "session is null");
-        requireNonNull(extraCredentials, "credentials is null");
+        requireNonNull(extraCredentials, "extraCredentials is null");
         requireNonNull(fragment, "fragment is null");
         requireNonNull(sources, "sources is null");
         requireNonNull(outputIds, "outputIds is null");

--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -221,7 +221,7 @@ class Query
         requireNonNull(exchangeClient, "exchangeClient is null");
         requireNonNull(resultsProcessorExecutor, "resultsProcessorExecutor is null");
         requireNonNull(timeoutExecutor, "timeoutExecutor is null");
-        requireNonNull(blockEncodingSerde, "serde is null");
+        requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
 
         this.queryManager = queryManager;
 

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchange.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchange.java
@@ -109,7 +109,7 @@ public class OAuth2TokenExchange
 
         static TokenPoll error(String error)
         {
-            requireNonNull(error, "token is null");
+            requireNonNull(error, "error is null");
 
             return new TokenPoll(null, error);
         }

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchangeResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2TokenExchangeResource.java
@@ -61,7 +61,7 @@ public class OAuth2TokenExchangeResource
     public OAuth2TokenExchangeResource(OAuth2TokenExchange tokenExchange, DispatchExecutor executor)
     {
         this.tokenExchange = requireNonNull(tokenExchange, "tokenExchange is null");
-        this.responseExecutor = requireNonNull(executor, "responseExecutor is null").getExecutor();
+        this.responseExecutor = requireNonNull(executor, "executor is null").getExecutor();
     }
 
     @ResourceSecurity(PUBLIC)

--- a/core/trino-main/src/main/java/io/trino/split/SampledSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/SampledSplitSource.java
@@ -35,7 +35,7 @@ public class SampledSplitSource
 
     public SampledSplitSource(SplitSource splitSource, double sampleRatio)
     {
-        this.splitSource = requireNonNull(splitSource, "dataSource is null");
+        this.splitSource = requireNonNull(splitSource, "splitSource is null");
         this.sampleRatio = sampleRatio;
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -198,7 +198,7 @@ public class Analysis
     public Analysis(@Nullable Statement root, Map<NodeRef<Parameter>, Expression> parameters, boolean isDescribe)
     {
         this.root = root;
-        this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameterMap is null"));
+        this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
         this.isDescribe = isDescribe;
     }
 
@@ -770,7 +770,7 @@ public class Analysis
 
     public void registerTableForView(Table tableReference)
     {
-        tablesForView.push(requireNonNull(tableReference, "table is null"));
+        tablesForView.push(requireNonNull(tableReference, "tableReference is null"));
     }
 
     public void unregisterTableForView()
@@ -1106,7 +1106,7 @@ public class Analysis
 
         public RefreshMaterializedViewAnalysis(QualifiedObjectName materializedViewName, TableHandle target, Query query, List<ColumnHandle> columns)
         {
-            this.materializedViewName = requireNonNull(materializedViewName, "Materialized view handle is null");
+            this.materializedViewName = requireNonNull(materializedViewName, "materializedViewName is null");
             this.target = requireNonNull(target, "target is null");
             this.query = query;
             this.columns = requireNonNull(columns, "columns is null");

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
@@ -71,7 +71,7 @@ public class Analyzer
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
-        this.queryExplainer = requireNonNull(queryExplainer, "query explainer is null");
+        this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
         this.parameters = parameters;
         this.parameterLookup = parameterLookup;
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalysis.java
@@ -57,7 +57,7 @@ public class ExpressionAnalysis
         this.typeOnlyCoercions = ImmutableSet.copyOf(requireNonNull(typeOnlyCoercions, "typeOnlyCoercions is null"));
         this.columnReferences = ImmutableMap.copyOf(requireNonNull(columnReferences, "columnReferences is null"));
         this.subqueryInPredicates = ImmutableSet.copyOf(requireNonNull(subqueryInPredicates, "subqueryInPredicates is null"));
-        this.scalarSubqueries = ImmutableSet.copyOf(requireNonNull(scalarSubqueries, "subqueryInPredicates is null"));
+        this.scalarSubqueries = ImmutableSet.copyOf(requireNonNull(scalarSubqueries, "scalarSubqueries is null"));
         this.existsSubqueries = ImmutableSet.copyOf(requireNonNull(existsSubqueries, "existsSubqueries is null"));
         this.quantifiedComparisons = ImmutableSet.copyOf(requireNonNull(quantifiedComparisons, "quantifiedComparisons is null"));
         this.windowFunctions = ImmutableSet.copyOf(requireNonNull(windowFunctions, "windowFunctions is null"));

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -275,11 +275,11 @@ public class ExpressionAnalyzer
         this.statementAnalyzerFactory = requireNonNull(statementAnalyzerFactory, "statementAnalyzerFactory is null");
         this.session = requireNonNull(session, "session is null");
         this.symbolTypes = requireNonNull(symbolTypes, "symbolTypes is null");
-        this.parameters = requireNonNull(parameters, "parameterMap is null");
+        this.parameters = requireNonNull(parameters, "parameters is null");
         this.isDescribe = isDescribe;
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
         this.typeCoercion = new TypeCoercion(metadata::getType);
-        this.correlationSupport = requireNonNull(correlationSupport, "correlation is null");
+        this.correlationSupport = requireNonNull(correlationSupport, "correlationSupport is null");
         this.getPreanalyzedType = requireNonNull(getPreanalyzedType, "getPreanalyzedType is null");
         this.getResolvedWindow = requireNonNull(getResolvedWindow, "getResolvedWindow is null");
     }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Scope.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Scope.java
@@ -387,7 +387,7 @@ public class Scope
 
         public AsteriskedIdentifierChainBasis(BasisType basisType, Optional<Scope> scope, Optional<RelationType> relationType)
         {
-            this.basisType = requireNonNull(basisType, "type is null");
+            this.basisType = requireNonNull(basisType, "basisType is null");
             this.scope = requireNonNull(scope, "scope is null");
             this.relationType = requireNonNull(relationType, "relationType is null");
             checkArgument(basisType == FIELD || scope.isPresent(), "missing scope");

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -308,7 +308,7 @@ class StatementAnalyzer
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.session = requireNonNull(session, "session is null");
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
-        this.correlationSupport = requireNonNull(correlationSupport, "correlationAllowed is null");
+        this.correlationSupport = requireNonNull(correlationSupport, "correlationSupport is null");
     }
 
     public Scope analyze(Node node, Scope outerQueryScope)

--- a/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeGeneratorContext.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/BytecodeGeneratorContext.java
@@ -48,7 +48,7 @@ public class BytecodeGeneratorContext
             CachedInstanceBinder cachedInstanceBinder,
             Metadata metadata)
     {
-        requireNonNull(rowExpressionCompiler, "bytecodeGenerator is null");
+        requireNonNull(rowExpressionCompiler, "rowExpressionCompiler is null");
         requireNonNull(cachedInstanceBinder, "cachedInstanceBinder is null");
         requireNonNull(scope, "scope is null");
         requireNonNull(callSiteBinder, "callSiteBinder is null");

--- a/core/trino-main/src/main/java/io/trino/sql/gen/LambdaBytecodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/LambdaBytecodeGenerator.java
@@ -370,9 +370,9 @@ public final class LambdaBytecodeGenerator
                 ParameterizedType returnType,
                 List<ParameterizedType> parameterTypes)
         {
-            this.lambdaAsmHandle = requireNonNull(lambdaAsmHandle, "lambdaMethodAsmHandle is null");
+            this.lambdaAsmHandle = requireNonNull(lambdaAsmHandle, "lambdaAsmHandle is null");
             this.returnType = requireNonNull(returnType, "returnType is null");
-            this.parameterTypes = ImmutableList.copyOf(requireNonNull(parameterTypes, "returnType is null"));
+            this.parameterTypes = ImmutableList.copyOf(requireNonNull(parameterTypes, "parameterTypes is null"));
         }
 
         public Handle getLambdaAsmHandle()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -1048,7 +1048,7 @@ public final class DomainTranslator
 
         public NormalizedSimpleComparison(Expression symbolExpression, ComparisonExpression.Operator comparisonOperator, NullableValue value)
         {
-            this.symbolExpression = requireNonNull(symbolExpression, "nameReference is null");
+            this.symbolExpression = requireNonNull(symbolExpression, "symbolExpression is null");
             this.comparisonOperator = requireNonNull(comparisonOperator, "comparisonOperator is null");
             this.value = requireNonNull(value, "value is null");
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -369,9 +369,9 @@ public class LocalExecutionPlanner
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
         this.pageSinkManager = requireNonNull(pageSinkManager, "pageSinkManager is null");
-        this.expressionCompiler = requireNonNull(expressionCompiler, "compiler is null");
+        this.expressionCompiler = requireNonNull(expressionCompiler, "expressionCompiler is null");
         this.pageFunctionCompiler = requireNonNull(pageFunctionCompiler, "pageFunctionCompiler is null");
-        this.joinFilterFunctionCompiler = requireNonNull(joinFilterFunctionCompiler, "compiler is null");
+        this.joinFilterFunctionCompiler = requireNonNull(joinFilterFunctionCompiler, "joinFilterFunctionCompiler is null");
         this.indexJoinLookupStats = requireNonNull(indexJoinLookupStats, "indexJoinLookupStats is null");
         this.maxIndexMemorySize = requireNonNull(taskManagerConfig, "taskManagerConfig is null").getMaxIndexMemoryUsage();
         this.spillerFactory = requireNonNull(spillerFactory, "spillerFactory is null");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ParameterRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ParameterRewriter.java
@@ -36,7 +36,7 @@ public class ParameterRewriter
 
     public ParameterRewriter(Map<NodeRef<Parameter>, Expression> parameters)
     {
-        requireNonNull(parameters, "parameterMap is null");
+        requireNonNull(parameters, "parameters is null");
         this.parameters = parameters;
         this.analysis = null;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PartialTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PartialTranslator.java
@@ -42,7 +42,7 @@ public final class PartialTranslator
             TypeAnalyzer typeAnalyzer,
             TypeProvider typeProvider)
     {
-        requireNonNull(inputExpression, "expressions is null");
+        requireNonNull(inputExpression, "inputExpression is null");
         requireNonNull(session, "session is null");
         requireNonNull(typeAnalyzer, "typeAnalyzer is null");
         requireNonNull(typeProvider, "typeProvider is null");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlan.java
@@ -45,7 +45,7 @@ class RelationPlan
     public RelationPlan(PlanNode root, Scope scope, List<Symbol> fieldMappings, Optional<TranslationMap> outerContext)
     {
         requireNonNull(root, "root is null");
-        requireNonNull(fieldMappings, "outputSymbols is null");
+        requireNonNull(fieldMappings, "fieldMappings is null");
         requireNonNull(scope, "scope is null");
         requireNonNull(outerContext, "outerContext is null");
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/StageExecutionPlan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/StageExecutionPlan.java
@@ -42,8 +42,8 @@ public class StageExecutionPlan
             List<StageExecutionPlan> subStages, Map<PlanNodeId, TableInfo> tables)
     {
         this.fragment = requireNonNull(fragment, "fragment is null");
-        this.splitSources = requireNonNull(splitSources, "dataSource is null");
-        this.subStages = ImmutableList.copyOf(requireNonNull(subStages, "dependencies is null"));
+        this.splitSources = requireNonNull(splitSources, "splitSources is null");
+        this.subStages = ImmutableList.copyOf(requireNonNull(subStages, "subStages is null"));
 
         fieldNames = (fragment.getRoot() instanceof OutputNode) ?
                 Optional.of(ImmutableList.copyOf(((OutputNode) fragment.getRoot()).getColumnNames())) :

--- a/core/trino-main/src/main/java/io/trino/sql/planner/StatisticsAggregationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/StatisticsAggregationPlanner.java
@@ -150,7 +150,7 @@ public class StatisticsAggregationPlanner
                 StatisticAggregations aggregations,
                 StatisticAggregationsDescriptor<Symbol> descriptor)
         {
-            this.aggregations = requireNonNull(aggregations, "statisticAggregations is null");
+            this.aggregations = requireNonNull(aggregations, "aggregations is null");
             this.descriptor = requireNonNull(descriptor, "descriptor is null");
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SymbolAllocator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SymbolAllocator.java
@@ -69,7 +69,7 @@ public class SymbolAllocator
 
     public Symbol newSymbol(String nameHint, Type type, String suffix)
     {
-        requireNonNull(nameHint, "name is null");
+        requireNonNull(nameHint, "nameHint is null");
         requireNonNull(type, "type is null");
 
         // TODO: workaround for the fact that QualifiedName lowercases parts

--- a/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/TranslationMap.java
@@ -86,7 +86,7 @@ class TranslationMap
         this.outerContext = requireNonNull(outerContext, "outerContext is null");
         this.scope = requireNonNull(scope, "scope is null");
         this.analysis = requireNonNull(analysis, "analysis is null");
-        this.lambdaArguments = requireNonNull(lambdaArguments, "lambdaDeclarationToSymbolMap is null");
+        this.lambdaArguments = requireNonNull(lambdaArguments, "lambdaArguments is null");
 
         requireNonNull(fieldSymbols, "fieldSymbols is null");
         this.fieldSymbols = fieldSymbols.clone();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationNodeTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationNodeTranslator.java
@@ -66,7 +66,7 @@ public class SetOperationNodeTranslator
     public SetOperationNodeTranslator(Metadata metadata, SymbolAllocator symbolAllocator, PlanNodeIdAllocator idAllocator)
     {
         this.symbolAllocator = requireNonNull(symbolAllocator, "SymbolAllocator is null");
-        this.idAllocator = requireNonNull(idAllocator, "PlanNodeIdAllocator is null");
+        this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
         requireNonNull(metadata, "metadata is null");
         this.countFunction = metadata.resolveFunction(QualifiedName.of("count"), fromTypes(BOOLEAN));
         this.rowNumberFunction = metadata.resolveFunction(QualifiedName.of("row_number"), ImmutableList.of());
@@ -232,7 +232,7 @@ public class SetOperationNodeTranslator
 
         public TranslationResult(PlanNode planNode, List<Symbol> countSymbols, Optional<Symbol> rowNumberSymbol)
         {
-            this.planNode = requireNonNull(planNode, "AggregationNode is null");
+            this.planNode = requireNonNull(planNode, "planNode is null");
             this.countSymbols = ImmutableList.copyOf(requireNonNull(countSymbols, "countSymbols is null"));
             this.rowNumberSymbol = requireNonNull(rowNumberSymbol, "rowNumberSymbol is null");
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -839,7 +839,7 @@ public class AddLocalExchanges
         public PlanWithProperties(PlanNode node, StreamProperties properties)
         {
             this.node = requireNonNull(node, "node is null");
-            this.properties = requireNonNull(properties, "StreamProperties is null");
+            this.properties = requireNonNull(properties, "properties is null");
         }
 
         public PlanNode getNode()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeSearcher.java
@@ -65,7 +65,7 @@ public class PlanNodeSearcher
 
     public PlanNodeSearcher recurseOnlyWhen(Predicate<PlanNode> skipOnly)
     {
-        this.recurseOnlyWhen = requireNonNull(skipOnly, "recurseOnlyWhen is null");
+        this.recurseOnlyWhen = requireNonNull(skipOnly, "skipOnly is null");
         return this;
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PreferredProperties.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PreferredProperties.java
@@ -310,7 +310,7 @@ class PreferredProperties
         private PartitioningProperties(Set<Symbol> partitioningColumns, Optional<Partitioning> partitioning, boolean nullsAndAnyReplicated)
         {
             this.partitioningColumns = ImmutableSet.copyOf(requireNonNull(partitioningColumns, "partitioningColumns is null"));
-            this.partitioning = requireNonNull(partitioning, "function is null");
+            this.partitioning = requireNonNull(partitioning, "partitioning is null");
             this.nullsAndAnyReplicated = nullsAndAnyReplicated;
 
             checkArgument(partitioning.isEmpty() || partitioning.get().getColumns().equals(partitioningColumns), "Partitioning input must match partitioningColumns");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -654,7 +654,7 @@ public final class StreamPropertyDerivations
         {
             this.distribution = requireNonNull(distribution, "distribution is null");
 
-            this.partitioningColumns = requireNonNull(partitioningColumns, "partitioningProperties is null")
+            this.partitioningColumns = requireNonNull(partitioningColumns, "partitioningColumns is null")
                     .map(ImmutableList::copyOf);
 
             checkArgument(distribution != SINGLE || this.partitioningColumns.equals(Optional.of(ImmutableList.of())),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/AggregationNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/AggregationNode.java
@@ -385,7 +385,7 @@ public class AggregationNode
                 @JsonProperty("orderingScheme") Optional<OrderingScheme> orderingScheme,
                 @JsonProperty("mask") Optional<Symbol> mask)
         {
-            this.resolvedFunction = requireNonNull(resolvedFunction, "signature is null");
+            this.resolvedFunction = requireNonNull(resolvedFunction, "resolvedFunction is null");
             this.arguments = ImmutableList.copyOf(requireNonNull(arguments, "arguments is null"));
             for (Expression argument : arguments) {
                 checkArgument(argument instanceof SymbolReference || argument instanceof LambdaExpression,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/ApplyNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/ApplyNode.java
@@ -80,8 +80,8 @@ public class ApplyNode
     {
         super(id);
         requireNonNull(input, "input is null");
-        requireNonNull(subquery, "right is null");
-        requireNonNull(subqueryAssignments, "assignments is null");
+        requireNonNull(subquery, "subquery is null");
+        requireNonNull(subqueryAssignments, "subqueryAssignments is null");
         requireNonNull(correlation, "correlation is null");
         requireNonNull(originSubquery, "originSubquery is null");
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/AssignUniqueId.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/AssignUniqueId.java
@@ -34,11 +34,11 @@ public class AssignUniqueId
     public AssignUniqueId(
             @JsonProperty("id") PlanNodeId id,
             @JsonProperty("source") PlanNode source,
-            @JsonProperty("idColumn") Symbol unique)
+            @JsonProperty("idColumn") Symbol idColumn)
     {
         super(id);
         this.source = requireNonNull(source, "source is null");
-        this.idColumn = requireNonNull(unique, "idColumn is null");
+        this.idColumn = requireNonNull(idColumn, "idColumn is null");
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/CorrelatedJoinNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/CorrelatedJoinNode.java
@@ -104,7 +104,7 @@ public class CorrelatedJoinNode
     {
         super(id);
         requireNonNull(input, "input is null");
-        requireNonNull(subquery, "right is null");
+        requireNonNull(subquery, "subquery is null");
         requireNonNull(correlation, "correlation is null");
         requireNonNull(filter, "filter is null");
         requireNonNull(originSubquery, "originSubquery is null");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/GroupIdNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/GroupIdNode.java
@@ -61,7 +61,7 @@ public class GroupIdNode
             @JsonProperty("groupIdSymbol") Symbol groupIdSymbol)
     {
         super(id);
-        this.source = requireNonNull(source);
+        this.source = requireNonNull(source, "source is null");
         this.groupingSets = listOfListsCopy(requireNonNull(groupingSets, "groupingSets is null"));
         this.groupingColumns = ImmutableMap.copyOf(requireNonNull(groupingColumns));
         this.aggregationArguments = ImmutableList.copyOf(aggregationArguments);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/SampleNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/SampleNode.java
@@ -64,7 +64,7 @@ public class SampleNode
         checkArgument(sampleRatio >= 0.0, "sample ratio must be greater than or equal to 0");
         checkArgument((sampleRatio <= 1.0), "sample ratio must be less than or equal to 1");
 
-        this.sampleType = requireNonNull(sampleType, "sample type is null");
+        this.sampleType = requireNonNull(sampleType, "sampleType is null");
         this.source = requireNonNull(source, "source is null");
         this.sampleRatio = sampleRatio;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableScanNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableScanNode.java
@@ -100,7 +100,7 @@ public class TableScanNode
         checkArgument(assignments.keySet().containsAll(outputs), "assignments does not cover all of outputs");
         this.enforcedConstraint = requireNonNull(enforcedConstraint, "enforcedConstraint is null");
         this.updateTarget = updateTarget;
-        this.useConnectorNodePartitioning = requireNonNull(useConnectorNodePartitioning, "useTableNodePartitioning is null");
+        this.useConnectorNodePartitioning = requireNonNull(useConnectorNodePartitioning, "useConnectorNodePartitioning is null");
     }
 
     @JsonProperty("table")

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
@@ -85,7 +85,7 @@ public class TableWriterNode
         this.fragmentSymbol = requireNonNull(fragmentSymbol, "fragmentSymbol is null");
         this.columns = ImmutableList.copyOf(columns);
         this.columnNames = ImmutableList.copyOf(columnNames);
-        this.notNullColumnSymbols = ImmutableSet.copyOf(requireNonNull(notNullColumnSymbols, "notNullColumns is null"));
+        this.notNullColumnSymbols = ImmutableSet.copyOf(requireNonNull(notNullColumnSymbols, "notNullColumnSymbols is null"));
         this.partitioningScheme = requireNonNull(partitioningScheme, "partitioningScheme is null");
         this.preferredPartitioningScheme = requireNonNull(preferredPartitioningScheme, "preferredPartitioningScheme is null");
         this.statisticsAggregation = requireNonNull(statisticsAggregation, "statisticsAggregation is null");
@@ -351,8 +351,8 @@ public class TableWriterNode
 
         public RefreshMaterializedViewReference(QualifiedObjectName materializedViewName, TableHandle storageTableHandle, List<TableHandle> sourceTableHandles)
         {
-            this.materializedViewName = requireNonNull(materializedViewName, "Materialized view handle is null");
-            this.storageTableHandle = requireNonNull(storageTableHandle, "Storage table handle is null");
+            this.materializedViewName = requireNonNull(materializedViewName, "materializedViewName is null");
+            this.storageTableHandle = requireNonNull(storageTableHandle, "storageTableHandle is null");
             this.sourceTableHandles = ImmutableList.copyOf(sourceTableHandles);
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/UnnestNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/UnnestNode.java
@@ -63,7 +63,7 @@ public class UnnestNode
         checkArgument(!mappings.isEmpty(), "mappings is empty");
         this.mappings = ImmutableList.copyOf(mappings);
         this.ordinalitySymbol = requireNonNull(ordinalitySymbol, "ordinalitySymbol is null");
-        this.joinType = requireNonNull(joinType, "type is null");
+        this.joinType = requireNonNull(joinType, "joinType is null");
         this.filter = requireNonNull(filter, "filter is null");
         if (filter.isPresent()) {
             Set<Symbol> outputs = ImmutableSet.copyOf(getOutputSymbols());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/JsonRenderer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/JsonRenderer.java
@@ -70,7 +70,7 @@ public class JsonRenderer
             this.identifier = requireNonNull(identifier, "identifier is null");
             this.details = requireNonNull(details, "details is null");
             this.children = requireNonNull(children, "children is null");
-            this.remoteSources = requireNonNull(remoteSources, "id is null");
+            this.remoteSources = requireNonNull(remoteSources, "remoteSources is null");
         }
 
         @JsonProperty

--- a/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
@@ -140,7 +140,7 @@ public final class SqlToRowExpressionTranslator
         Visitor visitor = new Visitor(metadata, types, layout);
         RowExpression result = visitor.process(expression, null);
 
-        requireNonNull(result, "translated expression is null");
+        requireNonNull(result, "result is null");
 
         if (optimize) {
             ExpressionOptimizer optimizer = new ExpressionOptimizer(metadata, session);

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ExplainRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ExplainRewrite.java
@@ -81,7 +81,7 @@ final class ExplainRewrite
                 WarningCollector warningCollector)
         {
             this.session = requireNonNull(session, "session is null");
-            this.queryPreparer = new QueryPreparer(requireNonNull(parser, "queryPreparer is null"));
+            this.queryPreparer = new QueryPreparer(requireNonNull(parser, "parser is null"));
             this.queryExplainer = requireNonNull(queryExplainer, "queryExplainer is null");
             this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
         }

--- a/core/trino-main/src/main/java/io/trino/transaction/TransactionInfo.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/TransactionInfo.java
@@ -51,7 +51,7 @@ public class TransactionInfo
         this.autoCommitContext = autoCommitContext;
         this.createTime = requireNonNull(createTime, "createTime is null");
         this.idleTime = requireNonNull(idleTime, "idleTime is null");
-        this.catalogNames = ImmutableList.copyOf(requireNonNull(catalogNames, "connectorIds is null"));
+        this.catalogNames = ImmutableList.copyOf(requireNonNull(catalogNames, "catalogNames is null"));
         this.writtenConnectorId = requireNonNull(writtenConnectorId, "writtenConnectorId is null");
     }
 

--- a/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/block/BlockAssertions.java
@@ -92,7 +92,7 @@ public final class BlockAssertions
 
     public static Block createStringsBlock(String... values)
     {
-        requireNonNull(values, "varargs 'values' is null");
+        requireNonNull(values, "values is null");
 
         return createStringsBlock(Arrays.asList(values));
     }
@@ -115,7 +115,7 @@ public final class BlockAssertions
 
     public static Block createSlicesBlock(Slice... values)
     {
-        requireNonNull(values, "varargs 'values' is null");
+        requireNonNull(values, "values is null");
         return createSlicesBlock(Arrays.asList(values));
     }
 
@@ -181,7 +181,7 @@ public final class BlockAssertions
 
     public static Block createBooleansBlock(Boolean... values)
     {
-        requireNonNull(values, "varargs 'values' is null");
+        requireNonNull(values, "values is null");
 
         return createBooleansBlock(Arrays.asList(values));
     }
@@ -209,7 +209,7 @@ public final class BlockAssertions
 
     public static Block createShortDecimalsBlock(String... values)
     {
-        requireNonNull(values, "varargs 'values' is null");
+        requireNonNull(values, "values is null");
 
         return createShortDecimalsBlock(Arrays.asList(values));
     }
@@ -233,7 +233,7 @@ public final class BlockAssertions
 
     public static Block createLongDecimalsBlock(String... values)
     {
-        requireNonNull(values, "varargs 'values' is null");
+        requireNonNull(values, "values is null");
 
         return createLongDecimalsBlock(Arrays.asList(values));
     }
@@ -257,7 +257,7 @@ public final class BlockAssertions
 
     public static Block createIntsBlock(Integer... values)
     {
-        requireNonNull(values, "varargs 'values' is null");
+        requireNonNull(values, "values is null");
 
         return createIntsBlock(Arrays.asList(values));
     }
@@ -343,7 +343,7 @@ public final class BlockAssertions
 
     public static Block createLongsBlock(Long... values)
     {
-        requireNonNull(values, "varargs 'values' is null");
+        requireNonNull(values, "values is null");
 
         return createLongsBlock(Arrays.asList(values));
     }
@@ -436,7 +436,7 @@ public final class BlockAssertions
 
     public static Block createBlockOfReals(Float... values)
     {
-        requireNonNull(values, "varargs 'values' is null");
+        requireNonNull(values, "values is null");
 
         return createBlockOfReals(Arrays.asList(values));
     }
@@ -468,7 +468,7 @@ public final class BlockAssertions
 
     public static Block createDoublesBlock(Double... values)
     {
-        requireNonNull(values, "varargs 'values' is null");
+        requireNonNull(values, "values is null");
 
         return createDoublesBlock(Arrays.asList(values));
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
@@ -284,7 +284,7 @@ public class TestCreateTableTask
             this.tablePropertyManager = requireNonNull(tablePropertyManager, "tablePropertyManager is null");
             this.columnPropertyManager = requireNonNull(columnPropertyManager, "columnPropertyManager is null");
             this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
-            this.connectorCapabilities = requireNonNull(immutableEnumSet(connectorCapabilities), "connectorCapabilities is null");
+            this.connectorCapabilities = immutableEnumSet(requireNonNull(connectorCapabilities, "connectorCapabilities is null"));
             this.metadata = createTestMetadataManager();
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/unnest/TestingUnnesterUtil.java
+++ b/core/trino-main/src/test/java/io/trino/operator/unnest/TestingUnnesterUtil.java
@@ -170,8 +170,8 @@ public final class TestingUnnesterUtil
 
     public static void validateTestInput(int[] requiredOutputCounts, int[] unnestedLengths, Slice[][][] slices, int fieldCount)
     {
-        requireNonNull(requiredOutputCounts, "output counts array is null");
-        requireNonNull(unnestedLengths, "unnested lengths is null");
+        requireNonNull(requiredOutputCounts, "requiredOutputCounts is null");
+        requireNonNull(unnestedLengths, "unnestedLengths is null");
         requireNonNull(slices, "slices array is null");
 
         // verify lengths

--- a/core/trino-main/src/test/java/io/trino/split/TestBufferingSplitSource.java
+++ b/core/trino-main/src/test/java/io/trino/split/TestBufferingSplitSource.java
@@ -249,7 +249,7 @@ public class TestBufferingSplitSource
 
         public NextBatchResult(SplitBatch splitBatch)
         {
-            this.splitBatch = requireNonNull(splitBatch, "splits is null");
+            this.splitBatch = requireNonNull(splitBatch, "splitBatch is null");
         }
 
         public NextBatchResult assertSize(int expectedSize)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/AggregationFunctionMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/AggregationFunctionMatcher.java
@@ -37,7 +37,7 @@ public class AggregationFunctionMatcher
 
     public AggregationFunctionMatcher(ExpectedValueProvider<FunctionCall> callMaker)
     {
-        this.callMaker = requireNonNull(callMaker, "functionCall is null");
+        this.callMaker = requireNonNull(callMaker, "callMaker is null");
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionMatcher.java
@@ -43,14 +43,14 @@ public class ExpressionMatcher
 
     public ExpressionMatcher(String expression)
     {
-        this.sql = requireNonNull(expression);
-        this.expression = expression(requireNonNull(expression));
+        this.sql = requireNonNull(expression, "expression is null");
+        this.expression = expression(expression);
     }
 
     public ExpressionMatcher(Expression expression)
     {
         this.expression = requireNonNull(expression, "expression is null");
-        this.sql = requireNonNull(expression).toString();
+        this.sql = expression.toString();
     }
 
     private Expression expression(String sql)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/NotPlanNodeMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/NotPlanNodeMatcher.java
@@ -30,7 +30,7 @@ final class NotPlanNodeMatcher
 
     NotPlanNodeMatcher(Class<? extends PlanNode> excludedNodeClass)
     {
-        this.excludedNodeClass = requireNonNull(excludedNodeClass, "functionCalls is null");
+        this.excludedNodeClass = requireNonNull(excludedNodeClass, "excludedNodeClass is null");
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchingState.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchingState.java
@@ -36,7 +36,7 @@ final class PlanMatchingState
 
     PlanMatchingState(List<PlanMatchPattern> patterns)
     {
-        requireNonNull(patterns, "matchers is null");
+        requireNonNull(patterns, "patterns is null");
         this.patterns = ImmutableList.copyOf(patterns);
     }
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/WindowFunctionMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/WindowFunctionMatcher.java
@@ -48,7 +48,7 @@ public class WindowFunctionMatcher
             Optional<ResolvedFunction> resolvedFunction,
             Optional<ExpectedValueProvider<WindowNode.Frame>> frameMaker)
     {
-        this.callMaker = requireNonNull(callMaker, "functionCall is null");
+        this.callMaker = requireNonNull(callMaker, "callMaker is null");
         this.resolvedFunction = requireNonNull(resolvedFunction, "resolvedFunction is null");
         this.frameMaker = requireNonNull(frameMaker, "frameMaker is null");
     }

--- a/core/trino-main/src/test/java/io/trino/tests/QueryTemplate.java
+++ b/core/trino-main/src/test/java/io/trino/tests/QueryTemplate.java
@@ -141,7 +141,7 @@ public class QueryTemplate
         private Parameter(String key, Optional<String> value)
         {
             this.key = requireNonNull(key, "key is null");
-            this.value = requireNonNull(value, "defaultValue is null");
+            this.value = requireNonNull(value, "value is null");
         }
 
         public Optional<String> getValue()

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AddColumn.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AddColumn.java
@@ -43,7 +43,7 @@ public class AddColumn
     private AddColumn(Optional<NodeLocation> location, QualifiedName name, ColumnDefinition column, boolean tableExists, boolean columnNotExists)
     {
         super(location);
-        this.name = requireNonNull(name, "table is null");
+        this.name = requireNonNull(name, "name is null");
         this.column = requireNonNull(column, "column is null");
         this.tableExists = tableExists;
         this.columnNotExists = columnNotExists;

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Analyze.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Analyze.java
@@ -41,7 +41,7 @@ public class Analyze
     private Analyze(Optional<NodeLocation> location, QualifiedName tableName, List<Property> properties)
     {
         super(location);
-        this.tableName = requireNonNull(tableName, "table is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
         this.properties = ImmutableList.copyOf(requireNonNull(properties, "properties is null"));
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/BindExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/BindExpression.java
@@ -65,7 +65,7 @@ public class BindExpression
     private BindExpression(Optional<NodeLocation> location, List<Expression> values, Expression function)
     {
         super(location);
-        this.values = requireNonNull(values, "value is null");
+        this.values = requireNonNull(values, "values is null");
         this.function = requireNonNull(function, "function is null");
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Comment.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Comment.java
@@ -48,7 +48,7 @@ public final class Comment
     {
         super(location);
         this.type = requireNonNull(type, "type is null");
-        this.name = requireNonNull(name, "table is null");
+        this.name = requireNonNull(name, "name is null");
         this.comment = requireNonNull(comment, "comment is null");
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ComparisonExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ComparisonExpression.java
@@ -41,7 +41,7 @@ public class ComparisonExpression
     private ComparisonExpression(Optional<NodeLocation> location, Operator operator, Expression left, Expression right)
     {
         super(location);
-        requireNonNull(operator, "type is null");
+        requireNonNull(operator, "operator is null");
         requireNonNull(left, "left is null");
         requireNonNull(right, "right is null");
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CreateTable.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CreateTable.java
@@ -44,7 +44,7 @@ public class CreateTable
     private CreateTable(Optional<NodeLocation> location, QualifiedName name, List<TableElement> elements, boolean notExists, List<Property> properties, Optional<String> comment)
     {
         super(location);
-        this.name = requireNonNull(name, "table is null");
+        this.name = requireNonNull(name, "name is null");
         this.elements = ImmutableList.copyOf(requireNonNull(elements, "elements is null"));
         this.notExists = notExists;
         this.properties = requireNonNull(properties, "properties is null");

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentTime.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentTime.java
@@ -71,7 +71,7 @@ public class CurrentTime
     private CurrentTime(Optional<NodeLocation> location, Function function, Integer precision)
     {
         super(location);
-        requireNonNull(function, "type is null");
+        requireNonNull(function, "function is null");
         this.function = function;
         this.precision = precision;
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Execute.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Execute.java
@@ -42,7 +42,7 @@ public class Execute
     {
         super(location);
         this.name = requireNonNull(name, "name is null");
-        this.parameters = requireNonNull(ImmutableList.copyOf(parameters), "parameters is null");
+        this.parameters = ImmutableList.copyOf(requireNonNull(parameters, "parameters is null"));
     }
 
     public Identifier getName()

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/QuantifiedComparisonExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/QuantifiedComparisonExpression.java
@@ -49,7 +49,7 @@ public class QuantifiedComparisonExpression
     private QuantifiedComparisonExpression(Optional<NodeLocation> location, ComparisonExpression.Operator operator, Quantifier quantifier, Expression value, Expression subquery)
     {
         super(location);
-        this.operator = requireNonNull(operator, "comparisonType is null");
+        this.operator = requireNonNull(operator, "operator is null");
         this.quantifier = requireNonNull(quantifier, "quantifier is null");
         this.value = requireNonNull(value, "value is null");
         this.subquery = requireNonNull(subquery, "subquery is null");

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/SetPath.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/SetPath.java
@@ -40,7 +40,7 @@ public class SetPath
     private SetPath(Optional<NodeLocation> location, PathSpecification pathSpecification)
     {
         super(location);
-        this.pathSpecification = requireNonNull(pathSpecification, "path is null");
+        this.pathSpecification = requireNonNull(pathSpecification, "pathSpecification is null");
     }
 
     public PathSpecification getPathSpecification()

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/TypeParameter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/TypeParameter.java
@@ -29,7 +29,7 @@ public class TypeParameter
     public TypeParameter(DataType type)
     {
         super(Optional.empty());
-        this.type = requireNonNull(type, "value is null");
+        this.type = requireNonNull(type, "type is null");
     }
 
     public DataType getValue()

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Update.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Update.java
@@ -43,7 +43,7 @@ public class Update
     {
         super(location);
         this.table = requireNonNull(table, "table is null");
-        this.assignments = requireNonNull(assignments, "targets is null");
+        this.assignments = requireNonNull(assignments, "assignments is null");
         this.where = requireNonNull(where, "where is null");
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/AggregateFunction.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/AggregateFunction.java
@@ -44,10 +44,10 @@ public class AggregateFunction
             throw new IllegalArgumentException("DISTINCT requires inputs");
         }
 
-        this.functionName = requireNonNull(aggregateFunctionName, "name is null");
+        this.functionName = requireNonNull(aggregateFunctionName, "aggregateFunctionName is null");
         this.outputType = requireNonNull(outputType, "outputType is null");
         requireNonNull(inputs, "inputs is null");
-        requireNonNull(sortItems, "sortOrder is null");
+        requireNonNull(sortItems, "sortItems is null");
         this.inputs = List.copyOf(inputs);
         this.sortItems = List.copyOf(sortItems);
         this.isDistinct = isDistinct;

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/AggregationApplicationResult.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/AggregationApplicationResult.java
@@ -34,9 +34,9 @@ public class AggregationApplicationResult<T>
             Map<ColumnHandle, ColumnHandle> groupingColumnMapping)
     {
         this.handle = requireNonNull(handle, "handle is null");
-        requireNonNull(groupingColumnMapping, "goupingSetMapping is null");
+        requireNonNull(groupingColumnMapping, "groupingColumnMapping is null");
         requireNonNull(projections, "projections is null");
-        requireNonNull(assignments, "assignment is null");
+        requireNonNull(assignments, "assignments is null");
         this.groupingColumnMapping = Map.copyOf(groupingColumnMapping);
         this.projections = List.copyOf(projections);
         this.assignments = List.copyOf(assignments);

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableLayout.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableLayout.java
@@ -56,7 +56,7 @@ public class ConnectorTableLayout
     {
         requireNonNull(handle, "handle is null");
         requireNonNull(columns, "columns is null");
-        requireNonNull(streamPartitioningColumns, "partitioningColumns is null");
+        requireNonNull(streamPartitioningColumns, "streamPartitioningColumns is null");
         requireNonNull(tablePartitioning, "tablePartitioning is null");
         requireNonNull(predicate, "predicate is null");
         requireNonNull(discretePredicates, "discretePredicates is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableProperties.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableProperties.java
@@ -53,7 +53,7 @@ public class ConnectorTableProperties
             Optional<DiscretePredicates> discretePredicates,
             List<LocalProperty<ColumnHandle>> localProperties)
     {
-        requireNonNull(streamPartitioningColumns, "partitioningColumns is null");
+        requireNonNull(streamPartitioningColumns, "streamPartitioningColumns is null");
         requireNonNull(tablePartitioning, "tablePartitioning is null");
         requireNonNull(predicate, "predicate is null");
         requireNonNull(discretePredicates, "discretePredicates is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/MaterializedViewNotFoundException.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/MaterializedViewNotFoundException.java
@@ -40,7 +40,7 @@ public class MaterializedViewNotFoundException
     public MaterializedViewNotFoundException(SchemaTableName materializedViewName, String message, Throwable cause)
     {
         super(message, cause);
-        this.materializedViewName = requireNonNull(materializedViewName, "viewName is null");
+        this.materializedViewName = requireNonNull(materializedViewName, "materializedViewName is null");
     }
 
     public SchemaTableName getMaterializedViewName()

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SortItem.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SortItem.java
@@ -29,7 +29,7 @@ public class SortItem
     public SortItem(String name, SortOrder sortOrder)
     {
         this.name = requireNonNull(name, "name is null");
-        this.sortOrder = requireNonNull(sortOrder, "name is null");
+        this.sortOrder = requireNonNull(sortOrder, "sortOrder is null");
     }
 
     @JsonProperty

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryCompletedEvent.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryCompletedEvent.java
@@ -51,7 +51,7 @@ public class QueryCompletedEvent
         this.context = requireNonNull(context, "context is null");
         this.ioMetadata = requireNonNull(ioMetadata, "ioMetadata is null");
         this.failureInfo = requireNonNull(failureInfo, "failureInfo is null");
-        this.warnings = requireNonNull(warnings, "queryWarnings is null");
+        this.warnings = requireNonNull(warnings, "warnings is null");
         this.createTime = requireNonNull(createTime, "createTime is null");
         this.executionStartTime = requireNonNull(executionStartTime, "executionStartTime is null");
         this.endTime = requireNonNull(endTime, "endTime is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/SelectionCriteria.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/resourcegroups/SelectionCriteria.java
@@ -42,9 +42,9 @@ public final class SelectionCriteria
     {
         this.authenticated = authenticated;
         this.user = requireNonNull(user, "user is null");
-        this.userGroups = requireNonNull(userGroups, "groups is null");
+        this.userGroups = requireNonNull(userGroups, "userGroups is null");
         this.source = requireNonNull(source, "source is null");
-        this.clientTags = Set.copyOf(requireNonNull(clientTags, "tags is null"));
+        this.clientTags = Set.copyOf(requireNonNull(clientTags, "clientTags is null"));
         this.resourceEstimates = requireNonNull(resourceEstimates, "resourceEstimates is null");
         this.queryType = requireNonNull(queryType, "queryType is null");
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/session/PropertyMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/session/PropertyMetadata.java
@@ -53,7 +53,7 @@ public final class PropertyMetadata<T>
     {
         requireNonNull(name, "name is null");
         requireNonNull(description, "description is null");
-        requireNonNull(sqlType, "type is null");
+        requireNonNull(sqlType, "sqlType is null");
         requireNonNull(javaType, "javaType is null");
         requireNonNull(decoder, "decoder is null");
         requireNonNull(encoder, "encoder is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TimeZoneKey.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TimeZoneKey.java
@@ -165,7 +165,7 @@ public final class TimeZoneKey
      */
     public static TimeZoneKey getTimeZoneKey(String zoneId)
     {
-        requireNonNull(zoneId, "Zone id is null");
+        requireNonNull(zoneId, "zoneId is null");
         checkArgument(!zoneId.isEmpty(), "Zone id is an empty string");
 
         TimeZoneKey zoneKey = ZONE_ID_TO_KEY.get(zoneId);

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/serde/JtsGeometrySerde.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/serde/JtsGeometrySerde.java
@@ -259,7 +259,7 @@ public final class JtsGeometrySerde
      */
     public static Slice serialize(Geometry geometry)
     {
-        requireNonNull(geometry, "input is null");
+        requireNonNull(geometry, "geometry is null");
         DynamicSliceOutput output = new DynamicSliceOutput(100);
         writeGeometry(geometry, output);
         return output.slice();

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcRecordReader.java
@@ -158,7 +158,7 @@ public class OrcRecordReader
         requireNonNull(fileStripes, "fileStripes is null");
         requireNonNull(stripeStats, "stripeStats is null");
         requireNonNull(orcDataSource, "orcDataSource is null");
-        this.orcTypes = requireNonNull(orcTypes, "types is null");
+        this.orcTypes = requireNonNull(orcTypes, "orcTypes is null");
         requireNonNull(decompressor, "decompressor is null");
         requireNonNull(legacyFileTimeZone, "legacyFileTimeZone is null");
         requireNonNull(userMetadata, "userMetadata is null");
@@ -632,7 +632,7 @@ public class OrcRecordReader
         public StripeInfo(StripeInformation stripe, Optional<StripeStatistics> stats)
         {
             this.stripe = requireNonNull(stripe, "stripe is null");
-            this.stats = requireNonNull(stats, "metadata is null");
+            this.stats = requireNonNull(stats, "stats is null");
         }
 
         public StripeInformation getStripe()

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriter.java
@@ -617,7 +617,7 @@ public final class OrcWriter
         public ClosedStripe(StripeInformation stripeInformation, StripeStatistics statistics)
         {
             this.stripeInformation = requireNonNull(stripeInformation, "stripeInformation is null");
-            this.statistics = requireNonNull(statistics, "stripeStatistics is null");
+            this.statistics = requireNonNull(statistics, "statistics is null");
         }
 
         public StripeInformation getStripeInformation()

--- a/lib/trino-orc/src/main/java/io/trino/orc/OrcWriterOptions.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/OrcWriterOptions.java
@@ -79,7 +79,7 @@ public class OrcWriterOptions
         requireNonNull(dictionaryMaxMemory, "dictionaryMaxMemory is null");
         requireNonNull(maxStringStatisticsLimit, "maxStringStatisticsLimit is null");
         requireNonNull(maxCompressionBufferSize, "maxCompressionBufferSize is null");
-        requireNonNull(bloomFilterColumns, "bloomFiltersColumns is null");
+        requireNonNull(bloomFilterColumns, "bloomFilterColumns is null");
         checkArgument(bloomFilterFpp > 0.0 && bloomFilterFpp < 1.0, "bloomFilterFpp should be > 0.0 & < 1.0");
 
         this.stripeMinSize = stripeMinSize;

--- a/lib/trino-orc/src/main/java/io/trino/orc/metadata/OrcType.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/metadata/OrcType.java
@@ -112,7 +112,7 @@ public class OrcType
 
     public OrcType(OrcTypeKind orcTypeKind, List<OrcColumnId> fieldTypeIndexes, List<String> fieldNames, Optional<Integer> length, Optional<Integer> precision, Optional<Integer> scale, Map<String, String> attributes)
     {
-        this.orcTypeKind = requireNonNull(orcTypeKind, "typeKind is null");
+        this.orcTypeKind = requireNonNull(orcTypeKind, "orcTypeKind is null");
         this.fieldTypeIndexes = ImmutableList.copyOf(requireNonNull(fieldTypeIndexes, "fieldTypeIndexes is null"));
         if (fieldNames == null || (fieldNames.isEmpty() && !fieldTypeIndexes.isEmpty())) {
             this.fieldNames = null;

--- a/lib/trino-orc/src/main/java/io/trino/orc/stream/UncompressedOrcChunkLoader.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/stream/UncompressedOrcChunkLoader.java
@@ -38,7 +38,7 @@ public final class UncompressedOrcChunkLoader
 
     public UncompressedOrcChunkLoader(OrcDataReader dataReader, AggregatedMemoryContext memoryContext)
     {
-        this.dataReader = requireNonNull(dataReader, "loader is null");
+        this.dataReader = requireNonNull(dataReader, "dataReader is null");
         requireNonNull(memoryContext, "memoryContext is null");
         this.dataReaderMemoryUsage = memoryContext.newLocalMemoryContext(UncompressedOrcChunkLoader.class.getSimpleName());
         dataReaderMemoryUsage.setBytes(dataReader.getRetainedSize());

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetReaderOptions.java
@@ -44,7 +44,7 @@ public class ParquetReaderOptions
             DataSize maxBufferSize)
     {
         this.ignoreStatistics = ignoreStatistics;
-        this.maxReadBlockSize = requireNonNull(maxReadBlockSize, "maxMergeDistance is null");
+        this.maxReadBlockSize = requireNonNull(maxReadBlockSize, "maxReadBlockSize is null");
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBufferSize = requireNonNull(maxBufferSize, "maxBufferSize is null");
     }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetDataOutput.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetDataOutput.java
@@ -44,7 +44,7 @@ public interface ParquetDataOutput
 
     static ParquetDataOutput createDataOutput(BytesInput bytesInput)
     {
-        requireNonNull(bytesInput, "slice is null");
+        requireNonNull(bytesInput, "bytesInput is null");
         return new ParquetDataOutput()
         {
             @Override

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
@@ -34,7 +34,7 @@ public class ParquetWriterOptions
 
     private ParquetWriterOptions(DataSize maxBlockSize, DataSize maxPageSize)
     {
-        this.maxRowGroupSize = toIntExact(requireNonNull(maxBlockSize, "maxRowGroupSize is null").toBytes());
+        this.maxRowGroupSize = toIntExact(requireNonNull(maxBlockSize, "maxBlockSize is null").toBytes());
         this.maxPageSize = toIntExact(requireNonNull(maxPageSize, "maxPageSize is null").toBytes());
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/CatalogAccessControlRule.java
@@ -49,8 +49,8 @@ public class CatalogAccessControlRule
             @JsonProperty("catalog") Optional<Pattern> catalogRegex)
     {
         this.accessMode = requireNonNull(accessMode, "accessMode is null");
-        this.userRegex = requireNonNull(userRegex, "user is null");
-        this.groupRegex = requireNonNull(groupRegex, "group is null");
+        this.userRegex = requireNonNull(userRegex, "userRegex is null");
+        this.groupRegex = requireNonNull(groupRegex, "groupRegex is null");
         this.catalogRegex = requireNonNull(catalogRegex, "catalogRegex is null");
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/SchemaAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/SchemaAccessControlRule.java
@@ -43,9 +43,9 @@ public class SchemaAccessControlRule
             @JsonProperty("schema") Optional<Pattern> schemaRegex)
     {
         this.owner = owner;
-        this.userRegex = requireNonNull(userRegex, "user is null");
-        this.groupRegex = requireNonNull(groupRegex, "group is null");
-        this.schemaRegex = requireNonNull(schemaRegex, "sourceRegex is null");
+        this.userRegex = requireNonNull(userRegex, "userRegex is null");
+        this.groupRegex = requireNonNull(groupRegex, "groupRegex is null");
+        this.schemaRegex = requireNonNull(schemaRegex, "schemaRegex is null");
     }
 
     public Optional<Boolean> match(String user, Set<String> groups, String schema)

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/SessionPropertyAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/SessionPropertyAccessControlRule.java
@@ -43,8 +43,8 @@ public class SessionPropertyAccessControlRule
             @JsonProperty("property") Optional<Pattern> propertyRegex)
     {
         this.allow = allow;
-        this.userRegex = requireNonNull(userRegex, "user is null");
-        this.groupRegex = requireNonNull(groupRegex, "group is null");
+        this.userRegex = requireNonNull(userRegex, "userRegex is null");
+        this.groupRegex = requireNonNull(groupRegex, "groupRegex is null");
         this.propertyRegex = requireNonNull(propertyRegex, "propertyRegex is null");
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableAccessControlRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/TableAccessControlRule.java
@@ -73,9 +73,9 @@ public class TableAccessControlRule
                 .collect(toImmutableSet());
         this.filter = requireNonNull(filter, "filter is null");
         this.filterEnvironment = requireNonNull(filterEnvironment, "filterEnvironment is null");
-        this.userRegex = requireNonNull(userRegex, "user is null");
-        this.groupRegex = requireNonNull(groupRegex, "group is null");
-        this.schemaRegex = requireNonNull(schemaRegex, "sourceRegex is null");
+        this.userRegex = requireNonNull(userRegex, "userRegex is null");
+        this.groupRegex = requireNonNull(groupRegex, "groupRegex is null");
+        this.schemaRegex = requireNonNull(schemaRegex, "schemaRegex is null");
         this.tableRegex = requireNonNull(tableRegex, "tableRegex is null");
     }
 

--- a/lib/trino-rcfile/src/main/java/io/trino/rcfile/RcFileReader.java
+++ b/lib/trino-rcfile/src/main/java/io/trino/rcfile/RcFileReader.java
@@ -129,7 +129,7 @@ public class RcFileReader
             Optional<RcFileWriteValidation> writeValidation)
             throws IOException
     {
-        this.dataSource = requireNonNull(dataSource, "rcFileDataSource is null");
+        this.dataSource = requireNonNull(dataSource, "dataSource is null");
         this.readColumns = ImmutableMap.copyOf(requireNonNull(readColumns, "readColumns is null"));
         this.input = new ChunkedSliceInput(new DataSourceSliceLoader(dataSource), toIntExact(bufferSize.toBytes()));
 

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroBytesDeserializer.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroBytesDeserializer.java
@@ -35,7 +35,7 @@ public class AvroBytesDeserializer<T>
 
     public AvroBytesDeserializer(AvroReaderSupplier<T> avroReaderSupplier)
     {
-        this.avroReaderSupplier = requireNonNull(avroReaderSupplier, "datumReaderSupplier is null");
+        this.avroReaderSupplier = requireNonNull(avroReaderSupplier, "avroReaderSupplier is null");
     }
 
     @Override

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroColumnDecoder.java
@@ -260,7 +260,7 @@ public class AvroColumnDecoder
 
     private static void serializePrimitive(BlockBuilder blockBuilder, Object value, Type type, String columnName)
     {
-        requireNonNull(blockBuilder, "parent blockBuilder is null");
+        requireNonNull(blockBuilder, "blockBuilder is null");
 
         if (value == null) {
             blockBuilder.appendNull();

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroFileDeserializer.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/AvroFileDeserializer.java
@@ -34,7 +34,7 @@ public class AvroFileDeserializer<T>
 
     public AvroFileDeserializer(AvroReaderSupplier<T> avroReaderSupplier)
     {
-        this.avroReaderSupplier = requireNonNull(avroReaderSupplier, "datumReaderSupplier is null");
+        this.avroReaderSupplier = requireNonNull(avroReaderSupplier, "avroReaderSupplier is null");
     }
 
     @Override

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/GenericRecordRowDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/GenericRecordRowDecoder.java
@@ -36,7 +36,7 @@ class GenericRecordRowDecoder
 
     public GenericRecordRowDecoder(AvroDeserializer<GenericRecord> deserializer, Set<DecoderColumnHandle> columns)
     {
-        this.deserializer = requireNonNull(deserializer, "dataReader is null");
+        this.deserializer = requireNonNull(deserializer, "deserializer is null");
         requireNonNull(columns, "columns is null");
         this.columnDecoders = columns.stream()
                 .map(column -> new AbstractMap.SimpleImmutableEntry<>(column, new AvroColumnDecoder(column)))

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/SingleValueRowDecoder.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/avro/SingleValueRowDecoder.java
@@ -31,7 +31,7 @@ class SingleValueRowDecoder
 
     public SingleValueRowDecoder(AvroDeserializer<Object> deserializer, DecoderColumnHandle column)
     {
-        this.deserializer = requireNonNull(deserializer, "dataReader is null");
+        this.deserializer = requireNonNull(deserializer, "deserializer is null");
         this.column = requireNonNull(column, "columns is null");
     }
 

--- a/lib/trino-record-decoder/src/main/java/io/trino/decoder/json/JsonRowDecoderFactory.java
+++ b/lib/trino-record-decoder/src/main/java/io/trino/decoder/json/JsonRowDecoderFactory.java
@@ -46,7 +46,7 @@ public class JsonRowDecoderFactory
     @Override
     public RowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
     {
-        requireNonNull(columns, "columnHandles is null");
+        requireNonNull(columns, "columns is null");
         return new JsonRowDecoder(objectMapper, chooseFieldDecoders(columns));
     }
 

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloClient.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloClient.java
@@ -622,7 +622,7 @@ public class AccumuloClient
 
     public AccumuloTable getTable(SchemaTableName table)
     {
-        requireNonNull(table, "schema table name is null");
+        requireNonNull(table, "table is null");
         return metaManager.getTable(table);
     }
 
@@ -634,7 +634,7 @@ public class AccumuloClient
 
     public AccumuloView getView(SchemaTableName viewName)
     {
-        requireNonNull(viewName, "schema table name is null");
+        requireNonNull(viewName, "viewName is null");
         return metaManager.getView(viewName);
     }
 

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloConnector.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloConnector.java
@@ -65,7 +65,7 @@ public class AccumuloConnector
             AccumuloTableProperties tableProperties)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
-        this.metadataFactory = requireNonNull(metadataFactory, "metadata is null");
+        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloConnectorFactory.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloConnectorFactory.java
@@ -40,7 +40,7 @@ public class AccumuloConnectorFactory
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
         requireNonNull(catalogName, "catalogName is null");
-        requireNonNull(config, "requiredConfig is null");
+        requireNonNull(config, "config is null");
         requireNonNull(context, "context is null");
 
         Bootstrap app = new Bootstrap(

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/io/AccumuloRecordSet.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/io/AccumuloRecordSet.java
@@ -76,7 +76,7 @@ public class AccumuloRecordSet
         serializer = table.getSerializerInstance();
 
         // Save off the column handles and createa list of the Accumulo types
-        this.columnHandles = requireNonNull(columnHandles, "column handles is null");
+        this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
         ImmutableList.Builder<Type> types = ImmutableList.builder();
         for (AccumuloColumnHandle column : columnHandles) {
             types.add(column.getType());

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ColumnMapping.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ColumnMapping.java
@@ -118,7 +118,7 @@ public final class ColumnMapping
                 type,
                 writeFunction,
                 writeFunction.getJavaType());
-        this.predicatePushdownController = requireNonNull(predicatePushdownController, "pushdownController is null");
+        this.predicatePushdownController = requireNonNull(predicatePushdownController, "predicatePushdownController is null");
     }
 
     public Type getType()

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadata.java
@@ -91,7 +91,7 @@ public class JdbcMetadata
 
     public JdbcMetadata(JdbcClient jdbcClient, boolean allowDropTable)
     {
-        this.jdbcClient = requireNonNull(jdbcClient, "client is null");
+        this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.allowDropTable = allowDropTable;
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcNamedRelationHandle.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcNamedRelationHandle.java
@@ -34,7 +34,7 @@ public class JdbcNamedRelationHandle
             @JsonProperty("remoteTableName") RemoteTableName remoteTableName)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
-        this.remoteTableName = requireNonNull(remoteTableName, "remoteTable is null");
+        this.remoteTableName = requireNonNull(remoteTableName, "remoteTableName is null");
     }
 
     @JsonProperty

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSet.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSet.java
@@ -39,7 +39,7 @@ public class JdbcRecordSet
         this.split = requireNonNull(split, "split is null");
 
         this.table = requireNonNull(table, "table is null");
-        this.columnHandles = requireNonNull(columnHandles, "column handles is null");
+        this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
         ImmutableList.Builder<Type> types = ImmutableList.builder();
         for (JdbcColumnHandle column : columnHandles) {
             types.add(column.getColumnType());

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplitManager.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSplitManager.java
@@ -32,7 +32,7 @@ public class JdbcSplitManager
     @Inject
     public JdbcSplitManager(JdbcClient jdbcClient)
     {
-        this.jdbcClient = requireNonNull(jdbcClient, "client is null");
+        this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
@@ -57,7 +57,7 @@ public class QueryBuilder
 
     public QueryBuilder(JdbcClient client)
     {
-        this.client = requireNonNull(client, "jdbcClient is null");
+        this.client = requireNonNull(client, "client is null");
     }
 
     public PreparedQuery prepareQuery(

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
@@ -135,7 +135,7 @@ public class CassandraSession
 
     public Set<Host> getReplicas(String caseSensitiveSchemaName, TokenRange tokenRange)
     {
-        requireNonNull(caseSensitiveSchemaName, "keyspace is null");
+        requireNonNull(caseSensitiveSchemaName, "caseSensitiveSchemaName is null");
         requireNonNull(tokenRange, "tokenRange is null");
         return executeWithSession(session ->
                 session.getCluster().getMetadata().getReplicas(validSchemaName(caseSensitiveSchemaName), tokenRange));
@@ -143,7 +143,7 @@ public class CassandraSession
 
     public Set<Host> getReplicas(String caseSensitiveSchemaName, ByteBuffer partitionKey)
     {
-        requireNonNull(caseSensitiveSchemaName, "keyspace is null");
+        requireNonNull(caseSensitiveSchemaName, "caseSensitiveSchemaName is null");
         requireNonNull(partitionKey, "partitionKey is null");
         return executeWithSession(session ->
                 session.getCluster().getMetadata().getReplicas(validSchemaName(caseSensitiveSchemaName), partitionKey));

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplit.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSplit.java
@@ -38,7 +38,7 @@ public class CassandraSplit
             @JsonProperty("splitCondition") String splitCondition,
             @JsonProperty("addresses") List<HostAddress> addresses)
     {
-        requireNonNull(partitionId, "partitionName is null");
+        requireNonNull(partitionId, "partitionId is null");
         requireNonNull(addresses, "addresses is null");
 
         this.partitionId = partitionId;

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
@@ -119,7 +119,7 @@ public class CassandraServer
 
     public CassandraSession getSession()
     {
-        return requireNonNull(session, "cluster is null");
+        return requireNonNull(session, "session is null");
     }
 
     public String getHost()

--- a/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleMetadata.java
+++ b/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleMetadata.java
@@ -44,7 +44,7 @@ public class ExampleMetadata
     @Inject
     public ExampleMetadata(ExampleClient exampleClient)
     {
-        this.exampleClient = requireNonNull(exampleClient, "client is null");
+        this.exampleClient = requireNonNull(exampleClient, "exampleClient is null");
     }
 
     @Override

--- a/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleRecordSet.java
+++ b/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleRecordSet.java
@@ -36,7 +36,7 @@ public class ExampleRecordSet
     {
         requireNonNull(split, "split is null");
 
-        this.columnHandles = requireNonNull(columnHandles, "column handles is null");
+        this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
         ImmutableList.Builder<Type> types = ImmutableList.builder();
         for (ExampleColumnHandle column : columnHandles) {
             types.add(column.getColumnType());

--- a/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleSplitManager.java
+++ b/plugin/trino-example-http/src/main/java/io/trino/plugin/example/ExampleSplitManager.java
@@ -40,7 +40,7 @@ public class ExampleSplitManager
     @Inject
     public ExampleSplitManager(ExampleClient exampleClient)
     {
-        this.exampleClient = requireNonNull(exampleClient, "client is null");
+        this.exampleClient = requireNonNull(exampleClient, "exampleClient is null");
     }
 
     @Override

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsMetadata.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsMetadata.java
@@ -47,7 +47,7 @@ public class SheetsMetadata
     @Inject
     public SheetsMetadata(SheetsClient sheetsClient)
     {
-        this.sheetsClient = requireNonNull(sheetsClient, "client is null");
+        this.sheetsClient = requireNonNull(sheetsClient, "sheetsClient is null");
     }
 
     @Override

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsRecordSet.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsRecordSet.java
@@ -32,7 +32,7 @@ public class SheetsRecordSet
     public SheetsRecordSet(SheetsSplit split, List<SheetsColumnHandle> columnHandles)
     {
         requireNonNull(split, "split is null");
-        this.columnHandles = requireNonNull(columnHandles, "column handles is null");
+        this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
         this.values = split.getValues();
         this.columnTypes = columnHandles.stream().map(SheetsColumnHandle::getColumnType).collect(Collectors.toList());
     }

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplit.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplit.java
@@ -38,8 +38,8 @@ public class SheetsSplit
             @JsonProperty("tableName") String tableName,
             @JsonProperty("values") List<List<Object>> values)
     {
-        this.schemaName = requireNonNull(schemaName, "schema name is null");
-        this.tableName = requireNonNull(tableName, "table name is null");
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
         this.values = requireNonNull(values, "values is null");
         this.hostAddresses = ImmutableList.of();
     }

--- a/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplitManager.java
+++ b/plugin/trino-google-sheets/src/main/java/io/trino/plugin/google/sheets/SheetsSplitManager.java
@@ -40,7 +40,7 @@ public class SheetsSplitManager
     @Inject
     public SheetsSplitManager(SheetsClient sheetsClient)
     {
-        this.sheetsClient = requireNonNull(sheetsClient, "client is null");
+        this.sheetsClient = requireNonNull(sheetsClient, "sheetsClient is null");
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -204,7 +204,7 @@ public class BackgroundHiveSplitLoader
             Optional<ValidWriteIdList> validWriteIds)
     {
         this.table = table;
-        this.transaction = requireNonNull(transaction, "tranaction is null");
+        this.transaction = requireNonNull(transaction, "transaction is null");
         this.compactEffectivePredicate = compactEffectivePredicate;
         this.dynamicFilter = dynamicFilter;
         this.dynamicFilteringProbeBlockingTimeoutMillis = dynamicFilteringProbeBlockingTimeout.toMillis();
@@ -938,7 +938,7 @@ public class BackgroundHiveSplitLoader
         public static Optional<BucketSplitInfo> createBucketSplitInfo(Optional<HiveBucketHandle> bucketHandle, Optional<HiveBucketFilter> bucketFilter)
         {
             requireNonNull(bucketHandle, "bucketHandle is null");
-            requireNonNull(bucketFilter, "buckets is null");
+            requireNonNull(bucketFilter, "bucketFilter is null");
 
             if (bucketHandle.isEmpty()) {
                 checkArgument(bucketFilter.isEmpty(), "bucketHandle must be present if bucketFilter is present");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCoercionRecordCursor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveCoercionRecordCursor.java
@@ -60,7 +60,7 @@ public class HiveCoercionRecordCursor
             TypeManager typeManager,
             RecordCursor delegate)
     {
-        requireNonNull(columnMappings, "columns is null");
+        requireNonNull(columnMappings, "columnMappings is null");
         requireNonNull(typeManager, "typeManager is null");
 
         this.delegate = requireNonNull(delegate, "delegate is null");
@@ -379,7 +379,7 @@ public class HiveCoercionRecordCursor
 
         public ListCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, BridgingRecordCursor bridgingRecordCursor)
         {
-            requireNonNull(typeManager, "typeManage is null");
+            requireNonNull(typeManager, "typeManager is null");
             requireNonNull(fromHiveType, "fromHiveType is null");
             requireNonNull(toHiveType, "toHiveType is null");
             this.bridgingRecordCursor = requireNonNull(bridgingRecordCursor, "bridgingRecordCursor is null");
@@ -436,7 +436,7 @@ public class HiveCoercionRecordCursor
 
         public MapCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, BridgingRecordCursor bridgingRecordCursor)
         {
-            requireNonNull(typeManager, "typeManage is null");
+            requireNonNull(typeManager, "typeManager is null");
             requireNonNull(fromHiveType, "fromHiveType is null");
             requireNonNull(toHiveType, "toHiveType is null");
             this.bridgingRecordCursor = requireNonNull(bridgingRecordCursor, "bridgingRecordCursor is null");
@@ -498,7 +498,7 @@ public class HiveCoercionRecordCursor
 
         public StructCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType, BridgingRecordCursor bridgingRecordCursor)
         {
-            requireNonNull(typeManager, "typeManage is null");
+            requireNonNull(typeManager, "typeManager is null");
             requireNonNull(fromHiveType, "fromHiveType is null");
             requireNonNull(toHiveType, "toHiveType is null");
             this.bridgingRecordCursor = requireNonNull(bridgingRecordCursor, "bridgingRecordCursor is null");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
@@ -85,7 +85,7 @@ public class HiveConnector
             ClassLoader classLoader)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
-        this.metadataFactory = requireNonNull(metadataFactory, "metadata is null");
+        this.metadataFactory = requireNonNull(metadataFactory, "metadataFactory is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -165,7 +165,7 @@ public class HiveModule
         public TypeDeserializer(TypeManager typeManager)
         {
             super(Type.class);
-            this.typeManager = requireNonNull(typeManager, "metadata is null");
+            this.typeManager = requireNonNull(typeManager, "typeManager is null");
         }
 
         @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
@@ -102,7 +102,7 @@ public class HivePageSinkProvider
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.eventClient = requireNonNull(eventClient, "eventClient is null");
         this.hiveSessionProperties = requireNonNull(hiveSessionProperties, "hiveSessionProperties is null");
-        this.hiveWriterStats = requireNonNull(hiveWriterStats, "stats is null");
+        this.hiveWriterStats = requireNonNull(hiveWriterStats, "hiveWriterStats is null");
         this.perTransactionMetastoreCacheMaximumSize = config.getPerTransactionMetastoreCacheMaximumSize();
         this.parquetTimeZone = config.getParquetDateTimeZone();
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -494,7 +494,7 @@ public class HivePageSource
 
         public MapCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType)
         {
-            requireNonNull(typeManager, "typeManage is null");
+            requireNonNull(typeManager, "typeManager is null");
             requireNonNull(fromHiveType, "fromHiveType is null");
             this.toType = requireNonNull(toHiveType, "toHiveType is null").getType(typeManager);
             HiveType fromKeyHiveType = HiveType.valueOf(((MapTypeInfo) fromHiveType.getTypeInfo()).getMapKeyTypeInfo().getTypeName());
@@ -529,7 +529,7 @@ public class HivePageSource
 
         public StructCoercer(TypeManager typeManager, HiveType fromHiveType, HiveType toHiveType)
         {
-            requireNonNull(typeManager, "typeManage is null");
+            requireNonNull(typeManager, "typeManager is null");
             requireNonNull(fromHiveType, "fromHiveType is null");
             requireNonNull(toHiveType, "toHiveType is null");
             List<HiveType> fromFieldTypes = extractStructFieldTypes(fromHiveType);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveRecordCursor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveRecordCursor.java
@@ -79,7 +79,7 @@ public class HiveRecordCursor
 
     public HiveRecordCursor(List<ColumnMapping> columnMappings, RecordCursor delegate)
     {
-        requireNonNull(columnMappings, "columns is null");
+        requireNonNull(columnMappings, "columnMappings is null");
 
         this.delegate = requireNonNull(delegate, "delegate is null");
         this.columnMappings = columnMappings;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -157,7 +157,7 @@ public class HiveSplitManager
             boolean recursiveDfsWalkerEnabled,
             TypeManager typeManager)
     {
-        this.metastoreProvider = requireNonNull(metastoreProvider, "metastore is null");
+        this.metastoreProvider = requireNonNull(metastoreProvider, "metastoreProvider is null");
         this.partitionManager = requireNonNull(partitionManager, "partitionManager is null");
         this.namenodeStats = requireNonNull(namenodeStats, "namenodeStats is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
@@ -209,7 +209,7 @@ public class HiveTableHandle
 
     public HiveTableHandle withUpdateProcessor(AcidTransaction transaction, HiveUpdateProcessor updateProcessor)
     {
-        requireNonNull(updateProcessor, "updatedColumns is null");
+        requireNonNull(updateProcessor, "updateProcessor is null");
         return new HiveTableHandle(
                 schemaName,
                 tableName,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateProcessor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateProcessor.java
@@ -63,7 +63,7 @@ public class HiveUpdateProcessor
             @JsonProperty("allColumns") List<HiveColumnHandle> allDataColumns,
             @JsonProperty("updatedColumns") List<HiveColumnHandle> updatedColumns)
     {
-        this.allDataColumns = requireNonNull(allDataColumns, "allColumns is null");
+        this.allDataColumns = requireNonNull(allDataColumns, "allDataColumns is null");
         this.updatedColumns = requireNonNull(updatedColumns, "updatedColumns is null");
         this.updatedColumnNames = updatedColumns.stream().map(HiveColumnHandle::getName).collect(toImmutableSet());
         Set<String> allDataColumnNames = allDataColumns.stream().map(HiveColumnHandle::getName).collect(toImmutableSet());
@@ -194,7 +194,7 @@ public class HiveUpdateProcessor
      */
     public Block createMergedColumnsBlock(Page page, List<Integer> columnValueAndRowIdChannels)
     {
-        requireNonNull(page, "originalPage is null");
+        requireNonNull(page, "page is null");
         RowBlock acidBlock = getAcidRowBlock(page, columnValueAndRowIdChannels);
         List<Block> acidBlocks = acidBlock.getChildren();
         List<Block> nonUpdatedColumnRowBlocks;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionNotFoundException.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionNotFoundException.java
@@ -46,7 +46,7 @@ public class PartitionNotFoundException
     {
         super(message, cause);
         this.tableName = requireNonNull(tableName, "tableName is null");
-        this.partitionValues = requireNonNull(partitionValues, "partitionValue is null");
+        this.partitionValues = requireNonNull(partitionValues, "partitionValues is null");
     }
 
     public SchemaTableName getTableName()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionOfflineException.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionOfflineException.java
@@ -30,7 +30,7 @@ public class PartitionOfflineException
     {
         super(HIVE_PARTITION_OFFLINE, formatMessage(tableName, partitionName, forPresto, offlineMessage));
         this.tableName = requireNonNull(tableName, "tableName is null");
-        this.partition = requireNonNull(partitionName, "partition is null");
+        this.partition = requireNonNull(partitionName, "partitionName is null");
     }
 
     public SchemaTableName getTableName()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriter.java
@@ -83,7 +83,7 @@ public class RcFileFileWriter
                 validationInputFactory.isPresent());
         this.rollbackAction = requireNonNull(rollbackAction, "rollbackAction is null");
 
-        this.fileInputColumnIndexes = requireNonNull(fileInputColumnIndexes, "outputColumnInputIndexes is null");
+        this.fileInputColumnIndexes = requireNonNull(fileInputColumnIndexes, "fileInputColumnIndexes is null");
 
         ImmutableList.Builder<Block> nullBlocks = ImmutableList.builder();
         for (Type fileColumnType : fileColumnTypes) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderProjectionsAdapter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderProjectionsAdapter.java
@@ -214,7 +214,7 @@ public class ReaderProjectionsAdapter
         {
             checkArgument(inputBlockIndex >= 0, "inputBlockIndex cannot be negative");
             this.inputChannelIndex = inputBlockIndex;
-            this.dereferenceSequence = ImmutableList.copyOf(requireNonNull(dereferenceSequence, "dereferences is null"));
+            this.dereferenceSequence = ImmutableList.copyOf(requireNonNull(dereferenceSequence, "dereferenceSequence is null"));
         }
 
         public int getInputChannelIndex()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -153,7 +153,7 @@ public final class ViewReaderUtil
 
         public HiveViewReader(HiveMetastoreClient hiveMetastoreClient, TypeManager typemanager)
         {
-            this.metastoreClient = requireNonNull(hiveMetastoreClient, "metastoreClient is null");
+            this.metastoreClient = requireNonNull(hiveMetastoreClient, "hiveMetastoreClient is null");
             this.typeManager = requireNonNull(typemanager, "typeManager is null");
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/authentication/CachingKerberosHadoopAuthentication.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/authentication/CachingKerberosHadoopAuthentication.java
@@ -37,7 +37,7 @@ public class CachingKerberosHadoopAuthentication
 
     public CachingKerberosHadoopAuthentication(KerberosHadoopAuthentication delegate)
     {
-        this.delegate = requireNonNull(delegate, "hadoopAuthentication is null");
+        this.delegate = requireNonNull(delegate, "delegate is null");
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -1702,7 +1702,7 @@ public class SemiTransactionalHiveMetastore
                 PartitionStatistics updatedStatistics = statistics.withAdjustedRowCount(-rowCount);
                 requireNonNull(updatedStatistics, "updatedStatistics is null");
                 Partition updatedPartition = updatedPartitions.get(partitionId);
-                requireNonNull(updatedPartition, "partition is null");
+                requireNonNull(updatedPartition, "updatedPartition is null");
                 Partition originalPartition = partitionsOptionalMap.get(partitionId).get();
                 alterPartitionOperations.add(new AlterPartitionOperation(
                         identity,
@@ -3246,7 +3246,7 @@ public class SemiTransactionalHiveMetastore
         {
             this.identity = requireNonNull(identity, "identity is null");
             this.tableName = requireNonNull(tableName, "tableName is null");
-            this.partitionName = requireNonNull(partitionName, "partitionValues is null");
+            this.partitionName = requireNonNull(partitionName, "partitionName is null");
             this.statistics = requireNonNull(statistics, "statistics is null");
             this.merge = merge;
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/UserDatabaseKey.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/UserDatabaseKey.java
@@ -32,7 +32,7 @@ public class UserDatabaseKey
     @JsonCreator
     public UserDatabaseKey(@JsonProperty("user") String user, @JsonProperty("database") String database)
     {
-        this.user = requireNonNull(user, "principalName is null");
+        this.user = requireNonNull(user, "user is null");
         this.database = requireNonNull(database, "database is null");
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -75,7 +75,7 @@ public class AlluxioHiveMetastore
     @Inject
     public AlluxioHiveMetastore(TableMasterClient client, MetastoreConfig metastoreConfig)
     {
-        this.client = requireNonNull(client);
+        this.client = requireNonNull(client, "client is null");
         requireNonNull(metastoreConfig, "metastoreConfig is null");
         checkArgument(!metastoreConfig.isHideDeltaLakeTables(), "Hiding Delta Lake tables is not supported"); // TODO
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -188,7 +188,7 @@ public class GlueHiveMetastore
         this.defaultDir = glueConfig.getDefaultWarehouseDir();
         this.catalogId = glueConfig.getCatalogId().orElse(null);
         this.partitionSegments = glueConfig.getPartitionSegments();
-        this.partitionsReadExecutor = requireNonNull(partitionsReadExecutor, "executor is null");
+        this.partitionsReadExecutor = requireNonNull(partitionsReadExecutor, "partitionsReadExecutor is null");
         this.assumeCanonicalPartitionKeys = glueConfig.isAssumeCanonicalPartitionKeys();
         this.tableFilter = requireNonNull(tableFilter, "tableFilter is null");
         this.columnStatisticsProvider = columnStatisticsProviderFactory.createGlueColumnStatisticsProvider(glueClient);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/StaticMetastoreLocator.java
@@ -142,7 +142,7 @@ public class StaticMetastoreLocator
 
     private static URI checkMetastoreUri(URI uri)
     {
-        requireNonNull(uri, "metastoreUri is null");
+        requireNonNull(uri, "uri is null");
         String scheme = uri.getScheme();
         checkArgument(!isNullOrEmpty(scheme), "metastoreUri scheme is missing: %s", uri);
         checkArgument(scheme.equals("thrift"), "metastoreUri scheme must be thrift: %s", uri);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
@@ -106,7 +106,7 @@ public class OrcFileWriter
 
         this.rollbackAction = requireNonNull(rollbackAction, "rollbackAction is null");
 
-        this.fileInputColumnIndexes = requireNonNull(fileInputColumnIndexes, "outputColumnInputIndexes is null");
+        this.fileInputColumnIndexes = requireNonNull(fileInputColumnIndexes, "fileInputColumnIndexes is null");
 
         ImmutableList.Builder<Block> nullBlocks = ImmutableList.builder();
         for (Type fileColumnType : fileColumnTypes) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriterFactory.java
@@ -117,7 +117,7 @@ public class OrcFileWriterFactory
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.writeLegacyVersion = writeLegacyVersion;
-        this.readStats = requireNonNull(readStats, "stats is null");
+        this.readStats = requireNonNull(readStats, "readStats is null");
         this.orcWriterOptions = requireNonNull(orcWriterOptions, "orcWriterOptions is null");
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/rcfile/RcFilePageSource.java
@@ -59,7 +59,7 @@ public class RcFilePageSource
 
     public RcFilePageSource(RcFileReader rcFileReader, List<HiveColumnHandle> columns)
     {
-        requireNonNull(rcFileReader, "rcReader is null");
+        requireNonNull(rcFileReader, "rcFileReader is null");
         requireNonNull(columns, "columns is null");
 
         this.rcFileReader = rcFileReader;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
@@ -56,7 +56,7 @@ public class LegacyAccessControl
             LegacyAccessControlMetastore accessControlMetastore,
             LegacySecurityConfig securityConfig)
     {
-        this.accessControlMetastore = requireNonNull(accessControlMetastore, "metastoreProvider is null");
+        this.accessControlMetastore = requireNonNull(accessControlMetastore, "accessControlMetastore is null");
 
         requireNonNull(securityConfig, "securityConfig is null");
         allowDropTable = securityConfig.getAllowDropTable();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FSDataInputStreamTail.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/FSDataInputStreamTail.java
@@ -36,7 +36,7 @@ public final class FSDataInputStreamTail
 
     private FSDataInputStreamTail(long fileSize, Slice tailSlice)
     {
-        this.tailSlice = requireNonNull(tailSlice, "tailBuffer is null");
+        this.tailSlice = requireNonNull(tailSlice, "tailSlice is null");
         this.fileSize = fileSize;
         checkArgument(fileSize >= 0, "fileSize is negative: %s", fileSize);
         checkArgument(tailSlice.length() <= fileSize, "length (%s) is greater than fileSize (%s)", tailSlice.length(), fileSize);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SerDeUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/SerDeUtils.java
@@ -69,8 +69,8 @@ public final class SerDeUtils
 
     public static Block getBlockObject(Type type, Object object, ObjectInspector objectInspector)
     {
-        Block block = serializeObject(type, null, object, objectInspector);
-        return requireNonNull(block, "serialized result is null");
+        Block serialized = serializeObject(type, null, object, objectInspector);
+        return requireNonNull(serialized, "serialized is null");
     }
 
     public static Block serializeObject(Type type, BlockBuilder builder, Object object, ObjectInspector inspector)
@@ -101,7 +101,7 @@ public final class SerDeUtils
 
     private static void serializePrimitive(Type type, BlockBuilder builder, Object object, PrimitiveObjectInspector inspector)
     {
-        requireNonNull(builder, "parent builder is null");
+        requireNonNull(builder, "builder is null");
 
         if (object == null) {
             builder.appendNull();
@@ -175,7 +175,7 @@ public final class SerDeUtils
     {
         List<?> list = inspector.getList(object);
         if (list == null) {
-            requireNonNull(builder, "parent builder is null").appendNull();
+            requireNonNull(builder, "builder is null").appendNull();
             return null;
         }
 
@@ -209,7 +209,7 @@ public final class SerDeUtils
     {
         Map<?, ?> map = inspector.getMap(object);
         if (map == null) {
-            requireNonNull(builder, "parent builder is null").appendNull();
+            requireNonNull(builder, "builder is null").appendNull();
             return null;
         }
 
@@ -248,7 +248,7 @@ public final class SerDeUtils
     private static Block serializeStruct(Type type, BlockBuilder builder, Object object, StructObjectInspector inspector)
     {
         if (object == null) {
-            requireNonNull(builder, "parent builder is null").appendNull();
+            requireNonNull(builder, "builder is null").appendNull();
             return null;
         }
 
@@ -282,7 +282,7 @@ public final class SerDeUtils
     private static Block serializeUnion(Type type, BlockBuilder builder, Object object, UnionObjectInspector inspector)
     {
         if (object == null) {
-            requireNonNull(builder, "parent builder is null").appendNull();
+            requireNonNull(builder, "builder is null").appendNull();
             return null;
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestReaderProjectionsAdapter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestReaderProjectionsAdapter.java
@@ -300,7 +300,7 @@ public class TestReaderProjectionsAdapter
 
         private RowData(Object... data)
         {
-            this.data = requireNonNull(Arrays.asList(data), "data is null");
+            this.data = Arrays.asList(requireNonNull(data, "data is null"));
         }
 
         static RowData rowData(Object... data)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergWritableTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergWritableTableHandle.java
@@ -50,7 +50,7 @@ public class IcebergWritableTableHandle
         this.schemaAsJson = requireNonNull(schemaAsJson, "schemaAsJson is null");
         this.partitionSpecAsJson = requireNonNull(partitionSpecAsJson, "partitionSpecAsJson is null");
         this.inputColumns = ImmutableList.copyOf(requireNonNull(inputColumns, "inputColumns is null"));
-        this.outputPath = requireNonNull(outputPath, "filePrefix is null");
+        this.outputPath = requireNonNull(outputPath, "outputPath is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTransforms.java
@@ -525,7 +525,7 @@ public final class PartitionTransforms
 
         public ColumnTransform(Type type, Function<Block, Block> transform)
         {
-            this.type = requireNonNull(type, "resultType is null");
+            this.type = requireNonNull(type, "type is null");
             this.transform = requireNonNull(transform, "transform is null");
         }
 

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxConnector.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxConnector.java
@@ -44,7 +44,7 @@ public class JmxConnector
         this.jmxMetadata = requireNonNull(jmxMetadata, "jmxMetadata is null");
         this.jmxSplitManager = requireNonNull(jmxSplitManager, "jmxSplitManager is null");
         this.jmxRecordSetProvider = requireNonNull(jmxRecordSetProvider, "jmxRecordSetProvider is null");
-        this.jmxPeriodicSampler = requireNonNull(jmxPeriodicSampler, "jmxHistoryDumper is null");
+        this.jmxPeriodicSampler = requireNonNull(jmxPeriodicSampler, "jmxPeriodicSampler is null");
     }
 
     @Override

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxMetadata.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxMetadata.java
@@ -87,7 +87,7 @@ public class JmxMetadata
     public JmxMetadata(MBeanServer mbeanServer, JmxHistoricalData jmxHistoricalData)
     {
         this.mbeanServer = requireNonNull(mbeanServer, "mbeanServer is null");
-        this.jmxHistoricalData = requireNonNull(jmxHistoricalData, "jmxStatsHolder is null");
+        this.jmxHistoricalData = requireNonNull(jmxHistoricalData, "jmxHistoricalData is null");
     }
 
     @Override

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxPeriodicSampler.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxPeriodicSampler.java
@@ -49,7 +49,7 @@ public class JmxPeriodicSampler
             JmxRecordSetProvider jmxRecordSetProvider,
             JmxConnectorConfig jmxConfig)
     {
-        this.jmxHistoricalData = requireNonNull(jmxHistoricalData, "jmxStatsHolder is null");
+        this.jmxHistoricalData = requireNonNull(jmxHistoricalData, "jmxHistoricalData is null");
         requireNonNull(jmxMetadata, "jmxMetadata is null");
         this.jmxRecordSetProvider = requireNonNull(jmxRecordSetProvider, "jmxRecordSetProvider is null");
         requireNonNull(jmxConfig, "jmxConfig is null");

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxRecordSetProvider.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxRecordSetProvider.java
@@ -58,7 +58,7 @@ public class JmxRecordSetProvider
     {
         this.mbeanServer = requireNonNull(mbeanServer, "mbeanServer is null");
         this.nodeId = requireNonNull(nodeManager, "nodeManager is null").getCurrentNode().getNodeIdentifier();
-        this.jmxHistoricalData = requireNonNull(jmxHistoricalData, "jmxHistoryHolder is null");
+        this.jmxHistoricalData = requireNonNull(jmxHistoricalData, "jmxHistoricalData is null");
     }
 
     public List<Object> getLiveRow(String objectName, List<? extends ColumnHandle> columns, long entryTimestamp)

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxTableHandle.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxTableHandle.java
@@ -48,7 +48,7 @@ public class JmxTableHandle
             @JsonProperty("nodeFilter") TupleDomain<ColumnHandle> nodeFilter)
     {
         this.tableName = requireNonNull(tableName, "tableName is null");
-        this.objectNames = ImmutableList.copyOf(requireNonNull(objectNames, "objectName is null"));
+        this.objectNames = ImmutableList.copyOf(requireNonNull(objectNames, "objectNames is null"));
         this.columnHandles = ImmutableList.copyOf(requireNonNull(columnHandles, "columnHandles is null"));
         this.liveData = liveData;
         this.nodeFilter = requireNonNull(nodeFilter, "nodeFilter is null");

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
@@ -69,7 +69,7 @@ public class KafkaFilterManager
     @Inject
     public KafkaFilterManager(KafkaConsumerFactory consumerFactory, KafkaAdminFactory adminFactory)
     {
-        this.consumerFactory = requireNonNull(consumerFactory, "consumerManager is null");
+        this.consumerFactory = requireNonNull(consumerFactory, "consumerFactory is null");
         this.adminFactory = requireNonNull(adminFactory, "adminFactory is null");
     }
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaMetadata.java
@@ -70,7 +70,7 @@ public class KafkaMetadata
         requireNonNull(kafkaConfig, "kafkaConfig is null");
         this.hideInternalColumns = kafkaConfig.isHideInternalColumns();
         this.tableDescriptionSupplier = requireNonNull(tableDescriptionSupplier, "tableDescriptionSupplier is null");
-        this.kafkaInternalFieldManager = requireNonNull(kafkaInternalFieldManager, "kafkaInternalFieldDescription is null");
+        this.kafkaInternalFieldManager = requireNonNull(kafkaInternalFieldManager, "kafkaInternalFieldManager is null");
     }
 
     @Override

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPageSink.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaPageSink.java
@@ -57,7 +57,7 @@ public class KafkaPageSink
             ConnectorSession session)
     {
         this.topicName = requireNonNull(topicName, "topicName is null");
-        this.columns = requireNonNull(ImmutableList.copyOf(columns), "columns is null");
+        this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.keyEncoder = requireNonNull(keyEncoder, "keyEncoder is null");
         this.messageEncoder = requireNonNull(messageEncoder, "messageEncoder is null");
         requireNonNull(producerFactory, "producerFactory is null");

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSet.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSet.java
@@ -85,11 +85,11 @@ public class KafkaRecordSet
             RowDecoder messageDecoder)
     {
         this.split = requireNonNull(split, "split is null");
-        this.consumerFactory = requireNonNull(consumerFactory, "consumerManager is null");
+        this.consumerFactory = requireNonNull(consumerFactory, "consumerFactory is null");
         this.connectorSession = requireNonNull(connectorSession, "connectorSession is null");
 
-        this.keyDecoder = requireNonNull(keyDecoder, "rowDecoder is null");
-        this.messageDecoder = requireNonNull(messageDecoder, "rowDecoder is null");
+        this.keyDecoder = requireNonNull(keyDecoder, "keyDecoder is null");
+        this.messageDecoder = requireNonNull(messageDecoder, "messageDecoder is null");
 
         this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSetProvider.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaRecordSetProvider.java
@@ -45,7 +45,7 @@ public class KafkaRecordSetProvider
     public KafkaRecordSetProvider(DispatchingRowDecoderFactory decoderFactory, KafkaConsumerFactory consumerFactory)
     {
         this.decoderFactory = requireNonNull(decoderFactory, "decoderFactory is null");
-        this.consumerFactory = requireNonNull(consumerFactory, "consumerManager is null");
+        this.consumerFactory = requireNonNull(consumerFactory, "consumerFactory is null");
     }
 
     @Override

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplit.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplit.java
@@ -49,7 +49,7 @@ public class KafkaSplit
             @JsonProperty("leader") HostAddress leader)
     {
         this.topicName = requireNonNull(topicName, "topicName is null");
-        this.keyDataFormat = requireNonNull(keyDataFormat, "dataFormat is null");
+        this.keyDataFormat = requireNonNull(keyDataFormat, "keyDataFormat is null");
         this.messageDataFormat = requireNonNull(messageDataFormat, "messageDataFormat is null");
         this.keyDataSchemaContents = keyDataSchemaContents;
         this.messageDataSchemaContents = messageDataSchemaContents;

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplitManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaSplitManager.java
@@ -50,7 +50,7 @@ public class KafkaSplitManager
     @Inject
     public KafkaSplitManager(KafkaConsumerFactory consumerFactory, KafkaConfig kafkaConfig, KafkaFilterManager kafkaFilterManager, ContentSchemaReader contentSchemaReader)
     {
-        this.consumerFactory = requireNonNull(consumerFactory, "consumerManager is null");
+        this.consumerFactory = requireNonNull(consumerFactory, "consumerFactory is null");
         this.messagesPerSplit = requireNonNull(kafkaConfig, "kafkaConfig is null").getMessagesPerSplit();
         this.kafkaFilterManager = requireNonNull(kafkaFilterManager, "kafkaFilterManager is null");
         this.contentSchemaReader = requireNonNull(contentSchemaReader, "contentSchemaReader is null");

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTableHandle.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaTableHandle.java
@@ -80,7 +80,7 @@ public final class KafkaTableHandle
         this.messageDataSchemaLocation = requireNonNull(messageDataSchemaLocation, "messageDataSchemaLocation is null");
         this.keySubject = requireNonNull(keySubject, "keySubject is null");
         this.messageSubject = requireNonNull(messageSubject, "messageSubject is null");
-        this.columns = requireNonNull(ImmutableList.copyOf(columns), "columns is null");
+        this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.constraint = requireNonNull(constraint, "constraint is null");
     }
 

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/avro/AvroRowEncoderFactory.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/encoder/avro/AvroRowEncoderFactory.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
 
 public class AvroRowEncoderFactory
         implements RowEncoderFactory
@@ -32,7 +31,7 @@ public class AvroRowEncoderFactory
     public RowEncoder create(ConnectorSession session, Optional<String> dataSchema, List<EncoderColumnHandle> columnHandles)
     {
         checkArgument(dataSchema.isPresent(), "dataSchema for Avro format is not present");
-        Schema parsedSchema = new Schema.Parser().parse(requireNonNull(dataSchema.get(), "dataSchema is null"));
+        Schema parsedSchema = new Schema.Parser().parse(dataSchema.get());
         return new AvroRowEncoder(session, columnHandles, parsedSchema);
     }
 }

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisMetadata.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisMetadata.java
@@ -52,7 +52,7 @@ public class KinesisMetadata
     {
         requireNonNull(kinesisConfig, "kinesisConfig is null");
         isHideInternalColumns = kinesisConfig.isHideInternalColumns();
-        this.tableDescriptionSupplier = requireNonNull(tableDescriptionSupplier);
+        this.tableDescriptionSupplier = requireNonNull(tableDescriptionSupplier, "tableDescriptionSupplier is null");
         this.internalFieldDescriptions = requireNonNull(internalFieldDescriptions, "internalFieldDescriptions is null");
     }
 

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisStreamDescription.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisStreamDescription.java
@@ -40,7 +40,7 @@ public class KinesisStreamDescription
     {
         checkArgument(!isNullOrEmpty(tableName), "tableName is null or is empty");
         this.tableName = tableName;
-        this.streamName = requireNonNull(streamName, "topicName is null");
+        this.streamName = requireNonNull(streamName, "streamName is null");
         this.schemaName = schemaName;
         this.message = message;
     }

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableDescriptionSupplier.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableDescriptionSupplier.java
@@ -59,7 +59,7 @@ public class KinesisTableDescriptionSupplier
     {
         this.kinesisConfig = requireNonNull(kinesisConfig, "kinesisConfig is null");
         this.streamDescriptionCodec = requireNonNull(streamDescriptionCodec, "streamDescriptionCodec is null");
-        this.s3TableConfigClient = requireNonNull(s3TableConfigClient, "S3 table config client is null");
+        this.s3TableConfigClient = requireNonNull(s3TableConfigClient, "s3TableConfigClient is null");
     }
 
     @Override

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableHandle.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisTableHandle.java
@@ -59,7 +59,7 @@ public class KinesisTableHandle
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
-        this.streamName = requireNonNull(streamName, "topicName is null");
+        this.streamName = requireNonNull(streamName, "streamName is null");
         this.messageDataFormat = requireNonNull(messageDataFormat, "messageDataFormat is null");
         this.compressionCodec = requireNonNull(compressionCodec, "compressionCodec is null");
     }

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestingKinesisConnectorFactory.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestingKinesisConnectorFactory.java
@@ -44,7 +44,7 @@ public class TestingKinesisConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        requireNonNull(catalogName, "connectorId is null");
+        requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
 
         try {

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduConnector.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduConnector.java
@@ -69,7 +69,7 @@ public class KuduConnector
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
         this.procedures = ImmutableSet.copyOf(requireNonNull(procedures, "procedures is null"));
         this.nodePartitioningProvider = requireNonNull(nodePartitioningProvider, "nodePartitioningProvider is null");
-        this.sessionProperties = requireNonNull(sessionProperties, "KuduSessionProperties is null").getSessionProperties();
+        this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null").getSessionProperties();
     }
 
     @Override

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduMetadata.java
@@ -100,7 +100,7 @@ public class KuduMetadata
     @Override
     public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        requireNonNull(prefix, "SchemaTablePrefix is null");
+        requireNonNull(prefix, "prefix is null");
 
         List<SchemaTableName> tables;
         if (prefix.getTable().isEmpty()) {

--- a/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileRecordSet.java
+++ b/plugin/trino-local-file/src/main/java/io/trino/plugin/localfile/LocalFileRecordSet.java
@@ -38,7 +38,7 @@ public class LocalFileRecordSet
 
     public LocalFileRecordSet(LocalFileTables localFileTables, LocalFileSplit split, LocalFileTableHandle table, List<LocalFileColumnHandle> columns)
     {
-        this.columns = requireNonNull(columns, "column handles is null");
+        this.columns = requireNonNull(columns, "columns is null");
         requireNonNull(split, "split is null");
 
         ImmutableList.Builder<Type> types = ImmutableList.builder();

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoColumnHandle.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoColumnHandle.java
@@ -39,7 +39,7 @@ public class MongoColumnHandle
             @JsonProperty("hidden") boolean hidden)
     {
         this.name = requireNonNull(name, "name is null");
-        this.type = requireNonNull(type, "columnType is null");
+        this.type = requireNonNull(type, "type is null");
         this.hidden = hidden;
     }
 

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -163,7 +163,7 @@ public class OracleClient
     {
         super(config, "\"", connectionFactory);
 
-        requireNonNull(oracleConfig, "oracle config is null");
+        requireNonNull(oracleConfig, "oracleConfig is null");
         this.synonymsEnabled = oracleConfig.isSynonymsEnabled();
     }
 

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
@@ -67,7 +67,7 @@ public class PhoenixMetadata
     public PhoenixMetadata(PhoenixClient phoenixClient, JdbcMetadataConfig metadataConfig)
     {
         super(phoenixClient, metadataConfig.isAllowDropTable());
-        this.phoenixClient = requireNonNull(phoenixClient, "client is null");
+        this.phoenixClient = requireNonNull(phoenixClient, "phoenixClient is null");
     }
 
     @Override

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
@@ -67,7 +67,7 @@ public class PhoenixSplitManager
     @Inject
     public PhoenixSplitManager(PhoenixClient phoenixClient)
     {
-        this.phoenixClient = requireNonNull(phoenixClient, "client is null");
+        this.phoenixClient = requireNonNull(phoenixClient, "phoenixClient is null");
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -67,7 +67,7 @@ public class PhoenixMetadata
     public PhoenixMetadata(PhoenixClient phoenixClient, JdbcMetadataConfig metadataConfig)
     {
         super(phoenixClient, metadataConfig.isAllowDropTable());
-        this.phoenixClient = requireNonNull(phoenixClient, "client is null");
+        this.phoenixClient = requireNonNull(phoenixClient, "phoenixClient is null");
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
@@ -67,7 +67,7 @@ public class PhoenixSplitManager
     @Inject
     public PhoenixSplitManager(PhoenixClient phoenixClient)
     {
-        this.phoenixClient = requireNonNull(phoenixClient, "client is null");
+        this.phoenixClient = requireNonNull(phoenixClient, "phoenixClient is null");
     }
 
     @Override

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotBrokerPageSource.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotBrokerPageSource.java
@@ -54,7 +54,7 @@ public class PinotBrokerPageSource
             List<PinotColumnHandle> columnHandles,
             PinotClient pinotClient)
     {
-        this.query = requireNonNull(query, "broker is null");
+        this.query = requireNonNull(query, "query is null");
         this.pinotClient = requireNonNull(pinotClient, "pinotClient is null");
         this.session = requireNonNull(session, "session is null");
         this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotColumnHandle.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotColumnHandle.java
@@ -35,8 +35,8 @@ public class PinotColumnHandle
             @JsonProperty("columnName") String columnName,
             @JsonProperty("dataType") Type dataType)
     {
-        this.columnName = requireNonNull(columnName, "column name is null");
-        this.dataType = requireNonNull(dataType, "data type name is null");
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.dataType = requireNonNull(dataType, "dataType is null");
     }
 
     @JsonProperty

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnector.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnector.java
@@ -54,7 +54,7 @@ public class PinotConnector
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.partitioningProvider = requireNonNull(partitioningProvider, "partitioningProvider is null");
-        this.sessionProperties = requireNonNull(pinotSessionProperties, "sessionProperties is null");
+        this.sessionProperties = requireNonNull(pinotSessionProperties, "pinotSessionProperties is null");
     }
 
     @Override

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotConnectorFactory.java
@@ -54,7 +54,7 @@ public class PinotConnectorFactory
     @Override
     public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
     {
-        requireNonNull(catalogName, "connectorId is null");
+        requireNonNull(catalogName, "catalogName is null");
         requireNonNull(config, "config is null");
 
         ImmutableList.Builder<Module> modulesBuilder = ImmutableList.<Module>builder()

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotPageSourceProvider.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotPageSourceProvider.java
@@ -51,7 +51,7 @@ public class PinotPageSourceProvider
     {
         requireNonNull(pinotConfig, "pinotConfig is null");
         this.pinotQueryClient = requireNonNull(pinotQueryClient, "pinotQueryClient is null");
-        this.clusterInfoFetcher = requireNonNull(clusterInfoFetcher, "cluster info fetcher is null");
+        this.clusterInfoFetcher = requireNonNull(clusterInfoFetcher, "clusterInfoFetcher is null");
         this.limitForSegmentQueries = pinotConfig.getMaxRowsPerSplitForSegmentQueries();
         estimatedNonNumericColumnSize = pinotConfig.getEstimatedSizeInBytesForNonNumericColumn();
     }

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplit.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplit.java
@@ -45,8 +45,8 @@ public class PinotSplit
     {
         this.splitType = requireNonNull(splitType, "splitType id is null");
         this.suffix = requireNonNull(suffix, "suffix is null");
-        this.segments = ImmutableList.copyOf(requireNonNull(segments, "segment is null"));
-        this.segmentHost = requireNonNull(segmentHost, "host is null");
+        this.segments = ImmutableList.copyOf(requireNonNull(segments, "segments is null"));
+        this.segmentHost = requireNonNull(segmentHost, "segmentHost is null");
         this.timePredicate = requireNonNull(timePredicate, "timePredicate is null");
 
         // make sure the segment properties are present when the split type is segment

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplitManager.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotSplitManager.java
@@ -56,7 +56,7 @@ public class PinotSplitManager
     @Inject
     public PinotSplitManager(PinotClient pinotClient)
     {
-        this.pinotClient = requireNonNull(pinotClient, "pinotClusterInfoFetcher is null");
+        this.pinotClient = requireNonNull(pinotClient, "pinotClient is null");
     }
 
     protected ConnectorSplitSource generateSplitForBrokerBasedScan(PinotTableHandle pinotTableHandle)
@@ -138,9 +138,9 @@ public class PinotSplitManager
                 ConnectorTableHandle connectorTableHandle,
                 String connectorId)
         {
-            super(requireNonNull(errorCode, "error code is null"), (String) null);
-            this.connectorId = requireNonNull(connectorId, "connector id is null");
-            this.connectorTableHandle = requireNonNull(connectorTableHandle, "connector table handle is null");
+            super(requireNonNull(errorCode, "errorCode is null"), (String) null);
+            this.connectorId = requireNonNull(connectorId, "connectorId is null");
+            this.connectorTableHandle = requireNonNull(connectorTableHandle, "connectorTableHandle is null");
         }
 
         @Override

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -114,9 +114,9 @@ public class PinotClient
             JsonCodec<TimeBoundary> timeBoundaryJsonCodec,
             JsonCodec<BrokerResponseNative> brokerResponseCodec)
     {
-        this.brokersForTableJsonCodec = requireNonNull(brokersForTableJsonCodec, "brokers for table json codec is null");
-        this.timeBoundaryJsonCodec = requireNonNull(timeBoundaryJsonCodec, "time boundary json codec is null");
-        this.tablesJsonCodec = requireNonNull(tablesJsonCodec, "json codec is null");
+        this.brokersForTableJsonCodec = requireNonNull(brokersForTableJsonCodec, "brokersForTableJsonCodec is null");
+        this.timeBoundaryJsonCodec = requireNonNull(timeBoundaryJsonCodec, "timeBoundaryJsonCodec is null");
+        this.tablesJsonCodec = requireNonNull(tablesJsonCodec, "tablesJsonCodec is null");
         this.schemaJsonCodec = new JsonCodecFactory(() -> new ObjectMapper()
                 .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)).jsonCodec(Schema.class);
         this.brokerResponseCodec = requireNonNull(brokerResponseCodec, "brokerResponseCodec is null");

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTable.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/DynamicTable.java
@@ -51,7 +51,7 @@ public final class DynamicTable
             @JsonProperty("offset") OptionalLong offset,
             @JsonProperty("query") String query)
     {
-        this.tableName = requireNonNull(tableName, "table is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
         this.suffix = requireNonNull(suffix, "suffix is null");
         this.selections = ImmutableList.copyOf(requireNonNull(selections, "selections is null"));
         this.groupingColumns = ImmutableList.copyOf(requireNonNull(groupingColumns, "groupingColumns is null"));

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestMinimalFunctionality.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestMinimalFunctionality.java
@@ -232,8 +232,8 @@ public class TestMinimalFunctionality
             this.neighbors = requireNonNull(neighbors, "neighbors is null");
             this.luckyNumbers = requireNonNull(luckyNumbers, "luckyNumbers is null");
             this.prices = requireNonNull(prices, "prices is null");
-            this.unluckyNumbers = requireNonNull(unluckyNumbers, "luckyNumbers is null");
-            this.longNumbers = requireNonNull(longNumbers, "luckyNumbers is null");
+            this.unluckyNumbers = requireNonNull(unluckyNumbers, "unluckyNumbers is null");
+            this.longNumbers = requireNonNull(longNumbers, "longNumbers is null");
             this.price = requireNonNull(price, "price is null");
             this.luckyNumber = requireNonNull(luckyNumber, "luckyNumber is null");
             this.unluckyNumber = requireNonNull(unluckyNumber, "unluckyNumber is null");

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusMetadata.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusMetadata.java
@@ -47,8 +47,7 @@ public class PrometheusMetadata
     @Inject
     public PrometheusMetadata(PrometheusClient prometheusClient)
     {
-        this.prometheusClient = prometheusClient;
-        requireNonNull(this.prometheusClient, "client is null");
+        this.prometheusClient = requireNonNull(prometheusClient, "prometheusClient is null");
     }
 
     @Override

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordSet.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusRecordSet.java
@@ -35,7 +35,7 @@ public class PrometheusRecordSet
         requireNonNull(prometheusClient, "prometheusClient is null");
         requireNonNull(split, "split is null");
 
-        this.columnHandles = requireNonNull(columnHandles, "column handles is null");
+        this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
         ImmutableList.Builder<Type> types = ImmutableList.builder();
         for (PrometheusColumnHandle column : columnHandles) {
             types.add(column.getColumnType());

--- a/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusSplitManager.java
+++ b/plugin/trino-prometheus/src/main/java/io/trino/plugin/prometheus/PrometheusSplitManager.java
@@ -69,7 +69,7 @@ public class PrometheusSplitManager
     @Inject
     public PrometheusSplitManager(PrometheusClient prometheusClient, PrometheusClock prometheusClock, PrometheusConnectorConfig config)
     {
-        this.prometheusClient = requireNonNull(prometheusClient, "client is null");
+        this.prometheusClient = requireNonNull(prometheusClient, "prometheusClient is null");
         this.prometheusClock = requireNonNull(prometheusClock, "prometheusClock is null");
 
         requireNonNull(config, "config is null");

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorSplit.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorSplit.java
@@ -69,7 +69,7 @@ public class RaptorSplit
             List<HostAddress> addresses,
             OptionalLong transactionId)
     {
-        this.shardUuids = ImmutableSet.copyOf(requireNonNull(shardUuids, "shardUuid is null"));
+        this.shardUuids = ImmutableSet.copyOf(requireNonNull(shardUuids, "shardUuids is null"));
         this.bucketNumber = requireNonNull(bucketNumber, "bucketNumber is null");
         this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
         this.transactionId = requireNonNull(transactionId, "transactionId is null");

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisJedisManager.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisJedisManager.java
@@ -47,7 +47,7 @@ public class RedisJedisManager
             RedisConnectorConfig redisConnectorConfig,
             NodeManager nodeManager)
     {
-        this.redisConnectorConfig = requireNonNull(redisConnectorConfig, "redisConfig is null");
+        this.redisConnectorConfig = requireNonNull(redisConnectorConfig, "redisConnectorConfig is null");
         this.jedisPoolCache = CacheBuilder.newBuilder().build(CacheLoader.from(this::createConsumer));
         this.jedisPoolConfig = new JedisPoolConfig();
     }

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisMetadata.java
@@ -64,7 +64,7 @@ public class RedisMetadata
             RedisConnectorConfig redisConnectorConfig,
             Supplier<Map<SchemaTableName, RedisTableDescription>> redisTableDescriptionSupplier)
     {
-        requireNonNull(redisConnectorConfig, "redisConfig is null");
+        requireNonNull(redisConnectorConfig, "redisConnectorConfig is null");
         hideInternalColumns = redisConnectorConfig.isHideInternalColumns();
 
         log.debug("Loading redis table definitions from %s", redisConnectorConfig.getTableDescriptionDir().getAbsolutePath());

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplitManager.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/RedisSplitManager.java
@@ -51,7 +51,7 @@ public class RedisSplitManager
             RedisConnectorConfig redisConnectorConfig,
             RedisJedisManager jedisManager)
     {
-        this.redisConnectorConfig = requireNonNull(redisConnectorConfig, "redisConfig is null");
+        this.redisConnectorConfig = requireNonNull(redisConnectorConfig, "redisConnectorConfig is null");
         this.jedisManager = requireNonNull(jedisManager, "jedisManager is null");
     }
 

--- a/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/zset/ZsetRedisRowDecoderFactory.java
+++ b/plugin/trino-redis/src/main/java/io/trino/plugin/redis/decoder/zset/ZsetRedisRowDecoderFactory.java
@@ -31,7 +31,7 @@ public class ZsetRedisRowDecoderFactory
     @Override
     public RowDecoder create(Map<String, String> decoderParams, Set<DecoderColumnHandle> columns)
     {
-        requireNonNull(columns, "columnHandles is null");
+        requireNonNull(columns, "columns is null");
         checkArgument(columns.stream().noneMatch(DecoderColumnHandle::isInternal), "unexpected internal column");
         return DECODER_INSTANCE;
     }

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/MysqlDaoProvider.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/MysqlDaoProvider.java
@@ -30,7 +30,7 @@ public class MysqlDaoProvider
     @Inject
     public MysqlDaoProvider(DbResourceGroupConfig config)
     {
-        requireNonNull(config, "DbResourceGroupConfig is null");
+        requireNonNull(config, "config is null");
         MysqlDataSource dataSource = new MysqlDataSource();
         dataSource.setURL(requireNonNull(config.getConfigDbUrl(), "resource-groups.config-db-url is null"));
         this.dao = Jdbi.create(dataSource)

--- a/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupGlobalProperties.java
+++ b/plugin/trino-resource-group-managers/src/main/java/io/trino/plugin/resourcegroups/db/ResourceGroupGlobalProperties.java
@@ -30,7 +30,7 @@ public class ResourceGroupGlobalProperties
 
     public ResourceGroupGlobalProperties(Optional<Duration> cpuQuotaPeriod)
     {
-        this.cpuQuotaPeriod = requireNonNull(cpuQuotaPeriod, "Cpu Quota Period is null");
+        this.cpuQuotaPeriod = requireNonNull(cpuQuotaPeriod, "cpuQuotaPeriod is null");
     }
 
     public Optional<Duration> getCpuQuotaPeriod()

--- a/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ListBasedRecordSet.java
+++ b/plugin/trino-thrift-testing-server/src/main/java/io/trino/plugin/thrift/server/ListBasedRecordSet.java
@@ -34,7 +34,7 @@ public class ListBasedRecordSet
     public ListBasedRecordSet(List<List<String>> keys, List<Type> types)
     {
         this.types = requireNonNull(types, "types is null");
-        this.keys = requireNonNull(keys, "types is null");
+        this.keys = requireNonNull(keys, "keys is null");
         checkArgument(keys.isEmpty() || keys.size() == types.size(),
                 "number of types and key columns must match");
         this.totalRecords = keys.isEmpty() ? 0 : keys.get(0).size();

--- a/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftPageSourceProvider.java
+++ b/plugin/trino-thrift/src/main/java/io/trino/plugin/thrift/ThriftPageSourceProvider.java
@@ -42,7 +42,7 @@ public class ThriftPageSourceProvider
     public ThriftPageSourceProvider(DriftClient<TrinoThriftService> client, ThriftHeaderProvider thriftHeaderProvider, ThriftConnectorStats stats, ThriftConnectorConfig config)
     {
         this.client = requireNonNull(client, "client is null");
-        this.thriftHeaderProvider = requireNonNull(thriftHeaderProvider, "thriftHeaderFactor is null");
+        this.thriftHeaderProvider = requireNonNull(thriftHeaderProvider, "thriftHeaderProvider is null");
         this.maxBytesPerResponse = requireNonNull(config, "config is null").getMaxResponseSize().toBytes();
         this.stats = requireNonNull(stats, "stats is null");
     }

--- a/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/statistics/ColumnStatisticsData.java
+++ b/plugin/trino-tpcds/src/main/java/io/trino/plugin/tpcds/statistics/ColumnStatisticsData.java
@@ -39,8 +39,8 @@ public class ColumnStatisticsData
     {
         this.distinctValuesCount = distinctValuesCount;
         this.nullsCount = nullsCount;
-        this.min = requireNonNull(min);
-        this.max = requireNonNull(max);
+        this.min = requireNonNull(min, "min is null");
+        this.max = requireNonNull(max, "max is null");
         this.dataSize = requireNonNull(dataSize, "dataSize is null");
     }
 

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/statistics/ColumnStatisticsData.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/statistics/ColumnStatisticsData.java
@@ -35,8 +35,8 @@ public class ColumnStatisticsData
             @JsonProperty("dataSize") Optional<Long> dataSize)
     {
         this.distinctValuesCount = requireNonNull(distinctValuesCount, "distinctValuesCount is null");
-        this.min = requireNonNull(min);
-        this.max = requireNonNull(max);
+        this.min = requireNonNull(min, "min is null");
+        this.max = requireNonNull(max, "max is null");
         this.dataSize = requireNonNull(dataSize, "dataSize is null");
     }
 

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/BenchmarkSuite.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/BenchmarkSuite.java
@@ -153,7 +153,7 @@ public class BenchmarkSuite
 
         private ForwardingBenchmarkResultWriter(List<BenchmarkResultHook> benchmarkResultHooks)
         {
-            requireNonNull(benchmarkResultHooks, "benchmarkResultWriters is null");
+            requireNonNull(benchmarkResultHooks, "benchmarkResultHooks is null");
             this.benchmarkResultHooks = ImmutableList.copyOf(benchmarkResultHooks);
         }
 

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteList.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteList.java
@@ -80,7 +80,7 @@ public final class SuiteList
         @Inject
         public Execution(SuiteFactory suiteFactory, EnvironmentConfigFactory configFactory)
         {
-            this.configFactory = requireNonNull(configFactory, "factory is null");
+            this.configFactory = requireNonNull(configFactory, "configFactory is null");
             this.suiteFactory = requireNonNull(suiteFactory, "suiteFactory is null");
 
             try {

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteRun.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/SuiteRun.java
@@ -365,7 +365,7 @@ public class SuiteRun
             this.suiteName = suiteName;
             this.runId = runId;
             this.suiteRun = requireNonNull(suiteRun, "suiteRun is null");
-            this.environmentConfig = requireNonNull(environmentConfig, "suiteConfig is null");
+            this.environmentConfig = requireNonNull(environmentConfig, "environmentConfig is null");
             this.duration = requireNonNull(duration, "duration is null");
             this.throwable = requireNonNull(throwable, "throwable is null");
         }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/HadoopKerberosKms.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/HadoopKerberosKms.java
@@ -43,8 +43,8 @@ public class HadoopKerberosKms
     {
         this.configDir = dockerFiles.getDockerFilesHostDirectory("common/hadoop-kerberos-kms/");
         this.hadoopKerberos = requireNonNull(hadoopKerberos, "hadoopKerberos is null");
-        requireNonNull(environmentConfig, "environmentOptions is null");
-        hadoopImagesVersion = requireNonNull(environmentConfig, "environmentConfig is null").getHadoopImagesVersion();
+        requireNonNull(environmentConfig, "environmentConfig is null");
+        hadoopImagesVersion = environmentConfig.getHadoopImagesVersion();
     }
 
     @Override

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/cli/TestTrinoCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/cli/TestTrinoCli.java
@@ -455,10 +455,10 @@ public class TestTrinoCli
         }
 
         if (kerberosAuthentication) {
-            requireNonNull(kerberosPrincipal, "databases.presto.cli_kerberos_principal is null");
-            requireNonNull(kerberosKeytab, "databases.presto.cli_kerberos_keytab is null");
-            requireNonNull(kerberosServiceName, "databases.presto.cli_kerberos_service_name is null");
-            requireNonNull(kerberosConfigPath, "databases.presto.cli_kerberos_config_path is null");
+            requireNonNull(kerberosPrincipal, "kerberosPrincipal is null");
+            requireNonNull(kerberosKeytab, "kerberosKeytab is null");
+            requireNonNull(kerberosServiceName, "kerberosServiceName is null");
+            requireNonNull(kerberosConfigPath, "kerberosConfigPath is null");
 
             trinoClientOptions.add("--krb5-principal", kerberosPrincipal);
             trinoClientOptions.add("--krb5-keytab-path", kerberosKeytab);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/cli/TestTrinoLdapCli.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/cli/TestTrinoLdapCli.java
@@ -263,11 +263,11 @@ public class TestTrinoLdapCli
     private void launchTrinoCliWithServerArgument(String... arguments)
             throws IOException
     {
-        requireNonNull(ldapTruststorePath, "databases.presto.cli_ldap_truststore_path is null");
-        requireNonNull(ldapTruststorePassword, "databases.presto.cli_ldap_truststore_password is null");
-        requireNonNull(ldapUserName, "databases.presto.cli_ldap_user_name is null");
-        requireNonNull(ldapServerAddress, "databases.presto.cli_ldap_server_address is null");
-        requireNonNull(ldapUserPassword, "databases.presto.cli_ldap_user_password is null");
+        requireNonNull(ldapTruststorePath, "ldapTruststorePath is null");
+        requireNonNull(ldapTruststorePassword, "ldapTruststorePassword is null");
+        requireNonNull(ldapUserName, "ldapUserName is null");
+        requireNonNull(ldapServerAddress, "ldapServerAddress is null");
+        requireNonNull(ldapUserPassword, "ldapUserPassword is null");
 
         ImmutableList.Builder<String> prestoClientOptions = ImmutableList.builder();
         prestoClientOptions.add(

--- a/testing/trino-testing/src/main/java/io/trino/testing/statistics/StatsContext.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/statistics/StatsContext.java
@@ -31,7 +31,7 @@ public class StatsContext
     public StatsContext(Map<String, Symbol> columnSymbols, TypeProvider types)
     {
         this.columnSymbols = ImmutableMap.copyOf(columnSymbols);
-        this.types = requireNonNull(types, "symbolTypes is null");
+        this.types = requireNonNull(types, "types is null");
     }
 
     public Symbol getSymbolForColumn(String columnName)

--- a/testing/trino-testing/src/test/java/io/trino/testing/TestBaseConnectorTest.java
+++ b/testing/trino-testing/src/test/java/io/trino/testing/TestBaseConnectorTest.java
@@ -48,7 +48,7 @@ public class TestBaseConnectorTest
         private MethodSignature(String name, Class<?>[] parameters)
         {
             this.name = requireNonNull(name, "name is null");
-            this.parameters = ImmutableList.copyOf(requireNonNull(parameters, "fields is null"));
+            this.parameters = ImmutableList.copyOf(requireNonNull(parameters, "parameters is null"));
         }
 
         @Override

--- a/testing/trino-tests/src/test/java/io/trino/execution/EventsAwaitingQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/EventsAwaitingQueries.java
@@ -35,7 +35,7 @@ class EventsAwaitingQueries
 
     EventsAwaitingQueries(EventsCollector eventsCollector, QueryRunner queryRunner, Duration extraWaitTime)
     {
-        this.eventsCollector = requireNonNull(eventsCollector, "eventsBuilder is null");
+        this.eventsCollector = requireNonNull(eventsCollector, "eventsCollector is null");
         this.queryRunner = requireNonNull(queryRunner, "queryRunner is null");
         this.extraWaitTime = extraWaitTime;
     }

--- a/testing/trino-tests/src/test/java/io/trino/execution/EventsCollector.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/EventsCollector.java
@@ -41,7 +41,7 @@ class EventsCollector
 
     public EventsCollector(EventFilters eventFilters)
     {
-        this.eventFilters = requireNonNull(eventFilters, "filter is null");
+        this.eventFilters = requireNonNull(eventFilters, "eventFilters is null");
         reset(0);
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerPlugin.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerPlugin.java
@@ -31,7 +31,7 @@ public class TestEventListenerPlugin
 
         public TestingEventListenerPlugin(EventsCollector eventsCollector)
         {
-            this.eventsCollector = requireNonNull(eventsCollector, "eventsBuilder is null");
+            this.eventsCollector = requireNonNull(eventsCollector, "eventsCollector is null");
         }
 
         @Override


### PR DESCRIPTION
- some messages were outdated, after a variable rename
- some were always wrong
- some `requireNonNull` were placed on methods that are known to never
  return null (e.g. `ImmutableList.copyOf`), instead of parameter being
  passed there
- some messages were missing