### PR TITLE
Add static Server::start to avoid unnecessary inheritance

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/Server.java
+++ b/core/trino-main/src/main/java/io/trino/server/Server.java
@@ -72,12 +72,17 @@ import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
 
 public class Server
 {
-    public final void start(String trinoVersion)
+    public static void start(String trinoVersion)
     {
-        new EmbedVersion(trinoVersion).embedVersion(() -> doStart(trinoVersion)).run();
+        start(trinoVersion, ImmutableList.of());
     }
 
-    private void doStart(String trinoVersion)
+    public static void start(String trinoVersion, Iterable<? extends Module> additionalModules)
+    {
+        new EmbedVersion(trinoVersion).embedVersion(() -> doStart(trinoVersion, additionalModules)).run();
+    }
+
+    private static void doStart(String trinoVersion, Iterable<? extends Module> additionalModules)
     {
         verifyJvmRequirements();
         verifySystemTimeIsReasonable();
@@ -108,7 +113,7 @@ public class Server
                 new GracefulShutdownModule(),
                 new WarningCollectorModule());
 
-        modules.addAll(getAdditionalModules());
+        modules.addAll(additionalModules);
 
         Bootstrap app = new Bootstrap(modules.build());
 

--- a/core/trino-server-main/src/main/java/io/trino/server/TrinoServer.java
+++ b/core/trino-server-main/src/main/java/io/trino/server/TrinoServer.java
@@ -18,6 +18,7 @@ import com.google.common.primitives.Ints;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.nullToEmpty;
+import static io.trino.server.Server.start;
 import static java.lang.String.format;
 
 public final class TrinoServer
@@ -35,6 +36,6 @@ public final class TrinoServer
         }
 
         String version = TrinoServer.class.getPackage().getImplementationVersion();
-        new Server().start(firstNonNull(version, "unknown"));
+        start(firstNonNull(version, "unknown"));
     }
 }

--- a/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentServer.java
+++ b/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentServer.java
@@ -14,30 +14,23 @@
 package io.trino.server;
 
 import com.google.common.collect.ImmutableList;
-import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.trino.server.PluginManager.PluginsProvider;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
+import static io.trino.server.Server.start;
 
 public final class DevelopmentServer
-        extends Server
 {
     private DevelopmentServer() {}
 
-    @Override
-    protected Iterable<? extends Module> getAdditionalModules()
+    public static void main(String[] args)
     {
-        return ImmutableList.of(binder -> {
+        start("dev", ImmutableList.of(binder -> {
             newOptionalBinder(binder, PluginsProvider.class).setBinding()
                     .to(DevelopmentPluginsProvider.class).in(Scopes.SINGLETON);
             configBinder(binder).bindConfig(DevelopmentLoaderConfig.class);
-        });
-    }
-
-    public static void main(String[] args)
-    {
-        new DevelopmentServer().start("dev");
+        }));
     }
 }

--- a/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentServer.java
+++ b/testing/trino-server-dev/src/main/java/io/trino/server/DevelopmentServer.java
@@ -23,11 +23,13 @@ import static io.trino.server.Server.start;
 
 public final class DevelopmentServer
 {
+    public static final String DEV = "dev";
+
     private DevelopmentServer() {}
 
     public static void main(String[] args)
     {
-        start("dev", ImmutableList.of(binder -> {
+        start(DEV, ImmutableList.of(binder -> {
             newOptionalBinder(binder, PluginsProvider.class).setBinding()
                     .to(DevelopmentPluginsProvider.class).in(Scopes.SINGLETON);
             configBinder(binder).bindConfig(DevelopmentLoaderConfig.class);


### PR DESCRIPTION
Both `Server` and `DevelopmentServer` have no instance properties and introduce unnecessary inheritance. 
This could be substituted with static `start` method with optional explicit `additionalModules`.