### PR TITLE
Create Parquet column readers only once

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/ParquetReader.java
@@ -121,6 +121,7 @@ public class ParquetReader
         this.options = requireNonNull(options, "options is null");
         this.columnReaders = new PrimitiveColumnReader[columns.size()];
         this.maxBytesPerCell = new long[columns.size()];
+        initializeColumnReaders();
 
         firstRowsOfBlocks.ifPresent(firstRows -> {
             checkArgument(blocks.size() == firstRows.size(), "elements of firstRowsOfBlocks must correspond to blocks");
@@ -188,7 +189,6 @@ public class ParquetReader
         firstRowIndexInGroup = firstRowsOfBlocks.map(firstRows -> firstRows.get(currentRowGroup));
         nextRowInGroup = 0L;
         currentGroupRowCount = currentBlockMetadata.getRowCount();
-        initializeColumnReaders();
         return true;
     }
 


### PR DESCRIPTION
Instead of creating the same ones for every row group