### PR TITLE
Migrate To ParserAssert

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
@@ -25,6 +25,7 @@ import io.trino.sql.tree.GroupBy;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.LogicalBinaryExpression;
 import io.trino.sql.tree.Node;
+import io.trino.sql.tree.NodeLocation;
 import io.trino.sql.tree.Offset;
 import io.trino.sql.tree.OrderBy;
 import io.trino.sql.tree.QualifiedName;
@@ -62,11 +63,6 @@ public final class QueryUtil
         return new Identifier(name);
     }
 
-    public static Identifier quotedIdentifier(String name)
-    {
-        return new Identifier(name, true);
-    }
-
     public static Expression nameReference(String first, String... rest)
     {
         return DereferenceExpression.from(QualifiedName.of(first, rest));
@@ -96,6 +92,32 @@ public final class QueryUtil
         return new Select(false, items.build());
     }
 
+    public static Select selectList(NodeLocation location, Expression... expressions)
+    {
+        return new Select(location, false, selectListItems(expressions));
+    }
+
+    public static ImmutableList<SelectItem> selectListItems(Expression... expressions)
+    {
+        ImmutableList.Builder<SelectItem> items = ImmutableList.builder();
+
+        for (Expression expression : expressions) {
+            if (expression.getLocation().isPresent()) {
+                items.add(new SingleColumn(expression.getLocation().get(), expression, Optional.empty()));
+            }
+            else {
+                items.add(new SingleColumn(expression));
+            }
+        }
+
+        return items.build();
+    }
+
+    public static Select selectList(NodeLocation location, SelectItem... items)
+    {
+        return new Select(location, false, ImmutableList.copyOf(items));
+    }
+
     public static Select selectList(SelectItem... items)
     {
         return new Select(false, ImmutableList.copyOf(items));
@@ -116,9 +138,19 @@ public final class QueryUtil
         return new TableSubquery(query);
     }
 
+    public static Relation subquery(NodeLocation location, Query query)
+    {
+        return new TableSubquery(location, query);
+    }
+
     public static SortItem ascending(String name)
     {
         return new SortItem(identifier(name), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED);
+    }
+
+    public static SortItem ascending(NodeLocation location, String name)
+    {
+        return new SortItem(location, new Identifier(location, name, false), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED);
     }
 
     public static Expression logicalAnd(Expression left, Expression right)
@@ -146,14 +178,29 @@ public final class QueryUtil
         return new Values(ImmutableList.copyOf(row));
     }
 
+    public static Values values(NodeLocation location, Row... row)
+    {
+        return new Values(location, ImmutableList.copyOf(row));
+    }
+
     public static Row row(Expression... values)
     {
         return new Row(ImmutableList.copyOf(values));
     }
 
+    public static Row row(NodeLocation location, Expression... values)
+    {
+        return new Row(location, ImmutableList.copyOf(values));
+    }
+
     public static Relation aliased(Relation relation, String alias)
     {
         return new AliasedRelation(relation, identifier(alias), null);
+    }
+
+    public static Relation aliased(NodeLocation location, Relation relation, String alias)
+    {
+        return new AliasedRelation(location, relation, identifier(alias), null);
     }
 
     public static Relation aliased(Relation relation, String alias, List<String> columnAliases)
@@ -176,6 +223,11 @@ public final class QueryUtil
         return new OrderBy(ImmutableList.copyOf(items));
     }
 
+    public static OrderBy ordering(NodeLocation location, SortItem... items)
+    {
+        return new OrderBy(location, ImmutableList.copyOf(items));
+    }
+
     public static Query simpleQuery(Select select)
     {
         return query(new QuerySpecification(
@@ -190,14 +242,54 @@ public final class QueryUtil
                 Optional.empty()));
     }
 
+    public static Query simpleQuery(NodeLocation location, Select select)
+    {
+        return query(location, new QuerySpecification(
+                location,
+                select,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty()));
+    }
+
+    public static QuerySpecification simpleQuerySpecification(NodeLocation location, Select select)
+    {
+        return new QuerySpecification(
+                location,
+                select,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                ImmutableList.of(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
     public static Query simpleQuery(Select select, Relation from)
     {
         return simpleQuery(select, from, Optional.empty(), Optional.empty());
     }
 
+    public static Query simpleQuery(NodeLocation location, Select select, Relation from)
+    {
+        return simpleQuery(location, select, from, Optional.empty(), Optional.empty());
+    }
+
     public static Query simpleQuery(Select select, Relation from, OrderBy orderBy)
     {
         return simpleQuery(select, from, Optional.empty(), Optional.of(orderBy));
+    }
+
+    public static Query simpleQuery(NodeLocation location, Select select, Relation from, OrderBy orderBy)
+    {
+        return simpleQuery(location, select, from, Optional.empty(), Optional.of(orderBy));
     }
 
     public static Query simpleQuery(Select select, Relation from, Expression where)
@@ -213,6 +305,25 @@ public final class QueryUtil
     public static Query simpleQuery(Select select, Relation from, Optional<Expression> where, Optional<OrderBy> orderBy)
     {
         return simpleQuery(select, from, where, Optional.empty(), Optional.empty(), orderBy, Optional.empty(), Optional.empty());
+    }
+
+    public static Query simpleQuery(NodeLocation location, Select select, Relation from, Optional<Expression> where, Optional<OrderBy> orderBy)
+    {
+        return simpleQuery(location, select, from, where, Optional.empty(), Optional.empty(), orderBy, Optional.empty(), Optional.empty());
+    }
+
+    public static Query simpleQuery(
+            NodeLocation location,
+            Select select,
+            Relation from,
+            Optional<Expression> where,
+            Optional<GroupBy> groupBy,
+            Optional<Expression> having,
+            Optional<OrderBy> orderBy,
+            Optional<Offset> offset,
+            Optional<Node> limit)
+    {
+        return simpleQuery(location, select, from, where, groupBy, having, ImmutableList.of(), orderBy, offset, limit);
     }
 
     public static Query simpleQuery(
@@ -251,6 +362,31 @@ public final class QueryUtil
                 limit));
     }
 
+    public static Query simpleQuery(
+            NodeLocation location,
+            Select select,
+            Relation from,
+            Optional<Expression> where,
+            Optional<GroupBy> groupBy,
+            Optional<Expression> having,
+            List<WindowDefinition> windows,
+            Optional<OrderBy> orderBy,
+            Optional<Offset> offset,
+            Optional<Node> limit)
+    {
+        return query(location, new QuerySpecification(
+                location,
+                select,
+                Optional.of(from),
+                where,
+                groupBy,
+                having,
+                windows,
+                orderBy,
+                offset,
+                limit));
+    }
+
     public static Query singleValueQuery(String columnName, String value)
     {
         Relation values = values(row(new StringLiteral((value))));
@@ -270,6 +406,17 @@ public final class QueryUtil
     public static Query query(QueryBody body)
     {
         return new Query(
+                Optional.empty(),
+                body,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+    }
+
+    public static Query query(NodeLocation location, QueryBody body)
+    {
+        return new Query(
+                location,
                 Optional.empty(),
                 body,
                 Optional.empty(),

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -911,6 +911,9 @@ public final class SqlFormatter
             if (node.isAnalyze()) {
                 builder.append("ANALYZE ");
             }
+            if (node.isVerbose()) {
+                builder.append("VERBOSE ");
+            }
 
             List<String> options = new ArrayList<>();
 

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -1660,7 +1660,7 @@ public final class SqlFormatter
                 builder.append(node.getType().get());
                 builder.append(" ");
             }
-            builder.append(node.getName())
+            builder.append(formatName(node.getName()))
                     .append(" TO ")
                     .append(formatPrincipal(node.getGrantee()));
             if (node.isWithGrantOption()) {
@@ -1692,7 +1692,7 @@ public final class SqlFormatter
                 builder.append(node.getType().get());
                 builder.append(" ");
             }
-            builder.append(node.getName())
+            builder.append(formatName(node.getName()))
                     .append(" FROM ")
                     .append(formatPrincipal(node.getGrantee()));
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DereferenceExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DereferenceExpression.java
@@ -93,14 +93,19 @@ public class DereferenceExpression
 
     public static Expression from(QualifiedName name)
     {
+        return from(Optional.empty(), name);
+    }
+
+    public static Expression from(Optional<NodeLocation> location, QualifiedName name)
+    {
         Expression result = null;
 
         for (String part : name.getParts()) {
             if (result == null) {
-                result = new Identifier(part);
+                result = new Identifier(location, part);
             }
             else {
-                result = new DereferenceExpression(result, new Identifier(part));
+                result = new DereferenceExpression(location, result, new Identifier(location, part));
             }
         }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Identifier.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Identifier.java
@@ -42,6 +42,11 @@ public class Identifier
         this(Optional.empty(), value, delimited);
     }
 
+    public Identifier(Optional<NodeLocation> location, String value)
+    {
+        this(location, value, !NAME_PATTERN.matcher(value).matches());
+    }
+
     public Identifier(String value)
     {
         this(Optional.empty(), value, !NAME_PATTERN.matcher(value).matches());

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -1815,8 +1815,7 @@ public class TestSqlParser
         assertThat(statement("CREATE TABLE foo " +
                 "WITH ( string = 'bar', long = 42, computed = 'ban' || 'ana', a  = ARRAY[ 'v1', 'v2' ] ) " +
                 "AS " +
-                "SELECT * FROM t")).isEqualTo(
-                new CreateTableAsSelect(location(1, 1), table, query3, false, properties, true, Optional.empty(), Optional.empty()));
+                "SELECT * FROM t")).isEqualTo(new CreateTableAsSelect(location(1, 1), table, query3, false, properties, true, Optional.empty(), Optional.empty()));
 
         final Query querySelectColumn3 = simpleQuery(location(1, 112), selectList(location(1, 112),
                 new Identifier(location(1, 119), "a", false)),
@@ -1844,8 +1843,8 @@ public class TestSqlParser
                 "WITH ( string = 'bar', long = 42, computed = 'ban' || 'ana', a  = ARRAY[ 'v1', 'v2' ] ) " +
                 "AS " +
                 "SELECT a FROM t")).isEqualTo(
-                new CreateTableAsSelect(location(1, 1), table, querySelectColumn3, false, properties2, true, Optional.of(ImmutableList.of(
-                        new Identifier(location(1, 18), "x", false))), Optional.empty()));
+                        new CreateTableAsSelect(location(1, 1), table, querySelectColumn3, false, properties2, true, Optional.of(ImmutableList.of(
+                                new Identifier(location(1, 18), "x", false))), Optional.empty()));
 
         final Query querySelectColumns3 = simpleQuery(location(1, 114), selectList(location(1, 114),
                 new Identifier(location(1, 121), "a", false),
@@ -1875,7 +1874,7 @@ public class TestSqlParser
                 "AS " +
                 "SELECT a,b FROM t")).isEqualTo(new CreateTableAsSelect(location(1, 1),
                 table, querySelectColumns3, false, properties3, true, Optional.of(ImmutableList.of(
-                new Identifier(location(1, 18), "x", false), new Identifier(location(1, 20), "y", false))), Optional.empty()));
+                        new Identifier(location(1, 18), "x", false), new Identifier(location(1, 20), "y", false))), Optional.empty()));
 
         final Query query4 = simpleQuery(location(1, 109), selectList(location(1, 109),
                 new AllColumns(location(1, 116), Optional.empty(), ImmutableList.of())),
@@ -1886,23 +1885,23 @@ public class TestSqlParser
                 "AS " +
                 "SELECT * FROM t " +
                 "WITH NO DATA")).isEqualTo(
-                new CreateTableAsSelect(location(1, 1), table, query4, false, properties, false, Optional.empty(), Optional.empty()));
+                        new CreateTableAsSelect(location(1, 1), table, query4, false, properties, false, Optional.empty(), Optional.empty()));
 
         assertThat(statement("CREATE TABLE foo(x) " +
                 "WITH ( string = 'bar', long = 42, computed = 'ban' || 'ana', a  = ARRAY[ 'v1', 'v2' ] ) " +
                 "AS " +
                 "SELECT a FROM t " +
                 "WITH NO DATA")).isEqualTo(new CreateTableAsSelect(location(1, 1), table, querySelectColumn3, false, properties2, false, Optional.of(ImmutableList.of(
-                new Identifier(location(1, 18), "x", false))), Optional.empty()));
+                        new Identifier(location(1, 18), "x", false))), Optional.empty()));
 
         assertThat(statement("CREATE TABLE foo(x,y) " +
                 "WITH ( string = 'bar', long = 42, computed = 'ban' || 'ana', a  = ARRAY[ 'v1', 'v2' ] ) " +
                 "AS " +
                 "SELECT a,b FROM t " +
                 "WITH NO DATA")).isEqualTo(
-                new CreateTableAsSelect(location(1, 1), table, querySelectColumns3, false, properties3, false, Optional.of(ImmutableList.of(
-                        new Identifier(location(1, 18), "x", false),
-                        new Identifier(location(1, 20), "y", false))), Optional.empty()));
+                        new CreateTableAsSelect(location(1, 1), table, querySelectColumns3, false, properties3, false, Optional.of(ImmutableList.of(
+                                new Identifier(location(1, 18), "x", false),
+                                new Identifier(location(1, 20), "y", false))), Optional.empty()));
 
         final Query query5 = simpleQuery(location(1, 123), selectList(location(1, 123),
                 new AllColumns(location(1, 130), Optional.empty(), ImmutableList.of())),
@@ -1931,7 +1930,7 @@ public class TestSqlParser
                 "AS " +
                 "SELECT * FROM t " +
                 "WITH NO DATA")).isEqualTo(
-                new CreateTableAsSelect(location(1, 1), table, query5, false, properties4, false, Optional.empty(), Optional.of("test")));
+                        new CreateTableAsSelect(location(1, 1), table, query5, false, properties4, false, Optional.empty(), Optional.of("test")));
 
         List<Property> properties5 = ImmutableList.of(
                 new Property(location(1, 42),
@@ -1960,8 +1959,8 @@ public class TestSqlParser
                 "AS " +
                 "SELECT a FROM t " +
                 "WITH NO DATA")).isEqualTo(
-                new CreateTableAsSelect(location(1, 1), table, querySelectColumn4, false, properties5, false, Optional.of(ImmutableList.of(
-                        new Identifier(location(1, 18), "x", false))), Optional.of("test")));
+                        new CreateTableAsSelect(location(1, 1), table, querySelectColumn4, false, properties5, false, Optional.of(ImmutableList.of(
+                                new Identifier(location(1, 18), "x", false))), Optional.of("test")));
 
         List<Property> properties6 = ImmutableList.of(
                 new Property(location(1, 44),
@@ -1992,7 +1991,7 @@ public class TestSqlParser
                 "SELECT a,b FROM t " +
                 "WITH NO DATA")).isEqualTo(new CreateTableAsSelect(location(1, 1),
                 table, querySelectColumns4, false, properties6, false, Optional.of(ImmutableList.of(
-                new Identifier(location(1, 18), "x", false), new Identifier(location(1, 20), "y", false))), Optional.of("test")));
+                        new Identifier(location(1, 18), "x", false), new Identifier(location(1, 20), "y", false))), Optional.of("test")));
 
         List<Property> properties7 = ImmutableList.of(
                 new Property(location(1, 44),
@@ -2022,9 +2021,9 @@ public class TestSqlParser
                 "AS " +
                 "SELECT a,b FROM t " +
                 "WITH NO DATA")).isEqualTo(
-                new CreateTableAsSelect(location(1, 1), table, querySelectColumns5, false, properties7, false, Optional.of(ImmutableList.of(
-                        new Identifier(location(1, 18), "x", false),
-                        new Identifier(location(1, 20), "y", false))), Optional.of("test")));
+                        new CreateTableAsSelect(location(1, 1), table, querySelectColumns5, false, properties7, false, Optional.of(ImmutableList.of(
+                                new Identifier(location(1, 18), "x", false),
+                                new Identifier(location(1, 20), "y", false))), Optional.of("test")));
     }
 
     @Test
@@ -2227,9 +2226,9 @@ public class TestSqlParser
                 new Delete(location(1, 1),
                         new Table(location(1, 1),
                                 qualifiedName(location(1, 13), "t")), Optional.of(
-                        new ComparisonExpression(location(1, 23), ComparisonExpression.Operator.EQUAL,
-                                new Identifier(location(1, 21), "a", false),
-                                new Identifier(location(1, 25), "b", false)))));
+                                        new ComparisonExpression(location(1, 23), ComparisonExpression.Operator.EQUAL,
+                                                new Identifier(location(1, 21), "a", false),
+                                                new Identifier(location(1, 25), "b", false)))));
     }
 
     @Test
@@ -4092,12 +4091,12 @@ public class TestSqlParser
         assertThat(statement("CREATE OR REPLACE MATERIALIZED VIEW catalog.schema.matview COMMENT 'A partitioned materialized view' " +
                 "WITH (partitioned_by = ARRAY ['dateint'])" +
                 " AS WITH a (t, u) AS (SELECT * FROM x), b AS (SELECT * FROM a) TABLE b")).isEqualTo(
-                new CreateMaterializedView(Optional.of(location(1, 1)),
-                        QualifiedName.of(ImmutableList.of(
-                                new Identifier(location(1, 37), "catalog", false),
-                                new Identifier(location(1, 45), "schema", false),
-                                new Identifier(location(1, 52), "matview", false))), query4,
-                        true, false, properties2, Optional.of("A partitioned materialized view")));
+                        new CreateMaterializedView(Optional.of(location(1, 1)),
+                                QualifiedName.of(ImmutableList.of(
+                                        new Identifier(location(1, 37), "catalog", false),
+                                        new Identifier(location(1, 45), "schema", false),
+                                        new Identifier(location(1, 52), "matview", false))), query4,
+                                true, false, properties2, Optional.of("A partitioned materialized view")));
     }
 
     @Test


### PR DESCRIPTION
**Description**

https://github.com/trinodb/trino/issues/7520

- Migrated majority of tests to use ParserAssert for full field object matching in unit tests (all completed)

- Fixed bug that did not detect "VERBOSE" argument in EXPLAIN query strings: 
https://github.com/trinodb/trino/pull/7861/files#diff-246718b7dd2c7464c8567b431578d28b39e8f70589d84d8fac7254648d45aa93R915

- Fixed bug that did not detect delimited table names in GRANT and REVOKE query strings:
https://github.com/trinodb/trino/pull/7861/files#diff-246718b7dd2c7464c8567b431578d28b39e8f70589d84d8fac7254648d45aa93L1692


- Minor cleanup/refactor of SqlParser for readability
https://github.com/trinodb/trino/pull/7861/files#diff-ae75f9ca2605aab51fc718a9b1c7f27adb3ee662af2e1498f0c276062346441bR156

@joshthoward 