### PR TITLE
Not take range partitions into account for Kudu bucketing

### DIFF
--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduBucketFunction.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduBucketFunction.java
@@ -69,6 +69,11 @@ public class KuduBucketFunction
                 .map(hashBucketSchema -> this.calculateSchemaLevelBucketId(page, partialRow, hashBucketSchema, position))
                 .collect(toImmutableList());
 
+        return getBucket(bucketIds, hashBucketSchemas);
+    }
+
+    static int getBucket(List<Integer> bucketIds, List<HashBucketSchema> hashBucketSchemas)
+    {
         int bucketId = 0;
         for (int i = 0; i < bucketIds.size(); i++) {
             int dimensionBucket = 1;

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduClientSession.java
@@ -53,6 +53,7 @@ import org.apache.kudu.client.KuduScanner;
 import org.apache.kudu.client.KuduSession;
 import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.PartialRow;
+import org.apache.kudu.client.PartitionSchema.HashBucketSchema;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -204,8 +205,11 @@ public class KuduClientSession
 
         List<KuduScanToken> tokens = builder.build();
         ImmutableList.Builder<KuduSplit> tokenBuilder = ImmutableList.builder();
-        for (int tokenId = 0; tokenId < tokens.size(); tokenId++) {
-            tokenBuilder.add(toKuduSplit(tableHandle, tokens.get(tokenId), primaryKeyColumnCount, tokenId));
+        List<HashBucketSchema> hashBucketSchemas = table.getPartitionSchema().getHashBucketSchemas();
+        for (KuduScanToken token : tokens) {
+            List<Integer> hashBuckets = token.getTablet().getPartition().getHashBuckets();
+            int bucket = KuduBucketFunction.getBucket(hashBuckets, hashBucketSchemas);
+            tokenBuilder.add(toKuduSplit(tableHandle, token, primaryKeyColumnCount, bucket));
         }
         return tokenBuilder.build();
     }


### PR DESCRIPTION
When creating kudu split for table with range partitions from scan
tokens, using token index as bucket number could cause join result
error. When joining on the hash bucket key, even the hash bucket key
of two rows are the same, they might have diffrent bucket number
because of range partitions. Then some joining result are mistakenly
pruned due to the partition scheme over the bucket number.

This patch calculate the Kudu split bucket only from the tablet hash
buckets, does not take range partions into account for kudu bucketing.

Creating KuduTableHandle with the bucket count not depending on the kudu session property.
So this also fix issue #7738