### PR TITLE
Add username/password authentication in MongoDB docker tests (Issue #7854)

### DIFF
--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoQueryRunner.java
@@ -16,6 +16,7 @@ package io.trino.plugin.mongodb;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
 import io.airlift.log.Logger;
 import io.airlift.log.Logging;
 import io.trino.Session;
@@ -23,6 +24,7 @@ import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.tpch.TpchTable;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static io.airlift.testing.Closeables.closeAllSuppress;
@@ -57,7 +59,8 @@ public final class MongoQueryRunner
             Map<String, String> properties = ImmutableMap.of(
                     "mongodb.case-insensitive-name-matching", "true",
                     "mongodb.seeds", server.getAddress().toString(),
-                    "mongodb.socket-keep-alive", "true");
+                    "mongodb.socket-keep-alive", "true",
+                    "mongodb.credentials", "default");
 
             queryRunner.installPlugin(new MongoPlugin());
             queryRunner.createCatalog("mongodb", "mongodb", properties);
@@ -81,7 +84,8 @@ public final class MongoQueryRunner
 
     public static MongoClient createMongoClient(MongoServer server)
     {
-        return new MongoClient(server.getAddress().getHost(), server.getAddress().getPort());
+        return new MongoClient(new ServerAddress(server.getAddress().getHost(), server.getAddress().getPort()),
+                Arrays.asList(server.getDefaultCredentials()));
     }
 
     public static void main(String[] args)

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/MongoServer.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.mongodb;
 
 import com.google.common.net.HostAndPort;
+import com.mongodb.MongoCredential;
 import org.testcontainers.containers.MongoDBContainer;
 
 import java.io.Closeable;
@@ -22,6 +23,10 @@ public class MongoServer
         implements Closeable
 {
     private static final int MONGO_PORT = 27017;
+
+    private static final String USER = "mongoAdmin";
+
+    private static final String PASSWORD = "secret1234";
 
     private final MongoDBContainer dockerContainer;
 
@@ -34,6 +39,8 @@ public class MongoServer
     {
         this.dockerContainer = new MongoDBContainer("mongo:" + mongoVersion)
                 .withEnv("MONGO_INITDB_DATABASE", "tpch")
+                .withEnv("MONGO_INITDB_ROOT_USERNAME", USER)
+                .withEnv("MONGO_INITDB_ROOT_PASSWORD", PASSWORD)
                 .withCommand("--bind_ip 0.0.0.0");
         this.dockerContainer.start();
     }
@@ -41,6 +48,12 @@ public class MongoServer
     public HostAndPort getAddress()
     {
         return HostAndPort.fromParts(dockerContainer.getContainerIpAddress(), dockerContainer.getMappedPort(MONGO_PORT));
+    }
+
+    public MongoCredential getDefaultCredentials()
+    {
+        MongoCredential credential = MongoCredential.createCredential(USER, "tpch", PASSWORD.toCharArray());
+        return credential;
     }
 
     @Override


### PR DESCRIPTION
Add admin username + password, getter class for default credentials (MongoServer)
Add credentials to properties and include credentials in createMongoClient (MongoQueryRunner)

Fixes #7854