### PR TITLE
Fasten listing tables in BigQuery connector

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -113,6 +113,11 @@ class BigQueryClient
 
     Optional<RemoteDatabaseObject> toRemoteTable(String projectId, String remoteDatasetName, String tableName)
     {
+        return toRemoteTable(projectId, remoteDatasetName, tableName, listTables(DatasetId.of(projectId, remoteDatasetName), TABLE, VIEW));
+    }
+
+    Optional<RemoteDatabaseObject> toRemoteTable(String projectId, String remoteDatasetName, String tableName, Iterable<Table> tables)
+    {
         requireNonNull(projectId, "projectId is null");
         requireNonNull(remoteDatasetName, "remoteDatasetName is null");
         requireNonNull(tableName, "tableName is null");
@@ -129,7 +134,7 @@ class BigQueryClient
 
         // cache miss, reload the cache
         Map<TableId, Optional<RemoteDatabaseObject>> mapping = new HashMap<>();
-        for (Table table : listTables(DatasetId.of(projectId, remoteDatasetName), TABLE, VIEW)) {
+        for (Table table : tables) {
             mapping.merge(
                     tableIdToLowerCase(table.getTableId()),
                     Optional.of(RemoteDatabaseObject.of(table.getTableId().getTable())),

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -144,9 +144,10 @@ public class BigQueryMetadata
 
         ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (String remoteSchemaName : remoteSchemaNames) {
-            for (Table table : bigQueryClient.listTables(DatasetId.of(projectId, remoteSchemaName), TABLE, VIEW)) {
+            Iterable<Table> tables = bigQueryClient.listTables(DatasetId.of(projectId, remoteSchemaName), TABLE, VIEW);
+            for (Table table : tables) {
                 // filter ambiguous tables
-                boolean isAmbiguous = bigQueryClient.toRemoteTable(projectId, remoteSchemaName, table.getTableId().getTable().toLowerCase(ENGLISH))
+                boolean isAmbiguous = bigQueryClient.toRemoteTable(projectId, remoteSchemaName, table.getTableId().getTable().toLowerCase(ENGLISH), tables)
                         .filter(RemoteDatabaseObject::isAmbiguous)
                         .isPresent();
                 if (!isAmbiguous) {


### PR DESCRIPTION
There are 47 tables in my environment and the speed diff is 18sec → 3sec. 