### PR TITLE
Add principal-field documentation to Oauth

### DIFF
--- a/docs/src/main/sphinx/security/oauth2.rst
+++ b/docs/src/main/sphinx/security/oauth2.rst
@@ -98,6 +98,9 @@ The following configuration properties are available:
    * - ``http-server.authentication.oauth2.user-mapping.file``
      - File containing rules for mapping user. See :doc:`/security/user-mapping`
        for more information.
+   * - ``http-server.authentication.oauth2.principal-field``
+     - The field of the access token used for the Trino user principal. Defaults to ``sub``. Other commonly used fields include ``sAMAccountName``, ``name``, ``upn``, and ``email``.
+
 
 Troubleshooting
 ---------------


### PR DESCRIPTION
Added the description of the field `http-server.authentication.oauth2.principal-field` in Oauth docs. Let me know if any changes are required.

![image](https://user-images.githubusercontent.com/14219201/115949946-437a9200-a513-11eb-8090-4dd254ba70c8.png)
