### PR TITLE
Passing HiveIdentity through metastore database and get all tables/view calls

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -369,7 +369,7 @@ public class HiveMetadata
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
-        return metastore.getAllDatabases().stream()
+        return metastore.getAllDatabases(new HiveIdentity(session)).stream()
                 .filter(HiveMetadata::filterSchema)
                 .collect(toImmutableList());
     }
@@ -698,7 +698,7 @@ public class HiveMetadata
     {
         ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (String schemaName : listSchemas(session, optionalSchemaName)) {
-            for (String tableName : metastore.getAllTables(schemaName)) {
+            for (String tableName : metastore.getAllTables(new HiveIdentity(session), schemaName)) {
                 tableNames.add(new SchemaTableName(schemaName, tableName));
             }
         }
@@ -1973,7 +1973,7 @@ public class HiveMetadata
     {
         ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (String schemaName : listSchemas(session, optionalSchemaName)) {
-            for (String tableName : metastore.getAllViews(schemaName)) {
+            for (String tableName : metastore.getAllViews(new HiveIdentity(session), schemaName)) {
                 tableNames.add(new SchemaTableName(schemaName, tableName));
             }
         }
@@ -1985,7 +1985,7 @@ public class HiveMetadata
     {
         checkState(filterSchema(schemaName.getSchemaName()), "Schema is not accessible: %s", schemaName);
 
-        Optional<Database> db = metastore.getDatabase(schemaName.getSchemaName());
+        Optional<Database> db = metastore.getDatabase(new HiveIdentity(session), schemaName.getSchemaName());
         if (db.isPresent()) {
             return HiveSchemaProperties.fromDatabase(db.get());
         }
@@ -1998,7 +1998,7 @@ public class HiveMetadata
     {
         checkState(filterSchema(schemaName.getSchemaName()), "Schema is not accessible: %s", schemaName);
 
-        Optional<Database> database = metastore.getDatabase(schemaName.getSchemaName());
+        Optional<Database> database = metastore.getDatabase(new HiveIdentity(session), schemaName.getSchemaName());
         if (database.isPresent()) {
             return database.flatMap(db -> Optional.of(new TrinoPrincipal(db.getOwnerType(), db.getOwnerName())));
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetastoreClosure.java
@@ -55,14 +55,14 @@ public class HiveMetastoreClosure
         this.delegate = requireNonNull(delegate, "delegate is null");
     }
 
-    public Optional<Database> getDatabase(String databaseName)
+    public Optional<Database> getDatabase(HiveIdentity identity, String databaseName)
     {
-        return delegate.getDatabase(databaseName);
+        return delegate.getDatabase(identity, databaseName);
     }
 
-    public List<String> getAllDatabases()
+    public List<String> getAllDatabases(HiveIdentity identity)
     {
-        return delegate.getAllDatabases();
+        return delegate.getAllDatabases(identity);
     }
 
     private Table getExistingTable(HiveIdentity identity, String databaseName, String tableName)
@@ -104,19 +104,19 @@ public class HiveMetastoreClosure
         delegate.updatePartitionStatistics(identity, table, partitionName, update);
     }
 
-    public List<String> getAllTables(String databaseName)
+    public List<String> getAllTables(HiveIdentity identity, String databaseName)
     {
-        return delegate.getAllTables(databaseName);
+        return delegate.getAllTables(identity, databaseName);
     }
 
-    public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    public List<String> getTablesWithParameter(HiveIdentity identity, String databaseName, String parameterKey, String parameterValue)
     {
-        return delegate.getTablesWithParameter(databaseName, parameterKey, parameterValue);
+        return delegate.getTablesWithParameter(identity, databaseName, parameterKey, parameterValue);
     }
 
-    public List<String> getAllViews(String databaseName)
+    public List<String> getAllViews(HiveIdentity identity, String databaseName)
     {
-        return delegate.getAllViews(databaseName);
+        return delegate.getAllViews(identity, databaseName);
     }
 
     public void createDatabase(HiveIdentity identity, Database database)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/CoralSemiTransactionalHiveMSCAdapter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/CoralSemiTransactionalHiveMSCAdapter.java
@@ -43,20 +43,20 @@ public class CoralSemiTransactionalHiveMSCAdapter
     @Override
     public List<String> getAllDatabases()
     {
-        return delegate.getAllDatabases();
+        return delegate.getAllDatabases(identity);
     }
 
     // returning null for missing entry is as per Coral's requirements
     @Override
     public Database getDatabase(String dbName)
     {
-        return delegate.getDatabase(dbName).map(ThriftMetastoreUtil::toMetastoreApiDatabase).orElse(null);
+        return delegate.getDatabase(identity, dbName).map(ThriftMetastoreUtil::toMetastoreApiDatabase).orElse(null);
     }
 
     @Override
     public List<String> getAllTables(String dbName)
     {
-        return delegate.getAllTables(dbName);
+        return delegate.getAllTables(identity, dbName);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -35,9 +35,9 @@ import java.util.function.Function;
 
 public interface HiveMetastore
 {
-    Optional<Database> getDatabase(String databaseName);
+    Optional<Database> getDatabase(HiveIdentity identity, String databaseName);
 
-    List<String> getAllDatabases();
+    List<String> getAllDatabases(HiveIdentity identity);
 
     Optional<Table> getTable(HiveIdentity identity, String databaseName, String tableName);
 
@@ -51,11 +51,11 @@ public interface HiveMetastore
 
     void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update);
 
-    List<String> getAllTables(String databaseName);
+    List<String> getAllTables(HiveIdentity identity, String databaseName);
 
-    List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue);
+    List<String> getTablesWithParameter(HiveIdentity identity, String databaseName, String parameterKey, String parameterValue);
 
-    List<String> getAllViews(String databaseName);
+    List<String> getAllViews(HiveIdentity identity, String databaseName);
 
     void createDatabase(HiveIdentity identity, Database database);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/RecordingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/RecordingHiveMetastore.java
@@ -198,19 +198,19 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public Optional<Database> getDatabase(String databaseName)
+    public Optional<Database> getDatabase(HiveIdentity identity, String databaseName)
     {
-        return loadValue(databaseCache, databaseName, () -> delegate.getDatabase(databaseName));
+        return loadValue(databaseCache, databaseName, () -> delegate.getDatabase(identity, databaseName));
     }
 
     @Override
-    public List<String> getAllDatabases()
+    public List<String> getAllDatabases(HiveIdentity identity)
     {
         if (replay) {
             return allDatabases.orElseThrow(() -> new TrinoException(NOT_FOUND, "Missing entry for all databases"));
         }
 
-        List<String> result = delegate.getAllDatabases();
+        List<String> result = delegate.getAllDatabases(identity);
         allDatabases = Optional.of(result);
         return result;
     }
@@ -262,22 +262,22 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getAllTables(HiveIdentity identity, String databaseName)
     {
-        return loadValue(allTablesCache, databaseName, () -> delegate.getAllTables(databaseName));
+        return loadValue(allTablesCache, databaseName, () -> delegate.getAllTables(identity, databaseName));
     }
 
     @Override
-    public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    public List<String> getTablesWithParameter(HiveIdentity identity, String databaseName, String parameterKey, String parameterValue)
     {
         TablesWithParameterCacheKey key = new TablesWithParameterCacheKey(databaseName, parameterKey, parameterValue);
-        return loadValue(tablesWithParameterCache, key, () -> delegate.getTablesWithParameter(databaseName, parameterKey, parameterValue));
+        return loadValue(tablesWithParameterCache, key, () -> delegate.getTablesWithParameter(identity, databaseName, parameterKey, parameterValue));
     }
 
     @Override
-    public List<String> getAllViews(String databaseName)
+    public List<String> getAllViews(HiveIdentity identity, String databaseName)
     {
-        return loadValue(allViewsCache, databaseName, () -> delegate.getAllViews(databaseName));
+        return loadValue(allViewsCache, databaseName, () -> delegate.getAllViews(identity, databaseName));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -177,25 +177,25 @@ public class SemiTransactionalHiveMetastore
         this.configuredTransactionHeartbeatInterval = requireNonNull(hiveTransactionHeartbeatInterval, "hiveTransactionHeartbeatInterval is null");
     }
 
-    public synchronized List<String> getAllDatabases()
+    public synchronized List<String> getAllDatabases(HiveIdentity identity)
     {
         checkReadable();
-        return delegate.getAllDatabases();
+        return delegate.getAllDatabases(identity);
     }
 
-    public synchronized Optional<Database> getDatabase(String databaseName)
+    public synchronized Optional<Database> getDatabase(HiveIdentity identity, String databaseName)
     {
         checkReadable();
-        return delegate.getDatabase(databaseName);
+        return delegate.getDatabase(identity, databaseName);
     }
 
-    public synchronized List<String> getAllTables(String databaseName)
+    public synchronized List<String> getAllTables(HiveIdentity identity, String databaseName)
     {
         checkReadable();
         if (!tableActions.isEmpty()) {
             throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
         }
-        return delegate.getAllTables(databaseName);
+        return delegate.getAllTables(identity, databaseName);
     }
 
     public synchronized Optional<Table> getTable(HiveIdentity identity, String databaseName, String tableName)
@@ -345,13 +345,13 @@ public class SemiTransactionalHiveMetastore
                 modifiedPartitionMap);
     }
 
-    public synchronized List<String> getAllViews(String databaseName)
+    public synchronized List<String> getAllViews(HiveIdentity identity, String databaseName)
     {
         checkReadable();
         if (!tableActions.isEmpty()) {
             throw new UnsupportedOperationException("Listing all tables after adding/dropping/altering tables/views in a transaction is not supported");
         }
-        return delegate.getAllViews(databaseName);
+        return delegate.getAllViews(identity, databaseName);
     }
 
     public synchronized void createDatabase(HiveIdentity identity, Database database)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -81,7 +81,7 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public Optional<Database> getDatabase(String databaseName)
+    public Optional<Database> getDatabase(HiveIdentity identity, String databaseName)
     {
         try {
             return Optional.of(ProtoUtils.fromProto(client.getDatabase(databaseName)));
@@ -92,7 +92,7 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public List<String> getAllDatabases()
+    public List<String> getAllDatabases(HiveIdentity identity)
     {
         try {
             return client.getAllDatabases();
@@ -204,7 +204,7 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getAllTables(HiveIdentity identity, String databaseName)
     {
         try {
             return client.getAllTables(databaseName);
@@ -219,6 +219,7 @@ public class AlluxioHiveMetastore
 
     @Override
     public List<String> getTablesWithParameter(
+            HiveIdentity identity,
             String databaseName,
             String parameterKey,
             String parameterValue)
@@ -247,7 +248,7 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public List<String> getAllViews(String databaseName)
+    public List<String> getAllViews(HiveIdentity identity, String databaseName)
     {
         // TODO: Add views on the server side
         return Collections.emptyList();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -263,7 +263,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public Optional<Database> getDatabase(String databaseName)
+    public Optional<Database> getDatabase(HiveIdentity identity, String databaseName)
     {
         try {
             GetDatabaseResult result = stats.getGetDatabase().call(() ->
@@ -279,7 +279,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public List<String> getAllDatabases()
+    public List<String> getAllDatabases(HiveIdentity identity)
     {
         try {
             return stats.getGetAllDatabases().call(() -> {
@@ -410,7 +410,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getAllTables(HiveIdentity identity, String databaseName)
     {
         try {
             return stats.getGetAllTables().call(() -> {
@@ -443,14 +443,14 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public synchronized List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    public synchronized List<String> getTablesWithParameter(HiveIdentity identity, String databaseName, String parameterKey, String parameterValue)
     {
         // TODO
         throw new UnsupportedOperationException("getTablesWithParameter for GlueHiveMetastore is not implemented");
     }
 
     @Override
-    public List<String> getAllViews(String databaseName)
+    public List<String> getAllViews(HiveIdentity identity, String databaseName)
     {
         try {
             return stats.getGetAllViews().call(() -> {
@@ -527,7 +527,7 @@ public class GlueHiveMetastore
     public void renameDatabase(HiveIdentity identity, String databaseName, String newDatabaseName)
     {
         try {
-            Database database = getDatabase(databaseName).orElseThrow(() -> new SchemaNotFoundException(databaseName));
+            Database database = getDatabase(identity, databaseName).orElseThrow(() -> new SchemaNotFoundException(databaseName));
             DatabaseInput renamedDatabase = GlueInputConverter.convertDatabase(database).withName(newDatabaseName);
             stats.getRenameDatabase().call(() ->
                     glueClient.updateDatabase(new UpdateDatabaseRequest()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -79,13 +79,13 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public Optional<Database> getDatabase(String databaseName)
+    public Optional<Database> getDatabase(HiveIdentity identity, String databaseName)
     {
         return delegate.getDatabase(databaseName).map(ThriftMetastoreUtil::fromMetastoreApiDatabase);
     }
 
     @Override
-    public List<String> getAllDatabases()
+    public List<String> getAllDatabases(HiveIdentity identity)
     {
         return delegate.getAllDatabases();
     }
@@ -140,19 +140,19 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getAllTables(HiveIdentity identity, String databaseName)
     {
         return delegate.getAllTables(databaseName);
     }
 
     @Override
-    public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    public List<String> getTablesWithParameter(HiveIdentity identity, String databaseName, String parameterKey, String parameterValue)
     {
         return delegate.getTablesWithParameter(databaseName, parameterKey, parameterValue);
     }
 
     @Override
-    public List<String> getAllViews(String databaseName)
+    public List<String> getAllViews(HiveIdentity identity, String databaseName)
     {
         return delegate.getAllViews(databaseName);
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SemiTransactionalSqlStandardAccessControlMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SemiTransactionalSqlStandardAccessControlMetastore.java
@@ -59,6 +59,6 @@ public class SemiTransactionalSqlStandardAccessControlMetastore
     public Optional<Database> getDatabase(ConnectorSecurityContext context, String databaseName)
     {
         SemiTransactionalHiveMetastore metastore = metastoreProvider.apply(((HiveTransactionHandle) context.getTransactionHandle()));
-        return metastore.getDatabase(databaseName);
+        return metastore.getDatabase(new HiveIdentity(context.getIdentity()), databaseName);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -22,6 +22,7 @@ import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
 import io.trino.plugin.hive.HiveReadOnlyException;
 import io.trino.plugin.hive.HiveTimestampPrecision;
 import io.trino.plugin.hive.HiveType;
+import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.avro.AvroRecordWriter;
 import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.Partition;
@@ -434,7 +435,7 @@ public final class HiveWriteUtils
 
     public static Path getTableDefaultLocation(HdfsContext context, SemiTransactionalHiveMetastore metastore, HdfsEnvironment hdfsEnvironment, String schemaName, String tableName)
     {
-        Database database = metastore.getDatabase(schemaName)
+        Database database = metastore.getDatabase(new HiveIdentity(context.getIdentity()), schemaName)
                 .orElseThrow(() -> new SchemaNotFoundException(schemaName));
 
         return getTableDefaultLocation(database, context, hdfsEnvironment, schemaName, tableName);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -2744,7 +2744,7 @@ public abstract class AbstractTestHive
         table.getStorageBuilder()
                 .setStorageFormat(fromHiveStorageFormat(PARQUET))
                 .setLocation(getTableDefaultLocation(
-                        metastoreClient.getDatabase(tableName.getSchemaName()).orElseThrow(),
+                        metastoreClient.getDatabase(identity, tableName.getSchemaName()).orElseThrow(),
                         new HdfsContext(session.getIdentity()),
                         hdfsEnvironment,
                         tableName.getSchemaName(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -542,9 +542,9 @@ public abstract class AbstractTestHiveFileSystem
         }
 
         @Override
-        public Optional<Database> getDatabase(String databaseName)
+        public Optional<Database> getDatabase(HiveIdentity identity, String databaseName)
         {
-            return super.getDatabase(databaseName)
+            return super.getDatabase(identity, databaseName)
                     .map(database -> Database.builder(database)
                             .setLocation(Optional.of(basePath.toString()))
                             .build());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -200,12 +200,12 @@ public final class HiveQueryRunner
         private void populateData(DistributedQueryRunner queryRunner, HiveMetastore metastore)
         {
             HiveIdentity identity = new HiveIdentity(SESSION);
-            if (metastore.getDatabase(TPCH_SCHEMA).isEmpty()) {
+            if (metastore.getDatabase(identity, TPCH_SCHEMA).isEmpty()) {
                 metastore.createDatabase(identity, createDatabaseMetastoreObject(TPCH_SCHEMA));
                 copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(Optional.empty()), initialTables);
             }
 
-            if (metastore.getDatabase(TPCH_BUCKETED_SCHEMA).isEmpty()) {
+            if (metastore.getDatabase(identity, TPCH_BUCKETED_SCHEMA).isEmpty()) {
                 metastore.createDatabase(identity, createDatabaseMetastoreObject(TPCH_BUCKETED_SCHEMA));
                 copyTpchTablesBucketed(queryRunner, "tpch", TINY_SCHEMA_NAME, createBucketedSession(Optional.empty()), initialTables);
             }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestRecordingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestRecordingHiveMetastore.java
@@ -158,15 +158,15 @@ public class TestRecordingHiveMetastore
 
     private void validateMetadata(HiveMetastore hiveMetastore)
     {
-        assertEquals(hiveMetastore.getDatabase("database"), Optional.of(DATABASE));
-        assertEquals(hiveMetastore.getAllDatabases(), ImmutableList.of("database"));
+        assertEquals(hiveMetastore.getDatabase(HIVE_CONTEXT, "database"), Optional.of(DATABASE));
+        assertEquals(hiveMetastore.getAllDatabases(HIVE_CONTEXT), ImmutableList.of("database"));
         assertEquals(hiveMetastore.getTable(HIVE_CONTEXT, "database", "table"), Optional.of(TABLE));
         assertEquals(hiveMetastore.getSupportedColumnStatistics(createVarcharType(123)), ImmutableSet.of(MIN_VALUE, MAX_VALUE));
         assertEquals(hiveMetastore.getTableStatistics(HIVE_CONTEXT, TABLE), PARTITION_STATISTICS);
         assertEquals(hiveMetastore.getPartitionStatistics(HIVE_CONTEXT, TABLE, ImmutableList.of(PARTITION)), ImmutableMap.of("value", PARTITION_STATISTICS));
-        assertEquals(hiveMetastore.getAllTables("database"), ImmutableList.of("table"));
-        assertEquals(hiveMetastore.getTablesWithParameter("database", "param", "value3"), ImmutableList.of("table"));
-        assertEquals(hiveMetastore.getAllViews("database"), ImmutableList.of());
+        assertEquals(hiveMetastore.getAllTables(HIVE_CONTEXT, "database"), ImmutableList.of("table"));
+        assertEquals(hiveMetastore.getTablesWithParameter(HIVE_CONTEXT, "database", "param", "value3"), ImmutableList.of("table"));
+        assertEquals(hiveMetastore.getAllViews(HIVE_CONTEXT, "database"), ImmutableList.of());
         assertEquals(hiveMetastore.getPartition(HIVE_CONTEXT, TABLE, ImmutableList.of("value")), Optional.of(PARTITION));
         assertEquals(hiveMetastore.getPartitionNamesByFilter(HIVE_CONTEXT, "database", "table", PARTITION_COLUMN_NAMES, TupleDomain.all()), Optional.of(ImmutableList.of("value")));
         assertEquals(hiveMetastore.getPartitionNamesByFilter(HIVE_CONTEXT, "database", "table", PARTITION_COLUMN_NAMES, TUPLE_DOMAIN), Optional.of(ImmutableList.of("value")));
@@ -181,7 +181,7 @@ public class TestRecordingHiveMetastore
             extends UnimplementedHiveMetastore
     {
         @Override
-        public Optional<Database> getDatabase(String databaseName)
+        public Optional<Database> getDatabase(HiveIdentity identity, String databaseName)
         {
             if (databaseName.equals("database")) {
                 return Optional.of(DATABASE);
@@ -191,7 +191,7 @@ public class TestRecordingHiveMetastore
         }
 
         @Override
-        public List<String> getAllDatabases()
+        public List<String> getAllDatabases(HiveIdentity identity)
         {
             return ImmutableList.of("database");
         }
@@ -239,7 +239,7 @@ public class TestRecordingHiveMetastore
         }
 
         @Override
-        public List<String> getAllTables(String databaseName)
+        public List<String> getAllTables(HiveIdentity identity, String databaseName)
         {
             if (databaseName.equals("database")) {
                 return ImmutableList.of("table");
@@ -249,7 +249,7 @@ public class TestRecordingHiveMetastore
         }
 
         @Override
-        public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+        public List<String> getTablesWithParameter(HiveIdentity identity, String databaseName, String parameterKey, String parameterValue)
         {
             if (databaseName.equals("database") && parameterKey.equals("param") && parameterValue.equals("value3")) {
                 return ImmutableList.of("table");
@@ -258,7 +258,7 @@ public class TestRecordingHiveMetastore
         }
 
         @Override
-        public List<String> getAllViews(String databaseName)
+        public List<String> getAllViews(HiveIdentity identity, String databaseName)
         {
             return ImmutableList.of();
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/UnimplementedHiveMetastore.java
@@ -32,13 +32,13 @@ class UnimplementedHiveMetastore
         implements HiveMetastore
 {
     @Override
-    public Optional<Database> getDatabase(String databaseName)
+    public Optional<Database> getDatabase(HiveIdentity identity, String databaseName)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public List<String> getAllDatabases()
+    public List<String> getAllDatabases(HiveIdentity identity)
     {
         throw new UnsupportedOperationException();
     }
@@ -80,19 +80,19 @@ class UnimplementedHiveMetastore
     }
 
     @Override
-    public List<String> getAllTables(String databaseName)
+    public List<String> getAllTables(HiveIdentity identity, String databaseName)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    public List<String> getTablesWithParameter(HiveIdentity identity, String databaseName, String parameterKey, String parameterValue)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public List<String> getAllViews(String databaseName)
+    public List<String> getAllViews(HiveIdentity identity, String databaseName)
     {
         throw new UnsupportedOperationException();
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastore.java
@@ -128,16 +128,16 @@ public class TestCachingHiveMetastore
     public void testGetAllDatabases()
     {
         assertEquals(mockClient.getAccessCount(), 0);
-        assertEquals(metastore.getAllDatabases(), ImmutableList.of(TEST_DATABASE));
+        assertEquals(metastore.getAllDatabases(IDENTITY), ImmutableList.of(TEST_DATABASE));
         assertEquals(mockClient.getAccessCount(), 1);
-        assertEquals(metastore.getAllDatabases(), ImmutableList.of(TEST_DATABASE));
+        assertEquals(metastore.getAllDatabases(IDENTITY), ImmutableList.of(TEST_DATABASE));
         assertEquals(mockClient.getAccessCount(), 1);
         assertEquals(metastore.getDatabaseNamesStats().getRequestCount(), 2);
         assertEquals(metastore.getDatabaseNamesStats().getHitRate(), 0.5);
 
         metastore.flushCache();
 
-        assertEquals(metastore.getAllDatabases(), ImmutableList.of(TEST_DATABASE));
+        assertEquals(metastore.getAllDatabases(IDENTITY), ImmutableList.of(TEST_DATABASE));
         assertEquals(mockClient.getAccessCount(), 2);
         assertEquals(metastore.getDatabaseNamesStats().getRequestCount(), 3);
         assertEquals(metastore.getDatabaseNamesStats().getHitRate(), 1.0 / 3);
@@ -147,16 +147,16 @@ public class TestCachingHiveMetastore
     public void testGetAllTable()
     {
         assertEquals(mockClient.getAccessCount(), 0);
-        assertEquals(metastore.getAllTables(TEST_DATABASE), ImmutableList.of(TEST_TABLE));
+        assertEquals(metastore.getAllTables(IDENTITY, TEST_DATABASE), ImmutableList.of(TEST_TABLE));
         assertEquals(mockClient.getAccessCount(), 1);
-        assertEquals(metastore.getAllTables(TEST_DATABASE), ImmutableList.of(TEST_TABLE));
+        assertEquals(metastore.getAllTables(IDENTITY, TEST_DATABASE), ImmutableList.of(TEST_TABLE));
         assertEquals(mockClient.getAccessCount(), 1);
         assertEquals(metastore.getTableNamesStats().getRequestCount(), 2);
         assertEquals(metastore.getTableNamesStats().getHitRate(), 0.5);
 
         metastore.flushCache();
 
-        assertEquals(metastore.getAllTables(TEST_DATABASE), ImmutableList.of(TEST_TABLE));
+        assertEquals(metastore.getAllTables(IDENTITY, TEST_DATABASE), ImmutableList.of(TEST_TABLE));
         assertEquals(mockClient.getAccessCount(), 2);
         assertEquals(metastore.getTableNamesStats().getRequestCount(), 3);
         assertEquals(metastore.getTableNamesStats().getHitRate(), 1.0 / 3);
@@ -165,7 +165,7 @@ public class TestCachingHiveMetastore
     @Test
     public void testInvalidDbGetAllTAbles()
     {
-        assertTrue(metastore.getAllTables(BAD_DATABASE).isEmpty());
+        assertTrue(metastore.getAllTables(IDENTITY, BAD_DATABASE).isEmpty());
     }
 
     @Test
@@ -192,14 +192,14 @@ public class TestCachingHiveMetastore
     {
         assertEquals(mockClient.getAccessCount(), 0);
         assertNotNull(metastore.getTable(IDENTITY, TEST_DATABASE, TEST_TABLE));
-        assertNotNull(metastore.getDatabase(TEST_DATABASE));
+        assertNotNull(metastore.getDatabase(IDENTITY, TEST_DATABASE));
         assertEquals(mockClient.getAccessCount(), 2);
         metastore.setTableOwner(IDENTITY, TEST_DATABASE, TEST_TABLE, new HivePrincipal(USER, "ignore"));
         assertEquals(mockClient.getAccessCount(), 3);
         assertNotNull(metastore.getTable(IDENTITY, TEST_DATABASE, TEST_TABLE));
         assertEquals(mockClient.getAccessCount(), 4);
         // Assert that database cache has not been invalidated
-        assertNotNull(metastore.getDatabase(TEST_DATABASE));
+        assertNotNull(metastore.getDatabase(IDENTITY, TEST_DATABASE));
         assertEquals(mockClient.getAccessCount(), 4);
     }
 
@@ -426,7 +426,7 @@ public class TestCachingHiveMetastore
         // Throw exceptions on usage
         mockClient.setThrowException(true);
         try {
-            metastore.getAllDatabases();
+            metastore.getAllDatabases(IDENTITY);
         }
         catch (RuntimeException ignored) {
         }
@@ -434,7 +434,7 @@ public class TestCachingHiveMetastore
 
         // Second try should hit the client again
         try {
-            metastore.getAllDatabases();
+            metastore.getAllDatabases(IDENTITY);
         }
         catch (RuntimeException ignored) {
         }
@@ -461,9 +461,9 @@ public class TestCachingHiveMetastore
                 1000);
 
         assertEquals(mockClient.getAccessCount(), 0);
-        assertEquals(metastore.getAllDatabases(), ImmutableList.of(TEST_DATABASE));
+        assertEquals(metastore.getAllDatabases(IDENTITY), ImmutableList.of(TEST_DATABASE));
         assertEquals(mockClient.getAccessCount(), 1);
-        assertEquals(metastore.getAllDatabases(), ImmutableList.of(TEST_DATABASE));
+        assertEquals(metastore.getAllDatabases(IDENTITY), ImmutableList.of(TEST_DATABASE));
         assertEquals(mockClient.getAccessCount(), 1);
         assertEquals(metastore.getDatabaseNamesStats().getRequestCount(), 0);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestHiveGlueMetastore.java
@@ -228,7 +228,7 @@ public class TestHiveGlueMetastore
         GlueMetastoreStats stats = metastore.getStats();
         double initialCallCount = stats.getGetAllDatabases().getTime().getAllTime().getCount();
         long initialFailureCount = stats.getGetAllDatabases().getTotalFailures().getTotalCount();
-        getMetastoreClient().getAllDatabases();
+        getMetastoreClient().getAllDatabases(HIVE_CONTEXT);
         assertEquals(stats.getGetAllDatabases().getTime().getAllTime().getCount(), initialCallCount + 1.0);
         assertTrue(stats.getGetAllDatabases().getTime().getAllTime().getAvg() > 0.0);
         assertEquals(stats.getGetAllDatabases().getTotalFailures().getTotalCount(), initialFailureCount);
@@ -240,7 +240,7 @@ public class TestHiveGlueMetastore
         GlueHiveMetastore metastore = (GlueHiveMetastore) getMetastoreClient();
         GlueMetastoreStats stats = metastore.getStats();
         long initialFailureCount = stats.getGetDatabase().getTotalFailures().getTotalCount();
-        assertThatThrownBy(() -> getMetastoreClient().getDatabase(null))
+        assertThatThrownBy(() -> getMetastoreClient().getDatabase(HIVE_CONTEXT, null))
                 .isInstanceOf(TrinoException.class)
                 .hasMessageStartingWith("Database name cannot be equal to null or empty");
         assertEquals(stats.getGetDatabase().getTotalFailures().getTotalCount(), initialFailureCount + 1);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
@@ -23,6 +23,7 @@ import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.plugin.hive.HiveHdfsConfiguration;
 import io.trino.plugin.hive.NodeVersion;
 import io.trino.plugin.hive.TestingHivePlugin;
+import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.authentication.NoHdfsAuthentication;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.MetastoreConfig;
@@ -88,7 +89,7 @@ public class TestIcebergMetadataListing
         assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table1 (_string VARCHAR, _integer INTEGER)");
         assertQuerySucceeds("CREATE TABLE iceberg.test_schema.iceberg_table2 (_double DOUBLE) WITH (partitioning = ARRAY['_double'])");
         assertQuerySucceeds("CREATE TABLE hive.test_schema.hive_table (_double DOUBLE)");
-        assertEquals(ImmutableSet.copyOf(metastore.getAllTables("test_schema")), ImmutableSet.of("iceberg_table1", "iceberg_table2", "hive_table"));
+        assertEquals(ImmutableSet.copyOf(metastore.getAllTables(HiveIdentity.none(), "test_schema")), ImmutableSet.of("iceberg_table1", "iceberg_table2", "hive_table"));
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
Updates to the HiveMetastore interface to pass HiveIdentity through calls to getDatase, getAllDatabases, getAllTables, and getAllViews

Related to issue [#7581 ](https://github.com/trinodb/trino/issues/7581)