### PR TITLE
Add Role session name for S3 access in Hive Connector

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -43,6 +43,7 @@ public class GlueHiveMetastoreConfig
     private int readStatisticsThreads = 1;
     private int writeStatisticsThreads = 1;
     private boolean assumeCanonicalPartitionKeys;
+    private String s3SessionIdentifier = "trino-session";
 
     public Optional<String> getGlueRegion()
     {
@@ -270,6 +271,19 @@ public class GlueHiveMetastoreConfig
     public GlueHiveMetastoreConfig setWriteStatisticsThreads(int writeStatisticsThreads)
     {
         this.writeStatisticsThreads = writeStatisticsThreads;
+        return this;
+    }
+
+    public String getS3SessionIdentifier()
+    {
+        return s3SessionIdentifier;
+    }
+
+    @Config("hive.s3.session-identifier")
+    @ConfigDescription("Role session name for S3 access. ${USER} will be replaced with the Trino user.")
+    public GlueHiveMetastoreConfig setS3SessionIdentifier(String s3SessionIdentifier)
+    {
+        this.s3SessionIdentifier = s3SessionIdentifier;
         return this;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Config.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Config.java
@@ -68,6 +68,7 @@ public class HiveS3Config
     private boolean requesterPaysEnabled;
     private boolean s3StreamingUploadEnabled;
     private DataSize s3StreamingPartSize = DataSize.of(16, MEGABYTE);
+    private String s3SessionIdentifier = "trino-session";
 
     public String getS3AwsAccessKey()
     {
@@ -491,6 +492,19 @@ public class HiveS3Config
     public HiveS3Config setS3StreamingPartSize(DataSize s3StreamingPartSize)
     {
         this.s3StreamingPartSize = s3StreamingPartSize;
+        return this;
+    }
+
+    public String getS3SessionIdentifier()
+    {
+        return s3SessionIdentifier;
+    }
+
+    @Config("hive.s3.session-identifier")
+    @ConfigDescription("Role session name for S3 access. ${USER} will be replaced with the Trino user.")
+    public HiveS3Config setS3SessionIdentifier(String s3SessionIdentifier)
+    {
+        this.s3SessionIdentifier = s3SessionIdentifier;
         return this;
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -44,7 +44,8 @@ public class TestGlueHiveMetastoreConfig
                 .setGetPartitionThreads(20)
                 .setAssumeCanonicalPartitionKeys(false)
                 .setReadStatisticsThreads(1)
-                .setWriteStatisticsThreads(1));
+                .setWriteStatisticsThreads(1)
+                .setS3SessionIdentifier("trino-session"));
     }
 
     @Test
@@ -68,6 +69,7 @@ public class TestGlueHiveMetastoreConfig
                 .put("hive.metastore.glue.assume-canonical-partition-keys", "true")
                 .put("hive.metastore.glue.read-statistics-threads", "42")
                 .put("hive.metastore.glue.write-statistics-threads", "43")
+                .put("hive.s3.session-identifier", "trino-user")
                 .build();
 
         GlueHiveMetastoreConfig expected = new GlueHiveMetastoreConfig()
@@ -87,7 +89,8 @@ public class TestGlueHiveMetastoreConfig
                 .setGetPartitionThreads(42)
                 .setAssumeCanonicalPartitionKeys(true)
                 .setReadStatisticsThreads(42)
-                .setWriteStatisticsThreads(43);
+                .setWriteStatisticsThreads(43)
+                .setS3SessionIdentifier("trino-user");
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestHiveS3Config.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestHiveS3Config.java
@@ -68,7 +68,8 @@ public class TestHiveS3Config
                 .setSkipGlacierObjects(false)
                 .setRequesterPaysEnabled(false)
                 .setS3StreamingUploadEnabled(false)
-                .setS3StreamingPartSize(DataSize.of(16, Unit.MEGABYTE)));
+                .setS3StreamingPartSize(DataSize.of(16, Unit.MEGABYTE))
+                .setS3SessionIdentifier("trino-session"));
     }
 
     @Test
@@ -110,6 +111,7 @@ public class TestHiveS3Config
                 .put("hive.s3.requester-pays.enabled", "true")
                 .put("hive.s3.streaming.enabled", "true")
                 .put("hive.s3.streaming.part-size", "15MB")
+                .put("hive.s3.session-identifier", "trino-user")
                 .build();
 
         HiveS3Config expected = new HiveS3Config()
@@ -144,7 +146,8 @@ public class TestHiveS3Config
                 .setSkipGlacierObjects(true)
                 .setRequesterPaysEnabled(true)
                 .setS3StreamingUploadEnabled(true)
-                .setS3StreamingPartSize(DataSize.of(15, Unit.MEGABYTE));
+                .setS3StreamingPartSize(DataSize.of(15, Unit.MEGABYTE))
+                .setS3SessionIdentifier("trino-user");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Pass Role session name to query requests in hive connector.

Currently 'trino-session' is passed in the query request for all queries which access S3 data. This PR has code changes and config parameters which can identify the user who ran the query.

Had issues with GitHub User ID for https://github.com/trinodb/trino/pull/6994. Squashed all the commits and created this new PR.