### PR TITLE
Clear pagesIndex in WindowOperator#close()

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -733,7 +733,7 @@ public class WindowOperator
             spiller = Optional.empty();
         }
 
-        void clear()
+        void clearIndexes()
         {
             inMemoryPagesIndexWithHashStrategies.pagesIndex.clear();
             mergedPagesIndexWithHashStrategies.pagesIndex.clear();
@@ -943,7 +943,7 @@ public class WindowOperator
     public void close()
     {
         driverWindowInfo.set(Optional.of(windowInfo.build()));
-        spillablePagesToPagesIndexes.ifPresent(SpillablePagesToPagesIndexes::clear);
+        spillablePagesToPagesIndexes.ifPresent(SpillablePagesToPagesIndexes::clearIndexes);
         spillablePagesToPagesIndexes.ifPresent(SpillablePagesToPagesIndexes::closeSpiller);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -733,6 +733,12 @@ public class WindowOperator
             spiller = Optional.empty();
         }
 
+        void clear()
+        {
+            inMemoryPagesIndexWithHashStrategies.pagesIndex.clear();
+            mergedPagesIndexWithHashStrategies.pagesIndex.clear();
+        }
+
         TransformationState<WorkProcessor<PagesIndexWithHashStrategies>> fullGroupBuffered()
         {
             // Convert revocable memory to user memory as inMemoryPagesIndexWithHashStrategies holds on to memory so we no longer can revoke
@@ -937,6 +943,7 @@ public class WindowOperator
     public void close()
     {
         driverWindowInfo.set(Optional.of(windowInfo.build()));
+        spillablePagesToPagesIndexes.ifPresent(SpillablePagesToPagesIndexes::clear);
         spillablePagesToPagesIndexes.ifPresent(SpillablePagesToPagesIndexes::closeSpiller);
     }
 }


### PR DESCRIPTION
In WindowOperator, spillablePagesToPagesIndexes is not cleared entirely after query failed due to exceptions(eg. ExceededMemoryLimitException), resulting in holding unnecessary data in memory.

From my local profiling result, if query is interrupted or failed due to exception during "unspill" stage, 
 mergedPagesIndexWithHashStrategies will not be cleared and still holding considerable memory.

This commit adds clearIndexes() function to SpillablePagesToPagesIndexes to clear underlying pagesIndex, and calls it in WindowOperator#close().