### PR TITLE
Expose executor to BaseJdbcConnectorTest subclasses

### DIFF
--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -85,7 +85,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class BaseJdbcConnectorTest
         extends BaseConnectorTest
 {
-    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getName()));
+    protected final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed(getClass().getName()));
 
     protected abstract SqlExecutor onRemoteDatabase();
 


### PR DESCRIPTION
Expose executor to BaseJdbcConnectorTest subclasses

That way they are allowed to write concurrency related tests.
