### PR TITLE
Update Provisio Maven Plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1635,7 +1635,7 @@
                 <plugin>
                     <groupId>ca.vanzyl.provisio.maven.plugins</groupId>
                     <artifactId>provisio-maven-plugin</artifactId>
-                    <version>1.0.16</version>
+                    <version>1.0.18</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Update Provisio Maven Plugin version to 1.0.18 that would include direct dependencies in the published POM for the `trino-server` module. 