### PR TITLE
Canonicalize date function call to cast

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CanonicalizeExpressionRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CanonicalizeExpressionRewriter.java
@@ -17,8 +17,12 @@ import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.operator.scalar.FormatFunction;
+import io.trino.spi.type.DateType;
 import io.trino.spi.type.RowType;
+import io.trino.spi.type.TimestampType;
+import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
 import io.trino.sql.planner.FunctionCallBuilder;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.TypeProvider;
@@ -31,6 +35,7 @@ import io.trino.sql.tree.ExpressionRewriter;
 import io.trino.sql.tree.ExpressionTreeRewriter;
 import io.trino.sql.tree.Extract;
 import io.trino.sql.tree.Format;
+import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.IfExpression;
 import io.trino.sql.tree.IsNotNullPredicate;
 import io.trino.sql.tree.IsNullPredicate;
@@ -49,8 +54,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.metadata.ResolvedFunction.extractFunctionName;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.tree.ArithmeticBinaryExpression.Operator.ADD;
 import static io.trino.sql.tree.ArithmeticBinaryExpression.Operator.MULTIPLY;
 import static java.util.Objects.requireNonNull;
@@ -245,6 +253,25 @@ public final class CanonicalizeExpressionRewriter
             }
 
             throw new UnsupportedOperationException("not yet implemented: " + node.getField());
+        }
+
+        @Override
+        public Expression rewriteFunctionCall(FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            String functionName = extractFunctionName(node.getName());
+            if (functionName.equals("date")) {
+                verify(node.getArguments().size() == 1);
+                Expression argument = node.getArguments().get(0);
+                Type argumentType = expressionTypes.get(NodeRef.of(argument));
+                if (argumentType instanceof TimestampType
+                        || argumentType instanceof TimestampWithTimeZoneType
+                        || argumentType instanceof VarcharType) {
+                    // prefer `CAST(x as DATE)` to `date(x)`
+                    return new Cast(argument, toSqlType(DateType.DATE));
+                }
+            }
+
+            return treeRewriter.defaultRewrite(node, context);
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestCanonicalizeExpressionRewriter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestCanonicalizeExpressionRewriter.java
@@ -15,8 +15,9 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableMap;
 import io.trino.metadata.Metadata;
-import io.trino.metadata.MetadataManager;
+import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.type.Type;
+import io.trino.sql.analyzer.FeaturesConfig;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.TypeAnalyzer;
@@ -24,17 +25,26 @@ import io.trino.sql.planner.TypeProvider;
 import io.trino.sql.planner.assertions.SymbolAliases;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.tree.SymbolReference;
+import io.trino.transaction.TransactionManager;
 import org.testng.annotations.Test;
 
 import static io.trino.SessionTestUtils.TEST_SESSION;
+import static io.trino.metadata.MetadataManager.createTestMetadataManager;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.createTimestampWithTimeZoneType;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.ExpressionTestUtils.assertExpressionEquals;
 import static io.trino.sql.planner.iterative.rule.CanonicalizeExpressionRewriter.rewrite;
+import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
+import static io.trino.transaction.TransactionBuilder.transaction;
 
 public class TestCanonicalizeExpressionRewriter
 {
-    private static final Metadata METADATA = MetadataManager.createTestMetadataManager();
+    public static final TransactionManager TRANSACTION_MANAGER = createTestTransactionManager();
+    private static final Metadata METADATA = createTestMetadataManager(TRANSACTION_MANAGER, new FeaturesConfig());
     private static final TypeAnalyzer TYPE_ANALYZER = new TypeAnalyzer(new SqlParser(), METADATA);
+    public static final AllowAllAccessControl ACCESS_CONTROL = new AllowAllAccessControl();
 
     @Test
     public void testRewriteIsNotNullPredicate()
@@ -101,22 +111,38 @@ public class TestCanonicalizeExpressionRewriter
         assertRewritten("CAST(1 AS decimal(5,2)) + a", "a + CAST(1 AS decimal(5,2))");
     }
 
+    @Test
+    public void testCanonicalizeRewriteDateFunctionToCast()
+    {
+        assertRewritten("date(ts)", "CAST(ts as DATE)");
+        assertRewritten("date(tstz)", "CAST(tstz as DATE)");
+        assertRewritten("date(v)", "CAST(v as DATE)");
+    }
+
     private static void assertRewritten(String from, String to)
     {
         assertExpressionEquals(
-                rewrite(
-                        PlanBuilder.expression(from),
-                        TEST_SESSION,
-                        METADATA,
-                        TYPE_ANALYZER,
-                        TypeProvider.copyOf(ImmutableMap.<Symbol, Type>builder()
-                                .put(new Symbol("x"), BIGINT)
-                                .put(new Symbol("a"), BIGINT)
-                                .build())),
+                transaction(TRANSACTION_MANAGER, ACCESS_CONTROL).execute(TEST_SESSION, transactedSession -> {
+                    return rewrite(
+                            PlanBuilder.expression(from),
+                            transactedSession,
+                            METADATA,
+                            TYPE_ANALYZER,
+                                    TypeProvider.copyOf(ImmutableMap.<Symbol, Type>builder()
+                                            .put(new Symbol("x"), BIGINT)
+                                            .put(new Symbol("a"), BIGINT)
+                                            .put(new Symbol("ts"), createTimestampType(3))
+                                            .put(new Symbol("tstz"), createTimestampWithTimeZoneType(3))
+                                            .put(new Symbol("v"), createVarcharType(100))
+                                            .build()));
+                }),
                 PlanBuilder.expression(to),
                 SymbolAliases.builder()
                         .put("x", new SymbolReference("x"))
                         .put("a", new SymbolReference("a"))
+                        .put("ts", new SymbolReference("ts"))
+                        .put("tstz", new SymbolReference("tstz"))
+                        .put("v", new SymbolReference("v"))
                         .build());
     }
 }


### PR DESCRIPTION
``date`` function call and CAST(... as DATE) are synonym for arguments
of TIMESTAMP, TIMESTAMP WITH TIME ZONE and VARCHAR.
This commit adds cannonicalization rule which rewrites ``date`` calls to
CAST expressions.

This unlocks optimization rules which operate on CAST expressions.