### PR TITLE
Fix doc for complex grouping operations

### DIFF
--- a/docs/src/main/sphinx/sql/select.rst
+++ b/docs/src/main/sphinx/sql/select.rst
@@ -311,7 +311,7 @@ Trino also supports complex aggregations using the ``GROUPING SETS``, ``CUBE``
 and ``ROLLUP`` syntax. This syntax allows users to perform analysis that requires
 aggregation on multiple sets of columns in a single query. Complex grouping
 operations do not support grouping on expressions composed of input columns.
-Only column names or ordinals are allowed.
+Only column names are allowed.
 
 Complex grouping operations are often equivalent to a ``UNION ALL`` of simple
 ``GROUP BY`` expressions, as shown in the following examples. This equivalence


### PR DESCRIPTION
https://trino.io/docs/current/sql/select.html?#complex-grouping-operations
In this section it says "Only column names or ordinals are allowed." However as I checked, ordinals are not supported. The only thing that's supported is the column name.