### PR TITLE
Deprecate TupleDomain.transform

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
@@ -438,6 +438,12 @@ public final class TupleDomain<T>
         });
     }
 
+    /**
+     * @deprecated This method is deprecated because it drops part of the {@link TupleDomain} information
+     * when mapping function inadvertenly returns null. Use {@link #filter(BiPredicate)} or {@link #transformDomains(BiFunction)}
+     * instead.
+     */
+    @Deprecated
     public <U> TupleDomain<U> transform(Function<T, U> function)
     {
         if (isNone()) {
@@ -452,6 +458,9 @@ public final class TupleDomain<T>
         for (Map.Entry<T, Domain> entry : domains.entrySet()) {
             U key = function.apply(entry.getKey());
 
+            // TODO null-friendliness here is a source of potential bugs, for example code like
+            //      converted = tupleDomain.transform(tableScan.getAssignments()::get)
+            //  silently drops information about correlated symbols.
             if (key == null) {
                 continue;
             }


### PR DESCRIPTION
The `TupleDomain.transform` exhibits null-friendly behavior where `null`
returned from mapping function indicates a particular domain should be
dropped. This can lead to a silent information loss for code like

    TupleDomain<Smbol> tupleDomain = ...;
    TupleDomain<ColumnHandle> converted = tupleDomain.transform(tableScan.getAssignments()::get)


cc @sopel39 @martint @kasiafi 