### PR TITLE
Fix HttpRemoteTask node split count and queue space update order

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -493,9 +493,9 @@ public final class HttpRemoteTask
                 pendingSourceSplitCount -= removed;
             }
         }
-        updateSplitQueueSpace();
-
+        // Update node level split tracker before split queue space to ensure it's up to date before waking up the scheduler
         partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+        updateSplitQueueSpace();
     }
 
     private void updateTaskInfo(TaskInfo taskInfo)


### PR DESCRIPTION
Extracted from https://github.com/prestodb/presto/pull/15906

Reorders task split count (and therefore `NodeTaskMap`) and split queue space update in `HttpRemoteTask#processTaskUpdate`. Before this change, the scheduler could be started before the update to `NodeTaskMap` occurred and would then use stale values to assign splits.