### PR TITLE
Support TIMESTAMP(9) precision in trino-base-jdbc

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/StandardColumnMappings.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/StandardColumnMappings.java
@@ -501,7 +501,7 @@ public final class StandardColumnMappings
 
     private static ObjectReadFunction longTimestampReadFunction(TimestampType timestampType)
     {
-        checkArgument(timestampType.getPrecision() > TimestampType.MAX_SHORT_PRECISION && timestampType.getPrecision() < MAX_LOCAL_DATE_TIME_PRECISION,
+        checkArgument(timestampType.getPrecision() > TimestampType.MAX_SHORT_PRECISION && timestampType.getPrecision() <= MAX_LOCAL_DATE_TIME_PRECISION,
                 "Precision is out of range: %s", timestampType.getPrecision());
         return ObjectReadFunction.of(
                 LongTimestamp.class,

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcClient.java
@@ -28,10 +28,14 @@ import java.util.Optional;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_DOUBLE;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_REAL;
+import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_TIMESTAMP;
 import static io.trino.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -70,6 +74,7 @@ public class TestJdbcClient
         assertTrue(jdbcClient.getSchemaNames(session).containsAll(ImmutableSet.of("example", "tpch")));
         assertEquals(jdbcClient.getTableNames(session, Optional.of("example")), ImmutableList.of(
                 new SchemaTableName("example", "numbers"),
+                new SchemaTableName("example", "timestamps"),
                 new SchemaTableName("example", "view_source"),
                 new SchemaTableName("example", "view")));
         assertEquals(jdbcClient.getTableNames(session, Optional.of("tpch")), ImmutableList.of(
@@ -111,6 +116,18 @@ public class TestJdbcClient
                 new JdbcColumnHandle("COL2", JDBC_DOUBLE, DOUBLE),
                 new JdbcColumnHandle("COL3", JDBC_DOUBLE, DOUBLE),
                 new JdbcColumnHandle("COL4", JDBC_REAL, REAL)));
+    }
+
+    @Test
+    public void testMetadataWithTimestampCol()
+    {
+        SchemaTableName schemaTableName = new SchemaTableName("example", "timestamps");
+        Optional<JdbcTableHandle> table = jdbcClient.getTableHandle(session, schemaTableName);
+        assertTrue(table.isPresent(), "table is missing");
+        assertEquals(jdbcClient.getColumns(session, table.get()), ImmutableList.of(
+                new JdbcColumnHandle("TS_3", JDBC_TIMESTAMP, TIMESTAMP_MILLIS),
+                new JdbcColumnHandle("TS_6", JDBC_TIMESTAMP, TIMESTAMP_MICROS),
+                new JdbcColumnHandle("TS_9", JDBC_TIMESTAMP, TIMESTAMP_NANOS)));
     }
 
     @Test

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcMetadata.java
@@ -155,6 +155,7 @@ public class TestJdbcMetadata
         // all schemas
         assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.empty())), ImmutableSet.of(
                 new SchemaTableName("example", "numbers"),
+                new SchemaTableName("example", "timestamps"),
                 new SchemaTableName("example", "view_source"),
                 new SchemaTableName("example", "view"),
                 new SchemaTableName("tpch", "orders"),
@@ -165,6 +166,7 @@ public class TestJdbcMetadata
         // specific schema
         assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("example"))), ImmutableSet.of(
                 new SchemaTableName("example", "numbers"),
+                new SchemaTableName("example", "timestamps"),
                 new SchemaTableName("example", "view_source"),
                 new SchemaTableName("example", "view")));
         assertEquals(ImmutableSet.copyOf(metadata.listTables(SESSION, Optional.of("tpch"))), ImmutableSet.of(

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingDatabase.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingDatabase.java
@@ -52,6 +52,7 @@ final class TestingDatabase
         connection.createStatement().execute("CREATE SCHEMA example");
 
         connection.createStatement().execute("CREATE TABLE example.numbers(text varchar primary key, text_short varchar(32), value bigint)");
+        connection.createStatement().execute("CREATE TABLE example.timestamps(ts_3 timestamp(3) primary key, ts_6 timestamp(6), ts_9 timestamp(9))");
         connection.createStatement().execute("INSERT INTO example.numbers(text, text_short, value) VALUES " +
                 "('one', 'one', 1)," +
                 "('two', 'two', 2)," +

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarcharType;
 
@@ -61,6 +62,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.TIME_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TinyintType.TINYINT;
 
 class TestingH2JdbcClient
@@ -130,7 +132,15 @@ class TestingH2JdbcClient
                 return Optional.of(timeColumnMapping(TIME_MILLIS));
 
             case Types.TIMESTAMP:
-                return Optional.of(timestampColumnMapping(TIMESTAMP_MILLIS));
+                TimestampType timestampType;
+                Optional<Integer> decimalDigits = typeHandle.getDecimalDigits();
+                if (decimalDigits.isPresent()) {
+                    timestampType = createTimestampType(decimalDigits.get());
+                }
+                else {
+                    timestampType = TIMESTAMP_MILLIS;
+                }
+                return Optional.of(timestampColumnMapping(timestampType));
         }
 
         if (getUnsupportedTypeHandling(session) == CONVERT_TO_VARCHAR) {


### PR DESCRIPTION
FIx #7590 