### PR TITLE
Revert "Supports authentication using multiple ldap.user-bind-pattern value"

### DIFF
--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticator.java
@@ -133,7 +133,7 @@ public class LdapAuthenticator
                 log.debug("Authentication successful for user [%s]", user);
                 return new BasicPrincipal(user);
             }
-            catch (NamingException | AccessDeniedException e) {
+            catch (NamingException e) {
                 lastException = e;
             }
         }
@@ -152,7 +152,7 @@ public class LdapAuthenticator
             client.validatePassword(userDistinguishedName, credential.getPassword());
             log.debug("Authentication successful for user [%s]", user);
         }
-        catch (NamingException | AccessDeniedException e) {
+        catch (NamingException e) {
             log.debug(e, "Authentication failed for user [%s], %s", user, e.getMessage());
             throw new RuntimeException("Authentication error");
         }

--- a/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/test/java/io/trino/plugin/password/ldap/TestLdapAuthenticator.java
@@ -74,12 +74,8 @@ public class TestLdapAuthenticator
         client.addCredentials("alice@alt.example.com", "alt-alice-pass");
         assertEquals(ldapAuthenticator.createAuthenticatedPrincipal("alice", "alt-alice-pass"), new BasicPrincipal("alice"));
         ldapAuthenticator.invalidateCache();
-
         assertEquals(ldapAuthenticator.createAuthenticatedPrincipal("alice", "alice-pass"), new BasicPrincipal("alice"));
         ldapAuthenticator.invalidateCache();
-
-        assertThatThrownBy(() -> ldapAuthenticator.createAuthenticatedPrincipal("john", "john-pass"))
-                .isInstanceOf(RuntimeException.class);
     }
 
     @Test
@@ -100,7 +96,7 @@ public class TestLdapAuthenticator
         assertThatThrownBy(() -> ldapAuthenticator.createAuthenticatedPrincipal("unknown", "alice-pass"))
                 .isInstanceOf(RuntimeException.class);
         assertThatThrownBy(() -> ldapAuthenticator.createAuthenticatedPrincipal("alice", "alice-pass"))
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(AccessDeniedException.class);
         client.addGroupMember("alice");
         assertEquals(ldapAuthenticator.createAuthenticatedPrincipal("alice", "alice-pass"), new BasicPrincipal("alice"));
     }
@@ -139,7 +135,7 @@ public class TestLdapAuthenticator
 
         client.addDistinguishedNameForUser("alice", "another-mapping");
         assertThatThrownBy(() -> ldapAuthenticator.createAuthenticatedPrincipal("alice", "alice-pass"))
-                .isInstanceOf(RuntimeException.class);
+                .isInstanceOf(AccessDeniedException.class);
     }
 
     @Test
@@ -201,7 +197,7 @@ public class TestLdapAuthenticator
                 throws NamingException
         {
             if (!credentials.contains(new Credential(userDistinguishedName, password))) {
-                throw new AccessDeniedException("Invalid credentials");
+                throw new NamingException();
             }
         }
 


### PR DESCRIPTION
This reverts the following commits:
45f8cb4b7e0938ff6e723ac63a808214d0c3ba7a
8ca9a95531e504406a2303866143331a8c7c83c6
22ebcf7e610c93985a1eb77d4e0135e203f7d461
74a8b968c07ad185e7bd6f55457d1d487f8287ac
78293628ed5fbccc00f54fe2ca997f16e9d9b5cd

The change was implemented incorrectly and breaks tests but was not
caught because some tests were not run on the pull-request.