### PR TITLE
Reject CTAS with skip_header_line_count > 0

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -1326,6 +1326,18 @@ public class HiveMetadata
             throw new TrinoException(NOT_SUPPORTED, "CREATE TABLE AS not supported when Avro schema url is set");
         }
 
+        getHeaderSkipCount(tableMetadata.getProperties()).ifPresent(headerSkipCount -> {
+            if (headerSkipCount > 0) {
+                throw new TrinoException(NOT_SUPPORTED, format("Creating Hive table with data with value of %s property greater than 0 is not supported", SKIP_HEADER_COUNT_KEY));
+            }
+        });
+
+        getFooterSkipCount(tableMetadata.getProperties()).ifPresent(footerSkipCount -> {
+            if (footerSkipCount > 0) {
+                throw new TrinoException(NOT_SUPPORTED, format("Creating Hive table with data with value of %s property greater than 0 is not supported", SKIP_FOOTER_COUNT_KEY));
+            }
+        });
+
         HiveStorageFormat tableStorageFormat = getHiveStorageFormat(tableMetadata.getProperties());
         List<String> partitionedBy = getPartitionedBy(tableMetadata.getProperties());
         Optional<HiveBucketProperty> bucketProperty = getBucketProperty(tableMetadata.getProperties());

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCsvFileHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCsvFileHiveTable.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import io.trino.tempto.ProductTest;
+import org.testng.annotations.Test;
+
+import static io.trino.tests.product.utils.QueryExecutors.onHive;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestCsvFileHiveTable
+        extends ProductTest
+{
+    @Test
+    public void testCreateCsvFileTableAsSelectSkipHeaderFooter()
+    {
+        onHive().executeQuery("DROP TABLE IF EXISTS test_create_csv_skip_header");
+        assertThatThrownBy(() -> onTrino().executeQuery(
+                "CREATE TABLE test_create_csv_skip_header " +
+                        "WITH ( " +
+                        "   format = 'CSV', " +
+                        "   skip_header_line_count = 1 " +
+                        ") " +
+                        "AS SELECT CAST(1 AS VARCHAR)  AS col_header;")
+        ).hasMessageMatching(".* Creating Hive table with data with value of skip.header.line.count property greater than 0 is not supported");
+        onHive().executeQuery("DROP TABLE test_create_csv_skip_header");
+
+        onHive().executeQuery("DROP TABLE IF EXISTS test_create_csv_skip_footer");
+        assertThatThrownBy(() -> onTrino().executeQuery(
+                "CREATE TABLE test_create_csv_skip_footer " +
+                        "WITH ( " +
+                        "   format = 'CSV', " +
+                        "   skip_footer_line_count = 1 " +
+                        ") " +
+                        "AS SELECT CAST(1 AS VARCHAR)  AS col_header;")
+        ).hasMessageMatching(".* Creating Hive table with data with value of skip.footer.line.count property greater than 0 is not supported");
+        onHive().executeQuery("DROP TABLE test_create_csv_skip_footer");
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestTextFileHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestTextFileHiveTable.java
@@ -135,4 +135,30 @@ public class TestTextFileHiveTable
                 .hasMessageMatching(".* Inserting into Hive table with skip.header.line.count property not supported");
         onHive().executeQuery("DROP TABLE test_textfile_skip_header_footer");
     }
+
+    @Test
+    public void testCreateTextFileTableAsSelectSkipHeaderFooter()
+    {
+        onHive().executeQuery("DROP TABLE IF EXISTS test_create_textfile_skip_header");
+        assertThatThrownBy(() -> onTrino().executeQuery(
+                "CREATE TABLE test_create_textfile_skip_header " +
+                        "WITH ( " +
+                        "   format = 'TEXTFILE', " +
+                        "   skip_header_line_count = 1 " +
+                        ") " +
+                        "AS SELECT 1  AS col_header;")
+        ).hasMessageMatching(".* Creating Hive table with data with value of skip.header.line.count property greater than 0 is not supported");
+        onHive().executeQuery("DROP TABLE test_create_textfile_skip_header");
+
+        onHive().executeQuery("DROP TABLE IF EXISTS test_create_textfile_skip_footer");
+        assertThatThrownBy(() -> onTrino().executeQuery(
+                "CREATE TABLE test_create_textfile_skip_footer " +
+                        "WITH ( " +
+                        "   format = 'TEXTFILE', " +
+                        "   skip_footer_line_count = 1 " +
+                        ") " +
+                        "AS SELECT 1  AS col_header;")
+        ).hasMessageMatching(".* Creating Hive table with data with value of skip.footer.line.count property greater than 0 is not supported");
+        onHive().executeQuery("DROP TABLE test_create_textfile_skip_footer");
+    }
 }


### PR DESCRIPTION
Currently when CSV table is defined with `skip_header_line_count=N`
on CTAS Trino would still write just data to the table
(no header information). As a result on subsequent
read we will miss some rows.