### PR TITLE
Document the oauth2 callback/redirect URL

### DIFF
--- a/docs/src/main/sphinx/security/oauth2.rst
+++ b/docs/src/main/sphinx/security/oauth2.rst
@@ -22,6 +22,10 @@ To enable OAuth 2.0 authentication for Trino, configuration changes are made on
 the Trino coordinator. No changes are required to the worker configuration;
 only the communication from the clients to the coordinator is authenticated.
 
+Set the callback/redirect URL to ``https://<trino-coordinator-domain-name>/oauth2/callback``,
+when configuring an OAuth 2.0 authorization server like an OpenID-connect
+provider.
+
 Trino server configuration
 --------------------------
 


### PR DESCRIPTION
When configuring an OpenID connect server to work with OAuth2 authnz type of trino, I could not find the required callback/redirect URL of Trino, until found it here:

https://github.com/trinodb/trino/blob/00080c83b9a34632838b85cc747a37b9c791c2fb/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2CallbackResource.java#L51

So this PR will make others experience easier