### PR TITLE
Fix collect Iceberg primitive type missing the NestedType.

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
@@ -292,7 +292,7 @@ public class PartitionTable
             return ((ByteBuffer) value).array();
         }
         if (type instanceof Types.TimestampType) {
-            long epochMicros = (long) value;
+            long epochMicros = Long.parseLong(value.toString());
             if (((Types.TimestampType) type).shouldAdjustToUTC()) {
                 return timestampTzFromMicros(epochMicros, TimeZoneKey.UTC_KEY);
             }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsMaker.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableStatisticsMaker.java
@@ -15,6 +15,7 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.predicate.Domain;
@@ -43,7 +44,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
@@ -87,10 +87,7 @@ public class TableStatisticsMaker
         }
 
         List<Types.NestedField> columns = icebergTable.schema().columns();
-
-        Map<Integer, Type.PrimitiveType> idToTypeMapping = columns.stream()
-                .filter(column -> column.type().isPrimitiveType())
-                .collect(Collectors.toMap(Types.NestedField::fieldId, column -> column.type().asPrimitiveType()));
+        Map<Integer, Type.PrimitiveType> idToTypeMapping = buildIdPrimitiveTypeMapping(columns);
         List<PartitionField> partitionFields = icebergTable.spec().fields();
 
         Set<Integer> identityPartitionIds = getIdentityPartitions(icebergTable.spec()).keySet().stream()
@@ -114,7 +111,7 @@ public class TableStatisticsMaker
                     field,
                     idToColumnHandle.get(field.sourceId()),
                     type,
-                    toTrinoType(type, typeManager),
+                    toTrinoType(idToTypeMapping.get(field.sourceId()), typeManager),
                     type.typeId().javaClass()));
         }
         Map<Integer, ColumnFieldDetails> idToDetails = idToDetailsBuilder.build();
@@ -191,6 +188,26 @@ public class TableStatisticsMaker
             columnHandleBuilder.put(columnHandle, columnBuilder.build());
         }
         return new TableStatistics(Estimate.of(recordCount), columnHandleBuilder.build());
+    }
+
+    private Map<Integer, Type.PrimitiveType> buildIdPrimitiveTypeMapping(List<Types.NestedField> columns) {
+        ImmutableMap.Builder<Integer, Type.PrimitiveType> idToTypeMapping = ImmutableMap.builder();
+        for (Types.NestedField field : columns) {
+            buildIdPrimitiveTypeMapping(field, idToTypeMapping);
+        }
+        return idToTypeMapping.build();
+    }
+
+    private void buildIdPrimitiveTypeMapping(Types.NestedField field, ImmutableMap.Builder<Integer, Type.PrimitiveType> icebergIdToTypeMapping)
+    {
+        Type type = field.type();
+        if (type.isPrimitiveType()) {
+            icebergIdToTypeMapping.put(field.fieldId(), type.asPrimitiveType());
+            return;
+        }
+        if (type instanceof Type.NestedType) {
+            type.asNestedType().fields().forEach(child -> buildIdPrimitiveTypeMapping(child, icebergIdToTypeMapping));
+        }
     }
 
     private boolean dataFileMatches(

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestJoinQueryOnPartitionedColumn.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestJoinQueryOnPartitionedColumn.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.plugin.hive.HdfsConfig;
+import io.trino.plugin.hive.HdfsConfiguration;
+import io.trino.plugin.hive.HdfsConfigurationInitializer;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HiveHdfsConfiguration;
+import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.authentication.NoHdfsAuthentication;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.MetastoreConfig;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastore;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastoreConfig;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.MaterializedResult;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public class TestJoinQueryOnPartitionedColumn
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("iceberg")
+                .setSystemProperty("optimize_metadata_queries", "true")
+                .build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
+
+        HdfsConfig hdfsConfig = new HdfsConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
+
+        HiveMetastore metastore = new FileHiveMetastore(
+                new NodeVersion("test_version"),
+                hdfsEnvironment,
+                new MetastoreConfig(),
+                new FileHiveMetastoreConfig()
+                        .setCatalogDirectory(baseDir.toURI().toString())
+                        .setMetastoreUser("test"));
+
+        queryRunner.installPlugin(new TestingIcebergPlugin(metastore, false));
+        queryRunner.createCatalog("iceberg", "iceberg");
+
+        return queryRunner;
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        assertUpdate("CREATE SCHEMA test_schema");
+        assertUpdate("CREATE TABLE test_schema.test_table (a BIGINT, b TIMESTAMP(6) with time zone, c row(d BIGINT, e BIGINT)) WITH (partitioning = ARRAY['a', 'day(b)'])");
+        assertUpdate("create table test_schema.test_table_2 (foo BIGINT, bar BIGINT)");
+
+        assertUpdate("INSERT INTO test_schema.test_table VALUES (0, CAST('2019-09-08' AS TIMESTAMP(6) with time zone), (1, 1)), (1, CAST('2020-09-09' AS TIMESTAMP(6) with time zone), (1, 1)), (2, CAST('2021-09-09' AS TIMESTAMP(6) with time zone), (1, 1))", 3);
+        assertUpdate("INSERT INTO test_schema.test_table VALUES (15, CAST('2019-09-08' AS TIMESTAMP(6) with time zone), (1, 1)), (20, CAST('2020-09-09' AS TIMESTAMP(6) with time zone), (1, 1)), (50, CAST('2021-09-09' AS TIMESTAMP(6) with time zone), (1, 1))", 3);
+        assertUpdate("INSERT INTO test_schema.test_table_2 VALUES (0,100), (1,101), (15,102), (16,103)", 4);
+    }
+
+    @Test
+    public void testPartitionTable()
+    {
+        assertQuery("SELECT count(*) FROM test_schema.test_table join test_schema.test_table_2 on test_schema.test_table.a = test_schema.test_table_2.foo", "VALUES 3");
+        assertQuery("SELECT count(*) FROM test_schema.test_table join test_schema.test_table_2 on test_schema.test_table.a = test_schema.test_table_2.bar", "VALUES 0");
+    }
+}


### PR DESCRIPTION
Fix https://github.com/trinodb/trino/issues/7502 and https://github.com/trinodb/trino/issues/7999

Fix implicit convert (Iceberg) from DateType to TimestampType.

Fix collect Iceberg primitive type missing the NestedType.
