### PR TITLE
Add examples for bitwise right shift functions

### DIFF
--- a/docs/src/main/sphinx/functions/bitwise.rst
+++ b/docs/src/main/sphinx/functions/bitwise.rst
@@ -42,20 +42,50 @@ Bitwise functions
 
     Shifting a ``value`` by ``0`` always results in the original ``value``::
 
-      SELECT bitwise_left_shift(20 , 0); -- 20
-      SELECT bitwise_left_shift(42 , 0); -- 42
+      SELECT bitwise_left_shift(20, 0); -- 20
+      SELECT bitwise_left_shift(42, 0); -- 42
 
-    Shifting ``0`` by a ``value`` always results in ``0``::
+    Shifting ``0`` by a ``shift`` always results in ``0``::
 
       SELECT bitwise_left_shift(0, 1); -- 0
       SELECT bitwise_left_shift(0, 2); -- 0
 
-.. function:: bitwise_right_shift(value, shift, digits) -> [same as value]
+.. function:: bitwise_right_shift(value, shift) -> [same as value]
 
     Returns the logical right shifted value of ``value``.
+
+    Shifting ``8`` (binary: ``1000``) by three bits results in ``1`` (binary: ``001``)::
+
+      SELECT bitwise_right_shift(8, 3); -- 1
+
+    Shifting ``9`` (binary: ``1001``) by one bit results in ``4`` (binary: ``100``)::
+
+      SELECT bitwise_right_shift(9, 1); -- 4
+
+    Shifting a ``value`` by ``0`` always results in the original ``value``::
+
+      SELECT bitwise_right_shift(20, 0); -- 20
+      SELECT bitwise_right_shift(42, 0); -- 42
+
+    Shifting a ``value`` by ``64`` or more bits results in ``0``::
+
+      SELECT bitwise_right_shift( 12, 64); -- 0
+      SELECT bitwise_right_shift(-45, 64); -- 0
+
+    Shifting ``0`` by a ``shift`` always results in ``0``::
+
+      SELECT bitwise_right_shift(0, 1); -- 0
+      SELECT bitwise_right_shift(0, 2); -- 0
 
 .. function:: bitwise_right_shift_arithmetic(value, shift) -> [same as value]
 
     Returns the arithmetic right shifted value of ``value``.
+
+    Returns the same values as :func:`bitwise_right_shift` when shifting by less than
+    ``64`` bits. Shifting by ``64`` or more bits results in ``0`` for a positive and
+    ``-1`` for a negative ``value``::
+
+      SELECT bitwise_right_shift_arithmetic( 12, 64); --  0
+      SELECT bitwise_right_shift_arithmetic(-45, 64); -- -1
 
 See also :func:`bitwise_and_agg` and :func:`bitwise_or_agg`.


### PR DESCRIPTION
- Add examples for `bitwise_right_shift`
- Fix incorrect arguments for `bitwise_right_shift`
- Add examples for `bitwise_right_shift_arithmetic`
- Remove some whitespaces
- Correct `value` to `shift` for some examples in the description