### PR TITLE
Validate ordinal based grouping expressions during analysis

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -2858,6 +2858,7 @@ class StatementAnalyzer
                                 }
 
                                 column = outputExpressions.get(toIntExact(ordinal - 1));
+                                verifyNoAggregateWindowOrGroupingFunctions(metadata, column, "GROUP BY clause");
                             }
                             else {
                                 verifyNoAggregateWindowOrGroupingFunctions(metadata, column, "GROUP BY clause");

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -441,6 +441,18 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testGroupByAggregation()
+    {
+        assertFails("SELECT x, sum(y) FROM (VALUES (1, 2)) t(x, y) GROUP BY x, sum(y)")
+                .hasErrorCode(EXPRESSION_NOT_SCALAR)
+                .hasMessageMatching(".* GROUP BY clause cannot contain aggregations, window functions or grouping operations: .*");
+
+        assertFails("SELECT x, sum(y) FROM (VALUES (1, 2)) t(x, y) GROUP BY 1, 2")
+                .hasErrorCode(EXPRESSION_NOT_SCALAR)
+                .hasMessageMatching(".* GROUP BY clause cannot contain aggregations, window functions or grouping operations: .*");
+    }
+
+    @Test
     public void testGroupByWithSubquerySelectExpression()
     {
         analyze("SELECT (SELECT t1.a) FROM t1 GROUP BY a");


### PR DESCRIPTION
Queries with GROUP BY ordinals mapping to aggregate expressions pass analysis and fail during `ScanFilterProject`. 

```
Caused by: java.lang.ClassCastException: class io.trino.operator.aggregation.ParametricAggregation cannot be cast to class io.trino.metadata.SqlScalarFunction (io.trino.operator.aggregation.ParametricAggregation and 
```

(First of the two tests added also succeeds without the change.)