### PR TITLE
Update SPI docs

### DIFF
--- a/docs/src/main/sphinx/develop/spi-overview.rst
+++ b/docs/src/main/sphinx/develop/spi-overview.rst
@@ -90,7 +90,7 @@ plugin directory and add the relevant jars to that directory.
 
 By default, the plugin directory is the ``plugin`` directory relative to the
 directory in which Trino is installed, but it is configurable using the
-configuration variable ``catalog.config-dir``. In order for Trino to pick up
+configuration variable ``plugin.dir``. In order for Trino to pick up
 the new plugin, you must restart Trino.
 
 Plugins must be installed on all nodes in the Trino cluster (coordinator and workers).


### PR DESCRIPTION
Plugin directory is configured by `plugin.dir` and not `catalog.config-dir`