### PR TITLE
Hide Hive ORC ACID DML behind feature flag (disabled by default)

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -55,6 +55,8 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 })
 public class HiveConfig
 {
+    public static final String ORC_ACID_WRITES_ENABLED_CONFIG_PROPERTY = "hive.experimental.orc-acid-writes.enabled";
+
     private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
 
     private DataSize maxSplitSize = DataSize.of(64, MEGABYTE);
@@ -145,6 +147,8 @@ public class HiveConfig
     private boolean optimizeSymlinkListing = true;
 
     private boolean legacyHiveViewTranslation;
+
+    private boolean orcAcidWritesEnabled;
 
     public int getMaxInitialSplits()
     {
@@ -1040,5 +1044,19 @@ public class HiveConfig
     public boolean isLegacyHiveViewTranslation()
     {
         return this.legacyHiveViewTranslation;
+    }
+
+    // TODO drop property after resolving https://github.com/trinodb/trino/issues/7611
+    @Config(ORC_ACID_WRITES_ENABLED_CONFIG_PROPERTY)
+    @ConfigDescription("Enable writes to ORC ACID transactional tables")
+    public HiveConfig setOrcAcidWritesEnabled(boolean orcAcidWritesEnabled)
+    {
+        this.orcAcidWritesEnabled = orcAcidWritesEnabled;
+        return this;
+    }
+
+    public boolean isOrcAcidWritesEnabled()
+    {
+        return this.orcAcidWritesEnabled;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
@@ -61,6 +61,7 @@ public class HiveMetadataFactory
     private final AccessControlMetadataFactory accessControlMetadataFactory;
     private final Optional<Duration> hiveTransactionHeartbeatInterval;
     private final ScheduledExecutorService heartbeatService;
+    private final boolean orcAcidWritesEnabled;
 
     @Inject
     @SuppressWarnings("deprecation")
@@ -105,7 +106,8 @@ public class HiveMetadataFactory
                 nodeVersion.toString(),
                 hiveRedirectionsProvider,
                 hiveMaterializedViewMetadata,
-                accessControlMetadataFactory);
+                accessControlMetadataFactory,
+                hiveConfig.isOrcAcidWritesEnabled());
     }
 
     public HiveMetadataFactory(
@@ -132,7 +134,8 @@ public class HiveMetadataFactory
             String trinoVersion,
             HiveRedirectionsProvider hiveRedirectionsProvider,
             HiveMaterializedViewMetadata hiveMaterializedViewMetadata,
-            AccessControlMetadataFactory accessControlMetadataFactory)
+            AccessControlMetadataFactory accessControlMetadataFactory,
+            boolean orcAcidWritesEnabled)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.skipDeletionForAlter = skipDeletionForAlter;
@@ -165,6 +168,7 @@ public class HiveMetadataFactory
             updateExecutor = new BoundedExecutor(executorService, maxConcurrentMetastoreUpdates);
         }
         this.heartbeatService = requireNonNull(heartbeatService, "heartbeatService is null");
+        this.orcAcidWritesEnabled = orcAcidWritesEnabled;
     }
 
     @Override
@@ -197,6 +201,7 @@ public class HiveMetadataFactory
                 new MetastoreHiveStatisticsProvider(metastore),
                 hiveRedirectionsProvider,
                 hiveMaterializedViewMetadata,
-                accessControlMetadataFactory.create(metastore));
+                accessControlMetadataFactory.create(metastore),
+                orcAcidWritesEnabled);
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -841,7 +841,8 @@ public abstract class AbstractTestHive
                                 ImmutableMap.of()));
                     }
                 },
-                SqlStandardAccessControlMetadata::new);
+                SqlStandardAccessControlMetadata::new,
+                false);
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(
                 transactionHandle -> ((HiveMetadata) transactionManager.get(transactionHandle)).getMetastore(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -101,7 +101,8 @@ public class TestHiveConfig
                 .setDynamicFilteringProbeBlockingTimeout(new Duration(0, TimeUnit.MINUTES))
                 .setTimestampPrecision(HiveTimestampPrecision.DEFAULT_PRECISION)
                 .setOptimizeSymlinkListing(true)
-                .setLegacyHiveViewTranslation(false));
+                .setLegacyHiveViewTranslation(false)
+                .setOrcAcidWritesEnabled(false));
     }
 
     @Test
@@ -174,6 +175,7 @@ public class TestHiveConfig
                 .put("hive.timestamp-precision", "NANOSECONDS")
                 .put("hive.optimize-symlink-listing", "false")
                 .put("hive.legacy-hive-view-translation", "true")
+                .put("hive.experimental.orc-acid-writes.enabled", "true")
                 .build();
 
         HiveConfig expected = new HiveConfig()
@@ -242,7 +244,8 @@ public class TestHiveConfig
                 .setDynamicFilteringProbeBlockingTimeout(new Duration(10, TimeUnit.SECONDS))
                 .setTimestampPrecision(HiveTimestampPrecision.NANOSECONDS)
                 .setOptimizeSymlinkListing(false)
-                .setLegacyHiveViewTranslation(true);
+                .setLegacyHiveViewTranslation(true)
+                .setOrcAcidWritesEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop/hive.properties
@@ -13,3 +13,4 @@ hive.metastore-cache-ttl=0s
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
 hive.translate-hive-views=true
+hive.experimental.orc-acid-writes.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdfs-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hdfs-impersonation/hive.properties
@@ -13,3 +13,4 @@ hive.hdfs.authentication.type=NONE
 hive.hdfs.impersonation.enabled=true
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
+hive.experimental.orc-acid-writes.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-impersonation/hive.properties
@@ -15,3 +15,4 @@ hive.hdfs.impersonation.enabled=true
 hive.fs.new-directory-permissions=0700
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
+hive.experimental.orc-acid-writes.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-cross-realm/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-cross-realm/hive.properties
@@ -28,3 +28,5 @@ hive.hdfs.trino.principal=hdfs/hadoop-master@OTHERLABS.TERADATA.COM
 hive.hdfs.trino.keytab=/etc/hadoop/conf/hdfs-other.keytab
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
+
+hive.experimental.orc-acid-writes.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-data-protection/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-data-protection/hive.properties
@@ -16,3 +16,5 @@ hive.fs.cache.max-size=10
 
 #required for testGrantRevoke() product test
 hive.security=sql-standard
+
+hive.experimental.orc-acid-writes.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation-with-wire-encryption/hive.properties
@@ -20,3 +20,6 @@ hive.security=sql-standard
 hive.translate-hive-views=true
 
 hive.hdfs.wire-encryption.enabled=true
+
+hive.experimental.orc-acid-writes.enabled=true
+

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-impersonation/hive.properties
@@ -19,3 +19,5 @@ hive.max-partitions-per-scan=100
 hive.security=sql-standard
 #required for testAccessControlSetHiveViewAuthorization() product test
 hive.translate-hive-views=true
+
+hive.experimental.orc-acid-writes.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-no-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hdfs-no-impersonation/hive.properties
@@ -20,3 +20,5 @@ hive.hdfs.trino.principal=hdfs/hadoop-master@LABS.TERADATA.COM
 hive.hdfs.trino.keytab=/etc/hadoop/conf/hdfs.keytab
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
+
+hive.experimental.orc-acid-writes.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-hive-impersonation/hive.properties
@@ -23,3 +23,5 @@ hive.max-partitions-per-scan=100
 hive.security=sql-standard
 #required for testAccessControlSetHiveViewAuthorization() product test
 hive.translate-hive-views=true
+
+hive.experimental.orc-acid-writes.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation/hive.properties
@@ -22,3 +22,5 @@ hive.hdfs.trino.keytab=/etc/presto/conf/presto-server.keytab
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
 hive.config.resources=/etc/hadoop/conf/core-site.xml,/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-impersonation/hive-disable-key-provider-cache-site.xml
+
+hive.experimental.orc-acid-writes.enabled=true

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation/hive.properties
@@ -18,3 +18,5 @@ hive.hdfs.trino.keytab=/etc/presto/conf/presto-server.keytab
 hive.fs.cache.max-size=10
 hive.max-partitions-per-scan=100
 hive.config.resources=/etc/hadoop/conf/core-site.xml,/docker/presto-product-tests/conf/environment/singlenode-kerberos-kms-hdfs-no-impersonation/hive-disable-key-provider-cache-site.xml
+
+hive.experimental.orc-acid-writes.enabled=true


### PR DESCRIPTION
Temporarily make ORC ACID DML an opt-in feature, until rough edges now
are polished.