### PR TITLE
Externalised destination table cache expiry duration for BigQuery Connector

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.bigquery;
 
+import com.google.cloud.BaseServiceException;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Dataset;
@@ -31,6 +32,7 @@ import com.google.cloud.http.BaseHttpServiceException;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.TableNotFoundException;
@@ -41,6 +43,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
@@ -50,6 +54,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Streams.stream;
 import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_AMBIGUOUS_OBJECT_NAME;
+import static io.trino.plugin.bigquery.BigQueryUtil.convertToBigQueryException;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -59,6 +64,8 @@ import static java.util.stream.Collectors.joining;
 
 class BigQueryClient
 {
+    private static final Logger log = Logger.get(BigQueryClient.class);
+
     private final BigQuery bigQuery;
     private final Optional<String> viewMaterializationProject;
     private final Optional<String> viewMaterializationDataset;
@@ -335,6 +342,65 @@ class BigQueryClient
         public boolean isAmbiguous()
         {
             return remoteNames.size() > 1;
+        }
+    }
+
+    static class DestinationTableBuilder
+            implements Callable<TableInfo>
+    {
+        private final BigQueryClient bigQueryClient;
+        private final ReadSessionCreatorConfig config;
+        private final String query;
+        private final TableId table;
+
+        DestinationTableBuilder(BigQueryClient bigQueryClient, ReadSessionCreatorConfig config, String query, TableId table)
+        {
+            this.bigQueryClient = requireNonNull(bigQueryClient, "bigQueryClient is null");
+            this.config = requireNonNull(config, "config is null");
+            this.query = requireNonNull(query, "query is null");
+            this.table = requireNonNull(table, "table is null");
+        }
+
+        @Override
+        public TableInfo call()
+        {
+            return createTableFromQuery();
+        }
+
+        TableInfo createTableFromQuery()
+        {
+            TableId destinationTable = bigQueryClient.createDestinationTable(table);
+            log.debug("destinationTable is %s", destinationTable);
+            JobInfo jobInfo = JobInfo.of(
+                    QueryJobConfiguration
+                            .newBuilder(query)
+                            .setDestinationTable(destinationTable)
+                            .build());
+            log.debug("running query %s", jobInfo);
+            Job job = waitForJob(bigQueryClient.create(jobInfo));
+            log.debug("job has finished. %s", job);
+            if (job.getStatus().getError() != null) {
+                throw convertToBigQueryException(job.getStatus().getError());
+            }
+            // add expiration time to the table
+            TableInfo createdTable = bigQueryClient.getTable(destinationTable);
+            long expirationTime = createdTable.getCreationTime() +
+                    TimeUnit.HOURS.toMillis(config.viewExpirationTimeInHours);
+            Table updatedTable = bigQueryClient.update(createdTable.toBuilder()
+                    .setExpirationTime(expirationTime)
+                    .build());
+            return updatedTable;
+        }
+
+        Job waitForJob(Job job)
+        {
+            try {
+                return job.waitFor();
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new BigQueryException(BaseServiceException.UNKNOWN_CODE, format("Job %s has been interrupted", job.getJobId()), e);
+            }
         }
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -47,6 +47,7 @@ public class BigQueryConfig
     private int maxReadRowsRetries = DEFAULT_MAX_READ_ROWS_RETRIES;
     private boolean caseInsensitiveNameMatching;
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
+    private Duration viewsCacheTtl = new Duration(15, MINUTES);
 
     @AssertTrue(message = "Exactly one of 'bigquery.credentials-key' or 'bigquery.credentials-file' must be specified, or the default GoogleCredentials could be created")
     public boolean isCredentialsConfigurationValid()
@@ -216,6 +217,21 @@ public class BigQueryConfig
     public BigQueryConfig setCaseInsensitiveNameMatchingCacheTtl(Duration caseInsensitiveNameMatchingCacheTtl)
     {
         this.caseInsensitiveNameMatchingCacheTtl = caseInsensitiveNameMatchingCacheTtl;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("0m")
+    public Duration getViewsCacheTtl()
+    {
+        return viewsCacheTtl;
+    }
+
+    @Config("bigquery.views-cache-ttl")
+    @ConfigDescription("Duration for which the results of querying a view will be cached")
+    public BigQueryConfig setViewsCacheTtl(Duration viewsCacheTtl)
+    {
+        this.viewsCacheTtl = viewsCacheTtl;
         return this;
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ReadSessionCreator.java
@@ -13,12 +13,6 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.cloud.BaseServiceException;
-import com.google.cloud.bigquery.BigQueryException;
-import com.google.cloud.bigquery.Job;
-import com.google.cloud.bigquery.JobInfo;
-import com.google.cloud.bigquery.QueryJobConfiguration;
-import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
@@ -33,15 +27,12 @@ import io.trino.spi.TrinoException;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_VIEW_DESTINATION_TABLE_CREATION_FAILED;
-import static io.trino.plugin.bigquery.BigQueryUtil.convertToBigQueryException;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
-import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 // A helper class, also handles view materialization
@@ -130,7 +121,7 @@ public class ReadSessionCreator
             String query = bigQueryClient.selectSql(table.getTableId(), requiredColumns);
             log.debug("query is %s", query);
             try {
-                return destinationTableCache.get(query, new DestinationTableBuilder(bigQueryClient, config, query, table.getTableId()));
+                return destinationTableCache.get(query, new BigQueryClient.DestinationTableBuilder(bigQueryClient, config, query, table.getTableId()));
             }
             catch (ExecutionException e) {
                 throw new TrinoException(BIGQUERY_VIEW_DESTINATION_TABLE_CREATION_FAILED, "Error creating destination table", e);
@@ -140,65 +131,6 @@ public class ReadSessionCreator
             // not regular table or a view
             throw new TrinoException(NOT_SUPPORTED, format("Table type '%s' of table '%s.%s' is not supported",
                     tableType, table.getTableId().getDataset(), table.getTableId().getTable()));
-        }
-    }
-
-    private static class DestinationTableBuilder
-            implements Callable<TableInfo>
-    {
-        private final BigQueryClient bigQueryClient;
-        private final ReadSessionCreatorConfig config;
-        private final String query;
-        private final TableId table;
-
-        DestinationTableBuilder(BigQueryClient bigQueryClient, ReadSessionCreatorConfig config, String query, TableId table)
-        {
-            this.bigQueryClient = requireNonNull(bigQueryClient, "bigQueryClient is null");
-            this.config = requireNonNull(config, "config is null");
-            this.query = requireNonNull(query, "query is null");
-            this.table = requireNonNull(table, "table is null");
-        }
-
-        @Override
-        public TableInfo call()
-        {
-            return createTableFromQuery();
-        }
-
-        TableInfo createTableFromQuery()
-        {
-            TableId destinationTable = bigQueryClient.createDestinationTable(table);
-            log.debug("destinationTable is %s", destinationTable);
-            JobInfo jobInfo = JobInfo.of(
-                    QueryJobConfiguration
-                            .newBuilder(query)
-                            .setDestinationTable(destinationTable)
-                            .build());
-            log.debug("running query %s", jobInfo);
-            Job job = waitForJob(bigQueryClient.create(jobInfo));
-            log.debug("job has finished. %s", job);
-            if (job.getStatus().getError() != null) {
-                throw convertToBigQueryException(job.getStatus().getError());
-            }
-            // add expiration time to the table
-            TableInfo createdTable = bigQueryClient.getTable(destinationTable);
-            long expirationTime = createdTable.getCreationTime() +
-                    TimeUnit.HOURS.toMillis(config.viewExpirationTimeInHours);
-            Table updatedTable = bigQueryClient.update(createdTable.toBuilder()
-                    .setExpirationTime(expirationTime)
-                    .build());
-            return updatedTable;
-        }
-
-        Job waitForJob(Job job)
-        {
-            try {
-                return job.waitFor();
-            }
-            catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new BigQueryException(BaseServiceException.UNKNOWN_CODE, format("Job %s has been interrupted", job.getJobId()), e);
-            }
         }
     }
 }

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryConfig.java
@@ -44,7 +44,8 @@ public class TestBigQueryConfig
                 .setViewMaterializationDataset("vmdataset")
                 .setMaxReadRowsRetries(10)
                 .setCaseInsensitiveNameMatching(false)
-                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES));
+                .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES))
+                .setViewsCacheTtl(new Duration(15, MINUTES));
 
         assertEquals(config.getCredentialsKey(), Optional.of("key"));
         assertEquals(config.getCredentialsFile(), Optional.of("cfile"));
@@ -56,6 +57,7 @@ public class TestBigQueryConfig
         assertEquals(config.getMaxReadRowsRetries(), 10);
         assertEquals(config.isCaseInsensitiveNameMatching(), false);
         assertEquals(config.getCaseInsensitiveNameMatchingCacheTtl(), new Duration(1, MINUTES));
+        assertEquals(config.getViewsCacheTtl(), new Duration(15, MINUTES));
     }
 
     @Test
@@ -72,6 +74,7 @@ public class TestBigQueryConfig
                 .put("bigquery.max-read-rows-retries", "10")
                 .put("bigquery.case-insensitive-name-matching", "true")
                 .put("bigquery.case-insensitive-name-matching.cache-ttl", "1s")
+                .put("bigquery.views-cache-ttl", "1m")
                 .build();
 
         ConfigurationFactory configurationFactory = new ConfigurationFactory(properties);
@@ -87,6 +90,7 @@ public class TestBigQueryConfig
         assertEquals(config.getMaxReadRowsRetries(), 10);
         assertEquals(config.isCaseInsensitiveNameMatching(), true);
         assertEquals(config.getCaseInsensitiveNameMatchingCacheTtl(), new Duration(1, SECONDS));
+        assertEquals(config.getViewsCacheTtl(), new Duration(1, MINUTES));
     }
 
     @Test


### PR DESCRIPTION
Resolves https://github.com/trinodb/trino/issues/8236

Made destination table cache expiry duration configurable. This can be configured using **bigquery.destination-table-cache-expiry** property. Defaults to 15m.
