### PR TITLE
Add the trino namespace to the _meta properties in the Elasticsearch connector

### DIFF
--- a/docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/docs/src/main/sphinx/connector/elasticsearch.rst
@@ -194,7 +194,7 @@ For example, you can have an Elasticsearch index that contains documents with th
 .. code-block:: json
 
     {
-        "array_string_field": ["trino","is","the","besto"],
+        "array_string_field": ["trino","the","lean","machine-ohs"],
         "long_field": 314159265359,
         "id_field": "564e6982-88ee-4498-aa98-df9e3f6b6109",
         "timestamp_field": "1987-09-17T06:22:48.000Z",
@@ -205,7 +205,7 @@ For example, you can have an Elasticsearch index that contains documents with th
     }
 
 The array fields of this structure can be defined by using the following command to add the field
-property definition to the ``_meta.presto`` property of the target index mapping.
+property definition to the ``_meta.trino`` property of the target index mapping.
 
 .. code-block:: shell
 
@@ -215,7 +215,7 @@ property definition to the ``_meta.presto`` property of the target index mapping
         --data '
     {
         "_meta": {
-            "presto":{
+            "trino":{
                 "array_string_field":{
                     "isArray":true
                 },

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/client/ElasticsearchClient.java
@@ -562,7 +562,14 @@ public class ElasticsearchClient
 
                 JsonNode metaNode = nullSafeNode(mappings, "_meta");
 
-                return new IndexMetadata(parseType(mappings.get("properties"), nullSafeNode(metaNode, "presto")));
+                JsonNode metaProperties = nullSafeNode(metaNode, "trino");
+
+                //stay backwards compatible with _meta.presto namespace for meta properties for some releases
+                if (metaProperties.isNull()) {
+                    metaProperties = nullSafeNode(metaNode, "presto");
+                }
+
+                return new IndexMetadata(parseType(mappings.get("properties"), metaProperties));
             }
             catch (IOException e) {
                 throw new TrinoException(ELASTICSEARCH_INVALID_RESPONSE, e);

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -345,7 +345,7 @@ public abstract class BaseElasticsearchConnectorTest
         String mapping = "" +
                 "{" +
                 "      \"_meta\": {" +
-                "        \"presto\": {" +
+                "        \"trino\": {" +
                 "          \"a\": {" +
                 "            \"b\": {" +
                 "              \"y\": {" +
@@ -473,7 +473,7 @@ public abstract class BaseElasticsearchConnectorTest
         String mapping = "" +
                 "{" +
                 "  \"_meta\": {" +
-                "    \"presto\": {" +
+                "    \"trino\": {" +
                 "      \"es_object\": {" +
                 "        \"array_of_string_arrays\": {" +
                 "          \"asRawJson\": true" +
@@ -723,7 +723,7 @@ public abstract class BaseElasticsearchConnectorTest
         String mapping = "" +
                 "{" +
                 "  \"_meta\": {" +
-                "    \"presto\": {" +
+                "    \"trino\": {" +
                 "      \"es_binary\": {" +
                 "        \"asRawJson\": true" +
                 "      }," +
@@ -829,7 +829,7 @@ public abstract class BaseElasticsearchConnectorTest
         String mapping = "" +
                 "{" +
                 "  \"_meta\": {" +
-                "    \"presto\": {" +
+                "    \"trino\": {" +
                 "      \"es_binary\": {" +
                 "        \"asRawJson\": true" +
                 "      }," +
@@ -890,7 +890,7 @@ public abstract class BaseElasticsearchConnectorTest
         String mapping = "" +
                 "{" +
                 "  \"_meta\": {" +
-                "    \"presto\": {" +
+                "    \"trino\": {" +
                 "      \"array_raw_field\": {" +
                 "        \"asRawJson\": true," +
                 "        \"isArray\": true" +
@@ -926,7 +926,7 @@ public abstract class BaseElasticsearchConnectorTest
         String mapping = "" +
                 "{" +
                 "      \"_meta\": {" +
-                "        \"presto\": {" +
+                "        \"trino\": {" +
                 "          \"a\": {" +
                 "                \"isArray\": true" +
                 "          }" +


### PR DESCRIPTION
Fixes: #8383 