### PR TITLE
Migrate from assertThat to assertQueryFailure

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestAlterTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestAlterTable.java
@@ -21,6 +21,7 @@ import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequiremen
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.ALTER_TABLE;
@@ -67,10 +68,10 @@ public class TestAlterTable
                 .hasRowsCount(1);
         assertThat(query(format("SELECT count(nationkey) FROM %s", TABLE_NAME)))
                 .containsExactly(row(25));
-        assertThat(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO nATIoNkEy", TABLE_NAME)))
-                .failsWithMessage("Column 'nationkey' already exists");
-        assertThat(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_regionkeY", TABLE_NAME)))
-                .failsWithMessage("Column 'n_regionkey' already exists");
+        assertQueryFailure(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO nATIoNkEy", TABLE_NAME)))
+                .hasMessageContaining("Column 'nationkey' already exists");
+        assertQueryFailure(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_regionkeY", TABLE_NAME)))
+                .hasMessageContaining("Column 'n_regionkey' already exists");
 
         assertThat(query(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_nationkey", TABLE_NAME)));
     }
@@ -84,10 +85,10 @@ public class TestAlterTable
                 .containsExactly(row(25));
         assertThat(query(format("ALTER TABLE %s ADD COLUMN some_new_column BIGINT", TABLE_NAME)))
                 .hasRowsCount(1);
-        assertThat(() -> query(format("ALTER TABLE %s ADD COLUMN n_nationkey BIGINT", TABLE_NAME)))
-                .failsWithMessage("Column 'n_nationkey' already exists");
-        assertThat(() -> query(format("ALTER TABLE %s ADD COLUMN n_naTioNkEy BIGINT", TABLE_NAME)))
-                .failsWithMessage("Column 'n_naTioNkEy' already exists");
+        assertQueryFailure(() -> query(format("ALTER TABLE %s ADD COLUMN n_nationkey BIGINT", TABLE_NAME)))
+                .hasMessageContaining("Column 'n_nationkey' already exists");
+        assertQueryFailure(() -> query(format("ALTER TABLE %s ADD COLUMN n_naTioNkEy BIGINT", TABLE_NAME)))
+                .hasMessageContaining("Column 'n_naTioNkEy' already exists");
     }
 
     @Test(groups = {ALTER_TABLE, SMOKE})
@@ -101,8 +102,8 @@ public class TestAlterTable
                 .hasRowsCount(1);
         assertThat(query(format("ALTER TABLE %s DROP COLUMN n_nationkey", TABLE_NAME)))
                 .hasRowsCount(1);
-        assertThat(() -> query(format("ALTER TABLE %s DROP COLUMN n_regionkey", TABLE_NAME)))
-                .failsWithMessage("Cannot drop the only column in a table");
+        assertQueryFailure(() -> query(format("ALTER TABLE %s DROP COLUMN n_regionkey", TABLE_NAME)))
+                .hasMessageContaining("Cannot drop the only column in a table");
         query(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestInsertIntoCassandraTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestInsertIntoCassandraTable.java
@@ -29,6 +29,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.MutableTableRequirement.State.CREATED;
 import static io.trino.tempto.fulfillment.table.MutableTablesState.mutableTablesState;
@@ -137,8 +138,8 @@ public class TestInsertIntoCassandraTable
                 row("key 2", null, null, false, null, null, null, null, null, null, 999, null, null, null, null, "text 2", null, null, null, null, null, null));
 
         // negative test: failed to insert null to primary key
-        assertThat(() -> query(format("INSERT INTO %s (a) VALUES (null) ", tableNameInDatabase)))
-                .failsWithMessage("Invalid null value in condition for column a");
+        assertQueryFailure(() -> query(format("INSERT INTO %s (a) VALUES (null) ", tableNameInDatabase)))
+                .hasMessageContaining("Invalid null value in condition for column a");
     }
 
     @Test(groups = {CASSANDRA, PROFILE_SPECIFIC_TESTS})
@@ -159,11 +160,11 @@ public class TestInsertIntoCassandraTable
                 query(format("SELECT lower('%s')", CASSANDRA_MATERIALIZED_VIEW)),
                 new Duration(1, MINUTES));
 
-        assertThat(() -> query(format("INSERT INTO %s.%s.%s (a) VALUES (null) ", CONNECTOR_NAME, KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW)))
-                .failsWithMessage("Inserting into materialized views not yet supported");
+        assertQueryFailure(() -> query(format("INSERT INTO %s.%s.%s (a) VALUES (null) ", CONNECTOR_NAME, KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW)))
+                .hasMessageContaining("Inserting into materialized views not yet supported");
 
-        assertThat(() -> query(format("DROP TABLE %s.%s.%s", CONNECTOR_NAME, KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW)))
-                .failsWithMessage("Dropping materialized views not yet supported");
+        assertQueryFailure(() -> query(format("DROP TABLE %s.%s.%s", CONNECTOR_NAME, KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW)))
+                .hasMessageContaining("Dropping materialized views not yet supported");
 
         onCasssandra(format("DROP MATERIALIZED VIEW IF EXISTS %s.%s", KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW));
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaEvolution.java
@@ -19,6 +19,7 @@ import io.trino.tempto.ProductTest;
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.AVRO;
@@ -92,8 +93,8 @@ public class TestAvroSchemaEvolution
                 .containsExactly(row("string0", 0));
 
         alterTableSchemaTo(INCOMPATIBLE_TYPE_SCHEMA);
-        assertThat(() -> query(SELECT_STAR))
-                .failsWithMessage("Found int, expecting string");
+        assertQueryFailure(() -> query(SELECT_STAR))
+                .hasMessageContaining("Found int, expecting string");
     }
 
     @Test(groups = AVRO)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaUrl.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaUrl.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.AVRO;
 import static io.trino.tests.product.TestGroups.STORAGE_FORMATS;
@@ -125,8 +126,8 @@ public class TestAvroSchemaUrl
                         row("string_col", "varchar", "", ""),
                         row("int_col", "integer", "", ""));
 
-        assertThat(() -> onTrino().executeQuery("ALTER TABLE test_avro_schema_url_in_serde_properties ADD COLUMN new_dummy_col varchar"))
-                .failsWithMessage("ALTER TABLE not supported when Avro schema url is set");
+        assertQueryFailure(() -> onTrino().executeQuery("ALTER TABLE test_avro_schema_url_in_serde_properties ADD COLUMN new_dummy_col varchar"))
+                .hasMessageContaining("ALTER TABLE not supported when Avro schema url is set");
 
         onHive().executeQuery("INSERT INTO test_avro_schema_url_in_serde_properties VALUES ('some text', 2147483635)");
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestExternalHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestExternalHiveTable.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.Requirements.compose;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.MutableTablesState.mutableTablesState;
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
@@ -98,9 +99,9 @@ public class TestExternalHiveTable
         TableInstance<?> nation = mutableTablesState().get(NATION.getName());
         onHive().executeQuery("DROP TABLE IF EXISTS " + EXTERNAL_TABLE_NAME);
         onHive().executeQuery("CREATE EXTERNAL TABLE " + EXTERNAL_TABLE_NAME + " LIKE " + nation.getNameInDatabase());
-        assertThat(() -> onTrino().executeQuery(
+        assertQueryFailure(() -> onTrino().executeQuery(
                 "INSERT INTO hive.default." + EXTERNAL_TABLE_NAME + " SELECT * FROM hive.default." + nation.getNameInDatabase()))
-                .failsWithMessage("Cannot write to non-managed Hive table");
+                .hasMessageContaining("Cannot write to non-managed Hive table");
     }
 
     @Test
@@ -109,8 +110,8 @@ public class TestExternalHiveTable
         TableInstance<?> nation = mutableTablesState().get(NATION.getName());
         onHive().executeQuery("DROP TABLE IF EXISTS " + EXTERNAL_TABLE_NAME);
         onHive().executeQuery("CREATE EXTERNAL TABLE " + EXTERNAL_TABLE_NAME + " LIKE " + nation.getNameInDatabase());
-        assertThat(() -> onTrino().executeQuery("DELETE FROM hive.default." + EXTERNAL_TABLE_NAME))
-                .failsWithMessage("Cannot delete from non-managed Hive table");
+        assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM hive.default." + EXTERNAL_TABLE_NAME))
+                .hasMessageContaining("Cannot delete from non-managed Hive table");
     }
 
     @Test
@@ -125,8 +126,8 @@ public class TestExternalHiveTable
         assertThat(onTrino().executeQuery("SELECT * FROM " + EXTERNAL_TABLE_NAME))
                 .hasRowsCount(3 * NATION_PARTITIONED_BY_REGIONKEY_NUMBER_OF_LINES_PER_SPLIT);
 
-        assertThat(() -> onTrino().executeQuery("DELETE FROM hive.default." + EXTERNAL_TABLE_NAME + " WHERE p_name IS NOT NULL"))
-                .failsWithMessage("Deletes must match whole partitions for non-transactional tables");
+        assertQueryFailure(() -> onTrino().executeQuery("DELETE FROM hive.default." + EXTERNAL_TABLE_NAME + " WHERE p_name IS NOT NULL"))
+                .hasMessageContaining("Deletes must match whole partitions for non-transactional tables");
 
         onTrino().executeQuery("DELETE FROM hive.default." + EXTERNAL_TABLE_NAME + " WHERE p_regionkey = 1");
         assertThat(onTrino().executeQuery("SELECT * FROM " + EXTERNAL_TABLE_NAME))

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestGrantRevoke.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestGrantRevoke.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import static io.trino.tempto.assertions.QueryAssert.Row;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.context.ContextDsl.executeWith;
 import static io.trino.tempto.sql.SqlContexts.createViewAs;
@@ -117,17 +118,17 @@ public class TestGrantRevoke
         aliceExecutor.executeQuery(format("GRANT INSERT, SELECT ON %s TO bob", tableName));
         assertThat(bobExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).hasRowsCount(1);
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
-        assertThat(() -> bobExecutor.executeQuery(format("DELETE FROM %s WHERE day=3", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot delete from table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("DELETE FROM %s WHERE day=3", tableName)))
+                .hasMessageContaining(format("Access Denied: Cannot delete from table default.%s", tableName));
 
         // test REVOKE
         aliceExecutor.executeQuery(format("REVOKE INSERT ON %s FROM bob", tableName));
-        assertThat(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES ('y', 5)", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES ('y', 5)", tableName)))
+                .hasMessageContaining(format("Access Denied: Cannot insert into table default.%s", tableName));
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
         aliceExecutor.executeQuery(format("REVOKE INSERT, SELECT ON %s FROM bob", tableName));
-        assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining(format("Access Denied: Cannot select from table default.%s", tableName));
     }
 
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
@@ -167,8 +168,8 @@ public class TestGrantRevoke
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO ROLE PUBLIC", tableName));
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
         aliceExecutor.executeQuery(format("REVOKE SELECT ON %s FROM ROLE PUBLIC", tableName));
-        assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining(format("Access Denied: Cannot select from table default.%s", tableName));
         assertThat(aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
     }
 
@@ -180,8 +181,8 @@ public class TestGrantRevoke
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO ROLE role1", tableName));
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
         aliceExecutor.executeQuery(format("REVOKE SELECT ON %s FROM ROLE role1", tableName));
-        assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining(format("Access Denied: Cannot select from table default.%s", tableName));
         assertThat(aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
     }
 
@@ -195,8 +196,8 @@ public class TestGrantRevoke
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO ROLE role2", tableName));
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
         aliceExecutor.executeQuery(format("REVOKE SELECT ON %s FROM ROLE role2", tableName));
-        assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining(format("Access Denied: Cannot select from table default.%s", tableName));
         assertThat(aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
     }
 
@@ -208,8 +209,8 @@ public class TestGrantRevoke
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO ROLE role1", tableName));
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
         onTrino().executeQuery("DROP ROLE role1");
-        assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining(format("Access Denied: Cannot select from table default.%s", tableName));
         assertThat(aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
     }
 
@@ -261,11 +262,11 @@ public class TestGrantRevoke
 
     private static void assertAccessDeniedOnAllOperationsOnTable(QueryExecutor queryExecutor, String tableName)
     {
-        assertThat(() -> queryExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
-        assertThat(() -> queryExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
-        assertThat(() -> queryExecutor.executeQuery(format("DELETE FROM %s WHERE day=3", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot delete from table default.%s", tableName));
+        assertQueryFailure(() -> queryExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> queryExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName)))
+                .hasMessageContaining(format("Access Denied: Cannot insert into table default.%s", tableName));
+        assertQueryFailure(() -> queryExecutor.executeQuery(format("DELETE FROM %s WHERE day=3", tableName)))
+                .hasMessageContaining(format("Access Denied: Cannot delete from table default.%s", tableName));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveIgnoreAbsentPartitions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveIgnoreAbsentPartitions.java
@@ -23,6 +23,7 @@ import io.trino.tempto.hadoop.hdfs.HdfsClient;
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.MutableTableRequirement.State.LOADED;
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
@@ -65,7 +66,7 @@ public class TestHiveIgnoreAbsentPartitions
         query("SET SESSION hive.ignore_absent_partitions = false");
         hdfsClient.delete(partitionPath);
         assertFalse(hdfsClient.exist(partitionPath), format("Expected partition %s to not exist", partitionPath));
-        assertThat(() -> query("SELECT count(*) FROM " + tableNameInDatabase)).failsWithMessage("Partition location does not exist");
+        assertQueryFailure(() -> query("SELECT count(*) FROM " + tableNameInDatabase)).hasMessageContaining("Partition location does not exist");
 
         query("SET SESSION hive.ignore_absent_partitions = true");
         assertThat(query("SELECT count(*) FROM " + tableNameInDatabase)).containsOnly(row(15));
@@ -87,10 +88,10 @@ public class TestHiveIgnoreAbsentPartitions
         hdfsClient.delete(tablePath);
 
         query("SET SESSION hive.ignore_absent_partitions = false");
-        assertThat(() -> query("SELECT count(*) FROM " + tableName)).failsWithMessage("Partition location does not exist");
+        assertQueryFailure(() -> query("SELECT count(*) FROM " + tableName)).hasMessageContaining("Partition location does not exist");
 
         query("SET SESSION hive.ignore_absent_partitions = true");
-        assertThat(() -> query("SELECT count(*) FROM " + tableName)).failsWithMessage("Partition location does not exist");
+        assertQueryFailure(() -> query("SELECT count(*) FROM " + tableName)).hasMessageContaining("Partition location does not exist");
 
         assertThat(query("DROP TABLE " + tableName));
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMaterializedView.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveMaterializedView.java
@@ -18,6 +18,7 @@ import io.trino.tempto.BeforeTestWithContext;
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.STORAGE_FORMATS;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
@@ -99,7 +100,7 @@ public class TestHiveMaterializedView
             return;
         }
 
-        assertThat(() -> onTrino().executeQuery("INSERT INTO test_materialized_view_view(x, c) VALUES ('x', 42)"))
-                .failsWithMessage("Cannot write to Hive materialized view");
+        assertQueryFailure(() -> onTrino().executeQuery("INSERT INTO test_materialized_view_view(x, c) VALUES ('x', 42)"))
+                .hasMessageContaining("Cannot write to Hive materialized view");
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePartitionProcedures.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePartitionProcedures.java
@@ -78,8 +78,8 @@ public class TestHivePartitionProcedures
         createPartitionedTable(FIRST_TABLE);
         createView(VIEW_TABLE, FIRST_TABLE);
 
-        QueryAssert.assertThat(() -> dropPartition(VIEW_TABLE, "col", "a"))
-                .failsWithMessage("Table is a view: default." + VIEW_TABLE);
+        QueryAssert.assertQueryFailure(() -> dropPartition(VIEW_TABLE, "col", "a"))
+                .hasMessageContaining("Table is a view: default." + VIEW_TABLE);
     }
 
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
@@ -88,8 +88,8 @@ public class TestHivePartitionProcedures
     {
         createPartitionedTable(FIRST_TABLE);
 
-        QueryAssert.assertThat(() -> dropPartition("missing_table", "col", "f"))
-                .failsWithMessage("Table 'default.missing_table' not found");
+        QueryAssert.assertQueryFailure(() -> dropPartition("missing_table", "col", "f"))
+                .hasMessageContaining("Table 'default.missing_table' not found");
     }
 
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
@@ -98,8 +98,8 @@ public class TestHivePartitionProcedures
     {
         createUnpartitionedTable(SECOND_TABLE);
 
-        QueryAssert.assertThat(() -> dropPartition(SECOND_TABLE, "col", "a"))
-                .failsWithMessage("Table is not partitioned: default." + SECOND_TABLE);
+        QueryAssert.assertQueryFailure(() -> dropPartition(SECOND_TABLE, "col", "a"))
+                .hasMessageContaining("Table is not partitioned: default." + SECOND_TABLE);
     }
 
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
@@ -108,8 +108,8 @@ public class TestHivePartitionProcedures
     {
         createPartitionedTable(FIRST_TABLE);
 
-        QueryAssert.assertThat(() -> dropPartition(FIRST_TABLE, "not_existing_partition_col", "a"))
-                .failsWithMessage("Provided partition column names do not match actual partition column names: [col]");
+        QueryAssert.assertQueryFailure(() -> dropPartition(FIRST_TABLE, "not_existing_partition_col", "a"))
+                .hasMessageContaining("Provided partition column names do not match actual partition column names: [col]");
     }
 
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
@@ -118,16 +118,16 @@ public class TestHivePartitionProcedures
     {
         createPartitionedTable(FIRST_TABLE);
 
-        QueryAssert.assertThat(() -> dropPartition(FIRST_TABLE, "col", "f"))
-                .failsWithMessage("Partition 'col=f' does not exist");
+        QueryAssert.assertQueryFailure(() -> dropPartition(FIRST_TABLE, "col", "f"))
+                .hasMessageContaining("Partition 'col=f' does not exist");
     }
 
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
     @Flaky(issue = ERROR_COMMITTING_WRITE_TO_HIVE_ISSUE, match = ERROR_COMMITTING_WRITE_TO_HIVE_MATCH)
     public void testRegisterPartitionMissingTableShouldFail()
     {
-        QueryAssert.assertThat(() -> addPartition("missing_table", "col", "f", "/"))
-                .failsWithMessage("Table 'default.missing_table' not found");
+        QueryAssert.assertQueryFailure(() -> addPartition("missing_table", "col", "f", "/"))
+                .hasMessageContaining("Table 'default.missing_table' not found");
     }
 
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
@@ -136,8 +136,8 @@ public class TestHivePartitionProcedures
     {
         createUnpartitionedTable(SECOND_TABLE);
 
-        QueryAssert.assertThat(() -> addPartition(SECOND_TABLE, "col", "a", "/"))
-                .failsWithMessage("Table is not partitioned: default." + SECOND_TABLE);
+        QueryAssert.assertQueryFailure(() -> addPartition(SECOND_TABLE, "col", "a", "/"))
+                .hasMessageContaining("Table is not partitioned: default." + SECOND_TABLE);
     }
 
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
@@ -147,8 +147,8 @@ public class TestHivePartitionProcedures
         createPartitionedTable(FIRST_TABLE);
         createView(VIEW_TABLE, FIRST_TABLE);
 
-        QueryAssert.assertThat(() -> addPartition(VIEW_TABLE, "col", "a", "/"))
-                .failsWithMessage("Table is a view: default." + VIEW_TABLE);
+        QueryAssert.assertQueryFailure(() -> addPartition(VIEW_TABLE, "col", "a", "/"))
+                .hasMessageContaining("Table is a view: default." + VIEW_TABLE);
     }
 
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
@@ -157,8 +157,8 @@ public class TestHivePartitionProcedures
     {
         createPartitionedTable(FIRST_TABLE);
 
-        QueryAssert.assertThat(() -> addPartition(FIRST_TABLE, "col", "a", "/"))
-                .failsWithMessage("Partition [col=a] is already registered");
+        QueryAssert.assertQueryFailure(() -> addPartition(FIRST_TABLE, "col", "a", "/"))
+                .hasMessageContaining("Partition [col=a] is already registered");
     }
 
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
@@ -167,8 +167,8 @@ public class TestHivePartitionProcedures
     {
         createPartitionedTable(FIRST_TABLE);
 
-        QueryAssert.assertThat(() -> addPartition(FIRST_TABLE, "not_existing_partition_col", "a", "/"))
-                .failsWithMessage("Provided partition column names do not match actual partition column names: [col]");
+        QueryAssert.assertQueryFailure(() -> addPartition(FIRST_TABLE, "not_existing_partition_col", "a", "/"))
+                .hasMessageContaining("Provided partition column names do not match actual partition column names: [col]");
     }
 
     @Test(groups = {HIVE_PARTITIONING, SMOKE})
@@ -177,8 +177,8 @@ public class TestHivePartitionProcedures
     {
         createPartitionedTable(FIRST_TABLE);
 
-        QueryAssert.assertThat(() -> addPartition(FIRST_TABLE, "col", "f", "/some/non/existing/path"))
-                .failsWithMessage("Partition location does not exist: /some/non/existing/path");
+        QueryAssert.assertQueryFailure(() -> addPartition(FIRST_TABLE, "col", "f", "/some/non/existing/path"))
+                .hasMessageContaining("Partition location does not exist: /some/non/existing/path");
     }
 
     @Test(groups = {HIVE_PARTITIONING, SMOKE})

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePartitionsTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePartitionsTable.java
@@ -35,6 +35,7 @@ import java.util.stream.IntStream;
 
 import static io.trino.tempto.Requirements.compose;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
@@ -118,18 +119,18 @@ public class TestHivePartitionsTable
         assertThat(partitionListResult).containsExactly(row(1));
         assertColumnNames(partitionListResult, "part_col");
 
-        assertThat(() -> query(format("SELECT * FROM %s WHERE no_such_column = 1", partitionsTable)))
-                .failsWithMessage("Column 'no_such_column' cannot be resolved");
-        assertThat(() -> query(format("SELECT * FROM %s WHERE col = 1", partitionsTable)))
-                .failsWithMessage("Column 'col' cannot be resolved");
+        assertQueryFailure(() -> query(format("SELECT * FROM %s WHERE no_such_column = 1", partitionsTable)))
+                .hasMessageContaining("Column 'no_such_column' cannot be resolved");
+        assertQueryFailure(() -> query(format("SELECT * FROM %s WHERE col = 1", partitionsTable)))
+                .hasMessageContaining("Column 'col' cannot be resolved");
     }
 
     @Test(groups = HIVE_PARTITIONING)
     @Flaky(issue = ERROR_COMMITTING_WRITE_TO_HIVE_ISSUE, match = ERROR_COMMITTING_WRITE_TO_HIVE_MATCH)
     public void testShowPartitionsFromUnpartitionedTable()
     {
-        assertThat(() -> query("SELECT * FROM \"nation$partitions\""))
-                .failsWithMessageMatching(".*Table 'hive.default.nation\\$partitions' does not exist");
+        assertQueryFailure(() -> query("SELECT * FROM \"nation$partitions\""))
+                .hasMessageMatching(".*Table 'hive.default.nation\\$partitions' does not exist");
     }
 
     @Test(groups = HIVE_PARTITIONING)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSchema.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSchema.java
@@ -30,6 +30,7 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.STORAGE_FORMATS;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
@@ -63,20 +64,20 @@ public class TestHiveSchema
                 .doesNotHave(containsFirstColumnValue("sys"));
 
         // SHOW TABLES
-        assertThat(() -> onTrino().executeQuery("SHOW TABLES FROM hive.sys"))
-                .failsWithMessage("line 1:1: Schema 'sys' does not exist");
+        assertQueryFailure(() -> onTrino().executeQuery("SHOW TABLES FROM hive.sys"))
+                .hasMessageContaining("line 1:1: Schema 'sys' does not exist");
 
         // SHOW COLUMNS
-        assertThat(() -> onTrino().executeQuery("SHOW COLUMNS FROM hive.sys.version")) // sys.version exists in Hive 3 and is a view
-                .failsWithMessage("line 1:1: Schema 'sys' does not exist");
-        assertThat(() -> onTrino().executeQuery("SHOW COLUMNS FROM hive.sys.table_params")) // sys.table_params exists in Hive 3 and is a table
-                .failsWithMessage("line 1:1: Schema 'sys' does not exist");
+        assertQueryFailure(() -> onTrino().executeQuery("SHOW COLUMNS FROM hive.sys.version")) // sys.version exists in Hive 3 and is a view
+                .hasMessageContaining("line 1:1: Schema 'sys' does not exist");
+        assertQueryFailure(() -> onTrino().executeQuery("SHOW COLUMNS FROM hive.sys.table_params")) // sys.table_params exists in Hive 3 and is a table
+                .hasMessageContaining("line 1:1: Schema 'sys' does not exist");
 
         // DESCRIBE
-        assertThat(() -> onTrino().executeQuery("DESCRIBE hive.sys.version")) // sys.version exists in Hive 3 and is a view
-                .failsWithMessage("line 1:1: Schema 'sys' does not exist");
-        assertThat(() -> onTrino().executeQuery("DESCRIBE hive.sys.table_params")) // sys.table_params exists in Hive 3 and is a table
-                .failsWithMessage("line 1:1: Schema 'sys' does not exist");
+        assertQueryFailure(() -> onTrino().executeQuery("DESCRIBE hive.sys.version")) // sys.version exists in Hive 3 and is a view
+                .hasMessageContaining("line 1:1: Schema 'sys' does not exist");
+        assertQueryFailure(() -> onTrino().executeQuery("DESCRIBE hive.sys.table_params")) // sys.table_params exists in Hive 3 and is a table
+                .hasMessageContaining("line 1:1: Schema 'sys' does not exist");
 
         // information_schema.schemata
         assertThat(onTrino().executeQuery("SELECT schema_name FROM information_schema.schemata"))
@@ -117,10 +118,10 @@ public class TestHiveSchema
         }
 
         // SELECT
-        assertThat(() -> onTrino().executeQuery("SELECT * FROM hive.sys.version")) // sys.version exists in Hive 3 and is a view
-                .failsWithMessage("line 1:15: Schema 'sys' does not exist");
-        assertThat(() -> onTrino().executeQuery("SELECT * FROM hive.sys.table_params")) // sys.table_params exists in Hive 3 and is a table
-                .failsWithMessage("line 1:15: Schema 'sys' does not exist");
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM hive.sys.version")) // sys.version exists in Hive 3 and is a view
+                .hasMessageContaining("line 1:15: Schema 'sys' does not exist");
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM hive.sys.table_params")) // sys.table_params exists in Hive 3 and is a table
+                .hasMessageContaining("line 1:15: Schema 'sys' does not exist");
     }
 
     // Note: this test is run on various Hive versions. Hive before 3 did not have `information_schema` schema, but it does not hurt to run the test there too.
@@ -170,8 +171,8 @@ public class TestHiveSchema
                 .satisfies(containsFirstColumnValue("table_schema"))
                 .doesNotHave(containsFirstColumnValue("is_updatable")); // Hive 3's information_schema.columns has is_updatable column
 
-        assertThat(() -> onTrino().executeQuery("SHOW COLUMNS FROM hive.information_schema.column_privileges")) // Hive 3's information_schema has column_privileges view
-                .failsWithMessage("line 1:1: Table 'hive.information_schema.column_privileges' does not exist");
+        assertQueryFailure(() -> onTrino().executeQuery("SHOW COLUMNS FROM hive.information_schema.column_privileges")) // Hive 3's information_schema has column_privileges view
+                .hasMessageContaining("line 1:1: Table 'hive.information_schema.column_privileges' does not exist");
 
         // DESCRIBE
         assertThat(onTrino().executeQuery("DESCRIBE hive.information_schema.columns"))
@@ -180,8 +181,8 @@ public class TestHiveSchema
                 .satisfies(containsFirstColumnValue("column_name"))
                 .doesNotHave(containsFirstColumnValue("is_updatable")); // Hive 3's information_schema.columns has is_updatable column
 
-        assertThat(() -> onTrino().executeQuery("DESCRIBE hive.information_schema.column_privileges")) // Hive 3's information_schema has column_privileges view
-                .failsWithMessage("line 1:1: Table 'hive.information_schema.column_privileges' does not exist");
+        assertQueryFailure(() -> onTrino().executeQuery("DESCRIBE hive.information_schema.column_privileges")) // Hive 3's information_schema has column_privileges view
+                .hasMessageContaining("line 1:1: Table 'hive.information_schema.column_privileges' does not exist");
 
         // information_schema.schemata
         assertThat(onTrino().executeQuery("SELECT schema_name FROM information_schema.schemata"))
@@ -246,8 +247,8 @@ public class TestHiveSchema
         }
 
         // SELECT
-        assertThat(() -> onTrino().executeQuery("SELECT * FROM hive.information_schema.column_privileges"))  // information_schema.column_privileges exists in Hive 3
-                .failsWithMessage("line 1:15: Table 'hive.information_schema.column_privileges' does not exist");
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM hive.information_schema.column_privileges"))  // information_schema.column_privileges exists in Hive 3
+                .hasMessageContaining("line 1:15: Table 'hive.information_schema.column_privileges' does not exist");
     }
 
     /**

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestRoles.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestRoles.java
@@ -143,15 +143,15 @@ public class TestRoles
     public void testCreateDuplicateRole()
     {
         onTrino().executeQuery(format("CREATE ROLE %s", ROLE1));
-        QueryAssert.assertThat(() -> onTrino().executeQuery(format("CREATE ROLE %s", ROLE1)))
-                .failsWithMessage(format("Role '%s' already exists", ROLE1));
+        QueryAssert.assertQueryFailure(() -> onTrino().executeQuery(format("CREATE ROLE %s", ROLE1)))
+                .hasMessageContaining(format("Role '%s' already exists", ROLE1));
     }
 
     @Test(groups = {ROLES, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testDropNonExistentRole()
     {
-        QueryAssert.assertThat(() -> onTrino().executeQuery(format("DROP ROLE %s", ROLE3)))
-                .failsWithMessage(format("Role '%s' does not exist", ROLE3));
+        QueryAssert.assertQueryFailure(() -> onTrino().executeQuery(format("DROP ROLE %s", ROLE3)))
+                .hasMessageContaining(format("Role '%s' does not exist", ROLE3));
     }
 
     @Test(groups = {ROLES, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
@@ -159,12 +159,12 @@ public class TestRoles
     {
         // Only users that are granted with "admin" role can create, drop and list roles
         // Alice is not granted with "admin" role
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery(format("CREATE ROLE %s", ROLE3)))
-                .failsWithMessage(format("Cannot create role %s", ROLE3));
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery(format("DROP ROLE %s", ROLE3)))
-                .failsWithMessage(format("Cannot drop role %s", ROLE3));
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("SELECT * FROM hive.information_schema.roles"))
-                .failsWithMessage("Cannot select from table information_schema.roles");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery(format("CREATE ROLE %s", ROLE3)))
+                .hasMessageContaining(format("Cannot create role %s", ROLE3));
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery(format("DROP ROLE %s", ROLE3)))
+                .hasMessageContaining(format("Cannot drop role %s", ROLE3));
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("SELECT * FROM hive.information_schema.roles"))
+                .hasMessageContaining("Cannot select from table information_schema.roles");
     }
 
     @Test(groups = {ROLES, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
@@ -448,14 +448,14 @@ public class TestRoles
         onTrino().executeQuery("CREATE ROLE role1");
         onTrino().executeQuery("CREATE ROLE role2");
 
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob"))
-                .failsWithMessage("Cannot grant roles [role1] to [USER bob]");
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob WITH ADMIN OPTION"))
-                .failsWithMessage("Cannot grant roles [role1] to [USER bob]");
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("REVOKE role1 FROM USER bob"))
-                .failsWithMessage("Cannot revoke roles [role1] from [USER bob]");
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("REVOKE ADMIN OPTION FOR role1 FROM USER bob"))
-                .failsWithMessage("Cannot revoke roles [role1] from [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob"))
+                .hasMessageContaining("Cannot grant roles [role1] to [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob WITH ADMIN OPTION"))
+                .hasMessageContaining("Cannot grant roles [role1] to [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("REVOKE role1 FROM USER bob"))
+                .hasMessageContaining("Cannot revoke roles [role1] from [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("REVOKE ADMIN OPTION FOR role1 FROM USER bob"))
+                .hasMessageContaining("Cannot revoke roles [role1] from [USER bob]");
 
         onTrino().executeQuery("GRANT role1 TO USER alice WITH ADMIN OPTION");
 
@@ -466,14 +466,14 @@ public class TestRoles
 
         onTrino().executeQuery("REVOKE ADMIN OPTION FOR role1 FROM USER alice");
 
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob"))
-                .failsWithMessage("Cannot grant roles [role1] to [USER bob]");
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob WITH ADMIN OPTION"))
-                .failsWithMessage("Cannot grant roles [role1] to [USER bob]");
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("REVOKE role1 FROM USER bob"))
-                .failsWithMessage("Cannot revoke roles [role1] from [USER bob]");
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("REVOKE ADMIN OPTION FOR role1 FROM USER bob"))
-                .failsWithMessage("Cannot revoke roles [role1] from [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob"))
+                .hasMessageContaining("Cannot grant roles [role1] to [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob WITH ADMIN OPTION"))
+                .hasMessageContaining("Cannot grant roles [role1] to [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("REVOKE role1 FROM USER bob"))
+                .hasMessageContaining("Cannot revoke roles [role1] from [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("REVOKE ADMIN OPTION FOR role1 FROM USER bob"))
+                .hasMessageContaining("Cannot revoke roles [role1] from [USER bob]");
 
         onTrino().executeQuery("GRANT role2 TO USER alice");
         onTrino().executeQuery("GRANT role1 TO ROLE role2 WITH ADMIN OPTION");
@@ -485,14 +485,14 @@ public class TestRoles
 
         onPrestoAlice().executeQuery("REVOKE ADMIN OPTION FOR role1 FROM ROLE role2");
 
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob"))
-                .failsWithMessage("Cannot grant roles [role1] to [USER bob]");
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob WITH ADMIN OPTION"))
-                .failsWithMessage("Cannot grant roles [role1] to [USER bob]");
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("REVOKE role1 FROM USER bob"))
-                .failsWithMessage("Cannot revoke roles [role1] from [USER bob]");
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("REVOKE ADMIN OPTION FOR role1 FROM USER bob"))
-                .failsWithMessage("Cannot revoke roles [role1] from [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob"))
+                .hasMessageContaining("Cannot grant roles [role1] to [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("GRANT role1 TO USER bob WITH ADMIN OPTION"))
+                .hasMessageContaining("Cannot grant roles [role1] to [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("REVOKE role1 FROM USER bob"))
+                .hasMessageContaining("Cannot revoke roles [role1] from [USER bob]");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("REVOKE ADMIN OPTION FOR role1 FROM USER bob"))
+                .hasMessageContaining("Cannot revoke roles [role1] from [USER bob]");
     }
 
     @Test(groups = {ROLES, AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
@@ -567,8 +567,8 @@ public class TestRoles
                         row("public"),
                         row("admin"),
                         row("role1"));
-        QueryAssert.assertThat(() -> onPrestoAlice().executeQuery("SHOW ROLES"))
-                .failsWithMessage("Cannot show roles from catalog hive");
+        QueryAssert.assertQueryFailure(() -> onPrestoAlice().executeQuery("SHOW ROLES"))
+                .hasMessageContaining("Cannot show roles from catalog hive");
         onTrino().executeQuery("GRANT admin TO alice");
         onPrestoAlice().executeQuery("SET ROLE admin");
         QueryAssert.assertThat(onPrestoAlice().executeQuery("SHOW ROLES"))
@@ -781,24 +781,24 @@ public class TestRoles
                         row("alice", "USER", "role2", "ROLE", "hive", "default", "test_table", "INSERT", "NO", null)));
 
         onPrestoBob().executeQuery("SET ROLE NONE");
-        QueryAssert.assertThat(() -> onPrestoBob().executeQuery(select))
-                .failsWithMessage("Access Denied");
-        QueryAssert.assertThat(() -> onPrestoBob().executeQuery(insert))
-                .failsWithMessage("Access Denied");
+        QueryAssert.assertQueryFailure(() -> onPrestoBob().executeQuery(select))
+                .hasMessageContaining("Access Denied");
+        QueryAssert.assertQueryFailure(() -> onPrestoBob().executeQuery(insert))
+                .hasMessageContaining("Access Denied");
         QueryAssert.assertThat(onPrestoBob().executeQuery("SHOW GRANTS ON hive.default.test_table"))
                 .containsOnly(ImmutableList.of());
 
         onPrestoBob().executeQuery("SET ROLE role1");
         onPrestoBob().executeQuery(select);
-        QueryAssert.assertThat(() -> onPrestoBob().executeQuery(insert))
-                .failsWithMessage("Access Denied");
+        QueryAssert.assertQueryFailure(() -> onPrestoBob().executeQuery(insert))
+                .hasMessageContaining("Access Denied");
         QueryAssert.assertThat(onPrestoBob().executeQuery("SHOW GRANTS ON hive.default.test_table"))
                 .containsOnly(ImmutableList.of(
                         row("alice", "USER", "role1", "ROLE", "hive", "default", "test_table", "SELECT", "NO", null)));
 
         onPrestoBob().executeQuery("SET ROLE role2");
-        QueryAssert.assertThat(() -> onPrestoBob().executeQuery(select))
-                .failsWithMessage("Access Denied");
+        QueryAssert.assertQueryFailure(() -> onPrestoBob().executeQuery(select))
+                .hasMessageContaining("Access Denied");
         onPrestoBob().executeQuery(insert);
         QueryAssert.assertThat(onPrestoBob().executeQuery("SHOW GRANTS ON hive.default.test_table"))
                 .containsOnly(ImmutableList.of(
@@ -810,12 +810,12 @@ public class TestRoles
     private static void assertAdminExecute(String query)
     {
         onTrino().executeQuery("SET ROLE NONE");
-        QueryAssert.assertThat(() -> onTrino().executeQuery(query))
-                .failsWithMessage("Access Denied");
+        QueryAssert.assertQueryFailure(() -> onTrino().executeQuery(query))
+                .hasMessageContaining("Access Denied");
 
         onTrino().executeQuery("SET ROLE ALL");
-        QueryAssert.assertThat(() -> onTrino().executeQuery(query))
-                .failsWithMessage("Access Denied");
+        QueryAssert.assertQueryFailure(() -> onTrino().executeQuery(query))
+                .hasMessageContaining("Access Denied");
 
         onTrino().executeQuery("SET ROLE admin");
         onTrino().executeQuery(query);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSparkCompatibility.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.HIVE_SPARK_BUCKETING;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
@@ -91,8 +92,8 @@ public class TestSparkCompatibility
         assertThat(onTrino().executeQuery(format("SHOW CREATE TABLE %s.default.%s", TRINO_CATALOG, baseTableName)))
                 .containsOnly(row(format(trinoTableDefinition, TRINO_CATALOG, baseTableName)));
 
-        assertThat(() -> onTrino().executeQuery(format("%s, \"$bucket\" FROM %s", startOfSelect, format("%s.default.%s", TRINO_CATALOG, baseTableName))))
-                .failsWithMessage("Column '$bucket' cannot be resolved");
+        assertQueryFailure(() -> onTrino().executeQuery(format("%s, \"$bucket\" FROM %s", startOfSelect, format("%s.default.%s", TRINO_CATALOG, baseTableName))))
+                .hasMessageContaining("Column '$bucket' cannot be resolved");
 
         onSpark().executeQuery("DROP TABLE " + baseTableName);
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSyncPartitionMetadata.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSyncPartitionMetadata.java
@@ -25,6 +25,7 @@ import io.trino.testng.services.Flaky;
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.hive.InlineDataSource.createResourceDataSource;
 import static io.trino.tempto.query.QueryExecutor.query;
@@ -58,8 +59,8 @@ public class TestSyncPartitionMetadata
 
         query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'ADD')");
         assertPartitions(tableName, row("a", "1"), row("b", "2"), row("f", "9"));
-        assertThat(() -> query("SELECT payload, col_x, col_y FROM " + tableName + " ORDER BY 1, 2, 3 ASC"))
-                .failsWithMessage(format("Partition location does not exist: hdfs://hadoop-master:9000%s/%s/col_x=b/col_y=2", warehouseDirectory, tableName));
+        assertQueryFailure(() -> query("SELECT payload, col_x, col_y FROM " + tableName + " ORDER BY 1, 2, 3 ASC"))
+                .hasMessageContaining(format("Partition location does not exist: hdfs://hadoop-master:9000%s/%s/col_x=b/col_y=2", warehouseDirectory, tableName));
         cleanup(tableName);
     }
 
@@ -98,8 +99,8 @@ public class TestSyncPartitionMetadata
         String tableName = "test_repair_invalid_mode";
         prepare(hdfsClient, hdfsDataSourceWriter, tableName);
 
-        assertThat(() -> query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'INVALID')"))
-                .failsWithMessageMatching("java.sql.SQLException: Query failed (.*): Invalid partition metadata sync mode: INVALID");
+        assertQueryFailure(() -> query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'INVALID')"))
+                .hasMessageMatching("Query failed (.*): Invalid partition metadata sync mode: INVALID");
 
         cleanup(tableName);
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaAvroWritesSmokeTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaAvroWritesSmokeTest.java
@@ -17,6 +17,7 @@ import io.trino.tempto.ProductTest;
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.KAFKA;
@@ -61,11 +62,11 @@ public class TestKafkaAvroWritesSmokeTest
     @Test(groups = {KAFKA, PROFILE_SPECIFIC_TESTS})
     public void testInsertStructuralDataType()
     {
-        assertThat(() -> query(format(
+        assertQueryFailure(() -> query(format(
                 "INSERT INTO %s.%s VALUES " +
                         "(ARRAY[100, 102], map_from_entries(ARRAY[('key1', 'value1')]))",
                 KAFKA_CATALOG,
                 STRUCTURAL_AVRO_TABLE_NAME)))
-                .failsWithMessageMatching("java.sql.SQLException: Query failed \\(.+\\): Unsupported column type 'array\\(bigint\\)' for column 'c_array'");
+                .hasMessageMatching("Query failed \\(.+\\): Unsupported column type 'array\\(bigint\\)' for column 'c_array'");
     }
 }


### PR DESCRIPTION
Solves #8274 

- Migrate from io.trino.tempto.assertions.QueryAssert#assertThat(QueryCallback) to assertQueryFailure(QueryCallback)