### PR TITLE
Remove copy ability from X-Forwarded reference

### DIFF
--- a/docs/src/main/sphinx/security/tls.rst
+++ b/docs/src/main/sphinx/security/tls.rst
@@ -51,11 +51,7 @@ typically runs with default HTTP configuration on the default port, 8080.
 When a load balancer accepts a TLS encrypted connection, it adds a
 `forwarded
 <https://developer.mozilla.org/en-US/docs/Web/HTTP/Proxy_servers_and_tunneling#forwarding_client_information_through_proxies>`_
-HTTP header to the request, such as:
-
-.. code-block:: text
-
-    X-Forwarded-Proto: https
+HTTP header to the request, such as ``X-Forwarded-Proto: https``.
 
 This tells the Trino coordinator to process the connection as if a TLS
 connection has already been successfully negotiated for it. This is why you do


### PR DESCRIPTION
Using a code-block adds a copy to clipboard feature for the block contents. A reader pointed out that no one should be copying and using the phrase **X-Forwarded-Proto: https**. So this was pulled up into the paragraph above.