### PR TITLE
Make SHOW CREATE tests symmetrical and defensive

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -476,17 +476,17 @@ final class ShowQueriesRewrite
         {
             if (node.getType() == VIEW) {
                 QualifiedObjectName objectName = createQualifiedObjectName(session, node, node.getName());
-
-                if (metadata.getMaterializedView(session, objectName).isPresent()) {
-                    throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a materialized view, not a view", objectName);
-                }
-
                 Optional<ConnectorViewDefinition> viewDefinition = metadata.getView(session, objectName);
 
                 if (viewDefinition.isEmpty()) {
+                    if (metadata.getMaterializedView(session, objectName).isPresent()) {
+                        throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a materialized view, not a view", objectName);
+                    }
+
                     if (metadata.getTableHandle(session, objectName).isPresent()) {
                         throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a table, not a view", objectName);
                     }
+
                     throw semanticException(TABLE_NOT_FOUND, node, "View '%s' does not exist", objectName);
                 }
 
@@ -508,6 +508,10 @@ final class ShowQueriesRewrite
                 Optional<ConnectorMaterializedViewDefinition> viewDefinition = metadata.getMaterializedView(session, objectName);
 
                 if (viewDefinition.isEmpty()) {
+                    if (metadata.getView(session, objectName).isPresent()) {
+                        throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a view, not a materialized view", objectName);
+                    }
+
                     if (metadata.getTableHandle(session, objectName).isPresent()) {
                         throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a table, not a materialized view", objectName);
                     }
@@ -529,14 +533,17 @@ final class ShowQueriesRewrite
 
             if (node.getType() == TABLE) {
                 QualifiedObjectName objectName = createQualifiedObjectName(session, node, node.getName());
-                Optional<ConnectorViewDefinition> viewDefinition = metadata.getView(session, objectName);
-
-                if (viewDefinition.isPresent()) {
-                    throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a view, not a table", objectName);
-                }
-
                 Optional<TableHandle> tableHandle = metadata.getTableHandle(session, objectName);
+
                 if (tableHandle.isEmpty()) {
+                    if (metadata.getMaterializedView(session, objectName).isPresent()) {
+                        throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a materialized view, not a table", objectName);
+                    }
+
+                    if (metadata.getView(session, objectName).isPresent()) {
+                        throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a view, not a table", objectName);
+                    }
+
                     throw semanticException(TABLE_NOT_FOUND, node, "Table '%s' does not exist", objectName);
                 }
 


### PR DESCRIPTION
Only throw exception when VIEW, MATERIALIZED VIEW or TABLE
does not exist and there is a corresponding object of other
type with same name.