### PR TITLE
Reset glue partition fetcher use getGetPartitionThreads

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
@@ -86,7 +86,7 @@ public class GlueMetastoreModule
     @ForGlueHiveMetastore
     public Executor createExecutor(CatalogName catalogName, GlueHiveMetastoreConfig hiveConfig)
     {
-        return createExecutor("hive-glue-partitions-%s", hiveConfig.getWriteStatisticsThreads());
+        return createExecutor("hive-glue-partitions-%s", hiveConfig.getGetPartitionThreads());
     }
 
     @Provides


### PR DESCRIPTION
After https://github.com/trinodb/trino/pull/6178 , Glue cannot do parallel fetch partitions if not set `hive.metastore.glue.write-statistics-threads`. this gonna take long planning time cost on `GlueHiveMetastore#getPartitions`. I guess it's just a mistake