### PR TITLE
Correct assumption that OIDC access token is always a JWT

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Authenticator.java
@@ -13,15 +13,17 @@
  */
 package io.trino.server.security.oauth2;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
 import io.trino.server.security.AbstractBearerAuthenticator;
 import io.trino.server.security.AuthenticationException;
+import io.trino.spi.security.BasicPrincipal;
 
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
 
 import java.net.URI;
+import java.security.Principal;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import static io.trino.server.security.UserMapping.createUserMapping;
@@ -34,18 +36,26 @@ public class OAuth2Authenticator
         extends AbstractBearerAuthenticator
 {
     private final OAuth2Service service;
+    private final String principalField;
 
     @Inject
     public OAuth2Authenticator(OAuth2Service service, OAuth2Config config)
     {
-        super(config.getPrincipalField(), createUserMapping(config.getUserMappingPattern(), config.getUserMappingFile()));
+        super(createUserMapping(config.getUserMappingPattern(), config.getUserMappingFile()));
         this.service = requireNonNull(service, "service is null");
+        this.principalField = config.getPrincipalField();
     }
 
     @Override
-    protected Jws<Claims> parseClaimsJws(String jws)
+    protected Optional<Principal> extractPrincipalFromToken(String token)
     {
-        return service.parseClaimsJws(jws);
+        Map<String, Object> claims = service.convertTokenToClaims(token);
+        if (claims.containsKey(principalField)) {
+            return Optional.ofNullable(claims.get(principalField))
+                    .map(String.class::cast)
+                    .map(BasicPrincipal::new);
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/oauth2/OAuth2Service.java
@@ -18,7 +18,6 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.Resources;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.SigningKeyResolver;
@@ -34,6 +33,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.TemporalAmount;
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
@@ -177,11 +177,12 @@ public class OAuth2Service
         }
     }
 
-    public Jws<Claims> parseClaimsJws(String token)
+    public Map<String, Object> convertTokenToClaims(String token)
     {
         return Jwts.parser()
                 .setSigningKeyResolver(signingKeyResolver)
-                .parseClaimsJws(token);
+                .parseClaimsJws(token)
+                .getBody();
     }
 
     public String getSuccessHtml()


### PR DESCRIPTION
There is an assumption that the OAuth2/OIDC access token is always a JWT, this is not always the case as the OAuth2 and OIDC specifications both specify that it's implementation is undefined.

See: https://datatracker.ietf.org/doc/html/rfc6749#section-1.4 (OIDC defers to the OAuth2 definition of access tokens here: https://openid.net/specs/openid-connect-core-1_0.html#Terminology)