### PR TITLE
Support multilingual encoding in property files

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/PasswordAuthenticatorManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/PasswordAuthenticatorManager.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static io.trino.util.ConfigurationLoader.loadPropertiesFrom;
 import static java.util.Objects.requireNonNull;
 
 public class PasswordAuthenticatorManager

--- a/core/trino-main/src/main/java/io/trino/util/ConfigurationLoader.java
+++ b/core/trino-main/src/main/java/io/trino/util/ConfigurationLoader.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Maps;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.TreeMap;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Maps.fromProperties;
+
+public final class ConfigurationLoader
+{
+    private ConfigurationLoader() {}
+
+    public static Map<String, String> loadProperties()
+            throws IOException
+    {
+        Map<String, String> result = new TreeMap();
+        String configFile = System.getProperty("config");
+        if (configFile != null) {
+            result.putAll(loadPropertiesFrom(configFile));
+        }
+
+        result.putAll(getSystemProperties());
+        return ImmutableSortedMap.copyOf(result);
+    }
+
+    public static Map<String, String> loadPropertiesFrom(String path)
+            throws IOException
+    {
+        Properties properties = new Properties();
+        try (Reader inputStream = new BufferedReader(new InputStreamReader(new FileInputStream(path),
+                StandardCharsets.UTF_8))) {
+            properties.load(inputStream);
+        }
+
+        return fromProperties(properties).entrySet().stream()
+                .collect(toImmutableMap(Entry::getKey, entry -> entry.getValue().trim()));
+    }
+
+    public static Map<String, String> getSystemProperties()
+    {
+        return Maps.fromProperties(System.getProperties());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/util/TestConfigurationLoader.java
+++ b/core/trino-main/src/test/java/io/trino/util/TestConfigurationLoader.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.util;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static io.trino.util.ConfigurationLoader.loadPropertiesFrom;
+import static java.nio.file.Files.createTempFile;
+import static org.testng.Assert.assertEquals;
+
+public class TestConfigurationLoader
+{
+    @Test
+    public void testConfigFileContainingSpecialCharacters()
+            throws Exception
+    {
+        Path config = createTempFile("ldapConfig", "");
+
+        String propKey = "ldap.user-bind-pattern";
+        String propValue = "CN=${USER},OU=user,DC=example,DC=com:CN=${USER},OU=사용자,DC=example,DC=com:CN=${USER},OU=使用者,DC=example,DC=com:CN=${USER},OU=用戶,DC=example,DC=com:CN=${USER},OU=المستعمل,DC=example,DC=com:CN=${USER},OU=ユーザー,DC=example,DC=com";
+
+        Files.write(config, ImmutableList.of(propKey + "=" + propValue));
+
+        Map<String, String> property = loadPropertiesFrom(config.toAbsolutePath().toString());
+
+        assertEquals(property.get(propKey), propValue);
+    }
+}


### PR DESCRIPTION
Trino supports LDAP by external password authentication method.

However if ldap.user-bind-pattern value of the LDAP configuration file is not an English value, there is a bug that can not be read properly.

Trino is used in various countries and supports external authentication. So multilingual encoding support is required.

ex)
configuration value : ldap.user-bind-pattern=OU=사용자,DC=example,DC=com
compiled value : OU=ì�¬ì�©ì��,DC=example,DC=com