### PR TITLE
Add listMaterializedViews and getMaterializedViews SPI

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -357,7 +357,9 @@ public class InformationSchemaMetadata
                             .filter(this::isLowerCase)
                             .map(table -> new QualifiedObjectName(catalogName, prefix.getSchemaName().get(), table)))
                     .filter(objectName -> {
-                        if (!isColumnsEnumeratingTable(informationSchemaTable) || metadata.getView(session, objectName).isPresent()) {
+                        if (!isColumnsEnumeratingTable(informationSchemaTable) ||
+                                metadata.getMaterializedView(session, objectName).isPresent() ||
+                                metadata.getView(session, objectName).isPresent()) {
                             return true;
                         }
 

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -280,6 +280,7 @@ public class InformationSchemaPageSource
     {
         Set<SchemaTableName> tables = listTables(session, metadata, accessControl, prefix);
         Set<SchemaTableName> views = listViews(session, metadata, accessControl, prefix);
+        // TODO (https://github.com/trinodb/trino/issues/8207) define a type for materialized views
 
         for (SchemaTableName name : union(tables, views)) {
             // if table and view names overlap, the view wins

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -627,6 +627,11 @@ public interface Metadata
     void dropMaterializedView(Session session, QualifiedObjectName viewName);
 
     /**
+     * Get the names that match the specified table prefix (never null).
+     */
+    List<QualifiedObjectName> listMaterializedViews(Session session, QualifiedTablePrefix prefix);
+
+    /**
      * Returns the materialized view definition for the specified view name.
      */
     Optional<ConnectorMaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName);

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -632,6 +632,11 @@ public interface Metadata
     List<QualifiedObjectName> listMaterializedViews(Session session, QualifiedTablePrefix prefix);
 
     /**
+     * Get the materialized view definitions that match the specified table prefix (never null).
+     */
+    Map<QualifiedObjectName, ConnectorMaterializedViewDefinition> getMaterializedViews(Session session, QualifiedTablePrefix prefix);
+
+    /**
      * Returns the materialized view definition for the specified view name.
      */
     Optional<ConnectorMaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName);

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
@@ -120,6 +120,14 @@ public final class MetadataListing
                 .collect(toImmutableMap(Entry::getKey, Entry::getValue));
     }
 
+    public static Set<SchemaTableName> listMaterializedViews(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
+    {
+        Set<SchemaTableName> tableNames = metadata.listMaterializedViews(session, prefix).stream()
+                .map(QualifiedObjectName::asSchemaTableName)
+                .collect(toImmutableSet());
+        return accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), tableNames);
+    }
+
     public static Set<GrantInfo> listTablePrivileges(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
         List<GrantInfo> grants = metadata.listTablePrivileges(session, prefix);

--- a/core/trino-main/src/main/java/io/trino/security/AccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControl.java
@@ -206,7 +206,7 @@ public interface AccessControl
     void checkCanShowTables(SecurityContext context, CatalogSchemaName schema);
 
     /**
-     * Filter the list of tables and views to those visible to the identity.
+     * Filter the list of tables, materialized views and views to those visible to the identity.
      */
     Set<SchemaTableName> filterTables(SecurityContext context, String catalogName, Set<SchemaTableName> tableNames);
 

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -859,6 +859,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public Map<QualifiedObjectName, ConnectorMaterializedViewDefinition> getMaterializedViews(Session session, QualifiedTablePrefix prefix)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
     {
         throw new UnsupportedOperationException();

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -853,6 +853,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public List<QualifiedObjectName> listMaterializedViews(Session session, QualifiedTablePrefix prefix)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
     {
         throw new UnsupportedOperationException();

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1157,6 +1157,20 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Gets the definitions of materialized views, possibly filtered by schema.
+     * This optional method may be implemented by connectors that can support fetching
+     * view data in bulk. It is used to populate {@code information_schema.columns}.
+     */
+    default Map<SchemaTableName, ConnectorMaterializedViewDefinition> getMaterializedViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        Map<SchemaTableName, ConnectorMaterializedViewDefinition> materializedViews = new HashMap<>();
+        for (SchemaTableName name : listMaterializedViews(session, schemaName)) {
+            getMaterializedView(session, name).ifPresent(view -> materializedViews.put(name, view));
+        }
+        return materializedViews;
+    }
+
+    /**
      * Gets the materialized view data for the specified materialized view name. Returns {@link Optional#empty()}
      * if {@code viewName} relation does not or is not a materialized view (e.g. is a table, or a view).
      *

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1149,6 +1149,14 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Get the names that match the specified table prefix (never null).
+     */
+    default List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        return List.of();
+    }
+
+    /**
      * Gets the materialized view data for the specified materialized view name. Returns {@link Optional#empty()}
      * if {@code viewName} relation does not or is not a materialized view (e.g. is a table, or a view).
      *

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -864,6 +864,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.listMaterializedViews(session, schemaName);
+        }
+    }
+
+    @Override
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -872,6 +872,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public Map<SchemaTableName, ConnectorMaterializedViewDefinition> getMaterializedViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getMaterializedViews(session, schemaName);
+        }
+    }
+
+    @Override
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMaterializedViewMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMaterializedViewMetadata.java
@@ -18,6 +18,8 @@ import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.SchemaTableName;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface HiveMaterializedViewMetadata
@@ -25,6 +27,10 @@ public interface HiveMaterializedViewMetadata
     void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting);
 
     void dropMaterializedView(ConnectorSession session, SchemaTableName viewName);
+
+    List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> schemaName);
+
+    Map<SchemaTableName, ConnectorMaterializedViewDefinition> getMaterializedViews(ConnectorSession session, Optional<String> schemaName);
 
     Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -706,6 +706,8 @@ public class HiveMetadata
                 tableNames.add(new SchemaTableName(schemaName, tableName));
             }
         }
+
+        tableNames.addAll(listMaterializedViews(session, optionalSchemaName));
         return tableNames.build();
     }
 
@@ -3033,6 +3035,18 @@ public class HiveMetadata
     public void dropMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         hiveMaterializedViewMetadata.dropMaterializedView(session, viewName);
+    }
+
+    @Override
+    public List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        return hiveMaterializedViewMetadata.listMaterializedViews(session, schemaName);
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorMaterializedViewDefinition> getMaterializedViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        return hiveMaterializedViewMetadata.getMaterializedViews(session, schemaName);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/NoneHiveMaterializedViewMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/NoneHiveMaterializedViewMetadata.java
@@ -13,12 +13,16 @@
  */
 package io.trino.plugin.hive;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.MaterializedViewFreshness;
 import io.trino.spi.connector.SchemaTableName;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
@@ -37,6 +41,18 @@ public class NoneHiveMaterializedViewMetadata
     public void dropMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not support dropping materialized views");
+    }
+
+    @Override
+    public List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public Map<SchemaTableName, ConnectorMaterializedViewDefinition> getMaterializedViews(ConnectorSession session, Optional<String> schemaName)
+    {
+        return ImmutableMap.of();
     }
 
     @Override

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/AbstractTestIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/AbstractTestIcebergConnectorTest.java
@@ -209,22 +209,6 @@ public abstract class AbstractTestIcebergConnectorTest
     }
 
     @Override
-    protected void checkShowColumnsForMaterializedView(String schemaName, String viewName)
-    {
-        // TODO The query should not fail, obviously. It should return all the columns in the view
-        assertThatThrownBy(() -> super.checkShowColumnsForMaterializedView(schemaName, viewName))
-                .hasMessageContaining(format("Table 'iceberg.%s.%s' does not exist", schemaName, viewName));
-    }
-
-    @Override
-    protected void checkInformationSchemaColumnsForPointedQueryForMaterializedView(String schemaName, String viewName)
-    {
-        // TODO The query should not fail, obviously. It should return columns for the materialized view
-        assertThatThrownBy(() -> super.checkInformationSchemaColumnsForPointedQueryForMaterializedView(schemaName, viewName))
-                .hasMessageFindingMatch("(?s)Expecting.*to contain:.*, nationkey\\).*, name\\).*, regionkey\\).*, comment\\)");
-    }
-
-    @Override
     protected void checkInformationSchemaViewsForMaterializedView(String schemaName, String viewName)
     {
         // TODO should probably return materialized view, as it's also a view -- to be double checked

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/AbstractTestIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/AbstractTestIcebergConnectorTest.java
@@ -217,14 +217,6 @@ public abstract class AbstractTestIcebergConnectorTest
     }
 
     @Override
-    protected void checkInformationSchemaColumnsForMaterializedView(String schemaName, String viewName)
-    {
-        // TODO The query should not fail, obviously. It should return columns for all tables, views, and materialized views
-        assertThatThrownBy(() -> super.checkInformationSchemaColumnsForMaterializedView(schemaName, viewName))
-                .hasMessageFindingMatch("(?s)Expecting.*to contain:.*, nationkey\\).*, name\\).*, regionkey\\).*, comment\\)");
-    }
-
-    @Override
     protected void checkInformationSchemaColumnsForPointedQueryForMaterializedView(String schemaName, String viewName)
     {
         // TODO The query should not fail, obviously. It should return columns for the materialized view

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
@@ -137,13 +137,14 @@ public class TestIcebergMetadataListing
     public void testTableColumnListing()
     {
         // Verify information_schema.columns does not include columns from non-Iceberg tables
-        // TODO this should include columns from the materialized view as well
         assertQuery(
                 "SELECT table_name, column_name FROM iceberg.information_schema.columns WHERE table_schema = 'test_schema'",
                 "VALUES " +
                         "('iceberg_table1', '_string'), " +
                         "('iceberg_table1', '_integer'), " +
                         "('iceberg_table2', '_double'), " +
+                        "('iceberg_materialized_view', '_string'), " +
+                        "('iceberg_materialized_view', '_integer'), " +
                         "('" + storageTable.getTableName() + "', '_string'), " +
                         "('" + storageTable.getTableName() + "', '_integer')");
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveMetadataListing.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveMetadataListing.java
@@ -74,6 +74,8 @@ public class TestIcebergHiveMetadataListing
                 .containsOnly(
                         row("iceberg_table1", "_string"),
                         row("iceberg_table1", "_integer"),
+                        row("iceberg_materialized_view", "_string"),
+                        row("iceberg_materialized_view", "_integer"),
                         row(storageTable, "_string"),
                         row(storageTable, "_integer"));
     }


### PR DESCRIPTION
Used listMaterializedViews to list MV names for information_schema.tables, system.jdbc.tables and SHOW TABLES
Used getMaterializedViews to list MV columns in information_schema.columns, system.jdbc.columns and SHOW COLUMNS

Fixed DESCRIBE, SHOW COLUMNS, information_schema.columns, system.jdbc.columns for MVs in Iceberg.

Table type used for MVs in information_schema.tables is left unchanged as BASE TABLE.
MVs are not listed in information_schema.views.
getMaterializedViews can be used in future to introduce information_schema.trino_materialized_views or system.metadata.materialized_views for showing detailed information about materialized view definitions.
