### PR TITLE
Cache JDBC ConnectionMetadata.storesUpperCaseIdentifiers() result

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -69,6 +69,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.plugin.jdbc.ConnectionMetadataUtils.storesUpperCaseIdentifiers;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.jdbc.PredicatePushdownController.DISABLE_PUSHDOWN;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
@@ -548,7 +549,7 @@ public abstract class BaseJdbcClient
         }
 
         try (Connection connection = connectionFactory.openConnection(session)) {
-            boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
+            boolean uppercase = storesUpperCaseIdentifiers(connection);
             String remoteSchema = toRemoteSchemaName(identity, connection, schemaTableName.getSchemaName());
             String remoteTable = toRemoteTableName(identity, connection, remoteSchema, schemaTableName.getTableName());
             if (uppercase) {
@@ -609,7 +610,7 @@ public abstract class BaseJdbcClient
         JdbcIdentity identity = JdbcIdentity.from(session);
 
         try (Connection connection = connectionFactory.openConnection(session)) {
-            boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
+            boolean uppercase = storesUpperCaseIdentifiers(connection);
             String remoteSchema = toRemoteSchemaName(identity, connection, schemaTableName.getSchemaName());
             String remoteTable = toRemoteTableName(identity, connection, remoteSchema, schemaTableName.getTableName());
             String tableName = generateTemporaryTableName();
@@ -682,7 +683,7 @@ public abstract class BaseJdbcClient
         try (Connection connection = connectionFactory.openConnection(session)) {
             String newSchemaName = newTable.getSchemaName();
             String newTableName = newTable.getTableName();
-            if (connection.getMetaData().storesUpperCaseIdentifiers()) {
+            if (storesUpperCaseIdentifiers(connection)) {
                 newSchemaName = newSchemaName.toUpperCase(ENGLISH);
                 newTableName = newTableName.toUpperCase(ENGLISH);
             }
@@ -728,7 +729,7 @@ public abstract class BaseJdbcClient
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
             String columnName = column.getName();
-            if (connection.getMetaData().storesUpperCaseIdentifiers()) {
+            if (storesUpperCaseIdentifiers(connection)) {
                 columnName = columnName.toUpperCase(ENGLISH);
             }
             String sql = format(
@@ -746,7 +747,7 @@ public abstract class BaseJdbcClient
     public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
-            if (connection.getMetaData().storesUpperCaseIdentifiers()) {
+            if (storesUpperCaseIdentifiers(connection)) {
                 newColumnName = newColumnName.toUpperCase(ENGLISH);
             }
             String sql = format(
@@ -866,8 +867,7 @@ public abstract class BaseJdbcClient
         }
 
         try {
-            DatabaseMetaData metadata = connection.getMetaData();
-            if (metadata.storesUpperCaseIdentifiers()) {
+            if (storesUpperCaseIdentifiers(connection)) {
                 return schemaName.toUpperCase(ENGLISH);
             }
             return schemaName;
@@ -913,8 +913,7 @@ public abstract class BaseJdbcClient
         }
 
         try {
-            DatabaseMetaData metadata = connection.getMetaData();
-            if (metadata.storesUpperCaseIdentifiers()) {
+            if (storesUpperCaseIdentifiers(connection)) {
                 return tableName.toUpperCase(ENGLISH);
             }
             return tableName;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConnectionMetadataUtils.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ConnectionMetadataUtils.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public final class ConnectionMetadataUtils
+{
+    private static Boolean UPPERCASE;
+
+    private ConnectionMetadataUtils() {}
+
+    /**
+     * Allows to leverage LazyConnectionFactory. This property is vendor specific.
+     * It cannot be changed via configuration or at runtime. So we can cache its value.
+     */
+    public static boolean storesUpperCaseIdentifiers(Connection connection)
+            throws SQLException
+    {
+        if (UPPERCASE != null) {
+            return UPPERCASE;
+        }
+        boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
+        UPPERCASE = uppercase;
+        return uppercase;
+    }
+}

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.trino.plugin.jdbc.ConnectionMetadataUtils.storesUpperCaseIdentifiers;
 import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
@@ -190,7 +191,7 @@ public class ClickHouseClient
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
             String columnName = column.getName();
-            if (connection.getMetaData().storesUpperCaseIdentifiers()) {
+            if (storesUpperCaseIdentifiers(connection)) {
                 columnName = columnName.toUpperCase(ENGLISH);
             }
             String sql = format(
@@ -208,8 +209,7 @@ public class ClickHouseClient
     public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
-            DatabaseMetaData metadata = connection.getMetaData();
-            if (metadata.storesUpperCaseIdentifiers()) {
+            if (storesUpperCaseIdentifiers(connection)) {
                 newColumnName = newColumnName.toUpperCase(ENGLISH);
             }
             String sql = format("ALTER TABLE %s RENAME COLUMN %s TO %s ",

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
@@ -58,6 +58,7 @@ import java.util.stream.Stream;
 import static com.google.common.base.Verify.verify;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.base.util.JsonTypeUtil.jsonParse;
+import static io.trino.plugin.jdbc.ConnectionMetadataUtils.storesUpperCaseIdentifiers;
 import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
@@ -229,8 +230,7 @@ public class MemSqlClient
     public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
-            DatabaseMetaData metadata = connection.getMetaData();
-            if (metadata.storesUpperCaseIdentifiers()) {
+            if (storesUpperCaseIdentifiers(connection)) {
                 newColumnName = newColumnName.toUpperCase(ENGLISH);
             }
             // MemSQL versions earlier than 5.7 do not support the CHANGE syntax

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -78,6 +78,7 @@ import static com.mysql.jdbc.SQLError.SQL_STATE_ER_TABLE_EXISTS_ERROR;
 import static com.mysql.jdbc.SQLError.SQL_STATE_SYNTAX_ERROR;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.base.util.JsonTypeUtil.jsonParse;
+import static io.trino.plugin.jdbc.ConnectionMetadataUtils.storesUpperCaseIdentifiers;
 import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
 import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
@@ -414,8 +415,7 @@ public class MySqlClient
     public void renameColumn(ConnectorSession session, JdbcTableHandle handle, JdbcColumnHandle jdbcColumn, String newColumnName)
     {
         try (Connection connection = connectionFactory.openConnection(session)) {
-            DatabaseMetaData metadata = connection.getMetaData();
-            if (metadata.storesUpperCaseIdentifiers()) {
+            if (storesUpperCaseIdentifiers(connection)) {
                 newColumnName = newColumnName.toUpperCase(ENGLISH);
             }
             String sql = format(

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -106,6 +106,7 @@ import java.util.function.BiFunction;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.jdbc.ConnectionMetadataUtils.storesUpperCaseIdentifiers;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
@@ -524,7 +525,7 @@ public class PhoenixClient
         }
 
         try (Connection connection = connectionFactory.openConnection(session)) {
-            boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
+            boolean uppercase = storesUpperCaseIdentifiers(connection);
             if (uppercase) {
                 schema = schema.map(schemaName -> schemaName.toUpperCase(ENGLISH));
                 table = table.toUpperCase(ENGLISH);

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.jdbc.ConnectionMetadataUtils.storesUpperCaseIdentifiers;
 import static io.trino.plugin.phoenix.MetadataUtil.getEscapedTableName;
 import static io.trino.plugin.phoenix.MetadataUtil.toPrestoSchemaName;
 import static io.trino.plugin.phoenix.PhoenixErrorCode.PHOENIX_METADATA_ERROR;
@@ -134,7 +135,7 @@ public class PhoenixMetadata
     private String toMetadataCasing(ConnectorSession session, String schemaName)
     {
         try (Connection connection = phoenixClient.getConnection(session)) {
-            boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
+            boolean uppercase = storesUpperCaseIdentifiers(connection);
             if (uppercase) {
                 schemaName = schemaName.toUpperCase(ENGLISH);
             }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.jdbc.BaseJdbcClient;
-import io.trino.plugin.jdbc.BaseJdbcClient.TopNFunction;
 import io.trino.plugin.jdbc.ColumnMapping;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
@@ -107,6 +106,7 @@ import java.util.function.BiFunction;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.jdbc.ConnectionMetadataUtils.storesUpperCaseIdentifiers;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
@@ -525,7 +525,7 @@ public class PhoenixClient
         }
 
         try (Connection connection = connectionFactory.openConnection(session)) {
-            boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
+            boolean uppercase = storesUpperCaseIdentifiers(connection);
             if (uppercase) {
                 schema = schema.map(schemaName -> schemaName.toUpperCase(ENGLISH));
                 table = table.toUpperCase(ENGLISH);

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.jdbc.ConnectionMetadataUtils.storesUpperCaseIdentifiers;
 import static io.trino.plugin.phoenix5.MetadataUtil.getEscapedTableName;
 import static io.trino.plugin.phoenix5.MetadataUtil.toPrestoSchemaName;
 import static io.trino.plugin.phoenix5.PhoenixErrorCode.PHOENIX_METADATA_ERROR;
@@ -134,7 +135,7 @@ public class PhoenixMetadata
     private String toMetadataCasing(ConnectorSession session, String schemaName)
     {
         try (Connection connection = phoenixClient.getConnection(session)) {
-            boolean uppercase = connection.getMetaData().storesUpperCaseIdentifiers();
+            boolean uppercase = storesUpperCaseIdentifiers(connection);
             if (uppercase) {
                 schemaName = schemaName.toUpperCase(ENGLISH);
             }


### PR DESCRIPTION
Cache JDBC ConnectionMetadata.storesUpperCaseIdentifiers() result

Allows to leverage LazyConnectionFactory.
This property is vendor specific.
It cannot be changed via configuration or at runtime. So we
can cache its value.
