### PR TITLE
Collect build side before local dynamic filters are consumed

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/LookupJoinOperatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/LookupJoinOperatorFactory.java
@@ -46,6 +46,7 @@ public class LookupJoinOperatorFactory
     private final List<Type> buildOutputTypes;
     private final JoinType joinType;
     private final boolean outputSingleMatch;
+    private final boolean waitForBuild;
     private final JoinProbeFactory joinProbeFactory;
     private final Optional<OuterOperatorFactoryResult> outerOperatorFactoryResult;
     private final JoinBridgeManager<? extends LookupSourceFactory> joinBridgeManager;
@@ -64,6 +65,7 @@ public class LookupJoinOperatorFactory
             List<Type> buildOutputTypes,
             JoinType joinType,
             boolean outputSingleMatch,
+            boolean waitForBuild,
             JoinProbeFactory joinProbeFactory,
             BlockTypeOperators blockTypeOperators,
             OptionalInt totalOperatorsCount,
@@ -77,6 +79,7 @@ public class LookupJoinOperatorFactory
         this.buildOutputTypes = ImmutableList.copyOf(requireNonNull(buildOutputTypes, "buildOutputTypes is null"));
         this.joinType = requireNonNull(joinType, "joinType is null");
         this.outputSingleMatch = outputSingleMatch;
+        this.waitForBuild = waitForBuild;
         this.joinProbeFactory = requireNonNull(joinProbeFactory, "joinProbeFactory is null");
 
         this.joinBridgeManager = lookupSourceFactoryManager;
@@ -123,6 +126,7 @@ public class LookupJoinOperatorFactory
         buildOutputTypes = other.buildOutputTypes;
         joinType = other.joinType;
         outputSingleMatch = other.outputSingleMatch;
+        waitForBuild = other.waitForBuild;
         joinProbeFactory = other.joinProbeFactory;
         joinBridgeManager = other.joinBridgeManager;
         outerOperatorFactoryResult = other.outerOperatorFactoryResult;
@@ -193,6 +197,7 @@ public class LookupJoinOperatorFactory
                 buildOutputTypes,
                 joinType,
                 outputSingleMatch,
+                waitForBuild,
                 lookupSourceFactory,
                 joinProbeFactory,
                 () -> joinBridgeManager.probeOperatorClosed(processorContext.getLifespan()),
@@ -215,6 +220,7 @@ public class LookupJoinOperatorFactory
                 buildOutputTypes,
                 joinType,
                 outputSingleMatch,
+                waitForBuild,
                 lookupSourceFactory,
                 joinProbeFactory,
                 () -> joinBridgeManager.probeOperatorClosed(processorContext.getLifespan()),

--- a/core/trino-main/src/main/java/io/trino/operator/LookupJoinOperators.java
+++ b/core/trino-main/src/main/java/io/trino/operator/LookupJoinOperators.java
@@ -49,6 +49,7 @@ public class LookupJoinOperators
             JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
             List<Type> probeTypes,
             boolean outputSingleMatch,
+            boolean waitForBuild,
             List<Integer> probeJoinChannel,
             OptionalInt probeHashChannel,
             Optional<List<Integer>> probeOutputChannels,
@@ -66,6 +67,7 @@ public class LookupJoinOperators
                 probeOutputChannels.orElse(rangeList(probeTypes.size())),
                 JoinType.INNER,
                 outputSingleMatch,
+                waitForBuild,
                 totalOperatorsCount,
                 partitioningSpillerFactory,
                 blockTypeOperators);
@@ -94,6 +96,7 @@ public class LookupJoinOperators
                 probeOutputChannels.orElse(rangeList(probeTypes.size())),
                 JoinType.PROBE_OUTER,
                 outputSingleMatch,
+                false,
                 totalOperatorsCount,
                 partitioningSpillerFactory,
                 blockTypeOperators);
@@ -104,6 +107,7 @@ public class LookupJoinOperators
             PlanNodeId planNodeId,
             JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
             List<Type> probeTypes,
+            boolean waitForBuild,
             List<Integer> probeJoinChannel,
             OptionalInt probeHashChannel,
             Optional<List<Integer>> probeOutputChannels,
@@ -121,6 +125,7 @@ public class LookupJoinOperators
                 probeOutputChannels.orElse(rangeList(probeTypes.size())),
                 JoinType.LOOKUP_OUTER,
                 false,
+                waitForBuild,
                 totalOperatorsCount,
                 partitioningSpillerFactory,
                 blockTypeOperators);
@@ -148,6 +153,7 @@ public class LookupJoinOperators
                 probeOutputChannels.orElse(rangeList(probeTypes.size())),
                 JoinType.FULL_OUTER,
                 false,
+                false,
                 totalOperatorsCount,
                 partitioningSpillerFactory,
                 blockTypeOperators);
@@ -170,6 +176,7 @@ public class LookupJoinOperators
             List<Integer> probeOutputChannels,
             JoinType joinType,
             boolean outputSingleMatch,
+            boolean waitForBuild,
             OptionalInt totalOperatorsCount,
             PartitioningSpillerFactory partitioningSpillerFactory,
             BlockTypeOperators blockTypeOperators)
@@ -187,6 +194,7 @@ public class LookupJoinOperators
                 lookupSourceFactoryManager.getBuildOutputTypes(),
                 joinType,
                 outputSingleMatch,
+                waitForBuild,
                 new JoinProbeFactory(probeOutputChannels.stream().mapToInt(i -> i).toArray(), probeJoinChannel, probeHashChannel),
                 blockTypeOperators,
                 totalOperatorsCount,

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkHashBuildAndJoinOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkHashBuildAndJoinOperators.java
@@ -225,6 +225,7 @@ public class BenchmarkHashBuildAndJoinOperators
                     lookupSourceFactory,
                     types,
                     false,
+                    false,
                     hashChannels,
                     hashChannel,
                     Optional.of(outputChannels),

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashJoinOperator.java
@@ -243,6 +243,7 @@ public class TestHashJoinOperator
                 lookupSourceFactory,
                 probePages.getTypes(),
                 false,
+                false,
                 Ints.asList(0),
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
@@ -294,6 +295,7 @@ public class TestHashJoinOperator
                 new PlanNodeId("test"),
                 lookupSourceFactory,
                 probePages.getTypes(),
+                false,
                 false,
                 Ints.asList(0),
                 getHashChannelAsInt(probePages),
@@ -1146,6 +1148,7 @@ public class TestHashJoinOperator
                 lookupSourceFactoryManager,
                 probePages.getTypes(),
                 false,
+                false,
                 Ints.asList(0),
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
@@ -1183,6 +1186,7 @@ public class TestHashJoinOperator
                 new PlanNodeId("test"),
                 lookupSourceFactoryManager,
                 probePages.getTypes(),
+                false,
                 Ints.asList(0),
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
@@ -1319,6 +1323,7 @@ public class TestHashJoinOperator
                 lookupSourceFactoryManager,
                 probePages.getTypes(),
                 false,
+                false,
                 Ints.asList(0),
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
@@ -1339,16 +1344,32 @@ public class TestHashJoinOperator
     public void testInnerJoinWithBlockingLookupSourceAndEmptyProbe(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
             throws Exception
     {
+        // join that waits for build side to be collected
         TaskContext taskContext = createTaskContext();
-        OperatorFactory joinOperatorFactory = createJoinOperatorFactoryWithBlockingLookupSource(taskContext, parallelBuild, probeHashEnabled, buildHashEnabled);
-
+        OperatorFactory joinOperatorFactory = createJoinOperatorFactoryWithBlockingLookupSource(taskContext, parallelBuild, probeHashEnabled, buildHashEnabled, true);
         DriverContext driverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();
         try (Operator joinOperator = joinOperatorFactory.createOperator(driverContext)) {
             joinOperatorFactory.noMoreOperators();
             assertFalse(joinOperator.needsInput());
             joinOperator.finish();
-            // lookup join operator will yield once before finishing
             assertNull(joinOperator.getOutput());
+
+            // lookup join operator got blocked waiting for build side
+            assertFalse(joinOperator.isBlocked().isDone());
+            assertFalse(joinOperator.isFinished());
+        }
+
+        // join that doesn't wait for build side to be collected
+        taskContext = createTaskContext();
+        joinOperatorFactory = createJoinOperatorFactoryWithBlockingLookupSource(taskContext, parallelBuild, probeHashEnabled, buildHashEnabled, false);
+        driverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();
+        try (Operator joinOperator = joinOperatorFactory.createOperator(driverContext)) {
+            joinOperatorFactory.noMoreOperators();
+            assertTrue(joinOperator.needsInput());
+            joinOperator.finish();
+            assertNull(joinOperator.getOutput());
+
+            // lookup join operator will yield once before finishing
             assertNull(joinOperator.getOutput());
             assertTrue(joinOperator.isBlocked().isDone());
             assertTrue(joinOperator.isFinished());
@@ -1359,14 +1380,38 @@ public class TestHashJoinOperator
     public void testInnerJoinWithBlockingLookupSource(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
             throws Exception
     {
-        TaskContext taskContext = createTaskContext();
-        OperatorFactory joinOperatorFactory = createJoinOperatorFactoryWithBlockingLookupSource(taskContext, parallelBuild, probeHashEnabled, buildHashEnabled);
+        RowPagesBuilder probePages = rowPagesBuilder(probeHashEnabled, Ints.asList(0), ImmutableList.of(VARCHAR));
+        Page probePage = getOnlyElement(probePages.addSequencePage(1, 0).build());
 
+        // join that waits for build side to be collected
+        TaskContext taskContext = createTaskContext();
+        OperatorFactory joinOperatorFactory = createJoinOperatorFactoryWithBlockingLookupSource(taskContext, parallelBuild, probeHashEnabled, buildHashEnabled, true);
         DriverContext driverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();
         try (Operator joinOperator = joinOperatorFactory.createOperator(driverContext)) {
             joinOperatorFactory.noMoreOperators();
             assertFalse(joinOperator.needsInput());
             assertNull(joinOperator.getOutput());
+
+            // lookup join operator got blocked waiting for build side
+            assertFalse(joinOperator.isBlocked().isDone());
+            assertFalse(joinOperator.isFinished());
+        }
+
+        // join that doesn't wait for build side to be collected
+        taskContext = createTaskContext();
+        joinOperatorFactory = createJoinOperatorFactoryWithBlockingLookupSource(taskContext, parallelBuild, probeHashEnabled, buildHashEnabled, false);
+        driverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();
+        try (Operator joinOperator = joinOperatorFactory.createOperator(driverContext)) {
+            joinOperatorFactory.noMoreOperators();
+            assertTrue(joinOperator.needsInput());
+            assertNull(joinOperator.getOutput());
+
+            // join needs input page
+            assertTrue(joinOperator.isBlocked().isDone());
+            assertFalse(joinOperator.isFinished());
+            joinOperator.addInput(probePage);
+            assertNull(joinOperator.getOutput());
+
             // lookup join operator got blocked waiting for build side
             assertFalse(joinOperator.isBlocked().isDone());
             assertFalse(joinOperator.isFinished());
@@ -1453,7 +1498,7 @@ public class TestHashJoinOperator
         assertTrue(outputPages.isFinished());
     }
 
-    private OperatorFactory createJoinOperatorFactoryWithBlockingLookupSource(TaskContext taskContext, boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
+    private OperatorFactory createJoinOperatorFactoryWithBlockingLookupSource(TaskContext taskContext, boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled, boolean waitForBuild)
     {
         // build factory
         List<Type> buildTypes = ImmutableList.of(VARCHAR);
@@ -1470,6 +1515,7 @@ public class TestHashJoinOperator
                 lookupSourceFactoryManager,
                 probePages.getTypes(),
                 false,
+                waitForBuild,
                 Ints.asList(0),
                 getHashChannelAsInt(probePages),
                 Optional.empty(),
@@ -1543,6 +1589,7 @@ public class TestHashJoinOperator
                 lookupSourceFactoryManager,
                 probePages.getTypes(),
                 outputSingleMatch,
+                false,
                 Ints.asList(0),
                 getHashChannelAsInt(probePages),
                 Optional.empty(),

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashBuildAndJoinBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashBuildAndJoinBenchmark.java
@@ -137,6 +137,7 @@ public class HashBuildAndJoinBenchmark
                 lookupSourceFactoryManager,
                 sourceTypes,
                 false,
+                false,
                 Ints.asList(0),
                 hashChannel,
                 Optional.empty(),

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashBuildBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashBuildBenchmark.java
@@ -96,6 +96,7 @@ public class HashBuildBenchmark
                 lookupSourceFactoryManager,
                 ImmutableList.of(BIGINT),
                 false,
+                false,
                 Ints.asList(0),
                 OptionalInt.empty(),
                 Optional.empty(),

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashJoinBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashJoinBenchmark.java
@@ -106,6 +106,7 @@ public class HashJoinBenchmark
                     lookupSourceFactoryManager,
                     lineItemTypes,
                     false,
+                    false,
                     Ints.asList(0),
                     OptionalInt.empty(),
                     Optional.empty(),


### PR DESCRIPTION
In practice, join currently doesn't support probe short circuit.
Therefore, this commit makes it explicit that when local dynamic
filters are consumed by table scan then join should wait for build
side before requesting any probe rows. This way table scan has
a chance to consume local dynamic filters before producing any data.

In the future, join shirt-circuit should be fixed by
fetching probe rows first. This should be preceeded
by adding node local waiting for DFs at probe table scan
level (this is what current join semantics gives).