### PR TITLE
Merge materialized output pages

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -28,6 +28,7 @@ import io.trino.operator.OperationTimer.OperationTiming;
 import io.trino.operator.WorkProcessor.ProcessState;
 import io.trino.spi.Page;
 import io.trino.spi.connector.UpdatablePageSource;
+import io.trino.spi.type.Type;
 import io.trino.sql.planner.LocalExecutionPlanner.OperatorFactoryWithTypes;
 import io.trino.sql.planner.plan.PlanNodeId;
 
@@ -48,6 +49,7 @@ import static io.trino.operator.BlockedReason.WAITING_FOR_MEMORY;
 import static io.trino.operator.PageUtils.recordMaterializedBytes;
 import static io.trino.operator.WorkProcessor.ProcessState.Type.BLOCKED;
 import static io.trino.operator.WorkProcessor.ProcessState.Type.FINISHED;
+import static io.trino.operator.project.MergePages.mergePages;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -73,7 +75,10 @@ public class WorkProcessorPipelineSourceOperator
     private SettableFuture<?> blockedOnSplits = SettableFuture.create();
     private boolean operatorFinishing;
 
-    public static List<OperatorFactory> convertOperators(List<OperatorFactoryWithTypes> operatorFactoriesWithTypes)
+    public static List<OperatorFactory> convertOperators(
+            List<OperatorFactoryWithTypes> operatorFactoriesWithTypes,
+            DataSize minOutputPageSize,
+            int minOutputPageRowCount)
     {
         if (operatorFactoriesWithTypes.isEmpty() || !(operatorFactoriesWithTypes.get(0).getOperatorFactory() instanceof WorkProcessorSourceOperatorFactory)) {
             return toOperatorFactories(operatorFactoriesWithTypes);
@@ -96,7 +101,12 @@ public class WorkProcessorPipelineSourceOperator
         }
 
         return ImmutableList.<OperatorFactory>builder()
-                .add(new WorkProcessorPipelineSourceOperatorFactory(sourceOperatorFactory, workProcessorOperatorFactories))
+                .add(new WorkProcessorPipelineSourceOperatorFactory(
+                        sourceOperatorFactory,
+                        workProcessorOperatorFactories,
+                        operatorFactoriesWithTypes.get(operatorIndex - 1).getTypes(),
+                        minOutputPageSize,
+                        minOutputPageRowCount))
                 .addAll(toOperatorFactories(operatorFactoriesWithTypes.subList(operatorIndex, operatorFactoriesWithTypes.size())))
                 .build();
     }
@@ -111,7 +121,10 @@ public class WorkProcessorPipelineSourceOperator
     private WorkProcessorPipelineSourceOperator(
             DriverContext driverContext,
             WorkProcessorSourceOperatorFactory sourceOperatorFactory,
-            List<WorkProcessorOperatorFactory> operatorFactories)
+            List<WorkProcessorOperatorFactory> operatorFactories,
+            List<Type> outputTypes,
+            DataSize minOutputPageSize,
+            int minOutputPageRowCount)
     {
         requireNonNull(driverContext, "driverContext is null");
         requireNonNull(sourceOperatorFactory, "sourceOperatorFactory is null");
@@ -161,15 +174,22 @@ public class WorkProcessorPipelineSourceOperator
                     operatorFactory.getOperatorType(),
                     operatorMemoryTrackingContext));
             pages = operator.getOutputPages();
+            if (i == operatorFactories.size() - 1) {
+                // materialize output pages as there are no semantics guarantees for non WorkProcessor operators
+                pages = pages.map(Page::getLoadedPage);
+                pages = pages.transformProcessor(processor -> mergePages(
+                        outputTypes,
+                        minOutputPageSize.toBytes(),
+                        minOutputPageRowCount,
+                        processor,
+                        operatorContext.aggregateUserMemoryContext()));
+            }
             pages = pages
                     .yielding(() -> operatorContext.getDriverContext().getYieldSignal().isSet())
                     .withProcessEntryMonitor(() -> workProcessorOperatorEntryMonitor(operatorIndex))
                     .withProcessStateMonitor(state -> workProcessorOperatorStateMonitor(state, operatorIndex));
             pages = pages.map(page -> recordProcessedOutput(page, operatorIndex));
         }
-
-        // materialize output pages as there are no semantics guarantees for non WorkProcessor operators
-        pages = pages.map(Page::getLoadedPage);
 
         // finish early when entire pipeline is closed
         this.pages = pages.finishWhen(() -> operatorFinishing);
@@ -698,14 +718,23 @@ public class WorkProcessorPipelineSourceOperator
     {
         private final WorkProcessorSourceOperatorFactory sourceOperatorFactory;
         private final List<WorkProcessorOperatorFactory> operatorFactories;
+        private final List<Type> outputTypes;
+        private final DataSize minOutputPageSize;
+        private final int minOutputPageRowCount;
         private boolean closed;
 
         private WorkProcessorPipelineSourceOperatorFactory(
                 WorkProcessorSourceOperatorFactory sourceOperatorFactory,
-                List<WorkProcessorOperatorFactory> operatorFactories)
+                List<WorkProcessorOperatorFactory> operatorFactories,
+                List<Type> outputTypes,
+                DataSize minOutputPageSize,
+                int minOutputPageRowCount)
         {
             this.sourceOperatorFactory = requireNonNull(sourceOperatorFactory, "sourceOperatorFactory is null");
             this.operatorFactories = requireNonNull(operatorFactories, "operatorFactories is null");
+            this.outputTypes = requireNonNull(outputTypes, "outputTypes is null");
+            this.minOutputPageSize = requireNonNull(minOutputPageSize, "minOutputPageSize is null");
+            this.minOutputPageRowCount = minOutputPageRowCount;
         }
 
         @Override
@@ -718,7 +747,13 @@ public class WorkProcessorPipelineSourceOperator
         public SourceOperator createOperator(DriverContext driverContext)
         {
             checkState(!closed, "Factory is already closed");
-            return new WorkProcessorPipelineSourceOperator(driverContext, sourceOperatorFactory, operatorFactories);
+            return new WorkProcessorPipelineSourceOperator(
+                    driverContext,
+                    sourceOperatorFactory,
+                    operatorFactories,
+                    outputTypes,
+                    minOutputPageSize,
+                    minOutputPageRowCount);
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -578,7 +578,10 @@ public class LocalExecutionPlanner
 
         private List<OperatorFactory> handleLateMaterialization(List<OperatorFactoryWithTypes> operatorFactories)
         {
-            return WorkProcessorPipelineSourceOperator.convertOperators(operatorFactories);
+            return WorkProcessorPipelineSourceOperator.convertOperators(
+                    operatorFactories,
+                    getFilterAndProjectMinOutputPageSize(taskContext.getSession()),
+                    getFilterAndProjectMinOutputPageRowCount(taskContext.getSession()));
         }
 
         private void addLookupOuterDrivers(boolean isOutputDriver, List<OperatorFactory> operatorFactories)

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -26,6 +26,7 @@ import io.trino.operator.WorkProcessor.TransformationState;
 import io.trino.operator.WorkProcessorAssertion.Transform;
 import io.trino.spi.Page;
 import io.trino.spi.connector.UpdatablePageSource;
+import io.trino.sql.planner.LocalExecutionPlanner.OperatorFactoryWithTypes;
 import io.trino.sql.planner.plan.PlanNodeId;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -104,7 +105,10 @@ public class TestWorkProcessorPipelineSourceOperator
         TestWorkProcessorOperatorFactory secondOperatorFactory = new TestWorkProcessorOperatorFactory(3, secondOperatorPages);
 
         SourceOperatorFactory pipelineOperatorFactory = (SourceOperatorFactory) getOnlyElement(WorkProcessorPipelineSourceOperator.convertOperators(
-                ImmutableList.of(sourceOperatorFactory, firstOperatorFactory, secondOperatorFactory)));
+                ImmutableList.of(
+                        new OperatorFactoryWithTypes(sourceOperatorFactory, ImmutableList.of(BIGINT)),
+                        new OperatorFactoryWithTypes(firstOperatorFactory, ImmutableList.of(BIGINT)),
+                        new OperatorFactoryWithTypes(secondOperatorFactory, ImmutableList.of(BIGINT)))));
 
         DriverContext driverContext = TestingOperatorContext.create(scheduledExecutor).getDriverContext();
         SourceOperator pipelineOperator = pipelineOperatorFactory.createOperator(driverContext);

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -108,7 +108,9 @@ public class TestWorkProcessorPipelineSourceOperator
                 ImmutableList.of(
                         new OperatorFactoryWithTypes(sourceOperatorFactory, ImmutableList.of(BIGINT)),
                         new OperatorFactoryWithTypes(firstOperatorFactory, ImmutableList.of(BIGINT)),
-                        new OperatorFactoryWithTypes(secondOperatorFactory, ImmutableList.of(BIGINT)))));
+                        new OperatorFactoryWithTypes(secondOperatorFactory, ImmutableList.of(BIGINT))),
+                DataSize.ofBytes(0),
+                0));
 
         DriverContext driverContext = TestingOperatorContext.create(scheduledExecutor).getDriverContext();
         SourceOperator pipelineOperator = pipelineOperatorFactory.createOperator(driverContext);
@@ -216,6 +218,33 @@ public class TestWorkProcessorPipelineSourceOperator
         assertEquals(sourceOperatorStats.getInputPositions(), pipelineOperatorStats.getInputPositions());
 
         assertEquals(sourceOperatorStats.getAddInputWall(), pipelineOperatorStats.getAddInputWall());
+    }
+
+    @Test
+    public void testMergePages()
+    {
+        Transformation<Split, Page> sourceOperatorPages = split -> TransformationState.ofResult(createPage(1), false);
+        Transformation<Page, Page> firstOperatorPages = page -> TransformationState.ofResult(
+                getOnlyElement(rowPagesBuilder(BIGINT).addSequencePage(1, 0).build()));
+
+        TestWorkProcessorSourceOperatorFactory sourceOperatorFactory = new TestWorkProcessorSourceOperatorFactory(
+                1,
+                new PlanNodeId("1"),
+                sourceOperatorPages);
+        TestWorkProcessorOperatorFactory firstOperatorFactory = new TestWorkProcessorOperatorFactory(2, firstOperatorPages);
+
+        SourceOperatorFactory pipelineOperatorFactory = (SourceOperatorFactory) getOnlyElement(WorkProcessorPipelineSourceOperator.convertOperators(
+                ImmutableList.of(
+                        new OperatorFactoryWithTypes(sourceOperatorFactory, ImmutableList.of(BIGINT)),
+                        new OperatorFactoryWithTypes(firstOperatorFactory, ImmutableList.of(BIGINT))),
+                DataSize.ofBytes(100),
+                100));
+
+        DriverContext driverContext = TestingOperatorContext.create(scheduledExecutor).getDriverContext();
+        SourceOperator pipelineOperator = pipelineOperatorFactory.createOperator(driverContext);
+        pipelineOperator.addSplit(createSplit());
+
+        assertTrue(pipelineOperator.getOutput().getPositionCount() > 100);
     }
 
     private TestOperatorInfo getTestingOperatorInfo(OperatorStats operatorStats)


### PR DESCRIPTION
WorkProcessorPipelineSourceOperator allows
for smaller pages internally so that they can
potentially be filtered fully before being
materiaized. However, WorkProcessorPipelineSourceOperator
output pages should have reasonable size
to avoid processing overhead.