### PR TITLE
Raise minimum required Java version to 11.0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [CONTRIBUTING](CONTRIBUTING.md) for contribution requirements.
 ## Build requirements
 
 * Mac OS X or Linux
-* Java 11.0.7+, 64-bit
+* Java 11.0.11+, 64-bit
 * Docker
 
 ## Building Trino

--- a/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
+++ b/core/trino-main/src/main/java/io/trino/server/TrinoSystemRequirements.java
@@ -93,7 +93,7 @@ final class TrinoSystemRequirements
 
     private static void verifyJavaVersion()
     {
-        Version required = Version.parse("11.0.7");
+        Version required = Version.parse("11.0.11");
         if (Runtime.version().compareTo(required) < 0) {
             failRequirement("Trino requires Java %s at minimum (found %s)", required, Runtime.version());
         }

--- a/docs/src/main/sphinx/installation/deployment.rst
+++ b/docs/src/main/sphinx/installation/deployment.rst
@@ -27,10 +27,9 @@ Linux operating system
 Java runtime environment
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Trino requires a 64-bit version of Java 11, with a minimum required version of 11.0.7.
-Newer patch versions such as 11.0.8 or 11.0.9 are recommended. Earlier patch versions
-such as 11.0.2 do not work, nor will earlier major versions such as Java 8. Newer major
-versions such as Java 12 or 13 are not supported -- they may work, but are not tested.
+Trino requires a 64-bit version of Java 11, with a minimum required version of 11.0.11.
+Earlier patch versions such as 11.0.2 do not work, nor will earlier major versions such as Java 8.
+Newer major versions such as Java 12 or 13 are not supported -- they may work, but are not tested.
 
 We recommend using `Azul Zulu <https://www.azul.com/downloads/zulu-community/>`_
 as the JDK for Trino, as Trino is tested against that distribution.

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <air.check.skip-jacoco>true</air.check.skip-jacoco>
 
         <project.build.targetJdk>11</project.build.targetJdk>
-        <air.java.version>11.0.7</air.java.version>
+        <air.java.version>11.0.11</air.java.version>
         <air.modernizer.java-version>8</air.modernizer.java-version>
 
         <air.release.preparation-goals>clean verify -DskipTests</air.release.preparation-goals>


### PR DESCRIPTION
Follow-up to https://github.com/trinodb/trino/commit/989068064eb012f762c48f53ad65a2d6ae040522