### PR TITLE
Don't print resolved plan when no group references

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/AbstractQueryAssertionsTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/AbstractQueryAssertionsTest.java
@@ -228,12 +228,6 @@ public abstract class AbstractQueryAssertionsTest
                                 "\n" +
                                 "] but found [\n" +
                                 "\n" +
-                                "Output[name]\n")
-                .hasMessageContaining(
-                        "\n" +
-                                "\n" +
-                                "] which resolves to [\n" +
-                                "\n" +
                                 "Output[name]\n");
     }
 
@@ -263,12 +257,6 @@ public abstract class AbstractQueryAssertionsTest
                                 "\n" +
                                 "] but found [\n" +
                                 "\n" +
-                                "Output[_col0]\n")
-                .hasMessageContaining(
-                        "\n" +
-                                "\n" +
-                                "] which resolves to [\n" +
-                                "\n" +
                                 "Output[_col0]\n");
     }
 
@@ -288,12 +276,6 @@ public abstract class AbstractQueryAssertionsTest
                         "\n" +
                                 "\n" +
                                 "] but found [\n" +
-                                "\n" +
-                                "Output[name]\n")
-                .hasMessageContaining(
-                        "\n" +
-                                "\n" +
-                                "] which resolves to [\n" +
                                 "\n" +
                                 "Output[name]\n");
     }


### PR DESCRIPTION
In a plan test (not a rule unit test) the resulting plan has no
`GroupReference` nodes, so it is usually useless to print a resolved
plan.

cc @martint @kasiafi @sopel39 