### PR TITLE
Ensure older workflow runs for a PR/commit are cancelled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ env:
   MAVEN_TEST: "-B -Dair.check.skip-all --fail-at-end"
   RETRY: .github/bin/retry
 
+# Cancel previous PR builds.
+concurrency:
+  # Cancel all workflow runs except latest within a concurrency group. This is achieved by defining a concurrency group for the PR.
+  # Non-PR builds have singleton concurrency groups.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   maven-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,14 +1,21 @@
 name: cleanup
 
 on:
-  schedule:
-    - cron: '*/5 * * * *'
+  # Triggered on every PR merge or close
+  pull_request:
+    types:
+      - closed
 
 jobs:
   cancel:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
+      - name: 'Cancel Runs For Closed PRs'
+        uses: styfle/cancel-workflow-action@0.9.0
         with:
-          token: ${{ github.token }}
-          workflow: ci.yml
+          # Cancel workflow when PR closed. https://github.com/styfle/cancel-workflow-action#advanced-ignore-sha
+          ignore_sha: true
+          # Note: workflow_id can be a Workflow ID (number) or Workflow File Name (string).
+          workflow_id: "ci.yml"
+          access_token: ${{ github.token }}


### PR DESCRIPTION
The new `concurrency` setting can be used to ensure only a single
workflow run or job is in progress. When used in combination with the
`cancel-in-progress` setting, incomplete workflow runs can be cancelled
automatically to prevent running workflows unnecessarily.

Previously this was done by utilizing a 3rd-party action as a scheduled
workflow. It had the drawback that if there was already a queue of
workflows then the cancel action also had to wait in queue.

This option is currently in beta, but seems stable enough to use.