### PR TITLE
Take BUCKET_ID column into account when applying delete_delta

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
@@ -53,8 +53,8 @@ public class HiveUpdatablePageSource
 {
     // The channel numbers of the child blocks in the RowBlock passed to deleteRows()
     public static final int ORIGINAL_TRANSACTION_CHANNEL = 0;
-    public static final int ROW_ID_CHANNEL = 1;
-    public static final int BUCKET_CHANNEL = 2;
+    public static final int BUCKET_CHANNEL = 1;
+    public static final int ROW_ID_CHANNEL = 2;
     // Used for UPDATE operations
     public static final int ROW_CHANNEL = 3;
     public static final int ACID_ROW_STRUCT_COLUMN_ID = 6;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateProcessor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdateProcessor.java
@@ -124,8 +124,8 @@ public class HiveUpdateProcessor
 
         Block[] blocks = new Block[acidBlocks + (nonUpdatedColumns.isEmpty() ? 0 : 1)];
         blocks[ORIGINAL_TRANSACTION_CHANNEL] = page.getBlock(ORIGINAL_TRANSACTION_CHANNEL);
-        blocks[ROW_ID_CHANNEL] = page.getBlock(ROW_ID_CHANNEL);
         blocks[BUCKET_CHANNEL] = page.getBlock(BUCKET_CHANNEL);
+        blocks[ROW_ID_CHANNEL] = page.getBlock(ROW_ID_CHANNEL);
 
         if (!nonUpdatedColumns.isEmpty()) {
             Block[] nonUpdatedColumnBlocks = new Block[getNonUpdatedColumns().size()];

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/acid/AcidSchema.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/acid/AcidSchema.java
@@ -53,8 +53,8 @@ public final class AcidSchema
             ACID_COLUMN_ROW_STRUCT);
     public static final List<Field> ACID_READ_FIELDS = ImmutableList.of(
             field(ACID_COLUMN_ORIGINAL_TRANSACTION, BIGINT),
-            field(ACID_COLUMN_ROW_ID, BIGINT),
-            field(ACID_COLUMN_BUCKET, INTEGER));
+            field(ACID_COLUMN_BUCKET, INTEGER),
+            field(ACID_COLUMN_ROW_ID, BIGINT));
 
     public static final RowType ACID_ROW_ID_ROW_TYPE = RowType.from(ACID_READ_FIELDS);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeleteDeltaPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcDeleteDeltaPageSource.java
@@ -51,11 +51,13 @@ import static io.trino.orc.OrcReader.ProjectedLayout.fullyProjectedLayout;
 import static io.trino.orc.OrcReader.createOrcReader;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_CANNOT_OPEN_SPLIT;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_MISSING_DATA;
+import static io.trino.plugin.hive.acid.AcidSchema.ACID_COLUMN_BUCKET;
 import static io.trino.plugin.hive.acid.AcidSchema.ACID_COLUMN_ORIGINAL_TRANSACTION;
 import static io.trino.plugin.hive.acid.AcidSchema.ACID_COLUMN_ROW_ID;
 import static io.trino.plugin.hive.orc.OrcPageSource.handleException;
 import static io.trino.plugin.hive.orc.OrcPageSourceFactory.verifyAcidSchema;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -141,12 +143,13 @@ public class OrcDeleteDeltaPageSource
                 orcColumn -> orcColumn.getColumnName().toLowerCase(ENGLISH));
         List<OrcColumn> rowIdColumns = ImmutableList.of(
                 acidColumns.get(ACID_COLUMN_ORIGINAL_TRANSACTION.toLowerCase(ENGLISH)),
+                acidColumns.get(ACID_COLUMN_BUCKET.toLowerCase(ENGLISH)),
                 acidColumns.get(ACID_COLUMN_ROW_ID.toLowerCase(ENGLISH)));
 
         recordReader = reader.createRecordReader(
                 rowIdColumns,
-                ImmutableList.of(BIGINT, BIGINT),
-                ImmutableList.of(fullyProjectedLayout(), fullyProjectedLayout()),
+                ImmutableList.of(BIGINT, INTEGER, BIGINT),
+                ImmutableList.of(fullyProjectedLayout(), fullyProjectedLayout(), fullyProjectedLayout()),
                 OrcPredicate.TRUE,
                 0,
                 fileSize,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSource.java
@@ -333,8 +333,8 @@ public class OrcPageSource
                     Optional.empty(),
                     new Block[] {
                             sourcePage.getBlock(ORIGINAL_TRANSACTION_CHANNEL),
-                            sourcePage.getBlock(ROW_ID_CHANNEL),
                             sourcePage.getBlock(BUCKET_CHANNEL),
+                            sourcePage.getBlock(ROW_ID_CHANNEL),
                     }));
             return rowBlock;
         }
@@ -394,8 +394,8 @@ public class OrcPageSource
             ImmutableList.Builder<Block> originalFilesBlockBuilder = ImmutableList.builder();
             originalFilesBlockBuilder.add(
                     new RunLengthEncodedBlock(ORIGINAL_FILE_TRANSACTION_ID_BLOCK, positionCount),
-                    createOriginalFilesRowIdBlock(startingRowId, filePosition, positionCount),
-                    new RunLengthEncodedBlock(bucketBlock, positionCount));
+                    new RunLengthEncodedBlock(bucketBlock, positionCount),
+                    createOriginalFilesRowIdBlock(startingRowId, filePosition, positionCount));
             for (int channel = 0; channel < sourcePage.getChannelCount(); channel++) {
                 originalFilesBlockBuilder.add(sourcePage.getBlock(channel));
             }
@@ -425,8 +425,8 @@ public class OrcPageSource
                     Optional.empty(),
                     new Block[] {
                             new RunLengthEncodedBlock(ORIGINAL_FILE_TRANSACTION_ID_BLOCK, positionCount),
-                            createOriginalFilesRowIdBlock(startingRowId, filePosition, positionCount),
-                            new RunLengthEncodedBlock(bucketBlock, positionCount)
+                            new RunLengthEncodedBlock(bucketBlock, positionCount),
+                            createOriginalFilesRowIdBlock(startingRowId, filePosition, positionCount)
                     }));
             return rowBlock;
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -283,12 +283,12 @@ public class OrcPageSourceFactory
                 fileReadTypes.add(BIGINT);
                 fileReadLayouts.add(fullyProjectedLayout());
 
-                fileReadColumns.add(acidColumnsByName.get(AcidSchema.ACID_COLUMN_ROW_ID.toLowerCase(ENGLISH)));
-                fileReadTypes.add(BIGINT);
-                fileReadLayouts.add(fullyProjectedLayout());
-
                 fileReadColumns.add(acidColumnsByName.get(AcidSchema.ACID_COLUMN_BUCKET.toLowerCase(ENGLISH)));
                 fileReadTypes.add(INTEGER);
+                fileReadLayouts.add(fullyProjectedLayout());
+
+                fileReadColumns.add(acidColumnsByName.get(AcidSchema.ACID_COLUMN_ROW_ID.toLowerCase(ENGLISH)));
+                fileReadTypes.add(BIGINT);
                 fileReadLayouts.add(fullyProjectedLayout());
             }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSourceFactory.java
@@ -388,7 +388,8 @@ public class OrcPageSourceFactory
                             sessionUser,
                             configuration,
                             hdfsEnvironment,
-                            info));
+                            info,
+                            bucketNumber));
 
             Optional<Long> originalFileRowId = acidInfo
                     .filter(OrcPageSourceFactory::hasOriginalFilesAndDeleteDeltas)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeletedRows.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcDeletedRows.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.SESSION;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.testing.MaterializedResult.resultBuilder;
 import static org.testng.Assert.assertEquals;
 
@@ -42,6 +43,7 @@ public class TestOrcDeletedRows
 {
     private Path partitionDirectory;
     private Block rowIdBlock;
+    private Block bucketBlock;
 
     @BeforeClass
     public void setUp()
@@ -49,6 +51,9 @@ public class TestOrcDeletedRows
         partitionDirectory = new Path(TestOrcDeletedRows.class.getClassLoader().getResource("fullacid_delete_delta_test") + "/");
         rowIdBlock = BIGINT.createFixedSizeBlockBuilder(1)
                 .writeLong(0)
+                .build();
+        bucketBlock = INTEGER.createFixedSizeBlockBuilder(1)
+                .writeInt(536870912)
                 .build();
     }
 
@@ -160,7 +165,8 @@ public class TestOrcDeletedRows
                 "test",
                 configuration,
                 HDFS_ENVIRONMENT,
-                acidInfo);
+                acidInfo,
+                OptionalInt.of(0));
     }
 
     private Page createTestPage(int originalTransactionStart, int originalTransactionEnd)
@@ -174,6 +180,7 @@ public class TestOrcDeletedRows
         return new Page(
                 size,
                 originalTransaction.build(),
+                new RunLengthEncodedBlock(bucketBlock, size),
                 new RunLengthEncodedBlock(rowIdBlock, size));
     }
 }


### PR DESCRIPTION
Fix a bug when it was possible that more rows than expected
where excluded from a query result, when delete_delta contained two
rows with same ROW_ID/ORIGINAL_TRANSACTION pair but a different BUCKET_ID.
It was possible a single row was deleted from multiple rows created
with a Hive multi-insert statement.

See https://issues.apache.org/jira/browse/HIVE-16832 for more context

Bug was introduced as part of 62e1622, yet the fix does not exactly
restore previous logic which is no longer strictly applicable.