### PR TITLE
Make PlanOptimizers stateless

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -81,10 +81,10 @@ import io.trino.server.ui.WorkerResource;
 import io.trino.spi.memory.ClusterMemoryPoolManager;
 import io.trino.spi.security.SelectedRole;
 import io.trino.sql.analyzer.QueryExplainer;
+import io.trino.sql.planner.OptimizerStatsMBeanExporter;
 import io.trino.sql.planner.PlanFragmenter;
 import io.trino.sql.planner.PlanOptimizers;
 import io.trino.sql.planner.PlanOptimizersFactory;
-import io.trino.sql.planner.RuleStatsRecorder;
 import io.trino.transaction.ForTransactionManager;
 import io.trino.transaction.InMemoryTransactionManager;
 import io.trino.transaction.TransactionManager;
@@ -216,8 +216,8 @@ public class CoordinatorModule
         newOptionalBinder(binder, PlanOptimizersFactory.class)
                 .setDefault().to(PlanOptimizers.class).in(Scopes.SINGLETON);
 
-        // Rule Stats Recorder
-        binder.bind(RuleStatsRecorder.class).in(Scopes.SINGLETON);
+        // Optimizer/Rule Stats exporter
+        binder.bind(OptimizerStatsMBeanExporter.class).in(Scopes.SINGLETON);
 
         // query explainer
         binder.bind(QueryExplainer.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerStatsMBeanExporter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerStatsMBeanExporter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.planner.iterative.IterativeOptimizer;
+import io.trino.sql.planner.iterative.RuleStats;
+import io.trino.sql.planner.optimizations.OptimizerStats;
+import io.trino.sql.planner.optimizations.PlanOptimizer;
+import org.weakref.jmx.MBeanExport;
+import org.weakref.jmx.MBeanExporter;
+import org.weakref.jmx.ObjectNames;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.annotation.concurrent.GuardedBy;
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class OptimizerStatsMBeanExporter
+{
+    @GuardedBy("this")
+    private final List<MBeanExport> mbeanExports = new ArrayList<>();
+
+    private final MBeanExporter exporter;
+    private final Map<Class<?>, OptimizerStats> optimizerStats;
+    private final Map<Class<?>, RuleStats> ruleStats;
+
+    @Inject
+    public OptimizerStatsMBeanExporter(MBeanExporter exporter, PlanOptimizersFactory optimizers)
+    {
+        requireNonNull(optimizers, "optimizers is null");
+        optimizerStats = optimizers.getOptimizerStats();
+        ruleStats = optimizers.getRuleStats();
+
+        this.exporter = requireNonNull(exporter, "exporter is null");
+    }
+
+    @PostConstruct
+    public synchronized void export()
+    {
+        checkState(mbeanExports.isEmpty(), "MBeans already exported");
+
+        for (Map.Entry<Class<?>, OptimizerStats> entry : optimizerStats.entrySet()) {
+            verify(!entry.getKey().getSimpleName().isEmpty());
+            try {
+                mbeanExports.add(exporter.exportWithGeneratedName(entry.getValue(), PlanOptimizer.class, ImmutableMap.<String, String>builder()
+                        .put("name", PlanOptimizer.class.getSimpleName())
+                        .put("optimizer", entry.getKey().getSimpleName())
+                        .build()));
+            }
+            catch (RuntimeException e) {
+                throw new RuntimeException(format("Failed to export MBean with name '%s'", getName(entry.getKey())), e);
+            }
+        }
+
+        for (Map.Entry<Class<?>, RuleStats> entry : ruleStats.entrySet()) {
+            verify(!entry.getKey().getSimpleName().isEmpty());
+            try {
+                mbeanExports.add(exporter.exportWithGeneratedName(entry.getValue(), IterativeOptimizer.class, ImmutableMap.<String, String>builder()
+                        .put("name", IterativeOptimizer.class.getSimpleName())
+                        .put("rule", entry.getKey().getSimpleName())
+                        .build()));
+            }
+            catch (RuntimeException e) {
+                throw new RuntimeException(format("Failed to export MBean with for rule '%s'", entry.getKey().getSimpleName()), e);
+            }
+        }
+    }
+
+    @PreDestroy
+    public synchronized void unexport()
+    {
+        for (MBeanExport mbeanExport : mbeanExports) {
+            mbeanExport.unexport();
+        }
+        mbeanExports.clear();
+    }
+
+    private String getName(Class<?> key)
+    {
+        return ObjectNames.builder(PlanOptimizer.class)
+                .withProperty("optimizer", key.getSimpleName())
+                .build();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerStatsRecorder.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/OptimizerStatsRecorder.java
@@ -13,38 +13,30 @@
  */
 package io.trino.sql.planner;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.optimizations.OptimizerStats;
 import io.trino.sql.planner.optimizations.PlanOptimizer;
-import org.weakref.jmx.MBeanExport;
-import org.weakref.jmx.MBeanExporter;
-import org.weakref.jmx.ObjectNames;
 
-import javax.annotation.concurrent.GuardedBy;
-
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Verify.verify;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class OptimizerStatsRecorder
 {
     private final Map<Class<?>, OptimizerStats> stats = new HashMap<>();
 
-    @GuardedBy("this")
-    private final List<MBeanExport> mbeanExports = new ArrayList<>();
-
     public void register(PlanOptimizer optimizer)
     {
         requireNonNull(optimizer, "optimizer is null");
         checkArgument(!optimizer.getClass().isAnonymousClass());
         stats.put(optimizer.getClass(), new OptimizerStats());
+    }
+
+    public Map<Class<?>, OptimizerStats> getStats()
+    {
+        return Collections.unmodifiableMap(stats);
     }
 
     public void record(PlanOptimizer optimizer, long nanos)
@@ -59,37 +51,5 @@ public class OptimizerStatsRecorder
         requireNonNull(optimizer, "optimizer is null");
         OptimizerStats optimizerStats = requireNonNull(stats.get(optimizer.getClass()), "optimizer is not registered");
         optimizerStats.recordFailure();
-    }
-
-    public synchronized void export(MBeanExporter exporter)
-    {
-        checkState(mbeanExports.isEmpty(), "MBeans already exported");
-        for (Map.Entry<Class<?>, OptimizerStats> entry : stats.entrySet()) {
-            verify(!entry.getKey().getSimpleName().isEmpty());
-            try {
-                mbeanExports.add(exporter.exportWithGeneratedName(entry.getValue(), PlanOptimizer.class, ImmutableMap.<String, String>builder()
-                        .put("name", PlanOptimizer.class.getSimpleName())
-                        .put("optimizer", entry.getKey().getSimpleName())
-                        .build()));
-            }
-            catch (RuntimeException e) {
-                throw new RuntimeException(format("Failed to export MBean with name '%s'", getName(entry.getKey())), e);
-            }
-        }
-    }
-
-    public synchronized void unexport(MBeanExporter exporter)
-    {
-        for (MBeanExport mbeanExport : mbeanExports) {
-            mbeanExport.unexport();
-        }
-        mbeanExports.clear();
-    }
-
-    private String getName(Class<?> key)
-    {
-        return ObjectNames.builder(PlanOptimizer.class)
-                .withProperty("optimizer", key.getSimpleName())
-                .build();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizersFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizersFactory.java
@@ -13,11 +13,18 @@
  */
 package io.trino.sql.planner;
 
+import io.trino.sql.planner.iterative.RuleStats;
+import io.trino.sql.planner.optimizations.OptimizerStats;
 import io.trino.sql.planner.optimizations.PlanOptimizer;
 
 import java.util.List;
+import java.util.Map;
 
 public interface PlanOptimizersFactory
 {
     List<PlanOptimizer> get();
+
+    Map<Class<?>, OptimizerStats> getOptimizerStats();
+
+    Map<Class<?>, RuleStats> getRuleStats();
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RuleStatsRecorder.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RuleStatsRecorder.java
@@ -14,31 +14,18 @@
 package io.trino.sql.planner;
 
 import com.google.common.collect.ImmutableMap;
-import io.trino.sql.planner.iterative.IterativeOptimizer;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.iterative.RuleStats;
-import org.weakref.jmx.MBeanExport;
-import org.weakref.jmx.MBeanExporter;
 
-import javax.annotation.concurrent.GuardedBy;
-
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Verify.verify;
-import static java.lang.String.format;
 
 public class RuleStatsRecorder
 {
     private final Map<Class<?>, RuleStats> stats = new HashMap<>();
-
-    @GuardedBy("this")
-    private final List<MBeanExport> mbeanExports = new ArrayList<>();
 
     public void registerAll(Collection<Rule<?>> rules)
     {
@@ -56,31 +43,6 @@ public class RuleStatsRecorder
     public void recordFailure(Rule<?> rule)
     {
         stats.get(rule.getClass()).recordFailure();
-    }
-
-    public synchronized void export(MBeanExporter exporter)
-    {
-        checkState(mbeanExports.isEmpty(), "MBeans already exported");
-        for (Map.Entry<Class<?>, RuleStats> entry : stats.entrySet()) {
-            verify(!entry.getKey().getSimpleName().isEmpty());
-            try {
-                mbeanExports.add(exporter.exportWithGeneratedName(entry.getValue(), IterativeOptimizer.class, ImmutableMap.<String, String>builder()
-                        .put("name", IterativeOptimizer.class.getSimpleName())
-                        .put("rule", entry.getKey().getSimpleName())
-                        .build()));
-            }
-            catch (RuntimeException e) {
-                throw new RuntimeException(format("Failed to export MBean with for rule '%s'", entry.getKey().getSimpleName()), e);
-            }
-        }
-    }
-
-    public synchronized void unexport(MBeanExporter exporter)
-    {
-        for (MBeanExport mbeanExport : mbeanExports) {
-            mbeanExport.unexport();
-        }
-        mbeanExports.clear();
     }
 
     public Map<Class<?>, RuleStats> getStats()

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -147,7 +147,6 @@ import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.PlanFragmenter;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.PlanOptimizers;
-import io.trino.sql.planner.RuleStatsRecorder;
 import io.trino.sql.planner.SubPlan;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.optimizations.PlanOptimizer;
@@ -874,7 +873,6 @@ public class LocalQueryRunner
                 estimatedExchangesCostCalculator,
                 new CostComparator(featuresConfig),
                 taskCountEstimator,
-                new RuleStatsRecorder(),
                 nodePartitioningManager).get();
     }
 

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -39,7 +39,6 @@ import io.trino.sql.parser.SqlParser;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.PlanFragmenter;
 import io.trino.sql.planner.PlanOptimizers;
-import io.trino.sql.planner.RuleStatsRecorder;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.optimizations.PlanNodeSearcher;
 import io.trino.sql.planner.optimizations.PlanOptimizer;
@@ -434,7 +433,6 @@ public abstract class AbstractTestQueryFramework
                 new CostCalculatorWithEstimatedExchanges(costCalculator, taskCountEstimator),
                 new CostComparator(featuresConfig),
                 taskCountEstimator,
-                new RuleStatsRecorder(),
                 queryRunner.getNodePartitioningManager()).get();
         return new QueryExplainer(
                 optimizers,


### PR DESCRIPTION
The change in f3dda9c96289c38ac99024ac64393debdf2dab9d caused mbeans
to be exported unconditionally the first time PlanOptimizers.get() is
called. LocalQueryRunner.getPlanOptimizers creates a new instance
every time, so this causes the mbeans to be exported on every
invocation and results in tests spending the majority of their time
in mbean export.

This change moves the responsibility of exporting/unexporting the
optimizer mbeans to a separate class.

Fixes https://github.com/trinodb/trino/issues/7805