### PR TITLE
Remove valid UTF-8 disclaimer

### DIFF
--- a/docs/src/main/sphinx/functions/string.rst
+++ b/docs/src/main/sphinx/functions/string.rst
@@ -15,12 +15,7 @@ String functions
 
 .. note::
 
-    These functions assume that the input strings contain valid UTF-8 encoded
-    Unicode code points.  There are no explicit checks for valid UTF-8 and
-    the functions may return incorrect results on invalid UTF-8.
-    Invalid UTF-8 data can be corrected with :func:`from_utf8`.
-
-    Additionally, the functions operate on Unicode code points and not user
+    These functions operate on Unicode code points and not user
     visible *characters* (or *grapheme clusters*).  Some languages combine
     multiple code points into a single user-perceived *character*, the basic
     unit of a writing system for a language, but the functions will treat each


### PR DESCRIPTION
User is not responsible for char/varchar UTF-8 encoding, so should not
be made feel responsible for it.