### PR TITLE
support locality for iceberg connector

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -33,6 +33,7 @@ public class IcebergConfig
     private int maxPartitionsPerWriter = 100;
     private boolean uniqueTableLocation;
     private CatalogType catalogType = HIVE;
+    private boolean fetchSplitLocations;
 
     public CatalogType getCatalogType()
     {
@@ -43,6 +44,19 @@ public class IcebergConfig
     public IcebergConfig setCatalogType(CatalogType catalogType)
     {
         this.catalogType = catalogType;
+        return this;
+    }
+
+    public boolean isFetchSplitLocations()
+    {
+        return fetchSplitLocations;
+    }
+
+    @ConfigDescription("When true, we will get block locations for every datafile")
+    @Config("iceberg.fetch-split-locations")
+    public IcebergConfig setFetchSplitLocations(boolean fetchSplitLocations)
+    {
+        this.fetchSplitLocations = fetchSplitLocations;
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -45,6 +45,7 @@ public final class IcebergSessionProperties
 {
     private static final String COMPRESSION_CODEC = "compression_codec";
     private static final String USE_FILE_SIZE_FROM_METADATA = "use_file_size_from_metadata";
+    private static final String FETCH_SPLIT_LOCATIONS = "fetch_split_locations";
     private static final String ORC_BLOOM_FILTERS_ENABLED = "orc_bloom_filters_enabled";
     private static final String ORC_MAX_MERGE_DISTANCE = "orc_max_merge_distance";
     private static final String ORC_MAX_BUFFER_SIZE = "orc_max_buffer_size";
@@ -84,6 +85,11 @@ public final class IcebergSessionProperties
                         USE_FILE_SIZE_FROM_METADATA,
                         "Use file size stored in Iceberg metadata",
                         icebergConfig.isUseFileSizeFromMetadata(),
+                        false))
+                .add(booleanProperty(
+                        FETCH_SPLIT_LOCATIONS,
+                        "Get split locations from FileSystem for every datafile",
+                        icebergConfig.isFetchSplitLocations(),
                         false))
                 .add(booleanProperty(
                         ORC_BLOOM_FILTERS_ENABLED,
@@ -283,6 +289,11 @@ public final class IcebergSessionProperties
     public static boolean isUseFileSizeFromMetadata(ConnectorSession session)
     {
         return session.getProperty(USE_FILE_SIZE_FROM_METADATA, Boolean.class);
+    }
+
+    public static boolean isFetchSplitLocations(ConnectorSession session)
+    {
+        return session.getProperty(FETCH_SPLIT_LOCATIONS, Boolean.class);
     }
 
     public static DataSize getParquetMaxReadBlockSize(ConnectorSession session)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -150,7 +150,8 @@ public class IcebergSplitSource
         return new ArrayList<>(locations);
     }
 
-    private static List<HostAddress> getHostAddresses(BlockLocation blockLocation) throws IOException {
+    private static List<HostAddress> getHostAddresses(BlockLocation blockLocation) throws IOException
+    {
         // Hadoop FileSystem returns "localhost" as a default
         return Arrays.stream(blockLocation.getHosts())
                 .map(HostAddress::fromString)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -15,11 +15,18 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
+import io.airlift.log.Logger;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.trino.spi.HostAddress;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorPartitionHandle;
 import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.SchemaTableName;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.io.CloseableIterable;
@@ -27,13 +34,18 @@ import org.apache.iceberg.io.CloseableIterable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterators.limit;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -41,11 +53,20 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 public class IcebergSplitSource
         implements ConnectorSplitSource
 {
+    private static final Logger log = Logger.get(IcebergSplitSource.class);
     private final SchemaTableName schemaTableName;
     private final CloseableIterable<CombinedScanTask> combinedScanIterable;
     private final Iterator<FileScanTask> fileScanIterator;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final HdfsContext hdfsContext;
+    private final boolean fetchSplitLocations;
 
-    public IcebergSplitSource(SchemaTableName schemaTableName, CloseableIterable<CombinedScanTask> combinedScanIterable)
+    public IcebergSplitSource(
+            SchemaTableName schemaTableName,
+            CloseableIterable<CombinedScanTask> combinedScanIterable,
+            HdfsEnvironment hdfsEnvironment,
+            HdfsContext hdfsContext,
+            boolean fetchSplitLocations)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.combinedScanIterable = requireNonNull(combinedScanIterable, "combinedScanIterable is null");
@@ -54,6 +75,9 @@ public class IcebergSplitSource
                 .map(CombinedScanTask::files)
                 .flatMap(Collection::stream)
                 .iterator();
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.hdfsContext = requireNonNull(hdfsContext, "hdfsContext is null");
+        this.fetchSplitLocations = fetchSplitLocations;
     }
 
     @Override
@@ -97,7 +121,40 @@ public class IcebergSplitSource
                 task.length(),
                 task.file().fileSizeInBytes(),
                 task.file().format(),
-                ImmutableList.of(),
+                getAddresses(task),
                 getPartitionKeys(task));
+    }
+
+    private List<HostAddress> getAddresses(FileScanTask task)
+    {
+        if (!fetchSplitLocations) {
+            return ImmutableList.of();
+        }
+        return blockLocations(task);
+    }
+
+    private List<HostAddress> blockLocations(FileScanTask task)
+    {
+        Set<HostAddress> locations = new HashSet<>();
+        Path path = new Path(task.file().path().toString());
+        try {
+            FileSystem fs = hdfsEnvironment.getFileSystem(hdfsContext, path);
+            for (BlockLocation blockLocation : fs.getFileBlockLocations(path, task.start(), task.length())) {
+                locations.addAll(getHostAddresses(blockLocation));
+            }
+        }
+        catch (IOException e) {
+            log.error("Failed to get block locations for path %s", path, e);
+            throw new TrinoException(GENERIC_INTERNAL_ERROR, "Failed to get block locations", e);
+        }
+        return new ArrayList<>(locations);
+    }
+
+    private static List<HostAddress> getHostAddresses(BlockLocation blockLocation) throws IOException {
+        // Hadoop FileSystem returns "localhost" as a default
+        return Arrays.stream(blockLocation.getHosts())
+                .map(HostAddress::fromString)
+                .filter(address -> !"localhost".equals(address.getHostText()))
+                .collect(toImmutableList());
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -37,6 +37,7 @@ public class TestIcebergConfig
                 .setFileFormat(ORC)
                 .setCompressionCodec(GZIP)
                 .setUseFileSizeFromMetadata(true)
+                .setFetchSplitLocations(false)
                 .setMaxPartitionsPerWriter(100)
                 .setUniqueTableLocation(false)
                 .setCatalogType(HIVE));
@@ -49,6 +50,7 @@ public class TestIcebergConfig
                 .put("iceberg.file-format", "Parquet")
                 .put("iceberg.compression-codec", "NONE")
                 .put("iceberg.use-file-size-from-metadata", "false")
+                .put("iceberg.fetch-split-locations", "true")
                 .put("iceberg.max-partitions-per-writer", "222")
                 .put("iceberg.unique-table-location", "true")
                 .put("iceberg.catalog.type", "UNKNOWN")
@@ -58,6 +60,7 @@ public class TestIcebergConfig
                 .setFileFormat(PARQUET)
                 .setCompressionCodec(HiveCompressionCodec.NONE)
                 .setUseFileSizeFromMetadata(false)
+                .setFetchSplitLocations(true)
                 .setMaxPartitionsPerWriter(222)
                 .setUniqueTableLocation(true)
                 .setCatalogType(UNKNOWN);


### PR DESCRIPTION
trino supports getAddresses interface in ConnectorSplit to improve the query efficiency. but now iceberg connector don't implement it. so this pr support locality for iceberg connector.