### PR TITLE
Update SQL Server docker images to use the new repository

### DIFF
--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
@@ -60,8 +60,7 @@ public final class TestingSqlServer
                     event.getAttemptCount(),
                     event.getLastFailure().getMessage()));
 
-    private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("microsoft/mssql-server-linux:2017-CU13")
-            .asCompatibleSubstituteFor("mcr.microsoft.com/mssql/server:2017-CU12");
+    private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("mcr.microsoft.com/mssql/server:2017-CU13");
 
     private final MSSQLServerContainer<?> container;
     private final String databaseName;

--- a/plugin/trino-sqlserver/src/test/resources/container-license-acceptance.txt
+++ b/plugin/trino-sqlserver/src/test/resources/container-license-acceptance.txt
@@ -1,1 +1,1 @@
-microsoft/mssql-server-linux:2017-CU13
+mcr.microsoft.com/mssql/server:2017-CU13

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SinglenodeSqlserver.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SinglenodeSqlserver.java
@@ -63,7 +63,7 @@ public final class SinglenodeSqlserver
     @SuppressWarnings("resource")
     private DockerContainer createSqlServer()
     {
-        DockerContainer container = new DockerContainer("microsoft/mssql-server-linux:2017-CU13", "sqlserver")
+        DockerContainer container = new DockerContainer("mcr.microsoft.com/mssql/server:2017-CU13", "sqlserver")
                 .withEnv("ACCEPT_EULA", "Y")
                 .withEnv("SA_PASSWORD", "SQLServerPass1")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())

--- a/testing/trino-product-tests/README.md
+++ b/testing/trino-product-tests/README.md
@@ -175,7 +175,7 @@ groups.
 Below is a list of commands that explain how to run these profile specific tests
 and also the entire test suite:
 
-Note: SQL Server product-tests use `microsoft/mssql-server-linux` docker container.
+Note: SQL Server product-tests use `mcr.microsoft.com/mssql/server` docker container.
 By running SQL Server product tests you accept the license [ACCEPT_EULA](https://go.microsoft.com/fwlink/?LinkId=746388)
 
 ### Running test suites


### PR DESCRIPTION
The images at microsoft/mssql-server-linux were removed and moved to
mcr.microsoft.com/mssql/server.