### PR TITLE
Revert "Add tests for Hive views with unions"

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/AbstractTestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/AbstractTestHiveViews.java
@@ -17,7 +17,6 @@ import io.trino.tempto.Requires;
 import io.trino.tempto.assertions.QueryAssert;
 import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableNationTable;
 import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableOrdersTable;
-import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableRegionTable;
 import io.trino.tempto.query.QueryExecutor;
 import io.trino.tempto.query.QueryResult;
 import io.trino.testng.services.Flaky;
@@ -27,7 +26,6 @@ import org.testng.annotations.Test;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.function.Consumer;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
@@ -43,7 +41,6 @@ import static org.testng.Assert.assertEquals;
 @Requires({
         ImmutableNationTable.class,
         ImmutableOrdersTable.class,
-        ImmutableRegionTable.class,
 })
 public abstract class AbstractTestHiveViews
         extends HiveProductTest
@@ -363,72 +360,6 @@ public abstract class AbstractTestHiveViews
                         row(2, 1),
                         row(3, 1),
                         row(4, 1)));
-    }
-
-    @Test(groups = HIVE_VIEWS)
-    public void testUnionAllViews()
-    {
-        onHive().executeQuery("DROP TABLE IF EXISTS union_helper");
-        onHive().executeQuery("CREATE TABLE union_helper (\n"
-                + "r_regionkey BIGINT,\n"
-                + "r_name VARCHAR(25),\n"
-                + "r_comment VARCHAR(152)\n"
-                + ")");
-        onHive().executeQuery("INSERT INTO union_helper\n"
-                + "SELECT r_regionkey % 3, r_name, r_comment FROM region");
-
-        onHive().executeQuery("DROP VIEW IF EXISTS union_all_view");
-        onHive().executeQuery("CREATE VIEW union_all_view AS\n"
-                + "SELECT r_regionkey FROM region\n"
-                + "UNION ALL\n"
-                + "SELECT r_regionkey FROM union_helper\n");
-
-        assertThat(query("SELECT r_regionkey FROM union_all_view"))
-                // Copy the keys 5 times because there are 5 nations per region
-                .containsOnly(
-                        // base rows
-                        row(0),
-                        row(1),
-                        row(2),
-                        row(3),
-                        row(4),
-                        // mod 3
-                        row(0),
-                        row(1),
-                        row(2),
-                        row(0),
-                        row(1));
-    }
-
-    @Test(groups = HIVE_VIEWS)
-    public void testUnionDistinctViews()
-    {
-        onHive().executeQuery("DROP TABLE IF EXISTS union_helper");
-        onHive().executeQuery("CREATE TABLE union_helper (\n"
-                + "r_regionkey BIGINT,\n"
-                + "r_name VARCHAR(25),\n"
-                + "r_comment VARCHAR(152)\n"
-                + ")");
-        onHive().executeQuery("INSERT INTO union_helper\n"
-                + "SELECT r_regionkey % 3, r_name, r_comment FROM region");
-
-        for (String operator : List.of("UNION", "UNION DISTINCT")) {
-            String name = format("%s_view", operator.replace(" ", "_"));
-            onHive().executeQuery(format("DROP VIEW IF EXISTS %s", name));
-            // Add mod to one side to add duplicate and non-overlapping values
-            onHive().executeQuery(format(
-                    "CREATE VIEW %s AS\n"
-                            + "SELECT r_regionkey FROM region\n"
-                            + "%s\n"
-                            + "SELECT r_regionkey FROM union_helper\n",
-                    name,
-                    operator));
-
-            assertViewQuery(
-                    format("SELECT r_regionkey FROM %s", name),
-                    assertion -> assertion.as("View with %s", operator)
-                            .containsOnly(row(0), row(1), row(2), row(3), row(4)));
-        }
     }
 
     protected static void assertViewQuery(String query, Consumer<QueryAssert> assertion)


### PR DESCRIPTION
Reverts trinodb/trino#8336

This wasn't tested with CDH5 which does not support Hive's `UNION ALL` syntax.

cc @jirassimok 