### PR TITLE
Disable Phoenix tests due to GHA setup issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
           - ":trino-oracle"
           - ":trino-kudu"
           - ":trino-iceberg,:trino-druid"
-          - ":trino-phoenix,:trino-phoenix5"
+          # TODO (https://github.com/trinodb/trino/issues/7534) - ":trino-phoenix,:trino-phoenix5"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
They fail pretty much in every build.
The fix PR is ready, but still needs some paper work.

For https://github.com/trinodb/trino/issues/7534
Fix PR: https://github.com/trinodb/trino/pull/7588