### PR TITLE
Fix flaky TestExternalAuthenticator tests

### DIFF
--- a/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthenticator.java
+++ b/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthenticator.java
@@ -169,10 +169,10 @@ public class TestExternalAuthenticator
                 .withResult(URI.create("http://token.uri"), successful(new Token("valid-token-4")));
         MockRedirectHandler redirectHandler = new MockRedirectHandler();
 
-        ExternalAuthenticator authenticator = new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.local(), Duration.ofSeconds(1));
         List<Future<Request>> requests = times(
                 4,
-                () -> authenticator.authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
+                () -> new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.local(), Duration.ofSeconds(1))
+                        .authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
                 .map(executor::submit)
                 .collect(toImmutableList());
 
@@ -194,10 +194,10 @@ public class TestExternalAuthenticator
         MockRedirectHandler redirectHandler = new MockRedirectHandler()
                 .sleepOnRedirect(Duration.ofSeconds(1));
 
-        ExternalAuthenticator authenticator = new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.memoryCached(), Duration.ofSeconds(1));
         List<Future<Request>> requests = times(
                 2,
-                () -> authenticator.authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
+                () -> new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.memoryCached(), Duration.ofSeconds(1))
+                        .authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
                 .map(executor::submit)
                 .collect(toImmutableList());
 
@@ -224,7 +224,8 @@ public class TestExternalAuthenticator
 
         List<Future<Request>> requests = times(
                 4,
-                () -> authenticator.authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"", firstRequest)))
+                () -> new ExternalAuthenticator(redirectHandler, tokenPoller, KnownToken.memoryCached(), Duration.ofSeconds(1))
+                        .authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"", firstRequest)))
                 .map(executor::submit)
                 .collect(toImmutableList());
 
@@ -242,10 +243,10 @@ public class TestExternalAuthenticator
         MockRedirectHandler redirectHandler = new MockRedirectHandler()
                 .sleepOnRedirect(Duration.ofSeconds(1));
 
-        ExternalAuthenticator authenticator = new ExternalAuthenticator(redirectHandler, (uri, duration) -> TokenPollResult.pending(uri), KnownToken.memoryCached(), Duration.ofMillis(1));
         List<Future<Request>> requests = times(
                 2,
-                () -> authenticator.authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
+                () -> new ExternalAuthenticator(redirectHandler, (uri, duration) -> TokenPollResult.pending(uri), KnownToken.memoryCached(), Duration.ofMillis(1))
+                        .authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
                 .map(executor::submit)
                 .collect(toImmutableList());
 
@@ -270,7 +271,8 @@ public class TestExternalAuthenticator
         Thread.sleep(100); //It's here to make sure that authentication will start before the other threads.
         List<Future<Request>> requests = times(
                 2,
-                () -> authenticator.authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
+                () -> new ExternalAuthenticator(redirectHandler, (uri, duration) -> TokenPollResult.pending(uri), KnownToken.memoryCached(), Duration.ofMillis(1))
+                        .authenticate(null, getUnauthorizedResponse("Bearer x_token_server=\"http://token.uri\", x_redirect_server=\"http://redirect.uri\"")))
                 .map(executor::submit)
                 .collect(toImmutableList());
 

--- a/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthenticator.java
+++ b/client/trino-client/src/test/java/io/trino/client/auth/external/TestExternalAuthenticator.java
@@ -188,7 +188,6 @@ public class TestExternalAuthenticator
     @Test(timeOut = 2000)
     public void testAuthenticationFromMultipleThreadsWithCachedToken()
     {
-        ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(this.getClass().getName() + "%n"));
         MockTokenPoller tokenPoller = new MockTokenPoller()
                 .withResult(URI.create("http://token.uri"), successful(new Token("valid-token")));
         MockRedirectHandler redirectHandler = new MockRedirectHandler()


### PR DESCRIPTION
When testing against sharedToken(), we need to control all its usages in order to be able to assert the results in a proper way. When the tests were allowed to run concurrently, some of them were interfering with each other which made the token to be shared in an uncontrollable manner, which in turn has made tests failing in a fals negative way. 

The change switches off the concurrency between the tests and fixes a bit the way the ExternalAuthenticator is constructed, imitating how the authenticator is used on production. 