### PR TITLE
Fix Hive's file_modified_time value rendering

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -115,7 +115,9 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.lang.Math.floorDiv;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -223,7 +225,7 @@ public class HivePageSource
                 }
                 else if (type.equals(TIMESTAMP_TZ_MILLIS)) {
                     // used for $file_modified_time
-                    prefilledValue = packDateTimeWithZone(timestampPartitionKey(columnValue, name), DateTimeZone.getDefault().getID());
+                    prefilledValue = packDateTimeWithZone(floorDiv(timestampPartitionKey(columnValue, name), MICROSECONDS_PER_MILLISECOND), DateTimeZone.getDefault().getID());
                 }
                 else if (isShortDecimal(type)) {
                     prefilledValue = shortDecimalPartitionKey(columnValue, (DecimalType) type, name);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveRecordCursor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveRecordCursor.java
@@ -57,7 +57,9 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static java.lang.Math.floorDiv;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
@@ -147,7 +149,7 @@ public class HiveRecordCursor
                 }
                 else if (TIMESTAMP_TZ_MILLIS.equals(type)) {
                     // used for $file_modified_time
-                    longs[columnIndex] = packDateTimeWithZone(timestampPartitionKey(columnValue, name), DateTimeZone.getDefault().getID());
+                    longs[columnIndex] = packDateTimeWithZone(floorDiv(timestampPartitionKey(columnValue, name), MICROSECONDS_PER_MILLISECOND), DateTimeZone.getDefault().getID());
                 }
                 else if (isShortDecimal(type)) {
                     longs[columnIndex] = shortDecimalPartitionKey(columnValue, (DecimalType) type, name);


### PR DESCRIPTION
Before this change, $file_modified_time was reported incorrectly since version 341 (1c858f8696057099089c67abd17ada6f1d5275ed):

```
> select max("$file_modified_time") from hive.default.nation
53221-10-26 15:03:06
```

After this change value is scaled to a proper resolution and corresponding test, with an assertion that wouldn't catch upscaled value, was fixed :)