### PR TITLE
Remove unused ctor parameter in PlanOptimizers

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -235,7 +235,6 @@ import io.trino.sql.planner.optimizations.TableDeleteOptimizer;
 import io.trino.sql.planner.optimizations.TransformQuantifiedComparisonApplyToCorrelatedJoin;
 import io.trino.sql.planner.optimizations.UnaliasSymbolReferences;
 import io.trino.sql.planner.optimizations.WindowFilterPushDown;
-import org.weakref.jmx.MBeanExporter;
 
 import javax.inject.Inject;
 
@@ -258,7 +257,6 @@ public class PlanOptimizers
             TypeOperators typeOperators,
             TypeAnalyzer typeAnalyzer,
             TaskManagerConfig taskManagerConfig,
-            MBeanExporter exporter,
             SplitManager splitManager,
             PageSourceManager pageSourceManager,
             StatsCalculator statsCalculator,
@@ -273,7 +271,6 @@ public class PlanOptimizers
                 typeAnalyzer,
                 taskManagerConfig,
                 false,
-                exporter,
                 splitManager,
                 pageSourceManager,
                 statsCalculator,
@@ -290,7 +287,6 @@ public class PlanOptimizers
             TypeAnalyzer typeAnalyzer,
             TaskManagerConfig taskManagerConfig,
             boolean forceSingleNode,
-            MBeanExporter exporter,
             SplitManager splitManager,
             PageSourceManager pageSourceManager,
             StatsCalculator statsCalculator,

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -179,8 +179,6 @@ import io.trino.transaction.TransactionManagerConfig;
 import io.trino.type.BlockTypeOperators;
 import io.trino.util.FinalizerService;
 import org.intellij.lang.annotations.Language;
-import org.weakref.jmx.MBeanExporter;
-import org.weakref.jmx.testing.TestingMBeanServer;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -865,7 +863,6 @@ public class LocalQueryRunner
                 new TypeAnalyzer(sqlParser, metadata),
                 taskManagerConfig,
                 forceSingleNode,
-                new MBeanExporter(new TestingMBeanServer()),
                 splitManager,
                 pageSourceManager,
                 statsCalculator,

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -143,11 +143,6 @@
             <artifactId>testng</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.weakref</groupId>
-            <artifactId>jmxutils</artifactId>
-        </dependency>
-
         <!-- used by tests but also needed transitively -->
         <dependency>
             <groupId>io.airlift</groupId>

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -56,8 +56,6 @@ import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.weakref.jmx.MBeanExporter;
-import org.weakref.jmx.testing.TestingMBeanServer;
 
 import java.util.List;
 import java.util.Optional;
@@ -425,7 +423,6 @@ public abstract class AbstractTestQueryFramework
                 new TypeAnalyzer(sqlParser, metadata),
                 new TaskManagerConfig(),
                 forceSingleNode,
-                new MBeanExporter(new TestingMBeanServer()),
                 queryRunner.getSplitManager(),
                 queryRunner.getPageSourceManager(),
                 queryRunner.getStatsCalculator(),


### PR DESCRIPTION
This is a cleanup after 9777b4676720954cece4532d9996826bf3f5c608.