### PR TITLE
Avoid lenient Number cast in writeNativeValue

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -250,7 +250,7 @@ public class InformationSchemaPageSource
     {
         for (Map.Entry<SchemaTableName, List<ColumnMetadata>> entry : listTableColumns(session, metadata, accessControl, prefix).entrySet()) {
             SchemaTableName tableName = entry.getKey();
-            int ordinalPosition = 1;
+            long ordinalPosition = 1;
 
             for (ColumnMetadata column : entry.getValue()) {
                 if (column.isHidden()) {

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeUtils.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeUtils.java
@@ -73,10 +73,10 @@ public final class TypeUtils
             type.writeBoolean(blockBuilder, (Boolean) value);
         }
         else if (type.getJavaType() == double.class) {
-            type.writeDouble(blockBuilder, ((Number) value).doubleValue());
+            type.writeDouble(blockBuilder, ((double) value));
         }
         else if (type.getJavaType() == long.class) {
-            type.writeLong(blockBuilder, ((Number) value).longValue());
+            type.writeLong(blockBuilder, ((long) value));
         }
         else if (type.getJavaType() == Slice.class) {
             Slice slice;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
@@ -304,6 +304,9 @@ public class PartitionTable
         if (type instanceof Types.FloatType) {
             return Float.floatToIntBits((Float) value);
         }
+        if (type instanceof Types.IntegerType || type instanceof Types.DateType) {
+            return ((Integer) value).longValue();
+        }
         if (type instanceof Types.DecimalType) {
             Types.DecimalType icebergDecimalType = (Types.DecimalType) type;
             DecimalType trinoDecimalType = DecimalType.createDecimalType(icebergDecimalType.precision(), icebergDecimalType.scale());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
@@ -299,7 +299,7 @@ public class PartitionTable
             return epochMicros;
         }
         if (type instanceof Types.TimeType) {
-            return ((Long) value) * PICOSECONDS_PER_MICROSECOND;
+            return Math.multiplyExact((Long) value, PICOSECONDS_PER_MICROSECOND);
         }
         if (type instanceof Types.FloatType) {
             return Float.floatToIntBits((Float) value);

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/TypeUtils.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/TypeUtils.java
@@ -142,12 +142,21 @@ public final class TypeUtils
         }
 
         if (BOOLEAN.equals(type)
-                || TINYINT.equals(type)
-                || SMALLINT.equals(type)
-                || INTEGER.equals(type)
                 || BIGINT.equals(type)
                 || DOUBLE.equals(type)) {
             return jdbcObject;
+        }
+
+        if (TINYINT.equals(type)) {
+            return (long) (byte) jdbcObject;
+        }
+
+        if (SMALLINT.equals(type)) {
+            return (long) (short) jdbcObject;
+        }
+
+        if (INTEGER.equals(type)) {
+            return (long) (int) jdbcObject;
         }
 
         if (type instanceof ArrayType) {
@@ -164,7 +173,7 @@ public final class TypeUtils
         }
 
         if (REAL.equals(type)) {
-            return floatToRawIntBits((float) jdbcObject);
+            return (long) floatToRawIntBits((float) jdbcObject);
         }
 
         if (DATE.equals(type)) {

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/TypeUtils.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/TypeUtils.java
@@ -142,12 +142,21 @@ public final class TypeUtils
         }
 
         if (BOOLEAN.equals(type)
-                || TINYINT.equals(type)
-                || SMALLINT.equals(type)
-                || INTEGER.equals(type)
                 || BIGINT.equals(type)
                 || DOUBLE.equals(type)) {
             return jdbcObject;
+        }
+
+        if (TINYINT.equals(type)) {
+            return (long) (byte) jdbcObject;
+        }
+
+        if (SMALLINT.equals(type)) {
+            return (long) (short) jdbcObject;
+        }
+
+        if (INTEGER.equals(type)) {
+            return (long) (int) jdbcObject;
         }
 
         if (type instanceof ArrayType) {
@@ -164,7 +173,7 @@ public final class TypeUtils
         }
 
         if (REAL.equals(type)) {
-            return floatToRawIntBits((float) jdbcObject);
+            return (long) floatToRawIntBits((float) jdbcObject);
         }
 
         if (DATE.equals(type)) {


### PR DESCRIPTION
Fixes #8332

- Remove `Number.class` conversion from `io.trino.spi.type.TypeUtils#writeNativeValue`