### PR TITLE
Support es custom dateformats

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/BuiltinColumns.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/BuiltinColumns.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.elasticsearch;
 
+import io.trino.plugin.elasticsearch.client.IndexMetadata;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.type.Type;
@@ -28,21 +29,23 @@ import static java.util.function.Function.identity;
 
 enum BuiltinColumns
 {
-    ID("_id", VARCHAR, true),
-    SOURCE("_source", VARCHAR, false),
-    SCORE("_score", REAL, false);
+    ID("_id", VARCHAR, new IndexMetadata.PrimitiveType("keyword"), true),
+    SOURCE("_source", VARCHAR, new IndexMetadata.PrimitiveType("keyword"), false),
+    SCORE("_score", REAL, new IndexMetadata.PrimitiveType("float"), false);
 
     private static final Map<String, BuiltinColumns> COLUMNS_BY_NAME = stream(values())
             .collect(toImmutableMap(BuiltinColumns::getName, identity()));
 
     private final String name;
     private final Type type;
+    private final IndexMetadata.Type rawType;
     private final boolean supportsPredicates;
 
-    BuiltinColumns(String name, Type type, boolean supportsPredicates)
+    BuiltinColumns(String name, Type type, IndexMetadata.Type rawType, boolean supportsPredicates)
     {
         this.name = name;
         this.type = type;
+        this.rawType = rawType;
         this.supportsPredicates = supportsPredicates;
     }
 
@@ -77,6 +80,6 @@ enum BuiltinColumns
 
     public ColumnHandle getColumnHandle()
     {
-        return new ElasticsearchColumnHandle(name, type, supportsPredicates);
+        return new ElasticsearchColumnHandle(name, type, rawType, supportsPredicates);
     }
 }

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchColumnHandle.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchColumnHandle.java
@@ -15,6 +15,7 @@ package io.trino.plugin.elasticsearch;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.plugin.elasticsearch.client.IndexMetadata;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.type.Type;
 
@@ -28,15 +29,18 @@ public final class ElasticsearchColumnHandle
     private final String name;
     private final Type type;
     private final boolean supportsPredicates;
+    private final IndexMetadata.Type rawType;
 
     @JsonCreator
     public ElasticsearchColumnHandle(
             @JsonProperty("name") String name,
             @JsonProperty("type") Type type,
+            @JsonProperty("rawType") IndexMetadata.Type rawType,
             @JsonProperty("supportsPredicates") boolean supportsPredicates)
     {
         this.name = requireNonNull(name, "name is null");
         this.type = requireNonNull(type, "type is null");
+        this.rawType = rawType;
         this.supportsPredicates = supportsPredicates;
     }
 
@@ -50,6 +54,12 @@ public final class ElasticsearchColumnHandle
     public Type getType()
     {
         return type;
+    }
+
+    @JsonProperty
+    public IndexMetadata.Type getRawType()
+    {
+        return rawType;
     }
 
     @JsonProperty

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -92,7 +92,7 @@ public class ElasticsearchMetadata
 
     private static final Map<String, ColumnHandle> PASSTHROUGH_QUERY_COLUMNS = ImmutableMap.of(
             PASSTHROUGH_QUERY_RESULT_COLUMN_NAME,
-            new ElasticsearchColumnHandle(PASSTHROUGH_QUERY_RESULT_COLUMN_NAME, VARCHAR, false));
+            new ElasticsearchColumnHandle(PASSTHROUGH_QUERY_RESULT_COLUMN_NAME, VARCHAR, new PrimitiveType("keyword"), false));
 
     private final Type ipAddressType;
     private final ElasticsearchClient client;
@@ -238,6 +238,7 @@ public class ElasticsearchMetadata
             result.put(field.getName(), new ElasticsearchColumnHandle(
                     field.getName(),
                     toTrinoType(field),
+                    field.getType(),
                     supportsPredicates(field.getType())));
         }
 

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -306,10 +306,7 @@ public class ElasticsearchMetadata
             }
         }
         else if (type instanceof DateTimeType) {
-            if (((DateTimeType) type).getFormats().isEmpty()) {
-                return TIMESTAMP_MILLIS;
-            }
-            // otherwise, skip -- we don't support custom formats, yet
+            return TIMESTAMP_MILLIS;
         }
         else if (type instanceof ObjectType) {
             ObjectType objectType = (ObjectType) type;

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
@@ -30,7 +30,11 @@ import org.elasticsearch.index.query.TermQueryBuilder;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -51,7 +55,9 @@ import static java.time.format.DateTimeFormatter.ISO_DATE_TIME;
 
 public final class ElasticsearchQueryBuilder
 {
-    private ElasticsearchQueryBuilder() {}
+    private ElasticsearchQueryBuilder()
+    {
+    }
 
     public static QueryBuilder buildSearchQuery(TupleDomain<ElasticsearchColumnHandle> constraint, Optional<String> query)
     {
@@ -149,20 +155,21 @@ public final class ElasticsearchQueryBuilder
             return ((Slice) value).toStringUtf8();
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
-            if(rawType  instanceof IndexMetadata.DateTimeType ){
+            if (rawType instanceof IndexMetadata.DateTimeType) {
                 IndexMetadata.DateTimeType dateTimeType = (IndexMetadata.DateTimeType) rawType;
                 List<String> formats = dateTimeType.getFormats();
-                if(formats == null || formats.size() == 0){
+                if (formats == null || formats.size() == 0) {
                     return Instant.ofEpochMilli(floorDiv((Long) value, MICROSECONDS_PER_MILLISECOND))
-                        .atZone(ZoneOffset.UTC)
-                        .toLocalDateTime()
-                        .format(ISO_DATE_TIME);
-                }else{
+                            .atZone(ZoneOffset.UTC)
+                            .toLocalDateTime()
+                            .format(ISO_DATE_TIME);
+                }
+                else {
                     String format = formats.get(0);
                     return Instant.ofEpochMilli(floorDiv((Long) value, MICROSECONDS_PER_MILLISECOND))
-                        .atZone(ZoneOffset.UTC)
-                        .toLocalDateTime()
-                        .format(DateTimeFormatter.ofPattern(format));
+                            .atZone(ZoneOffset.UTC)
+                            .toLocalDateTime()
+                            .format(DateTimeFormatter.ofPattern(format));
                 }
             }
         }

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
@@ -17,6 +17,7 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import io.airlift.log.Logger;
 import io.trino.plugin.elasticsearch.client.ElasticsearchClient;
+import io.trino.plugin.elasticsearch.client.IndexMetadata;
 import io.trino.plugin.elasticsearch.decoders.ArrayDecoder;
 import io.trino.plugin.elasticsearch.decoders.BigintDecoder;
 import io.trino.plugin.elasticsearch.decoders.BooleanDecoder;
@@ -267,12 +268,12 @@ public class ScanQueryPageSource
                         return new SourceColumnDecoder();
                     }
 
-                    return createDecoder(column.getName(), column.getType());
+                    return createDecoder(column.getName(), column.getType(),column.getRawType());
                 })
                 .collect(toImmutableList());
     }
 
-    private Decoder createDecoder(String path, Type type)
+    private Decoder createDecoder(String path, Type type, IndexMetadata.Type rawType)
     {
         if (type.equals(VARCHAR)) {
             return new VarcharDecoder(path);
@@ -281,7 +282,8 @@ public class ScanQueryPageSource
             return new VarbinaryDecoder(path);
         }
         if (type.equals(TIMESTAMP_MILLIS)) {
-            return new TimestampDecoder(path);
+            IndexMetadata.DateTimeType dateTimeType = (IndexMetadata.DateTimeType) rawType;
+            return new TimestampDecoder(path, dateTimeType.getFormats());
         }
         if (type.equals(BOOLEAN)) {
             return new BooleanDecoder(path);
@@ -311,7 +313,7 @@ public class ScanQueryPageSource
             RowType rowType = (RowType) type;
 
             List<Decoder> decoders = rowType.getFields().stream()
-                    .map(field -> createDecoder(appendPath(path, field.getName().get()), field.getType()))
+                    .map(field -> createDecoder(appendPath(path, field.getName().get()), field.getType(), rawType))
                     .collect(toImmutableList());
 
             List<String> fieldNames = rowType.getFields().stream()
@@ -324,7 +326,7 @@ public class ScanQueryPageSource
         if (type instanceof ArrayType) {
             Type elementType = ((ArrayType) type).getElementType();
 
-            return new ArrayDecoder(createDecoder(path, elementType));
+            return new ArrayDecoder(createDecoder(path, elementType, rawType));
         }
 
         throw new UnsupportedOperationException("Type not supported: " + type);

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ScanQueryPageSource.java
@@ -268,7 +268,7 @@ public class ScanQueryPageSource
                         return new SourceColumnDecoder();
                     }
 
-                    return createDecoder(column.getName(), column.getType(),column.getRawType());
+                    return createDecoder(column.getName(), column.getType(), column.getRawType());
                 })
                 .collect(toImmutableList());
     }

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/IndexMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/IndexMetadata.java
@@ -13,6 +13,10 @@
  */
 package io.trino.plugin.elasticsearch.client;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -61,19 +65,28 @@ public class IndexMetadata
             return type;
         }
     }
-
+    @JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type")
+    @JsonSubTypes(
+        {
+            @JsonSubTypes.Type(value = PrimitiveType.class, name = "primitiveType"),
+            @JsonSubTypes.Type(value = DateTimeType.class, name = "dateTimeType"),
+            @JsonSubTypes.Type(value = ObjectType.class, name = "objectType")
+        })
     public interface Type {}
 
     public static class PrimitiveType
             implements Type
     {
         private final String name;
-
-        public PrimitiveType(String name)
+        @JsonCreator
+        public PrimitiveType(@JsonProperty("name") String name)
         {
             this.name = requireNonNull(name, "name is null");
         }
-
+        @JsonProperty
         public String getName()
         {
             return name;
@@ -84,14 +97,14 @@ public class IndexMetadata
             implements Type
     {
         private final List<String> formats;
-
-        public DateTimeType(List<String> formats)
+        @JsonCreator
+        public DateTimeType(@JsonProperty("formats") List<String> formats)
         {
             requireNonNull(formats, "formats is null");
 
             this.formats = ImmutableList.copyOf(formats);
         }
-
+        @JsonProperty
         public List<String> getFormats()
         {
             return formats;
@@ -102,14 +115,14 @@ public class IndexMetadata
             implements Type
     {
         private final List<Field> fields;
-
-        public ObjectType(List<Field> fields)
+        @JsonCreator
+        public ObjectType(@JsonProperty("fields") List<Field> fields)
         {
             requireNonNull(fields, "fields is null");
 
             this.fields = ImmutableList.copyOf(fields);
         }
-
+        @JsonProperty
         public List<Field> getFields()
         {
             return fields;

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/IndexMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/IndexMetadata.java
@@ -65,27 +65,30 @@ public class IndexMetadata
             return type;
         }
     }
+
     @JsonTypeInfo(
-        use = JsonTypeInfo.Id.NAME,
-        include = JsonTypeInfo.As.PROPERTY,
-        property = "type")
+            use = JsonTypeInfo.Id.NAME,
+            include = JsonTypeInfo.As.PROPERTY,
+            property = "type")
     @JsonSubTypes(
-        {
+            {
             @JsonSubTypes.Type(value = PrimitiveType.class, name = "primitiveType"),
             @JsonSubTypes.Type(value = DateTimeType.class, name = "dateTimeType"),
             @JsonSubTypes.Type(value = ObjectType.class, name = "objectType")
-        })
+            })
     public interface Type {}
 
     public static class PrimitiveType
             implements Type
     {
         private final String name;
+
         @JsonCreator
         public PrimitiveType(@JsonProperty("name") String name)
         {
             this.name = requireNonNull(name, "name is null");
         }
+
         @JsonProperty
         public String getName()
         {
@@ -97,6 +100,7 @@ public class IndexMetadata
             implements Type
     {
         private final List<String> formats;
+
         @JsonCreator
         public DateTimeType(@JsonProperty("formats") List<String> formats)
         {
@@ -104,6 +108,7 @@ public class IndexMetadata
 
             this.formats = ImmutableList.copyOf(formats);
         }
+
         @JsonProperty
         public List<String> getFormats()
         {
@@ -115,6 +120,7 @@ public class IndexMetadata
             implements Type
     {
         private final List<Field> fields;
+
         @JsonCreator
         public ObjectType(@JsonProperty("fields") List<Field> fields)
         {
@@ -122,6 +128,7 @@ public class IndexMetadata
 
             this.fields = ImmutableList.copyOf(fields);
         }
+
         @JsonProperty
         public List<Field> getFields()
         {

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TimestampDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TimestampDecoder.java
@@ -21,6 +21,9 @@ import org.elasticsearch.search.SearchHit;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.List;
 import java.util.function.Supplier;
 
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -36,10 +39,12 @@ public class TimestampDecoder
         implements Decoder
 {
     private final String path;
+    private final List<String> formats;
 
-    public TimestampDecoder(String path)
+    public TimestampDecoder(String path, List<String> formats)
     {
         this.path = requireNonNull(path, "path is null");
+        this.formats = requireNonNull(formats, "formats is null");
     }
 
     @Override
@@ -70,7 +75,11 @@ public class TimestampDecoder
                     timestamp = LocalDateTime.ofInstant(Instant.ofEpochMilli(epochMillis), UTC);
                 }
                 else {
-                    timestamp = ISO_DATE_TIME.parse(valueString, LocalDateTime::from);
+                    DateTimeFormatterBuilder formatterBuilder = new DateTimeFormatterBuilder().appendOptional(ISO_DATE_TIME);
+                    for(String format : formats){
+                        formatterBuilder.appendOptional(DateTimeFormatter.ofPattern(format));
+                    }
+                    timestamp = LocalDateTime.parse(valueString, formatterBuilder.toFormatter());
                 }
             }
             else if (value instanceof Number) {

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TimestampDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TimestampDecoder.java
@@ -76,7 +76,7 @@ public class TimestampDecoder
                 }
                 else {
                     DateTimeFormatterBuilder formatterBuilder = new DateTimeFormatterBuilder().appendOptional(ISO_DATE_TIME);
-                    for(String format : formats){
+                    for (String format : formats) {
                         formatterBuilder.appendOptional(DateTimeFormatter.ofPattern(format));
                     }
                     timestamp = LocalDateTime.parse(valueString, formatterBuilder.toFormatter());


### PR DESCRIPTION
Currently, trino could not parse date field  with custom formats from Elasticsearch.  We need support custom date formats in trino-elasticsearch connector.