### PR TITLE
Simplify PartitionedOutputOperator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
+++ b/core/trino-main/src/main/java/io/trino/operator/GroupByIdBlock.java
@@ -166,6 +166,12 @@ public class GroupByIdBlock
     }
 
     @Override
+    public boolean mayHaveNull()
+    {
+        return block.mayHaveNull();
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         return block.isNull(position);

--- a/core/trino-main/src/main/java/io/trino/operator/PartitionedOutputOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PartitionedOutputOperator.java
@@ -310,7 +310,7 @@ public class PartitionedOutputOperator
     private static class PagePartitioner
     {
         private final OutputBuffer outputBuffer;
-        private final List<Type> sourceTypes;
+        private final Type[] sourceTypes;
         private final PartitionFunction partitionFunction;
         private final int[] partitionChannels;
         @Nullable
@@ -318,7 +318,7 @@ public class PartitionedOutputOperator
         private final PagesSerde serde;
         private final PageBuilder[] pageBuilders;
         private final boolean replicatesAnyRow;
-        private final OptionalInt nullChannel; // when present, send the position to every partition if this channel is null.
+        private final int nullChannel; // when >= 0, send the position to every partition if this channel is null
         private final AtomicLong rowsAdded = new AtomicLong();
         private final AtomicLong pagesAdded = new AtomicLong();
         private boolean hasAnyRowBeenReplicated;
@@ -348,9 +348,9 @@ public class PartitionedOutputOperator
                 this.partitionConstantBlocks = null;
             }
             this.replicatesAnyRow = replicatesAnyRow;
-            this.nullChannel = requireNonNull(nullChannel, "nullChannel is null");
+            this.nullChannel = requireNonNull(nullChannel, "nullChannel is null").orElse(-1);
             this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
-            this.sourceTypes = requireNonNull(sourceTypes, "sourceTypes is null");
+            this.sourceTypes = requireNonNull(sourceTypes, "sourceTypes is null").toArray(new Type[0]);
             this.serde = requireNonNull(serdeFactory, "serdeFactory is null").createPagesSerde();
             this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
 
@@ -417,22 +417,46 @@ public class PartitionedOutputOperator
         public void partitionPage(Page page)
         {
             requireNonNull(page, "page is null");
+            if (page.getPositionCount() == 0) {
+                return;
+            }
+
+            int position;
+            // Handle "any row" replication outside of the inner loop processing
+            if (replicatesAnyRow && !hasAnyRowBeenReplicated) {
+                for (PageBuilder pageBuilder : pageBuilders) {
+                    appendRow(pageBuilder, page, 0);
+                }
+                hasAnyRowBeenReplicated = true;
+                position = 1;
+            }
+            else {
+                position = 0;
+            }
 
             Page partitionFunctionArgs = getPartitionFunctionArguments(page);
-            for (int position = 0; position < page.getPositionCount(); position++) {
-                boolean shouldReplicate = (replicatesAnyRow && !hasAnyRowBeenReplicated) ||
-                        nullChannel.isPresent() && page.getBlock(nullChannel.getAsInt()).isNull(position);
-                if (shouldReplicate) {
-                    for (PageBuilder pageBuilder : pageBuilders) {
-                        appendRow(pageBuilder, page, position);
+            // Skip null block checks if mayHaveNull reports that no positions will be null
+            if (nullChannel >= 0 && page.getBlock(nullChannel).mayHaveNull()) {
+                Block nullsBlock = page.getBlock(nullChannel);
+                for (; position < page.getPositionCount(); position++) {
+                    if (nullsBlock.isNull(position)) {
+                        for (PageBuilder pageBuilder : pageBuilders) {
+                            appendRow(pageBuilder, page, position);
+                        }
                     }
-                    hasAnyRowBeenReplicated = true;
+                    else {
+                        int partition = partitionFunction.getPartition(partitionFunctionArgs, position);
+                        appendRow(pageBuilders[partition], page, position);
+                    }
                 }
-                else {
+            }
+            else {
+                for (; position < page.getPositionCount(); position++) {
                     int partition = partitionFunction.getPartition(partitionFunctionArgs, position);
                     appendRow(pageBuilders[partition], page, position);
                 }
             }
+
             flush(false);
         }
 
@@ -460,8 +484,8 @@ public class PartitionedOutputOperator
         {
             pageBuilder.declarePosition();
 
-            for (int channel = 0; channel < sourceTypes.size(); channel++) {
-                Type type = sourceTypes.get(channel);
+            for (int channel = 0; channel < sourceTypes.length; channel++) {
+                Type type = sourceTypes[channel];
                 type.appendTo(page.getBlock(channel), position, pageBuilder.getBlockBuilder(channel));
             }
         }

--- a/core/trino-main/src/main/java/io/trino/operator/PartitionedOutputOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PartitionedOutputOperator.java
@@ -301,6 +301,12 @@ public class PartitionedOutputOperator
         return null;
     }
 
+    @Override
+    public void close()
+    {
+        systemMemoryContext.close();
+    }
+
     private static class PagePartitioner
     {
         private final OutputBuffer outputBuffer;

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -366,6 +366,12 @@ public class DictionaryBlock
     }
 
     @Override
+    public boolean mayHaveNull()
+    {
+        return positionCount > 0 && dictionary.mayHaveNull();
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         return dictionary.isNull(getId(position));

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RunLengthEncodedBlock.java
@@ -272,6 +272,12 @@ public class RunLengthEncodedBlock
     }
 
     @Override
+    public boolean mayHaveNull()
+    {
+        return positionCount > 0 && value.isNull(0);
+    }
+
+    @Override
     public boolean isNull(int position)
     {
         checkReadablePosition(position);


### PR DESCRIPTION
Simplifies `PartitionedOutputOperator` logic in the inner loop by hoisting "any row" replication outside of it and checking `Block#mayHaveNull()` before querying the null channel on each iteration.

Also adds `mayHaveNull()` implementations to `DictionaryBlock`, `RunLengthEncodedBlock`, and `GroupByIdBlock` without which that hoisted checking would be less effective.

This change also includes a fix for `PartitionedOutputOperator#close()` not calling `systemMemoryContext#close()` (memory was still being released by `OperatorContext#destroy()` but would use the "force free" allocation tag, resulting in incorrect query OOM top consumer reporting).