### PR TITLE
Reorder functions and operators list alphabetically

### DIFF
--- a/docs/src/main/sphinx/functions.rst
+++ b/docs/src/main/sphinx/functions.rst
@@ -15,32 +15,32 @@ and the :doc:`SQL statement and syntax reference</sql>`.
 .. toctree::
     :maxdepth: 1
 
-    Logical             <functions/logical>
+    Aggregate           <functions/aggregate>
+    Array               <functions/array>
+    Binary              <functions/binary>
+    Bitwise             <functions/bitwise>
+    Color               <functions/color>
     Comparison          <functions/comparison>
     Conditional         <functions/conditional>
-    Lambda              <functions/lambda>
     Conversion          <functions/conversion>
-    Math                <functions/math>
-    Bitwise             <functions/bitwise>
-    Decimal             <functions/decimal>
-    String              <functions/string>
-    Regular expression  <functions/regexp>
-    Binary              <functions/binary>
-    JSON                <functions/json>
     Date and time       <functions/datetime>
-    Aggregate           <functions/aggregate>
-    Window              <functions/window>
-    Array               <functions/array>
-    Map                 <functions/map>
-    URL                 <functions/url>
+    Decimal             <functions/decimal>
     Geospatial          <functions/geospatial>
     HyperLogLog         <functions/hyperloglog>
+    JSON                <functions/json>
+    Lambda              <functions/lambda>
+    Logical             <functions/logical>
+    Machine learning    <functions/ml>
+    Map                 <functions/map>
+    Math                <functions/math>
     Quantile digest     <functions/qdigest>
-    T-Digest            <functions/tdigest>
-    UUID                <functions/uuid>
-    Color               <functions/color>
+    Regular expression  <functions/regexp>
     Session             <functions/session>
+    String              <functions/string>
     System              <functions/system>
     Teradata            <functions/teradata>
-    Machine learning    <functions/ml>
+    T-Digest            <functions/tdigest>
+    URL                 <functions/url>
+    UUID                <functions/uuid>
+    Window              <functions/window>
     functions/list


### PR DESCRIPTION
https://trino.io/docs/current/functions.html

Reorder the list of SQL functions and operators by alphabet, for easier readability.