### PR TITLE
Ignore VSCode config folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ benchmark_outputs
 .mvn/timing.properties
 node_modules
 product-test-reports
+.vscode/


### PR DESCRIPTION
A lot of doc contributors work with VSCode and this helps us avoid accidental adds of the config. Also useful for any Java devs using VSCode of course ;-) 