### PR TITLE
Fix join spill race condition

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/PartitionedLookupSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PartitionedLookupSourceFactory.java
@@ -212,7 +212,7 @@ public final class PartitionedLookupSourceFactory
 
         lock.writeLock().lock();
         try {
-            if (destroyed.isDone()) {
+            if (partitionsNoLongerNeeded.isDone()) {
                 spilledLookupSourceHandle.dispose();
                 return;
             }
@@ -302,6 +302,14 @@ public final class PartitionedLookupSourceFactory
         try {
             if (!spillingInfo.hasSpilled()) {
                 finishedProbeOperators++;
+                if (lookupJoinsCount.isPresent()) {
+                    checkState(finishedProbeOperators <= lookupJoinsCount.getAsInt(), "%s probe operators finished out of %s declared", finishedProbeOperators, lookupJoinsCount.getAsInt());
+                    if (finishedProbeOperators == lookupJoinsCount.getAsInt()) {
+                        // We can dispose partitions now since right outer is not supported with spill and lookupJoinsCount should be absent
+                        freePartitions();
+                    }
+                }
+
                 return immediateFuture(new PartitionedConsumption<>(
                         1,
                         emptyList(),
@@ -322,7 +330,7 @@ public final class PartitionedLookupSourceFactory
 
             finishedProbeOperators++;
             if (finishedProbeOperators == operatorsCount) {
-                // We can dispose partitions now since as right outer is not supported with spill
+                // We can dispose partitions now since right outer is not supported with spill
                 freePartitions();
                 verify(!partitionedConsumption.isDone());
                 partitionedConsumption.set(new PartitionedConsumption<>(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2110,7 +2110,9 @@ public class LocalExecutionPlanner
             PhysicalOperation probeSource = probeNode.accept(this, context);
 
             // Plan build
-            boolean spillEnabled = isSpillEnabled(session) && node.isSpillable().orElseThrow(() -> new IllegalArgumentException("spillable not yet set"));
+            boolean spillEnabled = isSpillEnabled(session)
+                    && node.isSpillable().orElseThrow(() -> new IllegalArgumentException("spillable not yet set"))
+                    && probeSource.getPipelineExecutionStrategy() == UNGROUPED_EXECUTION;
             JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactory =
                     createLookupSourceFactory(node, buildNode, buildSymbols, buildHashSymbol, probeSource, context, spillEnabled, localDynamicFilters);
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashJoinOperator.java
@@ -393,7 +393,6 @@ public class TestHashJoinOperator
 
     @Test(dataProvider = "joinWithFailingSpillValues")
     public void testInnerJoinWithFailingSpill(boolean probeHashEnabled, List<WhenSpill> whenSpill, WhenSpillFails whenSpillFails, boolean isDictionaryProcessingJoinEnabled)
-            throws Exception
     {
         DummySpillerFactory buildSpillerFactory = new DummySpillerFactory();
         DummySpillerFactory joinSpillerFactory = new DummySpillerFactory();

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashJoinOperator.java
@@ -600,6 +600,41 @@ public class TestHashJoinOperator
         return OperatorAssertion.toMaterializedResult(joinOperator.getOperatorContext().getSession(), types, actualPages);
     }
 
+    @Test(timeOut = 30_000)
+    public void testBuildGracefulSpill()
+            throws Exception
+    {
+        TaskStateMachine taskStateMachine = new TaskStateMachine(new TaskId("query", 0, 0), executor);
+        TaskContext taskContext = TestingTaskContext.createTaskContext(executor, scheduledExecutor, TEST_SESSION, taskStateMachine);
+
+        // build factory
+        RowPagesBuilder buildPages = rowPagesBuilder(ImmutableList.of(VARCHAR, BIGINT))
+                .addSequencePage(4, 20, 200);
+
+        DummySpillerFactory buildSpillerFactory = new DummySpillerFactory();
+
+        BuildSideSetup buildSideSetup = setupBuildSide(true, taskContext, Ints.asList(0), buildPages, Optional.empty(), true, buildSpillerFactory);
+        instantiateBuildDrivers(buildSideSetup, taskContext);
+
+        JoinBridgeManager<PartitionedLookupSourceFactory> lookupSourceFactoryManager = buildSideSetup.getLookupSourceFactoryManager();
+        PartitionedLookupSourceFactory lookupSourceFactory = lookupSourceFactoryManager.getJoinBridge(Lifespan.taskWide());
+
+        // finish probe before any build partition is spilled
+        lookupSourceFactory.finishProbeOperator(OptionalInt.of(1));
+
+        // spill build partition after probe is finished
+        HashBuilderOperator hashBuilderOperator = buildSideSetup.getBuildOperators().get(0);
+        hashBuilderOperator.startMemoryRevoke().get();
+        hashBuilderOperator.finishMemoryRevoke();
+        hashBuilderOperator.finish();
+
+        // hash builder operator should not deadlock waiting for spilled lookup source to be disposed
+        hashBuilderOperator.isBlocked().get();
+
+        lookupSourceFactory.destroy();
+        assertTrue(hashBuilderOperator.isFinished());
+    }
+
     @Test(dataProvider = "hashJoinTestValues")
     public void testInnerJoinWithNullProbe(boolean parallelBuild, boolean probeHashEnabled, boolean buildHashEnabled)
     {


### PR DESCRIPTION
SpilledLookupSourceHandle needs to be disposed
immediately when join operators finished
processing probe data. Otherwise SpilledLookupSourceHandle
is never disposed as it's not registered in PartitionedConsumption.
This prevents HashBuilderOperator from finishing.

Fixes: https://github.com/trinodb/trino/issues/7454