### PR TITLE
Avoid task sendUpdate until callback clears current request

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
+++ b/core/trino-main/src/main/java/io/trino/server/remotetask/HttpRemoteTask.java
@@ -520,7 +520,8 @@ public final class HttpRemoteTask
         }
 
         // if there is a request already running, wait for it to complete
-        if (this.currentRequest != null && !this.currentRequest.isDone()) {
+        // currentRequest is always cleared when request is complete
+        if (currentRequest != null) {
             return;
         }
 


### PR DESCRIPTION
sendUpdate for the next request can be triggered after currentRequest
future is done but before UpdateResponseHandler callback execution.
This can overwrite value of currentRequestStartNanos before the
callback has recorded the stats for the completed request.
The next request may also miss the value of sendPlan set in the
callback execution in this scenario and send the plan an extra time.