### PR TITLE
Accept non-orderable type in SimplePagesHashStrategy

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/SimplePagesHashStrategy.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SimplePagesHashStrategy.java
@@ -39,7 +39,7 @@ public class SimplePagesHashStrategy
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SimplePagesHashStrategy.class).instanceSize();
     private final List<Type> types;
-    private final List<BlockPositionComparison> comparisonOperators;
+    private final List<Optional<BlockPositionComparison>> comparisonOperators;
     private final List<Integer> outputChannels;
     private final List<List<Block>> channels;
     private final List<Integer> hashChannels;
@@ -60,7 +60,7 @@ public class SimplePagesHashStrategy
     {
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         this.comparisonOperators = types.stream()
-                .map(blockTypeOperators::getComparisonOperator)
+                .map(type -> type.isOrderable() ? Optional.of(blockTypeOperators.getComparisonOperator(type)) : Optional.<BlockPositionComparison>empty())
                 .collect(toImmutableList());
         this.outputChannels = ImmutableList.copyOf(requireNonNull(outputChannels, "outputChannels is null"));
         this.channels = ImmutableList.copyOf(requireNonNull(channels, "channels is null"));
@@ -279,11 +279,12 @@ public class SimplePagesHashStrategy
     public int compareSortChannelPositions(int leftBlockIndex, int leftBlockPosition, int rightBlockIndex, int rightBlockPosition)
     {
         int channel = getSortChannel();
-
         Block leftBlock = channels.get(channel).get(leftBlockIndex);
         Block rightBlock = channels.get(channel).get(rightBlockIndex);
 
-        return (int) comparisonOperators.get(channel).compare(leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
+        return (int) comparisonOperators.get(channel)
+            .orElseThrow(() -> new IllegalArgumentException("type is not orderable"))
+            .compare(leftBlock, leftBlockPosition, rightBlock, rightBlockPosition);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/operator/TestSimplePagesHashStrategy.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestSimplePagesHashStrategy.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.IntArrayBlock;
+import io.trino.spi.type.MapType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeOperators;
+import io.trino.type.BlockTypeOperators;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestSimplePagesHashStrategy
+{
+    @Test
+    public void testHashRowWithIntegerType()
+    {
+        Block block = new IntArrayBlock(1, Optional.empty(), new int[]{1234});
+        SimplePagesHashStrategy strategy = createSimplePagesHashStrategy(INTEGER, ImmutableList.of(block));
+        Page page = new Page(block);
+
+        // This works because IntegerType is comparable.
+        assertEquals(strategy.hashRow(0, page), -4467490526933615037L);
+    }
+
+    @Test
+    public void testHashRowWithMapType()
+    {
+        MapType mapType = new MapType(INTEGER, INTEGER, new TypeOperators());
+        Block block = mapType.createBlockFromKeyValue(
+                Optional.empty(),
+                new int[]{0, 1},
+                new IntArrayBlock(1, Optional.empty(), new int[]{1234}),
+                new IntArrayBlock(1, Optional.empty(), new int[]{5678}));
+
+        SimplePagesHashStrategy strategy = createSimplePagesHashStrategy(mapType, ImmutableList.of(block));
+        Page page = new Page(block);
+
+        // This works because MapType is comparable.
+        assertEquals(strategy.hashRow(0, page), 451258269207618863L);
+    }
+
+    @Test
+    public void testRowEqualsRowWithIntegerType()
+    {
+        SimplePagesHashStrategy strategy = createSimplePagesHashStrategy(INTEGER, ImmutableList.of());
+
+        Page leftPage = new Page(new IntArrayBlock(1, Optional.empty(), new int[]{1234}));
+        Page rightPage1 = new Page(new IntArrayBlock(1, Optional.empty(), new int[]{1234}));
+        Page rightPage2 = new Page(new IntArrayBlock(1, Optional.empty(), new int[]{5678}));
+
+        // This works because IntegerType is comparable.
+        assertTrue(strategy.rowEqualsRow(0, leftPage, 0, rightPage1));
+        assertFalse(strategy.rowEqualsRow(0, leftPage, 0, rightPage2));
+    }
+
+    @Test
+    public void testRowEqualsRowWithMapType()
+    {
+        MapType mapType = new MapType(INTEGER, INTEGER, new TypeOperators());
+        SimplePagesHashStrategy strategy = createSimplePagesHashStrategy(mapType, ImmutableList.of());
+
+        Page leftPage = new Page(mapType.createBlockFromKeyValue(
+                Optional.empty(),
+                new int[]{0, 1},
+                new IntArrayBlock(1, Optional.empty(), new int[]{1234}),
+                new IntArrayBlock(1, Optional.empty(), new int[]{5678})));
+
+        Page rightPage1 = new Page(mapType.createBlockFromKeyValue(
+                Optional.empty(),
+                new int[]{0, 1},
+                new IntArrayBlock(1, Optional.empty(), new int[]{1234}),
+                new IntArrayBlock(1, Optional.empty(), new int[]{5678})));
+
+        Page rightPage2 = new Page(mapType.createBlockFromKeyValue(
+                Optional.empty(),
+                new int[]{0, 1},
+                new IntArrayBlock(1, Optional.empty(), new int[]{1234}),
+                new IntArrayBlock(1, Optional.empty(), new int[]{1234})));
+
+        // This works because MapType is comparable.
+        assertTrue(strategy.rowEqualsRow(0, leftPage, 0, rightPage1));
+        assertFalse(strategy.rowEqualsRow(0, leftPage, 0, rightPage2));
+    }
+
+    @Test
+    public void testCompareSortChannelPositionsWithIntegerType()
+    {
+        Block block = new IntArrayBlock(3, Optional.empty(), new int[]{1234, 5678, 1234});
+        SimplePagesHashStrategy strategy = createSimplePagesHashStrategy(INTEGER, ImmutableList.of(block));
+
+        // This works because IntegerType is orderable.
+        assertEquals(strategy.compareSortChannelPositions(0, 0, 0, 1), -1);
+        assertEquals(strategy.compareSortChannelPositions(0, 1, 0, 0), 1);
+        assertEquals(strategy.compareSortChannelPositions(0, 0, 0, 2), 0);
+    }
+
+    @Test
+    public void testCompareSortChannelPositionsWithMapType()
+    {
+        MapType mapType = new MapType(INTEGER, INTEGER, new TypeOperators());
+        Block block = mapType.createBlockFromKeyValue(
+                Optional.empty(),
+                new int[]{0, 1},
+                new IntArrayBlock(1, Optional.empty(), new int[]{1234}),
+                new IntArrayBlock(1, Optional.empty(), new int[]{5678}));
+
+        SimplePagesHashStrategy strategy = createSimplePagesHashStrategy(mapType, ImmutableList.of(block));
+
+        // This fails because MapType is not orderable.
+        assertThatThrownBy(() -> strategy.compareSortChannelPositions(0, 0, 0, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("type is not orderable");
+    }
+
+    private static SimplePagesHashStrategy createSimplePagesHashStrategy(Type type, List<Block> channelBlocks)
+    {
+        return new SimplePagesHashStrategy(
+                ImmutableList.of(type),
+                ImmutableList.of(),
+                ImmutableList.of(channelBlocks),
+                ImmutableList.of(0),
+                OptionalInt.empty(),
+                Optional.of(0),
+                new BlockTypeOperators());
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
@@ -6070,4 +6070,15 @@ public abstract class AbstractTestEngineOnlyQueries
     {
         return ZONED_DATE_TIME_FORMAT.parse(value, ZonedDateTime::from);
     }
+
+    @Test
+    public void testNonOrderableType()
+    {
+        assertQuerySucceeds("SELECT b.mapped FROM (SELECT 'trino' AS name) a\n" +
+                "LEFT JOIN (\n" +
+                "  SELECT \n" +
+                "    SPLIT(CAST(JSON '{\"key\": {\"name\": \"trino\"}}' AS MAP(VARCHAR, MAP(VARCHAR, VARCHAR)))['key']['name'], ',') AS names,\n" +
+                "    CAST(JSON '{\"key\": {\"name\": \"trino\"}}' AS MAP(VARCHAR, MAP(VARCHAR, VARCHAR)))['key'] mapped\n" +
+                ") b ON CONTAINS(b.names, a.name)");
+    }
 }


### PR DESCRIPTION
I got `java.lang.UnsupportedOperationException: map(varchar, varchar) is not orderable` for the following query with 350 and even on the latest Trino while this works with 344 or before.
```sql
SELECT b.mapped FROM (SELECT 'trino' AS name) a
LEFT JOIN (
  SELECT 
    SPLIT(CAST(JSON '{"key": {"name": "trino"}}' AS MAP(VARCHAR, MAP(VARCHAR, VARCHAR)))['key']['name'], ',') AS names,
    CAST(JSON '{"key": {"name": "trino"}}' AS MAP(VARCHAR, MAP(VARCHAR, VARCHAR)))['key'] mapped
) b ON CONTAINS(b.names, a.name)
```
This caused by the following change:
https://github.com/trinodb/trino/commit/b3308a1f13137602f6caf64a0563b6c4dc92f9b5#diff-41dab47f3c40a2c23cedc1991b35fe7aa9492bec301c654b10f4baefcd521b62

Due to the above change, `SimplePagesHashStrategy` now tries to create `comparisonOperators` in the constructor and this error happens if non-orderable types are given. As long as these types are not used for sorting, `SimplePagesHashStrategy` should work.

In order to avoid this error, this pull request makes `comparisonOperators` is created only when types are orderable to behave as 343 or before.

Full stacktrace on 350:
```
java.lang.UnsupportedOperationException: map(varchar, varchar) is not orderable
	at io.prestosql.spi.type.TypeOperators.getComparisonOperator(TypeOperators.java:122)
	at io.prestosql.type.BlockTypeOperators.lambda$getComparisonOperator$4(BlockTypeOperators.java:133)
	at io.prestosql.type.BlockTypeOperators.lambda$getBlockOperator$7(BlockTypeOperators.java:203)
	at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4876)
	at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3529)
	at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2278)
	at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2155)
	at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2045)
	at com.google.common.cache.LocalCache.get(LocalCache.java:3951)
	at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4871)
	at io.prestosql.type.BlockTypeOperators.getBlockOperator(BlockTypeOperators.java:201)
	at io.prestosql.type.BlockTypeOperators.getBlockOperator(BlockTypeOperators.java:194)
	at io.prestosql.type.BlockTypeOperators.getComparisonOperator(BlockTypeOperators.java:133)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
	at io.prestosql.operator.SimplePagesHashStrategy.<init>(SimplePagesHashStrategy.java:64)
	at io.prestosql.operator.PagesIndex.createLookupSourceSupplier(PagesIndex.java:518)
	at io.prestosql.operator.HashBuilderOperator.buildLookupSource(HashBuilderOperator.java:589)
	at io.prestosql.operator.HashBuilderOperator.finishInput(HashBuilderOperator.java:486)
	at io.prestosql.operator.HashBuilderOperator.finish(HashBuilderOperator.java:442)
	at io.prestosql.operator.Driver.processInternal(Driver.java:397)
	at io.prestosql.operator.Driver.lambda$processFor$8(Driver.java:283)
	at io.prestosql.operator.Driver.tryWithLock(Driver.java:675)
	at io.prestosql.operator.Driver.processFor(Driver.java:276)
	at io.prestosql.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1076)
	at io.prestosql.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:163)
	at io.prestosql.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:484)
	at io.prestosql.$gen.Presto_c7724d2____20210408_075520_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```