### PR TITLE
Migrate ListenableFuture<?> to ListenableFuture<Void>

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchQuery.java
@@ -22,7 +22,7 @@ public interface DispatchQuery
 {
     void recordHeartbeat();
 
-    ListenableFuture<?> getDispatchedFuture();
+    ListenableFuture<Void> getDispatchedFuture();
 
     DispatchInfo getDispatchInfo();
 

--- a/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/FailedDispatchQuery.java
@@ -35,7 +35,7 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.memory.LocalMemoryManager.GENERAL_POOL;
 import static io.trino.server.DynamicFilterService.DynamicFiltersStats;
 import static io.trino.util.Failures.toFailure;
@@ -103,9 +103,9 @@ public class FailedDispatchQuery
     }
 
     @Override
-    public ListenableFuture<?> getDispatchedFuture()
+    public ListenableFuture<Void> getDispatchedFuture()
     {
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/LocalDispatchQuery.java
@@ -62,7 +62,7 @@ public class LocalDispatchQuery
     private final Executor queryExecutor;
 
     private final Consumer<QueryExecution> querySubmitter;
-    private final SettableFuture<?> submitted = SettableFuture.create();
+    private final SettableFuture<Void> submitted = SettableFuture.create();
 
     private final AtomicBoolean notificationSentOrGuaranteed = new AtomicBoolean();
 
@@ -121,7 +121,7 @@ public class LocalDispatchQuery
             if (queryExecution.shouldWaitForMinWorkers()) {
                 executionMinCount = getRequiredWorkers(session);
             }
-            ListenableFuture<?> minimumWorkerFuture = clusterSizeMonitor.waitForMinimumWorkers(executionMinCount, getRequiredWorkersMaxWait(session));
+            ListenableFuture<Void> minimumWorkerFuture = clusterSizeMonitor.waitForMinimumWorkers(executionMinCount, getRequiredWorkersMaxWait(session));
             // when worker requirement is met, start the execution
             addSuccessCallback(minimumWorkerFuture, () -> startExecution(queryExecution));
             addExceptionCallback(minimumWorkerFuture, throwable -> queryExecutor.execute(() -> stateMachine.transitionToFailed(throwable)));
@@ -171,7 +171,7 @@ public class LocalDispatchQuery
     }
 
     @Override
-    public ListenableFuture<?> getDispatchedFuture()
+    public ListenableFuture<Void> getDispatchedFuture()
     {
         return nonCancellationPropagating(submitted);
     }

--- a/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/QueuedStatementResource.java
@@ -214,7 +214,7 @@ public class QueuedStatementResource
         Query query = getQuery(queryId, slug, token);
 
         // wait for query to be dispatched, up to the wait timeout
-        ListenableFuture<?> futureStateChange = addTimeout(
+        ListenableFuture<Void> futureStateChange = addTimeout(
                 query.waitForDispatched(),
                 () -> null,
                 WAIT_ORDERING.min(MAX_WAIT_TIME, maxWait),
@@ -335,7 +335,7 @@ public class QueuedStatementResource
         private final AtomicLong lastToken = new AtomicLong();
 
         @GuardedBy("this")
-        private ListenableFuture<?> querySubmissionFuture;
+        private ListenableFuture<Void> querySubmissionFuture;
 
         public Query(String query, SessionContext sessionContext, DispatchManager dispatchManager, QueryInfoUrlFactory queryInfoUrlFactory)
         {
@@ -367,7 +367,7 @@ public class QueuedStatementResource
             return querySubmissionFuture != null && querySubmissionFuture.isDone();
         }
 
-        private ListenableFuture<?> waitForDispatched()
+        private ListenableFuture<Void> waitForDispatched()
         {
             // if query submission has not finished, wait for it to finish
             synchronized (this) {

--- a/core/trino-main/src/main/java/io/trino/execution/AddColumnTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/AddColumnTask.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.COLUMN_ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.COLUMN_TYPE_UNKNOWN;
@@ -61,7 +61,7 @@ public class AddColumnTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             AddColumn statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -77,7 +77,7 @@ public class AddColumnTask
             if (!statement.isTableExists()) {
                 throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         CatalogName catalogName = metadata.getCatalogHandle(session, tableName.getCatalogName())
@@ -102,7 +102,7 @@ public class AddColumnTask
             if (!statement.isColumnNotExists()) {
                 throw semanticException(COLUMN_ALREADY_EXISTS, statement, "Column '%s' already exists", element.getName());
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
         if (!element.isNullable() && !metadata.getConnectorCapabilities(session, catalogName).contains(NOT_NULL_COLUMN_CONSTRAINT)) {
             throw semanticException(NOT_SUPPORTED, element, "Catalog '%s' does not support NOT NULL for column '%s'", catalogName.getCatalogName(), element.getName());
@@ -128,6 +128,6 @@ public class AddColumnTask
 
         metadata.addColumn(session, tableHandle.get(), column);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/CallTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CallTask.java
@@ -51,7 +51,7 @@ import java.util.function.Predicate;
 
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Verify.verify;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.INVALID_ARGUMENTS;
@@ -74,7 +74,7 @@ public class CallTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             Call call,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -201,7 +201,7 @@ public class CallTask
             throw new TrinoException(PROCEDURE_CALL_FAILED, t);
         }
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 
     private static Object toTypeObjectValue(Session session, Type type, Object value)

--- a/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.MISSING_TABLE;
@@ -48,7 +48,7 @@ public class CommentTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             Comment statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -96,6 +96,6 @@ public class CommentTask
             throw semanticException(NOT_SUPPORTED, statement, "Unsupported comment type: %s", statement.getType());
         }
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/CommitTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CommitTask.java
@@ -38,7 +38,7 @@ public class CommitTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             Commit statement,
             TransactionManager transactionManager,
             Metadata metadata,

--- a/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
@@ -40,7 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.sql.NodeUtils.mapFromProperties;
@@ -76,7 +76,7 @@ public class CreateMaterializedViewTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             CreateMaterializedView statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -129,6 +129,6 @@ public class CreateMaterializedViewTask
         stateMachine.setOutput(analysis.getTarget());
         stateMachine.setReferencedTables(analysis.getReferencedTables());
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/CreateRoleTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateRoleTask.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.getSessionCatalog;
 import static io.trino.spi.StandardErrorCode.ROLE_ALREADY_EXISTS;
@@ -46,7 +46,7 @@ public class CreateRoleTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             CreateRole statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -68,6 +68,6 @@ public class CreateRoleTask
             throw semanticException(ROLE_NOT_FOUND, statement, "Role '%s' does not exist", grantor.get().getName());
         }
         metadata.createRole(session, role, grantor, catalog);
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/CreateSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateSchemaTask.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.getSessionCatalog;
@@ -60,7 +60,7 @@ public class CreateSchemaTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             CreateSchema statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -73,7 +73,7 @@ public class CreateSchemaTask
     }
 
     @VisibleForTesting
-    ListenableFuture<?> internalExecute(CreateSchema statement, Metadata metadata, AccessControl accessControl, Session session, List<Expression> parameters)
+    ListenableFuture<Void> internalExecute(CreateSchema statement, Metadata metadata, AccessControl accessControl, Session session, List<Expression> parameters)
     {
         CatalogSchemaName schema = createCatalogSchemaName(session, statement, Optional.of(statement.getSchemaName()));
 
@@ -85,7 +85,7 @@ public class CreateSchemaTask
             if (!statement.isNotExists()) {
                 throw semanticException(SCHEMA_ALREADY_EXISTS, statement, "Schema '%s' already exists", schema);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         CatalogName catalogName = metadata.getCatalogHandle(session, schema.getCatalogName())
@@ -111,7 +111,7 @@ public class CreateSchemaTask
             }
         }
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 
     private TrinoPrincipal getCreatePrincipal(CreateSchema statement, Session session, Metadata metadata)

--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -56,7 +56,7 @@ import java.util.function.Consumer;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
@@ -94,7 +94,7 @@ public class CreateTableTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             CreateTable statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -107,7 +107,7 @@ public class CreateTableTask
     }
 
     @VisibleForTesting
-    ListenableFuture<?> internalExecute(CreateTable statement, Metadata metadata, AccessControl accessControl, Session session, List<Expression> parameters, Consumer<Output> outputConsumer)
+    ListenableFuture<Void> internalExecute(CreateTable statement, Metadata metadata, AccessControl accessControl, Session session, List<Expression> parameters, Consumer<Output> outputConsumer)
     {
         checkArgument(!statement.getElements().isEmpty(), "no columns for table");
 
@@ -118,7 +118,7 @@ public class CreateTableTask
             if (!statement.isNotExists()) {
                 throw semanticException(TABLE_ALREADY_EXISTS, statement, "Table '%s' already exists", tableName);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         CatalogName catalogName = metadata.getCatalogHandle(session, tableName.getCatalogName())
@@ -262,7 +262,7 @@ public class CreateTableTask
                 Optional.of(tableMetadata.getColumns().stream()
                         .map(column -> new OutputColumn(new Column(column.getName(), column.getType().toString()), ImmutableSet.of()))
                         .collect(toImmutableList()))));
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 
     private static Map<String, Object> combineProperties(Set<String> specifiedPropertyKeys, Map<String, Object> defaultProperties, Map<String, Object> inheritedProperties)

--- a/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
 import static io.trino.sql.ParameterUtils.parameterExtractor;
@@ -71,7 +71,7 @@ public class CreateViewTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             CreateView statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -115,6 +115,6 @@ public class CreateViewTask
         stateMachine.setOutput(analysis.getTarget());
         stateMachine.setReferencedTables(analysis.getReferencedTables());
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
@@ -167,11 +167,11 @@ public class DataDefinitionExecution<T extends Statement>
                 return;
             }
 
-            ListenableFuture<?> future = task.execute(statement, transactionManager, metadata, accessControl, stateMachine, parameters, warningCollector);
-            Futures.addCallback(future, new FutureCallback<Object>()
+            ListenableFuture<Void> future = task.execute(statement, transactionManager, metadata, accessControl, stateMachine, parameters, warningCollector);
+            Futures.addCallback(future, new FutureCallback<>()
             {
                 @Override
-                public void onSuccess(@Nullable Object result)
+                public void onSuccess(@Nullable Void result)
                 {
                     stateMachine.transitionToFinishing();
                 }

--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionTask.java
@@ -28,7 +28,7 @@ public interface DataDefinitionTask<T extends Statement>
 {
     String getName();
 
-    ListenableFuture<?> execute(
+    ListenableFuture<Void> execute(
             T statement,
             TransactionManager transactionManager,
             Metadata metadata,

--- a/core/trino-main/src/main/java/io/trino/execution/DeallocateTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DeallocateTask.java
@@ -23,7 +23,7 @@ import io.trino.transaction.TransactionManager;
 
 import java.util.List;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 
 public class DeallocateTask
         implements DataDefinitionTask<Deallocate>
@@ -35,7 +35,7 @@ public class DeallocateTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             Deallocate statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -46,6 +46,6 @@ public class DeallocateTask
     {
         String statementName = statement.getName().getValue();
         stateMachine.removePreparedStatement(statementName);
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/DropColumnTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropColumnTask.java
@@ -28,7 +28,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.COLUMN_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -46,7 +46,7 @@ public class DropColumnTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             DropColumn statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -63,7 +63,7 @@ public class DropColumnTask
             if (!statement.isTableExists()) {
                 throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
         TableHandle tableHandle = tableHandleOptional.get();
 
@@ -76,7 +76,7 @@ public class DropColumnTask
             if (!statement.isColumnExists()) {
                 throw semanticException(COLUMN_NOT_FOUND, statement, "Column '%s' does not exist", column);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         if (metadata.getColumnMetadata(session, tableHandle, columnHandle).isHidden()) {
@@ -90,6 +90,6 @@ public class DropColumnTask
 
         metadata.dropColumn(session, tableHandle, columnHandle);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/DropMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropMaterializedViewTask.java
@@ -27,7 +27,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
@@ -42,7 +42,7 @@ public class DropMaterializedViewTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             DropMaterializedView statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -59,13 +59,13 @@ public class DropMaterializedViewTask
             if (!statement.isExists()) {
                 throw semanticException(TABLE_NOT_FOUND, statement, "Materialized view '%s' does not exist", name);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         accessControl.checkCanDropMaterializedView(session.toSecurityContext(), name);
 
         metadata.dropMaterializedView(session, name);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/DropRoleTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropRoleTask.java
@@ -25,7 +25,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Set;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.getSessionCatalog;
 import static io.trino.spi.StandardErrorCode.ROLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
@@ -41,7 +41,7 @@ public class DropRoleTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             DropRole statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -59,6 +59,6 @@ public class DropRoleTask
             throw semanticException(ROLE_NOT_FOUND, statement, "Role '%s' does not exist", role);
         }
         metadata.dropRole(session, role, catalog);
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
@@ -27,7 +27,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
@@ -49,7 +49,7 @@ public class DropSchemaTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             DropSchema statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -69,13 +69,13 @@ public class DropSchemaTask
             if (!statement.isExists()) {
                 throw semanticException(SCHEMA_NOT_FOUND, statement, "Schema '%s' does not exist", schema);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         accessControl.checkCanDropSchema(session.toSecurityContext(), schema);
 
         metadata.dropSchema(session, schema);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
@@ -27,7 +27,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
@@ -42,7 +42,7 @@ public class DropTableTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             DropTable statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -59,13 +59,13 @@ public class DropTableTask
             if (!statement.isExists()) {
                 throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         accessControl.checkCanDropTable(session.toSecurityContext(), tableName);
 
         metadata.dropTable(session, tableHandle.get());
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
@@ -27,7 +27,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
@@ -42,7 +42,7 @@ public class DropViewTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             DropView statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -59,13 +59,13 @@ public class DropViewTask
             if (!statement.isExists()) {
                 throw semanticException(TABLE_NOT_FOUND, statement, "View '%s' does not exist", name);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         accessControl.checkCanDropView(session.toSecurityContext(), name);
 
         metadata.dropView(session, name);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/GrantRolesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/GrantRolesTask.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.getSessionCatalog;
 import static io.trino.spi.StandardErrorCode.ROLE_NOT_FOUND;
@@ -48,7 +48,7 @@ public class GrantRolesTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             GrantRoles statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -87,6 +87,6 @@ public class GrantRolesTask
         accessControl.checkCanGrantRoles(session.toSecurityContext(), roles, grantees, adminOption, grantor, catalog);
         metadata.grantRoles(session, roles, grantees, adminOption, grantor, catalog);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/GrantTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/GrantTask.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
@@ -52,7 +52,7 @@ public class GrantTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             Grant statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -67,7 +67,7 @@ public class GrantTask
         else {
             executeGrantOnTable(stateMachine.getSession(), statement, metadata, accessControl);
         }
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 
     private void executeGrantOnSchema(Session session, Grant statement, Metadata metadata, AccessControl accessControl)

--- a/core/trino-main/src/main/java/io/trino/execution/PrepareTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/PrepareTask.java
@@ -30,7 +30,7 @@ import javax.inject.Inject;
 
 import java.util.List;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.sql.SqlFormatterUtil.getFormattedSql;
 import static java.util.Locale.ENGLISH;
@@ -60,7 +60,7 @@ public class PrepareTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             Prepare prepare,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -77,6 +77,6 @@ public class PrepareTask
 
         String sql = getFormattedSql(statement, sqlParser);
         stateMachine.addPreparedStatement(prepare.getName().getValue(), sql);
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStateMachine.java
@@ -837,11 +837,11 @@ public class QueryStateMachine
 
         Optional<TransactionId> transactionId = session.getTransactionId();
         if (transactionId.isPresent() && transactionManager.transactionExists(transactionId.get()) && transactionManager.isAutoCommit(transactionId.get())) {
-            ListenableFuture<?> commitFuture = transactionManager.asyncCommit(transactionId.get());
-            Futures.addCallback(commitFuture, new FutureCallback<Object>()
+            ListenableFuture<Void> commitFuture = transactionManager.asyncCommit(transactionId.get());
+            Futures.addCallback(commitFuture, new FutureCallback<>()
             {
                 @Override
-                public void onSuccess(@Nullable Object result)
+                public void onSuccess(@Nullable Void result)
                 {
                     transitionToFinished();
                 }

--- a/core/trino-main/src/main/java/io/trino/execution/RemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RemoteTask.java
@@ -55,7 +55,7 @@ public interface RemoteTask
      */
     void addFinalTaskInfoListener(StateChangeListener<TaskInfo> stateChangeListener);
 
-    ListenableFuture<?> whenSplitQueueHasSpace(int threshold);
+    ListenableFuture<Void> whenSplitQueueHasSpace(int threshold);
 
     void cancel();
 

--- a/core/trino-main/src/main/java/io/trino/execution/RenameColumnTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameColumnTask.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.COLUMN_ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.COLUMN_NOT_FOUND;
@@ -48,7 +48,7 @@ public class RenameColumnTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             RenameColumn statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -64,7 +64,7 @@ public class RenameColumnTask
             if (!statement.isTableExists()) {
                 throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
         TableHandle tableHandle = tableHandleOptional.get();
 
@@ -79,7 +79,7 @@ public class RenameColumnTask
             if (!statement.isColumnExists()) {
                 throw semanticException(COLUMN_NOT_FOUND, statement, "Column '%s' does not exist", source);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         if (columnHandles.containsKey(target)) {
@@ -92,6 +92,6 @@ public class RenameColumnTask
 
         metadata.renameColumn(session, tableHandle, columnHandle, target);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/RenameSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameSchemaTask.java
@@ -26,7 +26,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
 import static io.trino.spi.StandardErrorCode.SCHEMA_ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
@@ -42,7 +42,7 @@ public class RenameSchemaTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             RenameSchema statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -67,6 +67,6 @@ public class RenameSchemaTask
 
         metadata.renameSchema(session, source, statement.getTarget().getValue());
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
@@ -27,7 +27,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -45,7 +45,7 @@ public class RenameTableTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             RenameTable statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -61,7 +61,7 @@ public class RenameTableTask
             if (!statement.isExists()) {
                 throw semanticException(TABLE_NOT_FOUND, statement, "Table '%s' does not exist", tableName);
             }
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         QualifiedObjectName target = createQualifiedObjectName(session, statement, statement.getTarget());
@@ -78,6 +78,6 @@ public class RenameTableTask
 
         metadata.renameTable(session, tableHandle.get(), target);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
@@ -27,7 +27,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -45,7 +45,7 @@ public class RenameViewTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             RenameView statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -76,6 +76,6 @@ public class RenameViewTask
 
         metadata.renameView(session, viewName, target);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/ResetSessionTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/ResetSessionTask.java
@@ -24,7 +24,7 @@ import io.trino.transaction.TransactionManager;
 
 import java.util.List;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
@@ -39,7 +39,7 @@ public class ResetSessionTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             ResetSession statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -69,6 +69,6 @@ public class ResetSessionTask
 
         stateMachine.addResetSessionProperties(statement.getName().toString());
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/RevokeRolesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RevokeRolesTask.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.getSessionCatalog;
 import static io.trino.spi.StandardErrorCode.ROLE_NOT_FOUND;
@@ -48,7 +48,7 @@ public class RevokeRolesTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             RevokeRoles statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -87,6 +87,6 @@ public class RevokeRolesTask
         accessControl.checkCanRevokeRoles(session.toSecurityContext(), roles, grantees, adminOption, grantor, catalog);
         metadata.revokeRoles(session, roles, grantees, adminOption, grantor, catalog);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/RevokeTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RevokeTask.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
@@ -52,7 +52,7 @@ public class RevokeTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             Revoke statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -67,7 +67,7 @@ public class RevokeTask
         else {
             executeRevokeOnTable(stateMachine.getSession(), statement, metadata, accessControl);
         }
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 
     private void executeRevokeOnSchema(Session session, Revoke statement, Metadata metadata, AccessControl accessControl)

--- a/core/trino-main/src/main/java/io/trino/execution/RollbackTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RollbackTask.java
@@ -26,7 +26,7 @@ import io.trino.transaction.TransactionManager;
 
 import java.util.List;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.spi.StandardErrorCode.NOT_IN_TRANSACTION;
 
 public class RollbackTask
@@ -39,7 +39,7 @@ public class RollbackTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             Rollback statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -56,6 +56,6 @@ public class RollbackTask
 
         stateMachine.clearTransactionId();
         transactionManager.asyncAbort(transactionId);
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SetPathTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetPathTask.java
@@ -29,7 +29,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.spi.StandardErrorCode.MISSING_CATALOG_NAME;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -46,7 +46,7 @@ public class SetPathTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             SetPath statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -77,6 +77,6 @@ public class SetPathTask
             });
         }
         stateMachine.setSetPath(sqlPath.toString());
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SetRoleTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetRoleTask.java
@@ -26,7 +26,7 @@ import io.trino.transaction.TransactionManager;
 
 import java.util.List;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.getSessionCatalog;
 import static java.util.Locale.ENGLISH;
 
@@ -40,7 +40,7 @@ public class SetRoleTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             SetRole statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -59,7 +59,7 @@ public class SetRoleTask
         }
         SelectedRole.Type type = toSelectedRoleType(statement.getType());
         stateMachine.addSetRole(catalog, new SelectedRole(type, statement.getRole().map(c -> c.getValue().toLowerCase(ENGLISH))));
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 
     private static SelectedRole.Type toSelectedRoleType(SetRole.Type statementRoleType)

--- a/core/trino-main/src/main/java/io/trino/execution/SetSchemaAuthorizationTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetSchemaAuthorizationTask.java
@@ -28,7 +28,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.getSessionCatalog;
@@ -46,7 +46,7 @@ public class SetSchemaAuthorizationTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             SetSchemaAuthorization statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -73,6 +73,6 @@ public class SetSchemaAuthorizationTask
 
         metadata.setSchemaAuthorization(session, source, principal);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SetSessionTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetSessionTask.java
@@ -30,7 +30,7 @@ import io.trino.transaction.TransactionManager;
 
 import java.util.List;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.SessionPropertyManager.evaluatePropertyValue;
 import static io.trino.metadata.SessionPropertyManager.serializeSessionProperty;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
@@ -49,7 +49,7 @@ public class SetSessionTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             SetSession statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -104,6 +104,6 @@ public class SetSessionTask
 
         stateMachine.addSetSessionProperties(propertyName.toString(), value);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SetTableAuthorizationTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetTableAuthorizationTask.java
@@ -29,7 +29,7 @@ import io.trino.transaction.TransactionManager;
 
 import java.util.List;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
@@ -47,7 +47,7 @@ public class SetTableAuthorizationTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             SetTableAuthorization statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -76,6 +76,6 @@ public class SetTableAuthorizationTask
 
         metadata.setTableAuthorization(session, tableName.asCatalogSchemaTableName(), principal);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SetViewAuthorizationTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetViewAuthorizationTask.java
@@ -29,7 +29,7 @@ import io.trino.transaction.TransactionManager;
 
 import java.util.List;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
@@ -47,7 +47,7 @@ public class SetViewAuthorizationTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             SetViewAuthorization statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -74,6 +74,6 @@ public class SetViewAuthorizationTask
 
         metadata.setViewAuthorization(session, viewName.asCatalogSchemaTableName(), principal);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SplitRunner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SplitRunner.java
@@ -23,7 +23,7 @@ public interface SplitRunner
 {
     boolean isFinished();
 
-    ListenableFuture<?> processFor(Duration duration);
+    ListenableFuture<Void> processFor(Duration duration);
 
     String getInfo();
 

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskExecution.java
@@ -67,6 +67,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.SystemSessionProperties.getInitialSplitsPerNode;
 import static io.trino.SystemSessionProperties.getMaxDriversPerTask;
 import static io.trino.SystemSessionProperties.getSplitConcurrencyAdjustmentInterval;
@@ -545,12 +546,12 @@ public class SqlTaskExecution
     private synchronized void enqueueDriverSplitRunner(boolean forceRunSplit, List<DriverSplitRunner> runners)
     {
         // schedule driver to be executed
-        List<ListenableFuture<?>> finishedFutures = taskExecutor.enqueueSplits(taskHandle, forceRunSplit, runners);
+        List<ListenableFuture<Void>> finishedFutures = taskExecutor.enqueueSplits(taskHandle, forceRunSplit, runners);
         checkState(finishedFutures.size() == runners.size(), "Expected %s futures but got %s", runners.size(), finishedFutures.size());
 
         // when driver completes, update state and fire events
         for (int i = 0; i < finishedFutures.size(); i++) {
-            ListenableFuture<?> finishedFuture = finishedFutures.get(i);
+            ListenableFuture<Void> finishedFuture = finishedFutures.get(i);
             DriverSplitRunner splitRunner = runners.get(i);
 
             // record new driver
@@ -1056,13 +1057,13 @@ public class SqlTaskExecution
         }
 
         @Override
-        public ListenableFuture<?> processFor(Duration duration)
+        public ListenableFuture<Void> processFor(Duration duration)
         {
             Driver driver;
             synchronized (this) {
                 // if close() was called before we get here, there's not point in even creating the driver
                 if (closed) {
-                    return Futures.immediateFuture(null);
+                    return immediateVoidFuture();
                 }
 
                 if (this.driver == null) {

--- a/core/trino-main/src/main/java/io/trino/execution/StartTransactionTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StartTransactionTask.java
@@ -31,7 +31,7 @@ import io.trino.transaction.TransactionManager;
 import java.util.List;
 import java.util.Optional;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.spi.StandardErrorCode.SYNTAX_ERROR;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 
@@ -45,7 +45,7 @@ public class StartTransactionTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             StartTransaction statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -76,7 +76,7 @@ public class StartTransactionTask
         // when this statement completes.
         transactionManager.trySetInactive(transactionId);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 
     private static Optional<IsolationLevel> extractIsolationLevel(StartTransaction startTransaction)

--- a/core/trino-main/src/main/java/io/trino/execution/UseTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/UseTask.java
@@ -26,7 +26,7 @@ import io.trino.transaction.TransactionManager;
 
 import java.util.List;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.spi.StandardErrorCode.MISSING_CATALOG_NAME;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
@@ -42,7 +42,7 @@ public class UseTask
     }
 
     @Override
-    public ListenableFuture<?> execute(
+    public ListenableFuture<Void> execute(
             Use statement,
             TransactionManager transactionManager,
             Metadata metadata,
@@ -74,6 +74,6 @@ public class UseTask
         }
         stateMachine.setSetSchema(schema);
 
-        return immediateFuture(null);
+        return immediateVoidFuture();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/ArbitraryOutputBuffer.java
@@ -201,7 +201,7 @@ public class ArbitraryOutputBuffer
     }
 
     @Override
-    public ListenableFuture<?> isFull()
+    public ListenableFuture<Void> isFull()
     {
         return memoryManager.getBufferBlockedFuture();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/BroadcastOutputBuffer.java
@@ -192,7 +192,7 @@ public class BroadcastOutputBuffer
     }
 
     @Override
-    public ListenableFuture<?> isFull()
+    public ListenableFuture<Void> isFull()
     {
         return memoryManager.getBufferBlockedFuture();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/LazyOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/LazyOutputBuffer.java
@@ -237,7 +237,7 @@ public class LazyOutputBuffer
     }
 
     @Override
-    public ListenableFuture<?> isFull()
+    public ListenableFuture<Void> isFull()
     {
         OutputBuffer outputBuffer = getDelegateOutputBufferOrFail();
         return outputBuffer.isFull();

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/OutputBuffer.java
@@ -79,7 +79,7 @@ public interface OutputBuffer
     /**
      * Get a future that will be completed when the buffer is not full.
      */
-    ListenableFuture<?> isFull();
+    ListenableFuture<Void> isFull();
 
     /**
      * Adds a split-up page to an unpartitioned buffer. If no-more-pages has been set, the enqueue

--- a/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/execution/buffer/PartitionedOutputBuffer.java
@@ -155,7 +155,7 @@ public class PartitionedOutputBuffer
     }
 
     @Override
-    public ListenableFuture<?> isFull()
+    public ListenableFuture<Void> isFull()
     {
         return memoryManager.getBufferBlockedFuture();
     }

--- a/core/trino-main/src/main/java/io/trino/execution/executor/PrioritizedSplitRunner.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/PrioritizedSplitRunner.java
@@ -51,7 +51,7 @@ public class PrioritizedSplitRunner
 
     private final Ticker ticker;
 
-    private final SettableFuture<?> finishedFuture = SettableFuture.create();
+    private final SettableFuture<Void> finishedFuture = SettableFuture.create();
 
     private final AtomicBoolean destroyed = new AtomicBoolean();
 
@@ -99,7 +99,7 @@ public class PrioritizedSplitRunner
         return taskHandle;
     }
 
-    public ListenableFuture<?> getFinishedFuture()
+    public ListenableFuture<Void> getFinishedFuture()
     {
         return finishedFuture;
     }
@@ -149,7 +149,7 @@ public class PrioritizedSplitRunner
         return waitNanos.get();
     }
 
-    public ListenableFuture<?> process()
+    public ListenableFuture<Void> process()
     {
         try {
             long startNanos = ticker.read();
@@ -160,7 +160,7 @@ public class PrioritizedSplitRunner
             waitNanos.getAndAdd(startNanos - lastReady.get());
 
             CpuTimer timer = new CpuTimer();
-            ListenableFuture<?> blocked = split.processFor(SPLIT_RUN_QUANTA);
+            ListenableFuture<Void> blocked = split.processFor(SPLIT_RUN_QUANTA);
             CpuTimer.CpuDuration elapsed = timer.elapsedTime();
 
             long quantaScheduledNanos = ticker.read() - startNanos;

--- a/core/trino-main/src/main/java/io/trino/execution/executor/TaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/TaskExecutor.java
@@ -127,7 +127,7 @@ public class TaskExecutor
     /**
      * Splits blocked by the driver.
      */
-    private final Map<PrioritizedSplitRunner, Future<?>> blockedSplits = new ConcurrentHashMap<>();
+    private final Map<PrioritizedSplitRunner, Future<Void>> blockedSplits = new ConcurrentHashMap<>();
 
     private final AtomicLongArray completedTasksPerLevel = new AtomicLongArray(5);
     private final AtomicLongArray completedSplitsPerLevel = new AtomicLongArray(5);
@@ -305,10 +305,10 @@ public class TaskExecutor
         log.debug("Task finished or failed " + taskHandle.getTaskId());
     }
 
-    public List<ListenableFuture<?>> enqueueSplits(TaskHandle taskHandle, boolean intermediate, List<? extends SplitRunner> taskSplits)
+    public List<ListenableFuture<Void>> enqueueSplits(TaskHandle taskHandle, boolean intermediate, List<? extends SplitRunner> taskSplits)
     {
         List<PrioritizedSplitRunner> splitsToDestroy = new ArrayList<>();
-        List<ListenableFuture<?>> finishedFutures = new ArrayList<>(taskSplits.size());
+        List<ListenableFuture<Void>> finishedFutures = new ArrayList<>(taskSplits.size());
         synchronized (this) {
             for (SplitRunner taskSplit : taskSplits) {
                 PrioritizedSplitRunner prioritizedSplitRunner = new PrioritizedSplitRunner(
@@ -479,7 +479,7 @@ public class TaskExecutor
                         runningSplitInfos.add(splitInfo);
                         runningSplits.add(split);
 
-                        ListenableFuture<?> blocked;
+                        ListenableFuture<Void> blocked;
                         try {
                             blocked = split.process();
                         }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -183,7 +183,7 @@ public class FixedSourcePartitionedScheduler
         }
 
         boolean allBlocked = true;
-        List<ListenableFuture<?>> blocked = new ArrayList<>();
+        List<ListenableFuture<Void>> blocked = new ArrayList<>();
         BlockedReason blockedReason = BlockedReason.NO_ACTIVE_DRIVER_GROUP;
 
         if (groupedLifespanScheduler.isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/NodeScheduler.java
@@ -17,6 +17,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.Session;
 import io.trino.connector.CatalogName;
@@ -43,7 +44,8 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.whenAnyCompleteCancelOthers;
 import static java.util.Objects.requireNonNull;
 
@@ -174,7 +176,7 @@ public class NodeScheduler
             }
         }
 
-        ListenableFuture<?> blocked = toWhenHasSplitQueueSpaceFuture(blockedNodes, existingTasks, calculateLowWatermark(maxPendingSplitsPerTask));
+        ListenableFuture<Void> blocked = toWhenHasSplitQueueSpaceFuture(blockedNodes, existingTasks, calculateLowWatermark(maxPendingSplitsPerTask));
         return new SplitPlacementResult(blocked, ImmutableMultimap.copyOf(assignments));
     }
 
@@ -183,35 +185,40 @@ public class NodeScheduler
         return (int) Math.ceil(maxPendingSplitsPerTask / 2.0);
     }
 
-    public static ListenableFuture<?> toWhenHasSplitQueueSpaceFuture(Set<InternalNode> blockedNodes, List<RemoteTask> existingTasks, int spaceThreshold)
+    public static ListenableFuture<Void> toWhenHasSplitQueueSpaceFuture(Set<InternalNode> blockedNodes, List<RemoteTask> existingTasks, int spaceThreshold)
     {
         if (blockedNodes.isEmpty()) {
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
         Map<String, RemoteTask> nodeToTaskMap = new HashMap<>();
         for (RemoteTask task : existingTasks) {
             nodeToTaskMap.put(task.getNodeId(), task);
         }
-        List<ListenableFuture<?>> blockedFutures = blockedNodes.stream()
+        List<ListenableFuture<Void>> blockedFutures = blockedNodes.stream()
                 .map(InternalNode::getNodeIdentifier)
                 .map(nodeToTaskMap::get)
                 .filter(Objects::nonNull)
                 .map(remoteTask -> remoteTask.whenSplitQueueHasSpace(spaceThreshold))
                 .collect(toImmutableList());
         if (blockedFutures.isEmpty()) {
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
-        return whenAnyCompleteCancelOthers(blockedFutures);
+        return asVoid(whenAnyCompleteCancelOthers(blockedFutures));
     }
 
-    public static ListenableFuture<?> toWhenHasSplitQueueSpaceFuture(List<RemoteTask> existingTasks, int spaceThreshold)
+    public static ListenableFuture<Void> toWhenHasSplitQueueSpaceFuture(List<RemoteTask> existingTasks, int spaceThreshold)
     {
         if (existingTasks.isEmpty()) {
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
-        List<ListenableFuture<?>> stateChangeFutures = existingTasks.stream()
+        List<ListenableFuture<Void>> stateChangeFutures = existingTasks.stream()
                 .map(remoteTask -> remoteTask.whenSplitQueueHasSpace(spaceThreshold))
                 .collect(toImmutableList());
-        return whenAnyCompleteCancelOthers(stateChangeFutures);
+        return asVoid(whenAnyCompleteCancelOthers(stateChangeFutures));
+    }
+
+    private static <T> ListenableFuture<Void> asVoid(ListenableFuture<T> future)
+    {
+        return Futures.transform(future, v -> null, directExecutor());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ScaledWriterScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ScaledWriterScheduler.java
@@ -48,7 +48,7 @@ public class ScaledWriterScheduler
     private final long writerMinSizeBytes;
     private final Set<InternalNode> scheduledNodes = new HashSet<>();
     private final AtomicBoolean done = new AtomicBoolean();
-    private volatile SettableFuture<?> future = SettableFuture.create();
+    private volatile SettableFuture<Void> future = SettableFuture.create();
 
     public ScaledWriterScheduler(
             SqlStageExecution stage,

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/ScheduleResult.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/ScheduleResult.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static java.util.Objects.requireNonNull;
 
 public class ScheduleResult
@@ -54,22 +54,22 @@ public class ScheduleResult
     }
 
     private final Set<RemoteTask> newTasks;
-    private final ListenableFuture<?> blocked;
+    private final ListenableFuture<Void> blocked;
     private final Optional<BlockedReason> blockedReason;
     private final boolean finished;
     private final int splitsScheduled;
 
     public ScheduleResult(boolean finished, Iterable<? extends RemoteTask> newTasks, int splitsScheduled)
     {
-        this(finished, newTasks, immediateFuture(null), Optional.empty(), splitsScheduled);
+        this(finished, newTasks, immediateVoidFuture(), Optional.empty(), splitsScheduled);
     }
 
-    public ScheduleResult(boolean finished, Iterable<? extends RemoteTask> newTasks, ListenableFuture<?> blocked, BlockedReason blockedReason, int splitsScheduled)
+    public ScheduleResult(boolean finished, Iterable<? extends RemoteTask> newTasks, ListenableFuture<Void> blocked, BlockedReason blockedReason, int splitsScheduled)
     {
         this(finished, newTasks, blocked, Optional.of(requireNonNull(blockedReason, "blockedReason is null")), splitsScheduled);
     }
 
-    private ScheduleResult(boolean finished, Iterable<? extends RemoteTask> newTasks, ListenableFuture<?> blocked, Optional<BlockedReason> blockedReason, int splitsScheduled)
+    private ScheduleResult(boolean finished, Iterable<? extends RemoteTask> newTasks, ListenableFuture<Void> blocked, Optional<BlockedReason> blockedReason, int splitsScheduled)
     {
         this.finished = finished;
         this.newTasks = ImmutableSet.copyOf(requireNonNull(newTasks, "newTasks is null"));
@@ -88,7 +88,7 @@ public class ScheduleResult
         return newTasks;
     }
 
-    public ListenableFuture<?> getBlocked()
+    public ListenableFuture<Void> getBlocked()
     {
         return blocked;
     }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SplitPlacementResult.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SplitPlacementResult.java
@@ -22,16 +22,16 @@ import static java.util.Objects.requireNonNull;
 
 public final class SplitPlacementResult
 {
-    private final ListenableFuture<?> blocked;
+    private final ListenableFuture<Void> blocked;
     private final Multimap<InternalNode, Split> assignments;
 
-    public SplitPlacementResult(ListenableFuture<?> blocked, Multimap<InternalNode, Split> assignments)
+    public SplitPlacementResult(ListenableFuture<Void> blocked, Multimap<InternalNode, Split> assignments)
     {
         this.blocked = requireNonNull(blocked, "blocked is null");
         this.assignments = requireNonNull(assignments, "assignments is null");
     }
 
-    public ListenableFuture<?> getBlocked()
+    public ListenableFuture<Void> getBlocked()
     {
         return blocked;
     }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelector.java
@@ -192,7 +192,7 @@ public class TopologyAwareNodeSelector
             }
         }
 
-        ListenableFuture<?> blocked;
+        ListenableFuture<Void> blocked;
         int maxPendingForWildcardNetworkAffinity = calculateMaxPendingSplits(0, topologicalSplitCounters.size() - 1);
         if (splitWaitingForAnyNode) {
             blocked = toWhenHasSplitQueueSpaceFuture(existingTasks, calculateLowWatermark(maxPendingForWildcardNetworkAffinity));

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/UniformNodeSelector.java
@@ -205,7 +205,7 @@ public class UniformNodeSelector
             }
         }
 
-        ListenableFuture<?> blocked;
+        ListenableFuture<Void> blocked;
         if (splitWaitingForAnyNode) {
             blocked = toWhenHasSplitQueueSpaceFuture(existingTasks, calculateLowWatermark(maxPendingSplitsPerTask));
         }

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/group/DynamicLifespanScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/group/DynamicLifespanScheduler.java
@@ -54,7 +54,7 @@ public class DynamicLifespanScheduler
     private boolean initialScheduled;
     // Write to newDriverGroupReady field is guarded. Read of the reference
     // is either guarded, or is guaranteed to happen in the same thread as the write.
-    private SettableFuture<?> newDriverGroupReady = SettableFuture.create();
+    private SettableFuture<Void> newDriverGroupReady = SettableFuture.create();
 
     @GuardedBy("this")
     private final List<Lifespan> recentlyCompletedDriverGroups = new ArrayList<>();
@@ -105,7 +105,7 @@ public class DynamicLifespanScheduler
     {
         checkState(initialScheduled);
 
-        SettableFuture<?> newDriverGroupReady;
+        SettableFuture<Void> newDriverGroupReady;
         synchronized (this) {
             for (Lifespan newlyCompletedDriverGroup : newlyCompletedDriverGroups) {
                 checkArgument(!newlyCompletedDriverGroup.isTaskWide());
@@ -117,7 +117,7 @@ public class DynamicLifespanScheduler
     }
 
     @Override
-    public SettableFuture<?> schedule(SourceScheduler scheduler)
+    public SettableFuture<Void> schedule(SourceScheduler scheduler)
     {
         // Return a new future even if newDriverGroupReady has not finished.
         // Returning the same SettableFuture instance could lead to ListenableFuture retaining too many listener objects.

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/group/FixedLifespanScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/group/FixedLifespanScheduler.java
@@ -53,7 +53,7 @@ public class FixedLifespanScheduler
     private final OptionalInt concurrentLifespansPerTask;
 
     private boolean initialScheduled;
-    private SettableFuture<?> newDriverGroupReady = SettableFuture.create();
+    private SettableFuture<Void> newDriverGroupReady = SettableFuture.create();
     @GuardedBy("this")
     private final List<Lifespan> recentlyCompletedDriverGroups = new ArrayList<>();
     private int totalDriverGroupsScheduled;
@@ -113,7 +113,7 @@ public class FixedLifespanScheduler
     {
         checkState(initialScheduled);
 
-        SettableFuture<?> newDriverGroupReady;
+        SettableFuture<Void> newDriverGroupReady;
         synchronized (this) {
             for (Lifespan newlyCompletedDriverGroup : newlyCompletedDriverGroups) {
                 checkArgument(!newlyCompletedDriverGroup.isTaskWide());
@@ -125,7 +125,7 @@ public class FixedLifespanScheduler
     }
 
     @Override
-    public SettableFuture<?> schedule(SourceScheduler scheduler)
+    public SettableFuture<Void> schedule(SourceScheduler scheduler)
     {
         // Return a new future even if newDriverGroupReady has not finished.
         // Returning the same SettableFuture instance could lead to ListenableFuture retaining too many listener objects.

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/group/LifespanScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/group/LifespanScheduler.java
@@ -30,5 +30,5 @@ public interface LifespanScheduler
 
     void onLifespanFinished(Iterable<Lifespan> newlyCompletedDriverGroups);
 
-    SettableFuture<?> schedule(SourceScheduler scheduler);
+    SettableFuture<Void> schedule(SourceScheduler scheduler);
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -299,7 +299,7 @@ public interface Metadata
     /**
      * Refresh materialized view
      */
-    ListenableFuture<?> refreshMaterializedView(Session session, QualifiedObjectName viewName);
+    ListenableFuture<Void> refreshMaterializedView(Session session, QualifiedObjectName viewName);
 
     /**
      * Begin refresh materialized view query

--- a/core/trino-main/src/main/java/io/trino/operator/Driver.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Driver.java
@@ -79,7 +79,7 @@ public class Driver
     // added to this staging area. This staging area will be drained asynchronously. That's when
     // the new splits get processed.
     private final AtomicReference<TaskSource> pendingTaskSourceUpdates = new AtomicReference<>();
-    private final Map<Operator, ListenableFuture<?>> revokingOperators = new HashMap<>();
+    private final Map<Operator, ListenableFuture<Void>> revokingOperators = new HashMap<>();
 
     private final AtomicReference<State> state = new AtomicReference<>(State.ALIVE);
 
@@ -88,7 +88,7 @@ public class Driver
     @GuardedBy("exclusiveLock")
     private TaskSource currentTaskSource;
 
-    private final AtomicReference<SettableFuture<?>> driverBlockedFuture = new AtomicReference<>();
+    private final AtomicReference<SettableFuture<Void>> driverBlockedFuture = new AtomicReference<>();
 
     private enum State
     {
@@ -148,7 +148,7 @@ public class Driver
 
         currentTaskSource = sourceOperator.map(operator -> new TaskSource(operator.getSourceId(), ImmutableSet.of(), false)).orElse(null);
         // initially the driverBlockedFuture is not blocked (it is completed)
-        SettableFuture<?> future = SettableFuture.create();
+        SettableFuture<Void> future = SettableFuture.create();
         future.set(null);
         driverBlockedFuture.set(future);
     }
@@ -267,28 +267,28 @@ public class Driver
         currentTaskSource = newSource;
     }
 
-    public ListenableFuture<?> processFor(Duration duration)
+    public ListenableFuture<Void> processFor(Duration duration)
     {
         checkLockNotHeld("Cannot process for a duration while holding the driver lock");
 
         requireNonNull(duration, "duration is null");
 
         // if the driver is blocked we don't need to continue
-        SettableFuture<?> blockedFuture = driverBlockedFuture.get();
+        SettableFuture<Void> blockedFuture = driverBlockedFuture.get();
         if (!blockedFuture.isDone()) {
             return blockedFuture;
         }
 
         long maxRuntime = duration.roundTo(TimeUnit.NANOSECONDS);
 
-        Optional<ListenableFuture<?>> result = tryWithLock(100, TimeUnit.MILLISECONDS, () -> {
+        Optional<ListenableFuture<Void>> result = tryWithLock(100, TimeUnit.MILLISECONDS, () -> {
             OperationTimer operationTimer = createTimer();
             driverContext.startProcessTimer();
             driverContext.getYieldSignal().setWithDelay(maxRuntime, driverContext.getYieldExecutor());
             try {
                 long start = System.nanoTime();
                 do {
-                    ListenableFuture<?> future = processInternal(operationTimer);
+                    ListenableFuture<Void> future = processInternal(operationTimer);
                     if (!future.isDone()) {
                         return updateDriverBlockedFuture(future);
                     }
@@ -304,18 +304,18 @@ public class Driver
         return result.orElse(NOT_BLOCKED);
     }
 
-    public ListenableFuture<?> process()
+    public ListenableFuture<Void> process()
     {
         checkLockNotHeld("Cannot process while holding the driver lock");
 
         // if the driver is blocked we don't need to continue
-        SettableFuture<?> blockedFuture = driverBlockedFuture.get();
+        SettableFuture<Void> blockedFuture = driverBlockedFuture.get();
         if (!blockedFuture.isDone()) {
             return blockedFuture;
         }
 
-        Optional<ListenableFuture<?>> result = tryWithLock(100, TimeUnit.MILLISECONDS, () -> {
-            ListenableFuture<?> future = processInternal(createTimer());
+        Optional<ListenableFuture<Void>> result = tryWithLock(100, TimeUnit.MILLISECONDS, () -> {
+            ListenableFuture<Void> future = processInternal(createTimer());
             return updateDriverBlockedFuture(future);
         });
         return result.orElse(NOT_BLOCKED);
@@ -328,11 +328,11 @@ public class Driver
                 driverContext.isCpuTimerEnabled() && driverContext.isPerOperatorCpuTimerEnabled());
     }
 
-    private ListenableFuture<?> updateDriverBlockedFuture(ListenableFuture<?> sourceBlockedFuture)
+    private ListenableFuture<Void> updateDriverBlockedFuture(ListenableFuture<Void> sourceBlockedFuture)
     {
         // driverBlockedFuture will be completed as soon as the sourceBlockedFuture is completed
         // or any of the operators gets a memory revocation request
-        SettableFuture<?> newDriverBlockedFuture = SettableFuture.create();
+        SettableFuture<Void> newDriverBlockedFuture = SettableFuture.create();
         driverBlockedFuture.set(newDriverBlockedFuture);
         sourceBlockedFuture.addListener(() -> newDriverBlockedFuture.set(null), directExecutor());
 
@@ -352,7 +352,7 @@ public class Driver
     }
 
     @GuardedBy("exclusiveLock")
-    private ListenableFuture<?> processInternal(OperationTimer operationTimer)
+    private ListenableFuture<Void> processInternal(OperationTimer operationTimer)
     {
         checkLockHeld("Lock must be held to call processInternal");
 
@@ -430,9 +430,9 @@ public class Driver
             // if we did not move any pages, check if we are blocked
             if (!movedPage) {
                 List<Operator> blockedOperators = new ArrayList<>();
-                List<ListenableFuture<?>> blockedFutures = new ArrayList<>();
+                List<ListenableFuture<Void>> blockedFutures = new ArrayList<>();
                 for (Operator operator : activeOperators) {
-                    Optional<ListenableFuture<?>> blocked = getBlockedFuture(operator);
+                    Optional<ListenableFuture<Void>> blocked = getBlockedFuture(operator);
                     if (blocked.isPresent()) {
                         blockedOperators.add(operator);
                         blockedFutures.add(blocked.get());
@@ -441,7 +441,7 @@ public class Driver
 
                 if (!blockedFutures.isEmpty()) {
                     // unblock when the first future is complete
-                    ListenableFuture<?> blocked = firstFinishedFuture(blockedFutures);
+                    ListenableFuture<Void> blocked = firstFinishedFuture(blockedFutures);
                     // driver records serial blocked time
                     driverContext.recordBlocked(blocked);
                     // each blocked operator is responsible for blocking the execution
@@ -483,7 +483,7 @@ public class Driver
                 checkOperatorFinishedRevoking(operator);
             }
             else if (operator.getOperatorContext().isMemoryRevokingRequested()) {
-                ListenableFuture<?> future = operator.startMemoryRevoke();
+                ListenableFuture<Void> future = operator.startMemoryRevoke();
                 revokingOperators.put(operator, future);
                 checkOperatorFinishedRevoking(operator);
             }
@@ -493,7 +493,7 @@ public class Driver
     @GuardedBy("exclusiveLock")
     private void checkOperatorFinishedRevoking(Operator operator)
     {
-        ListenableFuture<?> future = revokingOperators.get(operator);
+        ListenableFuture<Void> future = revokingOperators.get(operator);
         if (future.isDone()) {
             getFutureValue(future); // propagate exception if there was some
             revokingOperators.remove(operator);
@@ -587,9 +587,9 @@ public class Driver
         return inFlightException;
     }
 
-    private Optional<ListenableFuture<?>> getBlockedFuture(Operator operator)
+    private Optional<ListenableFuture<Void>> getBlockedFuture(Operator operator)
     {
-        ListenableFuture<?> blocked = revokingOperators.get(operator);
+        ListenableFuture<Void> blocked = revokingOperators.get(operator);
         if (blocked != null) {
             // We mark operator as blocked regardless of blocked.isDone(), because finishMemoryRevoke has not been called yet.
             return Optional.of(blocked);
@@ -640,15 +640,15 @@ public class Driver
         checkState(exclusiveLock.isHeldByCurrentThread(), message);
     }
 
-    private static ListenableFuture<?> firstFinishedFuture(List<ListenableFuture<?>> futures)
+    private static ListenableFuture<Void> firstFinishedFuture(List<ListenableFuture<Void>> futures)
     {
         if (futures.size() == 1) {
             return futures.get(0);
         }
 
-        SettableFuture<?> result = SettableFuture.create();
+        SettableFuture<Void> result = SettableFuture.create();
 
-        for (ListenableFuture<?> future : futures) {
+        for (ListenableFuture<Void> future : futures) {
             future.addListener(() -> result.set(null), directExecutor());
         }
 

--- a/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
@@ -146,7 +146,7 @@ public class DriverContext
         operationTimer.end(overallTiming);
     }
 
-    public void recordBlocked(ListenableFuture<?> blocked)
+    public void recordBlocked(ListenableFuture<Void> blocked)
     {
         requireNonNull(blocked, "blocked is null");
 
@@ -183,7 +183,7 @@ public class DriverContext
         return finished.get() || pipelineContext.isDone();
     }
 
-    public ListenableFuture<?> reserveSpill(long bytes)
+    public ListenableFuture<Void> reserveSpill(long bytes)
     {
         return pipelineContext.reserveSpill(bytes);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/ExchangeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExchangeOperator.java
@@ -92,7 +92,7 @@ public class ExchangeOperator
     private final PlanNodeId sourceId;
     private final ExchangeClient exchangeClient;
     private final PagesSerde serde;
-    private ListenableFuture<?> isBlocked = NOT_BLOCKED;
+    private ListenableFuture<Void> isBlocked = NOT_BLOCKED;
 
     public ExchangeOperator(
             OperatorContext operatorContext,
@@ -151,7 +151,7 @@ public class ExchangeOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         // Avoid registering a new callback in the ExchangeClient when one is already pending
         if (isBlocked.isDone()) {

--- a/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
@@ -450,7 +450,7 @@ public class HashAggregationOperator
     }
 
     @Override
-    public ListenableFuture<?> startMemoryRevoke()
+    public ListenableFuture<Void> startMemoryRevoke()
     {
         if (aggregationBuilder != null) {
             return aggregationBuilder.startMemoryRevoke();

--- a/core/trino-main/src/main/java/io/trino/operator/HashSemiJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashSemiJoinOperator.java
@@ -14,6 +14,7 @@
 package io.trino.operator;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.memory.context.LocalMemoryContext;
@@ -34,6 +35,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.checkSuccess;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.operator.BasicWorkProcessorOperatorAdapter.createAdapterOperatorFactory;
@@ -173,7 +175,7 @@ public class HashSemiJoinOperator
                 if (!channelSetFuture.isDone()) {
                     // This will materialize page but it shouldn't matter for the first page
                     localMemoryContext.setBytes(inputPage.getSizeInBytes());
-                    return blocked(channelSetFuture);
+                    return blocked(asVoid(channelSetFuture));
                 }
                 checkSuccess(channelSetFuture, "ChannelSet building failed");
                 channelSet = getFutureValue(channelSetFuture);
@@ -217,5 +219,10 @@ public class HashSemiJoinOperator
             // add the new boolean column to the page
             return ofResult(inputPage.appendColumn(blockBuilder.build()));
         }
+    }
+
+    private static <T> ListenableFuture<Void> asVoid(ListenableFuture<T> future)
+    {
+        return Futures.transform(future, v -> null, directExecutor());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeOperator.java
@@ -205,7 +205,7 @@ public class MergeOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         if (!blockedOnSplits.isDone()) {
             return blockedOnSplits;

--- a/core/trino-main/src/main/java/io/trino/operator/Operator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Operator.java
@@ -13,14 +13,15 @@
  */
 package io.trino.operator;
 
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.spi.Page;
+
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 
 public interface Operator
         extends AutoCloseable
 {
-    ListenableFuture<?> NOT_BLOCKED = Futures.immediateFuture(null);
+    ListenableFuture<Void> NOT_BLOCKED = immediateVoidFuture();
 
     OperatorContext getOperatorContext();
 
@@ -29,7 +30,7 @@ public interface Operator
      * unblocked.  If the operator is not blocked, this method should return
      * {@code NOT_BLOCKED}.
      */
-    default ListenableFuture<?> isBlocked()
+    default ListenableFuture<Void> isBlocked()
     {
         return NOT_BLOCKED;
     }
@@ -65,7 +66,7 @@ public interface Operator
      * processing methods on it (isBlocked/needsInput/addInput/getOutput) until
      * {@link #finishMemoryRevoke()} is called.
      */
-    default ListenableFuture<?> startMemoryRevoke()
+    default ListenableFuture<Void> startMemoryRevoke()
     {
         return NOT_BLOCKED;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OrderByOperator.java
@@ -36,7 +36,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.base.Verify.verifyNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterators.transform;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.concurrent.MoreFutures.checkSuccess;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.util.MergeSortedPages.mergeSortedPages;
@@ -156,7 +156,7 @@ public class OrderByOperator
     private final OrderingCompiler orderingCompiler;
 
     private Optional<Spiller> spiller = Optional.empty();
-    private ListenableFuture<?> spillInProgress = immediateFuture(null);
+    private ListenableFuture<Void> spillInProgress = immediateVoidFuture();
     private Runnable finishMemoryRevoke = () -> {};
 
     private Iterator<Optional<Page>> sortedPages;
@@ -290,20 +290,20 @@ public class OrderByOperator
     }
 
     @Override
-    public ListenableFuture<?> startMemoryRevoke()
+    public ListenableFuture<Void> startMemoryRevoke()
     {
         verify(state == State.NEEDS_INPUT || revocableMemoryContext.getBytes() == 0, "Cannot spill in state: %s", state);
         return spillToDisk();
     }
 
-    private ListenableFuture<?> spillToDisk()
+    private ListenableFuture<Void> spillToDisk()
     {
         checkSuccess(spillInProgress, "spilling failed");
 
         if (revocableMemoryContext.getBytes() == 0) {
             verify(pageIndex.getPositionCount() == 0 || state == State.HAS_OUTPUT);
             finishMemoryRevoke = () -> {};
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         // TODO try pageIndex.compact(); before spilling, as in HashBuilderOperator.startMemoryRevoke()

--- a/core/trino-main/src/main/java/io/trino/operator/PageBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PageBuffer.java
@@ -34,7 +34,7 @@ import static java.util.Objects.requireNonNull;
  */
 public class PageBuffer
 {
-    private final ListenableFuture<?> initialFuture;
+    private final ListenableFuture<Void> initialFuture;
 
     @Nullable
     private Page page;
@@ -45,7 +45,7 @@ public class PageBuffer
         this(NOT_BLOCKED);
     }
 
-    public PageBuffer(ListenableFuture<?> initialFuture)
+    public PageBuffer(ListenableFuture<Void> initialFuture)
     {
         this.initialFuture = initialFuture;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/PagesSpatialIndexFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesSpatialIndexFactory.java
@@ -66,7 +66,7 @@ public class PagesSpatialIndexFactory
     @Nullable
     private Supplier<PagesSpatialIndex> pagesSpatialIndex;
 
-    private final SettableFuture<?> destroyed = SettableFuture.create();
+    private final SettableFuture<Void> destroyed = SettableFuture.create();
 
     public PagesSpatialIndexFactory(List<Type> types, List<Type> outputTypes)
     {
@@ -114,7 +114,7 @@ public class PagesSpatialIndexFactory
      * <p>
      * Returns a Future that completes once all the {@link SpatialJoinOperator}s have completed.
      */
-    public ListenableFuture<?> lendPagesSpatialIndex(Supplier<PagesSpatialIndex> pagesSpatialIndex)
+    public ListenableFuture<Void> lendPagesSpatialIndex(Supplier<PagesSpatialIndex> pagesSpatialIndex)
     {
         requireNonNull(pagesSpatialIndex, "pagesSpatialIndex is null");
 

--- a/core/trino-main/src/main/java/io/trino/operator/PartitionedOutputOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PartitionedOutputOperator.java
@@ -200,7 +200,7 @@ public class PartitionedOutputOperator
     private final PagePartitioner partitionFunction;
     private final LocalMemoryContext systemMemoryContext;
     private final long partitionsInitialRetainedSize;
-    private ListenableFuture<?> isBlocked = NOT_BLOCKED;
+    private ListenableFuture<Void> isBlocked = NOT_BLOCKED;
     private boolean finished;
 
     public PartitionedOutputOperator(
@@ -256,7 +256,7 @@ public class PartitionedOutputOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         // Avoid re-synchronizing on the output buffer when operator is already blocked
         if (isBlocked.isDone()) {
@@ -366,7 +366,7 @@ public class PartitionedOutputOperator
             }
         }
 
-        public ListenableFuture<?> isFull()
+        public ListenableFuture<Void> isFull()
         {
             return outputBuffer.isFull();
         }

--- a/core/trino-main/src/main/java/io/trino/operator/PipelineContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PipelineContext.java
@@ -239,7 +239,7 @@ public class PipelineContext
         return taskContext.isDone();
     }
 
-    public synchronized ListenableFuture<?> reserveSpill(long bytes)
+    public synchronized ListenableFuture<Void> reserveSpill(long bytes)
     {
         return taskContext.reserveSpill(bytes);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/RefreshMaterializedViewOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/RefreshMaterializedViewOperator.java
@@ -70,7 +70,7 @@ public class RefreshMaterializedViewOperator
     private final Metadata metadata;
     private final QualifiedObjectName viewName;
     @Nullable
-    private ListenableFuture<?> refreshFuture;
+    private ListenableFuture<Void> refreshFuture;
     private boolean closed;
 
     public RefreshMaterializedViewOperator(OperatorContext operatorContext, Metadata metadata, QualifiedObjectName viewName)
@@ -87,7 +87,7 @@ public class RefreshMaterializedViewOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         if (refreshFuture == null) {
             return NOT_BLOCKED;

--- a/core/trino-main/src/main/java/io/trino/operator/SpatialIndexBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SpatialIndexBuilderOperator.java
@@ -145,7 +145,7 @@ public class SpatialIndexBuilderOperator
     private final Map<Integer, Rectangle> partitions;
 
     private final PagesIndex index;
-    private ListenableFuture<?> indexNotNeeded;
+    private ListenableFuture<Void> indexNotNeeded;
 
     private boolean finishing;
     private boolean finished;
@@ -214,7 +214,7 @@ public class SpatialIndexBuilderOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         if (indexNotNeeded != null && !indexNotNeeded.isDone()) {
             return indexNotNeeded;

--- a/core/trino-main/src/main/java/io/trino/operator/TableFinishOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableFinishOperator.java
@@ -165,7 +165,7 @@ public class TableFinishOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         return statisticsAggregationOperator.isBlocked();
     }

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanOperator.java
@@ -15,6 +15,7 @@ package io.trino.operator;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.trino.Session;
@@ -42,6 +43,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static java.util.Objects.requireNonNull;
 
@@ -144,7 +146,7 @@ public class TableScanOperator
     private final List<ColumnHandle> columns;
     private final DynamicFilter dynamicFilter;
     private final LocalMemoryContext systemMemoryContext;
-    private final SettableFuture<?> blocked = SettableFuture.create();
+    private final SettableFuture<Void> blocked = SettableFuture.create();
 
     @Nullable
     private Split split;
@@ -262,16 +264,21 @@ public class TableScanOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         if (!blocked.isDone()) {
             return blocked;
         }
         if (source != null) {
             CompletableFuture<?> pageSourceBlocked = source.isBlocked();
-            return pageSourceBlocked.isDone() ? NOT_BLOCKED : toListenableFuture(pageSourceBlocked);
+            return pageSourceBlocked.isDone() ? NOT_BLOCKED : asVoid(toListenableFuture(pageSourceBlocked));
         }
         return NOT_BLOCKED;
+    }
+
+    private static <T> ListenableFuture<Void> asVoid(ListenableFuture<T> future)
+    {
+        return Futures.transform(future, v -> null, directExecutor());
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slice;
 import io.airlift.units.Duration;
@@ -48,6 +49,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.allAsList;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static io.trino.SystemSessionProperties.isStatisticsCpuTimerEnabled;
@@ -155,7 +157,7 @@ public class TableWriterOperator
     private final Operator statisticAggregationOperator;
     private final List<Type> types;
 
-    private ListenableFuture<?> blocked = NOT_BLOCKED;
+    private ListenableFuture<Void> blocked = NOT_BLOCKED;
     private CompletableFuture<Collection<Slice>> finishFuture;
     private State state = State.RUNNING;
     private long rowCount;
@@ -199,13 +201,13 @@ public class TableWriterOperator
     @Override
     public void finish()
     {
-        ListenableFuture<?> currentlyBlocked = blocked;
+        ListenableFuture<Void> currentlyBlocked = blocked;
 
         OperationTimer timer = new OperationTimer(statisticsCpuTimerEnabled);
         statisticAggregationOperator.finish();
         timer.end(statisticsTiming);
 
-        ListenableFuture<?> blockedOnAggregation = statisticAggregationOperator.isBlocked();
+        ListenableFuture<Void> blockedOnAggregation = statisticAggregationOperator.isBlocked();
         ListenableFuture<?> blockedOnFinish = NOT_BLOCKED;
         if (state == State.RUNNING) {
             state = State.FINISHING;
@@ -213,7 +215,7 @@ public class TableWriterOperator
             blockedOnFinish = toListenableFuture(finishFuture);
             updateWrittenBytes();
         }
-        this.blocked = allAsList(currentlyBlocked, blockedOnAggregation, blockedOnFinish);
+        this.blocked = asVoid(allAsList(currentlyBlocked, blockedOnAggregation, blockedOnFinish));
     }
 
     @Override
@@ -223,7 +225,7 @@ public class TableWriterOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         return blocked;
     }
@@ -257,11 +259,11 @@ public class TableWriterOperator
         statisticAggregationOperator.addInput(page);
         timer.end(statisticsTiming);
 
-        ListenableFuture<?> blockedOnAggregation = statisticAggregationOperator.isBlocked();
+        ListenableFuture<Void> blockedOnAggregation = statisticAggregationOperator.isBlocked();
         CompletableFuture<?> future = pageSink.appendPage(new Page(blocks));
         updateMemoryUsage();
         ListenableFuture<?> blockedOnWrite = toListenableFuture(future);
-        blocked = allAsList(blockedOnAggregation, blockedOnWrite);
+        blocked = asVoid(allAsList(blockedOnAggregation, blockedOnWrite));
         rowCount += page.getPositionCount();
         updateWrittenBytes();
     }
@@ -483,5 +485,10 @@ public class TableWriterOperator
                     .add("validationCpuTime", validationCpuTime)
                     .toString();
         }
+    }
+
+    private static <T> ListenableFuture<Void> asVoid(ListenableFuture<T> future)
+    {
+        return Futures.transform(future, v -> null, directExecutor());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
@@ -290,7 +290,7 @@ public class TaskContext
         return pipelineContexts;
     }
 
-    public synchronized ListenableFuture<?> reserveSpill(long bytes)
+    public synchronized ListenableFuture<Void> reserveSpill(long bytes)
     {
         checkArgument(bytes >= 0, "bytes is negative");
         return queryContext.reserveSpill(bytes);

--- a/core/trino-main/src/main/java/io/trino/operator/TaskOutputOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskOutputOperator.java
@@ -91,7 +91,7 @@ public class TaskOutputOperator
     private final OutputBuffer outputBuffer;
     private final Function<Page, Page> pagePreprocessor;
     private final PagesSerde serde;
-    private ListenableFuture<?> isBlocked = NOT_BLOCKED;
+    private ListenableFuture<Void> isBlocked = NOT_BLOCKED;
     private boolean finished;
 
     public TaskOutputOperator(OperatorContext operatorContext, OutputBuffer outputBuffer, Function<Page, Page> pagePreprocessor, PagesSerdeFactory serdeFactory)
@@ -121,7 +121,7 @@ public class TaskOutputOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         // Avoid re-synchronizing on the output buffer when operator is already blocked
         if (isBlocked.isDone()) {

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessor.java
@@ -44,7 +44,7 @@ public interface WorkProcessor<T>
     /**
      * @return a blocked future when {@link WorkProcessor#isBlocked()} returned true.
      */
-    ListenableFuture<?> getBlockedFuture();
+    ListenableFuture<Void> getBlockedFuture();
 
     /**
      * @return true if the processor is finished. No more results are expected.
@@ -220,9 +220,9 @@ public interface WorkProcessor<T>
         @Nullable
         private final T result;
         @Nullable
-        private final ListenableFuture<?> blocked;
+        private final ListenableFuture<Void> blocked;
 
-        private TransformationState(Type type, boolean needsMoreData, @Nullable T result, @Nullable ListenableFuture<?> blocked)
+        private TransformationState(Type type, boolean needsMoreData, @Nullable T result, @Nullable ListenableFuture<Void> blocked)
         {
             this.type = requireNonNull(type, "type is null");
             this.needsMoreData = needsMoreData;
@@ -245,7 +245,7 @@ public interface WorkProcessor<T>
          * Signals that transformation is blocked. {@link #process()} will be called again with the same input
          * element after {@code blocked} future is done.
          */
-        public static <T> TransformationState<T> blocked(ListenableFuture<?> blocked)
+        public static <T> TransformationState<T> blocked(ListenableFuture<Void> blocked)
         {
             return new TransformationState<>(Type.BLOCKED, false, null, requireNonNull(blocked, "blocked is null"));
         }
@@ -304,7 +304,7 @@ public interface WorkProcessor<T>
         }
 
         @Nullable
-        ListenableFuture<?> getBlocked()
+        ListenableFuture<Void> getBlocked()
         {
             return blocked;
         }
@@ -328,9 +328,9 @@ public interface WorkProcessor<T>
         @Nullable
         private final T result;
         @Nullable
-        private final ListenableFuture<?> blocked;
+        private final ListenableFuture<Void> blocked;
 
-        private ProcessState(Type type, @Nullable T result, @Nullable ListenableFuture<?> blocked)
+        private ProcessState(Type type, @Nullable T result, @Nullable ListenableFuture<Void> blocked)
         {
             this.type = requireNonNull(type, "type is null");
             this.result = result;
@@ -340,7 +340,7 @@ public interface WorkProcessor<T>
         /**
          * Signals that process is blocked. {@link #process()} will be called again after {@code blocked} future is done.
          */
-        public static <T> ProcessState<T> blocked(ListenableFuture<?> blocked)
+        public static <T> ProcessState<T> blocked(ListenableFuture<Void> blocked)
         {
             return new ProcessState<>(Type.BLOCKED, null, requireNonNull(blocked, "blocked is null"));
         }
@@ -383,7 +383,7 @@ public interface WorkProcessor<T>
         }
 
         @Nullable
-        public ListenableFuture<?> getBlocked()
+        public ListenableFuture<Void> getBlocked()
         {
             return blocked;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorOperatorAdapter.java
@@ -161,7 +161,7 @@ public class WorkProcessorOperatorAdapter
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         if (!pages.isBlocked()) {
             return NOT_BLOCKED;

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -71,9 +71,9 @@ public class WorkProcessorPipelineSourceOperator
     private final List<WorkProcessorOperatorContext> workProcessorOperatorContexts = new ArrayList<>();
     private final List<Split> pendingSplits = new ArrayList<>();
 
-    private ListenableFuture<?> blockedFuture;
+    private ListenableFuture<Void> blockedFuture;
     private WorkProcessorSourceOperator sourceOperator;
-    private SettableFuture<?> blockedOnSplits = SettableFuture.create();
+    private SettableFuture<Void> blockedOnSplits = SettableFuture.create();
     private boolean operatorFinishing;
 
     public static List<OperatorFactory> convertOperators(
@@ -435,7 +435,7 @@ public class WorkProcessorPipelineSourceOperator
     }
 
     @Override
-    public ListenableFuture<?> startMemoryRevoke()
+    public ListenableFuture<Void> startMemoryRevoke()
     {
         // TODO: support spill
         throw new UnsupportedOperationException();
@@ -464,7 +464,7 @@ public class WorkProcessorPipelineSourceOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         if (!pages.isBlocked()) {
             return NOT_BLOCKED;
@@ -588,9 +588,9 @@ public class WorkProcessorPipelineSourceOperator
         }
 
         @Override
-        public ListenableFuture<?> setBytes(long bytes)
+        public ListenableFuture<Void> setBytes(long bytes)
         {
-            ListenableFuture<?> blocked = delegate.setBytes(bytes);
+            ListenableFuture<Void> blocked = delegate.setBytes(bytes);
             allocationListener.run();
             return blocked;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorSourceOperatorAdapter.java
@@ -123,7 +123,7 @@ public class WorkProcessorSourceOperatorAdapter
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         if (!pages.isBlocked()) {
             return NOT_BLOCKED;
@@ -236,7 +236,7 @@ public class WorkProcessorSourceOperatorAdapter
     {
         private final List<Split> pendingSplits = new ArrayList<>();
 
-        private SettableFuture<?> blockedOnSplits = SettableFuture.create();
+        private SettableFuture<Void> blockedOnSplits = SettableFuture.create();
         private boolean noMoreSplits;
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorUtils.java
@@ -386,7 +386,7 @@ public final class WorkProcessorUtils
         }
 
         @Override
-        public ListenableFuture<?> getBlockedFuture()
+        public ListenableFuture<Void> getBlockedFuture()
         {
             checkState(state.getType() == ProcessState.Type.BLOCKED, "Must be blocked to get blocked future");
             return state.getBlocked();

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/HashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/HashAggregationBuilder.java
@@ -35,7 +35,7 @@ public interface HashAggregationBuilder
     @Override
     void close();
 
-    ListenableFuture<?> startMemoryRevoke();
+    ListenableFuture<Void> startMemoryRevoke();
 
     void finishMemoryRevoke();
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -183,7 +183,7 @@ public class InMemoryHashAggregationBuilder
     }
 
     @Override
-    public ListenableFuture<?> startMemoryRevoke()
+    public ListenableFuture<Void> startMemoryRevoke()
     {
         throw new UnsupportedOperationException("startMemoryRevoke not supported for InMemoryHashAggregationBuilder");
     }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -39,7 +39,7 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.operator.Operator.NOT_BLOCKED;
 import static java.lang.Math.max;
@@ -63,7 +63,7 @@ public class SpillableHashAggregationBuilder
     private Optional<Spiller> spiller = Optional.empty();
     private Optional<MergingHashAggregationBuilder> merger = Optional.empty();
     private Optional<MergeHashSort> mergeHashSort = Optional.empty();
-    private ListenableFuture<?> spillInProgress = immediateFuture(null);
+    private ListenableFuture<Void> spillInProgress = immediateVoidFuture();
     private final JoinCompiler joinCompiler;
     private final BlockTypeOperators blockTypeOperators;
 
@@ -158,7 +158,7 @@ public class SpillableHashAggregationBuilder
     }
 
     @Override
-    public ListenableFuture<?> startMemoryRevoke()
+    public ListenableFuture<Void> startMemoryRevoke()
     {
         if (producingOutput) {
             // all revocable memory has been released in buildResult method
@@ -244,7 +244,7 @@ public class SpillableHashAggregationBuilder
         }
     }
 
-    private ListenableFuture<?> spillToDisk()
+    private ListenableFuture<Void> spillToDisk()
     {
         checkState(hasPreviousSpillCompletedSuccessfully(), "Previous spill hasn't yet finished");
         hashAggregationBuilder.setOutputPartial();

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/BroadcastExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/BroadcastExchanger.java
@@ -50,7 +50,7 @@ class BroadcastExchanger
     }
 
     @Override
-    public ListenableFuture<?> waitForWriting()
+    public ListenableFuture<Void> waitForWriting()
     {
         return memoryManager.getNotFullFuture();
     }

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSink.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSink.java
@@ -74,7 +74,7 @@ public class LocalExchangeSink
         exchanger.accept(page);
     }
 
-    public ListenableFuture<?> waitForWriting()
+    public ListenableFuture<Void> waitForWriting()
     {
         if (isFinished()) {
             return NOT_BLOCKED;

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSinkOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSinkOperator.java
@@ -99,7 +99,7 @@ public class LocalExchangeSinkOperator
     private final OperatorContext operatorContext;
     private final LocalExchangeSink sink;
     private final Function<Page, Page> pagePreprocessor;
-    private ListenableFuture<?> isBlocked = NOT_BLOCKED;
+    private ListenableFuture<Void> isBlocked = NOT_BLOCKED;
 
     LocalExchangeSinkOperator(OperatorContext operatorContext, LocalExchangeSink sink, Function<Page, Page> pagePreprocessor)
     {
@@ -127,7 +127,7 @@ public class LocalExchangeSinkOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         if (isBlocked.isDone()) {
             isBlocked = sink.waitForWriting();

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSourceOperator.java
@@ -74,7 +74,7 @@ public class LocalExchangeSourceOperator
 
     private final OperatorContext operatorContext;
     private final LocalExchangeSource source;
-    private ListenableFuture<?> isBlocked = NOT_BLOCKED;
+    private ListenableFuture<Void> isBlocked = NOT_BLOCKED;
 
     public LocalExchangeSourceOperator(OperatorContext operatorContext, LocalExchangeSource source)
     {
@@ -102,7 +102,7 @@ public class LocalExchangeSourceOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         if (isBlocked.isDone()) {
             isBlocked = source.waitForReading();

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchanger.java
@@ -26,7 +26,7 @@ public interface LocalExchanger
         public void accept(Page page) {}
 
         @Override
-        public ListenableFuture<?> waitForWriting()
+        public ListenableFuture<Void> waitForWriting()
         {
             return NOT_BLOCKED;
         }
@@ -34,7 +34,7 @@ public interface LocalExchanger
 
     void accept(Page page);
 
-    ListenableFuture<?> waitForWriting();
+    ListenableFuture<Void> waitForWriting();
 
     default void finish() {}
 }

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalMergeSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalMergeSourceOperator.java
@@ -136,7 +136,7 @@ public class LocalMergeSourceOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         if (mergedPages.isBlocked()) {
             return mergedPages.getBlockedFuture();

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PartitioningExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PartitioningExchanger.java
@@ -82,7 +82,7 @@ class PartitioningExchanger
     }
 
     @Override
-    public ListenableFuture<?> waitForWriting()
+    public ListenableFuture<Void> waitForWriting()
     {
         return memoryManager.getNotFullFuture();
     }

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PassthroughExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PassthroughExchanger.java
@@ -51,7 +51,7 @@ public class PassthroughExchanger
     }
 
     @Override
-    public ListenableFuture<?> waitForWriting()
+    public ListenableFuture<Void> waitForWriting()
     {
         return bufferMemoryManager.getNotFullFuture();
     }

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/RandomExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/RandomExchanger.java
@@ -47,7 +47,7 @@ class RandomExchanger
     }
 
     @Override
-    public ListenableFuture<?> waitForWriting()
+    public ListenableFuture<Void> waitForWriting()
     {
         return memoryManager.getNotFullFuture();
     }

--- a/core/trino-main/src/main/java/io/trino/operator/index/IndexLoader.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/IndexLoader.java
@@ -346,7 +346,7 @@ public class IndexLoader
                 ScheduledSplit split = new ScheduledSplit(0, sourcePlanNodeId, new Split(INDEX_CONNECTOR_ID, new IndexSplit(recordSetForLookupSource), Lifespan.taskWide()));
                 driver.updateSource(new TaskSource(sourcePlanNodeId, ImmutableSet.of(split), true));
                 while (!driver.isFinished()) {
-                    ListenableFuture<?> process = driver.process();
+                    ListenableFuture<Void> process = driver.process();
                     checkState(process.isDone(), "Driver should never block");
                 }
             }

--- a/core/trino-main/src/main/java/io/trino/operator/index/IndexLookupSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/IndexLookupSourceFactory.java
@@ -44,7 +44,7 @@ public class IndexLookupSourceFactory
     private final List<Type> outputTypes;
     private final Supplier<IndexLoader> indexLoaderSupplier;
     private TaskContext taskContext;
-    private final SettableFuture<?> whenTaskContextSet = SettableFuture.create();
+    private final SettableFuture<Void> whenTaskContextSet = SettableFuture.create();
 
     public IndexLookupSourceFactory(
             Set<Integer> lookupSourceInputChannels,
@@ -100,7 +100,7 @@ public class IndexLookupSourceFactory
     }
 
     @Override
-    public ListenableFuture<?> whenBuildFinishes()
+    public ListenableFuture<Void> whenBuildFinishes()
     {
         return Futures.transformAsync(
                 whenTaskContextSet,

--- a/core/trino-main/src/main/java/io/trino/operator/index/PageBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/PageBuffer.java
@@ -13,7 +13,6 @@
  */
 package io.trino.operator.index;
 
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.trino.spi.Page;
@@ -25,15 +24,16 @@ import java.util.Queue;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 
 @ThreadSafe
 public class PageBuffer
 {
-    private static final ListenableFuture<?> NOT_FULL = Futures.immediateFuture(null);
+    private static final ListenableFuture<Void> NOT_FULL = immediateVoidFuture();
 
     private final int maxBufferedPages;
     private final Queue<Page> pages;
-    private SettableFuture<?> settableFuture;
+    private SettableFuture<Void> settableFuture;
 
     public PageBuffer(int maxBufferedPages)
     {
@@ -51,7 +51,7 @@ public class PageBuffer
      * Adds a page to the buffer.
      * Returns a ListenableFuture that is marked as done when the next page can be added.
      */
-    public synchronized ListenableFuture<?> add(Page page)
+    public synchronized ListenableFuture<Void> add(Page page)
     {
         checkState(!isFull(), "PageBuffer is full!");
         pages.offer(page);

--- a/core/trino-main/src/main/java/io/trino/operator/index/PageBufferOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/index/PageBufferOperator.java
@@ -62,7 +62,7 @@ public class PageBufferOperator
 
     private final OperatorContext operatorContext;
     private final PageBuffer pageBuffer;
-    private ListenableFuture<?> blocked = NOT_BLOCKED;
+    private ListenableFuture<Void> blocked = NOT_BLOCKED;
     private boolean finished;
 
     public PageBufferOperator(OperatorContext operatorContext, PageBuffer pageBuffer)
@@ -91,7 +91,7 @@ public class PageBufferOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         updateBlockedIfNecessary();
         return blocked;
@@ -116,7 +116,7 @@ public class PageBufferOperator
     {
         requireNonNull(page, "page is null");
         checkState(blocked == NOT_BLOCKED, "output is already blocked");
-        ListenableFuture<?> future = pageBuffer.add(page);
+        ListenableFuture<Void> future = pageBuffer.add(page);
         if (!future.isDone()) {
             this.blocked = future;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
@@ -16,6 +16,7 @@ package io.trino.operator.join;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.execution.Lifespan;
 import io.trino.memory.context.LocalMemoryContext;
@@ -47,7 +48,8 @@ import java.util.Queue;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.checkSuccess;
 import static io.airlift.concurrent.MoreFutures.getDone;
 import static java.lang.String.format;
@@ -202,7 +204,7 @@ public class HashBuilderOperator
     private final LocalMemoryContext localUserMemoryContext;
     private final LocalMemoryContext localRevocableMemoryContext;
     private final PartitionedLookupSourceFactory lookupSourceFactory;
-    private final ListenableFuture<?> lookupSourceFactoryDestroyed;
+    private final ListenableFuture<Void> lookupSourceFactoryDestroyed;
     private final int partitionIndex;
 
     private final List<Integer> outputChannels;
@@ -220,10 +222,10 @@ public class HashBuilderOperator
     private final HashCollisionsCounter hashCollisionsCounter;
 
     private State state = State.CONSUMING_INPUT;
-    private Optional<ListenableFuture<?>> lookupSourceNotNeeded = Optional.empty();
+    private Optional<ListenableFuture<Void>> lookupSourceNotNeeded = Optional.empty();
     private final SpilledLookupSourceHandle spilledLookupSourceHandle = new SpilledLookupSourceHandle();
     private Optional<SingleStreamSpiller> spiller = Optional.empty();
-    private ListenableFuture<?> spillInProgress = NOT_BLOCKED;
+    private ListenableFuture<Void> spillInProgress = NOT_BLOCKED;
     private Optional<ListenableFuture<List<Page>>> unspillInProgress = Optional.empty();
     @Nullable
     private LookupSourceSupplier lookupSourceSupplier;
@@ -284,7 +286,7 @@ public class HashBuilderOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         switch (state) {
             case CONSUMING_INPUT:
@@ -300,7 +302,8 @@ public class HashBuilderOperator
                 return spilledLookupSourceHandle.getUnspillingOrDisposeRequested();
 
             case INPUT_UNSPILLING:
-                return unspillInProgress.orElseThrow(() -> new IllegalStateException("Unspilling in progress, but unspilling future not set"));
+                return unspillInProgress.map(HashBuilderOperator::asVoid)
+                        .orElseThrow(() -> new IllegalStateException("Unspilling in progress, but unspilling future not set"));
 
             case INPUT_UNSPILLED_AND_BUILT:
                 return spilledLookupSourceHandle.getDisposeRequested();
@@ -309,6 +312,11 @@ public class HashBuilderOperator
                 return NOT_BLOCKED;
         }
         throw new IllegalStateException("Unhandled state: " + state);
+    }
+
+    private static <T> ListenableFuture<Void> asVoid(ListenableFuture<T> future)
+    {
+        return Futures.transform(future, v -> null, directExecutor());
     }
 
     @Override
@@ -363,7 +371,7 @@ public class HashBuilderOperator
     }
 
     @Override
-    public ListenableFuture<?> startMemoryRevoke()
+    public ListenableFuture<Void> startMemoryRevoke()
     {
         checkState(spillEnabled, "Spill not enabled, no revokable memory should be reserved");
 
@@ -373,7 +381,7 @@ public class HashBuilderOperator
             long indexSizeAfterCompaction = index.getEstimatedSize().toBytes();
             if (indexSizeAfterCompaction < indexSizeBeforeCompaction * INDEX_COMPACTION_ON_REVOCATION_TARGET) {
                 finishMemoryRevoke = Optional.of(() -> {});
-                return immediateFuture(null);
+                return immediateVoidFuture();
             }
 
             finishMemoryRevoke = Optional.of(() -> {
@@ -401,13 +409,13 @@ public class HashBuilderOperator
         if (operatorContext.getReservedRevocableBytes() == 0) {
             // Probably stale revoking request
             finishMemoryRevoke = Optional.of(() -> {});
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         throw new IllegalStateException(format("State %s cannot have revocable memory, but has %s revocable bytes", state, operatorContext.getReservedRevocableBytes()));
     }
 
-    private ListenableFuture<?> spillIndex()
+    private ListenableFuture<Void> spillIndex()
     {
         checkState(spiller.isEmpty(), "Spiller already created");
         spiller = Optional.of(singleStreamSpillerFactory.create(

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinBridge.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinBridge.java
@@ -29,5 +29,5 @@ public interface JoinBridge
 
     void destroy();
 
-    ListenableFuture<?> whenBuildFinishes();
+    ListenableFuture<Void> whenBuildFinishes();
 }

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinBridgeManager.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinBridgeManager.java
@@ -471,8 +471,8 @@ public class JoinBridgeManager<T extends JoinBridge>
         private final ReferenceCount probeReferenceCount;
         private final ReferenceCount outerReferenceCount;
 
-        private final ListenableFuture<?> whenBuildAndProbeFinishes;
-        private final ListenableFuture<?> whenAllFinishes;
+        private final ListenableFuture<Void> whenBuildAndProbeFinishes;
+        private final ListenableFuture<Void> whenAllFinishes;
 
         public JoinLifecycle(JoinBridge joinBridge, int probeFactoryCount, int outerFactoryCount)
         {
@@ -492,7 +492,7 @@ public class JoinBridgeManager<T extends JoinBridge>
             whenAllFinishes.addListener(joinBridge::destroy, directExecutor());
         }
 
-        public ListenableFuture<?> whenBuildAndProbeFinishes()
+        public ListenableFuture<Void> whenBuildAndProbeFinishes()
         {
             return whenBuildAndProbeFinishes;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/join/LookupSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/LookupSourceFactory.java
@@ -58,7 +58,7 @@ public interface LookupSourceFactory
     @Override
     void destroy();
 
-    default ListenableFuture<?> isDestroyed()
+    default ListenableFuture<Void> isDestroyed()
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopBuildOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopBuildOperator.java
@@ -79,7 +79,7 @@ public class NestedLoopBuildOperator
     // Initially, probeDoneWithPages is not present.
     // Once finish is called, probeDoneWithPages will be set to a future that completes when the pages are no longer needed by the probe side.
     // When the pages are no longer needed, the isFinished method on this operator will return true.
-    private Optional<ListenableFuture<?>> probeDoneWithPages = Optional.empty();
+    private Optional<ListenableFuture<Void>> probeDoneWithPages = Optional.empty();
 
     public NestedLoopBuildOperator(OperatorContext operatorContext, NestedLoopJoinBridge nestedLoopJoinBridge)
     {
@@ -114,7 +114,7 @@ public class NestedLoopBuildOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
         return probeDoneWithPages.orElse(NOT_BLOCKED);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinBridge.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinBridge.java
@@ -23,7 +23,7 @@ public interface NestedLoopJoinBridge
 {
     ListenableFuture<NestedLoopJoinPages> getPagesFuture();
 
-    ListenableFuture<?> setPages(NestedLoopJoinPages nestedLoopJoinPages);
+    ListenableFuture<Void> setPages(NestedLoopJoinPages nestedLoopJoinPages);
 
     @Override
     void destroy();
@@ -35,7 +35,7 @@ public interface NestedLoopJoinBridge
     }
 
     @Override
-    default ListenableFuture<?> whenBuildFinishes()
+    default ListenableFuture<Void> whenBuildFinishes()
     {
         return transform(getPagesFuture(), ignored -> null, directExecutor());
     }

--- a/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinOperator.java
@@ -16,6 +16,7 @@ package io.trino.operator.join;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.execution.Lifespan;
 import io.trino.operator.DriverContext;
@@ -35,6 +36,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.tryGetFutureValue;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -127,6 +129,7 @@ public class NestedLoopJoinOperator
     }
 
     private final ListenableFuture<NestedLoopJoinPages> nestedLoopJoinPagesFuture;
+    private final ListenableFuture<Void> blockedFutureView;
 
     private final OperatorContext operatorContext;
     private final Runnable afterClose;
@@ -144,9 +147,15 @@ public class NestedLoopJoinOperator
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.nestedLoopJoinPagesFuture = joinBridge.getPagesFuture();
+        blockedFutureView = asVoid(nestedLoopJoinPagesFuture);
         this.probeChannels = Ints.toArray(requireNonNull(probeChannels, "probeChannels is null"));
         this.buildChannels = Ints.toArray(requireNonNull(buildChannels, "buildChannels is null"));
         this.afterClose = requireNonNull(afterClose, "afterClose is null");
+    }
+
+    private static <T> ListenableFuture<Void> asVoid(ListenableFuture<T> future)
+    {
+        return Futures.transform(future, v -> null, directExecutor());
     }
 
     @Override
@@ -173,9 +182,9 @@ public class NestedLoopJoinOperator
     }
 
     @Override
-    public ListenableFuture<?> isBlocked()
+    public ListenableFuture<Void> isBlocked()
     {
-        return nestedLoopJoinPagesFuture;
+        return blockedFutureView;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinPagesSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/NestedLoopJoinPagesSupplier.java
@@ -26,7 +26,7 @@ public final class NestedLoopJoinPagesSupplier
         implements NestedLoopJoinBridge
 {
     private final SettableFuture<NestedLoopJoinPages> pagesFuture = SettableFuture.create();
-    private final SettableFuture<?> pagesNoLongerNeeded = SettableFuture.create();
+    private final SettableFuture<Void> pagesNoLongerNeeded = SettableFuture.create();
 
     @Override
     public ListenableFuture<NestedLoopJoinPages> getPagesFuture()
@@ -35,7 +35,7 @@ public final class NestedLoopJoinPagesSupplier
     }
 
     @Override
-    public ListenableFuture<?> setPages(NestedLoopJoinPages nestedLoopJoinPages)
+    public ListenableFuture<Void> setPages(NestedLoopJoinPages nestedLoopJoinPages)
     {
         requireNonNull(nestedLoopJoinPages, "nestedLoopJoinPages is null");
         boolean wasSet = pagesFuture.set(nestedLoopJoinPages);

--- a/core/trino-main/src/main/java/io/trino/operator/join/SpilledLookupSourceHandle.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/SpilledLookupSourceHandle.java
@@ -41,17 +41,17 @@ final class SpilledLookupSourceHandle
     @GuardedBy("this")
     private State state = State.SPILLED;
 
-    private final SettableFuture<?> unspillingRequested = SettableFuture.create();
+    private final SettableFuture<Void> unspillingRequested = SettableFuture.create();
 
     @GuardedBy("this")
     @Nullable
     private SettableFuture<Supplier<LookupSource>> unspilledLookupSource;
 
-    private final SettableFuture<?> disposeRequested = SettableFuture.create();
+    private final SettableFuture<Void> disposeRequested = SettableFuture.create();
 
-    private final ListenableFuture<?> unspillingOrDisposeRequested = whenAnyComplete(ImmutableList.of(unspillingRequested, disposeRequested));
+    private final ListenableFuture<Void> unspillingOrDisposeRequested = whenAnyComplete(ImmutableList.of(unspillingRequested, disposeRequested));
 
-    public SettableFuture<?> getUnspillingRequested()
+    public SettableFuture<Void> getUnspillingRequested()
     {
         return unspillingRequested;
     }
@@ -88,12 +88,12 @@ final class SpilledLookupSourceHandle
         setState(State.DISPOSED);
     }
 
-    public SettableFuture<?> getDisposeRequested()
+    public SettableFuture<Void> getDisposeRequested()
     {
         return disposeRequested;
     }
 
-    public ListenableFuture<?> getUnspillingOrDisposeRequested()
+    public ListenableFuture<Void> getUnspillingOrDisposeRequested()
     {
         return unspillingOrDisposeRequested;
     }

--- a/core/trino-main/src/main/java/io/trino/operator/join/SpillingJoinProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/SpillingJoinProcessor.java
@@ -108,7 +108,7 @@ public class SpillingJoinProcessor
         // wait for build side to be completed before fetching any probe data
         // TODO: fix support for probe short-circuit: https://github.com/trinodb/trino/issues/3957
         if (waitForBuild && !lookupSourceProvider.isDone()) {
-            return WorkProcessor.ProcessState.blocked(lookupSourceProvider);
+            return WorkProcessor.ProcessState.blocked(asVoid(lookupSourceProvider));
         }
 
         if (!joinedSourcePages.isFinished()) {
@@ -117,7 +117,7 @@ public class SpillingJoinProcessor
 
         if (partitionedConsumption == null) {
             partitionedConsumption = lookupSourceFactory.finishProbeOperator(lookupJoinsCount);
-            return WorkProcessor.ProcessState.blocked(partitionedConsumption);
+            return WorkProcessor.ProcessState.blocked(asVoid(partitionedConsumption));
         }
 
         if (lookupPartitions == null) {
@@ -128,7 +128,7 @@ public class SpillingJoinProcessor
             // If we had no rows for the previous spill partition, we would finish before it is unspilled.
             // Partition must be loaded before it can be released. // TODO remove this constraint
             if (!previousPartitionLookupSource.isDone()) {
-                return WorkProcessor.ProcessState.blocked(previousPartitionLookupSource);
+                return WorkProcessor.ProcessState.blocked(asVoid(previousPartitionLookupSource));
             }
 
             previousPartition.release();
@@ -146,6 +146,11 @@ public class SpillingJoinProcessor
         previousPartitionLookupSource = partition.load();
 
         return WorkProcessor.ProcessState.ofResult(joinUnspilledPages(partition));
+    }
+
+    private static <T> ListenableFuture<Void> asVoid(ListenableFuture<T> future)
+    {
+        return Futures.transform(future, v -> null, directExecutor());
     }
 
     private WorkProcessor<Page> joinUnspilledPages(PartitionedConsumption.Partition<Supplier<LookupSource>> partition)

--- a/core/trino-main/src/main/java/io/trino/server/DynamicFilterService.java
+++ b/core/trino-main/src/main/java/io/trino/server/DynamicFilterService.java
@@ -151,7 +151,7 @@ public class DynamicFilterService
             Set<DynamicFilterId> lazyDynamicFilters,
             Set<DynamicFilterId> replicatedDynamicFilters)
     {
-        Map<DynamicFilterId, SettableFuture<?>> lazyDynamicFilterFutures = lazyDynamicFilters.stream()
+        Map<DynamicFilterId, SettableFuture<Void>> lazyDynamicFilterFutures = lazyDynamicFilters.stream()
                 .collect(toImmutableMap(filter -> filter, filter -> SettableFuture.create()));
         dynamicFilterContexts.putIfAbsent(queryId, new DynamicFilterContext(
                 session,
@@ -245,7 +245,7 @@ public class DynamicFilterService
             return EMPTY;
         }
 
-        List<ListenableFuture<?>> lazyDynamicFilterFutures = dynamicFilters.stream()
+        List<ListenableFuture<Void>> lazyDynamicFilterFutures = dynamicFilters.stream()
                 .map(context.getLazyDynamicFilters()::get)
                 .filter(Objects::nonNull)
                 .collect(toImmutableList());
@@ -257,7 +257,7 @@ public class DynamicFilterService
             public CompletableFuture<?> isBlocked()
             {
                 // wait for any of the requested dynamic filter domains to be completed
-                List<ListenableFuture<?>> undoneFutures = lazyDynamicFilterFutures.stream()
+                List<ListenableFuture<Void>> undoneFutures = lazyDynamicFilterFutures.stream()
                         .filter(future -> !future.isDone())
                         .collect(toImmutableList());
 
@@ -624,7 +624,7 @@ public class DynamicFilterService
         private final Map<DynamicFilterId, Domain> dynamicFilterSummaries = new ConcurrentHashMap<>();
         private final Map<DynamicFilterId, Long> dynamicFilterCollectionTime = new ConcurrentHashMap<>();
         private final Set<DynamicFilterId> dynamicFilters;
-        private final Map<DynamicFilterId, SettableFuture<?>> lazyDynamicFilters;
+        private final Map<DynamicFilterId, SettableFuture<Void>> lazyDynamicFilters;
         private final Set<DynamicFilterId> replicatedDynamicFilters;
         private final Map<StageId, Set<DynamicFilterId>> stageDynamicFilters = new ConcurrentHashMap<>();
         private final Map<StageId, Integer> stageNumberOfTasks = new ConcurrentHashMap<>();
@@ -636,7 +636,7 @@ public class DynamicFilterService
         private DynamicFilterContext(
                 Session session,
                 Set<DynamicFilterId> dynamicFilters,
-                Map<DynamicFilterId, SettableFuture<?>> lazyDynamicFilters,
+                Map<DynamicFilterId, SettableFuture<Void>> lazyDynamicFilters,
                 Set<DynamicFilterId> replicatedDynamicFilters)
         {
             this.session = requireNonNull(session, "session is null");
@@ -715,7 +715,7 @@ public class DynamicFilterService
             return dynamicFilterSummaries;
         }
 
-        private Map<DynamicFilterId, SettableFuture<?>> getLazyDynamicFilters()
+        private Map<DynamicFilterId, SettableFuture<Void>> getLazyDynamicFilters()
         {
             return lazyDynamicFilters;
         }

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/ContinuousTaskStatusFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/ContinuousTaskStatusFetcher.java
@@ -139,7 +139,7 @@ class ContinuousTaskStatusFetcher
         }
 
         // if throttled due to error, asynchronously wait for timeout and try again
-        ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
+        ListenableFuture<Void> errorRateLimit = errorTracker.acquireRequestPermit();
         if (!errorRateLimit.isDone()) {
             errorRateLimit.addListener(this::scheduleNextRequest, executor);
             return;

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/DynamicFiltersFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/DynamicFiltersFetcher.java
@@ -143,7 +143,7 @@ class DynamicFiltersFetcher
         }
 
         // if throttled due to error, asynchronously wait for timeout and try again
-        ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
+        ListenableFuture<Void> errorRateLimit = errorTracker.acquireRequestPermit();
         if (!errorRateLimit.isDone()) {
             errorRateLimit.addListener(this::fetchDynamicFiltersIfNecessary, executor);
             return;

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -82,7 +82,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.Request.Builder.prepareDelete;
@@ -137,7 +137,7 @@ public final class HttpRemoteTask
     private final Map<PlanNodeId, Boolean> noMoreSplits = new HashMap<>();
     @GuardedBy("this")
     private final AtomicReference<OutputBuffers> outputBuffers = new AtomicReference<>();
-    private final FutureStateChange<?> whenSplitQueueHasSpace = new FutureStateChange<>();
+    private final FutureStateChange<Void> whenSplitQueueHasSpace = new FutureStateChange<>();
     @GuardedBy("this")
     private boolean splitQueueHasSpace = true;
     @GuardedBy("this")
@@ -446,7 +446,7 @@ public final class HttpRemoteTask
     }
 
     @Override
-    public synchronized ListenableFuture<?> whenSplitQueueHasSpace(int threshold)
+    public synchronized ListenableFuture<Void> whenSplitQueueHasSpace(int threshold)
     {
         if (whenSplitQueueHasSpaceThreshold.isPresent()) {
             checkArgument(threshold == whenSplitQueueHasSpaceThreshold.getAsInt(), "Multiple split queue space notification thresholds not supported");
@@ -456,7 +456,7 @@ public final class HttpRemoteTask
             updateSplitQueueSpace();
         }
         if (splitQueueHasSpace) {
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
         return whenSplitQueueHasSpace.createNewListener();
     }
@@ -525,7 +525,7 @@ public final class HttpRemoteTask
         }
 
         // if throttled due to error, asynchronously wait for timeout and try again
-        ListenableFuture<?> errorRateLimit = updateErrorTracker.acquireRequestPermit();
+        ListenableFuture<Void> errorRateLimit = updateErrorTracker.acquireRequestPermit();
         if (!errorRateLimit.isDone()) {
             errorRateLimit.addListener(this::sendUpdate, executor);
             return;

--- a/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/TaskInfoFetcher.java
@@ -194,7 +194,7 @@ public class TaskInfoFetcher
         }
 
         // if throttled due to error, asynchronously wait for timeout and try again
-        ListenableFuture<?> errorRateLimit = errorTracker.acquireRequestPermit();
+        ListenableFuture<Void> errorRateLimit = errorTracker.acquireRequestPermit();
         if (!errorRateLimit.isDone()) {
             errorRateLimit.addListener(this::sendNextRequest, executor);
             return;

--- a/core/trino-main/src/main/java/io/trino/spiller/FileSingleStreamSpiller.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/FileSingleStreamSpiller.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.execution.buffer.PagesSerdeUtil.writeSerializedPage;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spiller.FileSingleStreamSpillerFactory.SPILL_FILE_PREFIX;
@@ -69,7 +70,7 @@ public class FileSingleStreamSpiller
 
     private boolean writable = true;
     private long spilledPagesInMemorySize;
-    private ListenableFuture<?> spillInProgress = Futures.immediateFuture(null);
+    private ListenableFuture<Void> spillInProgress = immediateVoidFuture();
 
     private final Runnable fileSystemErrorHandler;
 
@@ -113,11 +114,11 @@ public class FileSingleStreamSpiller
     }
 
     @Override
-    public ListenableFuture<?> spill(Iterator<Page> pageIterator)
+    public ListenableFuture<Void> spill(Iterator<Page> pageIterator)
     {
         requireNonNull(pageIterator, "pageIterator is null");
         checkNoSpillInProgress();
-        spillInProgress = executor.submit(() -> writePages(pageIterator));
+        spillInProgress = Futures.submit(() -> writePages(pageIterator), executor);
         return spillInProgress;
     }
 

--- a/core/trino-main/src/main/java/io/trino/spiller/GenericSpiller.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/GenericSpiller.java
@@ -14,7 +14,6 @@
 package io.trino.spiller;
 
 import com.google.common.io.Closer;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.operator.SpillContext;
@@ -29,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -41,7 +41,7 @@ public class GenericSpiller
     private final AggregatedMemoryContext aggregatedMemoryContext;
     private final SingleStreamSpillerFactory singleStreamSpillerFactory;
     private final Closer closer = Closer.create();
-    private ListenableFuture<?> previousSpill = Futures.immediateFuture(null);
+    private ListenableFuture<Void> previousSpill = immediateVoidFuture();
     private final List<SingleStreamSpiller> singleStreamSpillers = new ArrayList<>();
 
     public GenericSpiller(
@@ -57,7 +57,7 @@ public class GenericSpiller
     }
 
     @Override
-    public ListenableFuture<?> spill(Iterator<Page> pageIterator)
+    public ListenableFuture<Void> spill(Iterator<Page> pageIterator)
     {
         checkNoSpillInProgress();
         SingleStreamSpiller singleStreamSpiller = singleStreamSpillerFactory.create(types, spillContext, aggregatedMemoryContext.newLocalMemoryContext(GenericSpiller.class.getSimpleName()));

--- a/core/trino-main/src/main/java/io/trino/spiller/PartitioningSpiller.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/PartitioningSpiller.java
@@ -56,16 +56,16 @@ public interface PartitioningSpiller
 
     class PartitioningSpillResult
     {
-        private final ListenableFuture<?> spillingFuture;
+        private final ListenableFuture<Void> spillingFuture;
         private final Page retained;
 
-        public PartitioningSpillResult(ListenableFuture<?> spillingFuture, Page retained)
+        public PartitioningSpillResult(ListenableFuture<Void> spillingFuture, Page retained)
         {
             this.spillingFuture = requireNonNull(spillingFuture, "spillingFuture is null");
             this.retained = requireNonNull(retained, "retained is null");
         }
 
-        public ListenableFuture<?> getSpillingFuture()
+        public ListenableFuture<Void> getSpillingFuture()
         {
             return spillingFuture;
         }

--- a/core/trino-main/src/main/java/io/trino/spiller/SingleStreamSpiller.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/SingleStreamSpiller.java
@@ -30,13 +30,13 @@ public interface SingleStreamSpiller
      * Initiate spilling of pages stream. Returns completed future once spilling has finished.
      * Next spill can be initiated as soon as previous one completes.
      */
-    ListenableFuture<?> spill(Iterator<Page> page);
+    ListenableFuture<Void> spill(Iterator<Page> page);
 
     /**
      * Initiate spilling of single page. Returns completed future once spilling has finished.
      * Next spill can be initiated as soon as previous one completes.
      */
-    default ListenableFuture<?> spill(Page page)
+    default ListenableFuture<Void> spill(Page page)
     {
         return spill(singletonIterator(page));
     }

--- a/core/trino-main/src/main/java/io/trino/spiller/SpillSpaceTracker.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/SpillSpaceTracker.java
@@ -48,7 +48,7 @@ public class SpillSpaceTracker
      *
      * @throws ExceededSpillLimitException
      */
-    public synchronized ListenableFuture<?> reserve(long bytes)
+    public synchronized ListenableFuture<Void> reserve(long bytes)
     {
         checkArgument(bytes >= 0, "bytes is negative");
 

--- a/core/trino-main/src/main/java/io/trino/spiller/Spiller.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/Spiller.java
@@ -26,7 +26,7 @@ public interface Spiller
     /**
      * Initiate spilling of pages stream. Returns completed future once spilling has finished.
      */
-    ListenableFuture<?> spill(Iterator<Page> pageIterator);
+    ListenableFuture<Void> spill(Iterator<Page> pageIterator);
 
     /**
      * Returns list of previously spilled Pages streams.

--- a/core/trino-main/src/main/java/io/trino/split/BufferingSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/BufferingSplitSource.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
 
@@ -84,7 +84,7 @@ public class BufferingSplitSource
                 Lifespan lifespan)
         {
             GetNextBatch getNextBatch = new GetNextBatch(splitSource, min, max, partitionHandle, lifespan);
-            ListenableFuture<?> future = getNextBatch.fetchSplits();
+            ListenableFuture<Void> future = getNextBatch.fetchSplits();
             return Futures.transform(future, ignored -> new SplitBatch(getNextBatch.splits, getNextBatch.noMoreSplits), directExecutor());
         }
 
@@ -98,17 +98,17 @@ public class BufferingSplitSource
             this.lifespan = requireNonNull(lifespan, "lifespan is null");
         }
 
-        private ListenableFuture<?> fetchSplits()
+        private ListenableFuture<Void> fetchSplits()
         {
             if (splits.size() >= min) {
-                return immediateFuture(null);
+                return immediateVoidFuture();
             }
             ListenableFuture<SplitBatch> future = splitSource.getNextBatch(partitionHandle, lifespan, max - splits.size());
             return Futures.transformAsync(future, splitBatch -> {
                 splits.addAll(splitBatch.getSplits());
                 if (splitBatch.isLastBatch()) {
                     noMoreSplits = true;
-                    return immediateFuture(null);
+                    return immediateVoidFuture();
                 }
                 return fetchSplits();
             }, directExecutor());

--- a/core/trino-main/src/main/java/io/trino/transaction/NoOpTransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/NoOpTransactionManager.java
@@ -114,13 +114,13 @@ public class NoOpTransactionManager
     }
 
     @Override
-    public ListenableFuture<?> asyncCommit(TransactionId transactionId)
+    public ListenableFuture<Void> asyncCommit(TransactionId transactionId)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public ListenableFuture<?> asyncAbort(TransactionId transactionId)
+    public ListenableFuture<Void> asyncAbort(TransactionId transactionId)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/main/java/io/trino/transaction/TransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/TransactionManager.java
@@ -63,9 +63,9 @@ public interface TransactionManager
 
     void trySetInactive(TransactionId transactionId);
 
-    ListenableFuture<?> asyncCommit(TransactionId transactionId);
+    ListenableFuture<Void> asyncCommit(TransactionId transactionId);
 
-    ListenableFuture<?> asyncAbort(TransactionId transactionId);
+    ListenableFuture<Void> asyncAbort(TransactionId transactionId);
 
     void fail(TransactionId transactionId);
 

--- a/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
+++ b/core/trino-main/src/test/java/io/trino/execution/MockRemoteTaskFactory.java
@@ -172,7 +172,7 @@ public class MockRemoteTaskFactory
         private int unacknowledgedSplits;
 
         @GuardedBy("this")
-        private SettableFuture<?> whenSplitQueueHasSpace = SettableFuture.create();
+        private SettableFuture<Void> whenSplitQueueHasSpace = SettableFuture.create();
 
         private final PartitionedSplitCountTracker partitionedSplitCountTracker;
 
@@ -423,7 +423,7 @@ public class MockRemoteTaskFactory
         }
 
         @Override
-        public synchronized ListenableFuture<?> whenSplitQueueHasSpace(int threshold)
+        public synchronized ListenableFuture<Void> whenSplitQueueHasSpace(int threshold)
         {
             return nonCancellationPropagating(whenSplitQueueHasSpace);
         }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -697,7 +697,7 @@ public class TestSqlTaskExecution
 
     public static class Pauser
     {
-        private volatile SettableFuture<?> future = SettableFuture.create();
+        private volatile SettableFuture<Void> future = SettableFuture.create();
 
         public Pauser()
         {
@@ -799,7 +799,7 @@ public class TestSqlTaskExecution
             private final OperatorContext operatorContext;
             private final PlanNodeId planNodeId;
 
-            private final SettableFuture<?> blocked = SettableFuture.create();
+            private final SettableFuture<Void> blocked = SettableFuture.create();
 
             private TestingSplit split;
 
@@ -868,7 +868,7 @@ public class TestSqlTaskExecution
             }
 
             @Override
-            public ListenableFuture<?> isBlocked()
+            public ListenableFuture<Void> isBlocked()
             {
                 return blocked;
             }
@@ -1001,7 +1001,7 @@ public class TestSqlTaskExecution
             }
 
             @Override
-            public ListenableFuture<?> isBlocked()
+            public ListenableFuture<Void> isBlocked()
             {
                 if (!finishing) {
                     return NOT_BLOCKED;
@@ -1109,6 +1109,7 @@ public class TestSqlTaskExecution
             private final Lifespan lifespan;
 
             private final ListenableFuture<Integer> multiplierFuture;
+            private final ListenableFuture<Void> blockedFutureView;
             private final Queue<Page> pages = new ArrayDeque<>();
             private boolean finishing;
 
@@ -1124,6 +1125,7 @@ public class TestSqlTaskExecution
                             .mapToInt(Page::getPositionCount)
                             .sum();
                 }, directExecutor());
+                blockedFutureView = asVoid(multiplierFuture);
             }
 
             @Override
@@ -1142,9 +1144,9 @@ public class TestSqlTaskExecution
             }
 
             @Override
-            public ListenableFuture<?> isBlocked()
+            public ListenableFuture<Void> isBlocked()
             {
-                return multiplierFuture;
+                return blockedFutureView;
             }
 
             @Override
@@ -1178,6 +1180,11 @@ public class TestSqlTaskExecution
                 return result;
             }
         }
+    }
+
+    private static <T> ListenableFuture<Void> asVoid(ListenableFuture<T> future)
+    {
+        return Futures.transform(future, v -> null, directExecutor());
     }
 
     private static class BuildStates
@@ -1222,7 +1229,7 @@ public class TestSqlTaskExecution
         private static class BuildState
         {
             private final SettableFuture<List<Page>> pagesFuture = SettableFuture.create();
-            private final SettableFuture<?> lookupDoneFuture = SettableFuture.create();
+            private final SettableFuture<Void> lookupDoneFuture = SettableFuture.create();
 
             private final List<Page> pages = new ArrayList<>();
             private int pendingBuildCount;
@@ -1296,7 +1303,7 @@ public class TestSqlTaskExecution
                 }
             }
 
-            public ListenableFuture<?> getLookupDoneFuture()
+            public ListenableFuture<Void> getLookupDoneFuture()
             {
                 return lookupDoneFuture;
             }

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/BufferTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/BufferTestUtils.java
@@ -111,18 +111,18 @@ public final class BufferTestUtils
         buffer.acknowledge(bufferId, sequenceId);
     }
 
-    static ListenableFuture<?> enqueuePage(OutputBuffer buffer, Page page)
+    static ListenableFuture<Void> enqueuePage(OutputBuffer buffer, Page page)
     {
         buffer.enqueue(ImmutableList.of(serializePage(page)));
-        ListenableFuture<?> future = buffer.isFull();
+        ListenableFuture<Void> future = buffer.isFull();
         assertFalse(future.isDone());
         return future;
     }
 
-    static ListenableFuture<?> enqueuePage(OutputBuffer buffer, Page page, int partition)
+    static ListenableFuture<Void> enqueuePage(OutputBuffer buffer, Page page, int partition)
     {
         buffer.enqueue(partition, ImmutableList.of(serializePage(page)));
-        ListenableFuture<?> future = buffer.isFull();
+        ListenableFuture<Void> future = buffer.isFull();
         assertFalse(future.isDone());
         return future;
     }

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestArbitraryOutputBuffer.java
@@ -133,7 +133,7 @@ public class TestArbitraryOutputBuffer
         assertQueueState(buffer, 9, FIRST, 1, 3);
 
         // try to add one more page, which should block
-        ListenableFuture<?> future = enqueuePage(buffer, createPage(13));
+        ListenableFuture<Void> future = enqueuePage(buffer, createPage(13));
         assertFalse(future.isDone());
         assertQueueState(buffer, 10, FIRST, 1, 3);
 
@@ -654,8 +654,8 @@ public class TestArbitraryOutputBuffer
         }
 
         // enqueue the addition two pages more pages
-        ListenableFuture<?> firstEnqueuePage = enqueuePage(buffer, createPage(5));
-        ListenableFuture<?> secondEnqueuePage = enqueuePage(buffer, createPage(6));
+        ListenableFuture<Void> firstEnqueuePage = enqueuePage(buffer, createPage(5));
+        ListenableFuture<Void> secondEnqueuePage = enqueuePage(buffer, createPage(6));
 
         // get and acknowledge one page
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(1), MAX_WAIT), bufferResult(0, createPage(0)));
@@ -736,8 +736,8 @@ public class TestArbitraryOutputBuffer
         }
 
         // add two pages to the buffer queue
-        ListenableFuture<?> firstEnqueuePage = enqueuePage(buffer, createPage(5));
-        ListenableFuture<?> secondEnqueuePage = enqueuePage(buffer, createPage(6));
+        ListenableFuture<Void> firstEnqueuePage = enqueuePage(buffer, createPage(5));
+        ListenableFuture<Void> secondEnqueuePage = enqueuePage(buffer, createPage(6));
 
         // get and acknowledge one page
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(1), MAX_WAIT), bufferResult(0, createPage(0)));
@@ -809,8 +809,8 @@ public class TestArbitraryOutputBuffer
         }
 
         // add two pages to the buffer queue
-        ListenableFuture<?> firstEnqueuePage = enqueuePage(buffer, createPage(5));
-        ListenableFuture<?> secondEnqueuePage = enqueuePage(buffer, createPage(6));
+        ListenableFuture<Void> firstEnqueuePage = enqueuePage(buffer, createPage(5));
+        ListenableFuture<Void> secondEnqueuePage = enqueuePage(buffer, createPage(6));
 
         // get and acknowledge one page
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(1), MAX_WAIT), bufferResult(0, createPage(0)));
@@ -986,10 +986,10 @@ public class TestArbitraryOutputBuffer
         return getFuture(future, maxWait);
     }
 
-    private static ListenableFuture<?> enqueuePage(OutputBuffer buffer, Page page)
+    private static ListenableFuture<Void> enqueuePage(OutputBuffer buffer, Page page)
     {
         buffer.enqueue(ImmutableList.of(serializePage(page)));
-        ListenableFuture<?> future = buffer.isFull();
+        ListenableFuture<Void> future = buffer.isFull();
         assertFalse(future.isDone());
         return future;
     }

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestBroadcastOutputBuffer.java
@@ -139,7 +139,7 @@ public class TestBroadcastOutputBuffer
         assertQueueState(buffer, FIRST, 7, 3);
 
         // try to add one more page, which should block
-        ListenableFuture<?> future = enqueuePage(buffer, createPage(10));
+        ListenableFuture<Void> future = enqueuePage(buffer, createPage(10));
         assertFalse(future.isDone());
         assertQueueState(buffer, FIRST, 8, 3);
 
@@ -325,7 +325,7 @@ public class TestBroadcastOutputBuffer
         assertEquals(notifyCount.get(), 0);
 
         // Add another page to block
-        ListenableFuture<?> future = enqueuePage(buffer, createPage(2));
+        ListenableFuture<Void> future = enqueuePage(buffer, createPage(2));
         assertFalse(future.isDone());
         assertEquals(notifyCount.get(), 1);
 
@@ -361,7 +361,7 @@ public class TestBroadcastOutputBuffer
         assertEquals(notifyCount.get(), 0);
 
         // Add another page to block
-        ListenableFuture<?> future = enqueuePage(buffer, createPage(2));
+        ListenableFuture<Void> future = enqueuePage(buffer, createPage(2));
         assertFalse(future.isDone());
         assertEquals(notifyCount.get(), 0); // stays 0 because no new buffers will be added
 
@@ -585,7 +585,7 @@ public class TestBroadcastOutputBuffer
         assertQueueState(buffer, FIRST, 2, 0);
 
         // third page is blocked
-        ListenableFuture<?> future = enqueuePage(buffer, createPage(3));
+        ListenableFuture<Void> future = enqueuePage(buffer, createPage(3));
 
         // we should be blocked
         assertFalse(future.isDone());
@@ -744,8 +744,8 @@ public class TestBroadcastOutputBuffer
         }
 
         // enqueue the addition two pages more pages
-        ListenableFuture<?> firstEnqueuePage = enqueuePage(buffer, createPage(5));
-        ListenableFuture<?> secondEnqueuePage = enqueuePage(buffer, createPage(6));
+        ListenableFuture<Void> firstEnqueuePage = enqueuePage(buffer, createPage(5));
+        ListenableFuture<Void> secondEnqueuePage = enqueuePage(buffer, createPage(6));
 
         // get and acknowledge one page
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(1), MAX_WAIT), bufferResult(0, createPage(0)));
@@ -824,8 +824,8 @@ public class TestBroadcastOutputBuffer
         }
 
         // add two pages to the buffer queue
-        ListenableFuture<?> firstEnqueuePage = enqueuePage(buffer, createPage(5));
-        ListenableFuture<?> secondEnqueuePage = enqueuePage(buffer, createPage(6));
+        ListenableFuture<Void> firstEnqueuePage = enqueuePage(buffer, createPage(5));
+        ListenableFuture<Void> secondEnqueuePage = enqueuePage(buffer, createPage(6));
 
         // get and acknowledge one page
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(1), MAX_WAIT), bufferResult(0, createPage(0)));
@@ -897,8 +897,8 @@ public class TestBroadcastOutputBuffer
         }
 
         // add two pages to the buffer queue
-        ListenableFuture<?> firstEnqueuePage = enqueuePage(buffer, createPage(5));
-        ListenableFuture<?> secondEnqueuePage = enqueuePage(buffer, createPage(6));
+        ListenableFuture<Void> firstEnqueuePage = enqueuePage(buffer, createPage(5));
+        ListenableFuture<Void> secondEnqueuePage = enqueuePage(buffer, createPage(6));
 
         // get and acknowledge one page
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(1), MAX_WAIT), bufferResult(0, createPage(0)));
@@ -1001,7 +1001,7 @@ public class TestBroadcastOutputBuffer
     @Test
     public void testSharedBufferBlocking()
     {
-        SettableFuture<?> blockedFuture = SettableFuture.create();
+        SettableFuture<Void> blockedFuture = SettableFuture.create();
         MockMemoryReservationHandler reservationHandler = new MockMemoryReservationHandler(blockedFuture);
         AggregatedMemoryContext memoryContext = newRootAggregatedMemoryContext(reservationHandler, 0L);
 
@@ -1031,7 +1031,7 @@ public class TestBroadcastOutputBuffer
     public void testSharedBufferBlocking2()
     {
         // start with a complete future
-        SettableFuture<?> blockedFuture = SettableFuture.create();
+        SettableFuture<Void> blockedFuture = SettableFuture.create();
         blockedFuture.set(null);
         MockMemoryReservationHandler reservationHandler = new MockMemoryReservationHandler(blockedFuture);
         AggregatedMemoryContext memoryContext = newRootAggregatedMemoryContext(reservationHandler, 0L);
@@ -1078,7 +1078,7 @@ public class TestBroadcastOutputBuffer
     @Test
     public void testSharedBufferBlockingNoBlockOnFull()
     {
-        SettableFuture<?> blockedFuture = SettableFuture.create();
+        SettableFuture<Void> blockedFuture = SettableFuture.create();
         MockMemoryReservationHandler reservationHandler = new MockMemoryReservationHandler(blockedFuture);
         AggregatedMemoryContext memoryContext = newRootAggregatedMemoryContext(reservationHandler, 0L);
 
@@ -1110,15 +1110,15 @@ public class TestBroadcastOutputBuffer
     private static class MockMemoryReservationHandler
             implements MemoryReservationHandler
     {
-        private ListenableFuture<?> blockedFuture;
+        private ListenableFuture<Void> blockedFuture;
 
-        public MockMemoryReservationHandler(ListenableFuture<?> blockedFuture)
+        public MockMemoryReservationHandler(ListenableFuture<Void> blockedFuture)
         {
             this.blockedFuture = requireNonNull(blockedFuture, "blockedFuture is null");
         }
 
         @Override
-        public ListenableFuture<?> reserveMemory(String allocationTag, long delta)
+        public ListenableFuture<Void> reserveMemory(String allocationTag, long delta)
         {
             return blockedFuture;
         }
@@ -1129,7 +1129,7 @@ public class TestBroadcastOutputBuffer
             return true;
         }
 
-        public void updateBlockedFuture(ListenableFuture<?> blockedFuture)
+        public void updateBlockedFuture(ListenableFuture<Void> blockedFuture)
         {
             this.blockedFuture = requireNonNull(blockedFuture);
         }

--- a/core/trino-main/src/test/java/io/trino/execution/buffer/TestPartitionedOutputBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/execution/buffer/TestPartitionedOutputBuffer.java
@@ -141,7 +141,7 @@ public class TestPartitionedOutputBuffer
         assertQueueState(buffer, SECOND, 10, 0);
 
         // try to add one more page, which should block
-        ListenableFuture<?> future = enqueuePage(buffer, createPage(13), firstPartition);
+        ListenableFuture<Void> future = enqueuePage(buffer, createPage(13), firstPartition);
         assertFalse(future.isDone());
         assertQueueState(buffer, FIRST, 11, 3);
         assertQueueState(buffer, SECOND, 10, 0);
@@ -397,7 +397,7 @@ public class TestPartitionedOutputBuffer
         assertQueueState(buffer, FIRST, 2, 0);
 
         // third page is blocked
-        ListenableFuture<?> future = enqueuePage(buffer, createPage(3), secondPartition);
+        ListenableFuture<Void> future = enqueuePage(buffer, createPage(3), secondPartition);
 
         // we should be blocked
         assertFalse(future.isDone());
@@ -552,8 +552,8 @@ public class TestPartitionedOutputBuffer
         }
 
         // enqueue the addition two pages more pages
-        ListenableFuture<?> firstEnqueuePage = enqueuePage(buffer, createPage(5));
-        ListenableFuture<?> secondEnqueuePage = enqueuePage(buffer, createPage(6));
+        ListenableFuture<Void> firstEnqueuePage = enqueuePage(buffer, createPage(5));
+        ListenableFuture<Void> secondEnqueuePage = enqueuePage(buffer, createPage(6));
 
         // get and acknowledge one page
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(1), MAX_WAIT), bufferResult(0, createPage(0)));
@@ -632,8 +632,8 @@ public class TestPartitionedOutputBuffer
         }
 
         // add two pages to the buffer queue
-        ListenableFuture<?> firstEnqueuePage = enqueuePage(buffer, createPage(5));
-        ListenableFuture<?> secondEnqueuePage = enqueuePage(buffer, createPage(6));
+        ListenableFuture<Void> firstEnqueuePage = enqueuePage(buffer, createPage(5));
+        ListenableFuture<Void> secondEnqueuePage = enqueuePage(buffer, createPage(6));
 
         // get and acknowledge one page
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(1), MAX_WAIT), bufferResult(0, createPage(0)));
@@ -705,8 +705,8 @@ public class TestPartitionedOutputBuffer
         }
 
         // add two pages to the buffer queue
-        ListenableFuture<?> firstEnqueuePage = enqueuePage(buffer, createPage(5));
-        ListenableFuture<?> secondEnqueuePage = enqueuePage(buffer, createPage(6));
+        ListenableFuture<Void> firstEnqueuePage = enqueuePage(buffer, createPage(5));
+        ListenableFuture<Void> secondEnqueuePage = enqueuePage(buffer, createPage(6));
 
         // get and acknowledge one page
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(1), MAX_WAIT), bufferResult(0, createPage(0)));

--- a/core/trino-main/src/test/java/io/trino/execution/executor/SimulationSplit.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/SimulationSplit.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.units.Duration.succinctNanos;
 import static io.trino.operator.Operator.NOT_BLOCKED;
 import static java.lang.String.format;
@@ -124,7 +124,7 @@ abstract class SimulationSplit
 
     abstract boolean process();
 
-    abstract ListenableFuture<?> getProcessResult();
+    abstract ListenableFuture<Void> getProcessResult();
 
     void setSplitReady()
     {
@@ -132,7 +132,7 @@ abstract class SimulationSplit
     }
 
     @Override
-    public ListenableFuture<?> processFor(Duration duration)
+    public ListenableFuture<Void> processFor(Duration duration)
     {
         calls.incrementAndGet();
 
@@ -154,10 +154,10 @@ abstract class SimulationSplit
                 task.splitComplete(this);
             }
 
-            return immediateFuture(null);
+            return immediateVoidFuture();
         }
 
-        ListenableFuture<?> processResult = getProcessResult();
+        ListenableFuture<Void> processResult = getProcessResult();
         if (processResult.isDone()) {
             setSplitReady();
         }
@@ -198,7 +198,7 @@ abstract class SimulationSplit
         }
 
         @Override
-        public ListenableFuture<?> getProcessResult()
+        public ListenableFuture<Void> getProcessResult()
         {
             return NOT_BLOCKED;
         }
@@ -225,8 +225,8 @@ abstract class SimulationSplit
 
         private final ScheduledExecutorService executorService;
 
-        private SettableFuture<?> future = SettableFuture.create();
-        private final SettableFuture<?> doneFuture = SettableFuture.create();
+        private SettableFuture<Void> future = SettableFuture.create();
+        private final SettableFuture<Void> doneFuture = SettableFuture.create();
 
         public IntermediateSplit(SimulationTask task, long scheduledTimeNanos, long wallTimeNanos, long numQuantas, long perQuantaNanos, long betweenQuantaNanos, ScheduledExecutorService executorService)
         {
@@ -258,7 +258,7 @@ abstract class SimulationSplit
         }
 
         @Override
-        public ListenableFuture<?> getProcessResult()
+        public ListenableFuture<Void> getProcessResult()
         {
             future = SettableFuture.create();
             try {

--- a/core/trino-main/src/test/java/io/trino/memory/TestMemoryPools.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestMemoryPools.java
@@ -15,7 +15,6 @@ package io.trino.memory;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.stats.TestingGcMonitor;
 import io.airlift.units.DataSize;
@@ -49,6 +48,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.testing.TestingSession.testSessionBuilder;
@@ -176,7 +176,7 @@ public class TestMemoryPools
     public void testMemoryFutureCancellation()
     {
         setUpCountStarFromOrdersWithJoin();
-        ListenableFuture<?> future = userPool.reserve(fakeQueryId, "test", TEN_MEGABYTES.toBytes());
+        ListenableFuture<Void> future = userPool.reserve(fakeQueryId, "test", TEN_MEGABYTES.toBytes());
         assertTrue(!future.isDone());
         assertThatThrownBy(() -> future.cancel(true))
                 .isInstanceOf(UnsupportedOperationException.class)
@@ -314,7 +314,7 @@ public class TestMemoryPools
             assertFalse(isOperatorBlocked(drivers, reason));
             boolean progress = false;
             for (Driver driver : drivers) {
-                ListenableFuture<?> blocked = driver.process();
+                ListenableFuture<Void> blocked = driver.process();
                 progress = progress | blocked.isDone();
             }
             // query should not block
@@ -365,9 +365,9 @@ public class TestMemoryPools
         }
 
         @Override
-        public ListenableFuture<?> startMemoryRevoke()
+        public ListenableFuture<Void> startMemoryRevoke()
         {
-            return Futures.immediateFuture(null);
+            return immediateVoidFuture();
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/memory/TestSystemMemoryBlocking.java
+++ b/core/trino-main/src/test/java/io/trino/memory/TestSystemMemoryBlocking.java
@@ -115,7 +115,7 @@ public class TestSystemMemoryBlocking
         Split testSplit = new Split(new CatalogName("test"), new TestSplit(), Lifespan.taskWide());
         driver.updateSource(new TaskSource(sourceId, ImmutableSet.of(new ScheduledSplit(0, sourceId, testSplit)), true));
 
-        ListenableFuture<?> blocked = driver.processFor(new Duration(1, NANOSECONDS));
+        ListenableFuture<Void> blocked = driver.processFor(new Duration(1, NANOSECONDS));
 
         // the driver shouldn't block in the first call as it will be able to move a page between source and the sink operator
         // but the operator should be blocked

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -366,7 +366,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public ListenableFuture<?> refreshMaterializedView(Session session, QualifiedObjectName viewName)
+    public ListenableFuture<Void> refreshMaterializedView(Session session, QualifiedObjectName viewName)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/test/java/io/trino/operator/DummySpillerFactory.java
+++ b/core/trino-main/src/test/java/io/trino/operator/DummySpillerFactory.java
@@ -26,7 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 
 public class DummySpillerFactory
         implements SpillerFactory
@@ -41,11 +41,11 @@ public class DummySpillerFactory
             private final List<Iterable<Page>> spills = new ArrayList<>();
 
             @Override
-            public ListenableFuture<?> spill(Iterator<Page> pageIterator)
+            public ListenableFuture<Void> spill(Iterator<Page> pageIterator)
             {
                 spillsCount++;
                 spills.add(ImmutableList.copyOf(pageIterator));
-                return immediateFuture(null);
+                return immediateVoidFuture();
             }
 
             @Override

--- a/core/trino-main/src/test/java/io/trino/operator/OperatorAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/operator/OperatorAssertion.java
@@ -139,7 +139,7 @@ public final class OperatorAssertion
 
     private static boolean handledBlocked(Operator operator)
     {
-        ListenableFuture<?> isBlocked = operator.isBlocked();
+        ListenableFuture<Void> isBlocked = operator.isBlocked();
         if (!isBlocked.isDone()) {
             tryGetFutureValue(isBlocked, 1, TimeUnit.MILLISECONDS);
             return true;

--- a/core/trino-main/src/test/java/io/trino/operator/TestDriver.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDriver.java
@@ -106,7 +106,7 @@ public class TestDriver
         assertSame(driver.getDriverContext(), driverContext);
 
         assertFalse(driver.isFinished());
-        ListenableFuture<?> blocked = driver.processFor(new Duration(1, TimeUnit.SECONDS));
+        ListenableFuture<Void> blocked = driver.processFor(new Duration(1, TimeUnit.SECONDS));
         assertTrue(blocked.isDone());
         assertTrue(driver.isFinished());
 
@@ -386,7 +386,7 @@ public class TestDriver
         }
 
         @Override
-        public ListenableFuture<?> isBlocked()
+        public ListenableFuture<Void> isBlocked()
         {
             waitForUnlock();
             return NOT_BLOCKED;
@@ -435,7 +435,7 @@ public class TestDriver
         }
 
         @Override
-        public ListenableFuture<?> isBlocked()
+        public ListenableFuture<Void> isBlocked()
         {
             // this operator is always blocked and when queried by the driver
             // it triggers memory revocation so that the driver gets unblocked
@@ -460,7 +460,7 @@ public class TestDriver
         }
 
         @Override
-        public ListenableFuture<?> isBlocked()
+        public ListenableFuture<Void> isBlocked()
         {
             return NOT_BLOCKED;
         }

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
@@ -774,7 +774,7 @@ public class TestHashAggregationOperator
             return new Spiller()
             {
                 @Override
-                public ListenableFuture<?> spill(Iterator<Page> pageIterator)
+                public ListenableFuture<Void> spill(Iterator<Page> pageIterator)
                 {
                     return immediateFailedFuture(new IOException("Failed to spill"));
                 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestOperatorAssertion.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestOperatorAssertion.java
@@ -14,8 +14,8 @@
 package io.trino.operator;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.Duration;
 import io.trino.spi.Page;
 import io.trino.testing.assertions.Assert;
@@ -61,7 +61,7 @@ public class TestOperatorAssertion
         private final Duration unblockAfter;
         private final OperatorContext operatorContext;
 
-        private ListenableFuture<?> isBlocked = NOT_BLOCKED;
+        private ListenableFuture<Void> isBlocked = NOT_BLOCKED;
 
         public BlockedOperator(Duration unblockAfter)
         {
@@ -76,7 +76,7 @@ public class TestOperatorAssertion
         }
 
         @Override
-        public ListenableFuture<?> isBlocked()
+        public ListenableFuture<Void> isBlocked()
         {
             return isBlocked;
         }
@@ -97,9 +97,7 @@ public class TestOperatorAssertion
         public void finish()
         {
             if (this.isBlocked == NOT_BLOCKED) {
-                SettableFuture<?> isBlocked = SettableFuture.create();
-                this.isBlocked = isBlocked;
-                executor.schedule(() -> isBlocked.set(null), unblockAfter.toMillis(), MILLISECONDS);
+                this.isBlocked = Futures.scheduleAsync(Futures::immediateVoidFuture, unblockAfter.toMillis(), MILLISECONDS, executor);
             }
         }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessor.java
@@ -94,7 +94,7 @@ public class TestWorkProcessor
                 ProcessState.ofResult(5),
                 ProcessState.finished());
 
-        SettableFuture<?> secondFuture = SettableFuture.create();
+        SettableFuture<Void> secondFuture = SettableFuture.create();
         List<ProcessState<Integer>> secondStream = ImmutableList.of(
                 ProcessState.ofResult(2),
                 ProcessState.ofResult(4),
@@ -136,13 +136,13 @@ public class TestWorkProcessor
     @Test(timeOut = 10_000)
     public void testMergeSortedEmptyStreams()
     {
-        SettableFuture<?> firstFuture = SettableFuture.create();
+        SettableFuture<Void> firstFuture = SettableFuture.create();
         List<ProcessState<Integer>> firstStream = ImmutableList.of(
                 ProcessState.blocked(firstFuture),
                 ProcessState.yield(),
                 ProcessState.finished());
 
-        SettableFuture<?> secondFuture = SettableFuture.create();
+        SettableFuture<Void> secondFuture = SettableFuture.create();
         List<ProcessState<Integer>> secondStream = ImmutableList.of(
                 ProcessState.blocked(secondFuture),
                 ProcessState.finished());
@@ -196,7 +196,7 @@ public class TestWorkProcessor
     @Test(timeOut = 10_000)
     public void testYield()
     {
-        SettableFuture<?> future = SettableFuture.create();
+        SettableFuture<Void> future = SettableFuture.create();
 
         List<ProcessState<Integer>> baseScenario = ImmutableList.of(
                 ProcessState.ofResult(1),
@@ -236,7 +236,7 @@ public class TestWorkProcessor
     @Test(timeOut = 10_000)
     public void testProcessStateMonitor()
     {
-        SettableFuture<?> future = SettableFuture.create();
+        SettableFuture<Void> future = SettableFuture.create();
 
         List<ProcessState<Integer>> baseScenario = ImmutableList.of(
                 ProcessState.ofResult(1),
@@ -262,7 +262,7 @@ public class TestWorkProcessor
     public void testFinished()
     {
         AtomicBoolean finished = new AtomicBoolean();
-        SettableFuture<?> future = SettableFuture.create();
+        SettableFuture<Void> future = SettableFuture.create();
 
         List<ProcessState<Integer>> scenario = ImmutableList.of(
                 ProcessState.ofResult(1),
@@ -321,7 +321,7 @@ public class TestWorkProcessor
     @Test(timeOut = 10_000)
     public void testFlatTransform()
     {
-        SettableFuture<?> baseFuture = SettableFuture.create();
+        SettableFuture<Void> baseFuture = SettableFuture.create();
         List<ProcessState<Double>> baseScenario = ImmutableList.of(
                 ProcessState.ofResult(1.0),
                 ProcessState.blocked(baseFuture),
@@ -331,7 +331,7 @@ public class TestWorkProcessor
                 ProcessState.ofResult(4.0),
                 ProcessState.finished());
 
-        SettableFuture<?> mappedFuture1 = SettableFuture.create();
+        SettableFuture<Void> mappedFuture1 = SettableFuture.create();
         List<ProcessState<Integer>> mappedScenario1 = ImmutableList.of(
                 ProcessState.ofResult(1),
                 ProcessState.yield(),
@@ -341,7 +341,7 @@ public class TestWorkProcessor
 
         List<ProcessState<Integer>> mappedScenario2 = ImmutableList.of(ProcessState.finished());
 
-        SettableFuture<?> mappedFuture3 = SettableFuture.create();
+        SettableFuture<Void> mappedFuture3 = SettableFuture.create();
         List<ProcessState<Integer>> mappedScenario3 = ImmutableList.of(
                 ProcessState.blocked(mappedFuture3),
                 ProcessState.finished());
@@ -350,7 +350,7 @@ public class TestWorkProcessor
                 ProcessState.ofResult(3),
                 ProcessState.finished());
 
-        SettableFuture<?> transformationFuture = SettableFuture.create();
+        SettableFuture<Void> transformationFuture = SettableFuture.create();
         List<Transform<Double, WorkProcessor<Integer>>> transformationScenario = ImmutableList.of(
                 Transform.of(Optional.of(1.0), TransformationState.ofResult(processorFrom(mappedScenario1), false)),
                 Transform.of(Optional.of(1.0), TransformationState.ofResult(processorFrom(mappedScenario2), false)),
@@ -408,7 +408,7 @@ public class TestWorkProcessor
     @Test(timeOut = 10_000)
     public void testTransform()
     {
-        SettableFuture<?> baseFuture = SettableFuture.create();
+        SettableFuture<Void> baseFuture = SettableFuture.create();
         List<ProcessState<Integer>> baseScenario = ImmutableList.of(
                 ProcessState.ofResult(1),
                 ProcessState.yield(),
@@ -417,7 +417,7 @@ public class TestWorkProcessor
                 ProcessState.ofResult(3),
                 ProcessState.finished());
 
-        SettableFuture<?> transformationFuture = SettableFuture.create();
+        SettableFuture<Void> transformationFuture = SettableFuture.create();
         List<Transform<Integer, String>> transformationScenario = ImmutableList.of(
                 Transform.of(Optional.of(1), TransformationState.needsMoreData()),
                 Transform.of(Optional.of(2), TransformationState.ofResult("foo")),
@@ -472,7 +472,7 @@ public class TestWorkProcessor
     @Test(timeOut = 10_000)
     public void testCreateFrom()
     {
-        SettableFuture<?> future = SettableFuture.create();
+        SettableFuture<Void> future = SettableFuture.create();
         List<ProcessState<Integer>> scenario = ImmutableList.of(
                 ProcessState.yield(),
                 ProcessState.ofResult(1),

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -82,7 +82,7 @@ public class TestWorkProcessorPipelineSourceOperator
                 Transform.of(Optional.of(split), TransformationState.ofResult(page1, false)),
                 Transform.of(Optional.of(split), TransformationState.ofResult(page2, true))));
 
-        SettableFuture<?> firstBlockedFuture = SettableFuture.create();
+        SettableFuture<Void> firstBlockedFuture = SettableFuture.create();
         Transformation<Page, Page> firstOperatorPages = transformationFrom(ImmutableList.of(
                 Transform.of(Optional.of(page1), TransformationState.blocked(firstBlockedFuture)),
                 Transform.of(Optional.of(page1), TransformationState.ofResult(page3, true)),
@@ -90,7 +90,7 @@ public class TestWorkProcessorPipelineSourceOperator
                 Transform.of(Optional.of(page2), TransformationState.finished())),
                 (left, right) -> left.getPositionCount() == right.getPositionCount());
 
-        SettableFuture<?> secondBlockedFuture = SettableFuture.create();
+        SettableFuture<Void> secondBlockedFuture = SettableFuture.create();
         Transformation<Page, Page> secondOperatorPages = transformationFrom(ImmutableList.of(
                 Transform.of(Optional.of(page3), TransformationState.ofResult(page5, true)),
                 Transform.of(Optional.of(page4), TransformationState.needsMoreData()),

--- a/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
+++ b/core/trino-main/src/test/java/io/trino/operator/exchange/TestLocalExchange.java
@@ -134,7 +134,7 @@ public class TestLocalExchange
             assertSource(source, 0);
 
             // add the first page which should cause the reader to unblock
-            ListenableFuture<?> readFuture = source.waitForReading();
+            ListenableFuture<Void> readFuture = source.waitForReading();
             assertFalse(readFuture.isDone());
             sink.addPage(createPage(0));
             assertTrue(readFuture.isDone());
@@ -630,8 +630,8 @@ public class TestLocalExchange
             assertSource(sourceB, 0);
 
             sinkA.addPage(createPage(0));
-            ListenableFuture<?> sinkAFuture = assertSinkWriteBlocked(sinkA);
-            ListenableFuture<?> sinkBFuture = assertSinkWriteBlocked(sinkB);
+            ListenableFuture<Void> sinkAFuture = assertSinkWriteBlocked(sinkA);
+            ListenableFuture<Void> sinkBFuture = assertSinkWriteBlocked(sinkB);
 
             assertSource(sourceA, 1);
             assertSource(sourceB, 1);
@@ -779,10 +779,10 @@ public class TestLocalExchange
         assertTrue(sink.waitForWriting().isDone());
     }
 
-    private static ListenableFuture<?> assertSinkWriteBlocked(LocalExchangeSink sink)
+    private static ListenableFuture<Void> assertSinkWriteBlocked(LocalExchangeSink sink)
     {
         assertFalse(sink.isFinished());
-        ListenableFuture<?> writeFuture = sink.waitForWriting();
+        ListenableFuture<Void> writeFuture = sink.waitForWriting();
         assertFalse(writeFuture.isDone());
         return writeFuture;
     }

--- a/core/trino-main/src/test/java/io/trino/operator/join/JoinTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/JoinTestUtils.java
@@ -62,6 +62,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterators.unmodifiableIterator;
 import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -336,14 +337,14 @@ public final class JoinTestUtils
                 private final List<Page> spills = new ArrayList<>();
 
                 @Override
-                public ListenableFuture<?> spill(Iterator<Page> pageIterator)
+                public ListenableFuture<Void> spill(Iterator<Page> pageIterator)
                 {
                     checkState(writing, "writing already finished");
                     if (failSpill) {
                         return immediateFailedFuture(new TrinoException(GENERIC_INTERNAL_ERROR, "Spill failed"));
                     }
                     Iterators.addAll(spills, pageIterator);
-                    return immediateFuture(null);
+                    return immediateVoidFuture();
                 }
 
                 @Override

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestExpressionCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestExpressionCompiler.java
@@ -164,7 +164,7 @@ public class TestExpressionCompiler
     private long start;
     private ListeningExecutorService executor;
     private FunctionAssertions functionAssertions;
-    private List<ListenableFuture<?>> futures;
+    private List<ListenableFuture<Void>> futures;
 
     @BeforeClass
     public void setupClass()
@@ -1930,7 +1930,7 @@ public class TestExpressionCompiler
     private void addCallable(Runnable runnable)
     {
         if (PARALLEL) {
-            futures.add(executor.submit(runnable));
+            futures.add(Futures.submit(runnable, executor));
         }
         else {
             runnable.run();

--- a/core/trino-main/src/test/java/io/trino/transaction/TestingTransactionManager.java
+++ b/core/trino-main/src/test/java/io/trino/transaction/TestingTransactionManager.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 
 public class TestingTransactionManager
         implements TransactionManager
@@ -137,17 +137,17 @@ public class TestingTransactionManager
     }
 
     @Override
-    public ListenableFuture<?> asyncCommit(TransactionId transactionId)
+    public ListenableFuture<Void> asyncCommit(TransactionId transactionId)
     {
         checkState(transactions.remove(transactionId) != null, "Transaction is already finished");
-        return immediateFuture(new Object());
+        return immediateVoidFuture();
     }
 
     @Override
-    public ListenableFuture<?> asyncAbort(TransactionId transactionId)
+    public ListenableFuture<Void> asyncAbort(TransactionId transactionId)
     {
         checkState(transactions.remove(transactionId) != null, "Transaction is already finished");
-        return immediateFuture(new Object());
+        return immediateVoidFuture();
     }
 
     @Override

--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/AbstractAggregatedMemoryContext.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/AbstractAggregatedMemoryContext.java
@@ -13,7 +13,6 @@
  */
 package io.trino.memory.context;
 
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import javax.annotation.Nullable;
@@ -21,13 +20,14 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static java.lang.String.format;
 
 @ThreadSafe
 abstract class AbstractAggregatedMemoryContext
         implements AggregatedMemoryContext
 {
-    static final ListenableFuture<?> NOT_BLOCKED = Futures.immediateFuture(null);
+    static final ListenableFuture<Void> NOT_BLOCKED = immediateVoidFuture();
 
     // When an aggregated memory context is closed, it force-frees the memory allocated by its
     // children local memory contexts. Since the memory pool API enforces a tag to be used for
@@ -87,7 +87,7 @@ abstract class AbstractAggregatedMemoryContext
         usedBytes = addExact(usedBytes, bytes);
     }
 
-    abstract ListenableFuture<?> updateBytes(String allocationTag, long bytes);
+    abstract ListenableFuture<Void> updateBytes(String allocationTag, long bytes);
 
     abstract boolean tryUpdateBytes(String allocationTag, long delta);
 

--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/ChildAggregatedMemoryContext.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/ChildAggregatedMemoryContext.java
@@ -31,11 +31,11 @@ class ChildAggregatedMemoryContext
     }
 
     @Override
-    synchronized ListenableFuture<?> updateBytes(String allocationTag, long bytes)
+    synchronized ListenableFuture<Void> updateBytes(String allocationTag, long bytes)
     {
         checkState(!isClosed(), "ChildAggregatedMemoryContext is already closed");
         // update the parent before updating usedBytes as it may throw a runtime exception (e.g., ExceededMemoryLimitException)
-        ListenableFuture<?> future = parentMemoryContext.updateBytes(allocationTag, bytes);
+        ListenableFuture<Void> future = parentMemoryContext.updateBytes(allocationTag, bytes);
         addBytes(bytes);
         return future;
     }

--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/LocalMemoryContext.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/LocalMemoryContext.java
@@ -28,7 +28,7 @@ public interface LocalMemoryContext
      * on memory, and callers blocked on this future will proceed to allocating more memory from the exhausted
      * pools, which will violate the protocol of Trino MemoryPool implementation.
      */
-    ListenableFuture<?> setBytes(long bytes);
+    ListenableFuture<Void> setBytes(long bytes);
 
     /**
      * This method can return false when there is not enough memory available to satisfy a positive delta allocation

--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/MemoryReservationHandler.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/MemoryReservationHandler.java
@@ -20,7 +20,7 @@ public interface MemoryReservationHandler
     /**
      * @return a future that signals the caller to block before reserving more memory.
      */
-    ListenableFuture<?> reserveMemory(String allocationTag, long delta);
+    ListenableFuture<Void> reserveMemory(String allocationTag, long delta);
 
     /**
      * Try reserving the given number of bytes.

--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/RootAggregatedMemoryContext.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/RootAggregatedMemoryContext.java
@@ -31,10 +31,10 @@ class RootAggregatedMemoryContext
     }
 
     @Override
-    synchronized ListenableFuture<?> updateBytes(String allocationTag, long bytes)
+    synchronized ListenableFuture<Void> updateBytes(String allocationTag, long bytes)
     {
         checkState(!isClosed(), "RootAggregatedMemoryContext is already closed");
-        ListenableFuture<?> future = reservationHandler.reserveMemory(allocationTag, bytes);
+        ListenableFuture<Void> future = reservationHandler.reserveMemory(allocationTag, bytes);
         addBytes(bytes);
         // make sure we never block queries below guaranteedMemory
         if (getBytes() < guaranteedMemory) {

--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/SimpleAggregatedMemoryContext.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/SimpleAggregatedMemoryContext.java
@@ -24,7 +24,7 @@ class SimpleAggregatedMemoryContext
         extends AbstractAggregatedMemoryContext
 {
     @Override
-    synchronized ListenableFuture<?> updateBytes(String allocationTag, long bytes)
+    synchronized ListenableFuture<Void> updateBytes(String allocationTag, long bytes)
     {
         checkState(!isClosed(), "SimpleAggregatedMemoryContext is already closed");
         addBytes(bytes);

--- a/lib/trino-memory-context/src/main/java/io/trino/memory/context/SimpleLocalMemoryContext.java
+++ b/lib/trino-memory-context/src/main/java/io/trino/memory/context/SimpleLocalMemoryContext.java
@@ -13,7 +13,6 @@
  */
 package io.trino.memory.context;
 
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import javax.annotation.concurrent.GuardedBy;
@@ -23,13 +22,14 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
 public final class SimpleLocalMemoryContext
         implements LocalMemoryContext
 {
-    private static final ListenableFuture<?> NOT_BLOCKED = Futures.immediateFuture(null);
+    private static final ListenableFuture<Void> NOT_BLOCKED = immediateVoidFuture();
 
     private final AbstractAggregatedMemoryContext parentMemoryContext;
     private final String allocationTag;
@@ -53,7 +53,7 @@ public final class SimpleLocalMemoryContext
     }
 
     @Override
-    public synchronized ListenableFuture<?> setBytes(long bytes)
+    public synchronized ListenableFuture<Void> setBytes(long bytes)
     {
         checkState(!closed, "SimpleLocalMemoryContext is already closed");
         checkArgument(bytes >= 0, "bytes cannot be negative");
@@ -63,7 +63,7 @@ public final class SimpleLocalMemoryContext
         }
 
         // update the parent first as it may throw a runtime exception (e.g., ExceededMemoryLimitException)
-        ListenableFuture<?> future = parentMemoryContext.updateBytes(allocationTag, bytes - usedBytes);
+        ListenableFuture<Void> future = parentMemoryContext.updateBytes(allocationTag, bytes - usedBytes);
         usedBytes = bytes;
         return future;
     }

--- a/lib/trino-memory-context/src/test/java/io/trino/memory/context/TestMemoryContexts.java
+++ b/lib/trino-memory-context/src/test/java/io/trino/memory/context/TestMemoryContexts.java
@@ -13,12 +13,12 @@
  */
 package io.trino.memory.context;
 
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.memory.context.AggregatedMemoryContext.newRootAggregatedMemoryContext;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -29,7 +29,7 @@ import static org.testng.Assert.assertTrue;
 
 public class TestMemoryContexts
 {
-    private static final ListenableFuture<?> NOT_BLOCKED = Futures.immediateFuture(null);
+    private static final ListenableFuture<Void> NOT_BLOCKED = immediateVoidFuture();
     private static final long GUARANTEED_MEMORY = DataSize.of(1, MEGABYTE).toBytes();
 
     @Test
@@ -169,7 +169,7 @@ public class TestMemoryContexts
     {
         private long reservation;
         private final long maxMemory;
-        private SettableFuture<?> future;
+        private SettableFuture<Void> future;
 
         public TestMemoryReservationHandler(long maxMemory)
         {
@@ -182,7 +182,7 @@ public class TestMemoryContexts
         }
 
         @Override
-        public ListenableFuture<?> reserveMemory(String allocationTag, long delta)
+        public ListenableFuture<Void> reserveMemory(String allocationTag, long delta)
         {
             reservation += delta;
             if (delta >= 0) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/ResumableTask.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/ResumableTask.java
@@ -13,8 +13,9 @@
  */
 package io.trino.plugin.hive.util;
 
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 
 public interface ResumableTask
 {
@@ -29,9 +30,9 @@ public interface ResumableTask
     class TaskStatus
     {
         private final boolean finished;
-        private final ListenableFuture<?> continuationFuture;
+        private final ListenableFuture<Void> continuationFuture;
 
-        private TaskStatus(boolean finished, ListenableFuture<?> continuationFuture)
+        private TaskStatus(boolean finished, ListenableFuture<Void> continuationFuture)
         {
             this.finished = finished;
             this.continuationFuture = continuationFuture;
@@ -39,10 +40,10 @@ public interface ResumableTask
 
         public static TaskStatus finished()
         {
-            return new TaskStatus(true, Futures.immediateFuture(null));
+            return new TaskStatus(true, immediateVoidFuture());
         }
 
-        public static TaskStatus continueOn(ListenableFuture<?> continuationFuture)
+        public static TaskStatus continueOn(ListenableFuture<Void> continuationFuture)
         {
             return new TaskStatus(false, continuationFuture);
         }
@@ -52,7 +53,7 @@ public interface ResumableTask
             return finished;
         }
 
-        public ListenableFuture<?> getContinuationFuture()
+        public ListenableFuture<Void> getContinuationFuture()
         {
             return continuationFuture;
         }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/ThrottledAsyncQueue.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/ThrottledAsyncQueue.java
@@ -24,7 +24,7 @@ import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 
 /**
  * An asynchronous queue that limits the rate at which batches will be
@@ -53,7 +53,7 @@ public class ThrottledAsyncQueue<T>
     {
         checkArgument(maxSize >= 0, "maxSize must be at least 0");
 
-        ListenableFuture<?> throttleFuture = immediateFuture(null);
+        ListenableFuture<Void> throttleFuture = immediateVoidFuture();
         if (size() > 0) {
             // the queue is not empty, try to return a batch immediately if we are not throttled
             int size = maxBatchSize(maxSize);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestAsyncQueue.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestAsyncQueue.java
@@ -23,6 +23,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -78,7 +79,7 @@ public class TestAsyncQueue
 
         assertFalse(queue.offer("4").isDone());
         assertFalse(queue.offer("5").isDone());
-        ListenableFuture<?> offerFuture = queue.offer("6");
+        ListenableFuture<Void> offerFuture = queue.offer("6");
         assertFalse(offerFuture.isDone());
 
         assertEquals(queue.getBatchAsync(2).get(), ImmutableList.of("1", "2"));
@@ -108,7 +109,7 @@ public class TestAsyncQueue
         assertTrue(queue.offer("3").isDone());
         assertEquals(queue.getBatchAsync(2).get(), ImmutableList.of("1", "2"));
         assertEquals(queue.getBatchAsync(2).get(), ImmutableList.of("3"));
-        ListenableFuture<?> batchFuture = queue.getBatchAsync(2);
+        ListenableFuture<List<String>> batchFuture = queue.getBatchAsync(2);
         assertFalse(batchFuture.isDone());
 
         assertTrue(queue.offer("4").isDone());
@@ -211,7 +212,7 @@ public class TestAsyncQueue
         queue.offer(4);
         queue.offer(5);
 
-        ListenableFuture<?> future1 = queue.offer(6);
+        ListenableFuture<Void> future1 = queue.offer(6);
         assertFalse(future1.isDone());
 
         Runnable runnable = () -> {
@@ -224,7 +225,7 @@ public class TestAsyncQueue
                 .isInstanceOf(ExecutionException.class)
                 .hasMessageContaining("test fail");
 
-        ListenableFuture<?> future2 = queue.offer(7);
+        ListenableFuture<Void> future2 = queue.offer(7);
         assertFalse(future1.isDone());
         assertFalse(future2.isDone());
         queue.finish();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestThrottledAsyncQueue.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/util/TestThrottledAsyncQueue.java
@@ -130,7 +130,7 @@ public class TestThrottledAsyncQueue
         queue.offer(4);
         queue.offer(5);
 
-        ListenableFuture<?> future1 = queue.offer(6);
+        ListenableFuture<Void> future1 = queue.offer(6);
         assertFalse(future1.isDone());
 
         Runnable runnable = () -> {
@@ -143,7 +143,7 @@ public class TestThrottledAsyncQueue
                 .isInstanceOf(ExecutionException.class)
                 .hasMessageContaining("test fail");
 
-        ListenableFuture<?> future2 = queue.offer(7);
+        ListenableFuture<Void> future2 = queue.offer(7);
         assertFalse(future1.isDone());
         assertFalse(future2.isDone());
         queue.finish();
@@ -190,7 +190,7 @@ public class TestThrottledAsyncQueue
 
         assertFalse(queue.offer("4").isDone());
         assertFalse(queue.offer("5").isDone());
-        ListenableFuture<?> offerFuture = queue.offer("6");
+        ListenableFuture<Void> offerFuture = queue.offer("6");
         assertFalse(offerFuture.isDone());
 
         assertEquals(queue.getBatchAsync(2).get(), ImmutableList.of("1", "2"));
@@ -220,7 +220,7 @@ public class TestThrottledAsyncQueue
         assertTrue(queue.offer("3").isDone());
         assertEquals(queue.getBatchAsync(2).get(), ImmutableList.of("1", "2"));
         assertEquals(queue.getBatchAsync(2).get(), ImmutableList.of("3"));
-        ListenableFuture<?> batchFuture = queue.getBatchAsync(2);
+        ListenableFuture<List<String>> batchFuture = queue.getBatchAsync(2);
         assertFalse(batchFuture.isDone());
 
         assertTrue(queue.offer("4").isDone());

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/backup/BackupManager.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/backup/BackupManager.java
@@ -75,7 +75,7 @@ public class BackupManager
         executorService.shutdownNow();
     }
 
-    public CompletableFuture<?> submit(UUID uuid, File source)
+    public CompletableFuture<Void> submit(UUID uuid, File source)
     {
         requireNonNull(uuid, "uuid is null");
         requireNonNull(source, "source is null");
@@ -86,7 +86,7 @@ public class BackupManager
 
         // TODO: decrement when the running task is finished (not immediately on cancel)
         pendingBackups.incrementAndGet();
-        CompletableFuture<?> future = runAsync(new BackgroundBackup(uuid, source), executorService);
+        CompletableFuture<Void> future = runAsync(new BackgroundBackup(uuid, source), executorService);
         future.whenComplete((none, throwable) -> pendingBackups.decrementAndGet());
         return future;
     }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/RaptorStorageManager.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/RaptorStorageManager.java
@@ -358,7 +358,7 @@ public class RaptorStorageManager
 
         if (!file.exists() && backupStore.isPresent()) {
             try {
-                Future<?> future = recoveryManager.recoverShard(shardUuid);
+                Future<Void> future = recoveryManager.recoverShard(shardUuid);
                 future.get(recoveryTimeout.toMillis(), TimeUnit.MILLISECONDS);
             }
             catch (InterruptedException e) {

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/util/PrioritizedFifoExecutor.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/util/PrioritizedFifoExecutor.java
@@ -60,7 +60,7 @@ public class PrioritizedFifoExecutor<T extends Runnable>
         this.queue = new PriorityBlockingQueue<>(maxThreads);
     }
 
-    public ListenableFuture<?> submit(T task)
+    public ListenableFuture<Void> submit(T task)
     {
         FifoRunnableTask<T> fifoTask = new FifoRunnableTask<>(task, sequenceNumber.incrementAndGet(), taskComparator);
         queue.add(fifoTask);

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestGracefulShutdown.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestGracefulShutdown.java
@@ -73,9 +73,13 @@ public class TestGracefulShutdown
                 .build();
 
         try (DistributedQueryRunner queryRunner = createQueryRunner(TINY_SESSION, properties)) {
-            List<ListenableFuture<?>> queryFutures = new ArrayList<>();
+            List<ListenableFuture<Void>> queryFutures = new ArrayList<>();
             for (int i = 0; i < 5; i++) {
-                queryFutures.add(executor.submit(() -> queryRunner.execute("SELECT COUNT(*), clerk FROM orders GROUP BY clerk")));
+                queryFutures.add(Futures.submit(
+                        () -> {
+                            queryRunner.execute("SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
+                        },
+                        executor));
             }
 
             TestingTrinoServer worker = queryRunner.getServers()


### PR DESCRIPTION
Using ListenableFuture<Void> has a number of type inference advantages compared to using ListenableFuture<?> when used purely for signaling, and there are no downsides.