### PR TITLE
Mark TestHiveViews.testRichSqlSyntax as @Flaky

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/hive/AbstractTestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/hive/AbstractTestHiveViews.java
@@ -19,6 +19,7 @@ import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequiremen
 import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableOrdersTable;
 import io.trino.tempto.query.QueryExecutor;
 import io.trino.tempto.query.QueryResult;
+import io.trino.testng.services.Flaky;
 import io.trino.tests.utils.QueryExecutors;
 import org.testng.annotations.Test;
 
@@ -168,6 +169,7 @@ public abstract class AbstractTestHiveViews
      * Test view containing IF, IN, LIKE, BETWEEN, CASE, COALESCE, operators, delimited and non-delimited columns, an inline comment
      */
     @Test(groups = HIVE_VIEWS)
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/7535", match = "FAILED: Execution Error, return code 2 from org.apache.hadoop.hive.ql.exec.mr.MapRedTask")
     public void testRichSqlSyntax()
     {
         onHive().executeQuery("DROP VIEW IF EXISTS view_with_rich_syntax");


### PR DESCRIPTION
See referenced issue for more info.


See also https://github.com/trinodb/trino/pull/7592#issuecomment-821083001 and next build there for `@Flaky` being effective (or not)