### PR TITLE
Remove dash as allowed character for environment

### DIFF
--- a/docs/src/main/sphinx/installation/deployment.rst
+++ b/docs/src/main/sphinx/installation/deployment.rst
@@ -65,6 +65,8 @@ This holds the following configuration:
 * Config Properties: configuration for the Trino server
 * Catalog Properties: configuration for :doc:`/connector` (data sources)
 
+.. _node_properties:
+
 Node properties
 ^^^^^^^^^^^^^^^
 
@@ -83,8 +85,8 @@ The above properties are described below:
 
 * ``node.environment``:
   The name of the environment. All Trino nodes in a cluster must have the same
-  environment name. The name must start with an alphanumeric character and
-  only contain alphanumeric, ``-``, or ``_`` characters.
+  environment name. The name must start with a lowercase alphanumeric character
+  and only contain lowercase alphanumeric or underscore (``_``) characters.
 
 * ``node.id``:
   The unique identifier for this installation of Trino. This must be


### PR DESCRIPTION
If you use dashes you are getting
```
 Invalid configuration property node.environment: is malformed (for class io.airlift.node.NodeConfig.environment)
```
at startup. I am assuming this is not a bug and hence fixing the docs.