### PR TITLE
Port 'geometry_nearest_points' UDF

### DIFF
--- a/docs/src/main/sphinx/functions/geospatial.rst
+++ b/docs/src/main/sphinx/functions/geospatial.rst
@@ -159,6 +159,15 @@ Relationship tests
 Operations
 ----------
 
+.. function:: geometry_nearest_points(Geometry, Geometry) -> row(Point, Point)
+
+    Returns the points on each geometry nearest the other.  If either geometry
+    is empty, return ``NULL``.  Otherwise, return a row of two Points that have
+    the minimum distance of any two points on the geometries.  The first Point
+    will be from the first Geometry argument, the second from the second Geometry
+    argument.  If there are multiple pairs with the minimum distance, one pair
+    is chosen arbitrarily.
+
 .. function:: geometry_union(array(Geometry)) -> Geometry
 
     Returns a geometry that represents the point set union of the input geometries. Performance

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
@@ -22,6 +22,7 @@ import io.trino.operator.scalar.AbstractTestFunctions;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.RowType;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -767,6 +768,43 @@ public class TestGeoFunctions
         assertFunction("ST_Distance(ST_GeometryFromText('MULTILINESTRING EMPTY'), ST_GeometryFromText('LINESTRING (10 20, 20 50)'))", DOUBLE, null);
         assertFunction("ST_Distance(ST_GeometryFromText('POLYGON ((1 1, 1 3, 3 3, 3 1))'), ST_GeometryFromText('POLYGON EMPTY'))", DOUBLE, null);
         assertFunction("ST_Distance(ST_GeometryFromText('MULTIPOLYGON EMPTY'), ST_GeometryFromText('POLYGON ((10 100, 30 10))'))", DOUBLE, null);
+    }
+
+    @Test
+    public void testGeometryNearestPoints()
+    {
+        assertNearestPoints("POINT (50 100)", "POINT (150 150)", "POINT (50 100)", "POINT (150 150)");
+        assertNearestPoints("MULTIPOINT (50 100, 50 200)", "POINT (50 100)", "POINT (50 100)", "POINT (50 100)");
+        assertNearestPoints("LINESTRING (50 100, 50 200)", "LINESTRING (10 10, 20 20)", "POINT (50 100)", "POINT (20 20)");
+        assertNearestPoints("MULTILINESTRING ((1 1, 5 1), (2 4, 4 4))", "LINESTRING (10 20, 20 50)", "POINT (4 4)", "POINT (10 20)");
+        assertNearestPoints("POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))", "POLYGON ((4 4, 4 5, 5 5, 5 4, 4 4))", "POINT (3 3)", "POINT (4 4)");
+        assertNearestPoints("MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1, 1 1)), ((0 0, 0 2, 2 2, 2 0, 0 0)))", "POLYGON ((10 100, 30 10, 30 100, 10 100))", "POINT (3 3)", "POINT (30 10)");
+        assertNearestPoints("GEOMETRYCOLLECTION (POINT (0 0), LINESTRING (0 20, 20 0))", "POLYGON ((5 5, 5 6, 6 6, 6 5, 5 5))", "POINT (10 10)", "POINT (6 6)");
+
+        assertNoNearestPoints("POINT EMPTY", "POINT (150 150)");
+        assertNoNearestPoints("POINT (50 100)", "POINT EMPTY");
+        assertNoNearestPoints("POINT EMPTY", "POINT EMPTY");
+        assertNoNearestPoints("MULTIPOINT EMPTY", "POINT (50 100)");
+        assertNoNearestPoints("LINESTRING (50 100, 50 200)", "LINESTRING EMPTY");
+        assertNoNearestPoints("MULTILINESTRING EMPTY", "LINESTRING (10 20, 20 50)");
+        assertNoNearestPoints("POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))", "POLYGON EMPTY");
+        assertNoNearestPoints("MULTIPOLYGON EMPTY", "POLYGON ((10 100, 30 10, 30 100, 10 100))");
+    }
+
+    private void assertNearestPoints(String leftInputWkt, String rightInputWkt, String leftPointWkt, String rightPointWkt)
+    {
+        assertFunction(
+                format("geometry_nearest_points(ST_GeometryFromText('%s'), ST_GeometryFromText('%s'))", leftInputWkt, rightInputWkt),
+                RowType.anonymous(ImmutableList.of(GEOMETRY, GEOMETRY)),
+                ImmutableList.of(leftPointWkt, rightPointWkt));
+    }
+
+    private void assertNoNearestPoints(String leftInputWkt, String rightInputWkt)
+    {
+        assertFunction(
+                format("geometry_nearest_points(ST_GeometryFromText('%s'), ST_GeometryFromText('%s'))", leftInputWkt, rightInputWkt),
+                RowType.anonymous(ImmutableList.of(GEOMETRY, GEOMETRY)),
+                null);
     }
 
     @Test


### PR DESCRIPTION
The port of the 'geometry_nearest_points' UDF from PrestoDB

The 'geometry_nearest_points' function returns the points on each geometry nearest the other.  If either geometry is empty, return ``NULL``.  Otherwise, return an array of two Points that have the minimum distance of any two points on the geometries.  The first Point will be from the first Geometry argument, the second from the second Geometry argument.  If there are multiple pairs with the minimum distance, one pair is chosen arbitrarily.

Extracted-From:[ https://github.com/prestodb/presto/pull/14923]( https://github.com/prestodb/presto/pull/14923)