### PR TITLE
Adding documentation on min/max-drivers-per-task config

### DIFF
--- a/docs/src/main/sphinx/admin/properties-task.rst
+++ b/docs/src/main/sphinx/admin/properties-task.rst
@@ -55,6 +55,17 @@ number of threads.
 Controls staleness of task information, which is used in scheduling. Larger values
 can reduce coordinator CPU load, but may result in suboptimal split scheduling.
 
+``task.max-drivers-per-task``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Minimum value:** ``1``
+* **Default Value:** ``2147483647``
+
+Controls the maximum number of drivers a task runs concurrently. Setting this value
+reduces the likelihood that a task uses too many drivers and can improve concurrent query
+performance. This can lead to resource waste if it runs too few concurrent queries.
+
 ``task.max-partial-aggregation-memory``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -89,6 +100,16 @@ each leaf task is guaranteed at least ``3`` running splits. Non-leaf tasks are a
 guaranteed to run in order to prevent deadlocks. A lower value may improve responsiveness
 for new tasks, but can result in underutilized resources. A higher value can increase
 resource utilization, but uses additional memory.
+
+``task.min-drivers-per-task``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``integer``
+* **Minimum value:** ``1``
+* **Default Value:** ``3``
+
+The minimum number of drivers guaranteed to run concurrently for a single task given
+the task has remaining splits to process.
 
 ``task.writer-count``
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
These config options were added back in 205 ([commit 1](https://github.com/trinodb/trino/commit/7d087ad20ac22ded87dda583bd351fd874bd0383), [commit 2](https://github.com/trinodb/trino/commit/da9b645c86dbd530c87ad9823356b3d9e40efda2)) but never made it into the documentation. 

Limiting `task.max-drivers-per-task` made a huge improvement to the throughput of our clusters, so I'd like to add these options to the documentation so that other users can discover them more easily.
