### PR TITLE
Add missing Thread::interrupt calls

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/ExplainAnalyzeOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExplainAnalyzeOperator.java
@@ -166,6 +166,7 @@ public class ExplainAnalyzeOperator
                 TimeUnit.MILLISECONDS.sleep(100);
             }
             catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new RuntimeException(e);
             }
         }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskExecution.java
@@ -632,6 +632,7 @@ public class TestSqlTaskExecution
                 Thread.sleep(10);
             }
             catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 // do nothing
             }
         }

--- a/core/trino-main/src/test/java/io/trino/execution/executor/SimulationController.java
+++ b/core/trino-main/src/test/java/io/trino/execution/executor/SimulationController.java
@@ -102,6 +102,7 @@ class SimulationController
                     MILLISECONDS.sleep(500);
                 }
                 catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                     return;
                 }
             }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/FileSystemFinalizerService.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/fs/FileSystemFinalizerService.java
@@ -80,6 +80,7 @@ public class FileSystemFinalizerService
                 finalizer.cleanup();
             }
             catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 return;
             }
             catch (Throwable t) {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -386,6 +386,7 @@ public class TestBackgroundHiveSplitLoader
                                 TimeUnit.HOURS.sleep(1);
                             }
                             catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
                                 throw new IllegalStateException(e);
                             }
                         });

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/s3config/TestS3TableConfigClient.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/s3config/TestS3TableConfigClient.java
@@ -105,6 +105,7 @@ public class TestS3TableConfigClient
             log.info("done sleeping, will now try to read the tables.");
         }
         catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             log.error("interrupted ...");
         }
 

--- a/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplitManager.java
+++ b/plugin/trino-kudu/src/main/java/io/trino/plugin/kudu/KuduSplitManager.java
@@ -129,7 +129,11 @@ public class KuduSplitManager
             try {
                 return splitSourceFuture.get().isFinished();
             }
-            catch (InterruptedException | ExecutionException e) {
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+            catch (ExecutionException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduIntegrationDynamicFilter.java
+++ b/plugin/trino-kudu/src/test/java/io/trino/plugin/kudu/TestKuduIntegrationDynamicFilter.java
@@ -119,6 +119,7 @@ public class TestKuduIntegrationDynamicFilter
                     TimeUnit.HOURS.sleep(1);
                 }
                 catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                     throw new IllegalStateException(e);
                 }
             });

--- a/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
+++ b/plugin/trino-oracle/src/test/java/io/trino/plugin/oracle/TestingOracleServer.java
@@ -65,7 +65,11 @@ public class TestingOracleServer
         try {
             execInContainer("/bin/bash", "/etc/init.d/oracle-xe", "restart");
         }
-        catch (InterruptedException | IOException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+        catch (IOException e) {
             throw new RuntimeException(e);
         }
 

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotQueryClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotQueryClient.java
@@ -112,6 +112,7 @@ public class PinotQueryClient
             return dataTableMap;
         }
         catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new PinotException(PINOT_EXCEPTION, Optional.of(query), "Pinot query execution was interrupted", e);
         }
     }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardManager.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardManager.java
@@ -375,6 +375,7 @@ public class DatabaseShardManager
                     SECONDS.sleep(multiplyExact(attempt, 2));
                 }
                 catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
                     throw metadataError(ie);
                 }
             }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardRecorder.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardRecorder.java
@@ -58,6 +58,7 @@ public class DatabaseShardRecorder
                     MILLISECONDS.sleep(millis + ThreadLocalRandom.current().nextLong(0, millis));
                 }
                 catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
                     throw metadataError(ie);
                 }
             }

--- a/service/trino-verifier/src/main/java/io/trino/verifier/VerifyCommand.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/VerifyCommand.java
@@ -180,7 +180,11 @@ public class VerifyCommand
             int numFailedQueries = new Verifier(System.out, config, eventClients).run(queries);
             System.exit((numFailedQueries > 0) ? 1 : 0);
         }
-        catch (InterruptedException | MalformedURLException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+        catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
         finally {
@@ -311,7 +315,11 @@ public class VerifyCommand
                 }
             }
         }
-        catch (InterruptedException | ExecutionException e) {
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+        catch (ExecutionException e) {
             throw new RuntimeException("Query rewriting failed", e);
         }
 

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Environment.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Environment.java
@@ -198,6 +198,7 @@ public final class Environment
             log.warn("Some of the containers are stopped or unhealthy");
         }
         catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             log.info("Interrupted");
             // It's OK not to restore interrupt flag here. When we return we're exiting the process.
         }

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestQueryTracker.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestQueryTracker.java
@@ -94,6 +94,7 @@ public class TestQueryTracker
             freeze.await();
         }
         catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             interrupted.countDown();
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This PR adds missing `Thread::interrupt` calls to the catch clauses for the `InterruptedException`.

Catching `InterruptedException` requires "extra hygiene": the interrupted flag must be restored with `Thread::interrupt`.
For more details see:
https://stackoverflow.com/a/3976377
https://dzone.com/articles/how-to-handle-the-interruptedexception
