### PR TITLE
SPI stream collectors housekeeping

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -45,7 +45,7 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 public interface ConnectorMetadata
 {
@@ -393,7 +393,7 @@ public interface ConnectorMetadata
                             .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
                     List<String> partitionColumns = partitioning.getPartitioningColumns().stream()
                             .map(columnNamesByHandle::get)
-                            .collect(toList());
+                            .collect(toUnmodifiableList());
 
                     return new ConnectorNewTableLayout(partitioning.getPartitioningHandle(), partitionColumns);
                 });

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/EquatableValueSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/EquatableValueSet.java
@@ -40,12 +40,10 @@ import static io.trino.spi.function.InvocationConvention.simpleConvention;
 import static io.trino.spi.predicate.Utils.TUPLE_DOMAIN_TYPE_OPERATORS;
 import static io.trino.spi.predicate.Utils.handleThrowable;
 import static java.lang.String.format;
-import static java.util.Collections.unmodifiableCollection;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toCollection;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
 /**
@@ -128,9 +126,9 @@ public class EquatableValueSet
 
     public Collection<Object> getValues()
     {
-        return unmodifiableCollection(entries.stream()
+        return entries.stream()
                 .map(ValueEntry::getValue)
-                .collect(toList()));
+                .collect(toUnmodifiableList());
     }
 
     public int getValuesCount()

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/TupleDomain.java
@@ -40,8 +40,8 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 /**
  * Defines a set of valid tuples according to the constraints on each of its constituent columns
@@ -184,7 +184,7 @@ public final class TupleDomain<T>
     {
         return domains.map(map -> map.entrySet().stream()
                 .map(entry -> new ColumnDomain<>(entry.getKey(), entry.getValue()))
-                .collect(toList()));
+                .collect(toUnmodifiableList()));
     }
 
     private static <T> boolean containsNoneDomain(Map<T, Domain> domains)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/RowType.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
@@ -116,7 +115,7 @@ public class RowType
         this.fields = fields;
         this.fieldTypes = fields.stream()
                 .map(Field::getType)
-                .collect(Collectors.toList());
+                .collect(toUnmodifiableList());
 
         this.comparable = fields.stream().allMatch(field -> field.getType().isComparable());
         this.orderable = fields.stream().allMatch(field -> field.getType().isOrderable());
@@ -131,7 +130,7 @@ public class RowType
     {
         List<Field> fields = types.stream()
                 .map(type -> new Field(Optional.empty(), type))
-                .collect(Collectors.toList());
+                .collect(toUnmodifiableList());
 
         return new RowType(makeSignature(fields), fields);
     }
@@ -172,7 +171,7 @@ public class RowType
         List<TypeSignatureParameter> parameters = fields.stream()
                 .map(field -> new NamedTypeSignature(field.getName().map(RowFieldName::new), field.getType().getTypeSignature()))
                 .map(TypeSignatureParameter::namedTypeParameter)
-                .collect(Collectors.toList());
+                .collect(toUnmodifiableList());
 
         return new TypeSignature(ROW, parameters);
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeSignature.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeSignature.java
@@ -22,12 +22,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static io.trino.spi.type.StandardTypes.TIME_WITH_TIME_ZONE;
 import static io.trino.spi.type.TypeSignatureParameter.typeParameter;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toUnmodifiableList;
 
 @Immutable
 public final class TypeSignature
@@ -200,7 +200,7 @@ public final class TypeSignature
                 name,
                 Arrays.asList(parameters).stream()
                         .map(TypeSignatureParameter::typeParameter)
-                        .collect(Collectors.toList()));
+                        .collect(toUnmodifiableList()));
     }
 
     public static TypeSignature functionType(TypeSignature first, TypeSignature... rest)

--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeSignature.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeSignature.java
@@ -198,7 +198,7 @@ public final class TypeSignature
     {
         return new TypeSignature(
                 name,
-                Arrays.asList(parameters).stream()
+                Arrays.stream(parameters)
                         .map(TypeSignatureParameter::typeParameter)
                         .collect(toUnmodifiableList()));
     }
@@ -208,7 +208,7 @@ public final class TypeSignature
         List<TypeSignatureParameter> parameters = new ArrayList<>();
         parameters.add(typeParameter(first));
 
-        Arrays.asList(rest).stream()
+        Arrays.stream(rest)
                 .map(TypeSignatureParameter::typeParameter)
                 .forEach(parameters::add);
 


### PR DESCRIPTION
Since Java 11 (or 9, don't really remember) you can use `toUnmodifiableList` instead of `toList` stream collector.
This mimics Guava's `toImmutableList` that we cannot use in SPI.