### PR TITLE
Cancel query when JDBC connection or statement is closed

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoPreparedStatement.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoPreparedStatement.java
@@ -56,6 +56,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -109,10 +110,10 @@ public class TrinoPreparedStatement
     private final String originalSql;
     private boolean isBatch;
 
-    TrinoPreparedStatement(TrinoConnection connection, String statementName, String sql)
+    TrinoPreparedStatement(TrinoConnection connection, Consumer<TrinoStatement> onClose, String statementName, String sql)
             throws SQLException
     {
-        super(connection);
+        super(connection, onClose);
         this.statementName = requireNonNull(statementName, "statementName is null");
         this.originalSql = requireNonNull(sql, "sql is null");
         super.execute(format("PREPARE %s FROM %s", statementName, sql));

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoStatement.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoStatement.java
@@ -83,7 +83,10 @@ public class TrinoStatement
     public void close()
             throws SQLException
     {
-        connection.set(null);
+        TrinoConnection connection = this.connection.getAndSet(null);
+        if (connection == null) {
+            return;
+        }
         closeResultSet();
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoStatement.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoStatement.java
@@ -46,6 +46,7 @@ public class TrinoStatement
     private final AtomicBoolean escapeProcessing = new AtomicBoolean(true);
     private final AtomicBoolean closeOnCompletion = new AtomicBoolean();
     private final AtomicReference<TrinoConnection> connection;
+    private final Consumer<TrinoStatement> onClose;
     private final AtomicReference<StatementClient> executingClient = new AtomicReference<>();
     private final AtomicReference<TrinoResultSet> currentResult = new AtomicReference<>();
     private final AtomicReference<Optional<WarningsManager>> currentWarningsManager = new AtomicReference<>(Optional.empty());
@@ -54,9 +55,10 @@ public class TrinoStatement
     private final AtomicReference<Optional<Consumer<QueryStats>>> progressCallback = new AtomicReference<>(Optional.empty());
     private final Consumer<QueryStats> progressConsumer = value -> progressCallback.get().ifPresent(callback -> callback.accept(value));
 
-    TrinoStatement(TrinoConnection connection)
+    TrinoStatement(TrinoConnection connection, Consumer<TrinoStatement> onClose)
     {
         this.connection = new AtomicReference<>(requireNonNull(connection, "connection is null"));
+        this.onClose = requireNonNull(onClose, "onClose is null");
     }
 
     public void setProgressMonitor(Consumer<QueryStats> progressMonitor)
@@ -87,6 +89,14 @@ public class TrinoStatement
         if (connection == null) {
             return;
         }
+
+        onClose.accept(this);
+
+        StatementClient client = executingClient.get();
+        if (client != null) {
+            client.close();
+        }
+
         closeResultSet();
     }
 

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
@@ -21,6 +21,7 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.airlift.log.Logging;
 import io.trino.client.ClientSelectedRole;
+import io.trino.plugin.blackhole.BlackHolePlugin;
 import io.trino.plugin.hive.HiveHadoop2Plugin;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.connector.ConnectorSession;
@@ -31,6 +32,7 @@ import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.testing.DataProviders;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -41,15 +43,26 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static io.airlift.concurrent.Threads.daemonThreadsNamed;
+import static io.airlift.testing.Closeables.closeAll;
 import static io.trino.metadata.MetadataUtil.TableMetadataBuilder.tableMetadataBuilder;
 import static io.trino.spi.connector.SystemTable.Distribution.ALL_NODES;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static io.trino.testing.assertions.Assert.assertEventually;
 import static java.lang.String.format;
+import static java.sql.Types.VARCHAR;
+import static java.util.UUID.randomUUID;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -59,6 +72,8 @@ import static org.testng.Assert.fail;
 
 public class TestJdbcConnection
 {
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getName()));
+
     private TestingTrinoServer server;
 
     @BeforeClass
@@ -77,20 +92,30 @@ public class TestJdbcConnection
                 .put("hive.metastore.catalog.dir", server.getBaseDataDir().resolve("hive").toAbsolutePath().toString())
                 .put("hive.security", "sql-standard")
                 .build());
+        server.installPlugin(new BlackHolePlugin());
+        server.createCatalog("blackhole", "blackhole", ImmutableMap.of());
 
         try (Connection connection = createConnection();
                 Statement statement = connection.createStatement()) {
             statement.execute("SET ROLE admin");
             statement.execute("CREATE SCHEMA default");
             statement.execute("CREATE SCHEMA fruit");
+            statement.execute(
+                    "CREATE TABLE blackhole.default.devzero(dummy bigint) " +
+                            "WITH (split_count = 100000, pages_per_split = 100000, rows_per_page = 10000)");
+            statement.execute(
+                    "CREATE TABLE blackhole.default.delay(dummy bigint) " +
+                            "WITH (split_count = 1, pages_per_split = 1, rows_per_page = 1, page_processing_delay = '60s')");
         }
     }
 
     @AfterClass(alwaysRun = true)
-    public void tearDownServer()
+    public void tearDown()
             throws Exception
     {
-        server.close();
+        closeAll(
+                server,
+                executor::shutdownNow);
     }
 
     @Test
@@ -405,6 +430,100 @@ public class TestJdbcConnection
         }
     }
 
+    @Test(timeOut = 60_000)
+    public void testCancellationOnStatementClose()
+            throws Exception
+    {
+        String sql = "SELECT * FROM blackhole.default.devzero -- test cancellation " + randomUUID();
+        try (Connection connection = createConnection()) {
+            Statement statement = connection.createStatement();
+            statement.execute(sql);
+            ResultSet resultSet = statement.getResultSet();
+
+            // read some data
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.next()).isTrue();
+            assertThat(resultSet.next()).isTrue();
+
+            // Make sure that query is still running
+            assertThat(listQueryStatuses(sql))
+                    .containsExactly("RUNNING")
+                    .hasSize(1);
+
+            // Closing statement should cancel queries and invalidate the result set
+            statement.close();
+
+            // verify that the query was cancelled
+            assertThatThrownBy(resultSet::next)
+                    .isInstanceOf(SQLException.class)
+                    .hasMessage("ResultSet is closed");
+            assertThat(listQueryErrorCodes(sql))
+                    .containsExactly("USER_CANCELED")
+                    .hasSize(1);
+        }
+    }
+
+    @Test(timeOut = 60_000)
+    public void testConcurrentCancellationOnStatementClose()
+            throws Exception
+    {
+        String sql = "SELECT * FROM blackhole.default.delay -- test cancellation " + randomUUID();
+        Future<?> future;
+        try (Connection connection = createConnection()) {
+            Statement statement = connection.createStatement();
+            future = executor.submit(() -> statement.execute(sql));
+
+            // Wait for the queries to be started
+            assertEventually(() -> assertThat(listQueryStatuses(sql))
+                    .contains("RUNNING")
+                    .hasSize(1));
+
+            // Closing statement should cancel queries
+            statement.close();
+
+            // verify that the query was cancelled
+            assertThatThrownBy(future::get)
+                    .hasCauseInstanceOf(SQLException.class)
+                    .hasStackTraceContaining("Error executing query");
+            assertThat(listQueryErrorCodes(sql))
+                    .containsExactly("USER_CANCELED")
+                    .hasSize(1);
+        }
+    }
+
+    @Test(timeOut = 60000, dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testConcurrentCancellationOnConnectionClose(boolean autoCommit)
+            throws Exception
+    {
+        String sql = "SELECT * FROM blackhole.default.delay -- test cancellation " + randomUUID();
+        List<Future<?>> futures;
+        Connection connection = createConnection();
+        connection.setAutoCommit(autoCommit);
+        futures = range(0, 10)
+                .mapToObj(i -> executor.submit(() -> {
+                    try (Statement statement = connection.createStatement()) {
+                        statement.execute(sql);
+                    }
+                    return null;
+                }))
+                .collect(toImmutableList());
+
+        // Wait for the queries to be started
+        assertEventually(() -> assertThat(listQueryStatuses(sql))
+                .hasSize(futures.size()));
+
+        // Closing connection should cancel queries
+        connection.close();
+
+        // verify that all queries were cancelled
+        futures.forEach(future -> assertThatThrownBy(future::get)
+                .hasCauseInstanceOf(SQLException.class)
+                .hasStackTraceContaining("Error executing query"));
+        assertThat(listQueryErrorCodes(sql))
+                .hasSize(futures.size())
+                .containsOnly("USER_CANCELED");
+    }
+
     private Connection createConnection()
             throws SQLException
     {
@@ -471,6 +590,34 @@ public class TestJdbcConnection
             }
         }
         return builder.build();
+    }
+
+    private List<String> listQueryStatuses(String sql)
+    {
+        return listSingleStringColumn(format("SELECT state FROM system.runtime.queries WHERE query = '%s'", sql));
+    }
+
+    private List<String> listQueryErrorCodes(String sql)
+    {
+        return listSingleStringColumn(format("SELECT error_code FROM system.runtime.queries WHERE query = '%s'", sql));
+    }
+
+    private List<String> listSingleStringColumn(String sql)
+    {
+        ImmutableList.Builder<String> statuses = ImmutableList.builder();
+        try (Connection connection = createConnection();
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery(sql)) {
+            assertThat(resultSet.getMetaData().getColumnCount()).isOne();
+            assertThat(resultSet.getMetaData().getColumnType(1)).isEqualTo(VARCHAR);
+            while (resultSet.next()) {
+                statuses.add(resultSet.getString(1));
+            }
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return statuses.build();
     }
 
     private static void assertConnectionSource(Connection connection, String expectedSource)


### PR DESCRIPTION
Cancel query when JDBC connection or statement is closed

When Statement or Connection is abandoned there is no point
to continue query execution.

Also doing this is in line with JDBC specifications (4.1):

> 9.4.4.1 Connection.close
> An application calls the method Connection.close() to indicate that it
> has finished using a connection. All Statement objects created from a given
> Connection object will be closed when the close method for the
> Connection object is called.

They mention that it should close Statement which means:

> An application calls the method Statement.close to indicate that it has
> finished processing a statement. All Statement objects will be closed when the
> connection that created them is closed.
> [...]
> applications to. This allows any external resources that the statement
> is using to be released immediately.
