### PR TITLE
Fix reverse DNS lookup for current hostname in GitHub Actions CI Runner VMs

### DIFF
--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -1,5 +1,10 @@
 name: Tune Runner VM
-description: tunes the GitHub Runner VM operation system
+description: |
+  Fine tunes the GitHub Runner VM operation system for Trino builds. 
+  The tuning currently includes a workaround for 
+  "Reverse name lookup is broken for current hostname in ubuntu-latest VMs",
+  reported as https://github.com/actions/virtual-environments/issues/3185
+
 runs:
   using: composite
   steps:
@@ -7,6 +12,9 @@ runs:
         if [[ "$OSTYPE" == "linux-gnu"* ]]; then
             # Ensure that reverse lookups for current hostname are handled properly
             # Add the current IP address, long hostname and short hostname record to /etc/hosts file
-            echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+            eth0_ip_addr=$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
+            hostname_fqdn=$(hostname -f)
+            hostname_short=$(hostname -s)
+            echo -e "${eth0_ip_addr}\t${hostname_fqdn} ${hostname_short}" | sudo tee -a /etc/hosts
         fi
       shell: bash

--- a/.github/actions/tune-runner-vm/action.yml
+++ b/.github/actions/tune-runner-vm/action.yml
@@ -1,0 +1,12 @@
+name: Tune Runner VM
+description: tunes the GitHub Runner VM operation system
+runs:
+  using: composite
+  steps:
+    - run: |
+        if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            # Ensure that reverse lookups for current hostname are handled properly
+            # Add the current IP address, long hostname and short hostname record to /etc/hosts file
+            echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+        fi
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           sudo apt-get clean
           df -h
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/tune-runner-vm
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}
@@ -54,6 +55,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/tune-runner-vm
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -75,6 +77,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/tune-runner-vm
       - name: Web UI Checks
         run: core/trino-main/bin/check_webui.sh
 
@@ -85,6 +88,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # checkout tags so version in Manifest is set properly
+      - uses: ./.github/actions/tune-runner-vm
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -110,6 +114,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/tune-runner-vm
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -198,6 +203,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/tune-runner-vm
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -249,6 +255,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/tune-runner-vm
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -264,6 +271,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/tune-runner-vm
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -287,6 +295,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/tune-runner-vm
       - uses: actions/setup-java@v1
         with:
           java-version: 11
@@ -382,6 +391,7 @@ jobs:
     timeout-minutes: 140
     steps:
       - uses: actions/checkout@v2
+      - uses: ./.github/actions/tune-runner-vm
       - uses: actions/setup-java@v1
         with:
           java-version: 11


### PR DESCRIPTION
Fixes #7534

- Add current ip address, long hostname and short hostname to /etc/hosts
- Fixes reverse DNS lookup for current hostname
  and related issues such as `java.net.BindException: Cannot assign requested address`