### PR TITLE
LDAP Group Provider Support

### DIFF
--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/PasswordAuthenticatorPlugin.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/PasswordAuthenticatorPlugin.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.plugin.password.file.FileAuthenticatorFactory;
 import io.trino.plugin.password.file.FileGroupProviderFactory;
 import io.trino.plugin.password.ldap.LdapAuthenticatorFactory;
+import io.trino.plugin.password.ldap.LdapGroupProviderFactory;
 import io.trino.plugin.password.salesforce.SalesforceAuthenticatorFactory;
 import io.trino.spi.Plugin;
 import io.trino.spi.security.GroupProviderFactory;
@@ -40,6 +41,7 @@ public class PasswordAuthenticatorPlugin
     {
         return ImmutableList.<GroupProviderFactory>builder()
                 .add(new FileGroupProviderFactory())
+                .add(new LdapGroupProviderFactory())
                 .build();
     }
 }

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/JdkLdapClient.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/JdkLdapClient.java
@@ -23,9 +23,13 @@ import javax.inject.Inject;
 import javax.naming.AuthenticationException;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import javax.naming.ldap.LdapName;
+import javax.naming.ldap.Rdn;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
@@ -36,6 +40,7 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.util.Arrays;
+import java.util.Enumeration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -49,16 +54,16 @@ import static javax.naming.Context.SECURITY_AUTHENTICATION;
 import static javax.naming.Context.SECURITY_CREDENTIALS;
 import static javax.naming.Context.SECURITY_PRINCIPAL;
 
-public class JdkLdapAuthenticatorClient
-        implements LdapAuthenticatorClient
+public class JdkLdapClient
+        implements LdapClient
 {
-    private static final Logger log = Logger.get(JdkLdapAuthenticatorClient.class);
+    private static final Logger log = Logger.get(JdkLdapClient.class);
 
     private final Map<String, String> basicEnvironment;
     private final Optional<SSLContext> sslContext;
 
     @Inject
-    public JdkLdapAuthenticatorClient(LdapConfig ldapConfig)
+    public JdkLdapClient(LdapConfig ldapConfig)
     {
         String ldapUrl = requireNonNull(ldapConfig.getLdapUrl(), "ldapUrl is null");
         if (ldapUrl.startsWith("ldap://")) {
@@ -72,7 +77,7 @@ public class JdkLdapAuthenticatorClient
                 .build();
 
         this.sslContext = Optional.ofNullable(ldapConfig.getTrustCertificate())
-                .map(JdkLdapAuthenticatorClient::createSslContext);
+                .map(JdkLdapClient::createSslContext);
     }
 
     @Override
@@ -106,11 +111,45 @@ public class JdkLdapAuthenticatorClient
         }
     }
 
+    @Override
+    public Set<String> lookupUserGroups(String searchBase, String searchFilter, String contextUserDistinguishedName, String contextPassword)
+            throws NamingException
+    {
+        try (CloseableContext context = createUserDirContext(contextUserDistinguishedName, contextPassword); CloseableSearchResults search = searchContext(searchBase, searchFilter, context)) {
+            ImmutableSet.Builder<String> groupNames = ImmutableSet.builder();
+            if (search.hasMore()) {
+                Attributes attributes = search.next().getAttributes();
+                Attribute memberOfAttribute = attributes.get("memberof");
+                if (memberOfAttribute == null) {
+                    log.error("No memberOf attribute found... The ldap group provider requires the memberOf overlay to be enabled.");
+                }
+                else {
+                    for (Enumeration groupDns = memberOfAttribute.getAll(); groupDns.hasMoreElements(); ) {
+                        String dn = groupDns.nextElement().toString();
+                        LdapName ln = new LdapName(dn);
+                        for (Rdn rdn : ln.getRdns()) {
+                            if (rdn.getType().equalsIgnoreCase("cn")) {
+                                groupNames.add(rdn.getValue().toString());
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            search.close();
+            return groupNames.build();
+        }
+    }
+
     private static CloseableSearchResults searchContext(String searchBase, String searchFilter, CloseableContext context)
             throws NamingException
     {
         SearchControls searchControls = new SearchControls();
         searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+        searchControls.setReturningAttributes(new String[]
+        {
+                "memberOf"
+        });
         return new CloseableSearchResults(context.search(searchBase, searchFilter, searchControls));
     }
 

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapClient.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapClient.java
@@ -17,7 +17,7 @@ import javax.naming.NamingException;
 
 import java.util.Set;
 
-public interface LdapAuthenticatorClient
+public interface LdapClient
 {
     void validatePassword(String userDistinguishedName, String password)
             throws NamingException;
@@ -26,5 +26,8 @@ public interface LdapAuthenticatorClient
             throws NamingException;
 
     Set<String> lookupUserDistinguishedNames(String searchBase, String searchFilter, String contextUserDistinguishedName, String contextPassword)
+            throws NamingException;
+
+    Set<String> lookupUserGroups(String searchBase, String searchFilter, String contextUserDistinguishedName, String contextPassword)
             throws NamingException;
 }

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapGroupProvider.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapGroupProvider.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.password.ldap;
+
+import io.airlift.log.Logger;
+import io.trino.spi.security.AccessDeniedException;
+import io.trino.spi.security.GroupProvider;
+
+import javax.inject.Inject;
+import javax.naming.NamingException;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class LdapGroupProvider
+        implements GroupProvider
+{
+    private static final Logger log = Logger.get(LdapGroupProvider.class);
+
+    private final LdapClient client;
+
+    private final List<String> userBindSearchPatterns;
+    private final Optional<String> userBaseDistinguishedName;
+    private final Optional<String> bindDistinguishedName;
+    private final Optional<String> bindPassword;
+
+    @Inject
+    public LdapGroupProvider(LdapClient client, LdapConfig ldapConfig)
+    {
+        this.client = requireNonNull(client, "client is null");
+
+        this.userBindSearchPatterns = ldapConfig.getUserBindSearchPatterns();
+        this.userBaseDistinguishedName = Optional.ofNullable(ldapConfig.getUserBaseDistinguishedName());
+        this.bindDistinguishedName = Optional.ofNullable(ldapConfig.getBindDistingushedName());
+        this.bindPassword = Optional.ofNullable(ldapConfig.getBindPassword());
+
+        checkArgument(
+                 userBaseDistinguishedName.isPresent(),
+                "Base distinguished name (DN) for user must be provided");
+        checkArgument(
+                bindDistinguishedName.isPresent() == bindPassword.isPresent(),
+                "Both bind distinguished name and bind password must be provided");
+        checkArgument(
+                !userBindSearchPatterns.isEmpty(),
+                "User bind search pattern must be provided");
+    }
+
+    @Override
+    public Set<String> getGroups(String user)
+    {
+        if (LdapUtil.containsSpecialCharacters(user)) {
+            throw new AccessDeniedException("Username contains a special LDAP character");
+        }
+        for (String userBindSearchPattern : userBindSearchPatterns) {
+            String userDistinguishedName = LdapUtil.replaceUser(userBindSearchPattern, user);
+            String searchBase = userBaseDistinguishedName.orElseThrow();
+            try {
+                return client.lookupUserGroups(searchBase, userDistinguishedName, bindDistinguishedName.orElseThrow(), bindPassword.orElseThrow());
+            }
+            catch (NamingException e) {
+                log.debug(e, "Authentication failed for user [%s], %s", user, e.getMessage());
+                throw new RuntimeException("Authentication error");
+            }
+        }
+        return null;
+    }
+}

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapGroupProviderFactory.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapGroupProviderFactory.java
@@ -16,15 +16,15 @@ package io.trino.plugin.password.ldap;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
 import io.airlift.bootstrap.Bootstrap;
-import io.trino.spi.security.PasswordAuthenticator;
-import io.trino.spi.security.PasswordAuthenticatorFactory;
+import io.trino.spi.security.GroupProvider;
+import io.trino.spi.security.GroupProviderFactory;
 
 import java.util.Map;
 
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
-public class LdapAuthenticatorFactory
-        implements PasswordAuthenticatorFactory
+public class LdapGroupProviderFactory
+        implements GroupProviderFactory
 {
     @Override
     public String getName()
@@ -33,12 +33,12 @@ public class LdapAuthenticatorFactory
     }
 
     @Override
-    public PasswordAuthenticator create(Map<String, String> config)
+    public GroupProvider create(Map<String, String> config)
     {
         Bootstrap app = new Bootstrap(
                 binder -> {
                     configBinder(binder).bindConfig(LdapConfig.class);
-                    binder.bind(LdapAuthenticator.class).in(Scopes.SINGLETON);
+                    binder.bind(LdapGroupProvider.class).in(Scopes.SINGLETON);
                     binder.bind(LdapClient.class).to(JdkLdapClient.class).in(Scopes.SINGLETON);
                 });
 
@@ -48,6 +48,6 @@ public class LdapAuthenticatorFactory
                 .setRequiredConfigurationProperties(config)
                 .initialize();
 
-        return injector.getInstance(LdapAuthenticator.class);
+        return injector.getInstance(LdapGroupProvider.class);
     }
 }

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapUtil.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.password.ldap;
+
+import com.google.common.base.CharMatcher;
+
+public class LdapUtil
+{
+    private static final CharMatcher SPECIAL_CHARACTERS = CharMatcher.anyOf(",=+<>#;*()\"\\\u0000");
+    private static final CharMatcher WHITESPACE = CharMatcher.anyOf(" \r");
+
+    private LdapUtil()
+    {
+    }
+
+    /**
+     * Returns {@code true} when parameter contains a character that has a special meaning in
+     * LDAP search or bind name (DN).
+     * <p>
+     * Based on <a href="https://www.owasp.org/index.php/Preventing_LDAP_Injection_in_Java">Preventing_LDAP_Injection_in_Java</a> and
+     * {@link javax.naming.ldap.Rdn#escapeValue(Object) escapeValue} method.
+     */
+    public static boolean containsSpecialCharacters(String user)
+    {
+        if (WHITESPACE.indexIn(user) == 0 || WHITESPACE.lastIndexIn(user) == user.length() - 1) {
+            return true;
+        }
+        return SPECIAL_CHARACTERS.matchesAnyOf(user);
+    }
+
+    public static String replaceUser(String pattern, String user)
+    {
+        return pattern.replace("${USER}", user);
+    }
+}

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
@@ -13,20 +13,10 @@
  */
 package io.trino.plugin.password.ldap;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.ImmutableSet;
-import io.trino.plugin.password.Credential;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.BasicPrincipal;
 import org.testng.annotations.Test;
 
-import javax.naming.NamingException;
-
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
@@ -38,7 +28,7 @@ public class TestLdapAuthenticator
     @Test
     public void testSingleBindPattern()
     {
-        TestLdapAuthenticatorClient client = new TestLdapAuthenticatorClient();
+        TestLdapClient client = new TestLdapClient();
         client.addCredentials("alice@example.com", "alice-pass");
 
         LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(
@@ -56,7 +46,7 @@ public class TestLdapAuthenticator
     @Test
     public void testMultipleBindPattern()
     {
-        TestLdapAuthenticatorClient client = new TestLdapAuthenticatorClient();
+        TestLdapClient client = new TestLdapClient();
 
         LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(
                 client,
@@ -81,7 +71,7 @@ public class TestLdapAuthenticator
     @Test
     public void testGroupMembership()
     {
-        TestLdapAuthenticatorClient client = new TestLdapAuthenticatorClient();
+        TestLdapClient client = new TestLdapClient();
         client.addCredentials("alice@example.com", "alice-pass");
 
         LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(
@@ -104,7 +94,7 @@ public class TestLdapAuthenticator
     @Test
     public void testDistinguishedNameLookup()
     {
-        TestLdapAuthenticatorClient client = new TestLdapAuthenticatorClient();
+        TestLdapClient client = new TestLdapClient();
         client.addCredentials("alice@example.com", "alice-pass");
 
         LdapAuthenticator ldapAuthenticator = new LdapAuthenticator(
@@ -136,100 +126,5 @@ public class TestLdapAuthenticator
         client.addDistinguishedNameForUser("alice", "another-mapping");
         assertThatThrownBy(() -> ldapAuthenticator.createAuthenticatedPrincipal("alice", "alice-pass"))
                 .isInstanceOf(AccessDeniedException.class);
-    }
-
-    @Test
-    public void testContainsSpecialCharacters()
-    {
-        assertThat(LdapAuthenticator.containsSpecialCharacters("The quick brown fox jumped over the lazy dogs"))
-                .as("English pangram")
-                .isEqualTo(false);
-        assertThat(LdapAuthenticator.containsSpecialCharacters("Pchnąć w tę łódź jeża lub ośm skrzyń fig"))
-                .as("Perfect polish pangram")
-                .isEqualTo(false);
-        assertThat(LdapAuthenticator.containsSpecialCharacters("いろはにほへと ちりぬるを わかよたれそ つねならむ うゐのおくやま けふこえて あさきゆめみし ゑひもせす（ん）"))
-                .as("Japanese hiragana pangram - Iroha")
-                .isEqualTo(false);
-        assertThat(LdapAuthenticator.containsSpecialCharacters("*"))
-                .as("LDAP wildcard")
-                .isEqualTo(true);
-        assertThat(LdapAuthenticator.containsSpecialCharacters("   John Doe"))
-                .as("Beginning with whitespace")
-                .isEqualTo(true);
-        assertThat(LdapAuthenticator.containsSpecialCharacters("John Doe  \r"))
-                .as("Ending with whitespace")
-                .isEqualTo(true);
-        assertThat(LdapAuthenticator.containsSpecialCharacters("Hi (This) = is * a \\ test # ç à ô"))
-                .as("Multiple special characters")
-                .isEqualTo(true);
-        assertThat(LdapAuthenticator.containsSpecialCharacters("John\u0000Doe"))
-                .as("NULL character")
-                .isEqualTo(true);
-        assertThat(LdapAuthenticator.containsSpecialCharacters("John Doe <john.doe@company.com>"))
-                .as("Angle brackets")
-                .isEqualTo(true);
-    }
-
-    private static class TestLdapAuthenticatorClient
-            implements LdapAuthenticatorClient
-    {
-        private final Set<Credential> credentials = new HashSet<>();
-        private final Set<String> groupMembers = new HashSet<>();
-        private final HashMultimap<String, String> userDNs = HashMultimap.create();
-
-        public void addCredentials(String userDistinguishedName, String password)
-        {
-            credentials.add(new Credential(userDistinguishedName, password));
-        }
-
-        public void addGroupMember(String userName)
-        {
-            groupMembers.add(userName);
-        }
-
-        public void addDistinguishedNameForUser(String userName, String distinguishedName)
-        {
-            userDNs.put(userName, distinguishedName);
-        }
-
-        @Override
-        public void validatePassword(String userDistinguishedName, String password)
-                throws NamingException
-        {
-            if (!credentials.contains(new Credential(userDistinguishedName, password))) {
-                throw new NamingException();
-            }
-        }
-
-        @Override
-        public boolean isGroupMember(String searchBase, String groupSearch, String contextUserDistinguishedName, String contextPassword)
-                throws NamingException
-        {
-            validatePassword(contextUserDistinguishedName, contextPassword);
-            return getSearchUser(searchBase, groupSearch)
-                    .map(groupMembers::contains)
-                    .orElse(false);
-        }
-
-        @Override
-        public Set<String> lookupUserDistinguishedNames(String searchBase, String searchFilter, String contextUserDistinguishedName, String contextPassword)
-                throws NamingException
-        {
-            validatePassword(contextUserDistinguishedName, contextPassword);
-            return getSearchUser(searchBase, searchFilter)
-                    .map(userDNs::get)
-                    .orElse(ImmutableSet.of());
-        }
-
-        private static Optional<String> getSearchUser(String searchBase, String groupSearch)
-        {
-            if (!searchBase.equals(BASE_DN)) {
-                return Optional.empty();
-            }
-            if (!groupSearch.startsWith(PATTERN_PREFIX)) {
-                return Optional.empty();
-            }
-            return Optional.of(groupSearch.substring(PATTERN_PREFIX.length()));
-        }
     }
 }

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapClient.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapClient.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.password.ldap;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.password.Credential;
+
+import javax.naming.NamingException;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+public class TestLdapClient
+        implements LdapClient
+{
+    private static final String BASE_DN = "base-dn";
+    private static final String PATTERN_PREFIX = "pattern::";
+    private final Set<Credential> credentials = new HashSet<>();
+    private final Set<String> groupMembers = new HashSet<>();
+    private final HashMultimap<String, String> userDNs = HashMultimap.create();
+    private final HashMap<String, Set<String>> userGroupMapping = new HashMap();
+
+    public void addCredentials(String userDistinguishedName, String password)
+    {
+        credentials.add(new Credential(userDistinguishedName, password));
+    }
+
+    public void addGroupMember(String userName)
+    {
+        groupMembers.add(userName);
+    }
+
+    public void addDistinguishedNameForUser(String userName, String distinguishedName)
+    {
+        userDNs.put(userName, distinguishedName);
+    }
+
+    public void addUserGroups(String user, Set<String> groups)
+    {
+        userGroupMapping.put(user, groups);
+    }
+
+    @Override
+    public void validatePassword(String userDistinguishedName, String password)
+            throws NamingException
+    {
+        if (!credentials.contains(new Credential(userDistinguishedName, password))) {
+            throw new NamingException();
+        }
+    }
+
+    @Override
+    public boolean isGroupMember(String searchBase, String groupSearch, String contextUserDistinguishedName, String contextPassword)
+            throws NamingException
+    {
+        validatePassword(contextUserDistinguishedName, contextPassword);
+        return getSearchUser(searchBase, groupSearch)
+                .map(groupMembers::contains)
+                .orElse(false);
+    }
+
+    @Override
+    public Set<String> lookupUserDistinguishedNames(String searchBase, String searchFilter, String contextUserDistinguishedName, String contextPassword)
+            throws NamingException
+    {
+        validatePassword(contextUserDistinguishedName, contextPassword);
+        return getSearchUser(searchBase, searchFilter)
+                .map(userDNs::get)
+                .orElse(ImmutableSet.of());
+    }
+
+    @Override
+    public Set<String> lookupUserGroups(String searchBase, String searchFilter, String contextUserDistinguishedName, String contextPassword) throws NamingException
+    {
+        return userGroupMapping.get(searchFilter);
+    }
+
+    private static Optional<String> getSearchUser(String searchBase, String groupSearch)
+    {
+        if (!searchBase.equals(BASE_DN)) {
+            return Optional.empty();
+        }
+        if (!groupSearch.startsWith(PATTERN_PREFIX)) {
+            return Optional.empty();
+        }
+        return Optional.of(groupSearch.substring(PATTERN_PREFIX.length()));
+    }
+}

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapGroupProvider.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapGroupProvider.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.password.ldap;
+
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestLdapGroupProvider
+{
+    @Test
+    public void testUserGroupLookup()
+    {
+        TestLdapClient client = new TestLdapClient();
+
+        client.addUserGroups("alice@example.com", ImmutableSet.of("group_a", "group_b"));
+
+        LdapGroupProvider ldapGroupProvider = new LdapGroupProvider(
+                client,
+                new LdapConfig()
+                        .setUserBaseDistinguishedName("base-dn")
+                        .setUserBindSearchPatterns("${USER}@example.com")
+                        .setBindDistingushedName("server")
+                        .setBindPassword("server-pass"));
+
+        assertEquals(ldapGroupProvider.getGroups("alice"), ImmutableSet.of("group_a", "group_b"));
+    }
+}

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapUtil.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.password.ldap;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLdapUtil
+{
+    @Test
+    public void testContainsSpecialCharacters()
+    {
+        assertThat(LdapUtil.containsSpecialCharacters("The quick brown fox jumped over the lazy dogs"))
+                .as("English pangram")
+                .isEqualTo(false);
+        assertThat(LdapUtil.containsSpecialCharacters("Pchnąć w tę łódź jeża lub ośm skrzyń fig"))
+                .as("Perfect polish pangram")
+                .isEqualTo(false);
+        assertThat(LdapUtil.containsSpecialCharacters("いろはにほへと ちりぬるを わかよたれそ つねならむ うゐのおくやま けふこえて あさきゆめみし ゑひもせす（ん）"))
+                .as("Japanese hiragana pangram - Iroha")
+                .isEqualTo(false);
+        assertThat(LdapUtil.containsSpecialCharacters("*"))
+                .as("LDAP wildcard")
+                .isEqualTo(true);
+        assertThat(LdapUtil.containsSpecialCharacters("   John Doe"))
+                .as("Beginning with whitespace")
+                .isEqualTo(true);
+        assertThat(LdapUtil.containsSpecialCharacters("John Doe  \r"))
+                .as("Ending with whitespace")
+                .isEqualTo(true);
+        assertThat(LdapUtil.containsSpecialCharacters("Hi (This) = is * a \\ test # ç à ô"))
+                .as("Multiple special characters")
+                .isEqualTo(true);
+        assertThat(LdapUtil.containsSpecialCharacters("John\u0000Doe"))
+                .as("NULL character")
+                .isEqualTo(true);
+        assertThat(LdapUtil.containsSpecialCharacters("John Doe <john.doe@company.com>"))
+                .as("Angle brackets")
+                .isEqualTo(true);
+    }
+}


### PR DESCRIPTION
This PR adds the code necessarily to reference LDAP groups in Trino ACLs.

### Context
We're using file based ACLs to authorize users connected to Trino.
https://trino.io/docs/current/security/file-system-access-control.html

In the documentation, it's mentioned "For group-based rules to match, users need to be assigned to groups by a Group provider."

In other words, we have to create a group provider to specify the following:
```
{
"group": "trino_admins",
"privileges": ["SELECT", "INSERT", "DELETE", "OWNERSHIP"]
}
```

There exists a trino-password-authenticators plugin that takes care of authenticating users using their LDAP credentials.
https://github.com/trinodb/trino/tree/master/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap

In the same plugin, there's already have a file based Group Provider.
https://github.com/trinodb/trino/blob/master/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/PasswordAuthenticatorPlugin.java

There's an open issue asking to add this as a feature.
https://github.com/trinodb/trino/issues/6824

### Testing
- Configure the memberOf overlay in your LDAP instance
- Create a group-provider.properties with the following properties:
```
group-provider.name=ldap
ldap.allow-insecure=
ldap.url=
ldap.user-base-dn=
ldap.user-bind-pattern=
ldap.bind-dn=
ldap.bind-password=
```
- Connect to Trino and verify the ACLs are applied accordingly.