### PR TITLE
Flatten AND and OR expressions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AggregationAnalyzer.java
@@ -45,7 +45,7 @@ import io.trino.sql.tree.IsNullPredicate;
 import io.trino.sql.tree.LambdaExpression;
 import io.trino.sql.tree.LikePredicate;
 import io.trino.sql.tree.Literal;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NodeRef;
@@ -596,9 +596,10 @@ class AggregationAnalyzer
         }
 
         @Override
-        protected Boolean visitLogicalBinaryExpression(LogicalBinaryExpression node, Void context)
+        protected Boolean visitLogicalExpression(LogicalExpression node, Void context)
         {
-            return process(node.getLeft(), context) && process(node.getRight(), context);
+            return node.getTerms().stream()
+                    .allMatch(item -> process(item, context));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -97,7 +97,7 @@ import io.trino.sql.tree.IsNullPredicate;
 import io.trino.sql.tree.LambdaArgumentDeclaration;
 import io.trino.sql.tree.LambdaExpression;
 import io.trino.sql.tree.LikePredicate;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Node;
@@ -681,10 +681,11 @@ public class ExpressionAnalyzer
         }
 
         @Override
-        protected Type visitLogicalBinaryExpression(LogicalBinaryExpression node, StackableAstVisitorContext<Context> context)
+        protected Type visitLogicalExpression(LogicalExpression node, StackableAstVisitorContext<Context> context)
         {
-            coerceType(context, node.getLeft(), BOOLEAN, "Left side of logical expression");
-            coerceType(context, node.getRight(), BOOLEAN, "Right side of logical expression");
+            for (Expression term : node.getTerms()) {
+                coerceType(context, term, BOOLEAN, "Logical expression term");
+            }
 
             return setExpressionType(node, BOOLEAN);
         }

--- a/core/trino-main/src/main/java/io/trino/sql/gen/OrCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/OrCodeGenerator.java
@@ -21,23 +21,24 @@ import io.airlift.bytecode.instruction.LabelNode;
 import io.trino.sql.relational.RowExpression;
 import io.trino.sql.relational.SpecialForm;
 
+import java.util.List;
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantFalse;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class OrCodeGenerator
         implements BytecodeGenerator
 {
-    private final RowExpression left;
-    private final RowExpression right;
+    private final List<RowExpression> terms;
 
     public OrCodeGenerator(SpecialForm specialForm)
     {
         requireNonNull(specialForm, "specialForm is null");
+        checkArgument(specialForm.getArguments().size() >= 2);
 
-        checkArgument(specialForm.getArguments().size() == 2);
-        left = specialForm.getArguments().get(0);
-        right = specialForm.getArguments().get(1);
+        terms = specialForm.getArguments();
     }
 
     @Override
@@ -48,58 +49,41 @@ public class OrCodeGenerator
                 .comment("OR")
                 .setDescription("OR");
 
-        block.append(generator.generate(left));
-
-        IfStatement ifLeftIsNull = new IfStatement("if left wasNull...")
-                .condition(wasNull);
+        block.push(false); // keep track of whether we've seen a null so far
 
         LabelNode end = new LabelNode("end");
-        ifLeftIsNull.ifTrue(new BytecodeBlock()
-                .comment("clear the null flag, pop left value off stack, and push left null flag on the stack (true)")
+        LabelNode returnTrue = new LabelNode("returnTrue");
+        for (int i = 0; i < terms.size(); i++) {
+            RowExpression term = terms.get(i);
+            block.append(generator.generate(term));
+
+            IfStatement ifWasNull = new IfStatement(format("if term %s wasNull...", i))
+                    .condition(wasNull);
+
+            ifWasNull.ifTrue()
+                    .comment("clear the null flag, pop residual value off stack, and push was null flag on the stack (true)")
+                    .pop(term.getType().getJavaType()) // discard residual value
+                    .pop(boolean.class) // discard the previous "we've seen a null flag"
+                    .push(true);
+
+            ifWasNull.ifFalse()
+                    .comment("if term is true, short circuit and return true")
+                    .ifTrueGoto(returnTrue);
+
+            block.append(ifWasNull)
+                    .append(wasNull.set(constantFalse())); // prepare for the next loop
+        }
+
+        block.putVariable(wasNull)
+                .push(false) // result is false
+                .gotoLabel(end);
+
+        block.visitLabel(returnTrue)
                 .append(wasNull.set(constantFalse()))
-                .pop(left.getType().getJavaType()) // discard left value
-                .push(true));
+                .pop(boolean.class) // discard the previous "we've seen a null flag"
+                .push(true); // result is true
 
-        LabelNode leftIsFalse = new LabelNode("leftIsFalse");
-        ifLeftIsNull.ifFalse(new BytecodeBlock()
-                .comment("if left is true, push true, and goto end")
-                .ifFalseGoto(leftIsFalse)
-                .push(true)
-                .gotoLabel(end)
-                .comment("left was false; push left null flag on the stack (false)")
-                .visitLabel(leftIsFalse)
-                .push(false));
-
-        block.append(ifLeftIsNull);
-
-        // At this point we know the left expression was either NULL or FALSE.  The stack contains a single boolean
-        // value for this expression which indicates if the left value was NULL.
-
-        // eval right!
-        block.append(generator.generate(right));
-
-        IfStatement ifRightIsNull = new IfStatement("if right wasNull...")
-                .condition(wasNull);
-
-        // this leaves a single boolean on the stack which is ignored since the value in NULL
-        ifRightIsNull.ifTrue()
-                .comment("right was null, pop the right value off the stack; wasNull flag remains set to TRUE")
-                .pop(right.getType().getJavaType());
-
-        LabelNode rightIsTrue = new LabelNode("rightIsTrue");
-        ifRightIsNull.ifFalse()
-                .comment("if right is true, pop left null flag off stack, push true and goto end")
-                .ifFalseGoto(rightIsTrue)
-                .pop(boolean.class)
-                .push(true)
-                .gotoLabel(end)
-                .comment("right was false; store left null flag (on stack) in wasNull variable, and push false")
-                .visitLabel(rightIsTrue)
-                .putVariable(wasNull)
-                .push(false);
-
-        block.append(ifRightIsNull)
-                .visitLabel(end);
+        block.visitLabel(end);
 
         return block;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/DomainTranslator.java
@@ -53,7 +53,7 @@ import io.trino.sql.tree.InPredicate;
 import io.trino.sql.tree.IsNotNullPredicate;
 import io.trino.sql.tree.IsNullPredicate;
 import io.trino.sql.tree.LikePredicate;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullLiteral;
@@ -69,6 +69,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -355,23 +356,29 @@ public final class DomainTranslator
         }
 
         @Override
-        protected ExtractionResult visitLogicalBinaryExpression(LogicalBinaryExpression node, Boolean complement)
+        protected ExtractionResult visitLogicalExpression(LogicalExpression node, Boolean complement)
         {
-            ExtractionResult leftResult = process(node.getLeft(), complement);
-            ExtractionResult rightResult = process(node.getRight(), complement);
+            List<ExtractionResult> results = node.getTerms().stream()
+                    .map(term -> process(term, complement))
+                    .collect(toImmutableList());
 
-            TupleDomain<Symbol> leftTupleDomain = leftResult.getTupleDomain();
-            TupleDomain<Symbol> rightTupleDomain = rightResult.getTupleDomain();
+            List<TupleDomain<Symbol>> tupleDomains = results.stream()
+                    .map(ExtractionResult::getTupleDomain)
+                    .collect(toImmutableList());
 
-            LogicalBinaryExpression.Operator operator = complement ? node.getOperator().flip() : node.getOperator();
+            List<Expression> residuals = results.stream()
+                    .map(ExtractionResult::getRemainingExpression)
+                    .collect(toImmutableList());
+
+            LogicalExpression.Operator operator = complement ? node.getOperator().flip() : node.getOperator();
             switch (operator) {
                 case AND:
                     return new ExtractionResult(
-                            leftTupleDomain.intersect(rightTupleDomain),
-                            combineConjuncts(metadata, leftResult.getRemainingExpression(), rightResult.getRemainingExpression()));
+                            TupleDomain.intersect(tupleDomains),
+                            combineConjuncts(metadata, residuals));
 
                 case OR:
-                    TupleDomain<Symbol> columnUnionedTupleDomain = TupleDomain.columnWiseUnion(leftTupleDomain, rightTupleDomain);
+                    TupleDomain<Symbol> columnUnionedTupleDomain = TupleDomain.columnWiseUnion(tupleDomains);
 
                     // In most cases, the columnUnionedTupleDomain is only a superset of the actual strict union
                     // and so we can return the current node as the remainingExpression so that all bounds will be double checked again at execution time.
@@ -380,21 +387,27 @@ public final class DomainTranslator
                     // However, there are a few cases where the column-wise union is actually equivalent to the strict union, so we if can detect
                     // some of these cases, we won't have to double check the bounds unnecessarily at execution time.
 
-                    // We can only make inferences if the remaining expressions on both side are equal and deterministic
-                    if (leftResult.getRemainingExpression().equals(rightResult.getRemainingExpression()) &&
-                            DeterminismEvaluator.isDeterministic(leftResult.getRemainingExpression(), metadata)) {
-                        // The column-wise union is equivalent to the strict union if
-                        // 1) If both TupleDomains consist of the same exact single column (e.g. left TupleDomain => (a > 0), right TupleDomain => (a < 10))
-                        // 2) If one TupleDomain is a superset of the other (e.g. left TupleDomain => (a > 0, b > 0 && b < 10), right TupleDomain => (a > 5, b = 5))
-                        boolean matchingSingleSymbolDomains = !leftTupleDomain.isNone()
-                                && !rightTupleDomain.isNone()
-                                && leftTupleDomain.getDomains().get().size() == 1
-                                && rightTupleDomain.getDomains().get().size() == 1
-                                && leftTupleDomain.getDomains().get().keySet().equals(rightTupleDomain.getDomains().get().keySet());
-                        boolean oneSideIsSuperSet = leftTupleDomain.contains(rightTupleDomain) || rightTupleDomain.contains(leftTupleDomain);
+                    // We can only make inferences if the remaining expressions on all terms are equal and deterministic
+                    if (Set.copyOf(residuals).size() == 1 && DeterminismEvaluator.isDeterministic(residuals.get(0), metadata)) {
+                        // NONE are no-op for the purpose of OR
+                        tupleDomains = tupleDomains.stream()
+                                .filter(domain -> !domain.isNone())
+                                .collect(toList());
 
-                        if (oneSideIsSuperSet) {
-                            remainingExpression = leftResult.getRemainingExpression();
+                        // The column-wise union is equivalent to the strict union if
+                        // 1) If all TupleDomains consist of the same exact single column (e.g. one TupleDomain => (a > 0), another TupleDomain => (a < 10))
+                        // 2) If one TupleDomain is a superset of the others (e.g. TupleDomain => (a > 0, b > 0 && b < 10) vs TupleDomain => (a > 5, b = 5))
+                        boolean matchingSingleSymbolDomains = tupleDomains.stream().allMatch(domain -> domain.getDomains().get().size() == 1);
+
+                        matchingSingleSymbolDomains = matchingSingleSymbolDomains && tupleDomains.stream()
+                                .map(tupleDomain -> tupleDomain.getDomains().get().keySet())
+                                .distinct()
+                                .count() == 1;
+
+                        boolean oneTermIsSuperSet = TupleDomain.maximal(tupleDomains).isPresent();
+
+                        if (oneTermIsSuperSet) {
+                            remainingExpression = residuals.get(0);
                         }
                         else if (matchingSingleSymbolDomains) {
                             // Types REAL and DOUBLE require special handling because they include NaN value. In this case, we cannot rely on the union of domains.
@@ -405,9 +418,7 @@ public final class DomainTranslator
                             //          Let left TupleDomain => (a > 0) /false for NaN/, right TupleDomain => (a < 10) /false for NaN/.
                             //          Unioned TupleDomain => "is not null" /true for NaN/
                             // To guard against wrong results, the current node is returned as the remainingExpression.
-                            Domain leftDomain = getOnlyElement(leftTupleDomain.getDomains().get().values());
-                            Domain rightDomain = getOnlyElement(rightTupleDomain.getDomains().get().values());
-                            Type type = leftDomain.getType();
+                            Type type = getOnlyElement(tupleDomains.get(0).getDomains().get().values()).getType();
 
                             // A Domain of a floating point type contains NaN in the following cases:
                             // 1. When it contains all the values of the type and null.
@@ -421,11 +432,10 @@ public final class DomainTranslator
                                     (columnUnionedTupleDomain.getDomains().isPresent() &&
                                             getOnlyElement(columnUnionedTupleDomain.getDomains().get().values()).getValues().isAll());
                             boolean implicitlyAddedNaN = (type instanceof RealType || type instanceof DoubleType) &&
-                                    !leftDomain.getValues().isAll() &&
-                                    !rightDomain.getValues().isAll() &&
+                                    tupleDomains.stream().noneMatch(TupleDomain::isAll) &&
                                     unionedDomainContainsNaN;
                             if (!implicitlyAddedNaN) {
-                                remainingExpression = leftResult.getRemainingExpression();
+                                remainingExpression = residuals.get(0);
                             }
                         }
                     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownNegationsExpressionRewriter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDownNegationsExpressionRewriter.java
@@ -23,7 +23,7 @@ import io.trino.sql.tree.ComparisonExpression.Operator;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.ExpressionRewriter;
 import io.trino.sql.tree.ExpressionTreeRewriter;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.NotExpression;
 
@@ -65,8 +65,8 @@ public final class PushDownNegationsExpressionRewriter
         @Override
         public Expression rewriteNotExpression(NotExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
         {
-            if (node.getValue() instanceof LogicalBinaryExpression) {
-                LogicalBinaryExpression child = (LogicalBinaryExpression) node.getValue();
+            if (node.getValue() instanceof LogicalExpression) {
+                LogicalExpression child = (LogicalExpression) node.getValue();
                 List<Expression> predicates = extractPredicates(child);
                 List<Expression> negatedPredicates = predicates.stream().map(predicate -> treeRewriter.rewrite((Expression) new NotExpression(predicate), context)).collect(toImmutableList());
                 return combinePredicates(metadata, child.getOperator().flip(), negatedPredicates);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveDuplicateConditions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveDuplicateConditions.java
@@ -16,7 +16,7 @@ package io.trino.sql.planner.iterative.rule;
 import io.trino.metadata.Metadata;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.ExpressionTreeRewriter;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 
 import static io.trino.sql.ExpressionUtils.combinePredicates;
 import static io.trino.sql.ExpressionUtils.extractPredicates;
@@ -54,7 +54,7 @@ public class RemoveDuplicateConditions
         }
 
         @Override
-        public Expression rewriteLogicalBinaryExpression(LogicalBinaryExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        public Expression rewriteLogicalExpression(LogicalExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
         {
             return combinePredicates(metadata, node.getOperator(), extractPredicates(node));
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyFilterPredicate.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyFilterPredicate.java
@@ -23,7 +23,7 @@ import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.IfExpression;
 import io.trino.sql.tree.IsNullPredicate;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.NotExpression;
 import io.trino.sql.tree.NullIfExpression;
 import io.trino.sql.tree.NullLiteral;
@@ -42,8 +42,6 @@ import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.plan.Patterns.filter;
 import static io.trino.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
-import static io.trino.sql.tree.LogicalBinaryExpression.Operator.AND;
-import static io.trino.sql.tree.LogicalBinaryExpression.Operator.OR;
 
 /**
  * Simplify conditional expressions in filter predicate.
@@ -129,7 +127,7 @@ public class SimplifyFilterPredicate
 
         if (expression instanceof NullIfExpression) {
             NullIfExpression nullIfExpression = (NullIfExpression) expression;
-            return Optional.of(new LogicalBinaryExpression(AND, nullIfExpression.getFirst(), isFalseOrNullPredicate(nullIfExpression.getSecond())));
+            return Optional.of(LogicalExpression.and(nullIfExpression.getFirst(), isFalseOrNullPredicate(nullIfExpression.getSecond())));
         }
 
         if (expression instanceof SearchedCaseExpression) {
@@ -234,6 +232,6 @@ public class SimplifyFilterPredicate
 
     private static Expression isFalseOrNullPredicate(Expression expression)
     {
-        return new LogicalBinaryExpression(OR, new IsNullPredicate(expression), new NotExpression(expression));
+        return LogicalExpression.or(new IsNullPredicate(expression), new NotExpression(expression));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/relational/SqlToRowExpressionTranslator.java
@@ -56,7 +56,7 @@ import io.trino.sql.tree.IsNotNullPredicate;
 import io.trino.sql.tree.IsNullPredicate;
 import io.trino.sql.tree.LambdaArgumentDeclaration;
 import io.trino.sql.tree.LambdaExpression;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.NotExpression;
@@ -410,7 +410,7 @@ public final class SqlToRowExpressionTranslator
         }
 
         @Override
-        protected RowExpression visitLogicalBinaryExpression(LogicalBinaryExpression node, Void context)
+        protected RowExpression visitLogicalExpression(LogicalExpression node, Void context)
         {
             Form form;
             switch (node.getOperator()) {
@@ -426,8 +426,9 @@ public final class SqlToRowExpressionTranslator
             return new SpecialForm(
                     form,
                     BOOLEAN,
-                    process(node.getLeft(), context),
-                    process(node.getRight(), context));
+                    node.getTerms().stream()
+                            .map(term -> process(term, context))
+                            .collect(toImmutableList()));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -139,7 +139,7 @@ import static io.trino.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static io.trino.sql.tree.CreateView.Security.DEFINER;
 import static io.trino.sql.tree.CreateView.Security.INVOKER;
-import static io.trino.sql.tree.LogicalBinaryExpression.and;
+import static io.trino.sql.tree.LogicalExpression.and;
 import static io.trino.sql.tree.ShowCreate.Type.MATERIALIZED_VIEW;
 import static io.trino.sql.tree.ShowCreate.Type.SCHEMA;
 import static io.trino.sql.tree.ShowCreate.Type.TABLE;

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionUtils.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionUtils.java
@@ -13,13 +13,15 @@
  */
 package io.trino.sql;
 
+import com.google.common.collect.ImmutableList;
 import io.trino.metadata.Metadata;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Identifier;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import org.testng.annotations.Test;
 
 import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.sql.tree.LogicalExpression.Operator.AND;
 import static org.testng.Assert.assertEquals;
 
 public class TestExpressionUtils
@@ -37,20 +39,15 @@ public class TestExpressionUtils
 
         assertEquals(
                 ExpressionUtils.and(a, b, c, d, e),
-                and(and(and(a, b), and(c, d)), e));
+                new LogicalExpression(AND, ImmutableList.of(a, b, c, d, e)));
 
         assertEquals(
                 ExpressionUtils.combineConjuncts(metadata, a, b, a, c, d, c, e),
-                and(and(and(a, b), and(c, d)), e));
+                new LogicalExpression(AND, ImmutableList.of(a, b, c, d, e)));
     }
 
     private static Identifier name(String name)
     {
         return new Identifier(name);
-    }
-
-    private LogicalBinaryExpression and(Expression left, Expression right)
-    {
-        return new LogicalBinaryExpression(LogicalBinaryExpression.Operator.AND, left, right);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLocalExecutionPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLocalExecutionPlanner.java
@@ -58,9 +58,9 @@ public class TestLocalExecutionPlanner
     {
         // Filter Query
         String filterQueryInner = "FROM (SELECT rand() as c1, rand() as c2, rand() as c3)";
-        String filterQueryWhere = "WHERE c1 = rand() OR " + Joiner.on(" AND ").join(nCopies(250, "c1 = rand()"))
-                + " OR " + Joiner.on(" AND ").join(nCopies(200, " c2 = rand()"))
-                + " OR " + Joiner.on(" AND ").join(nCopies(200, " c3 = rand()"));
+        String filterQueryWhere = "WHERE c1 = rand() OR " + Joiner.on(" AND ").join(nCopies(1000, "c1 = rand()"))
+                + " OR " + Joiner.on(" AND ").join(nCopies(1000, " c2 = rand()"))
+                + " OR " + Joiner.on(" AND ").join(nCopies(1000, " c3 = rand()"));
 
         assertTrinoExceptionThrownBy(() -> runner.execute("SELECT * " + filterQueryInner + filterQueryWhere))
                 .hasErrorCode(COMPILER_ERROR)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestLogicalPlanner.java
@@ -1202,7 +1202,7 @@ public class TestLogicalPlanner
                                                         join(
                                                                 LEFT,
                                                                 ImmutableList.of(),
-                                                                Optional.of("((((region_regionkey IS NULL) OR (region_regionkey = nation_regionkey)) OR (nation_regionkey IS NULL)) AND (nation_name < region_name))"),
+                                                                Optional.of("(region_regionkey IS NULL OR region_regionkey = nation_regionkey OR nation_regionkey IS NULL) AND nation_name < region_name"),
                                                                 assignUniqueId(
                                                                         "unique",
                                                                         tableScan("region", ImmutableMap.of(

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionVerifier.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExpressionVerifier.java
@@ -34,7 +34,7 @@ import io.trino.sql.tree.IsNotNullPredicate;
 import io.trino.sql.tree.IsNullPredicate;
 import io.trino.sql.tree.LambdaExpression;
 import io.trino.sql.tree.LikePredicate;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NotExpression;
@@ -427,17 +427,25 @@ public final class ExpressionVerifier
     }
 
     @Override
-    protected Boolean visitLogicalBinaryExpression(LogicalBinaryExpression actual, Node expectedExpression)
+    protected Boolean visitLogicalExpression(LogicalExpression actual, Node expectedExpression)
     {
-        if (!(expectedExpression instanceof LogicalBinaryExpression)) {
+        if (!(expectedExpression instanceof LogicalExpression)) {
             return false;
         }
 
-        LogicalBinaryExpression expected = (LogicalBinaryExpression) expectedExpression;
+        LogicalExpression expected = (LogicalExpression) expectedExpression;
 
-        return actual.getOperator() == expected.getOperator() &&
-                process(actual.getLeft(), expected.getLeft()) &&
-                process(actual.getRight(), expected.getRight());
+        if (actual.getTerms().size() != expected.getTerms().size() || actual.getOperator() != expected.getOperator()) {
+            return false;
+        }
+
+        for (int i = 0; i < actual.getTerms().size(); i++) {
+            if (!process(actual.getTerms().get(i), expected.getTerms().get(i))) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     @Override

--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -383,10 +383,10 @@ expression
     ;
 
 booleanExpression
-    : valueExpression predicate[$valueExpression.ctx]?             #predicated
-    | NOT booleanExpression                                        #logicalNot
-    | left=booleanExpression operator=AND right=booleanExpression  #logicalBinary
-    | left=booleanExpression operator=OR right=booleanExpression   #logicalBinary
+    : valueExpression predicate[$valueExpression.ctx]?  #predicated
+    | NOT booleanExpression                             #logicalNot
+    | booleanExpression AND booleanExpression           #and
+    | booleanExpression OR booleanExpression            #or
     ;
 
 // workaround for https://github.com/antlr/antlr4/issues/780

--- a/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/ExpressionFormatter.java
@@ -65,7 +65,7 @@ import io.trino.sql.tree.LabelDereference;
 import io.trino.sql.tree.LambdaArgumentDeclaration;
 import io.trino.sql.tree.LambdaExpression;
 import io.trino.sql.tree.LikePredicate;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NotExpression;
@@ -106,6 +106,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.PrimitiveIterator;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -465,9 +466,13 @@ public final class ExpressionFormatter
         }
 
         @Override
-        protected String visitLogicalBinaryExpression(LogicalBinaryExpression node, Void context)
+        protected String visitLogicalExpression(LogicalExpression node, Void context)
         {
-            return formatBinaryExpression(node.getOperator().toString(), node.getLeft(), node.getRight());
+            return "(" +
+                    node.getTerms().stream()
+                            .map(term -> process(term, context))
+                            .collect(Collectors.joining(" " + node.getOperator().toString() + " ")) +
+                    ")";
         }
 
         @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
@@ -23,7 +23,7 @@ import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.GroupBy;
 import io.trino.sql.tree.Identifier;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.Offset;
@@ -124,7 +124,7 @@ public final class QueryUtil
 
     public static Expression logicalAnd(Expression left, Expression right)
     {
-        return new LogicalBinaryExpression(LogicalBinaryExpression.Operator.AND, left, right);
+        return LogicalExpression.and(left, right);
     }
 
     public static Expression equal(Expression left, Expression right)

--- a/core/trino-parser/src/main/java/io/trino/sql/TreePrinter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/TreePrinter.java
@@ -32,7 +32,7 @@ import io.trino.sql.tree.GroupingSets;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.InPredicate;
 import io.trino.sql.tree.LikePredicate;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.Node;
 import io.trino.sql.tree.OrderBy;
@@ -303,11 +303,11 @@ public class TreePrinter
             }
 
             @Override
-            protected Void visitLogicalBinaryExpression(LogicalBinaryExpression node, Integer indentLevel)
+            protected Void visitLogicalExpression(LogicalExpression node, Integer indentLevel)
             {
                 print(indentLevel, node.getOperator().toString());
 
-                super.visitLogicalBinaryExpression(node, indentLevel + 1);
+                super.visitLogicalExpression(node, indentLevel + 1);
 
                 return null;
             }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -432,7 +432,7 @@ public abstract class AstVisitor<R, C>
         return visitExpression(node, context);
     }
 
-    protected R visitLogicalBinaryExpression(LogicalBinaryExpression node, C context)
+    protected R visitLogicalExpression(LogicalExpression node, C context)
     {
         return visitExpression(node, context);
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DefaultTraversalVisitor.java
@@ -452,10 +452,11 @@ public abstract class DefaultTraversalVisitor<C>
     }
 
     @Override
-    protected Void visitLogicalBinaryExpression(LogicalBinaryExpression node, C context)
+    protected Void visitLogicalExpression(LogicalExpression node, C context)
     {
-        process(node.getLeft(), context);
-        process(node.getRight(), context);
+        for (Node child : node.getTerms()) {
+            process(child, context);
+        }
 
         return null;
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionRewriter.java
@@ -45,7 +45,7 @@ public class ExpressionRewriter<C>
         return rewriteExpression(node, context, treeRewriter);
     }
 
-    public Expression rewriteLogicalBinaryExpression(LogicalBinaryExpression node, C context, ExpressionTreeRewriter<C> treeRewriter)
+    public Expression rewriteLogicalExpression(LogicalExpression node, C context, ExpressionTreeRewriter<C> treeRewriter)
     {
         return rewriteExpression(node, context, treeRewriter);
     }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ExpressionTreeRewriter.java
@@ -236,20 +236,18 @@ public final class ExpressionTreeRewriter<C>
         }
 
         @Override
-        public Expression visitLogicalBinaryExpression(LogicalBinaryExpression node, Context<C> context)
+        public Expression visitLogicalExpression(LogicalExpression node, Context<C> context)
         {
             if (!context.isDefaultRewrite()) {
-                Expression result = rewriter.rewriteLogicalBinaryExpression(node, context.get(), ExpressionTreeRewriter.this);
+                Expression result = rewriter.rewriteLogicalExpression(node, context.get(), ExpressionTreeRewriter.this);
                 if (result != null) {
                     return result;
                 }
             }
 
-            Expression left = rewrite(node.getLeft(), context.get());
-            Expression right = rewrite(node.getRight(), context.get());
-
-            if (left != node.getLeft() || right != node.getRight()) {
-                return new LogicalBinaryExpression(node.getOperator(), left, right);
+            List<Expression> terms = rewrite(node.getTerms(), context);
+            if (!sameElements(node.getTerms(), terms)) {
+                return new LogicalExpression(node.getOperator(), terms);
             }
 
             return node;

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -96,7 +96,7 @@ import io.trino.sql.tree.LambdaExpression;
 import io.trino.sql.tree.Lateral;
 import io.trino.sql.tree.LikeClause;
 import io.trino.sql.tree.Limit;
-import io.trino.sql.tree.LogicalBinaryExpression;
+import io.trino.sql.tree.LogicalExpression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.MeasureDefinition;
 import io.trino.sql.tree.Merge;
@@ -785,23 +785,70 @@ public class TestSqlParser
     @Test
     public void testPrecedenceAndAssociativity()
     {
-        assertExpression("1 AND 2 OR 3", new LogicalBinaryExpression(LogicalBinaryExpression.Operator.OR,
-                new LogicalBinaryExpression(LogicalBinaryExpression.Operator.AND,
+        assertThat(expression("1 AND 2 AND 3 AND 4"))
+                .isEqualTo(new LogicalExpression(
+                        location(1, 1),
+                        LogicalExpression.Operator.AND,
+                        ImmutableList.of(
+                                new LongLiteral(location(1, 1), "1"),
+                                new LongLiteral(location(1, 7), "2"),
+                                new LongLiteral(location(1, 13), "3"),
+                                new LongLiteral(location(1, 19), "4"))));
+
+        assertThat(expression("1 OR 2 OR 3 OR 4"))
+                .isEqualTo(new LogicalExpression(
+                        location(1, 1),
+                        LogicalExpression.Operator.OR,
+                        ImmutableList.of(
+                                new LongLiteral(location(1, 1), "1"),
+                                new LongLiteral(location(1, 6), "2"),
+                                new LongLiteral(location(1, 11), "3"),
+                                new LongLiteral(location(1, 16), "4"))));
+
+        assertThat(expression("1 AND 2 AND 3 OR 4 AND 5 AND 6 OR 7 AND 8 AND 9"))
+                .isEqualTo(new LogicalExpression(
+                        location(1, 1),
+                        LogicalExpression.Operator.OR,
+                        ImmutableList.of(
+                                new LogicalExpression(
+                                        location(1, 1),
+                                        LogicalExpression.Operator.AND,
+                                        ImmutableList.of(
+                                                new LongLiteral(location(1, 1), "1"),
+                                                new LongLiteral(location(1, 7), "2"),
+                                                new LongLiteral(location(1, 13), "3"))),
+                                new LogicalExpression(
+                                        location(1, 18),
+                                        LogicalExpression.Operator.AND,
+                                        ImmutableList.of(
+                                                new LongLiteral(location(1, 18), "4"),
+                                                new LongLiteral(location(1, 24), "5"),
+                                                new LongLiteral(location(1, 30), "6"))),
+                                new LogicalExpression(
+                                        location(1, 35),
+                                        LogicalExpression.Operator.AND,
+                                        ImmutableList.of(
+                                                new LongLiteral(location(1, 35), "7"),
+                                                new LongLiteral(location(1, 41), "8"),
+                                                new LongLiteral(location(1, 47), "9"))))));
+
+        assertExpression("1 AND 2 OR 3", LogicalExpression.or(
+                LogicalExpression.and(
                         new LongLiteral("1"),
                         new LongLiteral("2")),
                 new LongLiteral("3")));
 
-        assertExpression("1 OR 2 AND 3", new LogicalBinaryExpression(LogicalBinaryExpression.Operator.OR,
+        assertExpression("1 OR 2 AND 3", LogicalExpression.or(
                 new LongLiteral("1"),
-                new LogicalBinaryExpression(LogicalBinaryExpression.Operator.AND,
+                LogicalExpression.and(
                         new LongLiteral("2"),
                         new LongLiteral("3"))));
 
-        assertExpression("NOT 1 AND 2", new LogicalBinaryExpression(LogicalBinaryExpression.Operator.AND,
+        assertExpression("NOT 1 AND 2", LogicalExpression.and(
                 new NotExpression(new LongLiteral("1")),
                 new LongLiteral("2")));
 
-        assertExpression("NOT 1 OR 2", new LogicalBinaryExpression(LogicalBinaryExpression.Operator.OR,
+        assertExpression("NOT 1 OR 2", LogicalExpression.or(
                 new NotExpression(new LongLiteral("1")),
                 new LongLiteral("2")));
 
@@ -2616,7 +2663,7 @@ public class TestSqlParser
                     createShowStats(qualifiedName,
                             ImmutableList.of(new AllColumns()),
                             Optional.of(
-                                    new LogicalBinaryExpression(LogicalBinaryExpression.Operator.OR,
+                                    LogicalExpression.or(
                                             new ComparisonExpression(ComparisonExpression.Operator.GREATER_THAN,
                                                     new Identifier("field"),
                                                     new LongLiteral("0")),

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -13,11 +13,9 @@
  */
 package io.trino.sql.parser;
 
-import com.google.common.base.Joiner;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static java.util.Collections.nCopies;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -227,7 +225,11 @@ public class TestSqlParserErrorHandling
     public void testStackOverflowExpression()
     {
         for (int size = 3000; size <= 100_000; size *= 2) {
-            SQL_PARSER.createExpression(Joiner.on(" OR ").join(nCopies(size, "x = y")), new ParsingOptions());
+            String expression = "x = y";
+            for (int i = 1; i < size; i++) {
+                expression = "(" + expression + ") OR x = y";
+            }
+            SQL_PARSER.createExpression(expression, new ParsingOptions());
         }
     }
 
@@ -235,7 +237,11 @@ public class TestSqlParserErrorHandling
     public void testStackOverflowStatement()
     {
         for (int size = 6000; size <= 100_000; size *= 2) {
-            SQL_PARSER.createStatement("SELECT " + Joiner.on(" OR ").join(nCopies(size, "x = y")), PARSING_OPTIONS);
+            String expression = "x = y";
+            for (int i = 1; i < size; i++) {
+                expression = "(" + expression + ") OR x = y";
+            }
+            SQL_PARSER.createStatement("SELECT " + expression, PARSING_OPTIONS);
         }
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
@@ -40,6 +40,7 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
@@ -234,35 +235,52 @@ public final class TupleDomain<T>
      */
     public TupleDomain<T> intersect(TupleDomain<T> other)
     {
-        requireNonNull(other, "other is null");
+        return intersect(List.of(this, other));
+    }
 
-        if (this.isNone() || other.isNone()) {
+    public static <T> TupleDomain<T> intersect(List<TupleDomain<T>> domains)
+    {
+        if (domains.size() < 2) {
+            throw new IllegalArgumentException("Expected at least 2 elements");
+        }
+
+        if (domains.stream().anyMatch(TupleDomain::isNone)) {
             return none();
         }
-        if (this == other) {
-            return this;
-        }
-        if (this.isAll()) {
-            return other;
-        }
-        if (other.isAll()) {
-            return this;
+
+        if (domains.stream().allMatch(domain -> domain.equals(domains.get(0)))) {
+            return domains.get(0);
         }
 
-        Map<T, Domain> intersected = new LinkedHashMap<>(this.getDomains().get());
-        for (Map.Entry<T, Domain> entry : other.getDomains().get().entrySet()) {
-            Domain intersectionDomain = intersected.get(entry.getKey());
-            if (intersectionDomain == null) {
-                intersected.put(entry.getKey(), entry.getValue());
-            }
-            else {
-                Domain intersect = intersectionDomain.intersect(entry.getValue());
-                if (intersect.isNone()) {
-                    return TupleDomain.none();
+        List<TupleDomain<T>> candidates = domains.stream()
+                .filter(domain -> !domain.isAll())
+                .collect(toList());
+
+        if (candidates.isEmpty()) {
+            return all();
+        }
+
+        if (candidates.size() == 1) {
+            return candidates.get(0);
+        }
+
+        Map<T, Domain> intersected = new LinkedHashMap<>(candidates.get(0).getDomains().get());
+        for (int i = 1; i < candidates.size(); i++) {
+            for (Map.Entry<T, Domain> entry : candidates.get(i).getDomains().get().entrySet()) {
+                Domain intersectionDomain = intersected.get(entry.getKey());
+                if (intersectionDomain == null) {
+                    intersected.put(entry.getKey(), entry.getValue());
                 }
-                intersected.put(entry.getKey(), intersect);
+                else {
+                    Domain intersect = intersectionDomain.intersect(entry.getValue());
+                    if (intersect.isNone()) {
+                        return TupleDomain.none();
+                    }
+                    intersected.put(entry.getKey(), intersect);
+                }
             }
         }
+
         return withColumnDomains(intersected);
     }
 
@@ -275,6 +293,31 @@ public final class TupleDomain<T>
         domains.addAll(Arrays.asList(rest));
 
         return columnWiseUnion(domains);
+    }
+
+    /**
+     * Returns the tuple domain that contains all other tuple domains, or {@code Optional.empty()} if they
+     * are not supersets of each other.
+     */
+    public static <T> Optional<TupleDomain<T>> maximal(List<TupleDomain<T>> domains)
+    {
+        if (domains.isEmpty()) {
+            return Optional.empty();
+        }
+
+        TupleDomain<T> largest = domains.get(0);
+        for (int i = 1; i < domains.size(); i++) {
+            TupleDomain<T> current = domains.get(i);
+
+            if (current.contains(largest)) {
+                largest = current;
+            }
+            else if (!largest.contains(current)) {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.of(largest);
     }
 
     /**


### PR DESCRIPTION
Allow these expressions to have more than two terms to avoid
deep expression trees for trivial chains of AND or OR expressions
and the ensuing StackOverflow errors.