### PR TITLE
Relax the restriction on predicate pushdown over projection

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -178,7 +178,7 @@ public class PredicatePushDown
         private final TypeProvider types;
         private final ExpressionEquivalence expressionEquivalence;
         private final boolean dynamicFiltering;
-        private static final int MAX_LINEAR_EXPANSION_LENGTH = 1024;
+        private static final int MAX_EXPR_REFERENCE_COUNT = 50;
 
         private Rewriter(
                 SymbolAllocator symbolAllocator,
@@ -348,9 +348,9 @@ public class PredicatePushDown
         private boolean isEligibleForLinearExpansion(Expression expr, long count)
         {
             // Qualify the expression that refers to at most a single symbol
-            // but also avoid excessive duplication of long expression
+            // but also avoid excessive duplication of repeated references to the same expression
             return SymbolsExtractor.extractAll(expr).size() <= 1 &&
-                    expr.toString().length() * count <= MAX_LINEAR_EXPANSION_LENGTH;
+                    count <= MAX_EXPR_REFERENCE_COUNT;
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
@@ -317,7 +317,7 @@ public abstract class AbstractPredicatePushdownTest
                                         tableScan("orders", ImmutableMap.of(
                                                 "orderdate", "orderdate"))))));
 
-        // Complex expression should not be pushed down, if the expansion exceeds the length threshold, even though there is only one symbol being referenced
+        // Complex expression should not be pushed down, if the expansion exceeds the expression count threshold, even though there is only one symbol being referenced
         assertPlan(
                 "WITH t AS (SELECT CAST(orderdate AS VARCHAR) x FROM orders) " +
                         "SELECT * FROM t WHERE x = '2021-01-01' OR x = '2021-01-02' OR x = '2021-01-03' OR x = '2021-01-04' OR x = '2021-01-05' OR x = '2021-01-06'" +
@@ -325,7 +325,10 @@ public abstract class AbstractPredicatePushdownTest
                         " OR x = '2021-01-14' OR x = '2021-01-15' OR x = '2021-01-16' OR x = '2021-01-17' OR x = '2021-01-18' OR x = '2021-01-19' OR x = '2021-01-20'" +
                         " OR x = '2021-02-01' OR x = '2021-02-02' OR x = '2021-02-03' OR x = '2021-02-04' OR x = '2021-02-05' OR x = '2021-02-06'" +
                         " OR x = '2021-02-07' OR x = '2021-02-08' OR x = '2021-02-09' OR x = '2021-02-10' OR x = '2021-02-11' OR x = '2021-02-12' OR x = '2021-02-13'" +
-                        " OR x = '2021-02-14' OR x = '2021-02-15' OR x = '2021-02-16' OR x = '2021-02-17' OR x = '2021-02-18' OR x = '2021-02-19' OR x = '2021-02-20'",
+                        " OR x = '2021-02-14' OR x = '2021-02-15' OR x = '2021-02-16' OR x = '2021-02-17' OR x = '2021-02-18' OR x = '2021-02-19' OR x = '2021-02-20'" +
+                        " OR x = '2021-03-01' OR x = '2021-03-02' OR x = '2021-03-03' OR x = '2021-03-04' OR x = '2021-03-05' OR x = '2021-03-06'" +
+                        " OR x = '2021-03-07' OR x = '2021-03-08' OR x = '2021-03-09' OR x = '2021-03-10' OR x = '2021-03-11' OR x = '2021-03-12' OR x = '2021-03-13'" +
+                        " OR x = '2021-03-14' OR x = '2021-03-15' OR x = '2021-03-16' OR x = '2021-03-17' OR x = '2021-03-18' OR x = '2021-03-19' OR x = '2021-03-20'",
                 anyTree(
                         filter("(((((((\"expr\" = VARCHAR '2021-01-01') OR (\"expr\" = VARCHAR '2021-01-02')) OR ((\"expr\" = VARCHAR '2021-01-03')" +
                                         " OR (\"expr\" = VARCHAR '2021-01-04'))) OR (((\"expr\" = VARCHAR '2021-01-05') OR (\"expr\" = VARCHAR '2021-01-06'))" +
@@ -337,10 +340,16 @@ public abstract class AbstractPredicatePushdownTest
                                         " OR (\"expr\" = VARCHAR '2021-02-02')) OR ((\"expr\" = VARCHAR '2021-02-03') OR (\"expr\" = VARCHAR '2021-02-04'))))" +
                                         " OR ((((\"expr\" = VARCHAR '2021-02-05') OR (\"expr\" = VARCHAR '2021-02-06')) OR ((\"expr\" = VARCHAR '2021-02-07')" +
                                         " OR (\"expr\" = VARCHAR '2021-02-08'))) OR (((\"expr\" = VARCHAR '2021-02-09') OR (\"expr\" = VARCHAR '2021-02-10'))" +
-                                        " OR ((\"expr\" = VARCHAR '2021-02-11') OR (\"expr\" = VARCHAR '2021-02-12')))))) OR ((((\"expr\" = VARCHAR '2021-02-13')" +
+                                        " OR ((\"expr\" = VARCHAR '2021-02-11') OR (\"expr\" = VARCHAR '2021-02-12')))))) OR ((((((\"expr\" = VARCHAR '2021-02-13')" +
                                         " OR (\"expr\" = VARCHAR '2021-02-14')) OR ((\"expr\" = VARCHAR '2021-02-15') OR (\"expr\" = VARCHAR '2021-02-16')))" +
                                         " OR (((\"expr\" = VARCHAR '2021-02-17') OR (\"expr\" = VARCHAR '2021-02-18')) OR ((\"expr\" = VARCHAR '2021-02-19')" +
-                                        " OR (\"expr\" = VARCHAR '2021-02-20')))))",
+                                        " OR (\"expr\" = VARCHAR '2021-02-20')))) OR ((((\"expr\" = VARCHAR '2021-03-01') OR (\"expr\" = VARCHAR '2021-03-02'))" +
+                                        " OR ((\"expr\" = VARCHAR '2021-03-03') OR (\"expr\" = VARCHAR '2021-03-04'))) OR (((\"expr\" = VARCHAR '2021-03-05')" +
+                                        " OR (\"expr\" = VARCHAR '2021-03-06')) OR ((\"expr\" = VARCHAR '2021-03-07') OR (\"expr\" = VARCHAR '2021-03-08')))))" +
+                                        " OR (((((\"expr\" = VARCHAR '2021-03-09') OR (\"expr\" = VARCHAR '2021-03-10')) OR ((\"expr\" = VARCHAR '2021-03-11')" +
+                                        " OR (\"expr\" = VARCHAR '2021-03-12'))) OR (((\"expr\" = VARCHAR '2021-03-13') OR (\"expr\" = VARCHAR '2021-03-14'))" +
+                                        " OR ((\"expr\" = VARCHAR '2021-03-15') OR (\"expr\" = VARCHAR '2021-03-16')))) OR (((\"expr\" = VARCHAR '2021-03-17')" +
+                                        " OR (\"expr\" = VARCHAR '2021-03-18')) OR ((\"expr\" = VARCHAR '2021-03-19') OR (\"expr\" = VARCHAR '2021-03-20'))))))",
                                 project(ImmutableMap.of("expr", expression("CAST(orderdate AS VARCHAR)")),
                                         tableScan("orders", ImmutableMap.of("orderdate", "orderdate"))))));
 


### PR DESCRIPTION
https://github.com/prestodb/presto/pull/10860 fixed potential issues of exponential processing time and memory usage in PredicatePushDown. However, the new heuristics (expressions are trivial or appear only once) are so strict that it prevented pushdown opportunities for some common cases. For example, 
```
-- Fails to push down, with a complex expression and more than 1 predicates in outer query
WITH cte AS (
    SELECT CAST(o_orderdate AS VARCHAR) AS dt
    FROM orders
)
SELECT *
FROM cte
WHERE dt = '1995-05-05' OR dt = '1996-06-06';
```
Similar issues have been reported by others:
https://github.com/prestodb/presto/issues/11265
https://github.com/prestodb/presto/issues/12538
https://github.com/trinodb/trino/pull/1114 

Although a later PR #1515 did relax the heuristics a little bit, and possibly fixed issue #1114, but it's still not enough to generalize the optimization to more use cases.

This PR is proposing to make the heuristics more relaxed, while keeping the original safeguard to avoid exponential expansion.