### PR TITLE
Make the intention of max pivot+1 test clearer

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
@@ -6042,17 +6042,6 @@ public abstract class AbstractTestEngineOnlyQueries
         assertQueryFails(pivotQuery(ARRAY_CONSTRUCTION_LIMIT + 1), "Too many arguments for array constructor");
     }
 
-    @Test(timeOut = 30_000)
-    public void testLateMaterializationOuterJoin()
-    {
-        Session session = Session.builder(getSession())
-                .setSystemProperty(LATE_MATERIALIZATION, "true")
-                .setSystemProperty(JOIN_REORDERING_STRATEGY, NONE.toString())
-                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, BROADCAST.toString())
-                .build();
-        assertQuery(session, "SELECT * FROM (SELECT * FROM nation WHERE nationkey < -1) a RIGHT JOIN nation b ON a.nationkey = b.nationkey");
-    }
-
     private static String pivotQuery(int columnsCount)
     {
         String values = IntStream.range(0, columnsCount)
@@ -6064,6 +6053,17 @@ public abstract class AbstractTestEngineOnlyQueries
                 .collect(joining(", "));
 
         return format("SELECT * FROM (SELECT %s) a(%s) INNER JOIN unnest(ARRAY[%1$s], ARRAY[%2$s]) b(b1, b2) ON true", values, columns);
+    }
+
+    @Test(timeOut = 30_000)
+    public void testLateMaterializationOuterJoin()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(LATE_MATERIALIZATION, "true")
+                .setSystemProperty(JOIN_REORDERING_STRATEGY, NONE.toString())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, BROADCAST.toString())
+                .build();
+        assertQuery(session, "SELECT * FROM (SELECT * FROM nation WHERE nationkey < -1) a RIGHT JOIN nation b ON a.nationkey = b.nationkey");
     }
 
     private static ZonedDateTime zonedDateTime(String value)

--- a/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
@@ -132,6 +132,8 @@ public abstract class AbstractTestEngineOnlyQueries
                     99.0,
                     false));
 
+    private static final int ARRAY_CONSTRUCTION_LIMIT = 254;
+
     @Test
     public void testDateLiterals()
     {
@@ -6026,23 +6028,18 @@ public abstract class AbstractTestEngineOnlyQueries
     @Test
     public void testLargePivot()
     {
-        int columns = 254;
-
-        MaterializedResult result = computeActual(pivotQuery(columns));
+        MaterializedResult result = computeActual(pivotQuery(ARRAY_CONSTRUCTION_LIMIT));
         assertThat(result.getRowCount())
                 .as("row count")
-                .isEqualTo(columns);
+                .isEqualTo(ARRAY_CONSTRUCTION_LIMIT);
 
         MaterializedRow row = result.getMaterializedRows().get(0);
         assertThat(row.getFieldCount())
                 .as("field count")
-                .isEqualTo(columns + 2);
-    }
+                .isEqualTo(ARRAY_CONSTRUCTION_LIMIT + 2);
 
-    @Test
-    public void testPivotExceedingMaximumArraySize()
-    {
-        assertQueryFails(pivotQuery(255), "Too many arguments for array constructor");
+        // Verify that ARRAY_CONSTRUCTION_LIMIT is the current limit so that the test stays relevant and prevents regression if we improve in the future.
+        assertQueryFails(pivotQuery(ARRAY_CONSTRUCTION_LIMIT + 1), "Too many arguments for array constructor");
     }
 
     @Test(timeOut = 30_000)


### PR DESCRIPTION
It can apparently escape noticing that
`testPivotExceedingMaximumArraySize` should be read together with
`testLargePivot` as they work in tandem. This commits squashes them
together and adds explanatory comment.