### PR TITLE
Update documentation for cast of row to json

### DIFF
--- a/docs/src/main/sphinx/functions/json.rst
+++ b/docs/src/main/sphinx/functions/json.rst
@@ -45,16 +45,12 @@ Behaviors of the casts are shown with the examples below::
 
     SELECT CAST(CAST(ROW(123, 'abc', true) AS
                 ROW(v1 BIGINT, v2 VARCHAR, v3 BOOLEAN)) AS JSON);
-    -- JSON '[123,"abc",true]'
+    -- JSON '{"v1":123,"v2":"abc","v3":true}'
 
 Casting from NULL to ``JSON`` is not straightforward. Casting
 from a standalone ``NULL`` will produce a SQL ``NULL`` instead of
 ``JSON 'null'``. However, when casting from arrays or map containing
 ``NULL``\s, the produced ``JSON`` will have ``null``\s in it.
-
-When casting from ``ROW`` to ``JSON``, the result is a JSON array rather
-than a JSON object. This is because positions are more important than
-names for rows in SQL.
 
 Cast from JSON
 --------------


### PR DESCRIPTION
This follows up on the change to produce a JSON object instead
of a JSON array when casting from a row type. (https://github.com/trinodb/trino/issues/3536)