### PR TITLE
Simplify JMX connector's jmx.dump-tables example

### DIFF
--- a/docs/src/main/sphinx/connector/jmx.rst
+++ b/docs/src/main/sphinx/connector/jmx.rst
@@ -32,17 +32,27 @@ To enable periodical dumps, define the following properties:
     jmx.max-entries=86400
 
 ``dump-tables`` is a comma separated list of Managed Beans (MBean). It specifies
-which MBeans is sampled and stored in memory every ``dump-period``.
-History has limited size of ``max-entries`` of entries. Both ``dump-period``
-and ``max-entries`` have default values of ``10s`` and ``86400`` accordingly.
+which MBeans are sampled and stored in memory every ``dump-period``. You can
+configure the maximum number of history entries with ``max-entries`` and it
+defaults to ``86400``. The time between dumps can be configured using
+``dump-period`` and it defaults to ``10s``.
 
-Commas in MBean names should be escaped in the following manner:
+Commas in MBean names must be escaped using double backslashes (``\\``) in the
+following manner:
+
+.. code-block:: text
+
+    connector.name=jmx
+    jmx.dump-tables=trino.memory:name=general\\,type=memorypool,trino.memory:name=reserved\\,type=memorypool
+
+Double backslashes are required because a single backslash (``\``) is used to
+split the value across multiple lines in the following manner:
 
 .. code-block:: text
 
     connector.name=jmx
     jmx.dump-tables=trino.memory:name=general\\,type=memorypool,\
-       trino.memory:name=reserved\\,type=memorypool
+        trino.memory:name=reserved\\,type=memorypool
 
 Querying JMX
 ------------


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/7782