### PR TITLE
Change test query to operate on BIGINT values

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
@@ -165,8 +165,8 @@ public abstract class AbstractTestQueries
     @Test
     public void testLimitWithAggregation()
     {
-        MaterializedResult actual = computeActual("SELECT custkey, SUM(CAST(totalprice * 100 AS BIGINT)) FROM orders GROUP BY custkey LIMIT 10");
-        MaterializedResult all = computeExpected("SELECT custkey, SUM(CAST(totalprice * 100 AS BIGINT)) FROM orders GROUP BY custkey", actual.getTypes());
+        MaterializedResult actual = computeActual("SELECT custkey, SUM(orderkey) FROM orders GROUP BY custkey LIMIT 10");
+        MaterializedResult all = computeExpected("SELECT custkey, SUM(orderkey) FROM orders GROUP BY custkey", actual.getTypes());
 
         assertEquals(actual.getMaterializedRows().size(), 10);
         assertContains(all, actual);


### PR DESCRIPTION
With previous  query assertion was failing for connectors which exposed totalprice as
double value due to different double rounding behaviour in Trino and H2.