### PR TITLE
Fix assertProperForwardingMethodsAreCalled for interface with private methods

### DIFF
--- a/core/trino-spi/src/test/java/io/trino/spi/testing/ForwardingInterfaceWithPrivateMethod.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/testing/ForwardingInterfaceWithPrivateMethod.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.testing;
+
+import static java.util.Objects.requireNonNull;
+
+public class ForwardingInterfaceWithPrivateMethod
+        implements InterfaceWithPrivateMethod
+{
+    // Declared as field for brevity. In a typical Forwarding class this would be delegate() abstract method
+    private final InterfaceWithPrivateMethod delegate;
+
+    public ForwardingInterfaceWithPrivateMethod(InterfaceWithPrivateMethod delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public void foo()
+    {
+        delegate.foo();
+    }
+
+    @Override
+    public void bar()
+    {
+        delegate.bar();
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/testing/InterfaceTestUtils.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/testing/InterfaceTestUtils.java
@@ -66,7 +66,7 @@ public final class InterfaceTestUtils
 
     public static <I, C extends I> void assertProperForwardingMethodsAreCalled(Class<I> iface, Function<I, C> forwardingInstanceFactory, Set<Method> exclusions)
     {
-        for (Method actualMethod : difference(ImmutableSet.copyOf(iface.getDeclaredMethods()), exclusions)) {
+        for (Method actualMethod : difference(ImmutableSet.copyOf(iface.getMethods()), exclusions)) {
             Object[] actualArguments = new Object[actualMethod.getParameterCount()];
             for (int i = 0; i < actualArguments.length; i++) {
                 if (actualMethod.getParameterTypes()[i].isPrimitive()) {

--- a/core/trino-spi/src/test/java/io/trino/spi/testing/InterfaceWithPrivateMethod.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/testing/InterfaceWithPrivateMethod.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.testing;
+
+// Must be defined in separate compilation unit from the test to effectively test private methods access
+public interface InterfaceWithPrivateMethod
+{
+    void foo();
+
+    default void bar()
+    {
+        defaultBar();
+    }
+
+    private static void defaultBar()
+    {
+        throw new UnsupportedOperationException("bar not implemented");
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/testing/TestInterfaceTestUtils.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/testing/TestInterfaceTestUtils.java
@@ -88,4 +88,10 @@ public class TestInterfaceTestUtils
         @Override
         public void foo(String s) {}
     }
+
+    @Test
+    public void testAssertProperForwardingMethodsAreCalledWithPrivateMethods()
+    {
+        InterfaceTestUtils.assertProperForwardingMethodsAreCalled(InterfaceWithPrivateMethod.class, ForwardingInterfaceWithPrivateMethod::new);
+    }
 }


### PR DESCRIPTION


Fix `assertProperForwardingMethodsAreCalled` test helper. Previously it
failed when interface had a private method (either explicitly defined
`private static`, or because if a lambda in a default implementation).

cc @kokosing @hashhar 