### PR TITLE
Supports authentication using multiple ldap.user-bind-pattern value

### DIFF
--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticator.java
@@ -133,7 +133,7 @@ public class LdapAuthenticator
                 log.debug("Authentication successful for user [%s]", user);
                 return new BasicPrincipal(user);
             }
-            catch (NamingException e) {
+            catch (NamingException | AccessDeniedException e) {
                 lastException = e;
             }
         }

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticator.java
@@ -152,7 +152,7 @@ public class LdapAuthenticator
             client.validatePassword(userDistinguishedName, credential.getPassword());
             log.debug("Authentication successful for user [%s]", user);
         }
-        catch (NamingException e) {
+        catch (NamingException | AccessDeniedException e) {
             log.debug(e, "Authentication failed for user [%s], %s", user, e.getMessage());
             throw new RuntimeException("Authentication error");
         }

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
@@ -16,6 +16,7 @@ package io.trino.plugin.password.ldap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.password.Credential;
+import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.BasicPrincipal;
 import org.testng.annotations.Test;
 
@@ -73,6 +74,7 @@ public class TestLdapAuthenticator
         client.addCredentials("alice@alt.example.com", "alt-alice-pass");
         assertEquals(ldapAuthenticator.createAuthenticatedPrincipal("alice", "alt-alice-pass"), new BasicPrincipal("alice"));
         ldapAuthenticator.invalidateCache();
+
         assertEquals(ldapAuthenticator.createAuthenticatedPrincipal("alice", "alice-pass"), new BasicPrincipal("alice"));
         ldapAuthenticator.invalidateCache();
 
@@ -199,7 +201,7 @@ public class TestLdapAuthenticator
                 throws NamingException
         {
             if (!credentials.contains(new Credential(userDistinguishedName, password))) {
-                throw new NamingException();
+                throw new AccessDeniedException("Invalid credentials");
             }
         }
 

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
@@ -16,7 +16,6 @@ package io.trino.plugin.password.ldap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.plugin.password.Credential;
-import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.BasicPrincipal;
 import org.testng.annotations.Test;
 

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
@@ -76,6 +76,9 @@ public class TestLdapAuthenticator
         ldapAuthenticator.invalidateCache();
         assertEquals(ldapAuthenticator.createAuthenticatedPrincipal("alice", "alice-pass"), new BasicPrincipal("alice"));
         ldapAuthenticator.invalidateCache();
+
+        assertThatThrownBy(() -> ldapAuthenticator.createAuthenticatedPrincipal("john", "john-pass"))
+                .isInstanceOf(RuntimeException.class);
     }
 
     @Test
@@ -96,7 +99,7 @@ public class TestLdapAuthenticator
         assertThatThrownBy(() -> ldapAuthenticator.createAuthenticatedPrincipal("unknown", "alice-pass"))
                 .isInstanceOf(RuntimeException.class);
         assertThatThrownBy(() -> ldapAuthenticator.createAuthenticatedPrincipal("alice", "alice-pass"))
-                .isInstanceOf(AccessDeniedException.class);
+                .isInstanceOf(RuntimeException.class);
         client.addGroupMember("alice");
         assertEquals(ldapAuthenticator.createAuthenticatedPrincipal("alice", "alice-pass"), new BasicPrincipal("alice"));
     }
@@ -135,7 +138,7 @@ public class TestLdapAuthenticator
 
         client.addDistinguishedNameForUser("alice", "another-mapping");
         assertThatThrownBy(() -> ldapAuthenticator.createAuthenticatedPrincipal("alice", "alice-pass"))
-                .isInstanceOf(AccessDeniedException.class);
+                .isInstanceOf(RuntimeException.class);
     }
 
     @Test


### PR DESCRIPTION
Trino LDAP authentication documents are described as shown below.

>> The property can contain multiple patterns separated by a colon. Each pattern will be checked in order until a login succeeds or all logins fail. Example: ${USER}@corp.example.com:${USER}@corp.example.co.uk

But multiple ldap.user-bind-pattern values do not work as intended.

Only the first user-bind-pattern value tries to authenticate.

To work properly, add additional AccessDeniedException and handle exceptions.