### PR TITLE
Fixed #3605: Elastic searching for field with null and value not working correctly

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchQueryBuilder.java
@@ -130,6 +130,10 @@ public final class ElasticsearchQueryBuilder
             }
             queryBuilder.should(rangeQueryBuilder);
         }
+
+        if (domain.isNullAllowed()) {
+            queryBuilder.should(new BoolQueryBuilder().mustNot(new ExistsQueryBuilder(columnName)));
+        }
         return queryBuilder;
     }
 


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/3605

Issue:
Below query pushes only value=32 to elasticsearch. But not `value not exists`.
`select * from table where value is null or value = 32`

Fix:
Push both the queries within the `should` clause. One with `term` query and other with `not_exists` query.

Testcases:

- Test `is null` push down query.
- Test `is not null` push down query.
- Test `is null OR value` push down query.
- Test `is not null OR value` push down query.