### PR TITLE
Make OrcFileWriter number ACID rows correctly across multiple pages

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriter.java
@@ -76,6 +76,7 @@ public class OrcFileWriter
     private final List<Block> nullBlocks;
     private final Optional<Supplier<OrcDataSource>> validationInputFactory;
     private OptionalLong maxWriteId = OptionalLong.empty();
+    private long nextRowId;
 
     private long validationCpuNanos;
 
@@ -308,7 +309,7 @@ public class OrcFileWriter
     {
         long[] rowIds = new long[positionCount];
         for (int i = 0; i < positionCount; i++) {
-            rowIds[i] = i;
+            rowIds[i] = nextRowId++;
         }
         return new LongArrayBlock(positionCount, Optional.empty(), rowIds);
     }


### PR DESCRIPTION
Previously, ACID rows were numbered starting from 0 on each page. Now, the numbering continues where the last page left off.

This resolves #8452.
