### PR TITLE
Revert "Clarify metastore filtering and remove unnecessary code"

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastore.java
@@ -93,13 +93,13 @@ public interface HiveMetastore
     Optional<Partition> getPartition(HiveIdentity identity, Table table, List<String> partitionValues);
 
     /**
-     * Return a list of partition names, with optional filtering (hint to improve performance if possible).
+     * return a list of partition names where partitionKeysFilter is used as a hint to each implementation.
      *
      * @param databaseName the name of the database
      * @param tableName the name of the table
      * @param columnNames the list of partition column names
-     * @param partitionKeysFilter optional filter for the partition column values
-     * @return a list of partition names as created by {@link MetastoreUtil#toPartitionName}
+     * @param partitionKeysFilter map of filters (Domain) for each partition column
+     * @return optionally, a list of strings where each entry is in the form of {key}={value}
      * @see TupleDomain
      */
     Optional<List<String>> getPartitionNamesByFilter(HiveIdentity identity, String databaseName, String tableName, List<String> columnNames, TupleDomain<String> partitionKeysFilter);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/MetastoreUtil.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.hive.metastore;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.primitives.Longs;
@@ -325,22 +324,30 @@ public final class MetastoreUtil
                 ImmutableMultimap.of());
     }
 
+    public static boolean isPartitionKeyFilterFalse(TupleDomain<String> partitionKeysFilter)
+    {
+        return partitionKeysFilter.isNone() || partitionKeysFilter.getDomains().get().values().stream().anyMatch(Domain::isNone);
+    }
+
     /**
      * @param assumeCanonicalPartitionKeys allow conversion of non-char types (eg BIGINT, timestamp) to canonical string formats. If false, non-char types will be replaced
      * with the wildcard
-     * @return the domain for each partition key to either the wildcard or an equals check, or empty if {@code TupleDomain.isNone()}
+     * @return the Domain for each partition key to either the wildcard or an equals check.
+     * TupleDomain.none() or any column's Domain.isNone() -> Optional.empty()
      */
     public static Optional<List<String>> partitionKeyFilterToStringList(List<String> columnNames, TupleDomain<String> partitionKeysFilter, boolean assumeCanonicalPartitionKeys)
     {
-        if (partitionKeysFilter.isNone()) {
+        if (isPartitionKeyFilterFalse(partitionKeysFilter)) {
             return Optional.empty();
         }
 
-        Map<String, Domain> domainMap = partitionKeysFilter.getDomains().orElseThrow(VerifyException::new);
+        checkArgument(partitionKeysFilter.getDomains().isPresent());
 
-        return Optional.of(columnNames.stream()
+        Map<String, Domain> domainMap = partitionKeysFilter.getDomains().orElse(ImmutableMap.of());
+        List<String> partitionList = columnNames.stream()
                 .map(cn -> domainToString(domainMap.get(cn), assumeCanonicalPartitionKeys, HIVE_PARTITION_VALUE_WILDCARD))
-                .collect(toImmutableList()));
+                .collect(toImmutableList());
+        return Optional.of(partitionList);
     }
 
     /**

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -675,6 +675,10 @@ public class CachingHiveMetastore
     @Override
     public Optional<List<String>> getPartitionNamesByFilter(HiveIdentity identity, String databaseName, String tableName, List<String> columnNames, TupleDomain<String> partitionKeysFilter)
     {
+        if (partitionKeysFilter.isNone()) {
+            return Optional.of(ImmutableList.of());
+        }
+
         return get(partitionFilterCache, new WithIdentity<>(updateIdentity(identity), partitionFilter(databaseName, tableName, columnNames, partitionKeysFilter)));
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastoreConfig.java
@@ -15,13 +15,11 @@ package io.trino.plugin.hive.metastore.file;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
-import io.airlift.configuration.DefunctConfig;
 
 import javax.validation.constraints.NotNull;
 
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastoreConfig.VersionCompatibility.NOT_SUPPORTED;
 
-@DefunctConfig("hive.metastore.assume-canonical-partition-keys")
 public class FileHiveMetastoreConfig
 {
     public static final String VERSION_COMPATIBILITY_CONFIG = "hive.metastore.version-compatibility";
@@ -35,6 +33,7 @@ public class FileHiveMetastoreConfig
     private String catalogDirectory;
     private VersionCompatibility versionCompatibility = NOT_SUPPORTED;
     private String metastoreUser = "presto";
+    private boolean assumeCanonicalPartitionKeys;
 
     @NotNull
     public String getCatalogDirectory()
@@ -74,6 +73,18 @@ public class FileHiveMetastoreConfig
     public FileHiveMetastoreConfig setMetastoreUser(String metastoreUser)
     {
         this.metastoreUser = metastoreUser;
+        return this;
+    }
+
+    public boolean isAssumeCanonicalPartitionKeys()
+    {
+        return assumeCanonicalPartitionKeys;
+    }
+
+    @Config("hive.metastore.assume-canonical-partition-keys")
+    public FileHiveMetastoreConfig setAssumeCanonicalPartitionKeys(boolean assumeCanonicalPartitionKeys)
+    {
+        this.assumeCanonicalPartitionKeys = assumeCanonicalPartitionKeys;
         return this;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -78,6 +78,7 @@ import io.trino.plugin.hive.metastore.Database;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.HivePrincipal;
 import io.trino.plugin.hive.metastore.HivePrivilegeInfo;
+import io.trino.plugin.hive.metastore.MetastoreUtil;
 import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.PartitionWithStatistics;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
@@ -753,6 +754,13 @@ public class GlueHiveMetastore
             List<String> columnNames,
             TupleDomain<String> partitionKeysFilter)
     {
+        if (partitionKeysFilter.isNone()) {
+            return Optional.of(ImmutableList.of());
+        }
+        if (MetastoreUtil.isPartitionKeyFilterFalse(partitionKeysFilter)) {
+            return Optional.of(ImmutableList.of());
+        }
+
         Table table = getExistingTable(identity, databaseName, tableName);
         String expression = GlueExpressionUtil.buildGlueExpression(columnNames, partitionKeysFilter, assumeCanonicalPartitionKeys);
         List<Partition> partitions = getPartitions(table, expression);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hive.metastore.thrift;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.plugin.hive.HivePartition;
 import io.trino.plugin.hive.HiveType;
@@ -350,6 +351,10 @@ public class BridgingHiveMetastore
             List<String> columnNames,
             TupleDomain<String> partitionKeysFilter)
     {
+        if (partitionKeysFilter.isNone()) {
+            return Optional.of(ImmutableList.of());
+        }
+
         return delegate.getPartitionNamesByFilter(identity, databaseName, tableName, columnNames, partitionKeysFilter);
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -1188,9 +1188,8 @@ public class ThriftHiveMetastore
     @Override
     public Optional<List<String>> getPartitionNamesByFilter(HiveIdentity identity, String databaseName, String tableName, List<String> columnNames, TupleDomain<String> partitionKeysFilter)
     {
-        checkArgument(!columnNames.isEmpty() || partitionKeysFilter.isAll(), "must pass in all columnNames or the filter must be all");
-
         Optional<List<String>> parts = partitionKeyFilterToStringList(columnNames, partitionKeysFilter, assumeCanonicalPartitionKeys);
+        checkArgument(!columnNames.isEmpty() || partitionKeysFilter.isAll(), "must pass in all columnNames or the filter must be all");
         if (parts.isEmpty()) {
             return Optional.of(ImmutableList.of());
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -98,7 +98,8 @@ public final class HiveQueryRunner
                     new MetastoreConfig(),
                     new FileHiveMetastoreConfig()
                             .setCatalogDirectory(baseDir.toURI().toString())
-                            .setMetastoreUser("test"));
+                            .setMetastoreUser("test")
+                            .setAssumeCanonicalPartitionKeys(true));
         };
         private Module module = EMPTY_MODULE;
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/file/TestFileHiveMetastoreConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/file/TestFileHiveMetastoreConfig.java
@@ -32,7 +32,8 @@ public class TestFileHiveMetastoreConfig
         assertRecordedDefaults(recordDefaults(FileHiveMetastoreConfig.class)
                 .setCatalogDirectory(null)
                 .setVersionCompatibility(NOT_SUPPORTED)
-                .setMetastoreUser("presto"));
+                .setMetastoreUser("presto")
+                .setAssumeCanonicalPartitionKeys(false));
     }
 
     @Test
@@ -42,12 +43,14 @@ public class TestFileHiveMetastoreConfig
                 .put("hive.metastore.catalog.dir", "some path")
                 .put("hive.metastore.version-compatibility", "UNSAFE_ASSUME_COMPATIBILITY")
                 .put("hive.metastore.user", "some user")
+                .put("hive.metastore.assume-canonical-partition-keys", "true")
                 .build();
 
         FileHiveMetastoreConfig expected = new FileHiveMetastoreConfig()
                 .setCatalogDirectory("some path")
                 .setVersionCompatibility(UNSAFE_ASSUME_COMPATIBILITY)
-                .setMetastoreUser("some user");
+                .setMetastoreUser("some user")
+                .setAssumeCanonicalPartitionKeys(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This reverts commit d95eafe397fe4b476b2b1a73baeb7643349d4bdb (https://github.com/trinodb/trino/pull/7799), fixing
`TestHiveGlueMetastore`.