### PR TITLE
Unwrap single-column row comparisons in Apply

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -216,6 +216,7 @@ import io.trino.sql.planner.iterative.rule.TransformFilteringSemiJoinToInnerJoin
 import io.trino.sql.planner.iterative.rule.TransformUncorrelatedInPredicateSubqueryToSemiJoin;
 import io.trino.sql.planner.iterative.rule.TransformUncorrelatedSubqueryToJoin;
 import io.trino.sql.planner.iterative.rule.UnwrapCastInComparison;
+import io.trino.sql.planner.iterative.rule.UnwrapSingleColumnRowInApply;
 import io.trino.sql.planner.optimizations.AddExchanges;
 import io.trino.sql.planner.optimizations.AddLocalExchanges;
 import io.trino.sql.planner.optimizations.BeginTableWrite;
@@ -427,7 +428,9 @@ public class PlanOptimizers
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(columnPruningRules)
                                 .addAll(projectionPushdownRules)
+                                .addAll(new DesugarRowSubscript(typeAnalyzer).rules())
                                 .addAll(ImmutableSet.of(
+                                        new UnwrapSingleColumnRowInApply(typeAnalyzer),
                                         new MergeFilters(metadata),
                                         new InlineProjections(),
                                         new RemoveRedundantIdentityProjections(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapSingleColumnRowInApply.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/UnwrapSingleColumnRowInApply.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.TypeAnalyzer;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.ApplyNode;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.Assignments.Assignment;
+import io.trino.sql.planner.plan.ProjectNode;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.InPredicate;
+import io.trino.sql.tree.LongLiteral;
+import io.trino.sql.tree.QuantifiedComparisonExpression;
+import io.trino.sql.tree.SubscriptExpression;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import static io.trino.sql.planner.plan.Patterns.applyNode;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Given x::row(t) and y::row(t), converts assignments of the form
+ *
+ * <p><code>x IN (y...)</code> => <code>x[1] IN (y[1]...)</code>
+ *
+ * <p>and</p>
+ *
+ * <p> <code>x &lt;comparison&gt; &lt;quantifier&gt; (y...)</code></p> => <code>x[1] &lt;comparison&gt; &lt;quantifier&gt; (y[1]...)</code></p>
+ *
+ * <p>In particular, it transforms a plan with the following shape:</p>
+ *
+ * <pre>
+ * - Apply x IN y
+ *   - S [x :: row(T)]
+ *   - Q [y :: row(T)]
+ * </pre>
+ * <p>
+ * into
+ *
+ * <pre>
+ * - Project (to preserve the outputs of Apply)
+ *   - Apply x' IN y'
+ *     - Project [x' :: T]
+ *         x' = x[1]
+ *       - S [x :: row(T)]
+ *     - Project [y' :: T]
+ *         y' = y[1]
+ *       - Q [y :: row(T)]
+ * </pre>
+ */
+public class UnwrapSingleColumnRowInApply
+        implements Rule<ApplyNode>
+{
+    private static final Pattern<ApplyNode> PATTERN = applyNode();
+
+    private final TypeAnalyzer typeAnalyzer;
+
+    public UnwrapSingleColumnRowInApply(TypeAnalyzer typeAnalyzer)
+    {
+        this.typeAnalyzer = requireNonNull(typeAnalyzer, "typeAnalyzer is null");
+    }
+
+    @Override
+    public Pattern<ApplyNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(ApplyNode node, Captures captures, Context context)
+    {
+        Assignments.Builder inputAssignments = Assignments.builder()
+                .putIdentities(node.getInput().getOutputSymbols());
+
+        Assignments.Builder nestedPlanAssignments = Assignments.builder()
+                .putIdentities(node.getSubquery().getOutputSymbols());
+
+        boolean applied = false;
+        Assignments.Builder applyAssignments = Assignments.builder();
+        for (Map.Entry<Symbol, Expression> assignment : node.getSubqueryAssignments().entrySet()) {
+            Symbol output = assignment.getKey();
+            Expression expression = assignment.getValue();
+
+            Optional<Unwrapping> unwrapped = Optional.empty();
+            if (expression instanceof InPredicate) {
+                InPredicate predicate = (InPredicate) expression;
+
+                unwrapped = unwrapSingleColumnRow(
+                        context,
+                        predicate.getValue(),
+                        predicate.getValueList(),
+                        (value, list) -> new InPredicate(value.toSymbolReference(), list.toSymbolReference()));
+            }
+            else if (expression instanceof QuantifiedComparisonExpression) {
+                QuantifiedComparisonExpression comparison = (QuantifiedComparisonExpression) expression;
+
+                unwrapped = unwrapSingleColumnRow(
+                        context,
+                        comparison.getValue(),
+                        comparison.getSubquery(),
+                        (value, list) -> new QuantifiedComparisonExpression(comparison.getOperator(), comparison.getQuantifier(), value.toSymbolReference(), list.toSymbolReference()));
+            }
+
+            if (unwrapped.isPresent()) {
+                applied = true;
+
+                Unwrapping unwrapping = unwrapped.get();
+                inputAssignments.add(unwrapping.getInputAssignment());
+                nestedPlanAssignments.add(unwrapping.getNestedPlanAssignment());
+                applyAssignments.put(output, unwrapping.getExpression());
+            }
+            else {
+                applyAssignments.put(assignment);
+            }
+        }
+
+        if (!applied) {
+            return Result.empty();
+        }
+
+        return Result.ofPlanNode(
+                new ProjectNode(
+                        context.getIdAllocator().getNextId(),
+                        new ApplyNode(
+                                node.getId(),
+                                new ProjectNode(context.getIdAllocator().getNextId(), node.getInput(), inputAssignments.build()),
+                                new ProjectNode(context.getIdAllocator().getNextId(), node.getSubquery(), nestedPlanAssignments.build()),
+                                applyAssignments.build(),
+                                node.getCorrelation(),
+                                node.getOriginSubquery()),
+                        Assignments.identity(node.getOutputSymbols())));
+    }
+
+    private Optional<Unwrapping> unwrapSingleColumnRow(Context context, Expression value, Expression list, BiFunction<Symbol, Symbol, Expression> function)
+    {
+        Type type = typeAnalyzer.getType(context.getSession(), context.getSymbolAllocator().getTypes(), value);
+        if (type instanceof RowType) {
+            RowType rowType = (RowType) type;
+            if (rowType.getFields().size() == 1) {
+                Type elementType = rowType.getTypeParameters().get(0);
+
+                Symbol valueSymbol = context.getSymbolAllocator().newSymbol("input", elementType);
+                Symbol listSymbol = context.getSymbolAllocator().newSymbol("subquery", elementType);
+
+                Assignment inputAssignment = new Assignment(valueSymbol, new SubscriptExpression(value, new LongLiteral("1")));
+                Assignment nestedPlanAssignment = new Assignment(listSymbol, new SubscriptExpression(list, new LongLiteral("1")));
+                Expression comparison = function.apply(valueSymbol, listSymbol);
+
+                return Optional.of(new Unwrapping(comparison, inputAssignment, nestedPlanAssignment));
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static class Unwrapping
+    {
+        private final Expression expression;
+        private final Assignment inputAssignment;
+        private final Assignment nestedPlanAssignment;
+
+        public Unwrapping(Expression expression, Assignment inputAssignment, Assignment nestedPlanAssignment)
+        {
+            this.expression = requireNonNull(expression, "expression is null");
+            this.inputAssignment = requireNonNull(inputAssignment, "inputAssignment is null");
+            this.nestedPlanAssignment = requireNonNull(nestedPlanAssignment, "nestedPlanAssignment is null");
+        }
+
+        public Expression getExpression()
+        {
+            return expression;
+        }
+
+        public Assignment getInputAssignment()
+        {
+            return inputAssignment;
+        }
+
+        public Assignment getNestedPlanAssignment()
+        {
+            return nestedPlanAssignment;
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/Assignments.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/Assignments.java
@@ -224,6 +224,28 @@ public class Assignments
         return assignments.hashCode();
     }
 
+    public static class Assignment
+    {
+        private final Symbol output;
+        private final Expression expression;
+
+        public Assignment(Symbol output, Expression expression)
+        {
+            this.output = requireNonNull(output, "output is null");
+            this.expression = requireNonNull(expression, "expression is null");
+        }
+
+        public Symbol getOutput()
+        {
+            return output;
+        }
+
+        public Expression getExpression()
+        {
+            return expression;
+        }
+    }
+
     public static class Builder
     {
         private final Map<Symbol, Expression> assignments = new LinkedHashMap<>();
@@ -279,6 +301,12 @@ public class Assignments
         public Assignments build()
         {
             return new Assignments(assignments);
+        }
+
+        public Builder add(Assignment assignment)
+        {
+            put(assignment.getOutput(), assignment.getExpression());
+            return this;
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionVerifier.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionVerifier.java
@@ -39,6 +39,7 @@ import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullLiteral;
+import io.trino.sql.tree.QuantifiedComparisonExpression;
 import io.trino.sql.tree.Row;
 import io.trino.sql.tree.SearchedCaseExpression;
 import io.trino.sql.tree.SimpleCaseExpression;
@@ -286,6 +287,21 @@ public final class ExpressionVerifier
         IsNotNullPredicate expected = (IsNotNullPredicate) expectedExpression;
 
         return process(actual.getValue(), expected.getValue());
+    }
+
+    @Override
+    protected Boolean visitQuantifiedComparisonExpression(QuantifiedComparisonExpression actual, Node expectedExpression)
+    {
+        if (!(expectedExpression instanceof QuantifiedComparisonExpression)) {
+            return false;
+        }
+
+        QuantifiedComparisonExpression expected = (QuantifiedComparisonExpression) expectedExpression;
+
+        return actual.getQuantifier() == expected.getQuantifier() &&
+                actual.getOperator() == expected.getOperator() &&
+                process(actual.getValue(), expected.getValue()) &&
+                process(actual.getSubquery(), expected.getSubquery());
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUnwrapSingleColumnRowInApply.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestUnwrapSingleColumnRowInApply.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.type.RowType;
+import io.trino.sql.parser.SqlParser;
+import io.trino.sql.planner.TypeAnalyzer;
+import io.trino.sql.planner.assertions.ExpressionMatcher;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.tree.InPredicate;
+import io.trino.sql.tree.QuantifiedComparisonExpression;
+import io.trino.sql.tree.SymbolReference;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.IntegerType.INTEGER;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.apply;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.tree.ComparisonExpression.Operator.EQUAL;
+import static io.trino.sql.tree.QuantifiedComparisonExpression.Quantifier.ALL;
+import static java.util.Collections.emptyList;
+
+public class TestUnwrapSingleColumnRowInApply
+        extends BaseRuleTest
+{
+    @Test
+    public void testDoesNotFireOnNoSingleColumnRow()
+    {
+        tester().assertThat(new UnwrapSingleColumnRowInApply(new TypeAnalyzer(new SqlParser(), tester().getMetadata())))
+                .on(p -> p.apply(
+                        Assignments.builder()
+                                .put(p.symbol("output1", BOOLEAN), new InPredicate(new SymbolReference("value"), new SymbolReference("element")))
+                                .put(p.symbol("output2", BOOLEAN), new QuantifiedComparisonExpression(EQUAL, ALL, new SymbolReference("value"), new SymbolReference("element")))
+                                .build(),
+                        emptyList(),
+                        p.values(p.symbol("value", INTEGER)),
+                        p.values(p.symbol("element", INTEGER))))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testUnwrapInPredicate()
+    {
+        tester().assertThat(new UnwrapSingleColumnRowInApply(new TypeAnalyzer(new SqlParser(), tester().getMetadata())))
+                .on(p -> p.apply(
+                        Assignments.builder()
+                                .put(p.symbol("unwrapped", BOOLEAN), new InPredicate(new SymbolReference("rowValue"), new SymbolReference("rowElement")))
+                                .put(p.symbol("notUnwrapped", BOOLEAN), new InPredicate(new SymbolReference("nonRowValue"), new SymbolReference("nonRowElement")))
+                                .build(),
+                        emptyList(),
+                        p.values(
+                                p.symbol("rowValue", RowType.anonymousRow(INTEGER)),
+                                p.symbol("nonRowValue", INTEGER)),
+                        p.values(
+                                p.symbol("rowElement", RowType.anonymousRow(INTEGER)),
+                                p.symbol("nonRowElement", INTEGER))))
+                .matches(
+                        project(
+                                apply(
+                                        List.of(),
+                                        ImmutableMap.<String, ExpressionMatcher>builder()
+                                                .put("unwrapped", expression("unwrappedValue IN (unwrappedElement)"))
+                                                .put("notUnwrapped", expression("nonRowValue IN (nonRowElement)"))
+                                                .build(),
+                                        project(
+                                                ImmutableMap.<String, ExpressionMatcher>builder()
+                                                        .put("unwrappedValue", expression("rowValue[1]"))
+                                                        .put("nonRowValue", expression("nonRowValue"))
+                                                        .build(),
+                                                values("rowValue", "nonRowValue")),
+                                        project(
+                                                ImmutableMap.<String, ExpressionMatcher>builder()
+                                                        .put("unwrappedElement", expression("rowElement[1]"))
+                                                        .put("nonRowElement", expression("nonRowElement"))
+                                                        .build(),
+                                                values("rowElement", "nonRowElement")))));
+    }
+
+    @Test
+    public void testUnwrapQuantifiedComparison()
+    {
+        tester().assertThat(new UnwrapSingleColumnRowInApply(new TypeAnalyzer(new SqlParser(), tester().getMetadata())))
+                .on(p -> p.apply(
+                        Assignments.builder()
+                                .put(p.symbol("unwrapped", BOOLEAN), new QuantifiedComparisonExpression(EQUAL, ALL, new SymbolReference("rowValue"), new SymbolReference("rowElement")))
+                                .put(p.symbol("notUnwrapped", BOOLEAN), new QuantifiedComparisonExpression(EQUAL, ALL, new SymbolReference("nonRowValue"), new SymbolReference("nonRowElement")))
+                                .build(),
+                        emptyList(),
+                        p.values(
+                                p.symbol("rowValue", RowType.anonymousRow(INTEGER)),
+                                p.symbol("nonRowValue", INTEGER)),
+                        p.values(
+                                p.symbol("rowElement", RowType.anonymousRow(INTEGER)),
+                                p.symbol("nonRowElement", INTEGER))))
+                .matches(
+                        project(
+                                apply(
+                                        List.of(),
+                                        ImmutableMap.<String, ExpressionMatcher>builder()
+                                                .put("unwrapped", expression(new QuantifiedComparisonExpression(EQUAL, ALL, new SymbolReference("unwrappedValue"), new SymbolReference("unwrappedElement"))))
+                                                .put("notUnwrapped", expression(new QuantifiedComparisonExpression(EQUAL, ALL, new SymbolReference("nonRowValue"), new SymbolReference("nonRowElement"))))
+                                                .build(),
+                                        project(
+                                                ImmutableMap.<String, ExpressionMatcher>builder()
+                                                        .put("unwrappedValue", expression("rowValue[1]"))
+                                                        .put("nonRowValue", expression("nonRowValue"))
+                                                        .build(),
+                                                values("rowValue", "nonRowValue")),
+                                        project(
+                                                ImmutableMap.<String, ExpressionMatcher>builder()
+                                                        .put("unwrappedElement", expression("rowElement[1]"))
+                                                        .put("nonRowElement", expression("nonRowElement"))
+                                                        .build(),
+                                                values("rowElement", "nonRowElement")))));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSubqueries.java
@@ -1330,6 +1330,46 @@ public class TestSubqueries
         assertThat(assertions.query(
                 "SELECT (SELECT 2) > ALL (SELECT 1)"))
                 .matches("VALUES true");
+
+        assertThat(assertions.query(
+                "SELECT ROW(2) > ALL (VALUES ROW(ROW(0)), ROW(ROW(1)))"))
+                .describedAs("Single-element row type, non-null and non-indeterminate values")
+                .matches("VALUES true");
+
+        assertThat(assertions.query(
+                "SELECT ROW(2) > ALL (VALUES ROW(ROW(0)), ROW(ROW(1)), ROW(ROW(NULL)))"))
+                .describedAs("Single-element row type, indeterminate value")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT ROW(2) > ALL (VALUES ROW(ROW(0)), ROW(ROW(1)), NULL)"))
+                .describedAs("Single-element row type, null value")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT ROW(2) > ALL (SELECT ROW(0) WHERE false)"))
+                .describedAs("Single-element row type, with empty set")
+                .matches("VALUES true");
+
+        assertThat(assertions.query(
+                "SELECT NULL > ALL (VALUES ROW(ROW(0)), ROW(ROW(1)))"))
+                .describedAs("Single-element row type, null value, non-null and non-indeterminate elements")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT NULL > ALL (VALUES ROW(ROW(0)), ROW(ROW(NULL)))"))
+                .describedAs("Single-element row type, null value, indeterminate element")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT NULL > ALL (VALUES ROW(ROW(0)), NULL)"))
+                .describedAs("Single-element row type, null value, null element")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT NULL > ALL (SELECT ROW(ROW(0)) WHERE false)"))
+                .describedAs("Single-element row type, null value, empty set")
+                .matches("VALUES true");
     }
 
     @Test
@@ -1341,6 +1381,61 @@ public class TestSubqueries
 
         assertThat(assertions.query(
                 "SELECT (SELECT 2) IN (SELECT 1)"))
+                .matches("VALUES false");
+
+        assertThat(assertions.query(
+                "SELECT ROW(0) IN (VALUES ROW(ROW(0)), ROW(ROW(1)))"))
+                .describedAs("Single-element row type, non-null and non-indeterminate values, present")
+                .matches("VALUES true");
+
+        assertThat(assertions.query(
+                "SELECT ROW(0) IN (VALUES ROW(ROW(1)), ROW(ROW(2)))"))
+                .describedAs("Single-element row type, non-null and non-indeterminate values, not present")
+                .matches("VALUES false");
+
+        assertThat(assertions.query(
+                "SELECT ROW(0) IN (VALUES ROW(ROW(0)), ROW(ROW(NULL)))"))
+                .describedAs("Single-element row type, indeterminate element, present")
+                .matches("VALUES true");
+
+        assertThat(assertions.query(
+                "SELECT ROW(0) IN (VALUES ROW(ROW(1)), ROW(ROW(NULL)))"))
+                .describedAs("Single-element row type, indeterminate element, not present")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT ROW(0) IN (VALUES ROW(ROW(0)), NULL)"))
+                .describedAs("Single-element row type, null element, present")
+                .matches("VALUES true");
+
+        assertThat(assertions.query(
+                "SELECT ROW(0) IN (VALUES ROW(ROW(1)), NULL)"))
+                .describedAs("Single-element row type, null element, not present")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT ROW(0) IN (SELECT ROW(0) WHERE false)"))
+                .describedAs("Single-element row type, with empty set")
+                .matches("VALUES false");
+
+        assertThat(assertions.query(
+                "SELECT NULL IN (VALUES ROW(ROW(0)))"))
+                .describedAs("Single-element row type, null value, non-null and non-indeterminate elements")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT NULL IN (VALUES ROW(ROW(0)), ROW(ROW(NULL)))"))
+                .describedAs("Single-element row type, null value, indeterminate element")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT NULL IN (VALUES ROW(ROW(0)), NULL)"))
+                .describedAs("Single-element row type, null value, null element")
+                .matches("VALUES CAST(NULL AS boolean)");
+
+        assertThat(assertions.query(
+                "SELECT NULL IN (SELECT ROW(ROW(0)) WHERE false)"))
+                .describedAs("Single-element row type, null value, empty set")
                 .matches("VALUES false");
     }
 


### PR DESCRIPTION
Convert IN and quantified comparisons over single-column row values
to operate on the unwrapped field of the rows. This can improve
performance for queries involving such types.