### PR TITLE
Relax assertion in JdbcRecordSetProvider

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSetProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcRecordSetProvider.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorRecordSetProvider;
 import io.trino.spi.connector.ConnectorSession;
@@ -49,12 +50,12 @@ public class JdbcRecordSetProvider
         JdbcSplit jdbcSplit = (JdbcSplit) split;
         JdbcTableHandle jdbcTable = (JdbcTableHandle) table;
 
-        // In the current API, the columns (and order) needed by the engine are provided via an argument to this method. Make sure that
-        // any columns that were recorded in the table handle match the requested set.
+        // In the current API, the columns (and order) needed by the engine are provided via an argument to this method. Make sure we can
+        // satisfy the requirements using columns which were recorded in the table handle.
         // If no columns are recorded, it means that applyProjection never got called (e.g., in the case all columns are being used) and all
         // table columns should be returned. TODO: this is something that should be addressed once the getRecordSet API is revamped
         jdbcTable.getColumns()
-                .ifPresent(tableColumns -> verify(columns.equals(tableColumns)));
+                .ifPresent(tableColumns -> verify(ImmutableSet.copyOf(tableColumns).containsAll(columns)));
 
         ImmutableList.Builder<JdbcColumnHandle> handles = ImmutableList.builder();
         for (ColumnHandle handle : columns) {


### PR DESCRIPTION
We do not care about outputs order so assertion should not validate
that. The only thing we want to check is that we can cover the requested
set of columns with projection recorded in table handle.