### PR TITLE
Disable pushdown in AddExchanges when toggled off

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPredicateIntoTableScan.java
@@ -161,6 +161,10 @@ public class PushPredicateIntoTableScan
             TypeAnalyzer typeAnalyzer,
             DomainTranslator domainTranslator)
     {
+        if (!isAllowPushdownIntoConnectors(session)) {
+            return Optional.empty();
+        }
+
         // don't include non-deterministic predicates
         Expression deterministicPredicate = filterDeterministicConjuncts(metadata, predicate);
         Expression nonDeterministicPredicate = filterNonDeterministicConjuncts(metadata, predicate);


### PR DESCRIPTION
Make `AddExchanges` respect the `allow_pushdown_into_connectors`
diagnostic session property.