### PR TITLE
Relax dynamic filter left expression requirements

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PredicatePushDown.java
@@ -635,14 +635,14 @@ public class PredicatePushDown
                             })
                             .map(expression -> {
                                 ComparisonExpression comparison = expression.getComparison();
-                                Symbol leftSymbol = Symbol.from(comparison.getLeft());
-                                Symbol rightSymbol = Symbol.from(comparison.getRight());
-                                boolean alignedComparison = node.getLeft().getOutputSymbols().contains(leftSymbol);
+                                Expression leftExpression = comparison.getLeft();
+                                Expression rightExpression = comparison.getRight();
+                                boolean alignedComparison = node.getLeft().getOutputSymbols().containsAll(extractUnique(leftExpression));
                                 return new DynamicFilterExpression(
                                         new ComparisonExpression(
                                                 alignedComparison ? comparison.getOperator() : comparison.getOperator().flip(),
-                                                (alignedComparison ? leftSymbol : rightSymbol).toSymbolReference(),
-                                                (alignedComparison ? rightSymbol : leftSymbol).toSymbolReference()),
+                                                alignedComparison ? leftExpression : rightExpression,
+                                                alignedComparison ? rightExpression : leftExpression),
                                         expression.isNullAllowed());
                             }))
                     .collect(toImmutableList());
@@ -672,11 +672,12 @@ public class PredicatePushDown
                     .stream()
                     .map(clause -> {
                         ComparisonExpression comparison = clause.getComparison();
-                        Symbol probeSymbol = Symbol.from(comparison.getLeft());
+                        Expression probeExpression = comparison.getLeft();
                         Symbol buildSymbol = Symbol.from(comparison.getRight());
-                        Type type = symbolAllocator.getTypes().get(probeSymbol);
+                        // we can take type of buildSymbol instead probeExpression as comparison expression must have the same type on both sides
+                        Type type = symbolAllocator.getTypes().get(buildSymbol);
                         DynamicFilterId id = requireNonNull(buildSymbolToDynamicFilter.get(buildSymbol), () -> "missing dynamic filter for symbol " + buildSymbol);
-                        return createDynamicFilterExpression(metadata, id, type, probeSymbol.toSymbolReference(), comparison.getOperator(), clause.isNullAllowed());
+                        return createDynamicFilterExpression(metadata, id, type, probeExpression, comparison.getOperator(), clause.isNullAllowed());
                     })
                     .collect(toImmutableList());
             // Return a mapping from build symbols to corresponding dynamic filter IDs:
@@ -1280,7 +1281,10 @@ public class PredicatePushDown
                 }
                 comparison = (ComparisonExpression) expression;
             }
-            return comparison.getLeft() instanceof SymbolReference && comparison.getRight() instanceof SymbolReference;
+
+            // Build side expression must be a symbol reference, since DynamicFilterSourceOperator can only collect column values (not expressions)
+            return (comparison.getRight() instanceof SymbolReference && rightSymbols.contains(Symbol.from(comparison.getRight())))
+                    || (comparison.getLeft() instanceof SymbolReference && rightSymbols.contains(Symbol.from(comparison.getLeft())));
         }
 
         private boolean joinComparisonExpression(Expression expression, Collection<Symbol> leftSymbols, Collection<Symbol> rightSymbols, Set<ComparisonExpression.Operator> operators)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/SymbolMapper.java
@@ -63,7 +63,7 @@ public class SymbolMapper
 {
     private final Function<Symbol, Symbol> mappingFunction;
 
-    private SymbolMapper(Function<Symbol, Symbol> mappingFunction)
+    public SymbolMapper(Function<Symbol, Symbol> mappingFunction)
     {
         this.mappingFunction = requireNonNull(mappingFunction, "mappingFunction is null");
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDynamicFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDynamicFilter.java
@@ -28,6 +28,12 @@ import io.trino.sql.planner.assertions.SymbolAliases;
 import io.trino.sql.planner.plan.EnforceSingleRowNode;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.tree.Cast;
+import io.trino.sql.tree.DataType;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.GenericDataType;
+import io.trino.sql.tree.Identifier;
+import io.trino.sql.tree.NumericParameter;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -45,6 +51,7 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.output;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.semiJoin;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
@@ -119,6 +126,23 @@ public class TestDynamicFilter
     }
 
     @Test
+    public void testRightEquiJoinWithLeftExpression()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o RIGHT JOIN lineitem l ON l.orderkey + 1 = o.orderkey",
+                output(
+                        join(
+                                RIGHT,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "expr")),
+                                ImmutableMap.of("ORDERS_OK", "expr"),
+                                anyTree(
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
+                                anyTree(
+                                        project(
+                                                ImmutableMap.of("expr", expression("LINEITEM_OK + BIGINT '1'")),
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+    }
+
+    @Test
     public void testRightNonEquiJoin()
     {
         assertPlan("SELECT o.orderkey FROM orders o RIGHT JOIN lineitem l ON l.orderkey < o.orderkey",
@@ -155,6 +179,22 @@ public class TestDynamicFilter
     public void testCrossJoinInequalityDF()
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey > l.orderkey",
+                anyTree(filter("O_ORDERKEY > L_ORDERKEY",
+                        join(
+                                INNER,
+                                ImmutableList.of(),
+                                ImmutableList.of(new DynamicFilterPattern("O_ORDERKEY", GREATER_THAN, "L_ORDERKEY")),
+                                filter(
+                                        TRUE_LITERAL,
+                                        tableScan("orders", ImmutableMap.of("O_ORDERKEY", "orderkey"))),
+                                exchange(
+                                        tableScan("lineitem", ImmutableMap.of("L_ORDERKEY", "orderkey")))))));
+    }
+
+    @Test
+    public void testCrossJoinInequalityDFWithConditionReversed()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey < o.orderkey",
                 anyTree(filter("O_ORDERKEY > L_ORDERKEY",
                         join(
                                 INNER,
@@ -212,17 +252,41 @@ public class TestDynamicFilter
     }
 
     @Test
-    public void testCrossJoinInequalityNoDFWithCast()
+    public void testCrossJoinInequalityDFWithCastOnTheLeft()
     {
         assertPlan("SELECT o.comment, l.comment FROM lineitem l, orders o WHERE o.comment < l.comment",
                 anyTree(filter("CAST(L_COMMENT AS varchar(79)) > O_COMMENT",
                         join(
                                 INNER,
                                 ImmutableList.of(),
-                                tableScan("lineitem", ImmutableMap.of("L_COMMENT", "comment")),
+                                ImmutableList.of(
+                                        new DynamicFilterPattern(
+                                                typeOnlyCast("L_COMMENT", varchar(79)),
+                                                GREATER_THAN,
+                                                "O_COMMENT",
+                                                false)),
+                                filter(TRUE_LITERAL,
+                                        tableScan("lineitem", ImmutableMap.of("L_COMMENT", "comment"))),
                                 exchange(
                                         tableScan("orders", ImmutableMap.of("O_COMMENT", "comment")))))));
+    }
 
+    private DataType varchar(int size)
+    {
+        return new GenericDataType(
+                Optional.empty(),
+                new Identifier("varchar"),
+                ImmutableList.of(new NumericParameter(Optional.empty(), String.valueOf(size))));
+    }
+
+    private Expression typeOnlyCast(String symbol, DataType asDataType)
+    {
+        return new Cast(new Symbol(symbol).toSymbolReference(), asDataType, false, true);
+    }
+
+    @Test
+    public void testCrossJoinInequalityNoDFWithCastOnTheRight()
+    {
         assertPlan("SELECT o.comment, l.comment FROM orders o, lineitem l WHERE o.comment < l.comment",
                 anyTree(filter("O_COMMENT < CAST(L_COMMENT AS varchar(79))",
                         join(
@@ -237,6 +301,22 @@ public class TestDynamicFilter
     public void testJoin()
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey",
+                anyTree(
+                        join(
+                                INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
+                                ImmutableMap.of("ORDERS_OK", "LINEITEM_OK"),
+                                anyTree(
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
+                                exchange(
+                                        project(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+    }
+
+    @Test
+    public void testInnerJoinWithConditionReversed()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey = l.orderkey",
                 anyTree(
                         join(
                                 INNER,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestSortExpressionExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestSortExpressionExtractor.java
@@ -18,8 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.metadata.Metadata;
 import io.trino.spi.type.Type;
 import io.trino.sql.ExpressionTestUtils;
-import io.trino.sql.parser.ParsingOptions;
-import io.trino.sql.parser.SqlParser;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.SymbolReference;
 import org.testng.annotations.Test;
@@ -35,7 +34,6 @@ import static io.trino.metadata.MetadataManager.createTestMetadataManager;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.sql.ExpressionUtils.extractConjuncts;
-import static io.trino.sql.ExpressionUtils.rewriteIdentifiersToSymbolReferences;
 import static org.testng.Assert.assertEquals;
 
 public class TestSortExpressionExtractor
@@ -93,7 +91,7 @@ public class TestSortExpressionExtractor
 
     private Expression expression(String sql)
     {
-        return ExpressionTestUtils.planExpression(metadata, TEST_SESSION, TYPE_PROVIDER, rewriteIdentifiersToSymbolReferences(new SqlParser().createExpression(sql, new ParsingOptions())));
+        return ExpressionTestUtils.planExpression(metadata, TEST_SESSION, TYPE_PROVIDER, PlanBuilder.expression(sql));
     }
 
     private void assertNoSortExpression(String expression)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/JoinMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/JoinMatcher.java
@@ -152,17 +152,17 @@ final class JoinMatcher
         Map<DynamicFilterId, Symbol> idToBuildSymbolMap = joinNode.getDynamicFilters();
         Set<Expression> actual = new HashSet<>();
         for (DynamicFilters.Descriptor descriptor : descriptors) {
-            Symbol probe = Symbol.from(descriptor.getInput());
+            Expression probe = descriptor.getInput();
             Symbol build = idToBuildSymbolMap.get(descriptor.getId());
             if (build == null) {
                 return false;
             }
             Expression expression;
             if (descriptor.isNullAllowed()) {
-                expression = new NotExpression(new ComparisonExpression(IS_DISTINCT_FROM, probe.toSymbolReference(), build.toSymbolReference()));
+                expression = new NotExpression(new ComparisonExpression(IS_DISTINCT_FROM, probe, build.toSymbolReference()));
             }
             else {
-                expression = new ComparisonExpression(descriptor.getOperator(), probe.toSymbolReference(), build.toSymbolReference());
+                expression = new ComparisonExpression(descriptor.getOperator(), probe, build.toSymbolReference());
             }
             actual.add(expression);
         }


### PR DESCRIPTION
Allow dynamic filter sub expression,
referencing the probe side to be any expression
and not only symbol reference.