### PR TITLE
Add exit command to the help text

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/Help.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Help.java
@@ -22,6 +22,7 @@ public final class Help
         return "" +
                 "Supported commands:\n" +
                 "QUIT\n" +
+                "EXIT\n" +
                 "CLEAR\n" +
                 "EXPLAIN [ ( option [, ...] ) ] <query>\n" +
                 "    options: FORMAT { TEXT | GRAPHVIZ | JSON }\n" +


### PR DESCRIPTION
This is a follow up to the comment:

https://github.com/trinodb/trino/pull/7632#issuecomment-831582668


This is quite minor but it can help a newbie to know about the "exit" command in the CLI 
