### PR TITLE
Use ACID semantics for whole partition deletes

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -66,7 +66,6 @@ import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPartitioningHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
-import io.trino.spi.connector.ConnectorTableLayoutHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTablePartitioning;
 import io.trino.spi.connector.ConnectorTableProperties;
@@ -2006,13 +2005,6 @@ public class HiveMetadata
         }
 
         throw new SchemaNotFoundException(schemaName.getSchemaName());
-    }
-
-    @Override
-    public boolean supportsMetadataDelete(ConnectorSession session, ConnectorTableHandle tableHandle, ConnectorTableLayoutHandle tableLayoutHandle)
-    {
-        HiveTableHandle handle = (HiveTableHandle) tableHandle;
-        return handle.getTableParameters().isEmpty() || !isFullAcidTable(handle.getTableParameters().get());
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2147,7 +2147,10 @@ public class HiveMetadata
     @Override
     public Optional<ConnectorTableHandle> applyDelete(ConnectorSession session, ConnectorTableHandle handle)
     {
-        return Optional.of(handle);
+        Map<String, String> parameters = ((HiveTableHandle) handle).getTableParameters()
+                .orElseThrow(() -> new IllegalStateException("tableParameters missing from handle"));
+
+        return isFullAcidTable(parameters) ? Optional.empty() : Optional.of(handle);
     }
 
     @Override


### PR DESCRIPTION
Use a row level delete instead of dropping partitions when running a delete that exactly matches entire partitions.

Fixes #7291