### PR TITLE
Added a fix for BQ connector to correctly treat single quote in query criteria

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
@@ -179,7 +179,8 @@ public enum BigQueryType
     static String stringToStringConverter(Object value)
     {
         Slice slice = (Slice) value;
-        return quote(slice.toStringUtf8());
+        // TODO (https://github.com/trinodb/trino/issues/7900) Add support for all String and Bytes literals
+        return quote(slice.toStringUtf8().replace("'", "\\'"));
     }
 
     static String numericToStringConverter(Object value)

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
@@ -244,6 +244,21 @@ public class TestBigQueryIntegrationSmokeTest
         assertEquals((long) actualValues.getOnlyValue(), 1L);
     }
 
+    @Test(description = "regression test for https://github.com/trinodb/trino/issues/7784")
+    public void testSelectWithSingleQuoteInWhereClause()
+    {
+        String tableName = "test.select_with_single_quote";
+
+        onBigQuery("DROP TABLE IF EXISTS " + tableName);
+        onBigQuery("CREATE TABLE " + tableName + "(col INT64, val STRING)");
+        onBigQuery("INSERT INTO " + tableName + " VALUES (1,'escape\\'single quote')");
+
+        MaterializedResult actualValues = computeActual("SELECT val FROM " + tableName + " WHERE val = 'escape''single quote'");
+
+        assertEquals(actualValues.getRowCount(), 1);
+        assertEquals(actualValues.getOnlyValue(), "escape'single quote");
+    }
+
     @Test(description = "regression test for https://github.com/trinodb/trino/issues/5618")
     public void testPredicatePushdownPrunnedColumns()
     {

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryType.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryType.java
@@ -54,6 +54,10 @@ public class TestBigQueryType
         assertThat(BigQueryType.stringToStringConverter(
                 utf8Slice("test")))
                 .isEqualTo("'test'");
+
+        assertThat(BigQueryType.stringToStringConverter(
+                utf8Slice("test's test")))
+                .isEqualTo("'test\\'s test'");
     }
 
     @Test


### PR DESCRIPTION
Fix for https://github.com/trinodb/trino/issues/7784.

Added a change to properly rewrite filter values containing the ANSI SQL single quote Escape sequence into the one that BigQuery is happy with.

Example: 
'**Looney''s Lane**' string in Presto query filter will be changed to  '**Looney\\'s Lane**' in order to make the query work.