### PR TITLE
Add type mapping configuration section

### DIFF
--- a/docs/src/main/sphinx/connector/jdbc-type-mapping.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-type-mapping.fragment
@@ -1,11 +1,11 @@
-JDBC type mapping and metadata cache
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+General configuration properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following properties can be used to configure how data types from the
 connected data source are mapped to Trino data types and how the metadata is
 cached in Trino.
 
-.. list-table:: Configuration properties that manage JDBC type mapping and metadata cache
+.. list-table::
   :widths: 30, 40, 30
   :header-rows: 1
 

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -58,6 +58,13 @@ Finally, you can access the ``clicks`` table in the ``web`` database::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``memsql`` in the above examples.
 
+.. _memsql-type-mapping:
+
+Type mapping
+------------
+
+.. include:: jdbc-type-mapping.fragment
+
 .. _memsql-pushdown:
 
 Pushdown

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -31,8 +31,13 @@ with a different name, making sure it ends in ``.properties``. For
 example, if you name the property file ``sales.properties``, Trino
 creates a catalog named ``sales`` using the configured connector.
 
+.. _mysql-type-mapping:
+
+Type mapping
+------------
+
 Decimal type handling
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 ``DECIMAL`` types with precision larger than 38 can be mapped to a Trino ``DECIMAL``
 by setting the ``decimal-mapping`` configuration property or the ``decimal_mapping`` session property to
@@ -44,6 +49,8 @@ is controlled via the ``decimal-rounding-mode`` configuration property or the ``
 property, which can be set to ``UNNECESSARY`` (the default),
 ``UP``, ``DOWN``, ``CEILING``, ``FLOOR``, ``HALF_UP``, ``HALF_DOWN``, or ``HALF_EVEN``
 (see `RoundingMode <https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/math/RoundingMode.html#enum.constant.summary>`_).
+
+.. include:: jdbc-type-mapping.fragment
 
 Querying MySQL
 --------------

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -87,8 +87,10 @@ To access the clicks table in the web database, run the following::
 
     SELECT * FROM oracle.web.clicks;
 
-Mapping data types between Trino and Oracle
---------------------------------------------
+.. _oracle-type-mapping:
+
+Type mapping
+------------
 
 Both Oracle and Trino have types that are not supported by the Oracle
 connector. The following sections explain their type mapping.
@@ -158,15 +160,6 @@ Trino data type mapping:
   * - ``TIMESTAMP(p) WITH TIME ZONE``
     - ``TIMESTAMP WITH TIME ZONE``
     - See :ref:`datetime mapping`
-
-If an Oracle table uses a type not listed in the above table, then you can use the
-``unsupported-type-handling`` configuration property to specify Trino behavior.
-For example:
-
-- If ``unsupported-type-handling`` is set to ``IGNORE``,
-  then you can't see the unsupported types in Trino.
-- If ``unsupported-type-handling`` is set to ``CONVERT_TO_VARCHAR``,
-  then the column is exposed as unbounded ``VARCHAR``.
 
 Trino to Oracle type mapping
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -298,10 +291,12 @@ example::
 Attempting to write a ``CHAR`` that doesn't fit in the column's actual size
 fails. This is also true for the equivalent ``VARCHAR`` types.
 
-Type mapping configuration properties
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. include:: jdbc-type-mapping.fragment
 
-.. list-table:: Type Mapping Properties
+Number to decimal configuration properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
   :widths: 20, 20, 50, 10
   :header-rows: 1
 
@@ -309,14 +304,6 @@ Type mapping configuration properties
     - Session property name
     - Description
     - Default
-  * - ``unsupported-type-handling``
-    - ``unsupported_type_handling``
-    - Configures how unsupported column data types are handled:
-
-      - ``IGNORE`` - column is not accessible.
-      - ``CONVERT_TO_VARCHAR`` - column is converted to unbounded ``VARCHAR``.
-
-    - ``IGNORE``
   * - ``oracle.number.default-scale``
     - ``number_default_scale``
     - Default Trino ``DECIMAL`` scale for Oracle ``NUMBER`` (without precision

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -36,8 +36,13 @@ with a different name, making sure it ends in ``.properties``. For example,
 if you name the property file ``sales.properties``, Trino creates a
 catalog named ``sales`` using the configured connector.
 
+.. _postgresql-type-mapping:
+
+Type mapping
+------------
+
 Decimal type handling
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 ``DECIMAL`` types with precision larger than 38 can be mapped to a Trino ``DECIMAL``
 by setting the ``decimal-mapping`` configuration property or the ``decimal_mapping`` session property to
@@ -51,7 +56,7 @@ property, which can be set to ``UNNECESSARY`` (the default),
 (see `RoundingMode <https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/math/RoundingMode.html#enum.constant.summary>`_).
 
 Array type handling
--------------------
+^^^^^^^^^^^^^^^^^^^
 
 The PostgreSQL array implementation does not support fixed dimensions whereas Trino
 support only arrays with fixed dimensions.
@@ -62,6 +67,8 @@ The following values are accepted for this property:
 * ``DISABLED`` (default): array columns are skipped.
 * ``AS_ARRAY``: array columns are interpreted as Trino ``ARRAY`` type, for array columns with fixed dimensions.
 * ``AS_JSON``: array columns are interpreted as Trino ``JSON`` type, with no constraint on dimensions.
+
+.. include:: jdbc-type-mapping.fragment
 
 Querying PostgreSQL
 -------------------

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -62,6 +62,13 @@ Finally, you can access the ``clicks`` table in the ``web`` schema::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``redshift`` in the above examples.
 
+.. _redshift-type-mapping:
+
+Type mapping
+------------
+
+.. include:: jdbc-type-mapping.fragment
+
 Limitations
 -----------
 


### PR DESCRIPTION
As a follow up we also have to add type mapping info for a bunch of connectors but that should be done separately in another PR. 

Fixes https://github.com/trinodb/trino/issues/7825

As discussed on slack with @losipiuk 