### PR TITLE
Include *-non-generic suites on PR builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,15 +346,19 @@ jobs:
                || contains(github.event.pull_request.labels.*.name, 'tests:hive')
                }}
 
-          - config: hdp3
+          # Exclude *-non-generic for `default`, leave them included for `hdp3`. This is because `default` gets excluded from PR builds by default.
+          # as hdp3 is faster and provides better test coverage (e.g. Hive transactional tables).
+          # TODO remap: make `default` use hdp3 and let's introduce `hdp2` for what is currently default. Then we can exclude `hdp2` here and keep `default`, which
+          # feels more correct.
+          - config: default
             suite: suite-6-non-generic
-          - config: hdp3
+          - config: default
             suite: suite-7-non-generic
-          - config: hdp3
+          - config: default
             suite: suite-8-non-generic
-          - config: hdp3
+          - config: default
             suite: suite-tpcds
-          - config: hdp3
+          - config: default
             suite: suite-oauth2
 
           - config: cdh5

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite6NonGeneric.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite6NonGeneric.java
@@ -15,7 +15,6 @@ package io.trino.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
-import io.trino.tests.product.launcher.env.EnvironmentDefaults;
 import io.trino.tests.product.launcher.env.environment.MultinodeKafka;
 import io.trino.tests.product.launcher.env.environment.MultinodeKafkaSsl;
 import io.trino.tests.product.launcher.env.environment.SinglenodeCassandra;
@@ -30,7 +29,6 @@ import io.trino.tests.product.launcher.suite.SuiteTestRun;
 
 import java.util.List;
 
-import static com.google.common.base.Verify.verify;
 import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
 
 public class Suite6NonGeneric
@@ -39,7 +37,8 @@ public class Suite6NonGeneric
     @Override
     public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
-        verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
+        // TODO uncomment when the *-non-generic suites are run with `default` configuraton in ci.yml
+        //verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
 
         return ImmutableList.of(
                 testOnEnvironment(SinglenodeLdap.class).withGroups("ldap").build(),

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite7NonGeneric.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite7NonGeneric.java
@@ -15,7 +15,6 @@ package io.trino.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
-import io.trino.tests.product.launcher.env.EnvironmentDefaults;
 import io.trino.tests.product.launcher.env.environment.SinglenodeKerberosHdfsImpersonationCrossRealm;
 import io.trino.tests.product.launcher.env.environment.SinglenodeLdapBindDn;
 import io.trino.tests.product.launcher.env.environment.SinglenodeMysql;
@@ -30,7 +29,6 @@ import io.trino.tests.product.launcher.suite.SuiteTestRun;
 
 import java.util.List;
 
-import static com.google.common.base.Verify.verify;
 import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
 
 public class Suite7NonGeneric
@@ -39,7 +37,8 @@ public class Suite7NonGeneric
     @Override
     public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
-        verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
+        // TODO uncomment when the *-non-generic suites are run with `default` configuraton in ci.yml
+        //verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
 
         return ImmutableList.of(
                 testOnEnvironment(SinglenodeMysql.class).withGroups("mysql").build(),

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite8NonGeneric.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/suites/Suite8NonGeneric.java
@@ -15,14 +15,12 @@ package io.trino.tests.product.launcher.suite.suites;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
-import io.trino.tests.product.launcher.env.EnvironmentDefaults;
 import io.trino.tests.product.launcher.env.environment.SinglenodeHdp3;
 import io.trino.tests.product.launcher.suite.Suite;
 import io.trino.tests.product.launcher.suite.SuiteTestRun;
 
 import java.util.List;
 
-import static com.google.common.base.Verify.verify;
 import static io.trino.tests.product.launcher.suite.SuiteTestRun.testOnEnvironment;
 
 public class Suite8NonGeneric
@@ -31,7 +29,8 @@ public class Suite8NonGeneric
     @Override
     public List<SuiteTestRun> getTestRuns(EnvironmentConfig config)
     {
-        verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
+        // TODO uncomment when the *-non-generic suites are run with `default` configuraton in ci.yml
+        //verify(config.getHadoopBaseImage().equals(EnvironmentDefaults.HADOOP_BASE_IMAGE), "The suite should be run with default HADOOP_BASE_IMAGE. Leave HADOOP_BASE_IMAGE unset.");
 
         return ImmutableList.of(
                 testOnEnvironment(SinglenodeHdp3.class).withGroups("hdp3_only", "hive_transactional").build());


### PR DESCRIPTION
They got accidentally excluded from PR builds when `ignore excluded if`
mechanism was introduced in d6e8e96a557d931d7da0f9a04d35566531759f57.

cc @hashhar @skrzypo987 @kokosing @lukasz-walkiewicz @losipiuk 