### PR TITLE
Migrate Elasticsearch tests to use BaseConnectorTest

### DIFF
--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch6ConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch6ConnectorTest.java
@@ -23,10 +23,10 @@ import java.io.IOException;
 
 import static java.lang.String.format;
 
-public class TestElasticsearch6IntegrationSmokeTest
-        extends BaseElasticsearchSmokeTest
+public class TestElasticsearch6ConnectorTest
+        extends BaseElasticsearchConnectorTest
 {
-    public TestElasticsearch6IntegrationSmokeTest()
+    public TestElasticsearch6ConnectorTest()
     {
         super("docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0");
     }

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch7ConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch7ConnectorTest.java
@@ -15,10 +15,10 @@ package io.trino.plugin.elasticsearch;
 
 import static java.lang.String.format;
 
-public class TestElasticsearch7IntegrationSmokeTest
-        extends BaseElasticsearchSmokeTest
+public class TestElasticsearch7ConnectorTest
+        extends BaseElasticsearchConnectorTest
 {
-    public TestElasticsearch7IntegrationSmokeTest()
+    public TestElasticsearch7ConnectorTest()
     {
         super("elasticsearch:7.0.0");
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
@@ -232,7 +232,12 @@ public abstract class AbstractTestQueries
     }
 
     @DataProvider
-    public static Object[][] largeInValuesCount()
+    public Object[][] largeInValuesCount()
+    {
+        return largeInValuesCountData();
+    }
+
+    protected Object[][] largeInValuesCountData()
     {
         return new Object[][] {
                 {200},


### PR DESCRIPTION
This PR addresses https://github.com/trinodb/trino/issues/7109

Overview of changes:
 
- BaseElasticsearchSmokeTest.java has been renamed to BaseTestElasticsearchConnectorTest.java
- TestElasticsearch6IntegrationSmokeTest.java has been renamed to TestElasticsearch6ConnectorTest.java
- TestElasticsearch7IntegrationSmokeTest.java has been renamed to TestElasticsearch7ConnectorTest.java
- Added custom implementations in BaseTestElasticsearchConnectorTest for the tests that don't match the generic expectations.