### PR TITLE
Add compatibility with misbehaving client applications

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -55,6 +55,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<HostAndPort> HTTP_PROXY = new HttpProxy();
     public static final ConnectionProperty<String> APPLICATION_NAME_PREFIX = new ApplicationNamePrefix();
     public static final ConnectionProperty<Boolean> DISABLE_COMPRESSION = new DisableCompression();
+    public static final ConnectionProperty<Boolean> ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS = new AssumeLiteralNamesInMetadataCallsForNonConformingClients();
     public static final ConnectionProperty<Boolean> SSL = new Ssl();
     public static final ConnectionProperty<SslVerificationMode> SSL_VERIFICATION = new SslVerification();
     public static final ConnectionProperty<String> SSL_KEY_STORE_PATH = new SslKeyStorePath();
@@ -89,6 +90,7 @@ final class ConnectionProperties
             .add(HTTP_PROXY)
             .add(APPLICATION_NAME_PREFIX)
             .add(DISABLE_COMPRESSION)
+            .add(ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS)
             .add(SSL)
             .add(SSL_VERIFICATION)
             .add(SSL_KEY_STORE_PATH)
@@ -270,6 +272,15 @@ final class ConnectionProperties
         public DisableCompression()
         {
             super("disableCompression", NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
+        }
+    }
+
+    private static class AssumeLiteralNamesInMetadataCallsForNonConformingClients
+            extends AbstractConnectionProperty<Boolean>
+    {
+        public AssumeLiteralNamesInMetadataCallsForNonConformingClients()
+        {
+            super("assumeLiteralNamesInMetadataCallsForNonConformingClients", NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -91,6 +91,7 @@ public class TrinoConnection
     private final String user;
     private final Optional<String> sessionUser;
     private final boolean compressionDisabled;
+    private final boolean assumeLiteralNamesInMetadataCallsForNonConformingClients;
     private final Map<String, String> extraCredentials;
     private final Optional<String> applicationNamePrefix;
     private final Optional<String> source;
@@ -115,6 +116,7 @@ public class TrinoConnection
         this.source = uri.getSource();
         this.extraCredentials = uri.getExtraCredentials();
         this.compressionDisabled = uri.isCompressionDisabled();
+        this.assumeLiteralNamesInMetadataCallsForNonConformingClients = uri.isAssumeLiteralNamesInMetadataCallsForNonConformingClients();
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
         uri.getClientInfo().ifPresent(tags -> clientInfo.put(CLIENT_INFO, tags));
         uri.getClientTags().ifPresent(tags -> clientInfo.put(CLIENT_TAGS, tags));
@@ -238,7 +240,7 @@ public class TrinoConnection
     public DatabaseMetaData getMetaData()
             throws SQLException
     {
-        return new TrinoDatabaseMetaData(this);
+        return new TrinoDatabaseMetaData(this, assumeLiteralNamesInMetadataCallsForNonConformingClients);
     }
 
     @Override

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDatabaseMetaData.java
@@ -20,6 +20,8 @@ import io.trino.client.ClientTypeSignature;
 import io.trino.client.ClientTypeSignatureParameter;
 import io.trino.client.Column;
 
+import javax.annotation.Nullable;
+
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -31,6 +33,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Lists.newArrayList;
 import static io.trino.client.ClientTypeSignature.VARCHAR_UNBOUNDED_LENGTH;
 import static io.trino.jdbc.DriverInfo.DRIVER_NAME;
@@ -46,10 +49,12 @@ public class TrinoDatabaseMetaData
     private static final String SEARCH_STRING_ESCAPE = "\\";
 
     private final TrinoConnection connection;
+    private final boolean assumeLiteralNamesInMetadataCallsForNonConformingClients;
 
-    TrinoDatabaseMetaData(TrinoConnection connection)
+    TrinoDatabaseMetaData(TrinoConnection connection, boolean assumeLiteralNamesInMetadataCallsForNonConformingClients)
     {
         this.connection = requireNonNull(connection, "connection is null");
+        this.assumeLiteralNamesInMetadataCallsForNonConformingClients = assumeLiteralNamesInMetadataCallsForNonConformingClients;
     }
 
     @Override
@@ -897,6 +902,8 @@ public class TrinoDatabaseMetaData
     public ResultSet getProcedures(String catalog, String schemaPattern, String procedureNamePattern)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        procedureNamePattern = escapeIfNecessary(procedureNamePattern);
         return selectEmpty("" +
                 "SELECT PROCEDURE_CAT, PROCEDURE_SCHEM, PROCEDURE_NAME,\n " +
                 "  null, null, null, REMARKS, PROCEDURE_TYPE, SPECIFIC_NAME\n" +
@@ -908,6 +915,9 @@ public class TrinoDatabaseMetaData
     public ResultSet getProcedureColumns(String catalog, String schemaPattern, String procedureNamePattern, String columnNamePattern)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        procedureNamePattern = escapeIfNecessary(procedureNamePattern);
+        columnNamePattern = escapeIfNecessary(columnNamePattern);
         return selectEmpty("" +
                 "SELECT PROCEDURE_CAT, PROCEDURE_SCHEM, PROCEDURE_NAME, " +
                 "  COLUMN_NAME, COLUMN_TYPE, DATA_TYPE, TYPE_NAME,\n" +
@@ -922,6 +932,8 @@ public class TrinoDatabaseMetaData
     public ResultSet getTables(String catalog, String schemaPattern, String tableNamePattern, String[] types)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        tableNamePattern = escapeIfNecessary(tableNamePattern);
         StringBuilder query = new StringBuilder("" +
                 "SELECT TABLE_CAT, TABLE_SCHEM, TABLE_NAME, TABLE_TYPE, REMARKS,\n" +
                 "  TYPE_CAT, TYPE_SCHEM, TYPE_NAME, " +
@@ -974,6 +986,9 @@ public class TrinoDatabaseMetaData
     public ResultSet getColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        tableNamePattern = escapeIfNecessary(tableNamePattern);
+        columnNamePattern = escapeIfNecessary(columnNamePattern);
         StringBuilder query = new StringBuilder("" +
                 "SELECT TABLE_CAT, TABLE_SCHEM, TABLE_NAME, COLUMN_NAME, DATA_TYPE,\n" +
                 "  TYPE_NAME, COLUMN_SIZE, BUFFER_LENGTH, DECIMAL_DIGITS, NUM_PREC_RADIX,\n" +
@@ -999,6 +1014,7 @@ public class TrinoDatabaseMetaData
     public ResultSet getColumnPrivileges(String catalog, String schema, String table, String columnNamePattern)
             throws SQLException
     {
+        columnNamePattern = escapeIfNecessary(columnNamePattern);
         throw new SQLFeatureNotSupportedException("privileges not supported");
     }
 
@@ -1006,6 +1022,8 @@ public class TrinoDatabaseMetaData
     public ResultSet getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        tableNamePattern = escapeIfNecessary(tableNamePattern);
         throw new SQLFeatureNotSupportedException("privileges not supported");
     }
 
@@ -1168,6 +1186,8 @@ public class TrinoDatabaseMetaData
     public ResultSet getUDTs(String catalog, String schemaPattern, String typeNamePattern, int[] types)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        typeNamePattern = escapeIfNecessary(typeNamePattern);
         return selectEmpty("" +
                 "SELECT TYPE_CAT, TYPE_SCHEM, TYPE_NAME,\n" +
                 "  CLASS_NAME, DATA_TYPE, REMARKS, BASE_TYPE\n" +
@@ -1214,6 +1234,8 @@ public class TrinoDatabaseMetaData
     public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        typeNamePattern = escapeIfNecessary(typeNamePattern);
         return selectEmpty("" +
                 "SELECT TYPE_CAT, TYPE_SCHEM, TYPE_NAME,\n" +
                 "  SUPERTYPE_CAT, SUPERTYPE_SCHEM, SUPERTYPE_NAME\n" +
@@ -1225,6 +1247,8 @@ public class TrinoDatabaseMetaData
     public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        tableNamePattern = escapeIfNecessary(tableNamePattern);
         return selectEmpty("" +
                 "SELECT TABLE_CAT, TABLE_SCHEM, TABLE_NAME, SUPERTABLE_NAME\n" +
                 "FROM system.jdbc.super_tables\n" +
@@ -1235,6 +1259,9 @@ public class TrinoDatabaseMetaData
     public ResultSet getAttributes(String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        typeNamePattern = escapeIfNecessary(typeNamePattern);
+        attributeNamePattern = escapeIfNecessary(attributeNamePattern);
         return selectEmpty("" +
                 "SELECT TYPE_CAT, TYPE_SCHEM, TYPE_NAME, ATTR_NAME, DATA_TYPE,\n" +
                 "  ATTR_TYPE_NAME, ATTR_SIZE, DECIMAL_DIGITS, NUM_PREC_RADIX, NULLABLE,\n" +
@@ -1332,6 +1359,7 @@ public class TrinoDatabaseMetaData
     public ResultSet getSchemas(String catalog, String schemaPattern)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
         StringBuilder query = new StringBuilder("" +
                 "SELECT TABLE_SCHEM, TABLE_CATALOG\n" +
                 "FROM system.jdbc.schemas");
@@ -1391,6 +1419,8 @@ public class TrinoDatabaseMetaData
     public ResultSet getFunctions(String catalog, String schemaPattern, String functionNamePattern)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        functionNamePattern = escapeIfNecessary(functionNamePattern);
         // TODO: implement this
         throw new NotImplementedException("DatabaseMetaData", "getFunctions");
     }
@@ -1399,6 +1429,9 @@ public class TrinoDatabaseMetaData
     public ResultSet getFunctionColumns(String catalog, String schemaPattern, String functionNamePattern, String columnNamePattern)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        functionNamePattern = escapeIfNecessary(functionNamePattern);
+        columnNamePattern = escapeIfNecessary(columnNamePattern);
         // TODO: implement this
         throw new NotImplementedException("DatabaseMetaData", "getFunctionColumns");
     }
@@ -1407,6 +1440,9 @@ public class TrinoDatabaseMetaData
     public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
             throws SQLException
     {
+        schemaPattern = escapeIfNecessary(schemaPattern);
+        tableNamePattern = escapeIfNecessary(tableNamePattern);
+        columnNamePattern = escapeIfNecessary(columnNamePattern);
         return selectEmpty("" +
                 "SELECT TABLE_CAT, TABLE_SCHEM, TABLE_NAME, COLUMN_NAME, DATA_TYPE,\n" +
                 "  COLUMN_SIZE, DECIMAL_DIGITS, NUM_PREC_RADIX, COLUMN_USAGE, REMARKS,\n" +
@@ -1483,6 +1519,23 @@ public class TrinoDatabaseMetaData
 
         filter.append(")");
         filters.add(filter.toString());
+    }
+
+    @Nullable
+    private String escapeIfNecessary(@Nullable String namePattern)
+    {
+        return escapeIfNecessary(assumeLiteralNamesInMetadataCallsForNonConformingClients, namePattern);
+    }
+
+    @Nullable
+    static String escapeIfNecessary(boolean assumeLiteralNamesInMetadataCallsForNonConformingClients, @Nullable String namePattern)
+    {
+        if (namePattern == null || !assumeLiteralNamesInMetadataCallsForNonConformingClients) {
+            return namePattern;
+        }
+        //noinspection ConstantConditions
+        verify(SEARCH_STRING_ESCAPE.equals("\\"));
+        return namePattern.replaceAll("[_%\\\\]", "\\\\$0");
     }
 
     private static void optionalStringLikeFilter(List<String> filters, String columnName, String value)

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -53,6 +53,7 @@ import static io.trino.client.OkHttpUtil.setupSsl;
 import static io.trino.client.OkHttpUtil.tokenAuth;
 import static io.trino.jdbc.ConnectionProperties.ACCESS_TOKEN;
 import static io.trino.jdbc.ConnectionProperties.APPLICATION_NAME_PREFIX;
+import static io.trino.jdbc.ConnectionProperties.ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS;
 import static io.trino.jdbc.ConnectionProperties.CLIENT_INFO;
 import static io.trino.jdbc.ConnectionProperties.CLIENT_TAGS;
 import static io.trino.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
@@ -234,6 +235,12 @@ public final class TrinoDriverUri
             throws SQLException
     {
         return DISABLE_COMPRESSION.getValue(properties).orElse(false);
+    }
+
+    public boolean isAssumeLiteralNamesInMetadataCallsForNonConformingClients()
+            throws SQLException
+    {
+        return ASSUME_LITERAL_NAMES_IN_METADATA_CALLS_FOR_NON_CONFORMING_CLIENTS.getValue(properties).orElse(false);
     }
 
     public void setupClient(OkHttpClient.Builder builder)

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -987,7 +987,6 @@ public class TestTrinoDatabaseMetaData
     }
 
     @Test
-    @SuppressWarnings("resource")
     public void testGetSchemasMetadataCalls()
             throws Exception
     {
@@ -1052,7 +1051,6 @@ public class TestTrinoDatabaseMetaData
     }
 
     @Test
-    @SuppressWarnings("resource")
     public void testGetTablesMetadataCalls()
             throws Exception
     {
@@ -1181,7 +1179,6 @@ public class TestTrinoDatabaseMetaData
     }
 
     @Test
-    @SuppressWarnings("resource")
     public void testGetColumnsMetadataCalls()
             throws Exception
     {

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -1142,7 +1142,8 @@ public class TestTrinoDatabaseMetaData
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, "test\\_schema1", "test\\_table1", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
                 list(list(COUNTING_CATALOG, "test_schema1", "test_table1", "TABLE")),
-                new MetadataCallsCount());
+                new MetadataCallsCount()
+                        .withGetTableHandleCount(1));
 
         // LIKE predicate on schema name and table name
         assertMetadataCalls(
@@ -1304,6 +1305,7 @@ public class TestTrinoDatabaseMetaData
                 new MetadataCallsCount()
                         .withListSchemasCount(3)
                         .withListTablesCount(8)
+                        .withGetTableHandleCount(2)
                         .withGetColumnsCount(2));
 
         // Equality predicate on schema name and table name, but no predicate on catalog name

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDatabaseMetaData.java
@@ -994,6 +994,7 @@ public class TestTrinoDatabaseMetaData
 
         // No filter
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getSchemas(null, null),
                         list("TABLE_CATALOG", "TABLE_SCHEM")),
@@ -1002,6 +1003,7 @@ public class TestTrinoDatabaseMetaData
 
         // Equality predicate on catalog name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, null),
                         list("TABLE_CATALOG", "TABLE_SCHEM")),
@@ -1014,6 +1016,7 @@ public class TestTrinoDatabaseMetaData
 
         // Equality predicate on schema name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, "test\\_schema%"),
                         list("TABLE_CATALOG", "TABLE_SCHEM")),
@@ -1025,6 +1028,7 @@ public class TestTrinoDatabaseMetaData
 
         // LIKE predicate on schema name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, "test_sch_ma1"),
                         list("TABLE_CATALOG", "TABLE_SCHEM")),
@@ -1034,6 +1038,7 @@ public class TestTrinoDatabaseMetaData
 
         // Empty schema name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getSchemas(COUNTING_CATALOG, ""),
                         list("TABLE_CATALOG", "TABLE_SCHEM")),
@@ -1043,6 +1048,7 @@ public class TestTrinoDatabaseMetaData
 
         // catalog does not exist
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getSchemas("wrong", null),
                         list("TABLE_CATALOG", "TABLE_SCHEM")),
@@ -1058,6 +1064,7 @@ public class TestTrinoDatabaseMetaData
 
         // No filter
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables(null, null, null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1067,6 +1074,7 @@ public class TestTrinoDatabaseMetaData
 
         // Equality predicate on catalog name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, null, null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1076,6 +1084,7 @@ public class TestTrinoDatabaseMetaData
 
         // Equality predicate on schema name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, "test\\_schema1", null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1088,6 +1097,7 @@ public class TestTrinoDatabaseMetaData
 
         // LIKE predicate on schema name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, "test_sch_ma1", null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1101,6 +1111,7 @@ public class TestTrinoDatabaseMetaData
 
         // Equality predicate on table name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, null, "test\\_table1", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1113,6 +1124,7 @@ public class TestTrinoDatabaseMetaData
 
         // LIKE predicate on table name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, null, "test_t_ble1", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1125,6 +1137,7 @@ public class TestTrinoDatabaseMetaData
 
         // Equality predicate on schema name and table name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, "test\\_schema1", "test\\_table1", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1133,6 +1146,7 @@ public class TestTrinoDatabaseMetaData
 
         // LIKE predicate on schema name and table name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, "test_schema1", "test_table1", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1143,6 +1157,7 @@ public class TestTrinoDatabaseMetaData
 
         // catalog does not exist
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables("wrong", null, null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1151,6 +1166,7 @@ public class TestTrinoDatabaseMetaData
 
         // empty schema name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, "", null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1161,6 +1177,7 @@ public class TestTrinoDatabaseMetaData
 
         // empty table name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, null, "", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1171,6 +1188,7 @@ public class TestTrinoDatabaseMetaData
 
         // no table types selected
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getTables(COUNTING_CATALOG, null, null, new String[0]),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "TABLE_TYPE")),
@@ -1186,6 +1204,7 @@ public class TestTrinoDatabaseMetaData
 
         // No filter
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(null, null, null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1196,6 +1215,7 @@ public class TestTrinoDatabaseMetaData
 
         // Equality predicate on catalog name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(COUNTING_CATALOG, null, null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1206,6 +1226,7 @@ public class TestTrinoDatabaseMetaData
 
         // Equality predicate on catalog name, schema name and table name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(COUNTING_CATALOG, "test\\_schema1", "test\\_table1", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1218,6 +1239,7 @@ public class TestTrinoDatabaseMetaData
 
         // Equality predicate on catalog name, schema name, table name and column name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(COUNTING_CATALOG, "test\\_schema1", "test\\_table1", "column\\_17"),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1228,6 +1250,7 @@ public class TestTrinoDatabaseMetaData
 
         // Equality predicate on catalog name, LIKE predicate on schema name, table name and column name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(COUNTING_CATALOG, "test_schema1", "test_table1", "column_17"),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1239,6 +1262,7 @@ public class TestTrinoDatabaseMetaData
 
         // LIKE predicate on schema name and table name, but no predicate on catalog name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(null, "test_schema1", "test_table1", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1252,6 +1276,7 @@ public class TestTrinoDatabaseMetaData
 
         // LIKE predicate on schema name, but no predicate on catalog name and table name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(null, "test_schema1", null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1267,6 +1292,7 @@ public class TestTrinoDatabaseMetaData
 
         // LIKE predicate on table name, but no predicate on catalog name and schema name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(null, null, "test_table1", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1282,6 +1308,7 @@ public class TestTrinoDatabaseMetaData
 
         // Equality predicate on schema name and table name, but no predicate on catalog name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(null, "test\\_schema1", "test\\_table1", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1294,6 +1321,7 @@ public class TestTrinoDatabaseMetaData
 
         // catalog does not exist
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns("wrong", null, null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1302,6 +1330,7 @@ public class TestTrinoDatabaseMetaData
 
         // schema does not exist
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(COUNTING_CATALOG, "wrong\\_schema1", "test\\_table1", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1311,6 +1340,7 @@ public class TestTrinoDatabaseMetaData
 
         // schema does not exist
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(COUNTING_CATALOG, "wrong_schema1", "test_table1", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1322,6 +1352,7 @@ public class TestTrinoDatabaseMetaData
 
         // empty schema name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(COUNTING_CATALOG, "", null, null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1333,6 +1364,7 @@ public class TestTrinoDatabaseMetaData
 
         // empty table name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(COUNTING_CATALOG, null, "", null),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1344,6 +1376,7 @@ public class TestTrinoDatabaseMetaData
 
         // empty column name
         assertMetadataCalls(
+                connection,
                 readMetaData(
                         databaseMetaData -> databaseMetaData.getColumns(COUNTING_CATALOG, null, null, ""),
                         list("TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME", "COLUMN_NAME", "TYPE_NAME")),
@@ -1393,19 +1426,23 @@ public class TestTrinoDatabaseMetaData
                 .collect(toImmutableSet());
     }
 
-    private void assertMetadataCalls(MetaDataCallback<? extends Collection<List<Object>>> callback, MetadataCallsCount expectedMetadataCallsCount)
-            throws Exception
+    private void assertMetadataCalls(Connection connection, MetaDataCallback<? extends Collection<List<Object>>> callback, MetadataCallsCount expectedMetadataCallsCount)
     {
         assertMetadataCalls(
+                connection,
                 callback,
                 actual -> {},
                 expectedMetadataCallsCount);
     }
 
-    private void assertMetadataCalls(MetaDataCallback<? extends Collection<List<Object>>> callback, Collection<List<?>> expected, MetadataCallsCount expectedMetadataCallsCount)
-            throws Exception
+    private void assertMetadataCalls(
+            Connection connection,
+            MetaDataCallback<? extends Collection<List<Object>>> callback,
+            Collection<List<?>> expected,
+            MetadataCallsCount expectedMetadataCallsCount)
     {
         assertMetadataCalls(
+                connection,
                 callback,
                 actual -> assertThat(ImmutableMultiset.copyOf(requireNonNull(actual, "actual is null")))
                         .isEqualTo(ImmutableMultiset.copyOf(requireNonNull(expected, "expected is null"))),
@@ -1413,23 +1450,20 @@ public class TestTrinoDatabaseMetaData
     }
 
     private void assertMetadataCalls(
+            Connection connection,
             MetaDataCallback<? extends Collection<List<Object>>> callback,
             Consumer<Collection<List<Object>>> resultsVerification,
             MetadataCallsCount expectedMetadataCallsCount)
-            throws Exception
     {
-        MetadataCallsCount actualMetadataCallsCount;
-        try (Connection connection = createConnection()) {
-            actualMetadataCallsCount = countingMockConnector.runCounting(() -> {
-                try {
-                    Collection<List<Object>> actual = callback.apply(connection.getMetaData());
-                    resultsVerification.accept(actual);
-                }
-                catch (SQLException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        }
+        MetadataCallsCount actualMetadataCallsCount = countingMockConnector.runCounting(() -> {
+            try {
+                Collection<List<Object>> actual = callback.apply(connection.getMetaData());
+                resultsVerification.accept(actual);
+            }
+            catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        });
         assertEquals(actualMetadataCallsCount, expectedMetadataCallsCount);
     }
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/CountingMockConnector.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/CountingMockConnector.java
@@ -34,6 +34,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.connector.MockConnectorFactory.Builder.defaultGetColumns;
+import static io.trino.connector.MockConnectorFactory.Builder.defaultGetTableHandle;
 import static io.trino.spi.security.PrincipalType.USER;
 
 public class CountingMockConnector
@@ -54,6 +55,7 @@ public class CountingMockConnector
 
     private final AtomicLong listSchemasCallsCounter = new AtomicLong();
     private final AtomicLong listTablesCallsCounter = new AtomicLong();
+    private final AtomicLong getTableHandleCallsCounter = new AtomicLong();
     private final AtomicLong getColumnsCallsCounter = new AtomicLong();
     private final ListRoleGrantsCounter listRoleGranstCounter = new ListRoleGrantsCounter();
 
@@ -81,13 +83,16 @@ public class CountingMockConnector
         synchronized (lock) {
             listSchemasCallsCounter.set(0);
             listTablesCallsCounter.set(0);
+            getTableHandleCallsCounter.set(0);
             getColumnsCallsCounter.set(0);
             listRoleGranstCounter.reset();
 
             runnable.run();
 
-            return new MetadataCallsCount(listSchemasCallsCounter.get(),
+            return new MetadataCallsCount(
+                    listSchemasCallsCounter.get(),
                     listTablesCallsCounter.get(),
+                    getTableHandleCallsCounter.get(),
                     getColumnsCallsCounter.get(),
                     listRoleGranstCounter.listRowGrantsCallsCounter.get(),
                     listRoleGranstCounter.rolesPushedCounter.get(),
@@ -113,6 +118,10 @@ public class CountingMockConnector
                     }
                     return ImmutableList.of();
                 })
+                .withGetTableHandle((connectorSession, schemaTableName) -> {
+                    getTableHandleCallsCounter.incrementAndGet();
+                    return defaultGetTableHandle().apply(connectorSession, schemaTableName);
+                })
                 .withGetColumns(schemaTableName -> {
                     getColumnsCallsCounter.incrementAndGet();
                     return defaultGetColumns().apply(schemaTableName);
@@ -130,6 +139,7 @@ public class CountingMockConnector
     {
         private final long listSchemasCount;
         private final long listTablesCount;
+        private final long getTableHandleCount;
         private final long getColumnsCount;
         private final long listRoleGrantsCount;
         private final long rolesPushedCount;
@@ -138,11 +148,13 @@ public class CountingMockConnector
 
         public MetadataCallsCount()
         {
-            this(0, 0, 0, 0, 0, 0, 0);
+            this(0, 0, 0, 0, 0, 0, 0, 0);
         }
 
-        public MetadataCallsCount(long listSchemasCount,
+        public MetadataCallsCount(
+                long listSchemasCount,
                 long listTablesCount,
+                long getTableHandleCount,
                 long getColumnsCount,
                 long listRoleGrantsCount,
                 long rolesPushedCount,
@@ -151,6 +163,7 @@ public class CountingMockConnector
         {
             this.listSchemasCount = listSchemasCount;
             this.listTablesCount = listTablesCount;
+            this.getTableHandleCount = getTableHandleCount;
             this.getColumnsCount = getColumnsCount;
             this.listRoleGrantsCount = listRoleGrantsCount;
             this.rolesPushedCount = rolesPushedCount;
@@ -160,37 +173,106 @@ public class CountingMockConnector
 
         public MetadataCallsCount withListSchemasCount(long listSchemasCount)
         {
-            return new MetadataCallsCount(listSchemasCount, listTablesCount, getColumnsCount, listRoleGrantsCount, rolesPushedCount, granteesPushedCount, limitPushedCount);
+            return new MetadataCallsCount(
+                    listSchemasCount,
+                    listTablesCount,
+                    getTableHandleCount,
+                    getColumnsCount,
+                    listRoleGrantsCount,
+                    rolesPushedCount,
+                    granteesPushedCount,
+                    limitPushedCount);
         }
 
         public MetadataCallsCount withListTablesCount(long listTablesCount)
         {
-            return new MetadataCallsCount(listSchemasCount, listTablesCount, getColumnsCount, listRoleGrantsCount, rolesPushedCount, granteesPushedCount, limitPushedCount);
+            return new MetadataCallsCount(
+                    listSchemasCount,
+                    listTablesCount,
+                    getTableHandleCount,
+                    getColumnsCount,
+                    listRoleGrantsCount,
+                    rolesPushedCount,
+                    granteesPushedCount,
+                    limitPushedCount);
+        }
+
+        public MetadataCallsCount withGetTableHandleCount(long getTableHandleCount)
+        {
+            return new MetadataCallsCount(
+                    listSchemasCount,
+                    listTablesCount,
+                    getTableHandleCount,
+                    getColumnsCount,
+                    listRoleGrantsCount,
+                    rolesPushedCount,
+                    granteesPushedCount,
+                    limitPushedCount);
         }
 
         public MetadataCallsCount withGetColumnsCount(long getColumnsCount)
         {
-            return new MetadataCallsCount(listSchemasCount, listTablesCount, getColumnsCount, listRoleGrantsCount, rolesPushedCount, granteesPushedCount, limitPushedCount);
+            return new MetadataCallsCount(
+                    listSchemasCount,
+                    listTablesCount,
+                    getTableHandleCount,
+                    getColumnsCount,
+                    listRoleGrantsCount,
+                    rolesPushedCount,
+                    granteesPushedCount,
+                    limitPushedCount);
         }
 
         public MetadataCallsCount withListRoleGrantsCount(long listRoleGrantsCount)
         {
-            return new MetadataCallsCount(listSchemasCount, listTablesCount, getColumnsCount, listRoleGrantsCount, rolesPushedCount, granteesPushedCount, limitPushedCount);
+            return new MetadataCallsCount(
+                    listSchemasCount,
+                    listTablesCount,
+                    getTableHandleCount,
+                    getColumnsCount,
+                    listRoleGrantsCount,
+                    rolesPushedCount,
+                    granteesPushedCount,
+                    limitPushedCount);
         }
 
         public MetadataCallsCount withRolesPushedCount(long rolesPushedCount)
         {
-            return new MetadataCallsCount(listSchemasCount, listTablesCount, getColumnsCount, listRoleGrantsCount, rolesPushedCount, granteesPushedCount, limitPushedCount);
+            return new MetadataCallsCount(
+                    listSchemasCount,
+                    listTablesCount,
+                    getTableHandleCount,
+                    getColumnsCount,
+                    listRoleGrantsCount,
+                    rolesPushedCount,
+                    granteesPushedCount,
+                    limitPushedCount);
         }
 
         public MetadataCallsCount withGranteesPushedCount(long granteesPushedCount)
         {
-            return new MetadataCallsCount(listSchemasCount, listTablesCount, getColumnsCount, listRoleGrantsCount, rolesPushedCount, granteesPushedCount, limitPushedCount);
+            return new MetadataCallsCount(
+                    listSchemasCount,
+                    listTablesCount,
+                    getTableHandleCount,
+                    getColumnsCount,
+                    listRoleGrantsCount,
+                    rolesPushedCount,
+                    granteesPushedCount,
+                    limitPushedCount);
         }
 
         public MetadataCallsCount withLimitPushedCount(long limitPushedCount)
         {
-            return new MetadataCallsCount(listSchemasCount, listTablesCount, getColumnsCount, listRoleGrantsCount, rolesPushedCount, granteesPushedCount, limitPushedCount);
+            return new MetadataCallsCount(
+                    listSchemasCount,
+                    listTablesCount,
+                    getTableHandleCount,
+                    getColumnsCount,
+                    listRoleGrantsCount,
+                    rolesPushedCount,
+                    granteesPushedCount,
+                    limitPushedCount);
         }
 
         @Override
@@ -205,6 +287,7 @@ public class CountingMockConnector
             MetadataCallsCount that = (MetadataCallsCount) o;
             return listSchemasCount == that.listSchemasCount &&
                     listTablesCount == that.listTablesCount &&
+                    getTableHandleCount == that.getTableHandleCount &&
                     getColumnsCount == that.getColumnsCount &&
                     listRoleGrantsCount == that.listRoleGrantsCount &&
                     rolesPushedCount == that.rolesPushedCount &&
@@ -215,8 +298,10 @@ public class CountingMockConnector
         @Override
         public int hashCode()
         {
-            return Objects.hash(listSchemasCount,
+            return Objects.hash(
+                    listSchemasCount,
                     listTablesCount,
+                    getTableHandleCount,
                     getColumnsCount,
                     listRoleGrantsCount,
                     rolesPushedCount,
@@ -230,6 +315,7 @@ public class CountingMockConnector
             return toStringHelper(this)
                     .add("listSchemasCount", listSchemasCount)
                     .add("listTablesCount", listTablesCount)
+                    .add("getTableHandleCount", getTableHandleCount)
                     .add("getColumnsCount", getColumnsCount)
                     .add("listRoleGrantsCount", listRoleGrantsCount)
                     .add("rolesPushedCount", rolesPushedCount)

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestInformationSchemaConnector.java
@@ -185,7 +185,8 @@ public class TestInformationSchemaConnector
                 "SELECT count(*) from test_catalog.information_schema.tables WHERE table_name = 'test_table1'",
                 "VALUES 2",
                 new MetadataCallsCount()
-                        .withListSchemasCount(1));
+                        .withListSchemasCount(1)
+                        .withGetTableHandleCount(2));
         assertMetadataCalls(
                 "SELECT count(*) from test_catalog.information_schema.tables WHERE table_name LIKE 'test_t_ble1'",
                 "VALUES 2",
@@ -196,12 +197,14 @@ public class TestInformationSchemaConnector
                 "SELECT count(*) from test_catalog.information_schema.tables WHERE table_name LIKE 'test_t_ble1' AND table_name IN ('test_table1', 'test_table2')",
                 "VALUES 2",
                 new MetadataCallsCount()
-                        .withListSchemasCount(1));
+                        .withListSchemasCount(1)
+                        .withGetTableHandleCount(4));
         assertMetadataCalls(
                 "SELECT count(*) from test_catalog.information_schema.columns WHERE table_schema = 'test_schema1' AND table_name = 'test_table1'",
                 "VALUES 100",
                 new MetadataCallsCount()
                         .withListTablesCount(1)
+                        .withGetTableHandleCount(1)
                         .withGetColumnsCount(1));
         assertMetadataCalls(
                 "SELECT count(*) from test_catalog.information_schema.columns WHERE table_catalog = 'wrong'",
@@ -211,12 +214,14 @@ public class TestInformationSchemaConnector
                 "SELECT count(*) from test_catalog.information_schema.columns WHERE table_catalog = 'test_catalog' AND table_schema = 'wrong_schema1' AND table_name = 'test_table1'",
                 "VALUES 0",
                 new MetadataCallsCount()
-                        .withListTablesCount(1));
+                        .withListTablesCount(1)
+                        .withGetTableHandleCount(1));
         assertMetadataCalls(
                 "SELECT count(*) from test_catalog.information_schema.columns WHERE table_catalog IN ('wrong', 'test_catalog') AND table_schema = 'wrong_schema1' AND table_name = 'test_table1'",
                 "VALUES 0",
                 new MetadataCallsCount()
-                        .withListTablesCount(1));
+                        .withListTablesCount(1)
+                        .withGetTableHandleCount(1));
         assertMetadataCalls(
                 "SELECT count(*) FROM (SELECT * from test_catalog.information_schema.columns LIMIT 1)",
                 "VALUES 1",


### PR DESCRIPTION
Number of `DatabaseMetaData` methods accept name patterns (e.g.
`schemaPattern`, `tableNamePattern`, `columnNamePattern`, etc.). Values
provided, if ought to be treated as literals, should have underscores
`_` and percent signs `%` escaped with
`DatabaseMetaData.getSearchStringEscape()`. Sadly, many client
applications do not do that, which results in metadata queries which
cannot be answered efficiently by the server.

This commit adds a compatibility flag as a workaround for such
misbehaving client applications.

Closes https://github.com/trinodb/trino/issues/7424