### PR TITLE
Create test table without CTAS

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/hive/AbstractTestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/hive/AbstractTestHiveViews.java
@@ -297,7 +297,8 @@ public abstract class AbstractTestHiveViews
     public void testTimestampHiveView()
     {
         onHive().executeQuery("DROP TABLE IF EXISTS timestamp_hive_table");
-        onHive().executeQuery("CREATE TABLE timestamp_hive_table AS SELECT cast('1990-01-02 12:13:14.123456789' AS timestamp) ts");
+        onHive().executeQuery("CREATE TABLE timestamp_hive_table (ts timestamp)");
+        onHive().executeQuery("INSERT INTO timestamp_hive_table (ts) values ('1990-01-02 12:13:14.123456789')");
         onHive().executeQuery("DROP VIEW IF EXISTS timestamp_hive_view");
         onHive().executeQuery("CREATE VIEW timestamp_hive_view AS SELECT * FROM timestamp_hive_table");
 


### PR DESCRIPTION
Due to a https://issues.apache.org/jira/browse/HIVE-24625 managed table created
with CTAS could be empty on the new Hive versions. Creating tables as EXTERNAL
mitigates this bug without changing test logic.

