### PR TITLE
Add bing_tile_quadkey() to list.rst

### DIFF
--- a/docs/src/main/sphinx/functions/list.rst
+++ b/docs/src/main/sphinx/functions/list.rst
@@ -65,7 +65,7 @@ B
 - :func:`bing_tile_at`
 - :func:`bing_tile_coordinates`
 - :func:`bing_tile_polygon`
-- ``bing_tile_quadkey``
+- :func:`bing_tile_quadkey`
 - :func:`bing_tile_zoom_level`
 - :func:`bing_tiles_around`
 - :func:`bit_count`


### PR DESCRIPTION
**What this PR does / why we need it:**
Add documentation for `bing_tile_quadkey()` in trino/docs/src/main/sphinx/functions/list.rst

**Which issue(s) this PR fixes:**
Document bing_tile_quadkey function #7653

**Special notes for your reviewer:**
Please share feedback