### PR TITLE
Propagate runtime errors in ExpressionInterpreter

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -292,7 +292,7 @@ public class ExpressionInterpreter
             try {
                 return process(expression, context);
             }
-            catch (RuntimeException e) {
+            catch (TrinoException e) {
                 if (optimize) {
                     // Certain operations like 0 / 0 or likeExpression may throw exceptions.
                     // When optimizing, do not throw the exception, but delay it until the expression is actually executed.


### PR DESCRIPTION
The previous catching of `RuntimeException` could mask implementation issues such as
`VerifyException` or `NullPointerException`.