### PR TITLE
Fixes #8158 - Multiple entries with same key for aliases in elasticsearch connector

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchMetadata.java
@@ -351,6 +351,7 @@ public class ElasticsearchMetadata
                 .filter(entry -> indexes.contains(entry.getKey()))
                 .flatMap(entry -> entry.getValue().stream()
                         .map(alias -> new SchemaTableName(this.schemaName, alias)))
+                .distinct()
                 .forEach(result::add);
 
         return result.build();

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -1017,6 +1017,18 @@ public abstract class BaseElasticsearchConnectorTest
                 "SELECT count(*) FROM orders");
     }
 
+    @Test
+    public void testSelectInformationSchemaForMultiIndexAlias()
+            throws IOException
+    {
+        addAlias("nation", "multi_alias");
+        addAlias("region", "multi_alias");
+
+        // No duplicate entries should be found in information_schema.tables or information_schema.columns.
+        testSelectInformationSchemaTables();
+        testSelectInformationSchemaColumns();
+    }
+
     @Test(enabled = false) // TODO (https://github.com/trinodb/trino/issues/2428)
     public void testMultiIndexAlias()
             throws IOException


### PR DESCRIPTION
Fixes #8158 

The issue, RCA & fix is explained in this comment - https://github.com/trinodb/trino/issues/8158#issuecomment-860181923

Thanks.