### PR TITLE
Fix getPartitionNamesByFilter for Glue metastore

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -753,6 +753,9 @@ public class GlueHiveMetastore
             List<String> columnNames,
             TupleDomain<String> partitionKeysFilter)
     {
+        if (partitionKeysFilter.isNone()) {
+            return Optional.of(ImmutableList.of());
+        }
         Table table = getExistingTable(identity, databaseName, tableName);
         String expression = GlueExpressionUtil.buildGlueExpression(columnNames, partitionKeysFilter, assumeCanonicalPartitionKeys);
         List<Partition> partitions = getPartitions(table, expression);


### PR DESCRIPTION
This supposedly fixes `TestHiveGlueMetastore`.

Alternative to https://github.com/trinodb/trino/pull/8223 
cc @sopel39 @electrum 