### PR TITLE
Limit and topn pushdown for Phoenix.

### DIFF
--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -243,15 +243,12 @@ public class PhoenixClient
     public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
             throws SQLException
     {
-        PreparedQuery preparedQuery = prepareQuery(
+        PreparedStatement query = prepareStatement(
                 session,
                 connection,
                 table,
-                Optional.empty(),
                 columnHandles,
-                ImmutableMap.of(),
                 Optional.of(split));
-        PreparedStatement query = new QueryBuilder(this).prepareStatement(session, connection, preparedQuery);
         QueryPlan queryPlan = getQueryPlan((PhoenixPreparedStatement) query);
         ResultSet resultSet = getResultSet(((PhoenixSplit) split).getPhoenixInputSplit(), queryPlan);
         return new DelegatePreparedStatement(query)
@@ -262,6 +259,25 @@ public class PhoenixClient
                 return resultSet;
             }
         };
+    }
+
+    public PreparedStatement prepareStatement(
+            ConnectorSession session,
+            Connection connection,
+            JdbcTableHandle table,
+            List<JdbcColumnHandle> columns,
+            Optional<JdbcSplit> split)
+            throws SQLException
+    {
+        PreparedQuery preparedQuery = prepareQuery(
+                session,
+                connection,
+                table,
+                Optional.empty(),
+                columns,
+                ImmutableMap.of(),
+                split);
+        return new QueryBuilder(this).prepareStatement(session, connection, preparedQuery);
     }
 
     @Override

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
@@ -14,12 +14,9 @@
 package io.trino.plugin.phoenix;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
-import io.trino.plugin.jdbc.PreparedQuery;
-import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.spi.HostAddress;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
@@ -83,17 +80,12 @@ public class PhoenixSplitManager
             List<JdbcColumnHandle> columns = tableHandle.getColumns()
                     .map(columnSet -> columnSet.stream().map(JdbcColumnHandle.class::cast).collect(toList()))
                     .orElseGet(() -> phoenixClient.getColumns(session, tableHandle));
-            QueryBuilder queryBuilder = new QueryBuilder(phoenixClient);
-            PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+            PhoenixPreparedStatement inputQuery = (PhoenixPreparedStatement) phoenixClient.prepareStatement(
                     session,
                     connection,
-                    tableHandle.getRelationHandle(),
-                    Optional.empty(),
+                    tableHandle,
                     columns,
-                    ImmutableMap.of(),
-                    tableHandle.getConstraint(),
                     Optional.empty());
-            PhoenixPreparedStatement inputQuery = (PhoenixPreparedStatement) queryBuilder.prepareStatement(session, connection, preparedQuery);
 
             List<ConnectorSplit> splits = getSplits(inputQuery).stream()
                     .map(PhoenixInputSplit.class::cast)

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -244,15 +244,12 @@ public class PhoenixClient
     public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
             throws SQLException
     {
-        PreparedQuery preparedQuery = prepareQuery(
+        PreparedStatement query = prepareStatement(
                 session,
                 connection,
                 table,
-                Optional.empty(),
                 columnHandles,
-                ImmutableMap.of(),
                 Optional.of(split));
-        PreparedStatement query = new QueryBuilder(this).prepareStatement(session, connection, preparedQuery);
         QueryPlan queryPlan = getQueryPlan((PhoenixPreparedStatement) query);
         ResultSet resultSet = getResultSet(((PhoenixSplit) split).getPhoenixInputSplit(), queryPlan);
         return new DelegatePreparedStatement(query)
@@ -263,6 +260,25 @@ public class PhoenixClient
                 return resultSet;
             }
         };
+    }
+
+    public PreparedStatement prepareStatement(
+            ConnectorSession session,
+            Connection connection,
+            JdbcTableHandle table,
+            List<JdbcColumnHandle> columns,
+            Optional<JdbcSplit> split)
+            throws SQLException
+    {
+        PreparedQuery preparedQuery = prepareQuery(
+                session,
+                connection,
+                table,
+                Optional.empty(),
+                columns,
+                ImmutableMap.of(),
+                split);
+        return new QueryBuilder(this).prepareStatement(session, connection, preparedQuery);
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -17,10 +17,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.jdbc.BaseJdbcClient;
+import io.trino.plugin.jdbc.BaseJdbcClient.TopNFunction;
 import io.trino.plugin.jdbc.ColumnMapping;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcOutputTableHandle;
+import io.trino.plugin.jdbc.JdbcSortItem;
 import io.trino.plugin.jdbc.JdbcSplit;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
@@ -185,6 +187,7 @@ public class PhoenixClient
         extends BaseJdbcClient
 {
     private static final String ROWKEY = "ROWKEY";
+    private static final long MAX_TOPN_LIMIT = 2000000;
 
     private final Configuration configuration;
 
@@ -279,6 +282,33 @@ public class PhoenixClient
                 ImmutableMap.of(),
                 split);
         return new QueryBuilder(this).prepareStatement(session, connection, preparedQuery);
+    }
+
+    @Override
+    public boolean supportsTopN(ConnectorSession session, JdbcTableHandle handle, List<JdbcSortItem> sortOrder)
+    {
+        return true;
+    }
+
+    @Override
+    protected Optional<TopNFunction> topNFunction()
+    {
+        return Optional.of((query, sortItems, limit) -> {
+            // TODO: Remove when this is fixed in Phoenix.
+            // Phoenix severely over-estimates the memory
+            // required to execute a topN query.
+            // https://issues.apache.org/jira/browse/PHOENIX-6436
+            if (limit > MAX_TOPN_LIMIT) {
+                return query;
+            }
+            return TopNFunction.sqlStandard(this::quoted).apply(query, sortItems, limit);
+        });
+    }
+
+    @Override
+    public boolean isTopNLimitGuaranteed(ConnectorSession session)
+    {
+        return false;
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
@@ -14,12 +14,9 @@
 package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
-import io.trino.plugin.jdbc.PreparedQuery;
-import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.spi.HostAddress;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
@@ -83,17 +80,12 @@ public class PhoenixSplitManager
             List<JdbcColumnHandle> columns = tableHandle.getColumns()
                     .map(columnSet -> columnSet.stream().map(JdbcColumnHandle.class::cast).collect(toList()))
                     .orElseGet(() -> phoenixClient.getColumns(session, tableHandle));
-            QueryBuilder queryBuilder = new QueryBuilder(phoenixClient);
-            PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+            PhoenixPreparedStatement inputQuery = (PhoenixPreparedStatement) phoenixClient.prepareStatement(
                     session,
                     connection,
-                    tableHandle.getRelationHandle(),
-                    Optional.empty(),
+                    tableHandle,
                     columns,
-                    ImmutableMap.of(),
-                    tableHandle.getConstraint(),
                     Optional.empty());
-            PhoenixPreparedStatement inputQuery = (PhoenixPreparedStatement) queryBuilder.prepareStatement(session, connection, preparedQuery);
 
             List<ConnectorSplit> splits = getSplits(inputQuery).stream()
                     .map(PhoenixInputSplit.class::cast)


### PR DESCRIPTION
This adds topn pushdown for the Phoenix connector.
It turns out limit pushdown never worked, this PR fixes that as well.

The current code worked by "luck" only. When calculating the splits, the PhoenixConnector also generates the relevant HBase scans to execute as part of a split. However, those scans are created based on the original query, not the rewritten one, and so the scans would miss some of the annotation required by the rewritten query. It happened to work, but the limit was never applied.
When I first pushed in topn the results were non-sensical since the scans and the expected results disagreed on the shape. The change now uses the same code to generate the split-scans and the expected results during execution.

~~Only made the phoenix5 change, if the tests pass and we agree with the implementation I'll make the same change on Phoenix.~~

@vincentpoon @findepi 