### PR TITLE
Adjust pattern for matching sortItems in explain plan

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -290,8 +290,8 @@ public abstract class BaseConnectorTest
     {
         // Even if the sort items are pushed down into the table scan, it should still be reflected in EXPLAIN (via ConnectorTableHandle.toString)
         @Language("RegExp") String expectedPattern = hasBehavior(SUPPORTS_TOPN_PUSHDOWN)
-                ? "sortOrder=\\[nationkey:\\w+:\\w+ DESC NULLS LAST] limit=5"
-                : "\\[5 by \\(nationkey DESC NULLS LAST\\)]";
+                ? "sortOrder=\\[(?i:nationkey):.* DESC NULLS LAST] limit=5"
+                : "\\[5 by \\((?i:nationkey) DESC NULLS LAST\\)]";
 
         assertExplain(
                 "EXPLAIN SELECT name FROM nation ORDER BY nationkey DESC NULLS LAST LIMIT 5",


### PR DESCRIPTION
This makes the pattern match the column name in a case-insensitive manner (allowing connectors which return uppercased columns) to match the pattern.
Changed the `nationkey:\w+:\w+ DESC ...` to `nationkey:\S+:\S+ DESC...` to allow matching typenames which have non-word characters like `DECIMAL(p,s)`.