### PR TITLE
Update Phoenix 5 client to 5.1.2

### DIFF
--- a/plugin/trino-phoenix5/pom.xml
+++ b/plugin/trino-phoenix5/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.apache.phoenix</groupId>
             <artifactId>phoenix-client-embedded-hbase-2.2</artifactId>
-            <version>5.1.1</version>
+            <version>5.1.2</version>
         </dependency>
 
         <!-- used by tests but also needed transitively -->


### PR DESCRIPTION
Note that 5.1.x clients are forward and backward compatible to all 5.1.y servers.