### PR TITLE
Allow creation of Hive tables with non-existent HDFS paths

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveLocationService.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveLocationService.java
@@ -58,9 +58,9 @@ public class HiveLocationService
         HdfsContext context = new HdfsContext(session);
         Path targetPath = externalLocation.orElseGet(() -> getTableDefaultLocation(context, metastore, hdfsEnvironment, schemaName, tableName));
 
-        // verify the target directory for the table
+        // verify the target path for the table
         if (pathExists(context, hdfsEnvironment, targetPath)) {
-            throw new TrinoException(HIVE_PATH_ALREADY_EXISTS, format("Target directory for table '%s.%s' already exists: %s", schemaName, tableName, targetPath));
+            throw new TrinoException(HIVE_PATH_ALREADY_EXISTS, format("Target path for table '%s.%s' already exists: %s", schemaName, tableName, targetPath));
         }
 
         // TODO detect when existing table's location is a on a different file system than the temporary directory

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -1076,8 +1076,9 @@ public class HiveMetadata
     {
         try {
             if (!isS3FileSystem(context, hdfsEnvironment, path)) {
-                if (!hdfsEnvironment.getFileSystem(context, path).isDirectory(path)) {
-                    throw new TrinoException(INVALID_TABLE_PROPERTY, "External location must be a directory: " + path);
+                FileSystem fileSystem = hdfsEnvironment.getFileSystem(context, path);
+                if (fileSystem.exists(path) && !fileSystem.getFileStatus(path).isDirectory()) {
+                    throw new TrinoException(INVALID_TABLE_PROPERTY, "External location exists but is not a directory: " + path);
                 }
             }
         }


### PR DESCRIPTION
Currently, creation of a table using `CREATE TABLE` on a non-existent
HDFS path throws an exception saying that the external location must
be a directory, which is misleading. This is due to a missing check
whether the path exists or not.

There are two approaches to solve this:
1. Throw exception that the path does not exist.
2. Automatically create non-existent path.

2nd one is the approach taken by Hive and Spark. Also, Trino does the
same when running the `CTAS` command. So, 2 seems like the way to go.

`org.apache.hadoop.fs.FileSystem#isDirectory` is deprecated, so we
switch to using `org.apache.hadoop.fs.FileStatus#isDirectory`.

Was tested locally on HDP 3.3. Do let me know if we need to write additional tests for this.