### PR TITLE
Upgrade provisio and trino-maven-plugin to allow building with JDK 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1641,7 +1641,7 @@
                 <plugin>
                     <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
                     <artifactId>provisio-maven-plugin</artifactId>
-                    <version>1.0.9</version>
+                    <version>1.0.16</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -1650,7 +1650,7 @@
             <plugin>
                 <groupId>io.trino</groupId>
                 <artifactId>trino-maven-plugin</artifactId>
-                <version>10</version>
+                <version>11</version>
                 <extensions>true</extensions>
             </plugin>
 


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/7901.

Requires a release of `trino-maven-plugin` which includes https://github.com/trinodb/trino-maven-plugin/pull/12.