### PR TITLE
Push FINAL TopN into Table Scan

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushTopNIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushTopNIntoTableScan.java
@@ -238,6 +238,56 @@ public class TestPushTopNIntoTableScan
         }
     }
 
+    /**
+     * Ensure FINAL TopN can be pushed into table scan.
+     * <p>
+     * In case of TopN over outer join, TopN may become eligible for push down
+     * only after PARTIAL TopN was pushed down and only then the join was
+     * pushed down as well -- the connector may decide to accept Join pushdown
+     * only after it learns there is TopN in play which limits results size.
+     * <p>
+     * Thus the optimization sequence can be:
+     * <ol>
+     * <li>Try to push Join into Table Scan -- connector rejects that (e.g. too big data set size)
+     * <li>Create FINAL/PARTIAL TopN
+     * <li>Push PARTIAL TopN through Outer Join
+     * <li>Push PARTIAL TopN into Table Scan -- connector accepts that.
+     * <li>Push Join into Table Scan -- connector now accepts join pushdown.
+     * <li>Push FINAL TopN into Table Scan
+     * </ol>
+     */
+    @Test
+    public void testPushFinalTopNIntoTableScan()
+    {
+        try (RuleTester ruleTester = defaultRuleTester()) {
+            MockConnectorTableHandle connectorHandle = new MockConnectorTableHandle(TEST_SCHEMA_TABLE);
+            // make the mock connector return a new connectorHandle
+            MockConnectorFactory.ApplyTopN applyTopN =
+                    (session, handle, topNCount, sortItems, tableAssignments) -> Optional.of(new TopNApplicationResult<>(connectorHandle, true));
+            MockConnectorFactory mockFactory = createMockFactory(assignments, Optional.of(applyTopN));
+
+            ruleTester.getQueryRunner().createCatalog(MOCK_CATALOG, mockFactory, ImmutableMap.of());
+
+            ruleTester.assertThat(new PushTopNIntoTableScan(ruleTester.getMetadata()))
+                    .on(p -> {
+                        Symbol dimension = p.symbol(dimensionName, VARCHAR);
+                        Symbol metric = p.symbol(metricName, BIGINT);
+                        return p.topN(1, ImmutableList.of(dimension), TopNNode.Step.FINAL,
+                                p.tableScan(TEST_TABLE_HANDLE,
+                                        ImmutableList.of(dimension, metric),
+                                        ImmutableMap.of(
+                                                dimension, dimensionColumn,
+                                                metric, metricColumn)));
+                    })
+                    .withSession(MOCK_SESSION)
+                    .matches(
+                            tableScan(
+                                    connectorHandle::equals,
+                                    TupleDomain.all(),
+                                    new HashMap<>()));
+        }
+    }
+
     private MockConnectorFactory createMockFactory(Map<String, ColumnHandle> assignments, Optional<MockConnectorFactory.ApplyTopN> applyTopN)
     {
         List<ColumnMetadata> metadata = assignments.entrySet().stream()


### PR DESCRIPTION
In case of TopN over outer join, TopN may become eligible for push down
only after PARTIAL TopN was pushed down and only then the join was
pushed down as well -- the connector may decide to accept Join pushdown
only after it learns there is TopN in play which limits results size.

Thus the optimization sequence can be:

1. Try to push Join into Table Scan -- connector rejects that.
2. Create FINAL/PARTIAL TopN
3. Push PARTIAL TopN through Outer Join
4. Push PARTIAL TopN into Table Scan
5. Push Join into Table Scan
6. Push FINAL TopN into Table Scan

cc @sopel39 @kokosing @martint @kasiafi @hashhar @wendigo 