### PR TITLE
Add product test launcher 'env describe' command

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/EnvironmentDescribe.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/EnvironmentDescribe.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.launcher.cli;
+
+import com.github.dockerjava.api.model.Bind;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Module;
+import io.airlift.log.Logger;
+import io.airlift.units.DataSize;
+import io.trino.tests.product.launcher.Extensions;
+import io.trino.tests.product.launcher.LauncherModule;
+import io.trino.tests.product.launcher.cli.EnvironmentUp.EnvironmentUpOptions;
+import io.trino.tests.product.launcher.docker.DockerFiles;
+import io.trino.tests.product.launcher.env.DockerContainer;
+import io.trino.tests.product.launcher.env.Environment;
+import io.trino.tests.product.launcher.env.EnvironmentConfig;
+import io.trino.tests.product.launcher.env.EnvironmentFactory;
+import io.trino.tests.product.launcher.env.EnvironmentModule;
+import io.trino.tests.product.launcher.env.EnvironmentOptions;
+import io.trino.tests.product.launcher.util.ConsoleTable;
+import org.testcontainers.utility.MountableFile;
+import picocli.CommandLine;
+import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+import static io.trino.tests.product.launcher.cli.Commands.runCommand;
+import static io.trino.tests.product.launcher.docker.DockerFiles.ROOT_PATH;
+import static java.util.Objects.requireNonNull;
+
+@CommandLine.Command(
+        name = "describe",
+        description = "Describes provided environment",
+        usageHelpAutoWidth = true)
+public class EnvironmentDescribe
+        implements Callable<Integer>
+{
+    private static final Logger log = Logger.get(EnvironmentDescribe.class);
+
+    @Option(names = {"-h", "--help"}, usageHelp = true, description = "Show this help message and exit")
+    public boolean usageHelpRequested;
+
+    @Mixin
+    public EnvironmentOptions environmentOptions = new EnvironmentOptions();
+
+    @Mixin
+    public EnvironmentUpOptions environmentUpOptions = new EnvironmentUpOptions();
+
+    private final Module additionalEnvironments;
+
+    public EnvironmentDescribe(Extensions extensions)
+    {
+        this.additionalEnvironments = requireNonNull(extensions, "extensions is null").getAdditionalEnvironments();
+    }
+
+    @Override
+    public Integer call() throws Exception
+    {
+        return runCommand(
+                ImmutableList.<Module>builder()
+                        .add(new LauncherModule())
+                        .add(new EnvironmentModule(environmentOptions, additionalEnvironments))
+                        .add(environmentUpOptions.toModule())
+                        .build(),
+                EnvironmentDescribe.Execution.class);
+    }
+
+    public static class Execution
+            implements Callable<Integer>
+    {
+        private static final String[] CONTAINERS_LIST_HEADER = {
+                "container",
+                "image",
+                "network alias",
+                "env",
+                "ports",
+                "run command"
+        };
+
+        private static final String[] MOUNTS_LIST_HEADER = {
+                "container",
+                "type",
+                "from",
+                "to",
+                "type",
+                "size"
+        };
+
+        private static final Joiner JOINER = Joiner.on('\n').skipNulls();
+
+        private final EnvironmentFactory environmentFactory;
+        private final EnvironmentConfig environmentConfig;
+        private final EnvironmentOptions environmentOptions;
+        private final EnvironmentUpOptions environmentUpOptions;
+        private final Path dockerFilesBasePath;
+
+        @Inject
+        public Execution(DockerFiles dockerFiles, EnvironmentFactory environmentFactory, EnvironmentConfig environmentConfig, EnvironmentOptions environmentOptions, EnvironmentUpOptions environmentUpOptions)
+        {
+            this.dockerFilesBasePath = requireNonNull(dockerFiles, "dockerFiles is null").getDockerFilesHostPath();
+            this.environmentFactory = requireNonNull(environmentFactory, "environmentFactory is null");
+            this.environmentConfig = requireNonNull(environmentConfig, "environmentConfig is null");
+            this.environmentOptions = requireNonNull(environmentOptions, "environmentOptions is null");
+            this.environmentUpOptions = requireNonNull(environmentUpOptions, "environmentUpOptions is null");
+        }
+
+        @Override
+        public Integer call() throws Exception
+        {
+            Optional<Path> environmentLogPath = environmentUpOptions.logsDirBase.map(dir -> dir.resolve(environmentUpOptions.environment));
+
+            Environment.Builder builder = environmentFactory.get(environmentUpOptions.environment, environmentConfig)
+                    .setContainerOutputMode(environmentOptions.output)
+                    .setLogsBaseDir(environmentLogPath);
+
+            Environment environment = builder.build();
+            Collection<DockerContainer> containers = environment.getContainers();
+
+            ConsoleTable containersTable = new ConsoleTable();
+            containersTable.addHeader(CONTAINERS_LIST_HEADER);
+
+            for (DockerContainer container : containers) {
+                containersTable.addRow(
+                        container.getLogicalName(),
+                        container.getDockerImageName(),
+                        JOINER.join(container.getNetworkAliases()),
+                        JOINER.join(container.getEnv()),
+                        JOINER.join(container.getExposedPorts()),
+                        Joiner.on(' ').join(container.getCommandParts()));
+                containersTable.addSeparator();
+            }
+
+            log.info("Environment '%s' containers:\n%s", environmentUpOptions.environment, containersTable.render());
+
+            ConsoleTable mountsTable = new ConsoleTable();
+            mountsTable.addHeader(MOUNTS_LIST_HEADER);
+
+            for (DockerContainer container : containers) {
+                for (Map.Entry<MountableFile, String> file : container.getCopyToFileContainerPathMap().entrySet()) {
+                    MountableFile mountableFile = file.getKey();
+                    Path mountedFilePath = Paths.get(mountableFile.getFilesystemPath());
+                    boolean isDirectory = Files.isDirectory(mountedFilePath);
+
+                    mountsTable.addRow(
+                            container.getLogicalName(),
+                            "copy",
+                            simplifyPath(mountableFile.getDescription()),
+                            file.getValue(),
+                            isDirectory ? "dir" : "file",
+                            DataSize.ofBytes(isDirectory ? directorySize(mountedFilePath) : mountableFile.getSize()).succinct());
+                }
+
+                for (Bind bind : container.getBinds()) {
+                    Path path = Paths.get(bind.getPath());
+                    boolean isDirectory = Files.isDirectory(path);
+                    mountsTable.addRow(
+                            container.getLogicalName(),
+                            "bind",
+                            simplifyPath(bind.getPath()),
+                            bind.getVolume().getPath(),
+                            isDirectory ? "dir" : "file",
+                            DataSize.ofBytes(Files.size(path)).succinct());
+                }
+
+                mountsTable.addSeparator();
+            }
+
+            log.info("Environment '%s' file mounts:\n%s", environmentUpOptions.environment, mountsTable.render());
+
+            return 1;
+        }
+
+        private String simplifyPath(String path)
+        {
+            return path.replace(dockerFilesBasePath.toString(), "classpath:" + ROOT_PATH.substring(0, ROOT_PATH.length() - 1));
+        }
+    }
+
+    private static long directorySize(Path directory)
+    {
+        try {
+            return Files.walk(directory)
+                    .filter(path -> path.toFile().isFile())
+                    .mapToLong(path -> path.toFile().length())
+                    .sum();
+        }
+        catch (IOException e) {
+            log.warn(e, "Could not calculate directory size: %s", directory);
+            return 0;
+        }
+    }
+}

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/Launcher.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/cli/Launcher.java
@@ -105,6 +105,7 @@ public class Launcher
             subcommands = {
                     HelpCommand.class,
                     EnvironmentUp.class,
+                    EnvironmentDescribe.class,
                     EnvironmentDown.class,
                     EnvironmentList.class,
             })

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/docker/DockerFiles.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/docker/DockerFiles.java
@@ -40,6 +40,8 @@ import static java.util.UUID.randomUUID;
 public final class DockerFiles
         implements AutoCloseable
 {
+    public static final String ROOT_PATH = "docker/presto-product-tests/";
+
     private static final Logger log = Logger.get(DockerFiles.class);
 
     @GuardedBy("this")
@@ -97,10 +99,10 @@ public final class DockerFiles
             Path dockerFilesHostPath = createTemporaryDirectoryForDocker();
             ClassPath.from(Thread.currentThread().getContextClassLoader())
                     .getResources().stream()
-                    .filter(resourceInfo -> resourceInfo.getResourceName().startsWith("docker/presto-product-tests/"))
+                    .filter(resourceInfo -> resourceInfo.getResourceName().startsWith(ROOT_PATH))
                     .forEach(resourceInfo -> {
                         try {
-                            Path target = dockerFilesHostPath.resolve(resourceInfo.getResourceName().replaceFirst("^docker/presto-product-tests/", ""));
+                            Path target = dockerFilesHostPath.resolve(resourceInfo.getResourceName().replaceFirst("^" + ROOT_PATH, ""));
                             Files.createDirectories(target.getParent());
 
                             try (InputStream inputStream = resourceInfo.asByteSource().openStream()) {


### PR DESCRIPTION
This PR adds `env inspect` command that works similar to `env up` but instead of creating and starting environment it just displays what environment consists of in following form:

```
./testing/trino-product-tests-launcher/bin/run-launcher env describe --environment singlenode --config config-hdp3 --
2021-05-28T15:57:20.032+0200    INFO    main    io.trino.tests.product.launcher.cli.EnvironmentDescribe Environment 'singlenode' containers:
+---------------+-----------------------------------------+------------------------------+-----+-------+----------------------------------------------------+
|     container |                                   image |                network alias | env | ports |                                        run command |
+---------------+-----------------------------------------+------------------------------+-----+-------+----------------------------------------------------+
|         tests |  ghcr.io/trinodb/testing/centos6-oj8:34 |                  tc-GTsMqLcW |     |       | bash -xeuc echo 'No command provided' >&2; exit 69 |
|               |                                         |                        tests |     |       |                                                    |
+---------------+-----------------------------------------+------------------------------+-----+-------+----------------------------------------------------+
| presto-master | ghcr.io/trinodb/testing/centos7-oj11:34 |                  tc-EhATM6Y5 |     |  5005 |         /docker/presto-product-tests/run-presto.sh |
|               |                                         | presto-master.docker.cluster |     |  8080 |                                                    |
|               |                                         |                presto-master |     |       |                                                    |
+---------------+-----------------------------------------+------------------------------+-----+-------+----------------------------------------------------+
| hadoop-master |  ghcr.io/trinodb/testing/hdp3.1-hive:34 |                  tc-1T1oA325 |     |  1180 |                           /usr/local/hadoop-run.sh |
|               |                                         |                hadoop-master |     |  8020 |                                                    |
|               |                                         |                              |     |  8042 |                                                    |
|               |                                         |                              |     |  8088 |                                                    |
|               |                                         |                              |     |  9000 |                                                    |
|               |                                         |                              |     |  9083 |                                                    |
|               |                                         |                              |     |  9864 |                                                    |
|               |                                         |                              |     |  9870 |                                                    |
|               |                                         |                              |     | 10000 |                                                    |
|               |                                         |                              |     | 19888 |                                                    |
|               |                                         |                              |     | 50070 |                                                    |
|               |                                         |                              |     | 50075 |                                                    |
+---------------+-----------------------------------------+------------------------------+-----+-------+----------------------------------------------------+
2021-05-28T15:57:20.087+0200    INFO    main    io.trino.tests.product.launcher.cli.EnvironmentDescribe Environment 'singlenode' file mounts:
+---------------+------+------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+------+----------+
|     container | type |                                                                                                                   from |                                                                                        to | type |     size |
+---------------+------+------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+------+----------+
|         tests | copy |                                                                                  classpath:docker/presto-product-tests |                                                              /docker/presto-product-tests |  dir | 188.78kB |
+---------------+------+------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+------+----------+
| presto-master | copy |                                                                                  classpath:docker/presto-product-tests |                                                              /docker/presto-product-tests |  dir | 188.78kB |
| presto-master | copy |                                                       classpath:docker/presto-product-tests/conf/presto/etc/jvm.config |                                   /docker/presto-product-tests/conf/presto/etc/jvm.config | file |     656B |
| presto-master | copy |                                              classpath:docker/presto-product-tests/health-checks/trino-health-check.sh |                                                       /etc/health.d/trino-health-check.sh | file |     331B |
| presto-master | copy |                            /var/folders/kj/q89730fx15g7gs2lszthfp_40000gn/T/enable-java-debugger6646706103428298393.sh |                                             /docker/presto-init.d/enable-java-debugger.sh | file |     164B |
| presto-master | copy |                                        classpath:docker/presto-product-tests/common/standard/access-control.properties |                    /docker/presto-product-tests/conf/presto/etc/access-control.properties | file |      30B |
| presto-master | copy |                                                classpath:docker/presto-product-tests/common/standard/config.properties |                            /docker/presto-product-tests/conf/presto/etc/config.properties | file |     295B |
| presto-master | copy |                                                    classpath:docker/presto-product-tests/common/hadoop/hive.properties |                      /docker/presto-product-tests/conf/presto/etc/catalog/hive.properties | file |     532B |
| presto-master | copy |                               classpath:docker/presto-product-tests/common/hadoop/hive_with_external_writes.properties | /docker/presto-product-tests/conf/presto/etc/catalog/hive_with_external_writes.properties | file |     575B |
| presto-master | copy |                                    classpath:docker/presto-product-tests/common/hadoop/hive_timestamp_nanos.properties |      /docker/presto-product-tests/conf/presto/etc/catalog/hive_timestamp_nanos.properties | file |     290B |
| presto-master | copy |                                                 classpath:docker/presto-product-tests/common/hadoop/iceberg.properties |                   /docker/presto-product-tests/conf/presto/etc/catalog/iceberg.properties | file |     190B |
| presto-master | copy |                                              classpath:docker/presto-product-tests/common/standard/presto-init-hdp3.sh |                                                 /docker/presto-init.d/presto-init-hdp3.sh | file |     366B |
| presto-master | bind | /Users/mateuszgajewski/Projects/src/github.com/trinodb/trino/core/trino-server/target/trino-server-358-SNAPSHOT.tar.gz |                                                              /docker/presto-server.tar.gz | file | 582.36MB |
+---------------+------+------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+------+----------+
| hadoop-master | copy |                                                                                  classpath:docker/presto-product-tests |                                                             /docker/presto-product-tests/ |  dir | 188.78kB |
| hadoop-master | copy |                                             classpath:docker/presto-product-tests/health-checks/hadoop-health-check.sh |                                                      /etc/health.d/hadoop-health-check.sh | file |     415B |
| hadoop-master | copy |                                                      classpath:docker/presto-product-tests/common/hadoop/hadoop-run.sh |                                                                  /usr/local/hadoop-run.sh | file |     458B |
| hadoop-master | copy |                                          classpath:docker/presto-product-tests/common/hadoop/apply-config-overrides.sh |                                           /etc/hadoop-init.d/00-apply-config-overrides.sh | file |     458B |
| hadoop-master | copy |                                                          classpath:docker/presto-product-tests/health-checks/health.sh |                                                                  /usr/local/bin/health.sh | file |     327B |
+---------------+------+------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+------+----------+
```