### PR TITLE
Support string joining in SQL via LISTAGG clause

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionRegistry.java
@@ -287,6 +287,7 @@ import static io.trino.operator.aggregation.QuantileDigestAggregationFunction.QD
 import static io.trino.operator.aggregation.RealAverageAggregation.REAL_AVERAGE_AGGREGATION;
 import static io.trino.operator.aggregation.ReduceAggregationFunction.REDUCE_AGG;
 import static io.trino.operator.aggregation.arrayagg.ArrayAggregationFunction.ARRAY_AGG;
+import static io.trino.operator.aggregation.listagg.ListaggAggregationFunction.LISTAGG;
 import static io.trino.operator.aggregation.minmaxby.MaxByAggregationFunction.MAX_BY;
 import static io.trino.operator.aggregation.minmaxby.MinByAggregationFunction.MIN_BY;
 import static io.trino.operator.scalar.ArrayConcatFunction.ARRAY_CONCAT_FUNCTION;
@@ -563,6 +564,7 @@ public class FunctionRegistry
                 .function(ARRAY_CONCAT_FUNCTION)
                 .functions(ARRAY_CONSTRUCTOR, ARRAY_SUBSCRIPT, JSON_TO_ARRAY, JSON_STRING_TO_ARRAY)
                 .function(ARRAY_AGG)
+                .function(LISTAGG)
                 .functions(new MapSubscriptOperator())
                 .functions(MAP_CONSTRUCTOR, JSON_TO_MAP, JSON_STRING_TO_MAP)
                 .functions(new MapAggregationFunction(blockTypeOperators), new MapUnionAggregation(blockTypeOperators))

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AbstractGroupCollectionAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AbstractGroupCollectionAggregationState.java
@@ -158,7 +158,9 @@ public abstract class AbstractGroupCollectionAggregationState<T>
         short currentBlockId = headBlockIndex.get(getGroupId());
         int currentPosition = headPosition.get(getGroupId());
         while (currentBlockId != NULL) {
-            accept(consumer, values.get(currentBlockId), currentPosition);
+            if (!accept(consumer, values.get(currentBlockId), currentPosition)) {
+                break;
+            }
 
             long absoluteCurrentAddress = toAbsolutePosition(currentBlockId, currentPosition);
             currentBlockId = nextBlockIndex.get(absoluteCurrentAddress);
@@ -181,5 +183,5 @@ public abstract class AbstractGroupCollectionAggregationState<T>
         return sumPositions.get(blockId) + position;
     }
 
-    protected abstract void accept(T consumer, PageBuilder pageBuilder, int currentPosition);
+    protected abstract boolean accept(T consumer, PageBuilder pageBuilder, int currentPosition);
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/GroupArrayAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/GroupArrayAggregationState.java
@@ -39,8 +39,9 @@ public final class GroupArrayAggregationState
     }
 
     @Override
-    protected final void accept(ArrayAggregationStateConsumer consumer, PageBuilder pageBuilder, int currentPosition)
+    protected final boolean accept(ArrayAggregationStateConsumer consumer, PageBuilder pageBuilder, int currentPosition)
     {
         consumer.accept(pageBuilder.getBlockBuilder(VALUE_CHANNEL), currentPosition);
+        return true;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/GroupListaggAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/GroupListaggAggregationState.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.listagg;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.operator.aggregation.AbstractGroupCollectionAggregationState;
+import io.trino.spi.PageBuilder;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.Type;
+
+public final class GroupListaggAggregationState
+        extends AbstractGroupCollectionAggregationState<ListaggAggregationStateConsumer>
+        implements ListaggAggregationState
+{
+    private static final int MAX_BLOCK_SIZE = 1024 * 1024;
+    private static final int VALUE_CHANNEL = 0;
+
+    private Slice separator;
+    private boolean overflowError;
+    private Slice overflowFiller;
+    private boolean showOverflowEntryCount;
+
+    public GroupListaggAggregationState(Type valueType)
+    {
+        super(PageBuilder.withMaxPageSize(MAX_BLOCK_SIZE, ImmutableList.of(valueType)));
+    }
+
+    @Override
+    public void setSeparator(Slice separator)
+    {
+        this.separator = separator;
+    }
+
+    @Override
+    public Slice getSeparator()
+    {
+        return separator;
+    }
+
+    @Override
+    public void setOverflowFiller(Slice overflowFiller)
+    {
+        this.overflowFiller = overflowFiller;
+    }
+
+    @Override
+    public Slice getOverflowFiller()
+    {
+        return overflowFiller;
+    }
+
+    @Override
+    public void setOverflowError(boolean overflowError)
+    {
+        this.overflowError = overflowError;
+    }
+
+    @Override
+    public boolean isOverflowError()
+    {
+        return overflowError;
+    }
+
+    @Override
+    public void setShowOverflowEntryCount(boolean showOverflowEntryCount)
+    {
+        this.showOverflowEntryCount = showOverflowEntryCount;
+    }
+
+    @Override
+    public boolean showOverflowEntryCount()
+    {
+        return showOverflowEntryCount;
+    }
+
+    @Override
+    public final void add(Block block, int position)
+    {
+        prepareAdd();
+        appendAtChannel(VALUE_CHANNEL, block, position);
+    }
+
+    @Override
+    protected final boolean accept(ListaggAggregationStateConsumer consumer, PageBuilder pageBuilder, int currentPosition)
+    {
+        consumer.accept(pageBuilder.getBlockBuilder(VALUE_CHANNEL), currentPosition);
+        return true;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationFunction.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.listagg;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.airlift.bytecode.DynamicClassLoader;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.metadata.FunctionArgumentDefinition;
+import io.trino.metadata.FunctionBinding;
+import io.trino.metadata.FunctionMetadata;
+import io.trino.metadata.Signature;
+import io.trino.metadata.SqlAggregationFunction;
+import io.trino.operator.aggregation.AccumulatorCompiler;
+import io.trino.operator.aggregation.AggregationMetadata;
+import io.trino.operator.aggregation.AggregationMetadata.AccumulatorStateDescriptor;
+import io.trino.operator.aggregation.AggregationMetadata.ParameterMetadata;
+import io.trino.operator.aggregation.GenericAccumulatorFactoryBinder;
+import io.trino.operator.aggregation.InternalAggregationFunction;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AccumulatorState;
+import io.trino.spi.function.AccumulatorStateFactory;
+import io.trino.spi.function.AccumulatorStateSerializer;
+import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeSignature;
+import io.trino.spi.type.TypeSignatureParameter;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.metadata.FunctionKind.AGGREGATE;
+import static io.trino.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.BLOCK_INDEX;
+import static io.trino.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
+import static io.trino.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.NULLABLE_BLOCK_INPUT_CHANNEL;
+import static io.trino.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static io.trino.operator.aggregation.AggregationUtils.generateAggregationName;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_FUNCTION_MEMORY_LIMIT;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.util.Reflection.methodHandle;
+import static java.lang.String.format;
+
+public class ListaggAggregationFunction
+        extends SqlAggregationFunction
+{
+    public static final ListaggAggregationFunction LISTAGG = new ListaggAggregationFunction();
+    public static final String NAME = "listagg";
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(ListaggAggregationFunction.class, "input", Type.class, ListaggAggregationState.class, Block.class, Slice.class, boolean.class, Slice.class, boolean.class, int.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(ListaggAggregationFunction.class, "combine", Type.class, ListaggAggregationState.class, ListaggAggregationState.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(ListaggAggregationFunction.class, "output", Type.class, ListaggAggregationState.class, BlockBuilder.class);
+
+    private static final int MAX_OUTPUT_LENGTH = DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+    private static final int MAX_OVERFLOW_FILLER_LENGTH = 65_536;
+
+    private ListaggAggregationFunction()
+    {
+        super(
+                new FunctionMetadata(
+                        new Signature(
+                                NAME,
+                                ImmutableList.of(),
+                                ImmutableList.of(),
+                                VARCHAR.getTypeSignature(),
+                                ImmutableList.of(
+                                        new TypeSignature(StandardTypes.VARCHAR, TypeSignatureParameter.typeVariable("v")),
+                                        new TypeSignature(StandardTypes.VARCHAR, TypeSignatureParameter.typeVariable("d")),
+                                        BOOLEAN.getTypeSignature(),
+                                        new TypeSignature(StandardTypes.VARCHAR, TypeSignatureParameter.typeVariable("f")),
+                                        BOOLEAN.getTypeSignature()),
+                                false),
+                        true,
+                        ImmutableList.of(
+                                new FunctionArgumentDefinition(true),
+                                new FunctionArgumentDefinition(false),
+                                new FunctionArgumentDefinition(false),
+                                new FunctionArgumentDefinition(false),
+                                new FunctionArgumentDefinition(false)),
+                        false,
+                        true,
+                        "concatenates the input values with the specified separator",
+                        AGGREGATE),
+                true,
+                true);
+    }
+
+    @Override
+    public List<TypeSignature> getIntermediateTypes(FunctionBinding functionBinding)
+    {
+        return ImmutableList.of(new ListaggAggregationStateSerializer(VARCHAR).getSerializedType().getTypeSignature());
+    }
+
+    @Override
+    public InternalAggregationFunction specialize(FunctionBinding functionBinding)
+    {
+        return generateAggregation(VARCHAR);
+    }
+
+    private static InternalAggregationFunction generateAggregation(Type type)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(ListaggAggregationFunction.class.getClassLoader());
+
+        AccumulatorStateSerializer<?> stateSerializer = new ListaggAggregationStateSerializer(type);
+        AccumulatorStateFactory<?> stateFactory = new ListaggAggregationStateFactory(type);
+
+        List<Type> inputTypes = ImmutableList.of(VARCHAR, VARCHAR, BOOLEAN, VARCHAR, BOOLEAN);
+        Type outputType = VARCHAR;
+        Type intermediateType = stateSerializer.getSerializedType();
+        List<ParameterMetadata> inputParameterMetadata = ImmutableList.of(
+                new ParameterMetadata(STATE),
+                new ParameterMetadata(NULLABLE_BLOCK_INPUT_CHANNEL, type),
+                new ParameterMetadata(INPUT_CHANNEL, VARCHAR),
+                new ParameterMetadata(INPUT_CHANNEL, BOOLEAN),
+                new ParameterMetadata(INPUT_CHANNEL, VARCHAR),
+                new ParameterMetadata(INPUT_CHANNEL, BOOLEAN),
+                new ParameterMetadata(BLOCK_INDEX));
+
+        MethodHandle inputFunction = INPUT_FUNCTION.bindTo(type);
+        MethodHandle combineFunction = COMBINE_FUNCTION.bindTo(type);
+        MethodHandle outputFunction = OUTPUT_FUNCTION.bindTo(type);
+        Class<? extends AccumulatorState> stateInterface = ListaggAggregationState.class;
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                inputParameterMetadata,
+                inputFunction,
+                Optional.empty(),
+                combineFunction,
+                outputFunction,
+                ImmutableList.of(new AccumulatorStateDescriptor(
+                        stateInterface,
+                        stateSerializer,
+                        stateFactory)),
+                outputType);
+
+        GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
+        return new InternalAggregationFunction(NAME, inputTypes, ImmutableList.of(intermediateType), outputType, factory);
+    }
+
+    public static void input(Type type, ListaggAggregationState state, Block value, Slice separator, boolean overflowError, Slice overflowFiller, boolean showOverflowEntryCount, int position)
+    {
+        if (state.isEmpty()) {
+            if (overflowFiller.length() > MAX_OVERFLOW_FILLER_LENGTH) {
+                throw new TrinoException(INVALID_FUNCTION_ARGUMENT, format("Overflow filler length %d exceeds maximum length %d", overflowFiller.length(), MAX_OVERFLOW_FILLER_LENGTH));
+            }
+            // Set the parameters of the LISTAGG command within the state so that
+            // they can be used within the `output` function
+            state.setSeparator(separator);
+            state.setOverflowError(overflowError);
+            state.setOverflowFiller(overflowFiller);
+            state.setShowOverflowEntryCount(showOverflowEntryCount);
+        }
+        if (!value.isNull(position)) {
+            state.add(value, position);
+        }
+    }
+
+    public static void combine(Type type, ListaggAggregationState state, ListaggAggregationState otherState)
+    {
+        Slice previousSeparator = state.getSeparator();
+        if (previousSeparator == null) {
+            state.setSeparator(otherState.getSeparator());
+            state.setOverflowError(otherState.isOverflowError());
+            state.setOverflowFiller(otherState.getOverflowFiller());
+            state.setShowOverflowEntryCount(otherState.showOverflowEntryCount());
+        }
+
+        state.merge(otherState);
+    }
+
+    public static void output(Type type, ListaggAggregationState state, BlockBuilder out)
+    {
+        if (state.isEmpty()) {
+            out.appendNull();
+        }
+        else {
+            outputState(state, out, MAX_OUTPUT_LENGTH);
+        }
+    }
+
+    @VisibleForTesting
+    protected static void outputState(ListaggAggregationState state, BlockBuilder out, int maxOutputLength)
+    {
+        Slice separator = state.getSeparator();
+        int separatorLength = separator.length();
+        OutputContext context = new OutputContext();
+        state.forEach((block, position) -> {
+            int entryLength = block.getSliceLength(position);
+            int spaceRequired = entryLength + (context.emittedEntryCount > 0 ? separatorLength : 0);
+
+            if (context.outputLength + spaceRequired > maxOutputLength) {
+                context.overflow = true;
+                return false;
+            }
+
+            if (context.emittedEntryCount > 0) {
+                out.writeBytes(separator, 0, separatorLength);
+                context.outputLength += separatorLength;
+            }
+
+            block.writeBytesTo(position, 0, entryLength, out);
+            context.outputLength += entryLength;
+            context.emittedEntryCount++;
+
+            return true;
+        });
+
+        if (context.overflow) {
+            if (state.isOverflowError()) {
+                throw new TrinoException(EXCEEDED_FUNCTION_MEMORY_LIMIT, format("Concatenated string has the length in bytes larger than the maximum output length %d", maxOutputLength));
+            }
+
+            if (context.emittedEntryCount > 0) {
+                out.writeBytes(separator, 0, separatorLength);
+            }
+            out.writeBytes(state.getOverflowFiller(), 0, state.getOverflowFiller().length());
+
+            if (state.showOverflowEntryCount()) {
+                out.writeBytes(Slices.utf8Slice("("), 0, 1);
+                Slice count = Slices.utf8Slice(Integer.toString(state.getEntryCount() - context.emittedEntryCount));
+                out.writeBytes(count, 0, count.length());
+                out.writeBytes(Slices.utf8Slice(")"), 0, 1);
+            }
+        }
+
+        out.closeEntry();
+    }
+
+    private static class OutputContext
+    {
+        long outputLength;
+        int emittedEntryCount;
+        boolean overflow;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationState.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.listagg;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.block.Block;
+import io.trino.spi.function.AccumulatorState;
+
+public interface ListaggAggregationState
+        extends AccumulatorState
+{
+    void setSeparator(Slice separator);
+
+    Slice getSeparator();
+
+    void setOverflowFiller(Slice overflowFiller);
+
+    Slice getOverflowFiller();
+
+    void setOverflowError(boolean overflowError);
+
+    boolean isOverflowError();
+
+    void setShowOverflowEntryCount(boolean showOverflowEntryCount);
+
+    boolean showOverflowEntryCount();
+
+    void add(Block block, int position);
+
+    void forEach(ListaggAggregationStateConsumer consumer);
+
+    boolean isEmpty();
+
+    int getEntryCount();
+
+    default void merge(ListaggAggregationState otherState)
+    {
+        otherState.forEach((block, position) -> {
+            add(block, position);
+            return true;
+        });
+    }
+
+    default void reset()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationStateConsumer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationStateConsumer.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.listagg;
+
+import io.trino.spi.block.Block;
+
+public interface ListaggAggregationStateConsumer
+{
+    boolean accept(Block block, int position);
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationStateFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.listagg;
+
+import io.trino.spi.function.AccumulatorStateFactory;
+import io.trino.spi.type.Type;
+
+public class ListaggAggregationStateFactory
+        implements AccumulatorStateFactory<ListaggAggregationState>
+{
+    private final Type type;
+
+    public ListaggAggregationStateFactory(Type type)
+    {
+        this.type = type;
+    }
+
+    @Override
+    public ListaggAggregationState createSingleState()
+    {
+        return new SingleListaggAggregationState(type);
+    }
+
+    @Override
+    public Class<? extends ListaggAggregationState> getSingleStateClass()
+    {
+        return SingleListaggAggregationState.class;
+    }
+
+    @Override
+    public ListaggAggregationState createGroupedState()
+    {
+        return new GroupListaggAggregationState(type);
+    }
+
+    @Override
+    public Class<? extends ListaggAggregationState> getGroupedStateClass()
+    {
+        return GroupListaggAggregationState.class;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationStateSerializer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationStateSerializer.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.listagg;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.trino.spi.block.AbstractRowBlock;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.ColumnarRow;
+import io.trino.spi.function.AccumulatorStateSerializer;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.spi.block.ColumnarRow.toColumnarRow;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+public class ListaggAggregationStateSerializer
+        implements AccumulatorStateSerializer<ListaggAggregationState>
+{
+    private final Type elementType;
+    private final Type arrayType;
+    private final Type serializedType;
+
+    public ListaggAggregationStateSerializer(Type elementType)
+    {
+        this.elementType = elementType;
+        this.arrayType = new ArrayType(elementType);
+        this.serializedType = RowType.anonymous(ImmutableList.of(VARCHAR, BOOLEAN, VARCHAR, BOOLEAN, arrayType));
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return serializedType;
+    }
+
+    @Override
+    public void serialize(ListaggAggregationState state, BlockBuilder out)
+    {
+        if (state.isEmpty()) {
+            out.appendNull();
+        }
+        else {
+            BlockBuilder rowBlockBuilder = out.beginBlockEntry();
+            VARCHAR.writeSlice(rowBlockBuilder, state.getSeparator());
+            BOOLEAN.writeBoolean(rowBlockBuilder, state.isOverflowError());
+            VARCHAR.writeSlice(rowBlockBuilder, state.getOverflowFiller());
+            BOOLEAN.writeBoolean(rowBlockBuilder, state.showOverflowEntryCount());
+
+            BlockBuilder stateElementsBlockBuilder = rowBlockBuilder.beginBlockEntry();
+            state.forEach((block, position) -> {
+                elementType.appendTo(block, position, stateElementsBlockBuilder);
+                return true;
+            });
+            rowBlockBuilder.closeEntry();
+
+            out.closeEntry();
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, ListaggAggregationState state)
+    {
+        checkArgument(block instanceof AbstractRowBlock);
+        ColumnarRow columnarRow = toColumnarRow(block);
+
+        Slice separator = VARCHAR.getSlice(columnarRow.getField(0), index);
+        boolean overflowError = BOOLEAN.getBoolean(columnarRow.getField(1), index);
+        Slice overflowFiller = VARCHAR.getSlice(columnarRow.getField(2), index);
+        boolean showOverflowEntryCount = BOOLEAN.getBoolean(columnarRow.getField(3), index);
+        Block stateBlock = (Block) arrayType.getObject(columnarRow.getField(4), index);
+
+        state.reset();
+        state.setSeparator(separator);
+        state.setOverflowError(overflowError);
+        state.setOverflowFiller(overflowFiller);
+        state.setShowOverflowEntryCount(showOverflowEntryCount);
+        for (int i = 0; i < stateBlock.getPositionCount(); i++) {
+            state.add(stateBlock, i);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggArrayAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggArrayAggregationState.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.listagg;
+
+import io.trino.operator.aggregation.arrayagg.ArrayAggregationStateConsumer;
+import io.trino.spi.block.Block;
+import io.trino.spi.function.AccumulatorState;
+
+public interface ListaggArrayAggregationState
+        extends AccumulatorState
+{
+    void add(Block block, int position);
+
+    void forEach(ArrayAggregationStateConsumer consumer);
+
+    boolean isEmpty();
+
+    default void merge(ListaggArrayAggregationState otherState)
+    {
+        otherState.forEach(this::add);
+    }
+
+    default void reset()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/SingleListaggAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/SingleListaggAggregationState.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.listagg;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.Type;
+import org.openjdk.jol.info.ClassLayout;
+
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+
+public class SingleListaggAggregationState
+        implements ListaggAggregationState
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleListaggAggregationState.class).instanceSize();
+    private BlockBuilder blockBuilder;
+    private Slice separator;
+    private boolean overflowError;
+    private Slice overflowFiller;
+    private boolean showOverflowEntryCount;
+    private final Type type;
+
+    public SingleListaggAggregationState(Type type)
+    {
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @Override
+    public long getEstimatedSize()
+    {
+        long estimatedSize = INSTANCE_SIZE;
+        if (blockBuilder != null) {
+            estimatedSize += blockBuilder.getRetainedSizeInBytes();
+        }
+        return estimatedSize;
+    }
+
+    @Override
+    public void setSeparator(Slice separator)
+    {
+        this.separator = separator;
+    }
+
+    @Override
+    public Slice getSeparator()
+    {
+        return separator;
+    }
+
+    @Override
+    public void setOverflowFiller(Slice overflowFiller)
+    {
+        this.overflowFiller = overflowFiller;
+    }
+
+    @Override
+    public Slice getOverflowFiller()
+    {
+        return overflowFiller;
+    }
+
+    @Override
+    public void setOverflowError(boolean overflowError)
+    {
+        this.overflowError = overflowError;
+    }
+
+    @Override
+    public boolean isOverflowError()
+    {
+        return overflowError;
+    }
+
+    @Override
+    public void setShowOverflowEntryCount(boolean showOverflowEntryCount)
+    {
+        this.showOverflowEntryCount = showOverflowEntryCount;
+    }
+
+    @Override
+    public boolean showOverflowEntryCount()
+    {
+        return showOverflowEntryCount;
+    }
+
+    @Override
+    public void add(Block block, int position)
+    {
+        if (blockBuilder == null) {
+            blockBuilder = type.createBlockBuilder(null, 16);
+        }
+        type.appendTo(block, position, blockBuilder);
+    }
+
+    @Override
+    public void forEach(ListaggAggregationStateConsumer consumer)
+    {
+        if (blockBuilder == null) {
+            return;
+        }
+
+        for (int i = 0; i < blockBuilder.getPositionCount(); i++) {
+            if (!consumer.accept(blockBuilder, i)) {
+                break;
+            }
+        }
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        if (blockBuilder == null) {
+            return true;
+        }
+        verify(blockBuilder.getPositionCount() != 0);
+        return false;
+    }
+
+    @Override
+    public int getEntryCount()
+    {
+        if (blockBuilder == null) {
+            return 0;
+        }
+        return blockBuilder.getPositionCount();
+    }
+
+    @Override
+    public void reset()
+    {
+        separator = null;
+        overflowError = false;
+        overflowFiller = null;
+        showOverflowEntryCount = false;
+        blockBuilder = null;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/GroupedMultimapAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/GroupedMultimapAggregationState.java
@@ -41,8 +41,9 @@ public final class GroupedMultimapAggregationState
     }
 
     @Override
-    protected final void accept(MultimapAggregationStateConsumer consumer, PageBuilder pageBuilder, int currentPosition)
+    protected final boolean accept(MultimapAggregationStateConsumer consumer, PageBuilder pageBuilder, int currentPosition)
     {
         consumer.accept(pageBuilder.getBlockBuilder(KEY_CHANNEL), pageBuilder.getBlockBuilder(VALUE_CHANNEL), currentPosition);
+        return true;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -1120,6 +1120,18 @@ public class ExpressionAnalyzer
 
             List<TypeSignatureProvider> argumentTypes = getCallArgumentTypes(node.getArguments(), context);
 
+            if (QualifiedName.of("LISTAGG").equals(node.getName())) {
+                // Due to fact that the LISTAGG function is transformed out of pragmatic reasons
+                // in a synthetic function call, the type expression of this function call is evaluated
+                // explicitly here in order to make sure that it is a varchar.
+                List<Expression> arguments = node.getArguments();
+                Expression expression = arguments.get(0);
+                Type expressionType = process(expression, context);
+                if (!(expressionType instanceof VarcharType)) {
+                    throw semanticException(TYPE_MISMATCH, node, format("Expected expression of varchar, but '%s' has %s type", expression, expressionType.getDisplayName()));
+                }
+            }
+
             ResolvedFunction function;
             try {
                 function = metadata.resolveFunction(node.getName(), argumentTypes);

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestListagg.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestListagg.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation;
+
+import io.trino.metadata.Metadata;
+import io.trino.sql.tree.QualifiedName;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static io.trino.block.BlockAssertions.createBooleansBlock;
+import static io.trino.block.BlockAssertions.createStringsBlock;
+import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.operator.aggregation.AggregationTestUtils.assertAggregation;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+
+public class TestListagg
+{
+    private static final Metadata metadata = createTestMetadataManager();
+    private static final InternalAggregationFunction listagg = metadata.getAggregateFunctionImplementation(
+            metadata.resolveFunction(
+                    QualifiedName.of("listagg"),
+                    fromTypes(VARCHAR, VARCHAR, BOOLEAN, VARCHAR, BOOLEAN)));
+
+    @Test
+    public void testEmpty()
+    {
+        assertAggregation(
+                listagg,
+                null,
+                createStringsBlock(new String[] {null}),
+                createStringsBlock(","),
+                createBooleansBlock(true),
+                createStringsBlock("..."),
+                createBooleansBlock(false));
+    }
+
+    @Test
+    public void testOnlyNullValues()
+    {
+        assertAggregation(
+                listagg,
+                null,
+                createStringsBlock(null, null, null),
+                createStringsBlock(Collections.nCopies(3, ",")),
+                createBooleansBlock(Collections.nCopies(3, true)),
+                createStringsBlock(Collections.nCopies(3, "...")),
+                createBooleansBlock(Collections.nCopies(3, true)));
+    }
+
+    @Test
+    public void testOneValue()
+    {
+        assertAggregation(
+                listagg,
+                "value",
+                createStringsBlock("value"),
+                createStringsBlock(","),
+                createBooleansBlock(true),
+                createStringsBlock("..."),
+                createBooleansBlock(false));
+    }
+
+    @Test
+    public void testTwoValues()
+    {
+        assertAggregation(
+                listagg,
+                "value1,value2",
+                createStringsBlock("value1", "value2"),
+                createStringsBlock(Collections.nCopies(2, ",")),
+                createBooleansBlock(Collections.nCopies(2, true)),
+                createStringsBlock(Collections.nCopies(2, "...")),
+                createBooleansBlock(Collections.nCopies(2, true)));
+    }
+
+    @Test
+    public void testTwoValuesMixedWithNullValues()
+    {
+        assertAggregation(
+                listagg,
+                "value1,value2",
+                createStringsBlock(null, "value1", null, "value2", null),
+                createStringsBlock(Collections.nCopies(5, ",")),
+                createBooleansBlock(Collections.nCopies(5, true)),
+                createStringsBlock(Collections.nCopies(5, "...")),
+                createBooleansBlock(Collections.nCopies(5, true)));
+    }
+
+    @Test
+    public void testTwoValuesWithDefaultDelimiter()
+    {
+        assertAggregation(
+                listagg,
+                "value1value2",
+                createStringsBlock("value1", "value2"),
+                createStringsBlock(Collections.nCopies(2, "")),
+                createBooleansBlock(Collections.nCopies(2, true)),
+                createStringsBlock(Collections.nCopies(2, "...")),
+                createBooleansBlock(Collections.nCopies(2, true)));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/listagg/TestListaggAggregationFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/listagg/TestListaggAggregationFunction.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.listagg;
+
+import io.airlift.slice.Slice;
+import io.trino.block.BlockAssertions;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.VariableWidthBlockBuilder;
+import org.testcontainers.shaded.org.apache.commons.lang.StringUtils;
+import org.testng.annotations.Test;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.block.BlockAssertions.createStringsBlock;
+import static io.trino.spi.StandardErrorCode.EXCEEDED_FUNCTION_MEMORY_LIMIT;
+import static io.trino.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestListaggAggregationFunction
+{
+    @Test
+    public void testInputEmptyState()
+    {
+        SingleListaggAggregationState state = new SingleListaggAggregationState(VARCHAR);
+
+        String s = "value1";
+        Block value = createStringsBlock(s);
+        Slice separator = utf8Slice(",");
+        Slice overflowFiller = utf8Slice("...");
+        ListaggAggregationFunction.input(VARCHAR,
+                state,
+                value,
+                separator,
+                false,
+                overflowFiller,
+                true,
+                0);
+
+        assertFalse(state.isEmpty());
+        assertEquals(state.getSeparator(), separator);
+        assertFalse(state.isOverflowError());
+        assertEquals(state.getOverflowFiller(), overflowFiller);
+        assertTrue(state.showOverflowEntryCount());
+
+        BlockBuilder out = new VariableWidthBlockBuilder(null, 16, 128);
+        state.forEach((block, position) -> {
+            block.writeBytesTo(position, 0, block.getSliceLength(position), out);
+            return true;
+        });
+        out.closeEntry();
+        String result = (String) BlockAssertions.getOnlyValue(VARCHAR, out);
+        assertEquals(result, s);
+    }
+
+    @Test
+    public void testInputOverflowOverflowFillerTooLong()
+    {
+        String overflowFillerTooLong = StringUtils.repeat(".", 65_537);
+
+        SingleListaggAggregationState state = new SingleListaggAggregationState(VARCHAR);
+
+        assertThatThrownBy(() -> ListaggAggregationFunction.input(VARCHAR,
+                state,
+                createStringsBlock("value1"),
+                utf8Slice(","),
+                false,
+                utf8Slice(overflowFillerTooLong),
+                false,
+                0))
+                .isInstanceOf(TrinoException.class)
+                .matches(throwable -> ((TrinoException) throwable).getErrorCode() == INVALID_FUNCTION_ARGUMENT.toErrorCode());
+    }
+
+    @Test
+    public void testOutputStateSingleValue()
+    {
+        SingleListaggAggregationState state = createListaggAggregationState(",", true, "...", false,
+                "value1");
+        assertEquals(getOutputStateOnlyValue(state, 1024), "value1");
+    }
+
+    @Test
+    public void testOutputStateWithOverflowError()
+    {
+        SingleListaggAggregationState state = createListaggAggregationState("", true, "...", false,
+                "overflowvalue1", "overflowvalue2");
+
+        BlockBuilder out = new VariableWidthBlockBuilder(null, 16, 128);
+        assertThatThrownBy(() -> ListaggAggregationFunction.outputState(state, out, 20))
+                .isInstanceOf(TrinoException.class)
+                .matches(throwable -> ((TrinoException) throwable).getErrorCode() == EXCEEDED_FUNCTION_MEMORY_LIMIT.toErrorCode());
+    }
+
+    @Test
+    public void testOutputStateWithEmptyValues()
+    {
+        SingleListaggAggregationState state = createListaggAggregationState(",", true, "...", false,
+                "trino", "", "", "", "");
+        assertEquals(getOutputStateOnlyValue(state, 12), "trino,,,,");
+    }
+
+    @Test
+    public void testOutputStateWithEmptyDelimiter()
+    {
+        SingleListaggAggregationState state = createListaggAggregationState("", true, "...", false,
+                "value1", "value2");
+        assertEquals(getOutputStateOnlyValue(state, 12), "value1value2");
+    }
+
+    @Test
+    public void testOutputStateWithSeparatorSpecialUnicodeCharacter()
+    {
+        SingleListaggAggregationState state = createListaggAggregationState("♥", true, "...", false,
+                "Trino", "SQL", "on", "everything");
+        assertEquals(getOutputStateOnlyValue(state, 29), "Trino♥SQL♥on♥everything");
+    }
+
+    @Test
+    public void testOutputTruncatedStateFirstValueTooBigWithoutIndicationCount()
+    {
+        SingleListaggAggregationState state = createListaggAggregationState(",", false, "...", false,
+                "value1", "value2");
+
+        assertEquals(getOutputStateOnlyValue(state, 5), "...");
+    }
+
+    @Test
+    public void testOutputTruncatedStateLastDelimiterOmitted()
+    {
+        SingleListaggAggregationState state = createListaggAggregationState("###", false, "...", false,
+                "value1", "value2", "value3");
+        assertEquals(getOutputStateOnlyValue(state, 18), "value1###value2###...");
+        assertEquals(getOutputStateOnlyValue(state, 19), "value1###value2###...");
+        assertEquals(getOutputStateOnlyValue(state, 20), "value1###value2###...");
+        assertEquals(getOutputStateOnlyValue(state, 21), "value1###value2###...");
+        assertEquals(getOutputStateOnlyValue(state, 22), "value1###value2###...");
+    }
+
+    @Test
+    public void testOutputTruncatedStateWithoutIndicationCount()
+    {
+        SingleListaggAggregationState state = createListaggAggregationState(",", false, "...", false,
+                "value1", "value2");
+        assertEquals(getOutputStateOnlyValue(state, 9), "value1,...");
+        assertEquals(getOutputStateOnlyValue(state, 10), "value1,...");
+        assertEquals(getOutputStateOnlyValue(state, 11), "value1,...");
+        assertEquals(getOutputStateOnlyValue(state, 12), "value1,...");
+        assertEquals(getOutputStateOnlyValue(state, 13), "value1,value2");
+    }
+
+    @Test
+    public void testOutputTruncatedStateWithIndicationCount()
+    {
+        SingleListaggAggregationState state = createListaggAggregationState(",", false, "...", true,
+                "string1", "string2");
+        assertEquals(getOutputStateOnlyValue(state, 12), "string1,...(1)");
+        assertEquals(getOutputStateOnlyValue(state, 13), "string1,...(1)");
+        assertEquals(getOutputStateOnlyValue(state, 14), "string1,...(1)");
+    }
+
+    @Test
+    public void testOutputTruncatedStateWithIndicationCountAlphabet()
+    {
+        SingleListaggAggregationState state = createListaggAggregationState(",", false, "...", true,
+                "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "x", "y", "z");
+        assertEquals(getOutputStateOnlyValue(state, 13), "a,b,c,d,e,f,g,...(18)");
+        assertEquals(getOutputStateOnlyValue(state, 14), "a,b,c,d,e,f,g,...(18)");
+        assertEquals(getOutputStateOnlyValue(state, 15), "a,b,c,d,e,f,g,h,...(17)");
+        assertEquals(getOutputStateOnlyValue(state, 16), "a,b,c,d,e,f,g,h,...(17)");
+        assertEquals(getOutputStateOnlyValue(state, 17), "a,b,c,d,e,f,g,h,i,...(16)");
+        assertEquals(getOutputStateOnlyValue(state, 18), "a,b,c,d,e,f,g,h,i,...(16)");
+        assertEquals(getOutputStateOnlyValue(state, 19), "a,b,c,d,e,f,g,h,i,j,...(15)");
+        assertEquals(getOutputStateOnlyValue(state, 20), "a,b,c,d,e,f,g,h,i,j,...(15)");
+        assertEquals(getOutputStateOnlyValue(state, 21), "a,b,c,d,e,f,g,h,i,j,k,...(14)");
+    }
+
+    @Test
+    public void testOutputTruncatedStateWithIndicationCountComplexSeparator()
+    {
+        SingleListaggAggregationState state = createListaggAggregationState("###", false, "...", true,
+                "a", "b", "c", "dd", "e", "f", "g", "h", "i", "j", "k", "l");
+
+        assertEquals(getOutputStateOnlyValue(state, 100), "a###b###c###dd###e###f###g###h###i###j###k###l");
+        assertEquals(getOutputStateOnlyValue(state, 15), "a###b###c###dd###...(8)");
+        assertEquals(getOutputStateOnlyValue(state, 16), "a###b###c###dd###...(8)");
+        assertEquals(getOutputStateOnlyValue(state, 17), "a###b###c###dd###...(8)");
+        assertEquals(getOutputStateOnlyValue(state, 18), "a###b###c###dd###e###...(7)");
+        assertEquals(getOutputStateOnlyValue(state, 19), "a###b###c###dd###e###...(7)");
+        assertEquals(getOutputStateOnlyValue(state, 20), "a###b###c###dd###e###...(7)");
+        assertEquals(getOutputStateOnlyValue(state, 21), "a###b###c###dd###e###...(7)");
+    }
+
+    private static String getOutputStateOnlyValue(SingleListaggAggregationState state, int maxOutputLengthInBytes)
+    {
+        BlockBuilder out = new VariableWidthBlockBuilder(null, 32, 256);
+        ListaggAggregationFunction.outputState(state, out, maxOutputLengthInBytes);
+        return (String) BlockAssertions.getOnlyValue(VARCHAR, out);
+    }
+
+    private static SingleListaggAggregationState createListaggAggregationState(String separator, boolean overflowError, String overflowFiller, boolean showOverflowEntryCount, String... values)
+    {
+        SingleListaggAggregationState state = new SingleListaggAggregationState(VARCHAR);
+        state.setSeparator(utf8Slice(separator));
+        state.setOverflowError(overflowError);
+        state.setOverflowFiller(utf8Slice(overflowFiller));
+        state.setShowOverflowEntryCount(showOverflowEntryCount);
+        for (String value : values) {
+            state.add(createStringsBlock(value), 0);
+        }
+        return state;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestListagg.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestListagg.java
@@ -1,0 +1,397 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import io.trino.spi.TrinoException;
+import io.trino.sql.parser.ParsingException;
+import org.testcontainers.shaded.org.apache.commons.lang.StringUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static io.trino.spi.StandardErrorCode.EXCEEDED_FUNCTION_MEMORY_LIMIT;
+import static io.trino.spi.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestListagg
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testListaggQueryWithOneValue()
+    {
+        assertThat(assertions.query(
+                "SELECT listagg(value, ',') WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES 'a') t(value)"))
+                .matches("VALUES (VARCHAR 'a')");
+    }
+
+    @Test
+    public void testListaggQueryWithOneValueGrouping()
+    {
+        assertThat(assertions.query(
+                "SELECT id, listagg(value, ',') WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES (1, 'a')) t(id, value) " +
+                        "GROUP BY id " +
+                        "ORDER BY id "))
+                .matches("VALUES (1, VARCHAR 'a')");
+    }
+
+    @Test
+    public void testListaggQueryWithMultipleValues()
+    {
+        assertThat(assertions.query(
+                "SELECT listagg(value, ',') WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES 'a', 'bb', 'ccc', 'dddd') t(value) "))
+                .matches("VALUES (VARCHAR 'a,bb,ccc,dddd')");
+    }
+
+    @Test
+    public void testListaggQueryWithImplicitSeparator()
+    {
+        assertThat(assertions.query(
+                "SELECT listagg(value) WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES 'a', 'b', 'c') t(value) "))
+                .matches("VALUES (VARCHAR 'abc')");
+    }
+
+    @Test
+    public void testListaggQueryWithImplicitSeparatorGrouping()
+    {
+        assertThat(assertions.query(
+                "SELECT id, listagg(value) WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES " +
+                        "         (1, 'c'), " +
+                        "         (2, 'b'), " +
+                        "         (1, 'a')," +
+                        "         (2, 'd')" +
+                        "     )  t(id, value) " +
+                        "GROUP BY id " +
+                        "ORDER BY id "))
+                .matches("VALUES " +
+                        "        (1, VARCHAR 'ac')," +
+                        "        (2, VARCHAR 'bd')");
+    }
+
+    @Test
+    public void testListaggQueryWithMultipleValuesOrderedDescending()
+    {
+        assertThat(assertions.query(
+                "SELECT listagg(value, ',') WITHIN GROUP (ORDER BY value DESC) " +
+                        "FROM (VALUES 'a', 'bb', 'ccc', 'dddd') t(value) "))
+                .matches("VALUES (VARCHAR 'dddd,ccc,bb,a')");
+    }
+
+    @Test
+    public void testListaggQueryWithMultipleValuesMultipleSortItems()
+    {
+        assertThat(assertions.query(
+                "SELECT listagg(value, ',') WITHIN GROUP (ORDER BY sortitem1, sortitem2) " +
+                        "FROM (VALUES (2, 'C', 'ccc'), (2, 'B', 'bb'), (3, 'D', 'dddd'), (1, 'A', 'a')) t(sortitem1, sortitem2, value) "))
+                .matches("VALUES (VARCHAR 'a,bb,ccc,dddd')");
+    }
+
+    @Test
+    public void testListaggQueryWithMultipleValuesMultipleSortItemsGrouping()
+    {
+        assertThat(assertions.query(
+                "SELECT id, listagg(value, ',') WITHIN GROUP (ORDER BY weight, label) " +
+                        "FROM (VALUES (1, 200, 'C', 'ccc'), (1, 200, 'B', 'bb'), (2, 300, 'D', 'dddd'), (1, 100, 'A', 'a')) t(id, weight, label, value) " +
+                        "GROUP BY id " +
+                        "ORDER BY id "))
+                .matches("VALUES (1, VARCHAR 'a,bb,ccc')," +
+                        "        (2, VARCHAR 'dddd')");
+    }
+
+    @Test
+    public void testListaggQueryWithFunctionExpression()
+    {
+        assertThat(assertions.query(
+                "SELECT listagg(upper(value), ' ') WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES 'Trino', 'SQL', 'everything') t(value) "))
+                .matches("VALUES (VARCHAR 'SQL TRINO EVERYTHING')");
+    }
+
+    @Test
+    public void testListaggQueryWithNullValues()
+    {
+        assertThat(assertions.query(
+                "SELECT listagg(value, ',') WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES 'a', NULL, 'bb', NULL, 'ccc', NULL, 'dddd', NULL) t(value) "))
+                .matches("VALUES (VARCHAR 'a,bb,ccc,dddd')");
+    }
+
+    @Test
+    public void testListaggQueryWithNullValuesGrouping()
+    {
+        assertThat(assertions.query(
+                "SELECT id, listagg(value, ',') WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES " +
+                        "             (1, 'a'), " +
+                        "             (2, NULL), " +
+                        "             (3, 'bb'), " +
+                        "             (1, NULL), " +
+                        "             (1, 'ccc'), " +
+                        "             (2, NULL), " +
+                        "             (3, 'dddd'), " +
+                        "             (2, NULL)" +
+                        "     ) t(id, value) " +
+                        "GROUP BY id " +
+                        "ORDER BY id "))
+                .matches("VALUES (1, VARCHAR 'a,ccc')," +
+                        "        (2, NULL)," +
+                        "        (3, VARCHAR 'bb,dddd')");
+    }
+
+    @Test
+    public void testListaggQueryIncorrectSyntax()
+    {
+        // missing WITHIN GROUP (ORDER BY ...)
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT listagg(value, ',') " +
+                        "FROM (VALUES 'a') t(value)"))
+                .isInstanceOf(ParsingException.class)
+                .hasMessage("line 1:28: mismatched input 'FROM'. Expecting: 'WITHIN'");
+
+        // missing WITHIN GROUP (ORDER BY ...)
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT listagg(value) " +
+                        "FROM (VALUES 'a') t(value)"))
+                .isInstanceOf(ParsingException.class)
+                .hasMessage("line 1:23: mismatched input 'FROM'. Expecting: 'WITHIN'");
+
+        // too many arguments
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT listagg(value, ',', '...') WITHIN GROUP (ORDER BY value)" +
+                        "FROM (VALUES 'a') t(value)"))
+                .isInstanceOf(ParsingException.class)
+                .hasMessage("line 1:26: mismatched input ','. Expecting: ')', 'ON'");
+
+        // window frames are not supported
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT listagg(value, ',') WITHIN GROUP (ORDER BY value) OVER (PARTITION BY id)" +
+                        "FROM (VALUES (1, 'a')) t(id, value)"))
+                .isInstanceOf(ParsingException.class)
+                .hasMessage("line 1:63: mismatched input '('. Expecting: ',', 'EXCEPT', 'FETCH', 'FROM', 'GROUP', 'HAVING', 'INTERSECT', 'LIMIT', 'OFFSET', 'ORDER', 'UNION', 'WHERE', 'WINDOW', <EOF>");
+
+        // invalid argument for ON OVERFLOW clause
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT listagg(value, ',' ON OVERFLOW COLLAPSE) WITHIN GROUP (ORDER BY value)" +
+                        "FROM (VALUES 'a') t(value)"))
+                .isInstanceOf(ParsingException.class)
+                .hasMessage("line 1:39: mismatched input 'COLLAPSE'. Expecting: 'ERROR', 'TRUNCATE'");
+
+        // invalid separator type (integer instead of varchar)
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT LISTAGG(value, 123) WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES 'Trino', 'SQL', 'everything') t(value) "))
+                .isInstanceOf(ParsingException.class)
+                .hasMessage("line 1:23: mismatched input '123'. Expecting: <string>");
+
+        // invalid truncation filler type (integer instead of varchar)
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT LISTAGG(value, ',' ON OVERFLOW TRUNCATE 1234567890 WITHOUT COUNT) WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES 'Trino', 'SQL', 'everything') t(value) "))
+                .isInstanceOf(ParsingException.class)
+                .hasMessage("line 1:48: mismatched input '1234567890'. Expecting: 'WITH', 'WITHOUT', <string>");
+    }
+
+    @Test
+    public void testListaggQueryIncorrectExpression()
+    {
+        // integer values
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT listagg(value, ',') WITHIN GROUP (ORDER BY value)" +
+                        "FROM (VALUES 1, NULL, 2, 3, 4) t(value)"))
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("line 1:8: Expected expression of varchar, but 'value' has integer type");
+
+        // boolean values
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT listagg(value, ',') WITHIN GROUP (ORDER BY value)" +
+                        "FROM (VALUES TRUE, NULL, FALSE, FALSE, TRUE) t(value)"))
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("line 1:8: Expected expression of varchar, but 'value' has boolean type");
+
+        // array values
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT listagg(value, ',') WITHIN GROUP (ORDER BY value)" +
+                        "FROM (VALUES array['abc', 'def'], array['sql']) t(value)"))
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("line 1:8: Expected expression of varchar, but 'value' has array(varchar(3)) type");
+    }
+
+    @Test
+    public void testListaaggQueryIncorrectOrderByExpression()
+    {
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT listagg(label, ',') WITHIN GROUP (ORDER BY rgb) " +
+                        "FROM (VALUES ('red', rgb(255, 0, 0)), ('green', rgb(0, 128, 0)), ('blue', rgb(0, 0, 255))) color(label, rgb) "))
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("line 1:8: ORDER BY can only be applied to orderable types (actual: color)");
+    }
+
+    @Test
+    public void testListaggQueryWithExplicitlyCastedNumericValues()
+    {
+        assertThat(assertions.query(
+                "SELECT listagg(try_cast(value as varchar), ',') WITHIN GROUP (ORDER BY value)" +
+                        "FROM (VALUES 1, NULL, 2, 3, 4) t(value)"))
+                .matches("VALUES (VARCHAR '1,2,3,4')");
+    }
+
+    @Test
+    public void testListaggQueryWithDistinct()
+    {
+        assertThat(assertions.query(
+                "SELECT listagg( DISTINCT value, ',') WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES  'a', 'b', 'a', 'b', 'c', 'd', 'd', 'a', 'd', 'b', 'd') t(value)"))
+                .matches("VALUES (VARCHAR 'a,b,c,d')");
+    }
+
+    @Test
+    public void testListaggQueryWithDistinctGrouping()
+    {
+        assertThat(assertions.query(
+                "SELECT id, listagg( DISTINCT value, ',') WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES  " +
+                        "          (1, 'a'), " +
+                        "          (1, 'b'), " +
+                        "          (1, 'a'), " +
+                        "          (2, 'b'), " +
+                        "          (1, 'c'), " +
+                        "          (1, 'd'), " +
+                        "          (2, 'd'), " +
+                        "          (1, 'a'), " +
+                        "          (2, 'd'), " +
+                        "          (2, 'b'), " +
+                        "          (1, 'd')" +
+                        "    ) t(id, value) " +
+                        "GROUP BY id " +
+                        "ORDER BY id "))
+                .matches("VALUES (1, VARCHAR 'a,b,c,d')," +
+                        "        (2, VARCHAR 'b,d')");
+    }
+
+    @Test
+    public void testListaggQueryWithMultipleValuesWithDefaultSeparator()
+    {
+        assertThat(assertions.query(
+                "SELECT listagg(value) WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES 'a', 'bb', 'ccc', 'dddd') t(value) "))
+                .matches("VALUES (VARCHAR 'abbcccdddd')");
+    }
+
+    @Test
+    public void testListaggQueryWithOrderingAndGrouping()
+    {
+        assertThat(assertions.query("SELECT id, LISTAGG(value, ',') WITHIN GROUP (ORDER BY value) " +
+                "          FROM (VALUES " +
+                "                   (1, 'a'), " +
+                "                   (1, 'b'), " +
+                "                   (2, 'd'), " +
+                "                   (2, 'c') " +
+                "               ) t(id, value)" +
+                "          GROUP BY id" +
+                "          ORDER BY id"))
+                .matches("VALUES     " +
+                        "     (1, VARCHAR 'a,b')," +
+                        "     (2, VARCHAR 'c,d')");
+    }
+
+    @Test
+    public void testListaggQueryOverflowError()
+    {
+        String tooLargeValue = StringUtils.repeat("a", DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT LISTAGG(value, ',' ON OVERFLOW ERROR) WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES '" + tooLargeValue + "','Trino') t(value) "))
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("Concatenated string has the length in bytes larger than the maximum output length 1048576")
+                .matches(throwable -> ((TrinoException) throwable).getErrorCode() == EXCEEDED_FUNCTION_MEMORY_LIMIT.toErrorCode());
+    }
+
+    @Test
+    public void testListaggQueryOverflowErrorGrouping()
+    {
+        String tooLargeValue = StringUtils.repeat("a", DEFAULT_MAX_PAGE_SIZE_IN_BYTES);
+        assertThatThrownBy(() -> assertions.query(
+                "SELECT id, LISTAGG(value, ',' ON OVERFLOW ERROR) WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES " +
+                        "           (1, '" + tooLargeValue + "')," +
+                        "           (1, 'Trino')," +
+                        "           (2, 'SQL')" +
+                        "     ) t(id, value) " +
+                        "GROUP BY id " +
+                        "ORDER BY id "))
+                .isInstanceOf(TrinoException.class)
+                .hasMessage("Concatenated string has the length in bytes larger than the maximum output length 1048576")
+                .matches(throwable -> ((TrinoException) throwable).getErrorCode() == EXCEEDED_FUNCTION_MEMORY_LIMIT.toErrorCode());
+    }
+
+    @Test
+    public void testListaggQueryOverflowTruncateWithoutCountAndWithoutOverflowFiller()
+    {
+        String largeValue = StringUtils.repeat("a", DEFAULT_MAX_PAGE_SIZE_IN_BYTES - 6);
+        assertThat(assertions.query(
+                "SELECT LISTAGG(value, ',' ON OVERFLOW TRUNCATE WITHOUT COUNT) WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES '" + largeValue + "', 'trino', 'rocks') t(value) "))
+                .matches("VALUES (VARCHAR '" + largeValue + ",rocks,...')");
+    }
+
+    @Test
+    public void testListaggQueryOverflowTruncateWithCountAndWithOverflowFiller()
+    {
+        String largeValue = StringUtils.repeat("a", DEFAULT_MAX_PAGE_SIZE_IN_BYTES - 12);
+        assertThat(assertions.query(
+                "SELECT LISTAGG(value, ',' ON OVERFLOW TRUNCATE '.....' WITH COUNT) WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES '" + largeValue + "', 'trino', 'sql', 'everything') t(value) "))
+                .matches("VALUES (VARCHAR '" + largeValue + ",everything,.....(2)')");
+    }
+
+    @Test
+    public void testListaggQueryGroupingOverflowTruncateWithCountAndWithOverflowFiller()
+    {
+        String largeValue = StringUtils.repeat("a", DEFAULT_MAX_PAGE_SIZE_IN_BYTES - 12);
+        assertThat(assertions.query(
+                "SELECT id, LISTAGG(value, ',' ON OVERFLOW TRUNCATE '.....' WITH COUNT) WITHIN GROUP (ORDER BY value) " +
+                        "FROM (VALUES " +
+                        "             (1, '" + largeValue + "'), " +
+                        "             (1, 'trino'), " +
+                        "             (1, 'sql'), " +
+                        "             (1, 'everything'), " +
+                        "             (2, 'listagg'), " +
+                        "             (2, 'string joiner') " +
+                        "     ) t(id, value) " +
+                        "GROUP BY id " +
+                        "ORDER BY id "))
+                .matches("VALUES " +
+                        "   (1, VARCHAR '" + largeValue + ",everything,.....(2)')," +
+                        "   (2, VARCHAR 'listagg,string joiner')");
+    }
+}

--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -303,6 +303,16 @@ sampleType
     | SYSTEM
     ;
 
+listAggOverflowBehavior
+    : ERROR
+    | TRUNCATE string? listaggCountIndication
+    ;
+
+listaggCountIndication
+    : WITH COUNT
+    | WITHOUT COUNT
+    ;
+
 patternRecognition
     : aliasedRelation (
         MATCH_RECOGNIZE '('
@@ -411,6 +421,9 @@ primaryExpression
     | POSITION '(' valueExpression IN valueExpression ')'                                 #position
     | '(' expression (',' expression)+ ')'                                                #rowConstructor
     | ROW '(' expression (',' expression)* ')'                                            #rowConstructor
+    | name=LISTAGG '(' setQuantifier? expression (',' string)?
+        (ON OVERFLOW listAggOverflowBehavior)? ')'
+        (WITHIN GROUP '(' ORDER BY sortItem (',' sortItem)* ')')                          #listagg
     | qualifiedName '(' ASTERISK ')' filter? over?                                        #functionCall
     | processingMode? qualifiedName '(' (setQuantifier? expression (',' expression)*)?
         (ORDER BY sortItem (',' sortItem)*)? ')' filter? (nullTreatment? over)?           #functionCall
@@ -659,9 +672,9 @@ nonReserved
     // IMPORTANT: this rule must only contain tokens. Nested rules are not supported. See SqlParser.exitNonReserved
     : ADD | ADMIN | AFTER | ALL | ANALYZE | ANY | ARRAY | ASC | AT | AUTHORIZATION
     | BERNOULLI
-    | CALL | CASCADE | CATALOGS | COLUMN | COLUMNS | COMMENT | COMMIT | COMMITTED | CURRENT
+    | CALL | CASCADE | CATALOGS | COLUMN | COLUMNS | COMMENT | COMMIT | COMMITTED | COUNT | CURRENT
     | DATA | DATE | DAY | DEFINE | DEFINER | DESC | DISTRIBUTED | DOUBLE
-    | EMPTY | EXCLUDING | EXPLAIN
+    | EMPTY | ERROR | EXCLUDING | EXPLAIN
     | FETCH | FILTER | FINAL | FIRST | FOLLOWING | FORMAT | FUNCTIONS
     | GRANT | GRANTED | GRANTS | GRAPHVIZ | GROUPS
     | HOUR
@@ -670,15 +683,15 @@ nonReserved
     | LAST | LATERAL | LEVEL | LIMIT | LOCAL | LOGICAL
     | MAP | MATCH | MATCHED | MATCHES | MATCH_RECOGNIZE | MATERIALIZED | MEASURES | MERGE | MINUTE | MONTH
     | NEXT | NFC | NFD | NFKC | NFKD | NO | NONE | NULLIF | NULLS
-    | OFFSET | OMIT | ONE | ONLY | OPTION | ORDINALITY | OUTPUT | OVER
+    | OFFSET | OMIT | ONE | ONLY | OPTION | ORDINALITY | OUTPUT | OVER | OVERFLOW
     | PARTITION | PARTITIONS | PAST | PATH | PATTERN | PER | PERMUTE | POSITION | PRECEDING | PRECISION | PRIVILEGES | PROPERTIES
     | RANGE | READ | REFRESH | RENAME | REPEATABLE | REPLACE | RESET | RESPECT | RESTRICT | REVOKE | ROLE | ROLES | ROLLBACK | ROW | ROWS | RUNNING
     | SCHEMA | SCHEMAS | SECOND | SECURITY | SEEK | SERIALIZABLE | SESSION | SET | SETS
     | SHOW | SOME | START | STATS | SUBSET | SUBSTRING | SYSTEM
-    | TABLES | TABLESAMPLE | TEXT | TIES | TIME | TIMESTAMP | TO | TRANSACTION | TRY_CAST | TYPE
+    | TABLES | TABLESAMPLE | TEXT | TIES | TIME | TIMESTAMP | TO | TRANSACTION | TRUNCATE | TRY_CAST | TYPE
     | UNBOUNDED | UNCOMMITTED | UNMATCHED | UPDATE | USE | USER
     | VALIDATE | VERBOSE | VIEW
-    | WINDOW | WITHOUT | WORK | WRITE
+    | WINDOW | WITHIN | WITHOUT | WORK | WRITE
     | YEAR
     | ZONE
     ;
@@ -710,6 +723,7 @@ COMMENT: 'COMMENT';
 COMMIT: 'COMMIT';
 COMMITTED: 'COMMITTED';
 CONSTRAINT: 'CONSTRAINT';
+COUNT: 'COUNT';
 CREATE: 'CREATE';
 CROSS: 'CROSS';
 CUBE: 'CUBE';
@@ -738,6 +752,7 @@ DROP: 'DROP';
 ELSE: 'ELSE';
 EMPTY: 'EMPTY';
 END: 'END';
+ERROR: 'ERROR';
 ESCAPE: 'ESCAPE';
 EXCEPT: 'EXCEPT';
 EXCLUDING: 'EXCLUDING';
@@ -788,6 +803,7 @@ LEFT: 'LEFT';
 LEVEL: 'LEVEL';
 LIKE: 'LIKE';
 LIMIT: 'LIMIT';
+LISTAGG: 'LISTAGG';
 LOCAL: 'LOCAL';
 LOCALTIME: 'LOCALTIME';
 LOCALTIMESTAMP: 'LOCALTIMESTAMP';
@@ -827,6 +843,7 @@ ORDINALITY: 'ORDINALITY';
 OUTER: 'OUTER';
 OUTPUT: 'OUTPUT';
 OVER: 'OVER';
+OVERFLOW: 'OVERFLOW';
 PARTITION: 'PARTITION';
 PARTITIONS: 'PARTITIONS';
 PAST: 'PAST';
@@ -887,6 +904,7 @@ TIMESTAMP: 'TIMESTAMP';
 TO: 'TO';
 TRANSACTION: 'TRANSACTION';
 TRUE: 'TRUE';
+TRUNCATE: 'TRUNCATE';
 TRY_CAST: 'TRY_CAST';
 TYPE: 'TYPE';
 UESCAPE: 'UESCAPE';
@@ -907,6 +925,7 @@ WHEN: 'WHEN';
 WHERE: 'WHERE';
 WINDOW: 'WINDOW';
 WITH: 'WITH';
+WITHIN: 'WITHIN';
 WITHOUT: 'WITHOUT';
 WORK: 'WORK';
 WRITE: 'WRITE';

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -74,6 +74,7 @@ import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.NumericParameter;
 import io.trino.sql.tree.OrderBy;
 import io.trino.sql.tree.Parameter;
+import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.QuantifiedComparisonExpression;
 import io.trino.sql.tree.Rollup;
 import io.trino.sql.tree.Row;
@@ -380,6 +381,10 @@ public final class ExpressionFormatter
         @Override
         protected String visitFunctionCall(FunctionCall node, Void context)
         {
+            if (QualifiedName.of("LISTAGG").equals(node.getName())) {
+                return visitListagg(node);
+            }
+
             StringBuilder builder = new StringBuilder();
 
             if (node.getProcessingMode().isPresent()) {
@@ -786,6 +791,62 @@ public final class ExpressionFormatter
             return Joiner.on(", ").join(expressions.stream()
                     .map((e) -> process(e, null))
                     .iterator());
+        }
+
+        /**
+         * Returns the formatted `LISTAGG` function call corresponding to the specified node.
+         *
+         * During the parsing of the syntax tree, the `LISTAGG` expression is synthetically converted
+         * to a function call. This method formats the specified {@link FunctionCall} node to correspond
+         * to the standardised syntax of the `LISTAGG` expression.
+         *
+         * @param node the `LISTAGG` function call
+         */
+        private String visitListagg(FunctionCall node)
+        {
+            StringBuilder builder = new StringBuilder();
+
+            List<Expression> arguments = node.getArguments();
+            Expression expression = arguments.get(0);
+            Expression separator = arguments.get(1);
+            BooleanLiteral overflowError = (BooleanLiteral) arguments.get(2);
+            Expression overflowFiller = arguments.get(3);
+            BooleanLiteral showOverflowEntryCount = (BooleanLiteral) arguments.get(4);
+
+            String innerArguments = joinExpressions(ImmutableList.of(expression, separator));
+            if (node.isDistinct()) {
+                innerArguments = "DISTINCT " + innerArguments;
+            }
+
+            builder.append("LISTAGG")
+                    .append('(').append(innerArguments);
+
+            builder.append(" ON OVERFLOW ");
+            if (overflowError.getValue()) {
+                builder.append(" ERROR");
+            }
+            else {
+                builder.append(" TRUNCATE")
+                        .append(' ')
+                        .append(process(overflowFiller, null));
+                if (showOverflowEntryCount.getValue()) {
+                    builder.append(" WITH COUNT");
+                }
+                else {
+                    builder.append(" WITHOUT COUNT");
+                }
+            }
+
+            builder.append(')');
+
+            if (node.getOrderBy().isPresent()) {
+                builder.append(" WITHIN GROUP ")
+                        .append('(')
+                        .append(formatOrderBy(node.getOrderBy().get()))
+                        .append(')');
+            }
+
+            return builder.toString();
         }
     }
 

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -3423,6 +3423,112 @@ public class TestSqlParser
                         Optional.empty()));
     }
 
+    @Test
+    public void testListagg()
+    {
+        assertExpression("LISTAGG(x) WITHIN GROUP (ORDER BY x)",
+                new FunctionCall(
+                        Optional.empty(),
+                        QualifiedName.of("LISTAGG"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.of(new OrderBy(ImmutableList.of(new SortItem(new Identifier("x", false), ASCENDING, UNDEFINED)))),
+                        false,
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(
+                                identifier("x"),
+                                new StringLiteral(""),
+                                new BooleanLiteral("true"),
+                                new StringLiteral("..."),
+                                new BooleanLiteral("false"))));
+
+        assertExpression("LISTAGG( DISTINCT x) WITHIN GROUP (ORDER BY x)",
+                new FunctionCall(
+                        Optional.empty(),
+                        QualifiedName.of("LISTAGG"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.of(new OrderBy(ImmutableList.of(new SortItem(new Identifier("x", false), ASCENDING, UNDEFINED)))),
+                        true,
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(
+                                identifier("x"),
+                                new StringLiteral(""),
+                                new BooleanLiteral("true"),
+                                new StringLiteral("..."),
+                                new BooleanLiteral("false"))));
+
+        assertExpression("LISTAGG(x, ',') WITHIN GROUP (ORDER BY y)",
+                new FunctionCall(
+                        Optional.empty(),
+                        QualifiedName.of("LISTAGG"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.of(new OrderBy(ImmutableList.of(new SortItem(new Identifier("y", false), ASCENDING, UNDEFINED)))),
+                        false,
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(
+                                identifier("x"),
+                                new StringLiteral(","),
+                                new BooleanLiteral("true"),
+                                new StringLiteral("..."),
+                                new BooleanLiteral("false"))));
+
+        assertExpression("LISTAGG(x, ',' ON OVERFLOW ERROR) WITHIN GROUP (ORDER BY x)",
+                new FunctionCall(
+                        Optional.empty(),
+                        QualifiedName.of("LISTAGG"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.of(new OrderBy(ImmutableList.of(new SortItem(new Identifier("x", false), ASCENDING, UNDEFINED)))),
+                        false,
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(
+                                identifier("x"),
+                                new StringLiteral(","),
+                                new BooleanLiteral("true"),
+                                new StringLiteral("..."),
+                                new BooleanLiteral("false"))));
+
+        assertExpression("LISTAGG(x, ',' ON OVERFLOW TRUNCATE WITH COUNT) WITHIN GROUP (ORDER BY x)",
+                new FunctionCall(
+                        Optional.empty(),
+                        QualifiedName.of("LISTAGG"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.of(new OrderBy(ImmutableList.of(new SortItem(new Identifier("x", false), ASCENDING, UNDEFINED)))),
+                        false,
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(
+                                identifier("x"),
+                                new StringLiteral(","),
+                                new BooleanLiteral("false"),
+                                new StringLiteral("..."),
+                                new BooleanLiteral("true"))));
+
+        assertExpression("LISTAGG(x, ',' ON OVERFLOW TRUNCATE 'HIDDEN' WITHOUT COUNT) WITHIN GROUP (ORDER BY x)",
+                new FunctionCall(
+                        Optional.empty(),
+                        QualifiedName.of("LISTAGG"),
+                        Optional.empty(),
+                        Optional.empty(),
+                        Optional.of(new OrderBy(ImmutableList.of(new SortItem(new Identifier("x", false), ASCENDING, UNDEFINED)))),
+                        false,
+                        Optional.empty(),
+                        Optional.empty(),
+                        ImmutableList.of(
+                                identifier("x"),
+                                new StringLiteral(","),
+                                new BooleanLiteral("false"),
+                                new StringLiteral("HIDDEN"),
+                                new BooleanLiteral("false"))));
+    }
+
     private static QualifiedName makeQualifiedName(String tableName)
     {
         List<Identifier> parts = Splitter.on('.').splitToList(tableName).stream()

--- a/docs/src/main/sphinx/functions/aggregate.rst
+++ b/docs/src/main/sphinx/functions/aggregate.rst
@@ -144,6 +144,66 @@ General aggregate functions
 
     Returns the geometric mean of all input values.
 
+.. function:: listagg(x, separator)
+
+    Returns the concatenated input values, separated by the ``separator`` string.
+
+    Synopsis::
+
+        LISTAGG( expression [, separator] [ON OVERFLOW overflow_behaviour])
+            WITHIN GROUP (ORDER BY sort_item, [...])
+
+
+    If ``separator`` is not specified, the empty string will be used as ``separator``.
+
+    In its simplest form the function looks like::
+
+            SELECT listagg(value, ',') WITHIN GROUP (ORDER BY value) csv_value
+            FROM (VALUES 'a', 'c', 'b') t(value);
+
+    and results in::
+
+            csv_value
+            -----------
+            'a,b,c'
+
+    The overflow behaviour is by default to throw an error in case that the length of the output
+    of the function exceeds ``1048576`` bytes::
+
+            SELECT listagg(value, ',' ON OVERFLOW ERROR) WITHIN GROUP (ORDER BY value) csv_value
+            FROM (VALUES 'a', 'b', 'c') t(value);
+
+    There exists also the possibility to truncate the output ``WITH COUNT`` or ``WITHOUT COUNT``
+    of omitted non-null values in case that the length of the output of the
+    function exceeds ``1048576`` bytes::
+
+            SELECT LISTAGG(value, ',' ON OVERFLOW TRUNCATE '.....' WITH COUNT) WITHIN GROUP (ORDER BY value)
+            FROM (VALUES 'a', 'b', 'c') t(value);
+
+    If not specified, the truncation filler string is by default ``'...'``.
+
+    This aggregation function can be also used in a scenario involving grouping::
+
+            SELECT id, LISTAGG(value, ',') WITHIN GROUP (ORDER BY o) csv_value
+            FROM (VALUES
+                (100, 1, 'a'),
+                (200, 3, 'c'),
+                (200, 2, 'b')
+            ) t(id, o, value)
+            GROUP BY id
+            ORDER BY id;
+
+    results in:
+
+    .. code-block:: text
+
+         id  | csv_value
+        -----+-----------
+         100 | a
+         200 | b,c
+
+    The current implementation of ``LISTAGG`` function does not support window frames.
+
 .. function:: max(x) -> [same as input]
 
     Returns the maximum value of all input values.

--- a/docs/src/main/sphinx/functions/list.rst
+++ b/docs/src/main/sphinx/functions/list.rst
@@ -255,6 +255,7 @@ L
 - :func:`levenshtein_distance`
 - :func:`line_interpolate_point`
 - :func:`line_interpolate_points`
+- :func:`listagg`
 - :func:`ln`
 - :data:`localtime`
 - :data:`localtimestamp`

--- a/docs/src/main/sphinx/language/reserved.rst
+++ b/docs/src/main/sphinx/language/reserved.rst
@@ -56,6 +56,7 @@ Keyword                        SQL:2016      SQL-92
 ``JOIN``                       reserved      reserved
 ``LEFT``                       reserved      reserved
 ``LIKE``                       reserved      reserved
+``LISTAGG``                    reserved
 ``LOCALTIME``                  reserved
 ``LOCALTIMESTAMP``             reserved
 ``NATURAL``                    reserved      reserved


### PR DESCRIPTION
The LISTAGG joins varchar values from a group of rows
by using a configurable delimiter.

The syntax tree should represent the structure of the
original parsed query as closely as possible and any semantic
interpretation should be part of the analysis/planning phase.
In case of `LISTAGG` aggregation function though it is more pragmatic
now to create a synthetic FunctionCall expression during the parsing of
the syntax tree.

Resolves: #4835