### PR TITLE
Remove unused deprecated methods

### DIFF
--- a/core/trino-main/src/test/java/io/trino/operator/scalar/AbstractTestFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/AbstractTestFunctions.java
@@ -106,13 +106,6 @@ public abstract class AbstractTestFunctions
                 expectedResult);
     }
 
-    // this is not safe as it catches all RuntimeExceptions
-    @Deprecated
-    protected void assertInvalidFunction(String projection)
-    {
-        functionAssertions.assertInvalidFunction(projection);
-    }
-
     protected void assertInvalidFunction(String projection, ErrorCodeSupplier errorCode, String message)
     {
         functionAssertions.assertInvalidFunction(projection, errorCode, message);

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
@@ -307,19 +307,6 @@ public final class FunctionAssertions
         return Iterables.getOnlyElement(resultSet);
     }
 
-    // this is not safe as it catches all RuntimeExceptions
-    @Deprecated
-    public void assertInvalidFunction(String projection)
-    {
-        try {
-            evaluateInvalid(projection);
-            fail("Expected to fail");
-        }
-        catch (RuntimeException e) {
-            // Expected
-        }
-    }
-
     public void assertInvalidFunction(String projection, ErrorCodeSupplier errorCode, String message)
     {
         assertTrinoExceptionThrownBy(() -> evaluateInvalid(projection))


### PR DESCRIPTION
The last caller that use these methods was removed via 8a8391e4aff4d8efff36ee79d97f7e47130d7444.

According to https://github.com/trinodb/trino/pull/7392#discussion_r599766517
Remove these methods might be appropriate.