### PR TITLE
Replace deprecated installModuleIf with conditionalModule from airlift

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorModule.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/TopologyAwareNodeSelectorModule.java
@@ -17,7 +17,7 @@ import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.execution.scheduler.TopologyAwareNodeSelectorConfig.TopologyType.FILE;
 import static io.trino.execution.scheduler.TopologyAwareNodeSelectorConfig.TopologyType.FLAT;
@@ -39,12 +39,12 @@ public class TopologyAwareNodeSelectorModule
 
     private void bindNetworkTopology()
     {
-        install(installModuleIf(
+        install(conditionalModule(
                 TopologyAwareNodeSelectorConfig.class,
                 config -> config.getType() == FLAT,
                 binder -> binder.bind(NetworkTopology.class).to(FlatNetworkTopology.class).in(Scopes.SINGLETON)));
 
-        install(installModuleIf(
+        install(conditionalModule(
                 TopologyAwareNodeSelectorConfig.class,
                 config -> config.getType() == FILE,
                 binder -> {
@@ -53,7 +53,7 @@ public class TopologyAwareNodeSelectorModule
                     newExporter(binder).export(FileBasedNetworkTopology.class).withGeneratedName();
                 }));
 
-        install(installModuleIf(
+        install(conditionalModule(
                 TopologyAwareNodeSelectorConfig.class,
                 config -> config.getType() == SUBNET,
                 binder -> {

--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -104,7 +104,7 @@ import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.concurrent.Threads.threadsNamed;
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
@@ -334,7 +334,7 @@ public class CoordinatorModule
 
     private void bindLowMemoryKiller(LowMemoryKillerPolicy policy, Class<? extends LowMemoryKiller> clazz)
     {
-        install(installModuleIf(
+        install(conditionalModule(
                 MemoryManagerConfig.class,
                 config -> policy == config.getLowMemoryKillerPolicy(),
                 binder -> binder.bind(LowMemoryKiller.class).to(clazz).in(Scopes.SINGLETON)));

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -145,7 +145,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
@@ -247,11 +247,11 @@ public class ServerMainModule
 
         // network topology
         // TODO: move to CoordinatorModule when NodeScheduler is moved
-        install(installModuleIf(
+        install(conditionalModule(
                 NodeSchedulerConfig.class,
                 config -> UNIFORM == config.getNodeSchedulerPolicy(),
                 new UniformNodeSelectorModule()));
-        install(installModuleIf(
+        install(conditionalModule(
                 NodeSchedulerConfig.class,
                 config -> TOPOLOGY == config.getNodeSchedulerPolicy(),
                 new TopologyAwareNodeSelectorModule()));

--- a/core/trino-main/src/main/java/io/trino/server/security/ServerSecurityModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/ServerSecurityModule.java
@@ -38,7 +38,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.inject.multibindings.MapBinder.newMapBinder;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.configuration.ConfigurationAwareModule.combine;
 import static io.airlift.http.server.HttpServer.ClientCertificate.REQUESTED;
@@ -103,7 +103,7 @@ public class ServerSecurityModule
     {
         checkArgument(name.toLowerCase(ENGLISH).equals(name), "name is not lower case: %s", name);
         Module authModule = binder -> authenticatorBinder(binder).addBinding(name).to(clazz).in(Scopes.SINGLETON);
-        return installModuleIf(
+        return conditionalModule(
                 SecurityConfig.class,
                 config -> authenticationTypes(config).contains(name),
                 combine(module, authModule));

--- a/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/jwt/JwtAuthenticatorSupportModule.java
@@ -24,7 +24,7 @@ import javax.inject.Singleton;
 
 import java.net.URI;
 
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.http.client.HttpClientBinder.httpClientBinder;
 
@@ -35,7 +35,7 @@ public class JwtAuthenticatorSupportModule
     protected void setup(Binder binder)
     {
         configBinder(binder).bindConfig(JwtAuthenticatorConfig.class);
-        install(installModuleIf(
+        install(conditionalModule(
                 JwtAuthenticatorConfig.class,
                 JwtAuthenticatorSupportModule::isHttp,
                 new JwkModule(),

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
@@ -27,7 +27,7 @@ import io.trino.spi.connector.ConnectorHandleResolver;
 
 import java.util.Map;
 
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static java.util.Objects.requireNonNull;
 
 public class AtopConnectorFactory
@@ -67,11 +67,11 @@ public class AtopConnectorFactory
                             context.getNodeManager(),
                             context.getNodeManager().getEnvironment(),
                             catalogName),
-                    installModuleIf(
+                    conditionalModule(
                             AtopConnectorConfig.class,
                             config -> config.getSecurity() == AtopSecurity.NONE,
                             new AllowAllAccessControlModule()),
-                    installModuleIf(
+                    conditionalModule(
                             AtopConnectorConfig.class,
                             config -> config.getSecurity() == AtopSecurity.FILE,
                             binder -> {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RemoteQueryCancellationModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/RemoteQueryCancellationModule.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ExecutorService;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -38,7 +38,7 @@ public class RemoteQueryCancellationModule
     @Override
     protected void setup(Binder binder)
     {
-        install(installModuleIf(
+        install(conditionalModule(
                 RemoteQueryCancellationConfig.class,
                 RemoteQueryCancellationConfig::isRemoteQueryCancellationEnabled,
                 bindForRecordCursor()));

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/CredentialProviderModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/CredentialProviderModule.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.inject.Scopes.SINGLETON;
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
 import static io.trino.plugin.jdbc.credential.CredentialProviderType.FILE;
@@ -55,7 +55,7 @@ public class CredentialProviderModule
 
     private void bindCredentialProviderModule(CredentialProviderType name, Module module)
     {
-        install(installModuleIf(
+        install(conditionalModule(
                 CredentialProviderTypeConfig.class,
                 config -> name == config.getCredentialProviderType(),
                 module));

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorModule.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorModule.java
@@ -26,7 +26,7 @@ import io.trino.spi.type.TypeManager;
 import javax.inject.Inject;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonBinder.jsonBinder;
 import static io.trino.plugin.elasticsearch.ElasticsearchConfig.Security.AWS;
@@ -57,14 +57,14 @@ public class ElasticsearchConnectorModule
         newOptionalBinder(binder, AwsSecurityConfig.class);
         newOptionalBinder(binder, PasswordConfig.class);
 
-        install(installModuleIf(
+        install(conditionalModule(
                 ElasticsearchConfig.class,
                 config -> config.getSecurity()
                         .filter(isEqual(AWS))
                         .isPresent(),
                 conditionalBinder -> configBinder(conditionalBinder).bindConfig(AwsSecurityConfig.class)));
 
-        install(installModuleIf(
+        install(conditionalModule(
                 ElasticsearchConfig.class,
                 config -> config.getSecurity()
                         .filter(isEqual(PASSWORD))

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
@@ -68,7 +68,7 @@ import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static java.util.Objects.requireNonNull;
 
 public final class InternalHiveConnectorFactory
@@ -96,7 +96,7 @@ public final class InternalHiveConnectorFactory
                     new HiveS3Module(),
                     new HiveGcsModule(),
                     new HiveAzureModule(),
-                    installModuleIf(RubixEnabledConfig.class, RubixEnabledConfig::isCacheEnabled, new RubixModule()),
+                    conditionalModule(RubixEnabledConfig.class, RubixEnabledConfig::isCacheEnabled, new RubixModule()),
                     new HiveMetastoreModule(metastore),
                     new HiveSecurityModule(catalogName),
                     new HiveAuthenticationModule(),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/authentication/HiveAuthenticationModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/authentication/HiveAuthenticationModule.java
@@ -20,7 +20,7 @@ import io.trino.plugin.hive.authentication.HiveAuthenticationConfig.HdfsAuthenti
 
 import java.util.function.Predicate;
 
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.trino.plugin.hive.authentication.AuthenticationModules.kerberosHdfsAuthenticationModule;
 import static io.trino.plugin.hive.authentication.AuthenticationModules.kerberosImpersonatingHdfsAuthenticationModule;
 import static io.trino.plugin.hive.authentication.AuthenticationModules.noHdfsAuthenticationModule;
@@ -51,7 +51,7 @@ public class HiveAuthenticationModule
 
     private void bindAuthenticationModule(Predicate<HiveAuthenticationConfig> predicate, Module module)
     {
-        install(installModuleIf(HiveAuthenticationConfig.class, predicate, module));
+        install(conditionalModule(HiveAuthenticationConfig.class, predicate, module));
     }
 
     private static boolean noHdfsAuth(HiveAuthenticationConfig config)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/HiveMetastoreModule.java
@@ -25,7 +25,7 @@ import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreModule;
 
 import java.util.Optional;
 
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 
 public class HiveMetastoreModule
         extends AbstractConfigurationAwareModule
@@ -54,7 +54,7 @@ public class HiveMetastoreModule
 
     private void bindMetastoreModule(String name, Module module)
     {
-        install(installModuleIf(
+        install(conditionalModule(
                 MetastoreTypeConfig.class,
                 metastore -> name.equalsIgnoreCase(metastore.getMetastoreType()),
                 module));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueMetastoreModule.java
@@ -37,7 +37,7 @@ import java.util.function.Predicate;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
@@ -63,7 +63,7 @@ public class GlueMetastoreModule
         binder.bind(GlueHiveMetastore.class).in(Scopes.SINGLETON);
         newExporter(binder).export(GlueHiveMetastore.class).withGeneratedName();
 
-        install(installModuleIf(
+        install(conditionalModule(
                 HiveConfig.class,
                 HiveConfig::isTableStatisticsEnabled,
                 getGlueStatisticsModule(DefaultGlueColumnStatisticsProviderFactory.class),

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/HiveSecurityModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/HiveSecurityModule.java
@@ -19,7 +19,7 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.base.security.FileBasedAccessControlModule;
 import io.trino.plugin.base.security.ReadOnlySecurityModule;
 
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigurationModule.installModules;
 import static java.util.Objects.requireNonNull;
 
@@ -57,7 +57,7 @@ public class HiveSecurityModule
 
     private void bindSecurityModule(String name, Module module)
     {
-        install(installModuleIf(
+        install(conditionalModule(
                 SecurityConfig.class,
                 security -> name.equalsIgnoreCase(security.getSecuritySystem()),
                 module));

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaClientsModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaClientsModule.java
@@ -20,7 +20,7 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.kafka.security.ForKafkaSsl;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class KafkaClientsModule
@@ -36,7 +36,7 @@ public class KafkaClientsModule
 
     private void installClientModule(SecurityProtocol securityProtocol, Module module)
     {
-        install(installModuleIf(
+        install(conditionalModule(
                 KafkaSecurityConfig.class,
                 config -> config.getSecurityProtocol().equals(securityProtocol),
                 module));

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaConnectorModule.java
@@ -39,7 +39,7 @@ import io.trino.spi.type.TypeManager;
 import javax.inject.Inject;
 
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.json.JsonBinder.jsonBinder;
 import static io.airlift.json.JsonCodecBinder.jsonCodecBinder;
@@ -95,7 +95,7 @@ public class KafkaConnectorModule
 
     public void bindTopicSchemaProviderModule(String name, Module module)
     {
-        install(installModuleIf(
+        install(conditionalModule(
                 KafkaConfig.class,
                 kafkaConfig -> name.equalsIgnoreCase(kafkaConfig.getTableDescriptionSupplier()),
                 module));

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/security/KafkaSecurityModule.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/security/KafkaSecurityModule.java
@@ -19,7 +19,7 @@ import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.kafka.KafkaSecurityConfig;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigurationModule.installModules;
 
 public class KafkaSecurityModule
@@ -35,7 +35,7 @@ public class KafkaSecurityModule
 
     private void bindSecurityModule(SecurityProtocol securityProtocol, Module module)
     {
-        install(installModuleIf(
+        install(conditionalModule(
                 KafkaSecurityConfig.class,
                 config -> config.getSecurityProtocol().equals(securityProtocol),
                 module));

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/KafkaQueryRunner.java
@@ -42,7 +42,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.io.ByteStreams.toByteArray;
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigurationAwareModule.combine;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.plugin.kafka.util.TestUtils.loadTpchTopicDescription;
@@ -123,7 +123,7 @@ public final class KafkaQueryRunner
                     .build();
             setExtension(combine(
                     extension,
-                    installModuleIf(
+                    conditionalModule(
                             KafkaConfig.class,
                             kafkaConfig -> kafkaConfig.getTableDescriptionSupplier().equalsIgnoreCase(TEST),
                             binder -> binder.bind(TableDescriptionSupplier.class)

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseMetadataModule.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseMetadataModule.java
@@ -40,7 +40,7 @@ import javax.sql.DataSource;
 import java.lang.reflect.Type;
 
 import static com.google.common.base.Preconditions.checkState;
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.airlift.discovery.client.ServiceDescriptor.serviceDescriptor;
 import static java.util.Objects.requireNonNull;
@@ -51,7 +51,7 @@ public class DatabaseMetadataModule
     @Override
     protected void setup(Binder ignored)
     {
-        install(installModuleIf(
+        install(conditionalModule(
                 DatabaseConfig.class,
                 config -> "mysql".equals(config.getDatabaseType()),
                 binder -> {
@@ -59,7 +59,7 @@ public class DatabaseMetadataModule
                     bindDaoSupplier(binder, ShardDao.class, MySqlShardDao.class);
                 }));
 
-        install(installModuleIf(
+        install(conditionalModule(
                 DatabaseConfig.class,
                 config -> "h2".equals(config.getDatabaseType()),
                 binder -> {

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurityModule.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurityModule.java
@@ -20,7 +20,7 @@ import io.trino.plugin.base.security.AllowAllAccessControlModule;
 import io.trino.plugin.base.security.FileBasedAccessControlModule;
 import io.trino.plugin.base.security.ReadOnlySecurityModule;
 
-import static io.airlift.configuration.ConditionalModule.installModuleIf;
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static java.util.Objects.requireNonNull;
 
 public class RaptorSecurityModule
@@ -43,7 +43,7 @@ public class RaptorSecurityModule
 
     private void bindSecurityModule(String name, Module module)
     {
-        install(installModuleIf(
+        install(conditionalModule(
                 RaptorSecurityConfig.class,
                 security -> name.equalsIgnoreCase(security.getSecuritySystem()),
                 module));


### PR DESCRIPTION
Method `installModuleIf()` has been deprecated in the latest airlift library.

https://github.com/airlift/airlift/blob/29e304b3f186da3d20507f3929a2a3f019de653a/configuration/src/main/java/io/airlift/configuration/ConditionalModule.java#L27-L34

Updated the method to `conditionalModule()`.