### PR TITLE
Format JdbcSortItem in EXPLAIN output

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/SortOrder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/SortOrder.java
@@ -13,6 +13,8 @@
  */
 package io.trino.spi.connector;
 
+import static java.lang.String.format;
+
 public enum SortOrder
 {
     ASC_NULLS_FIRST(true, true),
@@ -37,5 +39,13 @@ public enum SortOrder
     public boolean isNullsFirst()
     {
         return nullsFirst;
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("%s %s",
+                ascending ? "ASC" : "DESC",
+                nullsFirst ? "NULLS FIRST" : "NULLS LAST");
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSortItem.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcSortItem.java
@@ -67,4 +67,14 @@ public final class JdbcSortItem
     {
         return Objects.hash(column, sortOrder);
     }
+
+    @Override
+    public String toString()
+    {
+        return new StringBuilder()
+                .append(column)
+                .append(" ")
+                .append(sortOrder)
+                .toString();
+    }
 }

--- a/plugin/trino-druid/src/test/java/io/trino/plugin/druid/BaseDruidConnectorTest.java
+++ b/plugin/trino-druid/src/test/java/io/trino/plugin/druid/BaseDruidConnectorTest.java
@@ -128,6 +128,7 @@ public abstract class BaseDruidConnectorTest
             case SUPPORTS_RENAME_TABLE:
             case SUPPORTS_COMMENT_ON_COLUMN:
             case SUPPORTS_COMMENT_ON_TABLE:
+            case SUPPORTS_TOPN_PUSHDOWN:
                 return false;
             default:
                 return super.hasBehavior(connectorBehavior);

--- a/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorTest.java
+++ b/plugin/trino-redis/src/test/java/io/trino/plugin/redis/TestRedisConnectorTest.java
@@ -45,6 +45,9 @@ public class TestRedisConnectorTest
     protected boolean hasBehavior(TestingConnectorBehavior connectorBehavior)
     {
         switch (connectorBehavior) {
+            case SUPPORTS_TOPN_PUSHDOWN:
+                return false;
+
             case SUPPORTS_CREATE_SCHEMA:
                 return false;
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -36,6 +36,7 @@ import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_DELETE;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_INSERT;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_RENAME_TABLE;
 import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_RENAME_TABLE_ACROSS_SCHEMAS;
+import static io.trino.testing.TestingConnectorBehavior.SUPPORTS_TOPN_PUSHDOWN;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.join;
@@ -282,6 +283,19 @@ public abstract class BaseConnectorTest
         assertExplain(
                 "EXPLAIN SELECT name FROM nation WHERE nationkey = 42",
                 "(predicate|filterPredicate|constraint).{0,10}(nationkey|NATIONKEY)");
+    }
+
+    @Test
+    public void testSortItemsReflectedInExplain()
+    {
+        // Even if the sort items are pushed down into the table scan, it should still be reflected in EXPLAIN (via ConnectorTableHandle.toString)
+        @Language("RegExp") String expectedPattern = hasBehavior(SUPPORTS_TOPN_PUSHDOWN)
+                ? "sortOrder=\\[nationkey:\\w+:\\w+ DESC NULLS LAST] limit=5"
+                : "\\[5 by \\(nationkey DESC NULLS LAST\\)]";
+
+        assertExplain(
+                "EXPLAIN SELECT name FROM nation ORDER BY nationkey DESC NULLS LAST LIMIT 5",
+                expectedPattern);
     }
 
     @Test


### PR DESCRIPTION
Formats the JdbcSortItems properly in the explain plan.

```diff
TableScan[postgresql:tpch.nation tpch.nation
-sortOrder=[io.trino.plugin.jdbc.JdbcSortItem@6fab0074]
+sortOrder=[name:varchar(25):varchar ASC NULLS LAST]
limit=5 columns=[regionkey:bigint:int8]]
```

Another option is to simply implement a normal `toString` for `JdbcSortItem` which would lead to a plan like

```diff
TableScan[postgresql:tpch.nation tpch.nation
-sortOrder=[io.trino.plugin.jdbc.JdbcSortItem@6fab0074]
+sortOrder=[JdbcSortItem{column=name:varchar(25):varchar, sortOrder=ASC_NULLS_LAST}]
limit=5 columns=[regionkey:bigint:int8]]
```