### PR TITLE
Enable Phoenix tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
           - ":trino-oracle"
           - ":trino-kudu"
           - ":trino-iceberg,:trino-druid"
-          # TODO (https://github.com/trinodb/trino/issues/7534) - ":trino-phoenix,:trino-phoenix5"
+          - ":trino-phoenix,:trino-phoenix5"
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This reverts "Disable Phoenix tests due to GHA setup issue" commit
(fea0e2a7527121306160195d3234635bb50abbdf).

Fixes https://github.com/trinodb/trino/issues/7534
Supersedes https://github.com/trinodb/trino/pull/7588
Depends on https://github.com/actions/virtual-environments/issues/3185 

Stress tests results https://github.com/trinodb/trino/runs/2408304130, https://github.com/trinodb/trino/runs/2408568095