### PR TITLE
Hive cannot read ORC ACID table updated by Trino twice

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplit.java
@@ -54,6 +54,7 @@ public class HiveSplit
     private final Optional<BucketValidation> bucketValidation;
     private final boolean s3SelectPushdownEnabled;
     private final Optional<AcidInfo> acidInfo;
+    private final long splitNumber;
 
     @JsonCreator
     public HiveSplit(
@@ -75,7 +76,8 @@ public class HiveSplit
             @JsonProperty("bucketConversion") Optional<BucketConversion> bucketConversion,
             @JsonProperty("bucketValidation") Optional<BucketValidation> bucketValidation,
             @JsonProperty("s3SelectPushdownEnabled") boolean s3SelectPushdownEnabled,
-            @JsonProperty("acidInfo") Optional<AcidInfo> acidInfo)
+            @JsonProperty("acidInfo") Optional<AcidInfo> acidInfo,
+            @JsonProperty("splitNumber") long splitNumber)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(length >= 0, "length must be positive");
@@ -112,6 +114,7 @@ public class HiveSplit
         this.bucketValidation = bucketValidation;
         this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
         this.acidInfo = acidInfo;
+        this.splitNumber = splitNumber;
     }
 
     @JsonProperty
@@ -235,6 +238,12 @@ public class HiveSplit
         return acidInfo;
     }
 
+    @JsonProperty
+    public long getSplitNumber()
+    {
+        return splitNumber;
+    }
+
     @Override
     public Object getInfo()
     {
@@ -250,6 +259,7 @@ public class HiveSplit
                 .put("partitionName", partitionName)
                 .put("deserializerClassName", getDeserializerClassName(schema))
                 .put("s3SelectPushdownEnabled", s3SelectPushdownEnabled)
+                .put("splitNumber", splitNumber)
                 .build();
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitSource.java
@@ -79,6 +79,7 @@ class HiveSplitSource
     private final DataSize maxSplitSize;
     private final DataSize maxInitialSplitSize;
     private final AtomicInteger remainingInitialSplits;
+    private final AtomicLong numberOfProcessedSplits;
 
     private final HiveSplitLoader splitLoader;
     private final AtomicReference<State> stateReference;
@@ -112,6 +113,7 @@ class HiveSplitSource
         this.maxSplitSize = getMaxSplitSize(session);
         this.maxInitialSplitSize = getMaxInitialSplitSize(session);
         this.remainingInitialSplits = new AtomicInteger(maxInitialSplits);
+        this.numberOfProcessedSplits = new AtomicLong(0);
     }
 
     public static HiveSplitSource allAtOnce(
@@ -381,7 +383,8 @@ class HiveSplitSource
                         internalSplit.getBucketConversion(),
                         internalSplit.getBucketValidation(),
                         internalSplit.isS3SelectPushdownEnabled(),
-                        internalSplit.getAcidInfo()));
+                        internalSplit.getAcidInfo(),
+                        numberOfProcessedSplits.getAndIncrement()));
 
                 internalSplit.increaseStart(splitBytes);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
@@ -42,8 +42,10 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_WRITER_CLOSE_ERROR;
 import static io.trino.plugin.hive.PartitionAndStatementId.CODEC;
+import static io.trino.spi.StandardErrorCode.GENERIC_INSUFFICIENT_RESOURCES;
 import static io.trino.spi.predicate.Utils.nativeValueToBlock;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
@@ -69,6 +71,8 @@ public class HiveUpdatablePageSource
     private long maxWriteId;
     private long rowCount;
     private long insertRowCounter;
+    private long initialRowId;
+    private long maxNumberOfRowsPerSplit;
 
     private boolean closed;
 
@@ -86,7 +90,9 @@ public class HiveUpdatablePageSource
             ConnectorSession session,
             HiveType hiveRowType,
             List<HiveColumnHandle> dependencyColumns,
-            AcidOperation updateKind)
+            AcidOperation updateKind,
+            long initialRowId,
+            long maxNumberOfRowsPerSplit)
     {
         super(hiveTableHandle.getTransaction(), statementId, bucketNumber, bucketPath, originalFile, orcFileWriterFactory, configuration, session, hiveRowType, updateKind);
         this.partitionName = requireNonNull(partitionName, "partitionName is null");
@@ -95,6 +101,8 @@ public class HiveUpdatablePageSource
         this.hiveRowTypeNullsBlock = nativeValueToBlock(hiveRowType.getType(typeManager), null);
         checkArgument(hiveTableHandle.isInAcidTransaction(), "Not in a transaction; hiveTableHandle: %s", hiveTableHandle);
         this.writeId = hiveTableHandle.getWriteId();
+        this.initialRowId = initialRowId;
+        this.maxNumberOfRowsPerSplit = maxNumberOfRowsPerSplit;
         if (updateKind == AcidOperation.UPDATE) {
             this.dependencyChannels = Optional.of(hiveTableHandle.getUpdateProcessor()
                     .orElseThrow(() -> new IllegalArgumentException("updateProcessor not present"))
@@ -171,7 +179,10 @@ public class HiveUpdatablePageSource
     {
         long[] rowIds = new long[positionCount];
         for (int index = 0; index < positionCount; index++) {
-            rowIds[index] = insertRowCounter++;
+            rowIds[index] = initialRowId + insertRowCounter++;
+        }
+        if (insertRowCounter >= maxNumberOfRowsPerSplit) {
+            throw new TrinoException(GENERIC_INSUFFICIENT_RESOURCES, format("Trying to insert too many rows in a single split, max allowed is %d per split", maxNumberOfRowsPerSplit));
         }
         return new LongArrayBlock(positionCount, Optional.empty(), rowIds);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHivePageSink.java
@@ -241,7 +241,8 @@ public class TestHivePageSink
                 Optional.empty(),
                 Optional.empty(),
                 false,
-                Optional.empty());
+                Optional.empty(),
+                0);
         ConnectorTableHandle table = new HiveTableHandle(SCHEMA_NAME, TABLE_NAME, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
         HivePageSourceProvider provider = new HivePageSourceProvider(
                 TYPE_MANAGER,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplit.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplit.java
@@ -80,7 +80,8 @@ public class TestHiveSplit
                         ImmutableList.of(createBaseColumn("col", 5, HIVE_LONG, BIGINT, ColumnType.REGULAR, Optional.of("comment"))))),
                 Optional.empty(),
                 false,
-                Optional.of(acidInfo));
+                Optional.of(acidInfo),
+                555534);
 
         String json = codec.toJson(expected);
         HiveSplit actual = codec.fromJson(json);
@@ -101,5 +102,6 @@ public class TestHiveSplit
         assertEquals(actual.isForceLocalScheduling(), expected.isForceLocalScheduling());
         assertEquals(actual.isS3SelectPushdownEnabled(), expected.isS3SelectPushdownEnabled());
         assertEquals(actual.getAcidInfo().get(), expected.getAcidInfo().get());
+        assertEquals(actual.getSplitNumber(), expected.getSplitNumber());
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
@@ -79,6 +79,33 @@ public class TestHiveSplitSource
     }
 
     @Test
+    public void testCorrectlyGeneratingInitialRowId()
+    {
+        HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
+                SESSION,
+                "database",
+                "table",
+                10,
+                10,
+                DataSize.of(1, MEGABYTE),
+                Integer.MAX_VALUE,
+                new TestingHiveSplitLoader(),
+                Executors.newFixedThreadPool(5),
+                new CounterStat());
+
+        // add 10 splits
+        for (int i = 0; i < 10; i++) {
+            hiveSplitSource.addToQueue(new TestSplit(i));
+            assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), i + 1);
+        }
+
+        List<ConnectorSplit> splits = getSplits(hiveSplitSource, 10);
+        assertEquals(((HiveSplit) splits.get(0)).getSplitNumber(), 0);
+        assertEquals(((HiveSplit) splits.get(5)).getSplitNumber(), 5);
+        assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), 0);
+    }
+
+    @Test
     public void testEvenlySizedSplitRemainder()
     {
         DataSize initialSplitSize = getMaxInitialSplitSize(SESSION);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestNodeLocalDynamicSplitPruning.java
@@ -106,7 +106,8 @@ public class TestNodeLocalDynamicSplitPruning
                 Optional.empty(),
                 Optional.empty(),
                 false,
-                Optional.empty());
+                Optional.empty(),
+                0);
 
         TableHandle tableHandle = new TableHandle(
                 new CatalogName(HIVE_CATALOG_NAME),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/AbstractFileFormat.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/AbstractFileFormat.java
@@ -152,7 +152,8 @@ public abstract class AbstractFileFormat
                 Optional.empty(),
                 Optional.empty(),
                 false,
-                Optional.empty());
+                Optional.empty(),
+                0);
 
         return factory.createPageSource(
                 TestingConnectorTransactionHandle.INSTANCE,


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/8268
The problem was caused by multiple rows having
the same (writeId, bucket, rowId). In order to fix this
it is necessary to ensure unique row IDs across writers.
To achieve it different writers will have separated
id ranges in the split assigned to them