### PR TITLE
Added the command `clear` used for clearing the trino CLI console.

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/Console.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Console.java
@@ -31,6 +31,7 @@ import org.jline.reader.LineReaderBuilder;
 import org.jline.reader.UserInterruptException;
 import org.jline.terminal.Terminal;
 import org.jline.utils.AttributedStringBuilder;
+import org.jline.utils.InfoCmp;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Option;
@@ -259,6 +260,11 @@ public class Console
                     case "exit":
                     case "quit":
                         return;
+                    case "clear":
+                        Terminal terminal = reader.getTerminal();
+                        terminal.puts(InfoCmp.Capability.clear_screen);
+                        terminal.flush();
+                        continue;
                     case "history":
                         for (History.Entry entry : reader.getHistory()) {
                             System.out.println(new AttributedStringBuilder()

--- a/client/trino-cli/src/main/java/io/trino/cli/Help.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Help.java
@@ -22,6 +22,7 @@ public final class Help
         return "" +
                 "Supported commands:\n" +
                 "QUIT\n" +
+                "CLEAR\n" +
                 "EXPLAIN [ ( option [, ...] ) ] <query>\n" +
                 "    options: FORMAT { TEXT | GRAPHVIZ | JSON }\n" +
                 "             TYPE { LOGICAL | DISTRIBUTED | VALIDATE | IO }\n" +

--- a/client/trino-cli/src/main/java/io/trino/cli/InputParser.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/InputParser.java
@@ -30,7 +30,7 @@ import static java.util.Locale.ENGLISH;
 public class InputParser
         implements Parser
 {
-    private static final Set<String> SPECIAL = ImmutableSet.of("exit", "quit", "history", "help");
+    private static final Set<String> SPECIAL = ImmutableSet.of("exit", "quit", "history", "help", "clear");
 
     @Override
     public ParsedLine parse(String line, int cursor, ParseContext context)


### PR DESCRIPTION
Added the command `clear` used for clearing the trino CLI console.

NOTE that this very same functionality can be already achieved by using "CTRL + L"  keyboard shortcut.

This functionality appeals newbie CLI users for clearing the content of the console when they don't know about the existence of "CTRL + L" shortcut.

