### PR TITLE
Show session timezone information in Query details UI 

### DIFF
--- a/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/core/trino-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -1206,6 +1206,14 @@ export class QueryDetail extends React.Component {
                             </tr>
                             <tr>
                                 <td className="info-title">
+                                    Time zone
+                                </td>
+                                <td className="info-text">
+                                    {query.session.timeZone}
+                                </td>
+                            </tr>
+                            <tr>
+                                <td className="info-title">
                                     Client Address
                                 </td>
                                 <td className="info-text">


### PR DESCRIPTION
Fixes #4196

Before
<img width="1195" alt="Query UI before this PR without timezone information" src="https://user-images.githubusercontent.com/29333147/118353073-6df3c400-b582-11eb-8a73-3cf13f672102.png">

After
<img width="1204" alt="Query UI after this PR with timezone information" src="https://user-images.githubusercontent.com/29333147/118353091-7ba94980-b582-11eb-811a-54fcf4163ec6.png">
