### PR TITLE
Improve message when _orc_acid_version not found or old

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -498,7 +498,8 @@ public class BackgroundHiveSplitLoader
                         : (directory.getCurrentDirectories().size() > 0 ? directory.getCurrentDirectories().get(0).getPath() : null);
 
                 if (baseOrDeltaPath != null && AcidUtils.OrcAcidVersion.getAcidVersionFromMetaFile(baseOrDeltaPath, fs) < 2) {
-                    throw new TrinoException(NOT_SUPPORTED, "Hive transactional tables are supported with Hive 3.0 and only after a major compaction has been run");
+                    throw new TrinoException(NOT_SUPPORTED, "Hive transactional tables are supported since Hive 3.0. " +
+                            "If you have upgraded from an older version of Hive, make sure a major compaction has been run at least once after the upgrade.");
                 }
             }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -713,7 +713,8 @@ public class TestBackgroundHiveSplitLoader
         backgroundHiveSplitLoader.start(hiveSplitSource);
         assertThatThrownBy(() -> drain(hiveSplitSource))
                 .isInstanceOfSatisfying(TrinoException.class, e -> assertEquals(NOT_SUPPORTED.toErrorCode(), e.getErrorCode()))
-                .hasMessage("Hive transactional tables are supported with Hive 3.0 and only after a major compaction has been run");
+                .hasMessage("Hive transactional tables are supported since Hive 3.0. " +
+                        "If you have upgraded from an older version of Hive, make sure a major compaction has been run at least once after the upgrade.");
 
         deleteRecursively(tablePath, ALLOW_INSECURE);
     }


### PR DESCRIPTION
Previously the message was suggesting Hive 3's ORC ACID tables are
supported only after major compaction, which is not true.