### PR TITLE
Add documentation for shared connector features, pushdown and reference updates to SQL Server connector 

### DIFF
--- a/docs/src/main/sphinx/connector/jdbc-type-mapping.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-type-mapping.fragment
@@ -1,0 +1,40 @@
+JDBC type mapping and metadata cache
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following properties can be used to configure how data types from the
+connected data source are mapped to Trino data types and how the metadata is
+cached in Trino.
+
+.. list-table:: Configuration properties that manage JDBC type mapping and metadata cache
+  :widths: 30, 40, 30
+  :header-rows: 1
+
+  * - Property name
+    - Description
+    - Default value
+  * - ``unsupported-type-handling``
+    - Configure how unsupported column data types are handled:
+
+      * ``IGNORE``, column is not accessible.
+      * ``CONVERT_TO_VARCHAR``, column is converted to unbounded ``VARCHAR``.
+
+      The respective catalog session property is ``unsupported_type_handling``.
+    - ``IGNORE``
+  * - ``jdbc-types-mapped-to-varchar``
+    - Allow forced mapping of comma separated lists of data types to convert to
+      unbounded ``VARCHAR``
+    -
+  * - ``case-insensitive-name-matching``
+    - Support case insensitive database and collection names
+    - False
+  * - ``case-insensitive-name-matching.cache-ttl``
+    -
+    - 1 minute
+  * - ``metadata.cache-ttl``
+    - Duration for which metadata, including table and column statistics, is
+      cached
+    - 0 (disabled caching)
+  * - ``metadata.cache-missing``
+    - Cache the fact that metadata, including table and column statistics, is
+      not available
+    - False

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -58,6 +58,17 @@ Finally, you can access the ``clicks`` table in the ``web`` database::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``memsql`` in the above examples.
 
+.. _memsql-pushdown:
+
+Pushdown
+--------
+
+The connector supports pushdown for a number of operations:
+
+* :ref:`join-pushdown`
+* :ref:`limit-pushdown`
+* :ref:`topn-pushdown`
+
 Limitations
 -----------
 

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -71,11 +71,19 @@ Finally, you can access the ``clicks`` table in the ``web`` database::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``mysql`` in the above examples.
 
+
+.. _mysql-pushdown:
+
 Pushdown
 --------
 
-The connector supports :doc:`pushdown </optimizer/pushdown>` for processing the
-following aggregate functions:
+The connector supports pushdown for a number of operations:
+
+* :ref:`join-pushdown`
+* :ref:`limit-pushdown`
+* :ref:`topn-pushdown`
+
+:ref:`Aggregate pushdown <aggregation-pushdown>` for the following functions:
 
 * :func:`avg`
 * :func:`count`

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -363,10 +363,16 @@ include ``SYNONYM``, add the following configuration property:
 
     oracle.synonyms.enabled=true
 
+.. _oracle-pushdown:
+
 Pushdown
 --------
 
-The connector supports :doc:`pushdown </optimizer/pushdown>` for optimized query processing.
+The connector supports pushdown for a number of operations:
+
+* :ref:`join-pushdown`
+* :ref:`limit-pushdown`
+* :ref:`topn-pushdown`
 
 Limitations
 -----------

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -89,11 +89,18 @@ Finally, you can access the ``clicks`` table in the ``web`` schema::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``postgresql`` in the above examples.
 
+.. _postgresql-pushdown:
+
 Pushdown
 --------
 
-The connector supports :doc:`pushdown </optimizer/pushdown>` for processing the
-following aggregate functions:
+The connector supports pushdown for a number of operations:
+
+* :ref:`join-pushdown`
+* :ref:`limit-pushdown`
+* :ref:`topn-pushdown`
+
+:ref:`Aggregate pushdown <aggregation-pushdown>` for the following functions:
 
 * :func:`avg`
 * :func:`count`

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -2,10 +2,16 @@
 SQL Server connector
 ====================
 
-The SQL Server connector allows querying and creating tables in an
-external `Microsoft SQL Server <https://www.microsoft.com/sql-server/>`_ database. This can be used to join data between
-different systems like SQL Server and Hive, or between two different
-SQL Server instances.
+The SQL Server connector allows querying and creating tables in an external
+`Microsoft SQL Server <https://www.microsoft.com/sql-server/>`_ database. This
+can be used to join data between different systems like SQL Server and Hive, or
+between two different SQL Server instances.
+
+Requirements
+------------
+
+The connector supports SQL Server 2016, SQL Server 2014, SQL Server 2012
+and Azure SQL Database as connected data sources.
 
 Configuration
 -------------
@@ -24,6 +30,16 @@ appropriate for your setup:
     connection-url=jdbc:sqlserver://<host>:<port>;database=<database>
     connection-user=root
     connection-password=secret
+
+The ``connection-url`` defines the connection information and parameters to pass
+to the SQL Server JDBC driver. The supported parameters for the URL are
+available in the `SQL Server JDBC driver documentation
+<https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url>`_.
+
+The ``connection-user`` and ``connection-password`` are typically required and
+determine the user credentials for the connection, often a service user. You can
+use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
+properties files.
 
 Multiple SQL Server databases or servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,13 +86,52 @@ Finally, you can query the ``clicks`` table in the ``web`` schema::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``sqlserver`` in the above examples.
 
+.. _sqlserver-type-mapping:
+
+Type mapping
+------------
+
+Trino supports the following SQL Server data types:
+
+==================================  ===============================
+SQL Server Type                     Trino Type
+==================================  ===============================
+``bigint``                          ``bigint``
+``smallint``                        ``smallint``
+``int``                             ``integer``
+``float``                           ``double``
+``char(n)``                         ``char(n)``
+``varchar(n)``                      ``varchar(n)``
+``date``                            ``date``
+``datetime2(n)``                    ``timestamp(n)``
+==================================  ===============================
+
+Complete list of `SQL Server data types
+<https://msdn.microsoft.com/en-us/library/ms187752.aspx>`_.
+
+.. include:: jdbc-type-mapping.fragment
+
+SQL support
+-----------
+
+The following SQL statements are not yet supported:
+
+* :doc:`/sql/delete`
+* :doc:`/sql/grant`
+* :doc:`/sql/revoke`
+
 .. _sqlserver-pushdown:
 
 Pushdown
 --------
 
-The connector supports :doc:`pushdown </optimizer/pushdown>` for processing the
-following aggregate functions:
+The connector supports pushdown for a number of operations:
+
+* :ref:`join-pushdown`
+* :ref:`limit-pushdown`
+* :ref:`topn-pushdown`
+
+:ref:`Aggregate pushdown <aggregation-pushdown>` for the following functions:
 
 * :func:`avg`
 * :func:`count`
@@ -108,34 +163,3 @@ Example::
     WITH (
       data_compression = 'ROW'
     );
-
-Limitations
------------
-
-Trino supports connecting to SQL Server 2016, SQL Server 2014, SQL Server 2012
-and Azure SQL Database.
-
-Trino supports the following SQL Server data types.
-The following table shows the mappings between SQL Server and Trino data types.
-
-============================= ============================
-SQL Server Type               Trino Type
-============================= ============================
-``bigint``                    ``bigint``
-``smallint``                  ``smallint``
-``int``                       ``integer``
-``float``                     ``double``
-``char(n)``                   ``char(n)``
-``varchar(n)``                ``varchar(n)``
-``date``                      ``date``
-``datetime2(n)``              ``timestamp(n)``
-============================= ============================
-
-Complete list of `SQL Server data types
-<https://msdn.microsoft.com/en-us/library/ms187752.aspx>`_.
-
-The following SQL statements are not yet supported:
-
-* :doc:`/sql/delete`
-* :doc:`/sql/grant`
-* :doc:`/sql/revoke`

--- a/docs/src/main/sphinx/optimizer/pushdown.rst
+++ b/docs/src/main/sphinx/optimizer/pushdown.rst
@@ -16,6 +16,8 @@ The results of this pushdown can include the following benefits:
 Support for pushdown is specific to each connector and the relevant underlying
 database or storage system.
 
+.. _aggregation-pushdown:
+
 Aggregation pushdown
 --------------------
 
@@ -127,9 +129,9 @@ performed, and instead Trino performs the aggregate processing.
                regionkey := tpch:regionkey
 
 Limitations
------------
+^^^^^^^^^^^
 
-Pushdown does not support a number of more complex statements:
+Aggregation pushdown does not support a number of more complex statements:
 
 * complex grouping operations such as ``ROLLUP``, ``CUBE``, or ``GROUPING SETS``
 * expressions inside the aggregation function call: ``sum(a * b)``
@@ -137,3 +139,52 @@ Pushdown does not support a number of more complex statements:
 * :ref:`aggregations with ordering <aggregate-function-ordering-during-aggregation>`
 * :ref:`aggregations with filter <aggregate-function-filtering-during-aggregation>`
 
+.. _join-pushdown:
+
+Join pushdown
+-------------
+
+Join pushdown allows the connector to delegate the table join operation to the
+underlying data source. This can result in performance gains, and allows Trino
+to perform the remaining query processing on a smaller amount of data.
+
+The specifics for the supported pushdown of table joins varies for each data
+source, and therefore for each connector.
+
+.. _limit-pushdown:
+
+Limit pushdown
+^^^^^^^^^^^^^^
+
+A :ref:`limit-clause` reduces the number of returned records for a statement.
+Limit pushdown enables a connector to push processing of such queries of
+unsorted record to the underlying data source.
+
+A pushdown of this clause can improve the performance of the query and
+significantly reduce the amount of data transferred from the data source to
+Trino.
+
+Queries include sections such as ``LIMIT N`` or ``FETCH FIRST N ROWS``.
+
+Implementation and support is connector-specific since different data sources have varying capabilities.
+
+.. _topn-pushdown:
+
+Top-N pushdown
+^^^^^^^^^^^^^^
+
+The combination of a :ref:`limit-clause` with an :ref:`order-by-clause` creates
+a small set of records to return out of a large sorted dataset. It relies on the
+order to determine which records need to be returned, and is therefore quite
+different to optimize compared to a :ref:`limit-pushdown`.
+
+The pushdown for such a query is called a Top-N pushdown, since the operation is
+returning the top N rows. It enables a connector to push processing of such
+queries to the underlying data source, and therefore significantly reduces the
+amount of data transferred to and processed by Trino.
+
+Queries include sections such as ``ORDER BY ... LIMIT N`` or ``ORDER BY ...
+FETCH FIRST N ROWS``.
+
+Implementation and support is connector-specific since different data sources
+support different SQL syntax and processing.

--- a/docs/src/main/sphinx/sql/select.rst
+++ b/docs/src/main/sphinx/sql/select.rst
@@ -867,8 +867,10 @@ Otherwise, it is arbitrary which rows are discarded.
 If the count specified in the ``OFFSET`` clause equals or exceeds the size
 of the result set, the final result is empty.
 
-LIMIT or FETCH FIRST clauses
-----------------------------
+.. _limit-clause:
+
+LIMIT or FETCH FIRST clause
+---------------------------
 
 The ``LIMIT`` or ``FETCH FIRST`` clause restricts the number of rows
 in the result set.


### PR DESCRIPTION
including numerous aspects
- shared config
- numerous performance improvements
- reference in SQL Server connector

@electrum and @findepi .. this is the first step at documenting features that are implemented in the jdbc connector base. It allows us to keep short references to features in the individual connectors and still have more complete documentation available to readers.

The initial need for this is to document the TopN pushdown in numerous connectors that we just added.
If this approach is ok I will farm the pushdown setup out into the other connectors that support this.  

In subsequent PRs we can add link to the JDBC connection pooling, case insensitive matching, and so on .. we can standardize on having the Performance section in each connector doc (and Configuration, Type mapping, Security, and Limitations)

Related code PR https://github.com/trinodb/trino/pull/7324/files

@m57lyra @Ordinant and @rosewms please review for grammar and such