### PR TITLE
Fix use kudu connector to query values of UNIXTIME_MICROS type, time zone didn't take effect

### DIFF
--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientConfig.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientConfig.java
@@ -45,6 +45,7 @@ public class KuduClientConfig
     private String schemaEmulationPrefix = "presto::";
     private boolean groupedExecutionEnabled;
     private Duration dynamicFilteringWaitTimeout = new Duration(0, MINUTES);
+    private String timeZone = "UTC";
 
     @NotNull
     @Size(min = 1)
@@ -169,5 +170,18 @@ public class KuduClientConfig
     {
         this.dynamicFilteringWaitTimeout = dynamicFilteringWaitTimeout;
         return this;
+    }
+
+    @Config("kudu.timezone")
+    public KuduClientConfig setTimeZone(String timeZoneStr)
+    {
+        this.timeZone = timeZoneStr;
+        TimestampHelper.setTimeZoneOffset(TimestampHelper.getZoneOffset(timeZone));
+        return this;
+    }
+
+    public String getTimeZone()
+    {
+        return timeZone;
     }
 }

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduPageSink.java
@@ -142,7 +142,7 @@ public class KuduPageSink
             row.setNull(destChannel);
         }
         else if (TIMESTAMP_MILLIS.equals(type)) {
-            row.addLong(destChannel, truncateEpochMicrosToMillis(type.getLong(block, position)));
+            row.addLong(destChannel, truncateEpochMicrosToMillis(type.getLong(block, position)) - (TimestampHelper.getTimeZoneOffset() * 1_000));
         }
         else if (REAL.equals(type)) {
             row.addFloat(destChannel, intBitsToFloat(toIntExact(type.getLong(block, position))));

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TimestampHelper.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TimestampHelper.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.kudu;
+
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.DateTimeFormatterBuilder;
+import org.joda.time.format.DateTimeParser;
+import org.joda.time.format.DateTimePrinter;
+
+public final class TimestampHelper
+{
+    private TimestampHelper() {}
+
+    private static Long timeZoneOffset = 0L;
+
+    public static Long getTimeZoneOffset()
+    {
+        return timeZoneOffset;
+    }
+
+    public static void setTimeZoneOffset(Long timeZoneOffset)
+    {
+        TimestampHelper.timeZoneOffset = timeZoneOffset;
+    }
+
+    public static Long getZoneOffset(String zone)
+    {
+        DateTimeFormatter timestampParser;
+        DateTimeParser[] timestampWithoutTimeZoneParser = {
+                DateTimeFormat.forPattern("yyyy-M-d").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSS").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSS").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSSSS").getParser(),
+        };
+        DateTimePrinter timestampWithoutTimeZonePrinter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS").getPrinter();
+        timestampParser = new DateTimeFormatterBuilder().append(timestampWithoutTimeZonePrinter, timestampWithoutTimeZoneParser).toFormatter().withZone(DateTimeZone.forID(zone));
+        Long unixTime = System.currentTimeMillis();
+        String timeSh = timestampParser.print(unixTime);
+        timestampParser = new DateTimeFormatterBuilder().append(timestampWithoutTimeZonePrinter, timestampWithoutTimeZoneParser).toFormatter().withZoneUTC();
+        Long unixTimeRet = timestampParser.parseMillis(timeSh);
+        Long offset = unixTimeRet - unixTime;
+        return offset;
+    }
+}

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/TypeHelper.java
@@ -133,7 +133,7 @@ public final class TypeHelper
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
             // Kudu's native format is in microseconds
-            return nativeValue;
+            return ((Long) nativeValue) - (TimestampHelper.getTimeZoneOffset() * 1_000);
         }
         if (type == BigintType.BIGINT) {
             return nativeValue;
@@ -179,7 +179,7 @@ public final class TypeHelper
             return row.getString(field);
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
-            return truncateEpochMicrosToMillis(row.getLong(field));
+            return truncateEpochMicrosToMillis(row.getLong(field)) + (TimestampHelper.getTimeZoneOffset() * 1_000);
         }
         if (type == BigintType.BIGINT) {
             return row.getLong(field);
@@ -214,7 +214,7 @@ public final class TypeHelper
     public static long getLong(Type type, RowResult row, int field)
     {
         if (type.equals(TIMESTAMP_MILLIS)) {
-            return truncateEpochMicrosToMillis(row.getLong(field));
+            return truncateEpochMicrosToMillis(row.getLong(field)) + (TimestampHelper.getTimeZoneOffset() * 1_000);
         }
         if (type == BigintType.BIGINT) {
             return row.getLong(field);


### PR DESCRIPTION
Fixes #6744

- Add kudu.timezone in kudu configuration
- Converting Kudu's UNIXTIME_MICROS to time at kudu.timezone when reading from Kudu or writing to Kudu