### PR TITLE
Create MongoDB index for _schema collection only if absent

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoSession.java
@@ -458,8 +458,10 @@ public class MongoSession
             else {
                 Document metadata = new Document(TABLE_NAME_KEY, tableName);
                 metadata.append(FIELDS_KEY, guessTableFields(schemaName, tableName));
+                if (!indexExists(schema)) {
+                    schema.createIndex(new Document(TABLE_NAME_KEY, 1), new IndexOptions().unique(true));
+                }
 
-                schema.createIndex(new Document(TABLE_NAME_KEY, 1), new IndexOptions().unique(true));
                 schema.insertOne(metadata);
 
                 return metadata;
@@ -477,6 +479,12 @@ public class MongoSession
             }
         }
         return false;
+    }
+
+    private boolean indexExists(MongoCollection<Document> schemaCollection)
+    {
+        return MongoIndex.parse(schemaCollection.listIndexes()).stream()
+                .anyMatch(index -> index.getKeys().size() == 1 && TABLE_NAME_KEY.equals(index.getKeys().get(0).getName()));
     }
 
     private Set<String> getTableMetadataNames(String schemaName)
@@ -515,7 +523,10 @@ public class MongoSession
         metadata.append(FIELDS_KEY, fields);
 
         MongoCollection<Document> schema = db.getCollection(schemaCollection);
-        schema.createIndex(new Document(TABLE_NAME_KEY, 1), new IndexOptions().unique(true));
+        if (!indexExists(schema)) {
+            schema.createIndex(new Document(TABLE_NAME_KEY, 1), new IndexOptions().unique(true));
+        }
+
         schema.insertOne(metadata);
     }
 


### PR DESCRIPTION
Fixes #8264

Description :
The change checks if the index on the meta data collection already exists on tableName. If so, it will not try to create the index again for every new collection in MongoDB.