### PR TITLE
Upgrade sql server jdbc driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1072,7 +1072,7 @@
             <dependency>
                 <groupId>com.microsoft.sqlserver</groupId>
                 <artifactId>mssql-jdbc</artifactId>
-                <version>8.4.1.jre8</version>
+                <version>9.2.1.jre8</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Version 9.2 is the latest general availability (GA) version
Release number: 9.2.1
Released: March 02, 2021