### PR TITLE
Disambiguate like titles for better search experience

### DIFF
--- a/docs/src/main/sphinx/develop/system-access-control.rst
+++ b/docs/src/main/sphinx/develop/system-access-control.rst
@@ -1,6 +1,6 @@
-=====================
-System access control
-=====================
+===========================================
+Custom system access control implementation
+===========================================
 
 Trino separates the concept of the principal who authenticates to the
 coordinator from the username that is responsible for running queries. When

--- a/docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -1,6 +1,6 @@
-=====================
-System access control
-=====================
+==============================
+Built-in system access control
+==============================
 
 A system access control enforces authorization at a global level,
 before any connector level authorization. You can use one of the built-in


### PR DESCRIPTION
When searching on "system access control" the most relevant files are not top results and have ambiguous titles: 

<img width="849" alt="Screen Shot 2021-05-03 at 1 24 30 PM" src="https://user-images.githubusercontent.com/1664457/116943950-66025e80-ac29-11eb-9401-94b965145768.png">

With this change, they appear higher and their context is more readily identifiable:

<img width="514" alt="Screen Shot 2021-05-03 at 4 07 00 PM" src="https://user-images.githubusercontent.com/1664457/116944210-e3c66a00-ac29-11eb-885a-7ab4b24731af.png">

