### PR TITLE
Mention that Redis Cluster is not supported

### DIFF
--- a/docs/src/main/sphinx/connector/redis.rst
+++ b/docs/src/main/sphinx/connector/redis.rst
@@ -17,7 +17,7 @@ Requirements
 Requirements for using the connector in a catalog to connect to a Redis data
 source are:
 
-* Redis 2.8.0 or higher
+* Redis 2.8.0 or higher (Redis Cluster is not supported)
 * Network access, by default on port 6379, from the Trino coordinator and
   workers to Redis.
 
@@ -90,7 +90,7 @@ The ``hostname:port`` pair for the Redis server.
 
 This property is required; there is no default.
 
-Redis clusters are not supported.
+Redis Cluster is not supported.
 
 ``redis.scan-count``
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Follow up to https://github.com/trinodb/trino/pull/7989.

From https://github.com/trinodb/trino/pull/7989#discussion_r636378935.

Anything non-cluster (singlenode, leader-follower etc.) is supported. Only cluster is not supported.
Using the term `Redis Cluster` since that's what Redis' documentation uses.