### PR TITLE
Add target pseudo css for anchors

### DIFF
--- a/docs/src/main/sphinx/static/trino.css
+++ b/docs/src/main/sphinx/static/trino.css
@@ -18,6 +18,20 @@ div.highlight {
     color: #F57C00;
 }
 
+.md-typeset span[id]:target:before {
+    display:block;
+    margin-top:-40px;
+    padding-top:40px;
+    content:"";
+}
+
+.md-typeset dl[id]:target:before {
+    display:block;
+    margin-top:-82px;
+    padding-top:82px;
+    content:"";
+}
+
 .md-nav__button img {
     height: 48px;
 }


### PR DESCRIPTION
This PR adds some additional css for elements that are used as `:ref:` anchors. 

It allows for the top navigation bar to not cover the anchor header. 

This can be tested by going to the `JKS Files` page and clicking on the `Java keystore (JKS)` link in the first sentence. This will bring you to the JKS entry in the glossary. This tests the `dl` `:target`

Also on the `JKS Files` page, clicking the `Configure the coordinator` link (if you scroll some). This tests the `span` `:target`