### PR TITLE
Fix flaky TestingSqlServer setup

### DIFF
--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
@@ -13,6 +13,9 @@
  */
 package io.trino.plugin.sqlserver;
 
+import io.airlift.log.Logger;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -22,14 +25,29 @@ import java.io.UncheckedIOException;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
+import static com.google.common.base.Throwables.getCausalChain;
 import static io.trino.testing.containers.TestContainers.startOrReuse;
 import static java.lang.String.format;
 
 public final class TestingSqlServer
         implements AutoCloseable
 {
+    private static final Logger log = Logger.get(TestingSqlServer.class);
+
+    private static final RetryPolicy<?> QUERY_RETRY_POLICY = new RetryPolicy<>()
+            .withBackoff(1, 5, ChronoUnit.SECONDS)
+            .withMaxRetries(5)
+            .handleIf(throwable -> getCausalChain(throwable).stream()
+                            .filter(SQLException.class::isInstance)
+                            .anyMatch(exception -> exception.getMessage().contains("Rerun the transaction.")))
+            .onRetry(event -> log.warn(
+                    "Query failed on attempt %s, will retry. Exception: %s",
+                    event.getAttemptCount(),
+                    event.getLastFailure().getMessage()));
+
     private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("microsoft/mssql-server-linux:2017-CU13")
             .asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server:2017-CU12");
     private final MSSQLServerContainer<?> container;
@@ -91,8 +109,10 @@ public final class TestingSqlServer
         execute("CREATE DATABASE " + databaseName);
 
         // Enable snapshot isolation by default to reduce flakiness on CI
-        execute(format("ALTER DATABASE %s SET ALLOW_SNAPSHOT_ISOLATION ON", databaseName));
-        execute(format("ALTER DATABASE %s SET READ_COMMITTED_SNAPSHOT ON", databaseName));
+        Failsafe.with(QUERY_RETRY_POLICY)
+                .run(() -> execute(format("ALTER DATABASE %s SET ALLOW_SNAPSHOT_ISOLATION ON", databaseName)));
+        Failsafe.with(QUERY_RETRY_POLICY)
+                .run(() -> execute(format("ALTER DATABASE %s SET READ_COMMITTED_SNAPSHOT ON", databaseName)));
 
         container.withUrlParam("database", this.databaseName);
     }


### PR DESCRIPTION
Fix flaky TestingSqlServer setup

Sometimes TestingSqlServer is fails to run:
ALTER DATABASE database_xxx SET READ_COMMITTED_SNAPSHOT ON
saying:
Transaction (Process ID 51) was deadlocked on lock resources with another process and
has been chosen as the deadlock victim. Rerun the transaction.
