### PR TITLE
Use and recommend -XX:-OmitStackTraceInFastThrow

### DIFF
--- a/core/docker/default/etc/jvm.config
+++ b/core/docker/default/etc/jvm.config
@@ -6,6 +6,7 @@
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:+ExitOnOutOfMemoryError
+-XX:-OmitStackTraceInFastThrow
 -XX:ReservedCodeCacheSize=256M
 -XX:PerMethodRecompilationCutoff=10000
 -XX:PerBytecodeRecompilationCutoff=10000

--- a/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
+++ b/core/trino-server-rpm/src/main/resources/dist/config/jvm.config
@@ -6,6 +6,7 @@
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+ExitOnOutOfMemoryError
 -XX:+HeapDumpOnOutOfMemoryError
+-XX:-OmitStackTraceInFastThrow
 -XX:ReservedCodeCacheSize=512M
 -XX:PerMethodRecompilationCutoff=10000
 -XX:PerBytecodeRecompilationCutoff=10000

--- a/docs/src/main/sphinx/installation/deployment.rst
+++ b/docs/src/main/sphinx/installation/deployment.rst
@@ -122,6 +122,7 @@ The following provides a good starting point for creating ``etc/jvm.config``:
     -XX:+ExplicitGCInvokesConcurrent
     -XX:+ExitOnOutOfMemoryError
     -XX:+HeapDumpOnOutOfMemoryError
+    -XX:-OmitStackTraceInFastThrow
     -XX:ReservedCodeCacheSize=512M
     -XX:PerMethodRecompilationCutoff=10000
     -XX:PerBytecodeRecompilationCutoff=10000

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-master-jvm.config
@@ -8,6 +8,7 @@
 -XX:+ExitOnOutOfMemoryError
 -XX:+UseGCOverheadLimit
 -XX:+HeapDumpOnOutOfMemoryError
+-XX:-OmitStackTraceInFastThrow
 -XX:ReservedCodeCacheSize=150M
 -XX:PerMethodRecompilationCutoff=10000
 -XX:PerBytecodeRecompilationCutoff=10000

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/multinode/multinode-worker-jvm.config
@@ -7,6 +7,7 @@
 -XX:+ExitOnOutOfMemoryError
 -XX:+UseGCOverheadLimit
 -XX:+HeapDumpOnOutOfMemoryError
+-XX:-OmitStackTraceInFastThrow
 -XX:ReservedCodeCacheSize=150M
 -XX:PerMethodRecompilationCutoff=10000
 -XX:PerBytecodeRecompilationCutoff=10000

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/presto/etc/jvm.config
@@ -6,6 +6,7 @@
 -XX:+ExplicitGCInvokesConcurrent
 -XX:+ExitOnOutOfMemoryError
 -XX:+HeapDumpOnOutOfMemoryError
+-XX:-OmitStackTraceInFastThrow
 -XX:ReservedCodeCacheSize=150M
 -XX:PerMethodRecompilationCutoff=10000
 -XX:PerBytecodeRecompilationCutoff=10000


### PR DESCRIPTION
This ensures that a bug eventually reported is not stripped from
important information.

cc @sopel39 @kokosing @dain @electrum @hashhar 