### PR TITLE
Handle repeated expressions in QueryPlanner.coerce()

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -1530,7 +1530,7 @@ class QueryPlanner
         public PlanAndMappings(PlanBuilder subPlan, Map<NodeRef<Expression>, Symbol> mappings)
         {
             this.subPlan = subPlan;
-            this.mappings = mappings;
+            this.mappings = ImmutableMap.copyOf(mappings);
         }
 
         public PlanBuilder getSubPlan()

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestGroupBy.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestGroupBy.java
@@ -155,4 +155,12 @@ public class TestGroupBy
                         "GROUP BY t.A + 1"))
                 .matches("VALUES 2");
     }
+
+    @Test
+    public void testGroupByRepeatedOrdinals()
+    {
+        assertThat(assertions.query(
+                "SELECT null GROUP BY 1, 1"))
+                .matches("VALUES null");
+    }
 }


### PR DESCRIPTION
This can happen as a result of resolving repeated GROUP BY ordinals.

Fixes https://github.com/trinodb/trino/issues/8027