### PR TITLE
Remove illegal overload version for hash_counts function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigestFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/type/setdigest/SetDigestFunctions.java
@@ -14,11 +14,7 @@
 
 package io.trino.type.setdigest;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.airlift.json.ObjectMapperProvider;
 import io.airlift.slice.Slice;
-import io.airlift.slice.Slices;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.ScalarFunction;
@@ -27,7 +23,6 @@ import io.trino.spi.function.TypeParameter;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
 
-import java.io.UncheckedIOException;
 import java.util.Map;
 
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -36,8 +31,6 @@ import static io.trino.type.setdigest.SetDigest.exactIntersectionCardinality;
 
 public final class SetDigestFunctions
 {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapperProvider().get();
-
     private SetDigestFunctions()
     {
     }
@@ -99,19 +92,5 @@ public final class SetDigestFunctions
         blockBuilder.closeEntry();
 
         return (Block) mapType.getObject(blockBuilder, 0);
-    }
-
-    @ScalarFunction
-    @SqlType(StandardTypes.VARCHAR)
-    public static Slice hashCounts(@SqlType(SetDigestType.NAME) Slice slice)
-    {
-        SetDigest digest = SetDigest.newInstance(slice);
-
-        try {
-            return Slices.utf8Slice(OBJECT_MAPPER.writeValueAsString(digest.getHashCounts()));
-        }
-        catch (JsonProcessingException e) {
-            throw new UncheckedIOException(e);
-        }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSetDigestFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSetDigestFunctions.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestSetDigestFunctions
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testCardinality()
+    {
+        assertThat(assertions.query(
+                "SELECT cardinality(make_set_digest(value)) " +
+                        "FROM (VALUES 1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5) T(value)"))
+                .matches("VALUES CAST(5 AS BIGINT)");
+    }
+
+    @Test
+    public void testExactIntersectionCardinality()
+    {
+        assertThat(assertions.query(
+                "SELECT intersection_cardinality(make_set_digest(v1), make_set_digest(v2)) " +
+                        "FROM (VALUES (1, 1), (NULL, 2), (2, 3), (3, 4)) T(v1, v2)"))
+                .matches("VALUES CAST(3 AS BIGINT)");
+    }
+
+    @Test
+    public void testJaccardIndex()
+    {
+        assertThat(assertions.query(
+                "SELECT jaccard_index(make_set_digest(v1), make_set_digest(v2)) " +
+                        "FROM (VALUES (1, 1), (NULL,2), (2, 3), (NULL, 4)) T(v1, v2)"))
+                .matches("VALUES CAST(0.5 AS DOUBLE)");
+    }
+
+    @Test
+    public void hashCounts()
+    {
+        assertThat(assertions.query(
+                "SELECT hash_counts(make_set_digest(value)) " +
+                        "FROM (VALUES 1, 1, 1, 2, 2) T(value)"))
+                .matches("VALUES map(cast(ARRAY[19144387141682250, -2447670524089286488] AS array(bigint)), cast(ARRAY[3, 2] AS array(smallint)))");
+    }
+}


### PR DESCRIPTION
```
trino:sf1> select hash_counts(make_set_digest(nationkey)) as varchar from customer;
Query 20210609_200503_00015_jr5tp failed: line 1:8: Could not choose a best candidate operator. Explicit type casts must be added.
Candidates are:
	 * hash_counts(setdigest):varchar
	 * hash_counts(setdigest):map(bigint,smallint)
```

Prefer using `hash_counts(setdigest):map(bigint,smallint)` over `hash_counts(setdigest):varchar`.


Along the way also a test showcasing the usage of setdigest functions has been added.