### PR TITLE
Fix ordering scheme rewrite with duplicate sort items

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -827,17 +827,24 @@ class QueryPlanner
 
     private OrderingScheme translateOrderingScheme(List<SortItem> items, Function<Expression, Symbol> coercions)
     {
-        List<Symbol> symbols = items.stream()
+        List<Symbol> coerced = items.stream()
                 .map(SortItem::getSortKey)
                 .map(coercions)
                 .collect(toImmutableList());
 
-        ImmutableMap.Builder<Symbol, SortOrder> orders = ImmutableMap.builder();
-        for (int i = 0; i < symbols.size(); i++) {
-            orders.put(symbols.get(i), OrderingScheme.sortItemToSortOrder(items.get(i)));
+        ImmutableList.Builder<Symbol> symbols = ImmutableList.builder();
+        Map<Symbol, SortOrder> orders = new HashMap<>();
+        for (int i = 0; i < coerced.size(); i++) {
+            Symbol symbol = coerced.get(i);
+            // for multiple sort items based on the same expression, retain the first one:
+            // ORDER BY x DESC, x ASC, y --> ORDER BY x DESC, y
+            if (!orders.containsKey(symbol)) {
+                symbols.add(symbol);
+                orders.put(symbol, OrderingScheme.sortItemToSortOrder(items.get(i)));
+            }
         }
 
-        return new OrderingScheme(symbols, orders.build());
+        return new OrderingScheme(symbols.build(), orders);
     }
 
     private List<Set<FieldId>> enumerateGroupingSets(GroupingSetAnalysis groupingSetAnalysis)

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestOrderedAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestOrderedAggregation.java
@@ -157,4 +157,11 @@ public class TestOrderedAggregation
                         "   (2, ARRAY[3, 4], BIGINT '2'), " +
                         "   (NULL, ARRAY[1, 3, 4], BIGINT '5')");
     }
+
+    @Test
+    public void testRepeatedSortItems()
+    {
+        assertThat(assertions.query("SELECT count(x ORDER BY y, y) FROM (VALUES ('a', 2)) t(x, y)"))
+                .matches("VALUES BIGINT '1'");
+    }
 }


### PR DESCRIPTION
In case of multiple sort items based on the same expression,
retain only the first of them with its corresponding ordering:

ORDER BY x DESC, x ASC, y --> ORDER BY x DESC, y

Lack of deduplication caused errors when building the
symbols to orderings map.

Fixes https://github.com/trinodb/trino/issues/8080