### PR TITLE
Support materialized view storage table column casting

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -231,6 +231,13 @@ class RelationPlanner
             PlanNode root = TableScanNode.newInstance(idAllocator.getNextId(), handle, outputSymbols, columns.build(), updateTarget, Optional.empty());
 
             plan = new RelationPlan(root, scope, outputSymbols, outerContext);
+
+            List<Type> types = analysis.getRelationCoercion(node);
+            if (types != null) {
+                // apply required coercion and prune invisible fields from child outputs
+                NodeAndMappings coerced = coerce(plan, types, symbolAllocator, idAllocator);
+                plan = new RelationPlan(coerced.getNode(), scope, coerced.getFields(), outerContext);
+            }
         }
 
         plan = addRowFilters(node, plan);

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -55,6 +55,7 @@ import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.sql.parser.ParsingOptions;
 import io.trino.sql.parser.SqlParser;
@@ -4759,7 +4760,7 @@ public class TestAnalyzer
                 .hasMessage("line 1:15: column [b] of type bigint projected from storage table at position 1 has a different name from column [c] of type bigint stored in materialized view definition");
         assertFails("SELECT * FROM fresh_materialized_view_mismatched_column_type")
                 .hasErrorCode(INVALID_VIEW)
-                .hasMessage("line 1:15: column [b] of type bigint projected from storage table at position 1 has a different type from column [b] of type tinyint stored in view definition");
+                .hasMessage("line 1:15: cannot cast column [b] of type bigint projected from storage table at position 1 into column [b] of type row(tinyint) stored in view definition");
     }
 
     @Test
@@ -5104,11 +5105,11 @@ public class TestAnalyzer
                 session,
                 freshMaterializedMismatchedColumnType,
                 new ConnectorMaterializedViewDefinition(
-                        "SELECT a, CAST(b as tinyint) b FROM t1",
+                        "SELECT a, null b FROM t1",
                         Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2")),
                         Optional.of(TPCH_CATALOG),
                         Optional.of("s1"),
-                        ImmutableList.of(new Column("a", BIGINT.getTypeId()), new Column("b", TINYINT.getTypeId())),
+                        ImmutableList.of(new Column("a", BIGINT.getTypeId()), new Column("b", RowType.anonymousRow(TINYINT).getTypeId())),
                         Optional.empty(),
                         "some user",
                         ImmutableMap.of()),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
@@ -33,9 +33,11 @@ import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.security.ViewExpression;
 import io.trino.spi.transaction.IsolationLevel;
 import io.trino.sql.planner.assertions.BasePlanTest;
 import io.trino.testing.LocalQueryRunner;
+import io.trino.testing.TestingAccessControlManager;
 import io.trino.testing.TestingMetadata;
 import org.testng.annotations.Test;
 
@@ -44,57 +46,84 @@ import java.util.Optional;
 import static io.trino.connector.CatalogName.createInformationSchemaCatalogName;
 import static io.trino.connector.CatalogName.createSystemTablesCatalogName;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 
 public class TestMaterializedViews
         extends BasePlanTest
 {
+    private static final String CATALOG = "local";
+    private static final String SCHEMA = "tiny";
+
     @Override
     protected LocalQueryRunner createLocalQueryRunner()
     {
-        String catalog = "local";
-        String schema = "tiny";
         Session.SessionBuilder sessionBuilder = testSessionBuilder()
-                .setCatalog(catalog)
-                .setSchema(schema)
+                .setCatalog(CATALOG)
+                .setSchema(SCHEMA)
                 .setSystemProperty("task_concurrency", "1"); // these tests don't handle exchanges from local parallel
 
         LocalQueryRunner queryRunner = LocalQueryRunner.create(sessionBuilder.build());
 
-        Catalog testCatalog = createTestingCatalog(catalog, new CatalogName(catalog), queryRunner);
+        Catalog testCatalog = createTestingCatalog(CATALOG, new CatalogName(CATALOG), queryRunner);
         queryRunner.getCatalogManager().registerCatalog(testCatalog);
-        TestingMetadata testingConnectorMetadata = (TestingMetadata) testCatalog.getConnector(new CatalogName(catalog)).getMetadata(null);
+        TestingMetadata testingConnectorMetadata = (TestingMetadata) testCatalog.getConnector(new CatalogName(CATALOG)).getMetadata(null);
 
         Metadata metadata = queryRunner.getMetadata();
-        SchemaTableName testTable = new SchemaTableName(schema, "test_table");
+        SchemaTableName testTable = new SchemaTableName(SCHEMA, "test_table");
         queryRunner.inTransaction(session -> {
             metadata.createTable(
                     session,
-                    catalog,
-                    new ConnectorTableMetadata(testTable, ImmutableList.of(new ColumnMetadata("a", BIGINT))),
+                    CATALOG,
+                    new ConnectorTableMetadata(
+                            testTable,
+                            ImmutableList.of(
+                                    new ColumnMetadata("a", BIGINT),
+                                    new ColumnMetadata("b", BIGINT))),
                     false);
             return null;
         });
 
-        SchemaTableName storageTable = new SchemaTableName(schema, "storage_table");
+        SchemaTableName storageTable = new SchemaTableName(SCHEMA, "storage_table");
         queryRunner.inTransaction(session -> {
             metadata.createTable(
                     session,
-                    catalog,
-                    new ConnectorTableMetadata(storageTable, ImmutableList.of(new ColumnMetadata("a", BIGINT))),
+                    CATALOG,
+                    new ConnectorTableMetadata(
+                            storageTable,
+                            ImmutableList.of(
+                                    new ColumnMetadata("a", BIGINT),
+                                    new ColumnMetadata("b", BIGINT))),
                     false);
             return null;
         });
 
-        QualifiedObjectName freshMaterializedView = new QualifiedObjectName(catalog, schema, "fresh_materialized_view");
+        SchemaTableName storageTableWithCasts = new SchemaTableName(SCHEMA, "storage_table_with_casts");
+        queryRunner.inTransaction(session -> {
+            metadata.createTable(
+                    session,
+                    CATALOG,
+                    new ConnectorTableMetadata(
+                            storageTableWithCasts,
+                            ImmutableList.of(
+                                    new ColumnMetadata("a", TINYINT),
+                                    new ColumnMetadata("b", VARCHAR))),
+                    false);
+            return null;
+        });
+
+        QualifiedObjectName freshMaterializedView = new QualifiedObjectName(CATALOG, SCHEMA, "fresh_materialized_view");
         ConnectorMaterializedViewDefinition materializedViewDefinition = new ConnectorMaterializedViewDefinition(
-                "SELECT a FROM test_table",
-                Optional.of(new CatalogSchemaTableName(catalog, schema, "storage_table")),
-                Optional.of(catalog),
-                Optional.of(schema),
-                ImmutableList.of(new Column("a", BIGINT.getTypeId())),
+                "SELECT a, b FROM test_table",
+                Optional.of(new CatalogSchemaTableName(CATALOG, SCHEMA, "storage_table")),
+                Optional.of(CATALOG),
+                Optional.of(SCHEMA),
+                ImmutableList.of(new Column("a", BIGINT.getTypeId()), new Column("b", BIGINT.getTypeId())),
                 Optional.empty(),
                 "some user",
                 ImmutableMap.of());
@@ -109,7 +138,7 @@ public class TestMaterializedViews
         });
         testingConnectorMetadata.markMaterializedViewIsFresh(freshMaterializedView.asSchemaTableName());
 
-        QualifiedObjectName notFreshMaterializedView = new QualifiedObjectName(catalog, schema, "not_fresh_materialized_view");
+        QualifiedObjectName notFreshMaterializedView = new QualifiedObjectName(CATALOG, SCHEMA, "not_fresh_materialized_view");
         queryRunner.inTransaction(session -> {
             metadata.createMaterializedView(
                     session,
@@ -119,7 +148,27 @@ public class TestMaterializedViews
                     false);
             return null;
         });
-        testingConnectorMetadata.markMaterializedViewIsFresh(freshMaterializedView.asSchemaTableName());
+
+        ConnectorMaterializedViewDefinition materializedViewDefinitionWithCasts = new ConnectorMaterializedViewDefinition(
+                "SELECT a, b FROM test_table",
+                Optional.of(new CatalogSchemaTableName(CATALOG, SCHEMA, "storage_table_with_casts")),
+                Optional.of(CATALOG),
+                Optional.of(SCHEMA),
+                ImmutableList.of(new Column("a", BIGINT.getTypeId()), new Column("b", BIGINT.getTypeId())),
+                Optional.empty(),
+                "some user",
+                ImmutableMap.of());
+        QualifiedObjectName materializedViewWithCasts = new QualifiedObjectName(CATALOG, SCHEMA, "materialized_view_with_casts");
+        queryRunner.inTransaction(session -> {
+            metadata.createMaterializedView(
+                    session,
+                    materializedViewWithCasts,
+                    materializedViewDefinitionWithCasts,
+                    false,
+                    false);
+            return null;
+        });
+        testingConnectorMetadata.markMaterializedViewIsFresh(materializedViewWithCasts.asSchemaTableName());
 
         return queryRunner;
     }
@@ -138,6 +187,24 @@ public class TestMaterializedViews
         assertPlan("SELECT * FROM not_fresh_materialized_view",
                 anyTree(
                         tableScan("test_table")));
+    }
+
+    @Test
+    public void testMaterializedViewWithCasts()
+    {
+        TestingAccessControlManager accessControl = getQueryRunner().getAccessControl();
+        accessControl.columnMask(
+                new QualifiedObjectName(CATALOG, SCHEMA, "materialized_view_with_casts"),
+                "a",
+                "user",
+                new ViewExpression("user", Optional.empty(), Optional.empty(), "a + 1"));
+        assertPlan("SELECT * FROM materialized_view_with_casts",
+                anyTree(
+                        project(
+                                ImmutableMap.of(
+                                        "A_CAST", expression("CAST(A as BIGINT) + BIGINT '1'"),
+                                        "B_CAST", expression("CAST(B as BIGINT)")),
+                                tableScan("storage_table_with_casts", ImmutableMap.of("A", "a", "B", "b")))));
     }
 
     private Catalog createTestingCatalog(String catalogName, CatalogName catalog, LocalQueryRunner queryRunner)


### PR DESCRIPTION
Trino will cast (if possible) storage table columns
if they don't match materialized view column types.