### PR TITLE
Add MySQL requirements

### DIFF
--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -6,6 +6,16 @@ The MySQL connector allows querying and creating tables in an external
 `MySQL <https://www.mysql.com/>`_ instance. This can be used to join data between different
 systems like MySQL and Hive, or between two different MySQL instances.
 
+Requirements
+------------
+
+Requirements for using the connector in a catalog to connect to a MySQL data
+source are:
+
+* MySQL 5.6, 5.7, 8.0 and higher
+* Network access, by default on port 3306, from the Trino coordinator and
+  workers to MySQL.
+
 Configuration
 -------------
 


### PR DESCRIPTION
JDBC driver version is 5.1.48, hence the version list

https://dev.mysql.com/doc/relnotes/connector-j/5.1/en/news-5-1-48.html

Also .. do we want to mention MariaDB ?
