### PR TITLE
Require that materialized view has owner

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
@@ -99,7 +99,7 @@ public class CreateMaterializedViewTask
                 .map(field -> new ConnectorMaterializedViewDefinition.Column(field.getName().get(), field.getType().getTypeId()))
                 .collect(toImmutableList());
 
-        Optional<String> owner = Optional.of(session.getUser());
+        String owner = session.getUser();
 
         CatalogName catalogName = metadata.getCatalogHandle(session, name.getCatalogName())
                 .orElseThrow(() -> new TrinoException(NOT_FOUND, "Catalog does not exist: " + name.getCatalogName()));

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1447,6 +1447,7 @@ class StatementAnalyzer
 
         private Scope createScopeForMaterializedView(Table table, QualifiedObjectName name, Optional<Scope> scope, ConnectorMaterializedViewDefinition view)
         {
+            checkArgument(view.getOwner().isPresent(), "owner must be present");
             return createScopeForView(
                     table,
                     name,

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -3055,7 +3055,7 @@ public class TestAnalyzer
                 Optional.of("s1"),
                 ImmutableList.of(new ConnectorMaterializedViewDefinition.Column("a", BIGINT.getTypeId())),
                 Optional.of("comment"),
-                Optional.of("user"),
+                "user",
                 ImmutableMap.of());
         inSetupTransaction(session -> metadata.createMaterializedView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "mv1"), materializedViewData1, false, true));
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMaterializedViewDefinition.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMaterializedViewDefinition.java
@@ -44,15 +44,16 @@ public class ConnectorMaterializedViewDefinition
             @JsonProperty("schema") Optional<String> schema,
             @JsonProperty("columns") List<Column> columns,
             @JsonProperty("comment") Optional<String> comment,
-            @JsonProperty("owner") Optional<String> owner,
+            @JsonProperty("owner") String owner,
             @JsonProperty("properties") Map<String, Object> properties)
     {
-        this(originalSql, requireNonNull(storageTable, "storageTable is null").orElse(null), catalog, schema, columns, comment, owner, properties);
+        this(originalSql, requireNonNull(storageTable, "storageTable is null").orElse(null), catalog, schema, columns, comment, Optional.of(owner), properties);
     }
 
     /*
      * This constructor is for JSON deserialization only. Do not use.
      */
+    // TODO: Simplify this constructor and getters: https://github.com/trinodb/trino/issues/7537
     @Deprecated
     @JsonCreator
     public ConnectorMaterializedViewDefinition(
@@ -79,6 +80,10 @@ public class ConnectorMaterializedViewDefinition
         this.properties = requireNonNull(properties, "properties are null");
         if (columns.isEmpty()) {
             throw new IllegalArgumentException("columns list is empty");
+        }
+
+        if (owner.isEmpty()) {
+            throw new IllegalArgumentException("owner must be present");
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -837,7 +837,7 @@ public abstract class AbstractTestHive
                                 Optional.empty(),
                                 ImmutableList.of(new ConnectorMaterializedViewDefinition.Column("abc", TypeId.of("type"))),
                                 Optional.empty(),
-                                Optional.empty(),
+                                "alice",
                                 ImmutableMap.of()));
                     }
                 },

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1001,7 +1001,7 @@ public class IcebergMetadata
                 Optional.of(viewName.getSchemaName()),
                 definition.getColumns(),
                 definition.getComment(),
-                Optional.of(materializedView.getOwner()),
+                materializedView.getOwner(),
                 new HashMap<>(materializedView.getParameters())));
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -135,7 +135,7 @@ public class TestEventListenerBasic
                                     Optional.empty(),
                                     ImmutableList.of(new Column("test_column", BIGINT.getTypeId())),
                                     Optional.empty(),
-                                    Optional.empty(),
+                                    "alice",
                                     ImmutableMap.of());
                             SchemaTableName materializedViewName = new SchemaTableName("default", "test_materialized_view");
                             return ImmutableMap.of(materializedViewName, definition);
@@ -373,7 +373,7 @@ public class TestEventListenerBasic
         assertThat(table.getCatalog()).isEqualTo("tpch");
         assertThat(table.getSchema()).isEqualTo("tiny");
         assertThat(table.getTable()).isEqualTo("nation");
-        assertThat(table.getAuthorization()).isEqualTo("user");
+        assertThat(table.getAuthorization()).isEqualTo("alice");
         assertThat(table.isDirectlyReferenced()).isFalse();
         assertThat(table.getFilters()).isEmpty();
         assertThat(table.getColumns()).hasSize(1);

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
@@ -59,7 +59,7 @@ public class TestMockConnector
                                                 Optional.of("default"),
                                                 ImmutableList.of(new Column("nationkey", BIGINT.getTypeId())),
                                                 Optional.empty(),
-                                                Optional.empty(),
+                                                "alice",
                                                 ImmutableMap.of())))
                                 .build()));
         queryRunner.createCatalog("mock", "mock");


### PR DESCRIPTION
Materialized views can only be analyzed with definer context.
Therefore view owner needs to be present.