### PR TITLE
Use airbase property to configure maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,8 @@
         <air.java.version>11.0.7</air.java.version>
         <air.modernizer.java-version>8</air.modernizer.java-version>
 
+        <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>
+
         <dep.accumulo.version>1.7.4</dep.accumulo.version>
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.antlr.version>4.9</dep.antlr.version>
@@ -1627,14 +1629,6 @@
                             <version>1.3.2</version>
                         </dependency>
                     </dependencies>
-                </plugin>
-
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <configuration>
-                        <preparationGoals>clean verify -DskipTests</preparationGoals>
-                    </configuration>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
We already depend on the configuration defined in airbase as https://github.com/airlift/airbase/blob/master/airbase/pom.xml#L481-L496.

This makes it easier to reason about where the plugin configuration is coming from IMO and allows configuring it instead of hardcoding it.