### PR TITLE
Enable Error Prone check: CheckedExceptionNotThrown

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/InputReader.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/InputReader.java
@@ -43,7 +43,6 @@ public class InputReader
     private final LineReader reader;
 
     public InputReader(ClientOptions.EditingMode editingMode, Path historyFile, boolean disableAutoSuggestion, Completer... completers)
-            throws IOException
     {
         reader = LineReaderBuilder.builder()
                 .terminal(TerminalUtils.getTerminal())

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDatabaseMetaData.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDatabaseMetaData.java
@@ -1569,7 +1569,6 @@ public class TrinoDatabaseMetaData
 
     @Nullable
     private String escapeIfNecessary(@Nullable String namePattern)
-            throws SQLException
     {
         return escapeIfNecessary(assumeLiteralNamesInMetadataCallsForNonConformingClients, assumeLiteralUnderscoreInMetadataCallsForNonConformingClients, namePattern);
     }

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoResultSet.java
@@ -63,7 +63,6 @@ public class TrinoResultSet
     }
 
     private TrinoResultSet(Statement statement, StatementClient client, List<Column> columns, long maxRows, Consumer<QueryStats> progressCallback, WarningsManager warningsManager)
-            throws SQLException
     {
         super(
                 Optional.of(requireNonNull(statement, "statement is null")),

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/ArbitraryAggregationFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/ArbitraryAggregationFunction.java
@@ -39,7 +39,6 @@ public final class ArbitraryAggregationFunction
             @AggregationState("T") InOut state,
             @BlockPosition @SqlType("T") Block block,
             @BlockIndex int position)
-            throws Throwable
     {
         if (state.isNull()) {
             state.set(block, position);
@@ -50,7 +49,6 @@ public final class ArbitraryAggregationFunction
     public static void combine(
             @AggregationState("T") InOut state,
             @AggregationState("T") InOut otherState)
-            throws Throwable
     {
         if (state.isNull()) {
             state.set(otherState);

--- a/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestResourceSecurity.java
@@ -35,7 +35,6 @@ import io.trino.security.AccessControlManager;
 import io.trino.server.HttpRequestSessionContextFactory;
 import io.trino.server.ProtocolConfig;
 import io.trino.server.protocol.PreparedStatementEncoder;
-import io.trino.server.security.oauth2.ChallengeFailedException;
 import io.trino.server.security.oauth2.OAuth2Client;
 import io.trino.server.security.oauth2.TokenPairSerializer;
 import io.trino.server.security.oauth2.TokenPairSerializer.TokenPair;
@@ -912,7 +911,6 @@ public class TestResourceSecurity
 
                 @Override
                 public Response refreshTokens(String refreshToken)
-                        throws ChallengeFailedException
                 {
                     throw new UnsupportedOperationException("refresh tokens not supported");
                 }

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/metadata/ZooKeeperMetadataManager.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/metadata/ZooKeeperMetadataManager.java
@@ -338,7 +338,6 @@ public class ZooKeeperMetadataManager
     }
 
     private AccumuloView toAccumuloView(byte[] data)
-            throws IOException
     {
         return parseJson(mapper, data, AccumuloView.class);
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyConnectionFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/LazyConnectionFactory.java
@@ -39,6 +39,7 @@ public final class LazyConnectionFactory
     }
 
     @Override
+    @SuppressWarnings("CheckedExceptionNotThrown") // preserve the "throws" contract of the interface declaration
     public Connection openConnection(ConnectorSession session)
             throws SQLException
     {

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestingScyllaServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestingScyllaServer.java
@@ -52,13 +52,11 @@ public class TestingScyllaServer
     private final CassandraSession session;
 
     public TestingScyllaServer()
-            throws Exception
     {
         this("2.2.0");
     }
 
     public TestingScyllaServer(String version)
-            throws Exception
     {
         container = new GenericContainer<>("scylladb/scylla:" + version)
                 .withCommand("--smp", "1") // Limit SMP to run in a machine having many cores https://github.com/scylladb/scylla/issues/5638

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/AddFileEntry.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/AddFileEntry.java
@@ -88,7 +88,7 @@ public class AddFileEntry
             try {
                 resultParsedStats = Optional.ofNullable(DeltaLakeJsonFileStatistics.create(stats.get()));
             }
-            catch (JsonProcessingException e) {
+            catch (RuntimeException e) {
                 LOG.debug(
                         e,
                         "File level stats could not be parsed and will be ignored. The JSON string was: %s",

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/TransactionLogParser.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.deltalake.transactionlog;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.airlift.json.ObjectMapperProvider;
@@ -131,7 +130,6 @@ public final class TransactionLogParser
             .withResolverStyle(ResolverStyle.STRICT);
 
     public static DeltaLakeTransactionLogEntry parseJson(String json)
-            throws JsonProcessingException
     {
         // lines are json strings followed by 'x' in some Databricks versions of Delta
         if (json.endsWith("x")) {

--- a/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
+++ b/plugin/trino-delta-lake/src/main/java/io/trino/plugin/deltalake/transactionlog/statistics/DeltaLakeJsonFileStatistics.java
@@ -15,7 +15,6 @@ package io.trino.plugin.deltalake.transactionlog.statistics;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.airlift.json.ObjectMapperProvider;
 import io.airlift.log.Logger;
@@ -61,7 +60,6 @@ public class DeltaLakeJsonFileStatistics
     private final Optional<Map<CanonicalColumnName, Object>> nullCount;
 
     public static DeltaLakeJsonFileStatistics create(String jsonStatistics)
-            throws JsonProcessingException
     {
         return parseJson(OBJECT_MAPPER, jsonStatistics, DeltaLakeJsonFileStatistics.class);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -264,7 +264,6 @@ public class TestBackgroundHiveSplitLoader
 
         @Override
         public RecordReader<Void, Void> getRecordReader(InputSplit inputSplit, JobConf jobConf, Reporter reporter)
-                throws IOException
         {
             throw new UnsupportedOperationException();
         }

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConnectionFactory.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerConnectionFactory.java
@@ -83,7 +83,6 @@ public class SqlServerConnectionFactory
     }
 
     private boolean hasSnapshotIsolationEnabled(Connection connection)
-            throws SQLException
     {
         try {
             return snapshotIsolationEnabled.get(SnapshotIsolationEnabledCacheKey.INSTANCE, () -> {

--- a/pom.xml
+++ b/pom.xml
@@ -2014,6 +2014,7 @@
                                     -Xplugin:ErrorProne \
                                     -Xep:BadInstanceof:ERROR \
                                     -Xep:BoxedPrimitiveConstructor:ERROR \
+                                    -Xep:CheckedExceptionNotThrown:ERROR \
                                     -Xep:ClassCanBeStatic:ERROR \
                                     -Xep:CompareToZero:ERROR \
                                     -Xep:DefaultCharset:ERROR \

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePropertiesTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePropertiesTable.java
@@ -16,7 +16,6 @@ package io.trino.tests.product.hive;
 import io.trino.tempto.assertions.QueryAssert.Row;
 import org.testng.annotations.Test;
 
-import java.sql.SQLException;
 import java.util.List;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -77,7 +76,6 @@ public class TestHivePropertiesTable
     }
 
     private static List<String> getTablePropertiesOnHive(String tableName)
-            throws SQLException
     {
         return onHive().executeQuery("SHOW TBLPROPERTIES " + tableName).rows().stream()
                 .map(row -> (String) row.get(1))


### PR DESCRIPTION
@kokosing keeps wishing that this was on.

The issue with this is that:

* This is an experimental checker
* It has a huge number of false negatives

Regarding the second point, it may be that making it more accurate would make it unviably slow (the equivalent inspection in IntelliJ IDEA takes a lot of time, has to look at the whole code base - it's definitely not local - and has to be done repeatedly until nothing more is found). But perhaps it's still useful.