### PR TITLE
Update StatementAnalyzer and extend AccessControl interface and to filter columns from table schema instead of throwing

### DIFF
--- a/core/trino-main/src/main/java/io/trino/security/AccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControl.java
@@ -222,9 +222,14 @@ public interface AccessControl
     void checkCanShowColumns(SecurityContext context, CatalogSchemaTableName table);
 
     /**
-     * Filter the list of columns to those visible to the identity.
+     * Filter the list of columns to those visible to the identity when executing SHOW COLUMNS, DESCRIBE, etc.
      */
     Set<String> filterColumns(SecurityContext context, CatalogSchemaTableName tableName, Set<String> columns);
+
+    /**
+     * Filter the list of columns to those visible to the identity when querying the table.
+     */
+    Set<String> filterTableSchema(SecurityContext context, QualifiedObjectName tableName, Set<String> columns);
 
     /**
      * Check if identity is allowed to add columns to the specified table.

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -533,6 +533,23 @@ public class AccessControlManager
     }
 
     @Override
+    public Set<String> filterTableSchema(SecurityContext securityContext, QualifiedObjectName table, Set<String> columns)
+    {
+        requireNonNull(securityContext, "securityContext is null");
+        requireNonNull(table, "tableName is null");
+
+        for (SystemAccessControl systemAccessControl : getSystemAccessControls()) {
+            columns = systemAccessControl.filterTableSchema(securityContext.toSystemSecurityContext(), table.asCatalogSchemaTableName(), columns);
+        }
+
+        CatalogAccessControlEntry entry = getConnectorAccessControl(securityContext.getTransactionId(), table.getCatalogName());
+        if (entry != null) {
+            columns = entry.getAccessControl().filterTableSchema(entry.toConnectorSecurityContext(securityContext), table.asSchemaTableName(), columns);
+        }
+        return columns;
+    }
+
+    @Override
     public void checkCanAddColumns(SecurityContext securityContext, QualifiedObjectName tableName)
     {
         requireNonNull(securityContext, "securityContext is null");

--- a/core/trino-main/src/main/java/io/trino/security/AllowAllAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AllowAllAccessControl.java
@@ -164,6 +164,12 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(SecurityContext context, QualifiedObjectName tableName, Set<String> columns)
+    {
+        return columns;
+    }
+
+    @Override
     public void checkCanAddColumns(SecurityContext context, QualifiedObjectName tableName)
     {
     }

--- a/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
@@ -230,6 +230,12 @@ public class DenyAllAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(SecurityContext context, QualifiedObjectName tableName, Set<String> columns)
+    {
+        return ImmutableSet.of();
+    }
+
+    @Override
     public void checkCanShowSchemas(SecurityContext context, String catalogName)
     {
         denyShowSchemas();

--- a/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
@@ -207,6 +207,12 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(SecurityContext context, QualifiedObjectName tableName, Set<String> columns)
+    {
+        return delegate().filterTableSchema(context, tableName, columns);
+    }
+
+    @Override
     public void checkCanAddColumns(SecurityContext context, QualifiedObjectName tableName)
     {
         delegate().checkCanAddColumns(context, tableName);

--- a/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/InjectedConnectorAccessControl.java
@@ -167,6 +167,13 @@ public class InjectedConnectorAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
+    {
+        checkArgument(context == null, "context must be null");
+        return accessControl.filterTableSchema(securityContext, new QualifiedObjectName(catalogName, tableName.getSchemaName(), tableName.getTableName()), columns);
+    }
+
+    @Override
     public void checkCanAddColumn(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         checkArgument(context == null, "context must be null");

--- a/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
@@ -83,6 +83,12 @@ public class ViewAccessControl
         return delegate.getColumnMasks(context, tableName, columnName, type);
     }
 
+    @Override
+    public Set<String> filterTableSchema(SecurityContext context, QualifiedObjectName tableName, Set<String> columns)
+    {
+        return delegate.filterTableSchema(context, tableName, columns);
+    }
+
     private static void wrapAccessDeniedException(Runnable runnable)
     {
         try {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -1643,8 +1643,18 @@ class StatementAnalyzer
         private List<Field> analyzeTableOutputFields(Table table, QualifiedObjectName tableName, TableSchema tableSchema, Map<String, ColumnHandle> columnHandles)
         {
             // TODO: discover columns lazily based on where they are needed (to support connectors that can't enumerate all tables)
+            QualifiedObjectName name = createQualifiedObjectName(session, table, table.getName());
+            Set<String> accessibleColumnNames = accessControl.filterTableSchema(
+                    session.toSecurityContext(),
+                    name,
+                    tableSchema.getColumns().stream()
+                            .map(ColumnSchema::getName)
+                            .collect(toImmutableSet()));
+            List<ColumnSchema> accessibleColumns = tableSchema.getColumns().stream()
+                    .filter(column -> accessibleColumnNames.contains(column.getName()))
+                    .collect(toImmutableList());
             ImmutableList.Builder<Field> fields = ImmutableList.builder();
-            for (ColumnSchema column : tableSchema.getColumns()) {
+            for (ColumnSchema column : accessibleColumns) {
                 Field field = Field.newQualified(
                         table.getName(),
                         Optional.of(column.getName()),

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestTableSchemaFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestTableSchemaFilter.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import io.trino.Session;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.plugin.tpch.TpchConnectorFactory;
+import io.trino.spi.security.Identity;
+import io.trino.testing.LocalQueryRunner;
+import io.trino.testing.TestingAccessControlManager;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Test(singleThreaded = true)
+public class TestTableSchemaFilter
+{
+    private static final String CATALOG = "local";
+    private static final String USER = "user";
+
+    private static final Session SESSION = testSessionBuilder()
+            .setCatalog(CATALOG)
+            .setSchema(TINY_SCHEMA_NAME)
+            .setIdentity(Identity.forUser(USER).build())
+            .build();
+
+    private QueryAssertions assertions;
+    private TestingAccessControlManager accessControl;
+
+    @BeforeClass
+    public void init()
+    {
+        LocalQueryRunner runner = LocalQueryRunner.builder(SESSION).build();
+        runner.createCatalog(CATALOG, new TpchConnectorFactory(1), ImmutableMap.of());
+        assertions = new QueryAssertions(runner);
+        accessControl = assertions.getQueryRunner().getAccessControl();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testSimpleTableSchemaFilter()
+    {
+        // No filtering baseline
+        accessControl.reset();
+        assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3', CAST('refully final requests. regular, ironi' AS VARCHAR(152)))");
+
+        // Add a filter but have it return all columns, the result should not change.
+        accessControl.reset();
+        accessControl.setTableSchemaFilter(
+                new QualifiedObjectName(CATALOG, "tiny", "nation"),
+                USER,
+                Sets.newHashSet("nationkey", "name", "regionkey", "comment"));
+        assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3', CAST('refully final requests. regular, ironi' AS VARCHAR(152)))");
+
+        // Modify the filter to remove the comment, validate that comment is no longer present in the result
+        accessControl.reset();
+        accessControl.setTableSchemaFilter(
+                new QualifiedObjectName(CATALOG, "tiny", "nation"),
+                USER,
+                Sets.newHashSet("nationkey", "name", "regionkey"));
+        assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3')");
+    }
+
+    /**
+     * Test filtering when columns are explicitly specified in SELECT
+     */
+    @Test
+    public void testFilterExplicitSelect()
+    {
+        // Select the columns that are available to us explicitly
+        accessControl.reset();
+        accessControl.setTableSchemaFilter(
+                new QualifiedObjectName(CATALOG, "tiny", "nation"),
+                USER,
+                Sets.newHashSet("nationkey", "name", "regionkey"));
+        assertThat(assertions.query("SELECT nationkey, name, regionkey FROM nation WHERE name = 'FRANCE'"))
+                .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3')");
+
+        // Select all columns explicitly
+        accessControl.reset();
+        accessControl.setTableSchemaFilter(
+                new QualifiedObjectName(CATALOG, "tiny", "nation"),
+                USER,
+                Sets.newHashSet("nationkey", "name", "regionkey"));
+        assertThatThrownBy(() -> assertions.query("SELECT nationkey, name, regionkey, comment FROM nation WHERE name = 'FRANCE'"))
+                .hasMessage("line 1:36: Column 'comment' cannot be resolved");
+    }
+
+    /**
+     * Test filtering when a hidden column is present in the predicate
+     */
+    @Test
+    public void testFilterSelectInPredicate()
+    {
+        // Hide name but use it in the query predicate
+        accessControl.reset();
+        accessControl.setTableSchemaFilter(
+                new QualifiedObjectName(CATALOG, "tiny", "nation"),
+                USER,
+                Sets.newHashSet("nationkey", "comment", "regionkey"));
+        assertThatThrownBy(() -> assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .hasMessage("line 1:28: Column 'name' cannot be resolved");
+    }
+
+    /**
+     * Test filtering when the access control implementation returns a column not part of the table
+     */
+    @Test
+    public void testFilterUnknownColumn()
+    {
+        accessControl.reset();
+        accessControl.setTableSchemaFilter(
+                new QualifiedObjectName(CATALOG, "tiny", "nation"),
+                USER,
+                Sets.newHashSet("nationkey", "name", "regionkey", "comment", "orderkey"));
+        assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3', CAST('refully final requests. regular, ironi' AS VARCHAR(152)))");
+    }
+
+    /**
+     * Test that filtering out "name" from the table doesn't change SHOW COLUMNS, DESCRIBE, or SELECT on INFORMATION_SCHEMA output.
+     */
+    @Test
+    public void testShowColumnsDescribe()
+    {
+        accessControl.reset();
+        accessControl.setTableSchemaFilter(
+                new QualifiedObjectName(CATALOG, "tiny", "nation"),
+                USER,
+                Sets.newHashSet("nationkey", "regionkey", "comment"));
+        assertThat(assertions.query("SHOW COLUMNS FROM nation")).skippingTypesCheck().matches(
+                "VALUES ('nationkey', 'bigint', '', '')," +
+                        "('name', 'varchar(25)', '', '')," +
+                        "('regionkey', 'bigint', '', '')," +
+                        "('comment', 'varchar(152)', '', '')");
+        assertThat(assertions.query("DESCRIBE nation")).skippingTypesCheck().matches(
+                "VALUES ('nationkey', 'bigint', '', '')," +
+                        "('name', 'varchar(25)', '', '')," +
+                        "('regionkey', 'bigint', '', '')," +
+                        "('comment', 'varchar(152)', '', '')");
+        assertThat(assertions.query("SELECT column_name FROM information_schema.columns WHERE table_name = 'nation' AND table_schema = 'tiny'"))
+                .skippingTypesCheck().matches(
+                    "VALUES ('nationkey')," +
+                            "('regionkey')," +
+                            "('comment')," +
+                            "('name')");
+    }
+
+    /**
+     * Test that filtering on INFORMATION_SCHEMA tables works as expected.
+     */
+    @Test
+    public void testFilterInformationSchema()
+    {
+        accessControl.reset();
+        accessControl.setTableSchemaFilter(
+                new QualifiedObjectName(CATALOG, "information_schema", "columns"),
+                USER,
+                Sets.newHashSet("column_name", "table_name", "table_schema"));
+        // SHOW COLUMNS and DESCRIBE fail since data_type isn't visible
+        assertThatThrownBy(() -> assertions.query("SHOW COLUMNS FROM nation")).hasMessage("Column 'data_type' cannot be resolved");
+        assertThatThrownBy(() -> assertions.query("DESCRIBE nation")).hasMessage("Column 'data_type' cannot be resolved");
+        // SELECT on INFORMATION_SCHEMA should provide just the visible columns
+        assertThat(assertions.query("SELECT * FROM information_schema.columns WHERE table_name = 'nation' AND table_schema = 'tiny'"))
+                .skippingTypesCheck().matches(
+                    "VALUES ('tiny', 'nation', 'nationkey')," +
+                            "('tiny', 'nation', 'regionkey')," +
+                            "('tiny', 'nation', 'comment')," +
+                            "('tiny', 'nation', 'name')");
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorAccessControl.java
@@ -239,11 +239,19 @@ public interface ConnectorAccessControl
     }
 
     /**
-     * Filter the list of columns to those visible to the identity.
+     * Filter the list of columns to those visible to the identity when executing SHOW COLUMNS, DESCRIBE, etc.
      */
-    default Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
+    default Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName table, Set<String> columns)
     {
         return emptySet();
+    }
+
+    /**
+     * Filter the list of columns to those visible to the identity when querying the table.
+     */
+    default Set<String> filterTableSchema(ConnectorSecurityContext context, SchemaTableName table, Set<String> columns)
+    {
+        return columns;
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/SystemAccessControl.java
@@ -358,11 +358,19 @@ public interface SystemAccessControl
     }
 
     /**
-     * Filter the list of columns to those visible to the identity.
+     * Filter the list of columns to those visible to the identity when executing SHOW COLUMNS, DESCRIBE, etc.
      */
     default Set<String> filterColumns(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
     {
         return emptySet();
+    }
+
+    /**
+     * Filter the list of columns to those visible to the identity when querying the table.
+     */
+    default Set<String> filterTableSchema(SystemSecurityContext context, CatalogSchemaTableName table, Set<String> columns)
+    {
+        return columns;
     }
 
     /**

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
@@ -180,6 +180,14 @@ public class ClassLoaderSafeConnectorAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.filterTableSchema(context, tableName, columns);
+        }
+    }
+
+    @Override
     public void checkCanAddColumn(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllAccessControl.java
@@ -117,6 +117,12 @@ public class AllowAllAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
+    {
+        return columns;
+    }
+
+    @Override
     public void checkCanAddColumn(ConnectorSecurityContext context, SchemaTableName tableName)
     {
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/AllowAllSystemAccessControl.java
@@ -206,6 +206,12 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(SystemSecurityContext context, CatalogSchemaTableName tableName, Set<String> columns)
+    {
+        return columns;
+    }
+
+    @Override
     public void checkCanAddColumn(SystemSecurityContext context, CatalogSchemaTableName table)
     {
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -245,6 +245,13 @@ public class FileBasedAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
+    {
+        // TODO
+        return columns;
+    }
+
+    @Override
     public void checkCanRenameTable(ConnectorSecurityContext context, SchemaTableName tableName, SchemaTableName newTableName)
     {
         // check if user owns the existing table, and if they will be an owner of the table after the rename

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -595,6 +595,13 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(SystemSecurityContext context, CatalogSchemaTableName tableName, Set<String> columns)
+    {
+        // TODO
+        return columns;
+    }
+
+    @Override
     public void checkCanAddColumn(SystemSecurityContext context, CatalogSchemaTableName table)
     {
         if (!checkTablePermission(context, table, OWNERSHIP)) {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingConnectorAccessControl.java
@@ -149,6 +149,12 @@ public abstract class ForwardingConnectorAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
+    {
+        return delegate().filterTableSchema(context, tableName, columns);
+    }
+
+    @Override
     public void checkCanAddColumn(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         delegate().checkCanAddColumn(context, tableName);

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ForwardingSystemAccessControl.java
@@ -219,6 +219,12 @@ public abstract class ForwardingSystemAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(SystemSecurityContext context, CatalogSchemaTableName tableName, Set<String> columns)
+    {
+        return delegate().filterTableSchema(context, tableName, columns);
+    }
+
+    @Override
     public void checkCanAddColumn(SystemSecurityContext context, CatalogSchemaTableName table)
     {
         delegate().checkCanAddColumn(context, table);

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlyAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlyAccessControl.java
@@ -131,6 +131,12 @@ public class ReadOnlyAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
+    {
+        return columns;
+    }
+
+    @Override
     public void checkCanRenameColumn(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         denyRenameColumn(tableName.toString());

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlySystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ReadOnlySystemAccessControl.java
@@ -135,6 +135,12 @@ public class ReadOnlySystemAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(SystemSecurityContext context, CatalogSchemaTableName tableName, Set<String> columns)
+    {
+        return columns;
+    }
+
+    @Override
     public void checkCanShowSchemas(SystemSecurityContext context, String catalogName)
     {
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
@@ -179,6 +179,12 @@ public class LegacyAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
+    {
+        return columns;
+    }
+
+    @Override
     public void checkCanAddColumn(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         if (!allowAddColumn) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -244,6 +244,12 @@ public class SqlStandardAccessControl
     }
 
     @Override
+    public Set<String> filterTableSchema(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
+    {
+        return columns;
+    }
+
+    @Override
     public void checkCanAddColumn(ConnectorSecurityContext context, SchemaTableName tableName)
     {
         if (!isTableOwner(context, tableName)) {


### PR DESCRIPTION
Initial PR for AccessControl interface changes, initial implementations, and StatementAnalyzer integration.

Will update specific AccessControl implementations (possibly FileBased) to support this feature. 

Fixes #7461 