### PR TITLE
Allow to customize JdbcIdentityCacheMapping for CredentialProvider

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ExtraCredentialsBasedJdbcIdentityCacheMappingModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ExtraCredentialsBasedJdbcIdentityCacheMappingModule.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+public class ExtraCredentialsBasedJdbcIdentityCacheMappingModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(JdbcIdentityCacheMapping.class).to(ExtraCredentialsBasedJdbcIdentityCacheMapping.class).in(Scopes.SINGLETON);
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPlugin.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPlugin.java
@@ -40,6 +40,11 @@ public class JdbcPlugin
     @Override
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
-        return ImmutableList.of(new JdbcConnectorFactory(name, combine(new CredentialProviderModule(), module)));
+        return ImmutableList.of(new JdbcConnectorFactory(
+                name,
+                combine(
+                        new CredentialProviderModule(),
+                        new ExtraCredentialsBasedJdbcIdentityCacheMappingModule(),
+                        module)));
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/CredentialProviderModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/CredentialProviderModule.java
@@ -16,11 +16,8 @@ package io.trino.plugin.jdbc.credential;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
-import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.airlift.configuration.ConfigurationFactory;
-import io.trino.plugin.jdbc.ExtraCredentialsBasedJdbcIdentityCacheMapping;
-import io.trino.plugin.jdbc.JdbcIdentityCacheMapping;
 import io.trino.plugin.jdbc.credential.file.ConfigFileBasedCredentialProviderConfig;
 import io.trino.plugin.jdbc.credential.keystore.KeyStoreBasedCredentialProviderConfig;
 
@@ -54,7 +51,6 @@ public class CredentialProviderModule
 
         configBinder(binder).bindConfig(ExtraCredentialConfig.class);
         binder.bind(CredentialProvider.class).to(ExtraCredentialProvider.class).in(SINGLETON);
-        binder.bind(JdbcIdentityCacheMapping.class).to(ExtraCredentialsBasedJdbcIdentityCacheMapping.class).in(Scopes.SINGLETON);
     }
 
     private void bindCredentialProviderModule(CredentialProviderType name, Module module)

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorFactory.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcConnectorFactory.java
@@ -25,7 +25,12 @@ public class TestJdbcConnectorFactory
     @Test
     public void test()
     {
-        ConnectorFactory connectorFactory = new JdbcConnectorFactory("test", combine(new CredentialProviderModule(), new TestingH2JdbcModule()));
+        ConnectorFactory connectorFactory = new JdbcConnectorFactory(
+                "test",
+                combine(
+                        new CredentialProviderModule(),
+                        new ExtraCredentialsBasedJdbcIdentityCacheMappingModule(),
+                        new TestingH2JdbcModule()));
 
         connectorFactory.create("test", TestingH2JdbcModule.createProperties(), new TestingConnectorContext());
     }


### PR DESCRIPTION
Allow to customize JdbcIdentityCacheMapping for CredentialProvider
