### PR TITLE
Allow disabling partial TopN

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -106,6 +106,7 @@ public final class SystemSessionProperties
     public static final String FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT = "filter_and_project_min_output_page_row_count";
     public static final String DISTRIBUTED_SORT = "distributed_sort";
     public static final String USE_PARTIAL_TOPN = "use_partial_topn";
+    public static final String USE_PARTIAL_DISTINCT_LIMIT = "use_partial_distinct_limit";
     public static final String MAX_RECURSION_DEPTH = "max_recursion_depth";
     public static final String USE_MARK_DISTINCT = "use_mark_distinct";
     public static final String PREFER_PARTIAL_AGGREGATION = "prefer_partial_aggregation";
@@ -459,6 +460,12 @@ public final class SystemSessionProperties
                         // Useful to make EXPLAIN or SHOW STATS provide stats for a query involving TopN
                         USE_PARTIAL_TOPN,
                         "Use partial TopN",
+                        true,
+                        true),
+                booleanProperty(
+                        // Useful to make EXPLAIN or SHOW STATS provide stats for a query involving TopN
+                        USE_PARTIAL_DISTINCT_LIMIT,
+                        "Use partial Distinct Limit",
                         true,
                         true),
                 new PropertyMetadata<>(
@@ -943,6 +950,11 @@ public final class SystemSessionProperties
     public static boolean isUsePartialTopN(Session session)
     {
         return session.getSystemProperty(USE_PARTIAL_TOPN, Boolean.class);
+    }
+
+    public static boolean isUsePartialDistinctLimit(Session session)
+    {
+        return session.getSystemProperty(USE_PARTIAL_DISTINCT_LIMIT, Boolean.class);
     }
 
     public static int getMaxRecursionDepth(Session session)

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -105,6 +105,7 @@ public final class SystemSessionProperties
     public static final String FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE = "filter_and_project_min_output_page_size";
     public static final String FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT = "filter_and_project_min_output_page_row_count";
     public static final String DISTRIBUTED_SORT = "distributed_sort";
+    public static final String USE_PARTIAL_TOPN = "use_partial_topn";
     public static final String MAX_RECURSION_DEPTH = "max_recursion_depth";
     public static final String USE_MARK_DISTINCT = "use_mark_distinct";
     public static final String PREFER_PARTIAL_AGGREGATION = "prefer_partial_aggregation";
@@ -454,6 +455,12 @@ public final class SystemSessionProperties
                         "Parallelize sort across multiple nodes",
                         featuresConfig.isDistributedSortEnabled(),
                         false),
+                booleanProperty(
+                        // Useful to make EXPLAIN or SHOW STATS provide stats for a query involving TopN
+                        USE_PARTIAL_TOPN,
+                        "Use partial TopN",
+                        true,
+                        true),
                 new PropertyMetadata<>(
                         MAX_RECURSION_DEPTH,
                         "Maximum recursion depth for recursive common table expression",
@@ -931,6 +938,11 @@ public final class SystemSessionProperties
     public static boolean isDistributedSortEnabled(Session session)
     {
         return session.getSystemProperty(DISTRIBUTED_SORT, Boolean.class);
+    }
+
+    public static boolean isUsePartialTopN(Session session)
+    {
+        return session.getSystemProperty(USE_PARTIAL_TOPN, Boolean.class);
     }
 
     public static int getMaxRecursionDepth(Session session)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CreatePartialTopN.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/CreatePartialTopN.java
@@ -13,11 +13,13 @@
  */
 package io.trino.sql.planner.iterative.rule;
 
+import io.trino.Session;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.plan.TopNNode;
 
+import static io.trino.SystemSessionProperties.isUsePartialTopN;
 import static io.trino.sql.planner.plan.Patterns.TopN.step;
 import static io.trino.sql.planner.plan.Patterns.topN;
 import static io.trino.sql.planner.plan.TopNNode.Step.FINAL;
@@ -29,6 +31,12 @@ public class CreatePartialTopN
 {
     private static final Pattern<TopNNode> PATTERN = topN()
             .with(step().equalTo(SINGLE));
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return isUsePartialTopN(session);
+    }
 
     @Override
     public Pattern<TopNNode> getPattern()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -90,6 +90,7 @@ import static io.trino.SystemSessionProperties.ignoreDownStreamPreferences;
 import static io.trino.SystemSessionProperties.isColocatedJoinEnabled;
 import static io.trino.SystemSessionProperties.isDistributedSortEnabled;
 import static io.trino.SystemSessionProperties.isForceSingleNodeOutput;
+import static io.trino.SystemSessionProperties.isUsePartialDistinctLimit;
 import static io.trino.sql.planner.FragmentTableScanCounter.countSources;
 import static io.trino.sql.planner.FragmentTableScanCounter.hasMultipleSources;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
@@ -517,7 +518,7 @@ public class AddExchanges
         {
             PlanWithProperties child = planChild(node, PreferredProperties.any());
 
-            if (!child.getProperties().isSingleNode()) {
+            if (!child.getProperties().isSingleNode() && isUsePartialDistinctLimit(session)) {
                 child = withDerivedProperties(
                         gatheringExchange(
                                 idAllocator.getNextId(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
@@ -21,6 +21,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static io.trino.SystemSessionProperties.PREFER_PARTIAL_AGGREGATION;
+import static io.trino.SystemSessionProperties.USE_PARTIAL_TOPN;
 import static io.trino.tpch.TpchTable.NATION;
 
 public class TestShowStats
@@ -440,6 +441,31 @@ public class TestShowStats
         assertQuery(
                 // TODO (https://github.com/trinodb/trino/pull/8026) don't use subquery
                 "SHOW STATS FOR (SELECT * FROM (SELECT * FROM nation LIMIT 7))",
+                "VALUES " +
+                        "   ('nationkey', null, 7, 0, null, 0, 24), " +
+                        "   ('name', 49.56, 7, 0, null, null, null), " +
+                        "   ('comment', 519.96, 7, 0, null, null, null), " +
+                        "   ('regionkey', null, 5, 0, null, 0, 4), " +
+                        "   (null, null, null, null, 7, null, null)");
+    }
+
+    @Test
+    public void testShowStatsWithTopN()
+    {
+        assertQuery(
+                // TODO (https://github.com/trinodb/trino/pull/8026) don't use subquery
+                "SHOW STATS FOR (SELECT * FROM (SELECT * FROM nation ORDER BY nationkey LIMIT 7))",
+                "VALUES " +
+                        "   ('nationkey', null, null, null, null, null, null), " +
+                        "   ('name', null, null, null, null, null, null), " +
+                        "   ('comment', null, null, null, null, null, null), " +
+                        "   ('regionkey', null, null, null, null, null, null), " +
+                        "   (null, null, null, null, null, null, null)");
+
+        assertQuery(
+                sessionWith(getSession(), USE_PARTIAL_TOPN, "false"),
+                // TODO (https://github.com/trinodb/trino/pull/8026) don't use subquery
+                "SHOW STATS FOR (SELECT * FROM (SELECT * FROM nation ORDER BY nationkey LIMIT 7))",
                 "VALUES " +
                         "   ('nationkey', null, 7, 0, null, 0, 24), " +
                         "   ('name', 49.56, 7, 0, null, null, null), " +

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
@@ -21,6 +21,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static io.trino.SystemSessionProperties.PREFER_PARTIAL_AGGREGATION;
+import static io.trino.SystemSessionProperties.USE_PARTIAL_DISTINCT_LIMIT;
 import static io.trino.SystemSessionProperties.USE_PARTIAL_TOPN;
 import static io.trino.tpch.TpchTable.NATION;
 
@@ -433,6 +434,26 @@ public class TestShowStats
                 "VALUES " +
                         "   ('regionkey', null, 5, 0, null, 0, 4), " +
                         "   (null, null, null, null, 5, null, null)");
+    }
+
+    @Test
+    public void testShowStatsWithDistinctLimit()
+    {
+        // TODO calculate row count - https://github.com/trinodb/trino/issues/6323
+        assertQuery(
+                // TODO (https://github.com/trinodb/trino/pull/8026) don't use subquery
+                "SHOW STATS FOR (SELECT * FROM (SELECT DISTINCT regionkey FROM nation LIMIT 3))",
+                "VALUES " +
+                        "   ('regionkey', null, null, null, null, null, null), " +
+                        "   (null, null, null, null, null, null, null)");
+
+        assertQuery(
+                sessionWith(getSession(), USE_PARTIAL_DISTINCT_LIMIT, "false"),
+                // TODO (https://github.com/trinodb/trino/pull/8026) don't use subquery
+                "SHOW STATS FOR (SELECT * FROM (SELECT DISTINCT regionkey FROM nation LIMIT 3))",
+                "VALUES " +
+                        "   ('regionkey', null, null, null, null, null, null), " +
+                        "   (null, null, null, null, null, null, null)");
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestShowStats.java
@@ -435,6 +435,20 @@ public class TestShowStats
     }
 
     @Test
+    public void testShowStatsWithLimit()
+    {
+        assertQuery(
+                // TODO (https://github.com/trinodb/trino/pull/8026) don't use subquery
+                "SHOW STATS FOR (SELECT * FROM (SELECT * FROM nation LIMIT 7))",
+                "VALUES " +
+                        "   ('nationkey', null, 7, 0, null, 0, 24), " +
+                        "   ('name', 49.56, 7, 0, null, null, null), " +
+                        "   ('comment', 519.96, 7, 0, null, null, null), " +
+                        "   ('regionkey', null, 5, 0, null, 0, 4), " +
+                        "   (null, null, null, null, 7, null, null)");
+    }
+
+    @Test
     public void testShowStatsWithSelectFunctionCall()
     {
         assertQuery(


### PR DESCRIPTION
This is useful, would one wanted to get good statistics from EXPLAIN
output for a query involving TopN.


cc @sopel39 @kokosing @martint 