### PR TITLE
Remove obsolete comment from PhoenixClient.isLimitGuaranteed

### DIFF
--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -273,7 +273,6 @@ public class PhoenixClient
     @Override
     public boolean isLimitGuaranteed(ConnectorSession session)
     {
-        // Note that limit exceeding Integer.MAX_VALUE gets completely ignored.
         return false;
     }
 

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -274,7 +274,6 @@ public class PhoenixClient
     @Override
     public boolean isLimitGuaranteed(ConnectorSession session)
     {
-        // Note that limit exceeding Integer.MAX_VALUE gets completely ignored.
         return false;
     }
 


### PR DESCRIPTION
Should have been removed in 3270b55e33d3dbd0b7b48e37f4080824a04113a1 (https://github.com/trinodb/trino/pull/7236).