### PR TITLE
Move write partitioning properties to new chapter

### DIFF
--- a/docs/src/main/sphinx/admin/properties-write-partitioning.rst
+++ b/docs/src/main/sphinx/admin/properties-write-partitioning.rst
@@ -1,0 +1,26 @@
+=============================
+Write partitioning properties
+=============================
+
+``use-preferred-write-partitioning``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* **Type:** ``boolean``
+* **Default value:** ``true``
+
+Enable preferred write partitioning. When set to ``true`` and more than the
+minimum number of partitions, set in ``preferred-write-partitioning-min-number-of-partitions``,
+are written, each partition is written by a separate writer. As a result, for some connectors such as the
+Hive connector, only a single new file is written per partition, instead of
+multiple files. Partition writer assignments are distributed across worker
+nodes for parallel processing.
+
+``preferred-write-partitioning-min-number-of-partitions``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* **Type:** ``integer``
+* **Default value:** ``50``
+
+The minimum number of written partitions that is required to use connector
+``preferred write partitioning``. If the number of partitions cannot be
+estimated from the statistics, then preferred write partitioning is not used.
+If the threshold value is ``1`` then ``preferred write partitioning`` is always
+used.

--- a/docs/src/main/sphinx/admin/properties-writer-scaling.rst
+++ b/docs/src/main/sphinx/admin/properties-writer-scaling.rst
@@ -33,26 +33,3 @@ another writer is eligible to be added. Each writer task may have multiple
 writers, controlled by ``task.writer-count``, thus this value is effectively
 divided by the number of writers per task. This can be specified on a
 per-query basis using the ``writer_min_size`` session property.
-
-``use-preferred-write-partitioning``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* **Type:** ``boolean``
-* **Default value:** ``true``
-
-Enable preferred write partitioning. When set to ``true`` and more than the
-minimum number of partitions, set in ``preferred-write-partitioning-min-number-of-partitions``,
-are written, each partition is written by a separate writer. As a result, for some connectors such as the
-Hive connector, only a single new file is written per partition, instead of
-multiple files. Partition writer assignments are distributed across worker
-nodes for parallel processing.
-
-``preferred-write-partitioning-min-number-of-partitions``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-* **Type:** ``integer``
-* **Default value:** ``50``
-
-The minimum number of written partitions that is required to use connector
-``preferred write partitioning``. If the number of partitions cannot be
-estimated from the statistics, then preferred write partitioning is not used.
-If the threshold value is ``1`` then ``preferred write partitioning`` is always
-used.

--- a/docs/src/main/sphinx/admin/properties.rst
+++ b/docs/src/main/sphinx/admin/properties.rst
@@ -14,6 +14,7 @@ may be used to tune Trino or alter its behavior when required.
     Spilling <properties-spilling>
     Exchange <properties-exchange>
     Task <properties-task>
+    Write partitioning <properties-write-partitioning>
     Writer scaling <properties-writer-scaling>
     Node scheduler <properties-node-scheduler>
     Optimizer <properties-optimizer>


### PR DESCRIPTION
These properties are not related to or compatible with writer scaling.