### PR TITLE
Reset JWK http clients default configuration

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/InternalCommunicationModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/InternalCommunicationModule.java
@@ -28,6 +28,12 @@ public class InternalCommunicationModule
     {
         InternalCommunicationConfig internalCommunicationConfig = buildConfigObject(InternalCommunicationConfig.class);
         configBinder(binder).bindConfigGlobalDefaults(HttpClientConfig.class, config -> {
+            // Set defaults for all HttpClients in the same guice context
+            // so in case of any additions or alternations here an update in:
+            //   io.trino.server.security.jwt.JwtAuthenticatorSupportModule.JwkModule.configure
+            // and
+            //   io.trino.server.security.oauth2.OAuth2ServiceModule.setup
+            // may also be required.
             config.setHttp2Enabled(internalCommunicationConfig.isHttp2Enabled());
             config.setKeyStorePath(internalCommunicationConfig.getKeyStorePath());
             config.setKeyStorePassword(internalCommunicationConfig.getKeyStorePassword());

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
@@ -51,7 +51,17 @@ public class JwtAuthenticatorSupportModule
             binder.bind(SigningKeyResolver.class).to(JwkSigningKeyResolver.class).in(Scopes.SINGLETON);
             binder.bind(JwkService.class).in(Scopes.SINGLETON);
             httpClientBinder(binder)
-                    .bindHttpClient("jwk", ForJwk.class);
+                    .bindHttpClient("jwk", ForJwk.class)
+                    // Reset HttpClient default configuration to override InternalCommunicationModule changes.
+                    // Setting a keystore and/or a truststore for internal communication changes the default SSL configuration
+                    // for all clients in the same guice context. This, however, does not make sense for this client which will
+                    // very rarely use the same SSL setup as internal communication, so using the system default truststore
+                    // makes more sense.
+                    .withConfigDefaults(config -> config
+                            .setKeyStorePath(null)
+                            .setKeyStorePassword(null)
+                            .setTrustStorePath(null)
+                            .setTrustStorePassword(null));
         }
 
         // this module can be added multiple times, and this prevents multiple processing by Guice

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2ServiceModule.java
@@ -49,7 +49,17 @@ public class OAuth2ServiceModule
                 .setDefault()
                 .to(ScribeJavaOAuth2Client.class)
                 .in(Scopes.SINGLETON);
-        httpClientBinder(binder).bindHttpClient("oauth2-jwk", ForOAuth2.class);
+        httpClientBinder(binder)
+                .bindHttpClient("oauth2-jwk", ForOAuth2.class)
+                // Reset to defaults to override InternalCommunicationModule changes to this client default configuration.
+                // Setting a keystore and/or a truststore for internal communication changes the default SSL configuration
+                // for all clients in this guice context. This does not make sense for this client which will very rarely
+                // use the same SSL configuration, so using the system default truststore makes more sense.
+                .withConfigDefaults(config -> config
+                        .setKeyStorePath(null)
+                        .setKeyStorePassword(null)
+                        .setTrustStorePath(null)
+                        .setTrustStorePassword(null));
     }
 
     @Provides


### PR DESCRIPTION
Reset JWK http clients default configuration to override
InternalCommunicationModule changes.
Setting a keystore and/or a truststore for internal communication changes
the default SSL configuration for all clients in the same guice context.
This, however, does not make sense for JWK clients which will very rarely
use the same SSL setup as internal communication, so using the system
default keystore/truststore makes more sense.