### PR TITLE
Revert "Refactor TypeCoercion.coerceTypeBase"

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
+++ b/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
@@ -311,193 +311,196 @@ public final class TypeCoercion
             return Optional.of(sourceType);
         }
 
-        if (UnknownType.NAME.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.BOOLEAN:
-                case StandardTypes.BIGINT:
-                case StandardTypes.INTEGER:
-                case StandardTypes.DOUBLE:
-                case StandardTypes.REAL:
-                case StandardTypes.VARBINARY:
-                case StandardTypes.DATE:
-                case StandardTypes.TIME:
-                case StandardTypes.TIME_WITH_TIME_ZONE:
-                case StandardTypes.TIMESTAMP:
-                case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
-                case StandardTypes.HYPER_LOG_LOG:
-                case SetDigestType.NAME:
-                case StandardTypes.P4_HYPER_LOG_LOG:
-                case StandardTypes.JSON:
-                case StandardTypes.INTERVAL_YEAR_TO_MONTH:
-                case StandardTypes.INTERVAL_DAY_TO_SECOND:
-                case JoniRegexpType.NAME:
-                case JsonPathType.NAME:
-                case ColorType.NAME:
-                case CodePointsType.NAME:
-                    return Optional.of(lookupType.apply(new TypeSignature(resultTypeBase)));
-                case StandardTypes.VARCHAR:
-                    return Optional.of(createVarcharType(0));
-                case StandardTypes.CHAR:
-                    return Optional.of(createCharType(0));
-                case StandardTypes.DECIMAL:
-                    return Optional.of(createDecimalType(1, 0));
-                default:
-                    return Optional.empty();
+        switch (sourceTypeName) {
+            case UnknownType.NAME: {
+                switch (resultTypeBase) {
+                    case StandardTypes.BOOLEAN:
+                    case StandardTypes.BIGINT:
+                    case StandardTypes.INTEGER:
+                    case StandardTypes.DOUBLE:
+                    case StandardTypes.REAL:
+                    case StandardTypes.VARBINARY:
+                    case StandardTypes.DATE:
+                    case StandardTypes.TIME:
+                    case StandardTypes.TIME_WITH_TIME_ZONE:
+                    case StandardTypes.TIMESTAMP:
+                    case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
+                    case StandardTypes.HYPER_LOG_LOG:
+                    case SetDigestType.NAME:
+                    case StandardTypes.P4_HYPER_LOG_LOG:
+                    case StandardTypes.JSON:
+                    case StandardTypes.INTERVAL_YEAR_TO_MONTH:
+                    case StandardTypes.INTERVAL_DAY_TO_SECOND:
+                    case JoniRegexpType.NAME:
+                    case JsonPathType.NAME:
+                    case ColorType.NAME:
+                    case CodePointsType.NAME:
+                        return Optional.of(lookupType.apply(new TypeSignature(resultTypeBase)));
+                    case StandardTypes.VARCHAR:
+                        return Optional.of(createVarcharType(0));
+                    case StandardTypes.CHAR:
+                        return Optional.of(createCharType(0));
+                    case StandardTypes.DECIMAL:
+                        return Optional.of(createDecimalType(1, 0));
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.TINYINT.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.SMALLINT:
-                    return Optional.of(SMALLINT);
-                case StandardTypes.INTEGER:
-                    return Optional.of(INTEGER);
-                case StandardTypes.BIGINT:
-                    return Optional.of(BIGINT);
-                case StandardTypes.REAL:
-                    return Optional.of(REAL);
-                case StandardTypes.DOUBLE:
-                    return Optional.of(DOUBLE);
-                case StandardTypes.DECIMAL:
-                    return Optional.of(createDecimalType(3, 0));
-                default:
-                    return Optional.empty();
+            case StandardTypes.TINYINT: {
+                switch (resultTypeBase) {
+                    case StandardTypes.SMALLINT:
+                        return Optional.of(SMALLINT);
+                    case StandardTypes.INTEGER:
+                        return Optional.of(INTEGER);
+                    case StandardTypes.BIGINT:
+                        return Optional.of(BIGINT);
+                    case StandardTypes.REAL:
+                        return Optional.of(REAL);
+                    case StandardTypes.DOUBLE:
+                        return Optional.of(DOUBLE);
+                    case StandardTypes.DECIMAL:
+                        return Optional.of(createDecimalType(3, 0));
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.SMALLINT.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.INTEGER:
-                    return Optional.of(INTEGER);
-                case StandardTypes.BIGINT:
-                    return Optional.of(BIGINT);
-                case StandardTypes.REAL:
-                    return Optional.of(REAL);
-                case StandardTypes.DOUBLE:
-                    return Optional.of(DOUBLE);
-                case StandardTypes.DECIMAL:
-                    return Optional.of(createDecimalType(5, 0));
-                default:
-                    return Optional.empty();
+            case StandardTypes.SMALLINT: {
+                switch (resultTypeBase) {
+                    case StandardTypes.INTEGER:
+                        return Optional.of(INTEGER);
+                    case StandardTypes.BIGINT:
+                        return Optional.of(BIGINT);
+                    case StandardTypes.REAL:
+                        return Optional.of(REAL);
+                    case StandardTypes.DOUBLE:
+                        return Optional.of(DOUBLE);
+                    case StandardTypes.DECIMAL:
+                        return Optional.of(createDecimalType(5, 0));
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.INTEGER.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.BIGINT:
-                    return Optional.of(BIGINT);
-                case StandardTypes.REAL:
-                    return Optional.of(REAL);
-                case StandardTypes.DOUBLE:
-                    return Optional.of(DOUBLE);
-                case StandardTypes.DECIMAL:
-                    return Optional.of(createDecimalType(10, 0));
-                default:
-                    return Optional.empty();
+            case StandardTypes.INTEGER: {
+                switch (resultTypeBase) {
+                    case StandardTypes.BIGINT:
+                        return Optional.of(BIGINT);
+                    case StandardTypes.REAL:
+                        return Optional.of(REAL);
+                    case StandardTypes.DOUBLE:
+                        return Optional.of(DOUBLE);
+                    case StandardTypes.DECIMAL:
+                        return Optional.of(createDecimalType(10, 0));
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.BIGINT.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.REAL:
-                    return Optional.of(REAL);
-                case StandardTypes.DOUBLE:
-                    return Optional.of(DOUBLE);
-                case StandardTypes.DECIMAL:
-                    return Optional.of(createDecimalType(19, 0));
-                default:
-                    return Optional.empty();
+            case StandardTypes.BIGINT: {
+                switch (resultTypeBase) {
+                    case StandardTypes.REAL:
+                        return Optional.of(REAL);
+                    case StandardTypes.DOUBLE:
+                        return Optional.of(DOUBLE);
+                    case StandardTypes.DECIMAL:
+                        return Optional.of(createDecimalType(19, 0));
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.DECIMAL.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.REAL:
-                    return Optional.of(REAL);
-                case StandardTypes.DOUBLE:
-                    return Optional.of(DOUBLE);
-                default:
-                    return Optional.empty();
+            case StandardTypes.DECIMAL: {
+                switch (resultTypeBase) {
+                    case StandardTypes.REAL:
+                        return Optional.of(REAL);
+                    case StandardTypes.DOUBLE:
+                        return Optional.of(DOUBLE);
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.REAL.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.DOUBLE:
-                    return Optional.of(DOUBLE);
-                default:
-                    return Optional.empty();
+            case StandardTypes.REAL: {
+                switch (resultTypeBase) {
+                    case StandardTypes.DOUBLE:
+                        return Optional.of(DOUBLE);
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.DATE.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.TIMESTAMP:
-                    return Optional.of(createTimestampType(0));
-                case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
-                    return Optional.of(TIMESTAMP_WITH_TIME_ZONE);
-                default:
-                    return Optional.empty();
+            case StandardTypes.DATE: {
+                switch (resultTypeBase) {
+                    case StandardTypes.TIMESTAMP:
+                        return Optional.of(createTimestampType(0));
+                    case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
+                        return Optional.of(TIMESTAMP_WITH_TIME_ZONE);
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.TIME.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.TIME_WITH_TIME_ZONE:
-                    return Optional.of(TIME_WITH_TIME_ZONE);
-                default:
-                    return Optional.empty();
+            case StandardTypes.TIME: {
+                switch (resultTypeBase) {
+                    case StandardTypes.TIME_WITH_TIME_ZONE:
+                        return Optional.of(TIME_WITH_TIME_ZONE);
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.TIMESTAMP.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
-                    return Optional.of(createTimestampWithTimeZoneType(((TimestampType) sourceType).getPrecision()));
-                default:
-                    return Optional.empty();
+            case StandardTypes.TIMESTAMP: {
+                switch (resultTypeBase) {
+                    case StandardTypes.TIMESTAMP_WITH_TIME_ZONE:
+                        return Optional.of(createTimestampWithTimeZoneType(((TimestampType) sourceType).getPrecision()));
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.VARCHAR.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.CHAR:
-                    VarcharType varcharType = (VarcharType) sourceType;
-                    if (varcharType.isUnbounded()) {
-                        return Optional.of(createCharType(CharType.MAX_LENGTH));
-                    }
+            case StandardTypes.VARCHAR: {
+                switch (resultTypeBase) {
+                    case StandardTypes.CHAR:
+                        VarcharType varcharType = (VarcharType) sourceType;
+                        if (varcharType.isUnbounded()) {
+                            return Optional.of(createCharType(CharType.MAX_LENGTH));
+                        }
 
-                    return Optional.of(createCharType(Math.min(CharType.MAX_LENGTH, varcharType.getBoundedLength())));
-                case JoniRegexpType.NAME:
-                    return Optional.of(JONI_REGEXP);
-                case Re2JRegexpType.NAME:
-                    return Optional.of(lookupType.apply(RE2J_REGEXP_SIGNATURE));
-                case JsonPathType.NAME:
-                    return Optional.of(JSON_PATH);
-                case CodePointsType.NAME:
-                    return Optional.of(CODE_POINTS);
-                default:
-                    return Optional.empty();
+                        return Optional.of(createCharType(Math.min(CharType.MAX_LENGTH, varcharType.getBoundedLength())));
+                    case JoniRegexpType.NAME:
+                        return Optional.of(JONI_REGEXP);
+                    case Re2JRegexpType.NAME:
+                        return Optional.of(lookupType.apply(RE2J_REGEXP_SIGNATURE));
+                    case JsonPathType.NAME:
+                        return Optional.of(JSON_PATH);
+                    case CodePointsType.NAME:
+                        return Optional.of(CODE_POINTS);
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.CHAR.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.VARCHAR:
-                    // CHAR could be coercible to VARCHAR, but they cannot be both coercible to each other.
-                    // VARCHAR to CHAR coercion provides natural semantics when comparing VARCHAR literals to CHAR columns.
-                    // WITH CHAR to VARCHAR coercion one would need to pad literals with spaces: char_column_len_5 = 'abc  ', so we would not run unmodified TPC-DS queries.
-                    return Optional.empty();
-                case JoniRegexpType.NAME:
-                    return Optional.of(JONI_REGEXP);
-                case Re2JRegexpType.NAME:
-                    return Optional.of(lookupType.apply(RE2J_REGEXP_SIGNATURE));
-                case JsonPathType.NAME:
-                    return Optional.of(JSON_PATH);
-                case CodePointsType.NAME:
-                    return Optional.of(CODE_POINTS);
-                default:
-                    return Optional.empty();
+            case StandardTypes.CHAR: {
+                switch (resultTypeBase) {
+                    case StandardTypes.VARCHAR:
+                        // CHAR could be coercible to VARCHAR, but they cannot be both coercible to each other.
+                        // VARCHAR to CHAR coercion provides natural semantics when comparing VARCHAR literals to CHAR columns.
+                        // WITH CHAR to VARCHAR coercion one would need to pad literals with spaces: char_column_len_5 = 'abc  ', so we would not run unmodified TPC-DS queries.
+                        return Optional.empty();
+                    case JoniRegexpType.NAME:
+                        return Optional.of(JONI_REGEXP);
+                    case Re2JRegexpType.NAME:
+                        return Optional.of(lookupType.apply(RE2J_REGEXP_SIGNATURE));
+                    case JsonPathType.NAME:
+                        return Optional.of(JSON_PATH);
+                    case CodePointsType.NAME:
+                        return Optional.of(CODE_POINTS);
+                    default:
+                        return Optional.empty();
+                }
             }
-        }
-        if (StandardTypes.P4_HYPER_LOG_LOG.equals(sourceTypeName)) {
-            switch (resultTypeBase) {
-                case StandardTypes.HYPER_LOG_LOG:
-                    return Optional.of(HYPER_LOG_LOG);
-                default:
-                    return Optional.empty();
+            case StandardTypes.P4_HYPER_LOG_LOG: {
+                switch (resultTypeBase) {
+                    case StandardTypes.HYPER_LOG_LOG:
+                        return Optional.of(HYPER_LOG_LOG);
+                    default:
+                        return Optional.empty();
+                }
             }
+            default:
+                return Optional.empty();
         }
-        return Optional.empty();
     }
 
     public static boolean isCovariantTypeBase(String typeBase)


### PR DESCRIPTION
This reverts commit faca065a458e1402f844716b0ba85869b7e8168d.

faca065a458e1402f844716b0ba85869b7e8168d was merged because it seemed to
reduce probability of a rare failure in function resolution. The failure
itself looked as if it was JIT-related. Later it was observed that even
if that commit reduced probability of such failures, it definitely did
not eliminate it. However, the problem was not observed recently, so it
is possible it stopped appearing thanks to a JDK version change
(probably from about 11.0.9 to 11.0.11 used on CI today).

The revert itself was a mechanical `git revert`.

Reverts https://github.com/trinodb/trino/pull/6321
Relates to https://github.com/trinodb/trino/issues/5758#issuecomment-847892608

cc @wendigo @martint @kasiafi @dain @sopel39 @kokosing 