### PR TITLE
Avoid over-retaining objects via operator info supplier

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -94,7 +94,7 @@ public class OperatorContext
     private final OperationTiming finishTiming = new OperationTiming();
 
     private final OperatorSpillContext spillContext;
-    private final AtomicReference<Supplier<OperatorInfo>> infoSupplier = new AtomicReference<>();
+    private final AtomicReference<Supplier<? extends OperatorInfo>> infoSupplier = new AtomicReference<>();
     private final AtomicReference<Supplier<List<OperatorStats>>> nestedOperatorStatsSupplier = new AtomicReference<>();
 
     private final AtomicLong peakUserMemoryReservation = new AtomicLong();
@@ -360,7 +360,7 @@ public class OperatorContext
             memoryRevocationRequestListener = null;
         }
         // memoize the result of and then clear any reference to the original suppliers (which might otherwise retain operators or other large objects)
-        Supplier<OperatorInfo> infoSupplier = this.infoSupplier.get();
+        Supplier<? extends OperatorInfo> infoSupplier = this.infoSupplier.get();
         if (infoSupplier != null) {
             OperatorInfo info = infoSupplier.get();
             this.infoSupplier.set(info == null ? null : Suppliers.ofInstance(info));
@@ -453,7 +453,7 @@ public class OperatorContext
         }
     }
 
-    public void setInfoSupplier(Supplier<OperatorInfo> infoSupplier)
+    public void setInfoSupplier(Supplier<? extends OperatorInfo> infoSupplier)
     {
         requireNonNull(infoSupplier, "infoSupplier is null");
         this.infoSupplier.set(infoSupplier);
@@ -498,7 +498,7 @@ public class OperatorContext
 
     public OperatorStats getOperatorStats()
     {
-        Supplier<OperatorInfo> infoSupplier = this.infoSupplier.get();
+        Supplier<? extends OperatorInfo> infoSupplier = this.infoSupplier.get();
         OperatorInfo info = Optional.ofNullable(infoSupplier).map(Supplier::get).orElse(null);
 
         long inputPositionsCount = inputPositions.getTotalCount();

--- a/core/trino-main/src/main/java/io/trino/operator/TableFinishOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableFinishOperator.java
@@ -13,7 +13,6 @@
  */
 package io.trino.operator;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
@@ -32,6 +31,8 @@ import io.trino.sql.planner.plan.StatisticAggregationsDescriptor;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -110,12 +111,14 @@ public class TableFinishOperator
 
     private State state = State.RUNNING;
     private long rowCount;
-    private Optional<ConnectorOutputMetadata> outputMetadata = Optional.empty();
+    private final AtomicReference<Optional<ConnectorOutputMetadata>> outputMetadata = new AtomicReference<>(Optional.empty());
     private final ImmutableList.Builder<Slice> fragmentBuilder = ImmutableList.builder();
     private final ImmutableList.Builder<ComputedStatistics> computedStatisticsBuilder = ImmutableList.builder();
 
     private final OperationTiming statisticsTiming = new OperationTiming();
     private final boolean statisticsCpuTimerEnabled;
+
+    private final Supplier<TableFinishInfo> tableFinishInfoSupplier;
 
     public TableFinishOperator(
             OperatorContext operatorContext,
@@ -129,8 +132,8 @@ public class TableFinishOperator
         this.statisticsAggregationOperator = requireNonNull(statisticsAggregationOperator, "statisticsAggregationOperator is null");
         this.descriptor = requireNonNull(descriptor, "descriptor is null");
         this.statisticsCpuTimerEnabled = statisticsCpuTimerEnabled;
-
-        operatorContext.setInfoSupplier(this::getInfo);
+        this.tableFinishInfoSupplier = createTableFinishInfoSupplier(outputMetadata, statisticsTiming);
+        operatorContext.setInfoSupplier(tableFinishInfoSupplier);
     }
 
     @Override
@@ -294,7 +297,7 @@ public class TableFinishOperator
         }
         state = State.FINISHED;
 
-        outputMetadata = tableFinisher.finishTable(fragmentBuilder.build(), computedStatisticsBuilder.build());
+        this.outputMetadata.set(tableFinisher.finishTable(fragmentBuilder.build(), computedStatisticsBuilder.build()));
 
         // output page will only be constructed once,
         // so a new PageBuilder is constructed (instead of using PageBuilder.reset)
@@ -323,11 +326,12 @@ public class TableFinishOperator
         return statistics.build();
     }
 
-    @VisibleForTesting
-    TableFinishInfo getInfo()
+    private static Supplier<TableFinishInfo> createTableFinishInfoSupplier(AtomicReference<Optional<ConnectorOutputMetadata>> outputMetadata, OperationTiming statisticsTiming)
     {
-        return new TableFinishInfo(
-                outputMetadata,
+        requireNonNull(outputMetadata, "outputMetadata is null");
+        requireNonNull(statisticsTiming, "statisticsTiming is null");
+        return () -> new TableFinishInfo(
+                outputMetadata.get(),
                 new Duration(statisticsTiming.getWallNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 new Duration(statisticsTiming.getCpuNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit());
     }

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -198,7 +199,7 @@ public class TableScanOperator
 
         Object splitInfo = split.getInfo();
         if (splitInfo != null) {
-            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(split.getCatalogName(), splitInfo));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.getCatalogName(), splitInfo)));
         }
 
         blocked.set(null);

--- a/core/trino-main/src/main/java/io/trino/operator/WindowInfo.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowInfo.java
@@ -25,11 +25,17 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.Iterables.concat;
 
 public class WindowInfo
         implements Mergeable<WindowInfo>, OperatorInfo
 {
+    private static final WindowInfo EMPTY_INFO = new WindowInfo(ImmutableList.of());
+
+    public static WindowInfo emptyInfo()
+    {
+        return EMPTY_INFO;
+    }
+
     private final List<DriverWindowInfo> windowInfos;
 
     @JsonCreator
@@ -47,7 +53,18 @@ public class WindowInfo
     @Override
     public WindowInfo mergeWith(WindowInfo other)
     {
-        return new WindowInfo(ImmutableList.copyOf(concat(this.windowInfos, other.windowInfos)));
+        int otherSize = other.windowInfos.size();
+        if (otherSize == 0) {
+            return this;
+        }
+        int thisSize = windowInfos.size();
+        if (thisSize == 0) {
+            return other;
+        }
+        return new WindowInfo(ImmutableList.<DriverWindowInfo>builderWithExpectedSize(thisSize + otherSize)
+                .addAll(windowInfos)
+                .addAll(other.windowInfos)
+                .build());
     }
 
     static class DriverWindowInfoBuilder

--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -207,7 +207,7 @@ public class WindowOperator
     private final int[] outputChannels;
     private final List<FramedWindowFunction> windowFunctions;
     private final WindowInfo.DriverWindowInfoBuilder windowInfo;
-    private final AtomicReference<Optional<WindowInfo.DriverWindowInfo>> driverWindowInfo = new AtomicReference<>(Optional.empty());
+    private final AtomicReference<WindowInfo> driverWindowInfo = new AtomicReference<>(WindowInfo.emptyInfo());
 
     private final Optional<SpillablePagesToPagesIndexes> spillablePagesToPagesIndexes;
 
@@ -335,14 +335,9 @@ public class WindowOperator
         }
 
         windowInfo = new WindowInfo.DriverWindowInfoBuilder();
-        operatorContext.setInfoSupplier(this::getWindowInfo);
+        operatorContext.setInfoSupplier(driverWindowInfo::get);
 
         this.partitioner = partitioner;
-    }
-
-    private OperatorInfo getWindowInfo()
-    {
-        return new WindowInfo(driverWindowInfo.get().map(ImmutableList::of).orElse(ImmutableList.of()));
     }
 
     @Override
@@ -941,7 +936,7 @@ public class WindowOperator
     @Override
     public void close()
     {
-        driverWindowInfo.set(Optional.of(windowInfo.build()));
+        driverWindowInfo.set(new WindowInfo(ImmutableList.of(windowInfo.build())));
         spillablePagesToPagesIndexes.ifPresent(SpillablePagesToPagesIndexes::clearIndexes);
         spillablePagesToPagesIndexes.ifPresent(SpillablePagesToPagesIndexes::closeSpiller);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator;
 
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -385,7 +386,7 @@ public class WorkProcessorPipelineSourceOperator
 
         Object splitInfo = split.getInfo();
         if (splitInfo != null) {
-            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(split.getCatalogName(), splitInfo));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.getCatalogName(), splitInfo)));
         }
 
         pendingSplits.add(split);

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator;
 
+import com.google.common.base.Suppliers;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.trino.Session;
@@ -102,7 +103,7 @@ public class WorkProcessorSourceOperatorAdapter
 
         Object splitInfo = split.getInfo();
         if (splitInfo != null) {
-            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(split.getCatalogName(), splitInfo));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.getCatalogName(), splitInfo)));
         }
 
         splitBuffer.add(split);

--- a/core/trino-main/src/main/java/io/trino/operator/index/IndexSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/IndexSourceOperator.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.index;
 
+import com.google.common.base.Suppliers;
 import io.trino.metadata.Split;
 import io.trino.operator.DriverContext;
 import io.trino.operator.FinishedOperator;
@@ -131,7 +132,7 @@ public class IndexSourceOperator
 
         Object splitInfo = split.getInfo();
         if (splitInfo != null) {
-            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(split.getCatalogName(), splitInfo));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(split.getCatalogName(), splitInfo)));
         }
 
         return Optional::empty;


### PR DESCRIPTION
Follows up on https://github.com/trinodb/trino/pull/7947 with changes to address and avoid certain patterns that can lead to accidentally over-retaining objects via operator info suppliers.

In general, the commits:
- Memoizes the result of and then clears any reference to the original `OperatorContext#infoSupplier` and `OperatorContext#nestedOperatorStatsSupplier` inside of `OperatorContext#destroy()`
- Creates `Supplier<OperatorInfo>` instances using a static method that takes only the required fields instead of using a method reference in the form of `Operator.this#getInfo()` which retains the whole operator
- Adds a minor the allocation rate improvement to the `WindowOperator` info supplier as well as to `WindowInfo#mergeWith`
- Adds a minor allocation rate improvement to scan operator info suppliers by reusing the same instance between calls to `Supplier#get`