### PR TITLE
Update ConnectorMaterializedViewDefinition

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -41,6 +41,7 @@ import io.trino.security.ViewAccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.spi.TrinoWarning;
 import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ColumnSchema;
@@ -48,6 +49,7 @@ import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
+import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.GroupProvider;
@@ -509,7 +511,7 @@ class StatementAnalyzer
                 throw semanticException(TABLE_NOT_FOUND, refreshMaterializedView, "Materialized view '%s' does not exist", name);
             }
 
-            Optional<QualifiedName> storageName = getMaterializedViewStorageTableName(optionalView.get(), name);
+            Optional<QualifiedName> storageName = getMaterializedViewStorageTableName(optionalView.get());
 
             if (storageName.isEmpty()) {
                 throw semanticException(TABLE_NOT_FOUND, refreshMaterializedView, "Storage Table '%s' for materialized view '%s' does not exist", storageName, name);
@@ -1225,16 +1227,17 @@ class StatementAnalyzer
             return createAndAssignScope(node, scope, queryScope.getRelationType());
         }
 
-        private Optional<QualifiedName> getMaterializedViewStorageTableName(ConnectorMaterializedViewDefinition viewDefinition, QualifiedObjectName name)
+        private Optional<QualifiedName> getMaterializedViewStorageTableName(ConnectorMaterializedViewDefinition viewDefinition)
         {
-            String storageTable = viewDefinition.getStorageTable();
-            if (storageTable == null || storageTable.isEmpty()) {
+            if (viewDefinition.getStorageTable().isEmpty()) {
                 return Optional.empty();
             }
-            Identifier catalogName = new Identifier(name.getCatalogName(), true);
-            Identifier schemaName = new Identifier(name.getSchemaName(), true);
-            Identifier tableName = new Identifier(storageTable, true);
-            return Optional.of(QualifiedName.of(ImmutableList.of(catalogName, schemaName, tableName)));
+            CatalogSchemaTableName catalogSchemaTableName = viewDefinition.getStorageTable().get();
+            SchemaTableName schemaTableName = catalogSchemaTableName.getSchemaTableName();
+            return Optional.of(QualifiedName.of(ImmutableList.of(
+                    new Identifier(catalogSchemaTableName.getCatalogName(), true),
+                    new Identifier(schemaTableName.getSchemaName(), true),
+                    new Identifier(schemaTableName.getTableName(), true))));
         }
 
         @Override
@@ -1267,7 +1270,7 @@ class StatementAnalyzer
             if (optionalMaterializedView.isPresent()) {
                 if (metadata.getMaterializedViewFreshness(session, name).isMaterializedViewFresh()) {
                     // If materialized view is current, answer the query using the storage table
-                    Optional<QualifiedName> storageName = getMaterializedViewStorageTableName(optionalMaterializedView.get(), name);
+                    Optional<QualifiedName> storageName = getMaterializedViewStorageTableName(optionalMaterializedView.get());
                     if (storageName.isPresent()) {
                         tableHandle = metadata.getTableHandle(session, createQualifiedObjectName(session, table, storageName.get()));
                     }
@@ -1447,7 +1450,6 @@ class StatementAnalyzer
 
         private Scope createScopeForMaterializedView(Table table, QualifiedObjectName name, Optional<Scope> scope, ConnectorMaterializedViewDefinition view)
         {
-            checkArgument(view.getOwner().isPresent(), "owner must be present");
             return createScopeForView(
                     table,
                     name,
@@ -1455,7 +1457,7 @@ class StatementAnalyzer
                     view.getOriginalSql(),
                     view.getCatalog(),
                     view.getSchema(),
-                    view.getOwner(),
+                    Optional.of(view.getOwner()),
                     translateMaterializedViewColumns(view.getColumns()));
         }
 

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -42,6 +42,7 @@ import io.trino.security.AccessControl;
 import io.trino.security.AccessControlConfig;
 import io.trino.security.AccessControlManager;
 import io.trino.security.AllowAllAccessControl;
+import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
@@ -3226,7 +3227,7 @@ public class TestAnalyzer
                 tableViewAndMaterializedView,
                 new ConnectorMaterializedViewDefinition(
                         "SELECT a FROM t1",
-                        Optional.of("t1"),
+                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t1")),
                         Optional.of(TPCH_CATALOG),
                         Optional.of("s1"),
                         ImmutableList.of(new Column("a", BIGINT.getTypeId())),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -25,7 +25,6 @@ import io.trino.plugin.hive.metastore.CoralSemiTransactionalHiveMSCAdapter;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.TrinoException;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
@@ -76,13 +75,8 @@ public final class ViewReaderUtil
     public static final String PRESTO_VIEW_FLAG = "presto_view";
     static final String VIEW_PREFIX = "/* Presto View: ";
     static final String VIEW_SUFFIX = " */";
-    private static final String MATERIALIZED_VIEW_PREFIX = "/* Presto Materialized View: ";
-    private static final String MATERIALIZED_VIEW_SUFFIX = " */";
     private static final JsonCodec<ConnectorViewDefinition> VIEW_CODEC =
             new JsonCodecFactory(new ObjectMapperProvider()).jsonCodec(ConnectorViewDefinition.class);
-
-    private static final JsonCodec<ConnectorMaterializedViewDefinition> MATERIALIZED_VIEW_CODEC =
-            new JsonCodecFactory(new ObjectMapperProvider()).jsonCodec(ConnectorMaterializedViewDefinition.class);
 
     public static boolean isPrestoView(Table table)
     {
@@ -107,13 +101,6 @@ public final class ViewReaderUtil
         return VIEW_PREFIX + data + VIEW_SUFFIX;
     }
 
-    public static String encodeMaterializedViewData(ConnectorMaterializedViewDefinition definition)
-    {
-        byte[] bytes = MATERIALIZED_VIEW_CODEC.toJsonBytes(definition);
-        String data = Base64.getEncoder().encodeToString(bytes);
-        return MATERIALIZED_VIEW_PREFIX + data + MATERIALIZED_VIEW_SUFFIX;
-    }
-
     /**
      * Supports decoding of Presto views
      */
@@ -129,16 +116,6 @@ public final class ViewReaderUtil
             viewData = viewData.substring(0, viewData.length() - VIEW_SUFFIX.length());
             byte[] bytes = Base64.getDecoder().decode(viewData);
             return VIEW_CODEC.fromJson(bytes);
-        }
-
-        public static ConnectorMaterializedViewDefinition decodeMaterializedViewData(String data)
-        {
-            checkCondition(data.startsWith(MATERIALIZED_VIEW_PREFIX), HIVE_INVALID_VIEW_DATA, "Materialized View data missing prefix: %s", data);
-            checkCondition(data.endsWith(MATERIALIZED_VIEW_SUFFIX), HIVE_INVALID_VIEW_DATA, "Materialized View data missing suffix: %s", data);
-            data = data.substring(MATERIALIZED_VIEW_PREFIX.length());
-            data = data.substring(0, data.length() - MATERIALIZED_VIEW_SUFFIX.length());
-            byte[] bytes = Base64.getDecoder().decode(data);
-            return MATERIALIZED_VIEW_CODEC.fromJson(bytes);
         }
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewDefinition.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewDefinition.java
@@ -76,7 +76,7 @@ public class IcebergMaterializedViewDefinition
                         .map(column -> new Column(column.getName(), column.getType()))
                         .collect(toImmutableList()),
                 definition.getComment(),
-                definition.getOwner().orElseThrow(() -> new IllegalArgumentException("owner must be present")));
+                definition.getOwner());
     }
 
     @JsonCreator

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewDefinition.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewDefinition.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.json.JsonCodec;
+import io.airlift.json.JsonCodecFactory;
+import io.airlift.json.ObjectMapperProvider;
+import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
+import io.trino.spi.type.TypeId;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.StringJoiner;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_VIEW_DATA;
+import static io.trino.plugin.hive.util.HiveUtil.checkCondition;
+import static java.util.Objects.requireNonNull;
+
+/*
+ * Serializable version of ConnectorMaterializedViewDefinition stored by iceberg connector
+ */
+public class IcebergMaterializedViewDefinition
+{
+    private static final String MATERIALIZED_VIEW_PREFIX = "/* Presto Materialized View: ";
+    private static final String MATERIALIZED_VIEW_SUFFIX = " */";
+
+    private static final JsonCodec<IcebergMaterializedViewDefinition> materializedViewCodec =
+            new JsonCodecFactory(new ObjectMapperProvider()).jsonCodec(IcebergMaterializedViewDefinition.class);
+
+    private final String originalSql;
+    private final Optional<String> catalog;
+    private final Optional<String> schema;
+    private final List<Column> columns;
+    private final Optional<String> comment;
+    private final String owner;
+
+    public static String encodeMaterializedViewData(IcebergMaterializedViewDefinition definition)
+    {
+        byte[] bytes = materializedViewCodec.toJsonBytes(definition);
+        String data = Base64.getEncoder().encodeToString(bytes);
+        return MATERIALIZED_VIEW_PREFIX + data + MATERIALIZED_VIEW_SUFFIX;
+    }
+
+    public static IcebergMaterializedViewDefinition decodeMaterializedViewData(String data)
+    {
+        checkCondition(data.startsWith(MATERIALIZED_VIEW_PREFIX), HIVE_INVALID_VIEW_DATA, "Materialized View data missing prefix: %s", data);
+        checkCondition(data.endsWith(MATERIALIZED_VIEW_SUFFIX), HIVE_INVALID_VIEW_DATA, "Materialized View data missing suffix: %s", data);
+        data = data.substring(MATERIALIZED_VIEW_PREFIX.length());
+        data = data.substring(0, data.length() - MATERIALIZED_VIEW_SUFFIX.length());
+        byte[] bytes = Base64.getDecoder().decode(data);
+        return materializedViewCodec.fromJson(bytes);
+    }
+
+    public static IcebergMaterializedViewDefinition fromConnectorMaterializedViewDefinition(ConnectorMaterializedViewDefinition definition)
+    {
+        return new IcebergMaterializedViewDefinition(
+                definition.getOriginalSql(),
+                definition.getCatalog(),
+                definition.getSchema(),
+                definition.getColumns().stream()
+                        .map(column -> new Column(column.getName(), column.getType()))
+                        .collect(toImmutableList()),
+                definition.getComment(),
+                definition.getOwner().orElseThrow(() -> new IllegalArgumentException("owner must be present")));
+    }
+
+    @JsonCreator
+    public IcebergMaterializedViewDefinition(
+            @JsonProperty("originalSql") String originalSql,
+            @JsonProperty("catalog") Optional<String> catalog,
+            @JsonProperty("schema") Optional<String> schema,
+            @JsonProperty("columns") List<Column> columns,
+            @JsonProperty("comment") Optional<String> comment,
+            @JsonProperty("owner") String owner)
+    {
+        this.originalSql = requireNonNull(originalSql, "originalSql is null");
+        this.catalog = requireNonNull(catalog, "catalog is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.columns = List.copyOf(requireNonNull(columns, "columns is null"));
+        this.comment = requireNonNull(comment, "comment is null");
+        this.owner = requireNonNull(owner, "owner is null");
+
+        if (catalog.isEmpty() && schema.isPresent()) {
+            throw new IllegalArgumentException("catalog must be present if schema is present");
+        }
+        if (columns.isEmpty()) {
+            throw new IllegalArgumentException("columns list is empty");
+        }
+    }
+
+    @JsonProperty
+    public String getOriginalSql()
+    {
+        return originalSql;
+    }
+
+    @JsonProperty
+    public Optional<String> getCatalog()
+    {
+        return catalog;
+    }
+
+    @JsonProperty
+    public Optional<String> getSchema()
+    {
+        return schema;
+    }
+
+    @JsonProperty
+    public List<Column> getColumns()
+    {
+        return columns;
+    }
+
+    @JsonProperty
+    public Optional<String> getComment()
+    {
+        return comment;
+    }
+
+    @JsonProperty
+    public String getOwner()
+    {
+        return owner;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringJoiner joiner = new StringJoiner(", ", "[", "]");
+        joiner.add("originalSql=[" + originalSql + "]");
+        catalog.ifPresent(value -> joiner.add("catalog=" + value));
+        schema.ifPresent(value -> joiner.add("schema=" + value));
+        joiner.add("columns=" + columns);
+        comment.ifPresent(value -> joiner.add("comment=" + value));
+        joiner.add("owner=" + owner);
+        return getClass().getSimpleName() + joiner;
+    }
+
+    public static final class Column
+    {
+        private final String name;
+        private final TypeId type;
+
+        @JsonCreator
+        public Column(
+                @JsonProperty("name") String name,
+                @JsonProperty("type") TypeId type)
+        {
+            this.name = requireNonNull(name, "name is null");
+            this.type = requireNonNull(type, "type is null");
+        }
+
+        @JsonProperty
+        public String getName()
+        {
+            return name;
+        }
+
+        @JsonProperty
+        public TypeId getType()
+        {
+            return type;
+        }
+
+        @Override
+        public String toString()
+        {
+            return name + " " + type;
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.iceberg;
 
 import io.airlift.json.JsonCodec;
+import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.type.TypeManager;
@@ -24,6 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 public class IcebergMetadataFactory
 {
+    private final CatalogName catalogName;
     private final HiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
@@ -31,21 +33,24 @@ public class IcebergMetadataFactory
 
     @Inject
     public IcebergMetadataFactory(
+            CatalogName catalogName,
             IcebergConfig config,
             HiveMetastore metastore,
             HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
             JsonCodec<CommitTaskData> commitTaskDataJsonCodec)
     {
-        this(metastore, hdfsEnvironment, typeManager, commitTaskDataJsonCodec);
+        this(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskDataJsonCodec);
     }
 
     public IcebergMetadataFactory(
+            CatalogName catalogName,
             HiveMetastore metastore,
             HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
             JsonCodec<CommitTaskData> commitTaskCodec)
     {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
@@ -54,6 +59,6 @@ public class IcebergMetadataFactory
 
     public IcebergMetadata create()
     {
-        return new IcebergMetadata(metastore, hdfsEnvironment, typeManager, commitTaskCodec);
+        return new IcebergMetadata(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskCodec);
     }
 }

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
@@ -19,6 +19,7 @@ import io.trino.connector.MockConnectorFactory;
 import io.trino.connector.MockConnectorPlugin;
 import io.trino.connector.MockConnectorTableHandle;
 import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition.Column;
@@ -54,7 +55,7 @@ public class TestMockConnector
                                         new SchemaTableName("default", "test_materialized_view"),
                                         new ConnectorMaterializedViewDefinition(
                                                 "SELECT nationkey FROM mock.default.test_table",
-                                                Optional.of("test_storage"),
+                                                Optional.of(new CatalogSchemaTableName("mock", "default", "test_storage")),
                                                 Optional.of("mock"),
                                                 Optional.of("default"),
                                                 ImmutableList.of(new Column("nationkey", BIGINT.getTypeId())),


### PR DESCRIPTION
Decoupled ConnectorMaterializedViewDefinition from the way MV is stored by iceberg connector.
This allows evolving ConnectorMaterializedViewDefinition class without affecting backward compatibility with existing MV stored in iceberg.

Allow storage table to be in a different catalog and schema from the one used for storing the
materialized view definition.