### PR TITLE
Fix failure when pruning partition columns with a date transform applied in Iceberg connector

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
@@ -291,6 +291,17 @@ public class PartitionTable
             // TODO the client sees the bytearray's tostring ouput instead of seeing actual bytes, needs to be fixed.
             return ((ByteBuffer) value).array();
         }
+        if (type instanceof Types.IntegerType || type instanceof Types.DateType) {
+            // date transform applied
+            if (value instanceof Integer) {
+                int actual = (int) value;
+                return (long) actual;
+            }
+            if (value instanceof Long) {
+                return value;
+            }
+            throw new IllegalArgumentException("Unexpected type : " + type);
+        }
         if (type instanceof Types.TimestampType) {
             long epochMicros = (long) value;
             if (((Types.TimestampType) type).shouldAdjustToUTC()) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
@@ -300,7 +300,7 @@ public class PartitionTable
             if (value instanceof Long) {
                 return value;
             }
-            throw new IllegalArgumentException("Unexpected type : " + type);
+            throw new IllegalArgumentException("Unexpected type of value : " + value);
         }
         if (type instanceof Types.TimestampType) {
             long epochMicros = (long) value;

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/AbstractTestIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/AbstractTestIcebergConnectorTest.java
@@ -1836,113 +1836,97 @@ public abstract class AbstractTestIcebergConnectorTest
     }
 
     @Test
-    public void testJoinWithPartitionTable()
+    public void testPartitionedTableWithDateTransformStatistics()
     {
-        // non partitioned tables
-        assertUpdate("CREATE TABLE test_join_partitioning_normal1(a BIGINT, b VARCHAR)");
-        assertUpdate("CREATE TABLE test_join_partitioning_normal2(a BIGINT, b VARCHAR, c row(d BIGINT, e VARCHAR), g map(BIGINT, VARCHAR))");
+        assertUpdate("CREATE TABLE iceberg.tpch.test_partitioned_table_with_date_transform_statistics " +
+                "(col1 REAL, col2 BIGINT, col3 DATE) WITH (partitioning = ARRAY['day(col3)'])");
 
-        String normalValues1 = "VALUES (0, 'a'), (1,'b'), (2, 'c'), (3, 'd'),(4, NULL)";
-        String normalValues2 = "VALUES " +
-                "(0, 'a', (0, 'a'), map(ARRAY[1], ARRAY['a']))," +
-                "(1, 'b', (1,'b'), map(ARRAY[1], ARRAY['b'])), " +
-                "(2, 'c', (2, 'c'), map(ARRAY[2], ARRAY['c'])), " +
-                "(3, 'd', (3, 'd'), map(ARRAY[3, 33], ARRAY['d', 'x']))," +
-                "(4, NULL, NULL, NULL), " +
-                "(5, 'f', (5, NULL), map()) ";
-        assertUpdate("INSERT INTO test_join_partitioning_normal1 " + normalValues1, 5);
-        assertUpdate("INSERT INTO test_join_partitioning_normal2 " + normalValues2, 6);
+        String insertStart = "INSERT INTO test_partitioned_table_with_date_transform_statistics";
+        assertUpdate(insertStart + " VALUES (-10, -1, DATE '2020-02-02')", 1);
+        assertUpdate(insertStart + " VALUES (100, 10, DATE '2020-03-01')", 1);
 
-        String expectedValues1 = "VALUES (1,'b'), (2, 'c'), (3, 'd'),(4, NULL)";
-        String expectedvalues2 = "VALUES " +
-                "(1, 'b'), " +
-                "(2, 'c'), " +
-                "(3, 'd')," +
-                "(4, NULL), " +
-                "(5, 'f') ";
+        MaterializedResult result = computeActual("SHOW STATS FOR iceberg.tpch.test_partitioned_table_with_date_transform_statistics");
+        assertEquals(result.getRowCount(), 4);
 
-        // partitioned tables
-        assertUpdate("CREATE TABLE test_join_partitioning1(a BIGINT, b VARCHAR, c TIMESTAMP(6) ) WITH (partitioning = ARRAY['a', 'day(c)'])");
-        assertUpdate("CREATE TABLE test_join_partitioning2(a BIGINT, b VARCHAR, c TIMESTAMP(6) WITH TIME ZONE) WITH (partitioning = ARRAY['a', 'month(c)'])");
-        assertUpdate("CREATE TABLE test_join_partitioning3(a BIGINT, b VARCHAR, c DATE) WITH (partitioning = ARRAY['year(c)'])");
-        assertUpdate("CREATE TABLE test_join_partitioning4(a BIGINT, b VARCHAR, c  row(d BIGINT, e VARCHAR ), g map(BIGINT, VARCHAR)) WITH (partitioning = ARRAY['a'])");
+        MaterializedRow row0 = result.getMaterializedRows().get(0);
+        assertEquals(row0.getField(0), "col1");
+        assertEquals(row0.getField(3), 0.0);
+        assertEquals(row0.getField(5), "-10.0");
+        assertEquals(row0.getField(6), "100.0");
 
-        // join non-partitioned table with partitioned table
-        String partitioningValues1 = "VALUES " +
-                "(0, 'a', CAST('2019-09-08' AS TIMESTAMP(6))), " +
-                "(1, 'b', TIMESTAMP '2020-09-09 10:10:23.123213'), " +
-                "(2, 'c',  TIMESTAMP '2020-09-09 11:10:33.234234')," +
-                "(3, 'd',  TIMESTAMP '2020-09-10 11:10:43.234234')," +
-                "(4, 'e',  TIMESTAMP '2020-09-10 11:10:53.234234')," +
-                "(5, 'f',  TIMESTAMP '2020-09-10 09:10:33.123355')";
-        assertUpdate("INSERT INTO test_join_partitioning1 " + partitioningValues1, 6);
-        assertQuery("SELECT nt.* FROM test_join_partitioning_normal1 nt JOIN test_join_partitioning1 pt ON nt.a = pt.a", normalValues1);
-        assertQuery("SELECT COUNT(*) FROM test_join_partitioning_normal1 nt JOIN test_join_partitioning1 pt ON nt.a = pt.a", "VALUES 5");
-        assertQuery("SELECT nt.* FROM test_join_partitioning_normal1 nt LEFT JOIN test_join_partitioning1 pt ON nt.a = pt.a", normalValues1);
-        assertQuery("SELECT pt.* FROM test_join_partitioning_normal2 nt RIGHT JOIN test_join_partitioning1 pt ON nt.a = pt.a", partitioningValues1);
+        MaterializedRow row1 = result.getMaterializedRows().get(1);
+        assertEquals(row1.getField(0), "col2");
+        assertEquals(row1.getField(3), 0.0);
+        assertEquals(row1.getField(5), "-1");
+        assertEquals(row1.getField(6), "10");
 
-        String partitioningValues2 = "VALUES " +
-                "(1, 'b', TIMESTAMP '2020-09-09 10:10:23.123213 UTC'), " +
-                "(2, 'c',  TIMESTAMP '2020-09-09 11:10:33.234234 UTC')," +
-                "(3, 'd',  TIMESTAMP '2020-09-10 11:10:33.234234 UTC')," +
-                "(4, 'e',  TIMESTAMP '2020-09-10 11:10:33.234234 UTC')," +
-                "(5, 'f',  TIMESTAMP '2020-09-10 11:10:33.234234 UTC')";
+        MaterializedRow row2 = result.getMaterializedRows().get(2);
+        assertEquals(row2.getField(0), "col3");
+        assertEquals(row2.getField(3), 0.0);
+        assertEquals(row2.getField(5), "2020-02-02");
+        assertEquals(row2.getField(6), "2020-03-01");
 
-        assertUpdate("INSERT INTO test_join_partitioning2 " + partitioningValues2, 5);
-        assertQuery("SELECT nt.* FROM test_join_partitioning_normal1 nt JOIN test_join_partitioning2 pt ON nt.a = pt.a", expectedValues1);
-        assertQuery("SELECT nt.a, nt.b FROM test_join_partitioning_normal2 nt JOIN test_join_partitioning2 pt ON nt.a = pt.a", expectedvalues2);
-        assertQuery("SELECT COUNT(nt.b) FROM test_join_partitioning_normal1 nt JOIN test_join_partitioning2 pt ON nt.a = pt.a", "VALUES 3");
-        assertQuery("SELECT COUNT(nt.b) FROM test_join_partitioning_normal2 nt JOIN test_join_partitioning2 pt ON nt.a = pt.a", "VALUES 4");
-        assertQuery("SELECT COUNT(nt.a) FROM test_join_partitioning_normal2 nt JOIN test_join_partitioning2 pt ON nt.a = pt.a", "VALUES 5");
+        MaterializedRow row3 = result.getMaterializedRows().get(3);
+        assertEquals(row3.getField(4), 2.0);
 
-        String partitioningValues3 = "VALUES " +
-                "(1, 'b', DATE '2020-09-09'), " +
-                "(2, 'c', DATE '2021-09-09')," +
-                "(3, 'd', DATE '2022-09-09')," +
-                "(4, 'e', DATE '2023-09-10')," +
-                "(5, 'f', DATE '2024-09-10')," +
-                "(6, 'z', DATE '2050-09-10')";
-        assertUpdate("INSERT INTO test_join_partitioning3 " + partitioningValues3, 6);
-        assertQuery("SELECT nt.* FROM test_join_partitioning_normal1 nt JOIN test_join_partitioning3 pt ON nt.a = pt.a", expectedValues1);
-        assertQuery("SELECT nt.a, nt.b FROM test_join_partitioning_normal2 nt JOIN test_join_partitioning3 pt ON nt.a = pt.a", expectedvalues2);
-        assertQuery("SELECT COUNT(nt.b) FROM test_join_partitioning_normal1 nt JOIN test_join_partitioning3 pt ON nt.b = pt.b", "VALUES 3");
-        assertQuery("SELECT COUNT(nt.b) FROM test_join_partitioning_normal2 nt JOIN test_join_partitioning3 pt ON nt.b = pt.b", "VALUES 4");
+        assertUpdate(insertStart + " VALUES " + IntStream.rangeClosed(1, 5)
+                .mapToObj(i -> format("(%d, 10, DATE '2021-03-0%d')", i + 100, i))
+                .collect(joining(", ")), 5);
 
-        assertUpdate("INSERT INTO test_join_partitioning4 SELECT * FROM test_join_partitioning_normal2", "VALUES 6");
-        assertQuery("SELECT nt.* FROM test_join_partitioning_normal1 nt JOIN test_join_partitioning4 pt ON nt.a = pt.a", normalValues1);
-        assertQuery("SELECT pt.a, pt.b FROM test_join_partitioning_normal2 nt JOIN test_join_partitioning4 pt ON nt.a = pt.a where nt.a > 0", expectedvalues2);
+        assertUpdate(insertStart + " VALUES " + IntStream.rangeClosed(16, 20)
+                .mapToObj(i -> format("(NULL, 20, DATE '2021-04-%d')", i))
+                .collect(joining(", ")), 5);
 
-        // join partitioned table with partitioned table
-        String expectedPartitioningValues1 = "VALUES " +
-                "(1, 'b', TIMESTAMP '2020-09-09 10:10:23.123213'), " +
-                "(2, 'c',  TIMESTAMP '2020-09-09 11:10:33.234234')," +
-                "(3, 'd',  TIMESTAMP '2020-09-10 11:10:43.234234')," +
-                "(4, 'e',  TIMESTAMP '2020-09-10 11:10:53.234234')," +
-                "(5, 'f',  TIMESTAMP '2020-09-10 09:10:33.123355')";
-        String expectedPartitioningValues2 = "VALUES " +
-                "(1, 'b')," +
-                "(2, 'c')," +
-                "(3, 'd')," +
-                "(4, 'e')," +
-                "(5, 'f')";
-        assertQuery("SELECT pt1.* FROM test_join_partitioning1 pt1 JOIN test_join_partitioning2 pt2 ON pt1.a = pt2.a", expectedPartitioningValues1);
-        assertQuery("SELECT pt1.* FROM test_join_partitioning1 pt1 JOIN test_join_partitioning3 pt3 ON pt1.b = pt3.b", expectedPartitioningValues1);
-        assertQuery("SELECT pt1.* FROM test_join_partitioning1 pt1 JOIN test_join_partitioning4 pt4 ON pt1.a = pt4.a", partitioningValues1);
+        result = computeActual("SHOW STATS FOR iceberg.tpch.test_partitioned_table_with_date_transform_statistics");
+        assertEquals(result.getRowCount(), 4);
+        row0 = result.getMaterializedRows().get(0);
+        assertEquals(row0.getField(0), "col1");
+        assertEquals(row0.getField(3), 5.0 / 12.0);
+        assertEquals(row0.getField(5), "-10.0");
+        assertEquals(row0.getField(6), "105.0");
 
-        assertQuery("SELECT pt2.a, pt2.b FROM test_join_partitioning2 pt2 JOIN test_join_partitioning3 pt3 ON pt2.a = pt3.a", expectedPartitioningValues2);
-        assertQuery("SELECT pt2.a, pt2.b FROM test_join_partitioning2 pt2 JOIN test_join_partitioning4 pt4 ON pt2.a = pt4.a", expectedPartitioningValues2);
-        assertQuery("SELECT pt3.a, pt3.b FROM test_join_partitioning3 pt3 JOIN test_join_partitioning4 pt4 ON pt3.a = pt4.a", expectedPartitioningValues2);
+        row1 = result.getMaterializedRows().get(1);
+        assertEquals(row1.getField(0), "col2");
+        assertEquals(row1.getField(3), 0.0);
+        assertEquals(row1.getField(5), "-1");
+        assertEquals(row1.getField(6), "20");
 
-        assertQuery("SELECT count(pt1.a) FROM test_join_partitioning1 pt1 JOIN test_join_partitioning2 pt2 ON pt1.a = pt2.a", "VALUES 5");
-        assertQuery("SELECT count(pt4.a) FROM test_join_partitioning1 pt1 JOIN test_join_partitioning4 pt4 ON pt1.a = pt4.a", "VALUES 6");
-        assertQuery("SELECT count(pt4.b) FROM test_join_partitioning1 pt1 JOIN test_join_partitioning4 pt4 ON pt1.a = pt4.a", "VALUES 5");
+        row2 = result.getMaterializedRows().get(2);
+        assertEquals(row2.getField(0), "col3");
+        assertEquals(row2.getField(3), 0.0);
+        assertEquals(row2.getField(5), "2020-02-02");
+        assertEquals(row2.getField(6), "2021-04-20");
 
-        dropTable("test_join_partitioning1");
-        dropTable("test_join_partitioning2");
-        dropTable("test_join_partitioning3");
-        dropTable("test_join_partitioning4");
-        dropTable("test_join_partitioning_normal1");
-        dropTable("test_join_partitioning_normal2");
+        row3 = result.getMaterializedRows().get(3);
+        assertEquals(row3.getField(4), 12.0);
+
+        assertUpdate(insertStart + " VALUES " + IntStream.rangeClosed(6, 10)
+                .mapToObj(i -> "(100, NULL, NULL)")
+                .collect(joining(", ")), 5);
+
+        result = computeActual("SHOW STATS FOR iceberg.tpch.test_partitioned_table_with_date_transform_statistics");
+        row0 = result.getMaterializedRows().get(0);
+        assertEquals(row0.getField(0), "col1");
+        assertEquals(row0.getField(3), 5.0 / 17.0);
+        assertEquals(row0.getField(5), "-10.0");
+        assertEquals(row0.getField(6), "105.0");
+
+        row1 = result.getMaterializedRows().get(1);
+        assertEquals(row1.getField(0), "col2");
+        assertEquals(row1.getField(3), 5.0 / 17.0);
+        assertEquals(row1.getField(5), "-1");
+        assertEquals(row1.getField(6), "20");
+
+        row2 = result.getMaterializedRows().get(2);
+        assertEquals(row2.getField(0), "col3");
+        assertEquals(row2.getField(3), 5.0 / 17.0);
+        assertEquals(row2.getField(5), "2020-02-02");
+        assertEquals(row2.getField(6), "2021-04-20");
+
+        row3 = result.getMaterializedRows().get(3);
+        assertEquals(row3.getField(4), 17.0);
+
+        dropTable("iceberg.tpch.test_partitioned_table_with_date_transform_statistics");
     }
 
     @Override


### PR DESCRIPTION
Recreated for https://github.com/trinodb/trino/pull/8101.

Fixes: #7502 
Fixes: #7999