### PR TITLE
Don't exclude tests in trino-tests module to only run on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,6 @@ jobs:
         modules:
           - ":trino-main"
           - ":trino-tests"
-          - ":trino-tests -P ci-only"
           - ":trino-raptor-legacy"
           - ":trino-accumulo"
           - ":trino-cassandra"

--- a/testing/trino-tests/pom.xml
+++ b/testing/trino-tests/pom.xml
@@ -251,43 +251,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- these tests take a very long time so only run them in the CI server -->
-                    <excludes>
-                        <exclude>**/TestDistributedQueriesNoHashGeneration.java</exclude>
-                        <exclude>**/TestLocalQueries.java</exclude>
-                        <exclude>**/TestNonIterativeDistributedQueries.java</exclude>
-                    </excludes>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-    <profiles>
-        <profile>
-            <id>ci-only</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes combine.self="override" />
-                            <includes>
-                                <include>**/TestDistributedQueriesNoHashGeneration.java</include>
-                                <include>**/TestLocalQueries.java</include>
-                                <include>**/TestNonIterativeDistributedQueries.java</include>
-                            </includes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
The tests excluded to run only on CI take < 3 mins to run in total while
the entire module takes ~30 mins.
Merging the CI runs allows more concurrent jobs to run.