### PR TITLE
Add debug listing to troubleshoot flaky build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Test Server RPM
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
-          $RETRY ./mvnw verify -B -P ci -pl :trino-server-rpm
+          $RETRY bash -c './mvnw verify -B -P ci -pl :trino-server-rpm || find core/trino-server-rpm/ -exec ls -ald {} +'
       - name: Clean Maven Output
         run: ./mvnw clean -pl '!:trino-server,!:trino-cli'
       - name: Test Docker Image


### PR DESCRIPTION
`./mvnw verify presto-server-rpm` is sometime retried for ever on the
CI. Let's see what the on-disk state is between retries.

For https://github.com/trinodb/trino/issues/5879 see https://github.com/trinodb/trino/issues/5879#issuecomment-817135108 
cc @losipiuk 