### PR TITLE
Add less-boilerplate way to override thread context class loader

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -34,7 +34,6 @@ import io.trino.security.AccessControlManager;
 import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.PageSorter;
 import io.trino.spi.VersionEmbedder;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorContext;
@@ -78,6 +77,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static io.trino.connector.CatalogName.createInformationSchemaCatalogName;
 import static io.trino.connector.CatalogName.createSystemTablesCatalogName;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -165,8 +165,8 @@ public class ConnectorManager
 
         for (Map.Entry<CatalogName, MaterializedConnector> entry : connectors.entrySet()) {
             Connector connector = entry.getValue().getConnector();
-            try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(connector.getClass().getClassLoader())) {
-                connector.shutdown();
+            try {
+                withClassLoaderOf(connector.getClass(), connector::shutdown);
             }
             catch (Throwable t) {
                 log.error(t, "Error shutting down connector: %s", entry.getKey());
@@ -337,12 +337,14 @@ public class ConnectorManager
         MaterializedConnector materializedConnector = connectors.remove(catalogName);
         if (materializedConnector != null) {
             Connector connector = materializedConnector.getConnector();
-            try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(connector.getClass().getClassLoader())) {
-                connector.shutdown();
-            }
-            catch (Throwable t) {
-                log.error(t, "Error shutting down connector: %s", catalogName);
-            }
+            withClassLoaderOf(connector.getClass(), () -> {
+                try {
+                    connector.shutdown();
+                }
+                catch (Throwable t) {
+                    log.error(t, "Error shutting down connector: %s", catalogName);
+                }
+            });
         }
     }
 
@@ -356,9 +358,9 @@ public class ConnectorManager
                 pageIndexerFactory,
                 factory.getDuplicatePluginClassLoaderFactory());
 
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(factory.getConnectorFactory().getClass().getClassLoader())) {
-            return factory.getConnectorFactory().create(catalogName.getCatalogName(), properties, context);
-        }
+        return withClassLoaderOf(
+                factory.getConnectorFactory().getClass(),
+                () -> factory.getConnectorFactory().create(catalogName.getCatalogName(), properties, context));
     }
 
     private static class InternalConnectorFactory

--- a/core/trino-main/src/main/java/io/trino/eventlistener/EventListenerManager.java
+++ b/core/trino-main/src/main/java/io/trino/eventlistener/EventListenerManager.java
@@ -16,7 +16,6 @@ package io.trino.eventlistener;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.eventlistener.EventListenerFactory;
 import io.trino.spi.eventlistener.QueryCompletedEvent;
@@ -40,6 +39,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -112,10 +112,7 @@ public class EventListenerManager
         EventListenerFactory factory = eventListenerFactories.get(name);
         checkArgument(factory != null, "Event listener factory '%s' is not registered. Available factories: %s", name, eventListenerFactories.keySet());
 
-        EventListener eventListener;
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(factory.getClass().getClassLoader())) {
-            eventListener = factory.create(properties);
-        }
+        EventListener eventListener = withClassLoaderOf(factory.getClass(), () -> factory.create(properties));
 
         log.info("-- Loaded event listener %s --", configFile);
         return eventListener;

--- a/core/trino-main/src/main/java/io/trino/server/PluginManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/PluginManager.java
@@ -25,7 +25,6 @@ import io.trino.server.security.CertificateAuthenticatorManager;
 import io.trino.server.security.PasswordAuthenticatorManager;
 import io.trino.spi.Plugin;
 import io.trino.spi.block.BlockEncoding;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.eventlistener.EventListenerFactory;
 import io.trino.spi.resourcegroups.ResourceGroupConfigurationManagerFactory;
@@ -49,6 +48,7 @@ import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.metadata.FunctionExtractor.extractFunctions;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
@@ -125,9 +125,7 @@ public class PluginManager
             log.debug("    %s", url.getPath());
         }
 
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(pluginClassLoader)) {
-            loadPlugin(pluginClassLoader);
-        }
+        withClassLoader(pluginClassLoader, () -> loadPlugin(pluginClassLoader));
 
         log.info("-- Finished loading plugin %s --", plugin);
     }

--- a/core/trino-main/src/main/java/io/trino/server/security/PasswordAuthenticatorManager.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/PasswordAuthenticatorManager.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.airlift.log.Logger;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.security.PasswordAuthenticator;
 import io.trino.spi.security.PasswordAuthenticatorFactory;
 
@@ -36,6 +35,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.airlift.configuration.ConfigurationLoader.loadPropertiesFrom;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static java.util.Objects.requireNonNull;
 
 public class PasswordAuthenticatorManager
@@ -104,10 +104,7 @@ public class PasswordAuthenticatorManager
         PasswordAuthenticatorFactory factory = factories.get(name);
         checkState(factory != null, "Password authenticator '%s' is not registered", name);
 
-        PasswordAuthenticator authenticator;
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(factory.getClass().getClassLoader())) {
-            authenticator = factory.create(ImmutableMap.copyOf(properties));
-        }
+        PasswordAuthenticator authenticator = withClassLoaderOf(factory.getClass(), () -> factory.create(ImmutableMap.copyOf(properties)));
 
         log.info("-- Loaded password authenticator %s --", name);
         return authenticator;

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorAccessControl.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.base.classloader;
 
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSecurityContext;
 import io.trino.spi.connector.SchemaRoutineName;
@@ -28,6 +27,7 @@ import javax.inject.Inject;
 import java.util.Optional;
 import java.util.Set;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class ClassLoaderSafeConnectorAccessControl
@@ -46,400 +46,300 @@ public class ClassLoaderSafeConnectorAccessControl
     @Override
     public void checkCanCreateSchema(ConnectorSecurityContext context, String schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanCreateSchema(context, schemaName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanCreateSchema(context, schemaName));
     }
 
     @Override
     public void checkCanDropSchema(ConnectorSecurityContext context, String schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanDropSchema(context, schemaName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanDropSchema(context, schemaName));
     }
 
     @Override
     public void checkCanRenameSchema(ConnectorSecurityContext context, String schemaName, String newSchemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanRenameSchema(context, schemaName, newSchemaName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanRenameSchema(context, schemaName, newSchemaName));
     }
 
     @Override
     public void checkCanSetSchemaAuthorization(ConnectorSecurityContext context, String schemaName, TrinoPrincipal principal)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanSetSchemaAuthorization(context, schemaName, principal);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanSetSchemaAuthorization(context, schemaName, principal));
     }
 
     @Override
     public void checkCanShowSchemas(ConnectorSecurityContext context)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanShowSchemas(context);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanShowSchemas(context));
     }
 
     @Override
     public Set<String> filterSchemas(ConnectorSecurityContext context, Set<String> schemaNames)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.filterSchemas(context, schemaNames);
-        }
+        return withClassLoader(classLoader, () -> delegate.filterSchemas(context, schemaNames));
     }
 
     @Override
     public void checkCanShowCreateSchema(ConnectorSecurityContext context, String schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanShowCreateSchema(context, schemaName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanShowCreateSchema(context, schemaName));
     }
 
     @Override
     public void checkCanShowCreateTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanShowCreateTable(context, tableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanShowCreateTable(context, tableName));
     }
 
     @Override
     public void checkCanCreateTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanCreateTable(context, tableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanCreateTable(context, tableName));
     }
 
     @Override
     public void checkCanDropTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanDropTable(context, tableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanDropTable(context, tableName));
     }
 
     @Override
     public void checkCanRenameTable(ConnectorSecurityContext context, SchemaTableName tableName, SchemaTableName newTableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanRenameTable(context, tableName, newTableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanRenameTable(context, tableName, newTableName));
     }
 
     @Override
     public void checkCanSetTableComment(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanSetTableComment(context, tableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanSetTableComment(context, tableName));
     }
 
     @Override
     public void checkCanSetColumnComment(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanSetColumnComment(context, tableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanSetColumnComment(context, tableName));
     }
 
     @Override
     public void checkCanShowTables(ConnectorSecurityContext context, String schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanShowTables(context, schemaName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanShowTables(context, schemaName));
     }
 
     @Override
     public Set<SchemaTableName> filterTables(ConnectorSecurityContext context, Set<SchemaTableName> tableNames)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.filterTables(context, tableNames);
-        }
+        return withClassLoader(classLoader, () -> delegate.filterTables(context, tableNames));
     }
 
     @Override
     public void checkCanShowColumns(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanShowColumns(context, tableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanShowColumns(context, tableName));
     }
 
     @Override
     public Set<String> filterColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columns)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.filterColumns(context, tableName, columns);
-        }
+        return withClassLoader(classLoader, () -> delegate.filterColumns(context, tableName, columns));
     }
 
     @Override
     public void checkCanAddColumn(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanAddColumn(context, tableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanAddColumn(context, tableName));
     }
 
     @Override
     public void checkCanDropColumn(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanDropColumn(context, tableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanDropColumn(context, tableName));
     }
 
     @Override
     public void checkCanSetTableAuthorization(ConnectorSecurityContext context, SchemaTableName tableName, TrinoPrincipal principal)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanSetTableAuthorization(context, tableName, principal);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanSetTableAuthorization(context, tableName, principal));
     }
 
     @Override
     public void checkCanRenameColumn(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanRenameColumn(context, tableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanRenameColumn(context, tableName));
     }
 
     @Override
     public void checkCanSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanSelectFromColumns(context, tableName, columnNames);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanSelectFromColumns(context, tableName, columnNames));
     }
 
     @Override
     public void checkCanInsertIntoTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanInsertIntoTable(context, tableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanInsertIntoTable(context, tableName));
     }
 
     @Override
     public void checkCanDeleteFromTable(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanDeleteFromTable(context, tableName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanDeleteFromTable(context, tableName));
     }
 
     @Override
     public void checkCanUpdateTableColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> updatedColumnNames)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanUpdateTableColumns(context, tableName, updatedColumnNames);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanUpdateTableColumns(context, tableName, updatedColumnNames));
     }
 
     @Override
     public void checkCanCreateView(ConnectorSecurityContext context, SchemaTableName viewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanCreateView(context, viewName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanCreateView(context, viewName));
     }
 
     @Override
     public void checkCanRenameView(ConnectorSecurityContext context, SchemaTableName viewName, SchemaTableName newViewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanRenameView(context, viewName, newViewName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanRenameView(context, viewName, newViewName));
     }
 
     @Override
     public void checkCanSetViewAuthorization(ConnectorSecurityContext context, SchemaTableName viewName, TrinoPrincipal principal)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanSetViewAuthorization(context, viewName, principal);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanSetViewAuthorization(context, viewName, principal));
     }
 
     @Override
     public void checkCanDropView(ConnectorSecurityContext context, SchemaTableName viewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanDropView(context, viewName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanDropView(context, viewName));
     }
 
     @Override
     public void checkCanCreateViewWithSelectFromColumns(ConnectorSecurityContext context, SchemaTableName tableName, Set<String> columnNames)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames));
     }
 
     @Override
     public void checkCanCreateMaterializedView(ConnectorSecurityContext context, SchemaTableName materializedViewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanCreateMaterializedView(context, materializedViewName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanCreateMaterializedView(context, materializedViewName));
     }
 
     @Override
     public void checkCanRefreshMaterializedView(ConnectorSecurityContext context, SchemaTableName materializedViewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanRefreshMaterializedView(context, materializedViewName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanRefreshMaterializedView(context, materializedViewName));
     }
 
     @Override
     public void checkCanDropMaterializedView(ConnectorSecurityContext context, SchemaTableName materializedViewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanDropMaterializedView(context, materializedViewName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanDropMaterializedView(context, materializedViewName));
     }
 
     @Override
     public void checkCanSetCatalogSessionProperty(ConnectorSecurityContext context, String propertyName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanSetCatalogSessionProperty(context, propertyName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanSetCatalogSessionProperty(context, propertyName));
     }
 
     @Override
     public void checkCanGrantSchemaPrivilege(ConnectorSecurityContext context, Privilege privilege, String schemaName, TrinoPrincipal grantee, boolean grantOption)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanGrantSchemaPrivilege(context, privilege, schemaName, grantee, grantOption);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanGrantSchemaPrivilege(context, privilege, schemaName, grantee, grantOption));
     }
 
     @Override
     public void checkCanRevokeSchemaPrivilege(ConnectorSecurityContext context, Privilege privilege, String schemaName, TrinoPrincipal revokee, boolean grantOption)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanRevokeSchemaPrivilege(context, privilege, schemaName, revokee, grantOption);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanRevokeSchemaPrivilege(context, privilege, schemaName, revokee, grantOption));
     }
 
     @Override
     public void checkCanGrantTablePrivilege(ConnectorSecurityContext context, Privilege privilege, SchemaTableName tableName, TrinoPrincipal grantee, boolean grantOption)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanGrantTablePrivilege(context, privilege, tableName, grantee, grantOption);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanGrantTablePrivilege(context, privilege, tableName, grantee, grantOption));
     }
 
     @Override
     public void checkCanRevokeTablePrivilege(ConnectorSecurityContext context, Privilege privilege, SchemaTableName tableName, TrinoPrincipal revokee, boolean grantOption)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanRevokeTablePrivilege(context, privilege, tableName, revokee, grantOption);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanRevokeTablePrivilege(context, privilege, tableName, revokee, grantOption));
     }
 
     @Override
     public void checkCanCreateRole(ConnectorSecurityContext context, String role, Optional<TrinoPrincipal> grantor)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanCreateRole(context, role, grantor);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanCreateRole(context, role, grantor));
     }
 
     @Override
     public void checkCanDropRole(ConnectorSecurityContext context, String role)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanDropRole(context, role);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanDropRole(context, role));
     }
 
     @Override
     public void checkCanGrantRoles(ConnectorSecurityContext context, Set<String> roles, Set<TrinoPrincipal> grantees, boolean adminOption, Optional<TrinoPrincipal> grantor, String catalogName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanGrantRoles(context, roles, grantees, adminOption, grantor, catalogName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanGrantRoles(context, roles, grantees, adminOption, grantor, catalogName));
     }
 
     @Override
     public void checkCanRevokeRoles(ConnectorSecurityContext context, Set<String> roles, Set<TrinoPrincipal> grantees, boolean adminOption, Optional<TrinoPrincipal> grantor, String catalogName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanRevokeRoles(context, roles, grantees, adminOption, grantor, catalogName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanRevokeRoles(context, roles, grantees, adminOption, grantor, catalogName));
     }
 
     @Override
     public void checkCanSetRole(ConnectorSecurityContext context, String role, String catalogName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanSetRole(context, role, catalogName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanSetRole(context, role, catalogName));
     }
 
     @Override
     public void checkCanShowRoleAuthorizationDescriptors(ConnectorSecurityContext context, String catalogName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanShowRoleAuthorizationDescriptors(context, catalogName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanShowRoleAuthorizationDescriptors(context, catalogName));
     }
 
     @Override
     public void checkCanShowRoles(ConnectorSecurityContext context, String catalogName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanShowRoles(context, catalogName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanShowRoles(context, catalogName));
     }
 
     @Override
     public void checkCanShowCurrentRoles(ConnectorSecurityContext context, String catalogName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanShowCurrentRoles(context, catalogName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanShowCurrentRoles(context, catalogName));
     }
 
     @Override
     public void checkCanShowRoleGrants(ConnectorSecurityContext context, String catalogName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanShowRoleGrants(context, catalogName);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanShowRoleGrants(context, catalogName));
     }
 
     @Override
     public void checkCanExecuteProcedure(ConnectorSecurityContext context, SchemaRoutineName procedure)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.checkCanExecuteProcedure(context, procedure);
-        }
+        withClassLoader(classLoader, () -> delegate.checkCanExecuteProcedure(context, procedure));
     }
 
     @Override
     public Optional<ViewExpression> getRowFilter(ConnectorSecurityContext context, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getRowFilter(context, tableName);
-        }
+        return withClassLoader(classLoader, () -> delegate.getRowFilter(context, tableName));
     }
 
     @Override
     public Optional<ViewExpression> getColumnMask(ConnectorSecurityContext context, SchemaTableName tableName, String columnName, Type type)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getColumnMask(context, tableName, columnName, type);
-        }
+        return withClassLoader(classLoader, () -> delegate.getColumnMask(context, tableName, columnName, type));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.base.classloader;
 
 import io.airlift.slice.Slice;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.AggregationApplicationResult;
 import io.trino.spi.connector.CatalogSchemaName;
@@ -77,6 +76,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class ClassLoaderSafeConnectorMetadata
@@ -99,401 +99,301 @@ public class ClassLoaderSafeConnectorMetadata
             Constraint constraint,
             Optional<Set<ColumnHandle>> desiredColumns)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getTableLayouts(session, table, constraint, desiredColumns);
-        }
+        return withClassLoader(classLoader, () -> delegate.getTableLayouts(session, table, constraint, desiredColumns));
     }
 
     @Override
     public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getTableLayout(session, handle);
-        }
+        return withClassLoader(classLoader, () -> delegate.getTableLayout(session, handle));
     }
 
     @Override
     public Optional<ConnectorPartitioningHandle> getCommonPartitioningHandle(ConnectorSession session, ConnectorPartitioningHandle left, ConnectorPartitioningHandle right)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getCommonPartitioningHandle(session, left, right);
-        }
+        return withClassLoader(classLoader, () -> delegate.getCommonPartitioningHandle(session, left, right));
     }
 
     @Override
     public ConnectorTableLayoutHandle makeCompatiblePartitioning(ConnectorSession session, ConnectorTableLayoutHandle tableLayoutHandle, ConnectorPartitioningHandle partitioningHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.makeCompatiblePartitioning(session, tableLayoutHandle, partitioningHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.makeCompatiblePartitioning(session, tableLayoutHandle, partitioningHandle));
     }
 
     @Override
     public ConnectorTableHandle makeCompatiblePartitioning(ConnectorSession session, ConnectorTableHandle tableHandle, ConnectorPartitioningHandle partitioningHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.makeCompatiblePartitioning(session, tableHandle, partitioningHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.makeCompatiblePartitioning(session, tableHandle, partitioningHandle));
     }
 
     @Override
     public Optional<ConnectorNewTableLayout> getNewTableLayout(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getNewTableLayout(session, tableMetadata);
-        }
+        return withClassLoader(classLoader, () -> delegate.getNewTableLayout(session, tableMetadata));
     }
 
     @Override
     public Optional<ConnectorNewTableLayout> getInsertLayout(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getInsertLayout(session, tableHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.getInsertLayout(session, tableHandle));
     }
 
     @Override
     public TableStatisticsMetadata getStatisticsCollectionMetadataForWrite(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getStatisticsCollectionMetadataForWrite(session, tableMetadata);
-        }
+        return withClassLoader(classLoader, () -> delegate.getStatisticsCollectionMetadataForWrite(session, tableMetadata));
     }
 
     @Override
     public TableStatisticsMetadata getStatisticsCollectionMetadata(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getStatisticsCollectionMetadata(session, tableMetadata);
-        }
+        return withClassLoader(classLoader, () -> delegate.getStatisticsCollectionMetadata(session, tableMetadata));
     }
 
     @Override
     public ConnectorTableHandle beginStatisticsCollection(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.beginStatisticsCollection(session, tableHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.beginStatisticsCollection(session, tableHandle));
     }
 
     @Override
     public void finishStatisticsCollection(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<ComputedStatistics> computedStatistics)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.finishStatisticsCollection(session, tableHandle, computedStatistics);
-        }
+        withClassLoader(classLoader, () -> delegate.finishStatisticsCollection(session, tableHandle, computedStatistics));
     }
 
     @Override
     public boolean schemaExists(ConnectorSession session, String schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.schemaExists(session, schemaName);
-        }
+        return withClassLoader(classLoader, () -> delegate.schemaExists(session, schemaName));
     }
 
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listSchemaNames(session);
-        }
+        return withClassLoader(classLoader, () -> delegate.listSchemaNames(session));
     }
 
     @Override
     public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getTableHandle(session, tableName);
-        }
+        return withClassLoader(classLoader, () -> delegate.getTableHandle(session, tableName));
     }
 
     @Override
     public ConnectorTableHandle getTableHandleForStatisticsCollection(ConnectorSession session, SchemaTableName tableName, Map<String, Object> analyzeProperties)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getTableHandleForStatisticsCollection(session, tableName, analyzeProperties);
-        }
+        return withClassLoader(classLoader, () -> delegate.getTableHandleForStatisticsCollection(session, tableName, analyzeProperties));
     }
 
     @Override
     public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSystemTable(session, tableName);
-        }
+        return withClassLoader(classLoader, () -> delegate.getSystemTable(session, tableName));
     }
 
     @Override
     public ConnectorTableSchema getTableSchema(ConnectorSession session, ConnectorTableHandle table)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getTableSchema(session, table);
-        }
+        return withClassLoader(classLoader, () -> delegate.getTableSchema(session, table));
     }
 
     @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getTableMetadata(session, table);
-        }
+        return withClassLoader(classLoader, () -> delegate.getTableMetadata(session, table));
     }
 
     @Override
     public Optional<Object> getInfo(ConnectorTableLayoutHandle table)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getInfo(table);
-        }
+        return withClassLoader(classLoader, () -> delegate.getInfo(table));
     }
 
     @Override
     public Optional<Object> getInfo(ConnectorTableHandle table)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getInfo(table);
-        }
+        return withClassLoader(classLoader, () -> delegate.getInfo(table));
     }
 
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listTables(session, schemaName);
-        }
+        return withClassLoader(classLoader, () -> delegate.listTables(session, schemaName));
     }
 
     @Override
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getColumnHandles(session, tableHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.getColumnHandles(session, tableHandle));
     }
 
     @Override
     public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getColumnMetadata(session, tableHandle, columnHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.getColumnMetadata(session, tableHandle, columnHandle));
     }
 
     @Override
     public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listTableColumns(session, prefix);
-        }
+        return withClassLoader(classLoader, () -> delegate.listTableColumns(session, prefix));
     }
 
     @Override
     public Stream<TableColumnsMetadata> streamTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.streamTableColumns(session, prefix);
-        }
+        return withClassLoader(classLoader, () -> delegate.streamTableColumns(session, prefix));
     }
 
     @Override
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getTableStatistics(session, tableHandle, constraint);
-        }
+        return withClassLoader(classLoader, () -> delegate.getTableStatistics(session, tableHandle, constraint));
     }
 
     @Override
     public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.addColumn(session, tableHandle, column);
-        }
+        withClassLoader(classLoader, () -> delegate.addColumn(session, tableHandle, column));
     }
 
     @Override
     public void setTableAuthorization(ConnectorSession session, SchemaTableName table, TrinoPrincipal principal)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.setTableAuthorization(session, table, principal);
-        }
+        withClassLoader(classLoader, () -> delegate.setTableAuthorization(session, table, principal));
     }
 
     @Override
     public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, TrinoPrincipal owner)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.createSchema(session, schemaName, properties, owner);
-        }
+        withClassLoader(classLoader, () -> delegate.createSchema(session, schemaName, properties, owner));
     }
 
     @Override
     public void dropSchema(ConnectorSession session, String schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.dropSchema(session, schemaName);
-        }
+        withClassLoader(classLoader, () -> delegate.dropSchema(session, schemaName));
     }
 
     @Override
     public void renameSchema(ConnectorSession session, String source, String target)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.renameSchema(session, source, target);
-        }
+        withClassLoader(classLoader, () -> delegate.renameSchema(session, source, target));
     }
 
     @Override
     public void setSchemaAuthorization(ConnectorSession session, String source, TrinoPrincipal principal)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.setSchemaAuthorization(session, source, principal);
-        }
+        withClassLoader(classLoader, () -> delegate.setSchemaAuthorization(session, source, principal));
     }
 
     @Override
     public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.createTable(session, tableMetadata, ignoreExisting);
-        }
+        withClassLoader(classLoader, () -> delegate.createTable(session, tableMetadata, ignoreExisting));
     }
 
     @Override
     public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.dropTable(session, tableHandle);
-        }
+        withClassLoader(classLoader, () -> delegate.dropTable(session, tableHandle));
     }
 
     @Override
     public void renameColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle source, String target)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.renameColumn(session, tableHandle, source, target);
-        }
+        withClassLoader(classLoader, () -> delegate.renameColumn(session, tableHandle, source, target));
     }
 
     @Override
     public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.dropColumn(session, tableHandle, column);
-        }
+        withClassLoader(classLoader, () -> delegate.dropColumn(session, tableHandle, column));
     }
 
     @Override
     public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.renameTable(session, tableHandle, newTableName);
-        }
+        withClassLoader(classLoader, () -> delegate.renameTable(session, tableHandle, newTableName));
     }
 
     @Override
     public void setTableComment(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<String> comment)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.setTableComment(session, tableHandle, comment);
-        }
+        withClassLoader(classLoader, () -> delegate.setTableComment(session, tableHandle, comment));
     }
 
     @Override
     public void setColumnComment(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column, Optional<String> comment)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.setColumnComment(session, tableHandle, column, comment);
-        }
+        withClassLoader(classLoader, () -> delegate.setColumnComment(session, tableHandle, column, comment));
     }
 
     @Override
     public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.beginCreateTable(session, tableMetadata, layout);
-        }
+        return withClassLoader(classLoader, () -> delegate.beginCreateTable(session, tableMetadata, layout));
     }
 
     @Override
     public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.finishCreateTable(session, tableHandle, fragments, computedStatistics);
-        }
+        return withClassLoader(classLoader, () -> delegate.finishCreateTable(session, tableHandle, fragments, computedStatistics));
     }
 
     @Override
     public void beginQuery(ConnectorSession session)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.beginQuery(session);
-        }
+        withClassLoader(classLoader, () -> delegate.beginQuery(session));
     }
 
     @Override
     public void cleanupQuery(ConnectorSession session)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.cleanupQuery(session);
-        }
+        withClassLoader(classLoader, () -> delegate.cleanupQuery(session));
     }
 
     @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.beginInsert(session, tableHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.beginInsert(session, tableHandle));
     }
 
     @Override
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> columns)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.beginInsert(session, tableHandle, columns);
-        }
+        return withClassLoader(classLoader, () -> delegate.beginInsert(session, tableHandle, columns));
     }
 
     @Override
     public boolean supportsMissingColumnsOnInsert()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.supportsMissingColumnsOnInsert();
-        }
+        return withClassLoader(classLoader, () -> delegate.supportsMissingColumnsOnInsert());
     }
 
     @Override
     public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.finishInsert(session, insertHandle, fragments, computedStatistics);
-        }
+        return withClassLoader(classLoader, () -> delegate.finishInsert(session, insertHandle, fragments, computedStatistics));
     }
 
     @Override
     public boolean delegateMaterializedViewRefreshToConnector(ConnectorSession session, SchemaTableName viewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.delegateMaterializedViewRefreshToConnector(session, viewName);
-        }
+        return withClassLoader(classLoader, () -> delegate.delegateMaterializedViewRefreshToConnector(session, viewName));
     }
 
     @Override
     public CompletableFuture<?> refreshMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.refreshMaterializedView(session, viewName);
-        }
+        return withClassLoader(classLoader, () -> delegate.refreshMaterializedView(session, viewName));
     }
 
     @Override
     public ConnectorInsertTableHandle beginRefreshMaterializedView(ConnectorSession session, ConnectorTableHandle tableHandle, List<ConnectorTableHandle> sourceTableHandles)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.beginRefreshMaterializedView(session, tableHandle, sourceTableHandles);
-        }
+        return withClassLoader(classLoader, () -> delegate.beginRefreshMaterializedView(session, tableHandle, sourceTableHandles));
     }
 
     @Override
@@ -505,313 +405,235 @@ public class ClassLoaderSafeConnectorMetadata
             Collection<ComputedStatistics> computedStatistics,
             List<ConnectorTableHandle> sourceTableHandles)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.finishRefreshMaterializedView(session, tableHandle, insertHandle, fragments, computedStatistics, sourceTableHandles);
-        }
+        return withClassLoader(classLoader, () -> delegate.finishRefreshMaterializedView(session, tableHandle, insertHandle, fragments, computedStatistics, sourceTableHandles));
     }
 
     @Override
     public ColumnHandle getDeleteRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getDeleteRowIdColumnHandle(session, tableHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.getDeleteRowIdColumnHandle(session, tableHandle));
     }
 
     @Override
     public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.createView(session, viewName, definition, replace);
-        }
+        withClassLoader(classLoader, () -> delegate.createView(session, viewName, definition, replace));
     }
 
     @Override
     public void renameView(ConnectorSession session, SchemaTableName source, SchemaTableName target)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.renameView(session, source, target);
-        }
+        withClassLoader(classLoader, () -> delegate.renameView(session, source, target));
     }
 
     @Override
     public void setViewAuthorization(ConnectorSession session, SchemaTableName viewName, TrinoPrincipal principal)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.setViewAuthorization(session, viewName, principal);
-        }
+        withClassLoader(classLoader, () -> delegate.setViewAuthorization(session, viewName, principal));
     }
 
     @Override
     public void dropView(ConnectorSession session, SchemaTableName viewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.dropView(session, viewName);
-        }
+        withClassLoader(classLoader, () -> delegate.dropView(session, viewName));
     }
 
     @Override
     public List<SchemaTableName> listViews(ConnectorSession session, Optional<String> schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listViews(session, schemaName);
-        }
+        return withClassLoader(classLoader, () -> delegate.listViews(session, schemaName));
     }
 
     @Override
     public Map<SchemaTableName, ConnectorViewDefinition> getViews(ConnectorSession session, Optional<String> schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getViews(session, schemaName);
-        }
+        return withClassLoader(classLoader, () -> delegate.getViews(session, schemaName));
     }
 
     @Override
     public Optional<ConnectorViewDefinition> getView(ConnectorSession session, SchemaTableName viewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getView(session, viewName);
-        }
+        return withClassLoader(classLoader, () -> delegate.getView(session, viewName));
     }
 
     @Override
     public Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSchemaProperties(session, schemaName);
-        }
+        return withClassLoader(classLoader, () -> delegate.getSchemaProperties(session, schemaName));
     }
 
     @Override
     public Optional<TrinoPrincipal> getSchemaOwner(ConnectorSession session, CatalogSchemaName schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSchemaOwner(session, schemaName);
-        }
+        return withClassLoader(classLoader, () -> delegate.getSchemaOwner(session, schemaName));
     }
 
     @Override
     public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getUpdateRowIdColumnHandle(session, tableHandle, updatedColumns);
-        }
+        return withClassLoader(classLoader, () -> delegate.getUpdateRowIdColumnHandle(session, tableHandle, updatedColumns));
     }
 
     @Override
     public ConnectorTableHandle beginDelete(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.beginDelete(session, tableHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.beginDelete(session, tableHandle));
     }
 
     @Override
     public void finishDelete(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<Slice> fragments)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.finishDelete(session, tableHandle, fragments);
-        }
+        withClassLoader(classLoader, () -> delegate.finishDelete(session, tableHandle, fragments));
     }
 
     @Override
     public boolean supportsMetadataDelete(ConnectorSession session, ConnectorTableHandle tableHandle, ConnectorTableLayoutHandle tableLayoutHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.supportsMetadataDelete(session, tableHandle, tableLayoutHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.supportsMetadataDelete(session, tableHandle, tableLayoutHandle));
     }
 
     @Override
     public OptionalLong metadataDelete(ConnectorSession session, ConnectorTableHandle tableHandle, ConnectorTableLayoutHandle tableLayoutHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.metadataDelete(session, tableHandle, tableLayoutHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.metadataDelete(session, tableHandle, tableLayoutHandle));
     }
 
     @Override
     public Optional<ConnectorTableHandle> applyDelete(ConnectorSession session, ConnectorTableHandle handle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applyDelete(session, handle);
-        }
+        return withClassLoader(classLoader, () -> delegate.applyDelete(session, handle));
     }
 
     @Override
     public OptionalLong executeDelete(ConnectorSession session, ConnectorTableHandle handle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.executeDelete(session, handle);
-        }
+        return withClassLoader(classLoader, () -> delegate.executeDelete(session, handle));
     }
 
     @Override
     public Optional<ConnectorResolvedIndex> resolveIndex(ConnectorSession session, ConnectorTableHandle tableHandle, Set<ColumnHandle> indexableColumns, Set<ColumnHandle> outputColumns, TupleDomain<ColumnHandle> tupleDomain)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.resolveIndex(session, tableHandle, indexableColumns, outputColumns, tupleDomain);
-        }
+        return withClassLoader(classLoader, () -> delegate.resolveIndex(session, tableHandle, indexableColumns, outputColumns, tupleDomain));
     }
 
     @Override
     public void createRole(ConnectorSession session, String role, Optional<TrinoPrincipal> grantor)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.createRole(session, role, grantor);
-        }
+        withClassLoader(classLoader, () -> delegate.createRole(session, role, grantor));
     }
 
     @Override
     public void dropRole(ConnectorSession session, String role)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.dropRole(session, role);
-        }
+        withClassLoader(classLoader, () -> delegate.dropRole(session, role));
     }
 
     @Override
     public Set<String> listRoles(ConnectorSession session)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listRoles(session);
-        }
+        return withClassLoader(classLoader, () -> delegate.listRoles(session));
     }
 
     @Override
     public Set<RoleGrant> listAllRoleGrants(ConnectorSession session, Optional<Set<String>> roles, Optional<Set<String>> grantees, OptionalLong limit)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listAllRoleGrants(session, roles, grantees, limit);
-        }
+        return withClassLoader(classLoader, () -> delegate.listAllRoleGrants(session, roles, grantees, limit));
     }
 
     @Override
     public Set<RoleGrant> listRoleGrants(ConnectorSession session, TrinoPrincipal principal)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listRoleGrants(session, principal);
-        }
+        return withClassLoader(classLoader, () -> delegate.listRoleGrants(session, principal));
     }
 
     @Override
     public void grantRoles(ConnectorSession connectorSession, Set<String> roles, Set<TrinoPrincipal> grantees, boolean adminOption, Optional<TrinoPrincipal> grantor)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.grantRoles(connectorSession, roles, grantees, adminOption, grantor);
-        }
+        withClassLoader(classLoader, () -> delegate.grantRoles(connectorSession, roles, grantees, adminOption, grantor));
     }
 
     @Override
     public void revokeRoles(ConnectorSession connectorSession, Set<String> roles, Set<TrinoPrincipal> grantees, boolean adminOption, Optional<TrinoPrincipal> grantor)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.revokeRoles(connectorSession, roles, grantees, adminOption, grantor);
-        }
+        withClassLoader(classLoader, () -> delegate.revokeRoles(connectorSession, roles, grantees, adminOption, grantor));
     }
 
     @Override
     public Set<RoleGrant> listApplicableRoles(ConnectorSession session, TrinoPrincipal principal)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listApplicableRoles(session, principal);
-        }
+        return withClassLoader(classLoader, () -> delegate.listApplicableRoles(session, principal));
     }
 
     @Override
     public Set<String> listEnabledRoles(ConnectorSession session)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listEnabledRoles(session);
-        }
+        return withClassLoader(classLoader, () -> delegate.listEnabledRoles(session));
     }
 
     @Override
     public void grantSchemaPrivileges(ConnectorSession session, String schemaName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.grantSchemaPrivileges(session, schemaName, privileges, grantee, grantOption);
-        }
+        withClassLoader(classLoader, () -> delegate.grantSchemaPrivileges(session, schemaName, privileges, grantee, grantOption));
     }
 
     @Override
     public void revokeSchemaPrivileges(ConnectorSession session, String schemaName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.revokeSchemaPrivileges(session, schemaName, privileges, grantee, grantOption);
-        }
+        withClassLoader(classLoader, () -> delegate.revokeSchemaPrivileges(session, schemaName, privileges, grantee, grantOption));
     }
 
     @Override
     public void grantTablePrivileges(ConnectorSession session, SchemaTableName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.grantTablePrivileges(session, tableName, privileges, grantee, grantOption);
-        }
+        withClassLoader(classLoader, () -> delegate.grantTablePrivileges(session, tableName, privileges, grantee, grantOption));
     }
 
     @Override
     public void revokeTablePrivileges(ConnectorSession session, SchemaTableName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.revokeTablePrivileges(session, tableName, privileges, grantee, grantOption);
-        }
+        withClassLoader(classLoader, () -> delegate.revokeTablePrivileges(session, tableName, privileges, grantee, grantOption));
     }
 
     @Override
     public List<GrantInfo> listTablePrivileges(ConnectorSession session, SchemaTablePrefix prefix)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listTablePrivileges(session, prefix);
-        }
+        return withClassLoader(classLoader, () -> delegate.listTablePrivileges(session, prefix));
     }
 
     @Override
     public boolean usesLegacyTableLayouts()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.usesLegacyTableLayouts();
-        }
+        return withClassLoader(classLoader, delegate::usesLegacyTableLayouts);
     }
 
     @Override
     public ConnectorTableProperties getTableProperties(ConnectorSession session, ConnectorTableHandle table)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getTableProperties(session, table);
-        }
+        return withClassLoader(classLoader, () -> delegate.getTableProperties(session, table));
     }
 
     @Override
     public Optional<LimitApplicationResult<ConnectorTableHandle>> applyLimit(ConnectorSession session, ConnectorTableHandle table, long limit)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applyLimit(session, table, limit);
-        }
+        return withClassLoader(classLoader, () -> delegate.applyLimit(session, table, limit));
     }
 
     @Override
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle table, Constraint constraint)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applyFilter(session, table, constraint);
-        }
+        return withClassLoader(classLoader, () -> delegate.applyFilter(session, table, constraint));
     }
 
     @Override
     public Optional<ProjectionApplicationResult<ConnectorTableHandle>> applyProjection(ConnectorSession session, ConnectorTableHandle table, List<ConnectorExpression> projections, Map<String, ColumnHandle> assignments)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applyProjection(session, table, projections, assignments);
-        }
+        return withClassLoader(classLoader, () -> delegate.applyProjection(session, table, projections, assignments));
     }
 
     @Override
     public Optional<SampleApplicationResult<ConnectorTableHandle>> applySample(ConnectorSession session, ConnectorTableHandle table, SampleType sampleType, double sampleRatio)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applySample(session, table, sampleType, sampleRatio);
-        }
+        return withClassLoader(classLoader, () -> delegate.applySample(session, table, sampleType, sampleRatio));
     }
 
     @Override
@@ -822,9 +644,7 @@ public class ClassLoaderSafeConnectorMetadata
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applyAggregation(session, table, aggregates, assignments, groupingSets);
-        }
+        return withClassLoader(classLoader, () -> delegate.applyAggregation(session, table, aggregates, assignments, groupingSets));
     }
 
     @Override
@@ -838,9 +658,7 @@ public class ClassLoaderSafeConnectorMetadata
             Map<String, ColumnHandle> rightAssignments,
             JoinStatistics statistics)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applyJoin(session, joinType, left, right, joinConditions, leftAssignments, rightAssignments, statistics);
-        }
+        return withClassLoader(classLoader, () -> delegate.applyJoin(session, joinType, left, right, joinConditions, leftAssignments, rightAssignments, statistics));
     }
 
     @Override
@@ -851,96 +669,72 @@ public class ClassLoaderSafeConnectorMetadata
             List<SortItem> sortItems,
             Map<String, ColumnHandle> assignments)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applyTopN(session, table, topNCount, sortItems, assignments);
-        }
+        return withClassLoader(classLoader, () -> delegate.applyTopN(session, table, topNCount, sortItems, assignments));
     }
 
     @Override
     public void validateScan(ConnectorSession session, ConnectorTableHandle handle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.validateScan(session, handle);
-        }
+        withClassLoader(classLoader, () -> delegate.validateScan(session, handle));
     }
 
     @Override
     public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.createMaterializedView(session, viewName, definition, replace, ignoreExisting);
-        }
+        withClassLoader(classLoader, () -> delegate.createMaterializedView(session, viewName, definition, replace, ignoreExisting));
     }
 
     @Override
     public void dropMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.dropMaterializedView(session, viewName);
-        }
+        withClassLoader(classLoader, () -> delegate.dropMaterializedView(session, viewName));
     }
 
     @Override
     public List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listMaterializedViews(session, schemaName);
-        }
+        return withClassLoader(classLoader, () -> delegate.listMaterializedViews(session, schemaName));
     }
 
     @Override
     public Map<SchemaTableName, ConnectorMaterializedViewDefinition> getMaterializedViews(ConnectorSession session, Optional<String> schemaName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getMaterializedViews(session, schemaName);
-        }
+        return withClassLoader(classLoader, () -> delegate.getMaterializedViews(session, schemaName));
     }
 
     @Override
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getMaterializedView(session, viewName);
-        }
+        return withClassLoader(classLoader, () -> delegate.getMaterializedView(session, viewName));
     }
 
     @Override
     public MaterializedViewFreshness getMaterializedViewFreshness(ConnectorSession session, SchemaTableName name)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getMaterializedViewFreshness(session, name);
-        }
+        return withClassLoader(classLoader, () -> delegate.getMaterializedViewFreshness(session, name));
     }
 
     @Override
     public Optional<TableScanRedirectApplicationResult> applyTableScanRedirect(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applyTableScanRedirect(session, tableHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.applyTableScanRedirect(session, tableHandle));
     }
 
     @Override
     public ConnectorTableHandle beginUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, List<ColumnHandle> updatedColumns)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.beginUpdate(session, tableHandle, updatedColumns);
-        }
+        return withClassLoader(classLoader, () -> delegate.beginUpdate(session, tableHandle, updatedColumns));
     }
 
     @Override
     public void finishUpdate(ConnectorSession session, ConnectorTableHandle tableHandle, Collection<Slice> fragments)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.finishUpdate(session, tableHandle, fragments);
-        }
+        withClassLoader(classLoader, () -> delegate.finishUpdate(session, tableHandle, fragments));
     }
 
     @Override
     public Optional<CatalogSchemaTableName> redirectTable(ConnectorSession session, SchemaTableName tableName)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.redirectTable(session, tableName);
-        }
+        return withClassLoader(classLoader, () -> delegate.redirectTable(session, tableName));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSink.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSink.java
@@ -15,7 +15,6 @@ package io.trino.plugin.base.classloader;
 
 import io.airlift.slice.Slice;
 import io.trino.spi.Page;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorPageSink;
 
 import javax.inject.Inject;
@@ -23,6 +22,7 @@ import javax.inject.Inject;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class ClassLoaderSafeConnectorPageSink
@@ -41,48 +41,36 @@ public class ClassLoaderSafeConnectorPageSink
     @Override
     public long getCompletedBytes()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getCompletedBytes();
-        }
+        return withClassLoader(classLoader, delegate::getCompletedBytes);
     }
 
     @Override
     public long getSystemMemoryUsage()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSystemMemoryUsage();
-        }
+        return withClassLoader(classLoader, delegate::getSystemMemoryUsage);
     }
 
     @Override
     public long getValidationCpuNanos()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getValidationCpuNanos();
-        }
+        return withClassLoader(classLoader, delegate::getValidationCpuNanos);
     }
 
     @Override
     public CompletableFuture<?> appendPage(Page page)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.appendPage(page);
-        }
+        return withClassLoader(classLoader, () -> delegate.appendPage(page));
     }
 
     @Override
     public CompletableFuture<Collection<Slice>> finish()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.finish();
-        }
+        return withClassLoader(classLoader, delegate::finish);
     }
 
     @Override
     public void abort()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.abort();
-        }
+        withClassLoader(classLoader, delegate::abort);
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.base.classloader;
 
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPageSink;
@@ -23,6 +22,7 @@ import io.trino.spi.connector.ConnectorTransactionHandle;
 
 import javax.inject.Inject;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public final class ClassLoaderSafeConnectorPageSinkProvider
@@ -41,16 +41,12 @@ public final class ClassLoaderSafeConnectorPageSinkProvider
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, outputTableHandle), classLoader);
-        }
+        return withClassLoader(classLoader, () -> new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, outputTableHandle), classLoader));
     }
 
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, insertTableHandle), classLoader);
-        }
+        return withClassLoader(classLoader, () -> new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, insertTableHandle), classLoader));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSourceProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSourceProvider.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.base.classloader;
 
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
@@ -27,6 +26,7 @@ import javax.inject.Inject;
 
 import java.util.List;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class ClassLoaderSafeConnectorPageSourceProvider
@@ -45,8 +45,6 @@ public class ClassLoaderSafeConnectorPageSourceProvider
     @Override
     public ConnectorPageSource createPageSource(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorSplit split, ConnectorTableHandle table, List<ColumnHandle> columns, DynamicFilter dynamicFilter)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.createPageSource(transaction, session, split, table, columns, dynamicFilter);
-        }
+        return withClassLoader(classLoader, () -> delegate.createPageSource(transaction, session, split, table, columns, dynamicFilter));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorSplitManager.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorSplitManager.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.base.classloader;
 
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorSplitSource;
@@ -24,6 +23,7 @@ import io.trino.spi.connector.DynamicFilter;
 
 import javax.inject.Inject;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public final class ClassLoaderSafeConnectorSplitManager
@@ -42,16 +42,12 @@ public final class ClassLoaderSafeConnectorSplitManager
     @Override
     public ConnectorSplitSource getSplits(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableLayoutHandle layout, SplitSchedulingStrategy splitSchedulingStrategy)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSplits(transactionHandle, session, layout, splitSchedulingStrategy);
-        }
+        return withClassLoader(classLoader, () -> delegate.getSplits(transactionHandle, session, layout, splitSchedulingStrategy));
     }
 
     @Override
     public ConnectorSplitSource getSplits(ConnectorTransactionHandle transaction, ConnectorSession session, ConnectorTableHandle table, SplitSchedulingStrategy splitSchedulingStrategy, DynamicFilter dynamicFilter)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSplits(transaction, session, table, splitSchedulingStrategy, dynamicFilter);
-        }
+        return withClassLoader(classLoader, () -> delegate.getSplits(transaction, session, table, splitSchedulingStrategy, dynamicFilter));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeEventListener.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeEventListener.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.base.classloader;
 
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.eventlistener.QueryCompletedEvent;
 import io.trino.spi.eventlistener.QueryCreatedEvent;
@@ -21,6 +20,7 @@ import io.trino.spi.eventlistener.SplitCompletedEvent;
 
 import javax.inject.Inject;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class ClassLoaderSafeEventListener
@@ -39,24 +39,18 @@ public class ClassLoaderSafeEventListener
     @Override
     public void queryCreated(QueryCreatedEvent queryCreatedEvent)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.queryCreated(queryCreatedEvent);
-        }
+        withClassLoader(classLoader, () -> delegate.queryCreated(queryCreatedEvent));
     }
 
     @Override
     public void queryCompleted(QueryCompletedEvent queryCompletedEvent)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.queryCompleted(queryCompletedEvent);
-        }
+        withClassLoader(classLoader, () -> delegate.queryCompleted(queryCompletedEvent));
     }
 
     @Override
     public void splitCompleted(SplitCompletedEvent splitCompletedEvent)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.splitCompleted(splitCompletedEvent);
-        }
+        withClassLoader(classLoader, () -> delegate.splitCompleted(splitCompletedEvent));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeNodePartitioningProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeNodePartitioningProvider.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.base.classloader;
 
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.BucketFunction;
 import io.trino.spi.connector.ConnectorBucketNodeMap;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
@@ -29,6 +28,7 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.function.ToIntFunction;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public final class ClassLoaderSafeNodePartitioningProvider
@@ -52,32 +52,24 @@ public final class ClassLoaderSafeNodePartitioningProvider
             List<Type> partitionChannelTypes,
             int bucketCount)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getBucketFunction(transactionHandle, session, partitioningHandle, partitionChannelTypes, bucketCount);
-        }
+        return withClassLoader(classLoader, () -> delegate.getBucketFunction(transactionHandle, session, partitioningHandle, partitionChannelTypes, bucketCount));
     }
 
     @Override
     public List<ConnectorPartitionHandle> listPartitionHandles(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.listPartitionHandles(transactionHandle, session, partitioningHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.listPartitionHandles(transactionHandle, session, partitioningHandle));
     }
 
     @Override
     public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getBucketNodeMap(transactionHandle, session, partitioningHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.getBucketNodeMap(transactionHandle, session, partitioningHandle));
     }
 
     @Override
     public ToIntFunction<ConnectorSplit> getSplitBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSplitBucketFunction(transactionHandle, session, partitioningHandle);
-        }
+        return withClassLoader(classLoader, () -> delegate.getSplitBucketFunction(transactionHandle, session, partitioningHandle));
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeRecordSet.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeRecordSet.java
@@ -14,7 +14,6 @@
 
 package io.trino.plugin.base.classloader;
 
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.RecordSet;
 import io.trino.spi.type.Type;
@@ -23,6 +22,7 @@ import javax.inject.Inject;
 
 import java.util.List;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class ClassLoaderSafeRecordSet
@@ -41,16 +41,12 @@ public class ClassLoaderSafeRecordSet
     @Override
     public List<Type> getColumnTypes()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getColumnTypes();
-        }
+        return withClassLoader(classLoader, delegate::getColumnTypes);
     }
 
     @Override
     public RecordCursor cursor()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.cursor();
-        }
+        return withClassLoader(classLoader, delegate::cursor);
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeSystemTable.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeSystemTable.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.base.classloader;
 
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -24,6 +23,7 @@ import io.trino.spi.predicate.TupleDomain;
 
 import javax.inject.Inject;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class ClassLoaderSafeSystemTable
@@ -42,32 +42,24 @@ public class ClassLoaderSafeSystemTable
     @Override
     public Distribution getDistribution()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getDistribution();
-        }
+        return withClassLoader(classLoader, delegate::getDistribution);
     }
 
     @Override
     public ConnectorTableMetadata getTableMetadata()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getTableMetadata();
-        }
+        return withClassLoader(classLoader, delegate::getTableMetadata);
     }
 
     @Override
     public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.cursor(transactionHandle, session, constraint);
-        }
+        return withClassLoader(classLoader, () -> delegate.cursor(transactionHandle, session, constraint));
     }
 
     @Override
     public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.pageSource(transactionHandle, session, constraint);
-        }
+        return withClassLoader(classLoader, () -> delegate.pageSource(transactionHandle, session, constraint));
     }
 }

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
@@ -19,7 +19,6 @@ import io.airlift.json.JsonModule;
 import io.trino.plugin.atop.AtopConnectorConfig.AtopSecurity;
 import io.trino.plugin.base.security.AllowAllAccessControlModule;
 import io.trino.plugin.base.security.FileBasedAccessControlModule;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
@@ -28,6 +27,7 @@ import io.trino.spi.connector.ConnectorHandleResolver;
 import java.util.Map;
 
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class AtopConnectorFactory
@@ -59,7 +59,7 @@ public class AtopConnectorFactory
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
 
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+        return withClassLoader(classLoader, () -> {
             Bootstrap app = new Bootstrap(
                     new AtopModule(
                             atopFactoryClass,
@@ -85,6 +85,6 @@ public class AtopConnectorFactory
                     .initialize();
 
             return injector.getInstance(AtopConnector.class);
-        }
+        });
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
@@ -49,7 +49,6 @@ import io.trino.spi.NodeManager;
 import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.PageSorter;
 import io.trino.spi.VersionEmbedder;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorContext;
@@ -69,6 +68,7 @@ import java.util.Set;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public final class InternalHiveConnectorFactory
@@ -85,7 +85,7 @@ public final class InternalHiveConnectorFactory
         requireNonNull(config, "config is null");
 
         ClassLoader classLoader = InternalHiveConnectorFactory.class.getClassLoader();
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+        return withClassLoader(classLoader, () -> {
             Bootstrap app = new Bootstrap(
                     new EventModule(),
                     new MBeanModule(),
@@ -157,7 +157,7 @@ public final class InternalHiveConnectorFactory
                     hiveMaterializedViewPropertiesProvider.getMaterializedViewProperties(),
                     accessControl,
                     classLoader);
-        }
+        });
     }
 
     public static void bindSessionPropertiesProvider(Binder binder, Class<? extends SessionPropertiesProvider> type)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/CreateEmptyPartitionProcedure.java
@@ -30,7 +30,6 @@ import io.trino.plugin.hive.TransactionalMetadataFactory;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.TrinoException;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
@@ -51,6 +50,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
 import static io.trino.spi.block.MethodHandleUtil.methodHandle;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -98,9 +98,7 @@ public class CreateEmptyPartitionProcedure
 
     public void createEmptyPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schema, String table, List<String> partitionColumnNames, List<String> partitionValues)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            doCreateEmptyPartition(session, accessControl, schema, table, partitionColumnNames, partitionValues);
-        }
+        withClassLoaderOf(getClass(), () -> doCreateEmptyPartition(session, accessControl, schema, table, partitionColumnNames, partitionValues));
     }
 
     private void doCreateEmptyPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schemaName, String tableName, List<String> partitionColumnNames, List<String> partitionValues)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/DropStatsProcedure.java
@@ -23,7 +23,6 @@ import io.trino.plugin.hive.TransactionalMetadataFactory;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.TrinoException;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSession;
@@ -44,6 +43,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
 import static io.trino.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
 import static io.trino.spi.block.MethodHandleUtil.methodHandle;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -91,9 +91,7 @@ public class DropStatsProcedure
 
     public void dropStats(ConnectorSession session, ConnectorAccessControl accessControl, String schema, String table, List<?> partitionValues)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            doDropStats(session, accessControl, schema, table, partitionValues);
-        }
+        withClassLoaderOf(getClass(), () -> doDropStats(session, accessControl, schema, table, partitionValues));
     }
 
     private void doDropStats(ConnectorSession session, ConnectorAccessControl accessControl, String schema, String table, List<?> partitionValues)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/RegisterPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/RegisterPartitionProcedure.java
@@ -28,7 +28,6 @@ import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.util.HiveWriteUtils;
 import io.trino.spi.TrinoException;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
@@ -52,6 +51,7 @@ import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.PERMISSION_DENIED;
 import static io.trino.spi.block.MethodHandleUtil.methodHandle;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -101,9 +101,7 @@ public class RegisterPartitionProcedure
 
     public void registerPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schemaName, String tableName, List<String> partitionColumn, List<String> partitionValues, String location)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            doRegisterPartition(session, accessControl, schemaName, tableName, partitionColumn, partitionValues, location);
-        }
+        withClassLoaderOf(getClass(), () -> doRegisterPartition(session, accessControl, schemaName, tableName, partitionColumn, partitionValues, location));
     }
 
     private void doRegisterPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schemaName, String tableName, List<String> partitionColumn, List<String> partitionValues, String location)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/SyncPartitionMetadataProcedure.java
@@ -25,7 +25,6 @@ import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.TrinoException;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
@@ -53,6 +52,7 @@ import static io.trino.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
 import static io.trino.plugin.hive.HivePartitionManager.extractPartitionValues;
 import static io.trino.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
 import static io.trino.spi.block.MethodHandleUtil.methodHandle;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.Boolean.TRUE;
@@ -105,9 +105,7 @@ public class SyncPartitionMetadataProcedure
 
     public void syncPartitionMetadata(ConnectorSession session, ConnectorAccessControl accessControl, String schemaName, String tableName, String mode, boolean caseSensitive)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            doSyncPartitionMetadata(session, accessControl, schemaName, tableName, mode, caseSensitive);
-        }
+        withClassLoaderOf(getClass(), () -> doSyncPartitionMetadata(session, accessControl, schemaName, tableName, mode, caseSensitive));
     }
 
     private void doSyncPartitionMetadata(ConnectorSession session, ConnectorAccessControl accessControl, String schemaName, String tableName, String mode, boolean caseSensitive)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/UnregisterPartitionProcedure.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/procedure/UnregisterPartitionProcedure.java
@@ -22,7 +22,6 @@ import io.trino.plugin.hive.metastore.Partition;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.TrinoException;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
@@ -41,6 +40,7 @@ import static io.trino.plugin.hive.procedure.Procedures.checkIsPartitionedTable;
 import static io.trino.plugin.hive.procedure.Procedures.checkPartitionColumns;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.spi.block.MethodHandleUtil.methodHandle;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -84,9 +84,7 @@ public class UnregisterPartitionProcedure
 
     public void unregisterPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schemaName, String tableName, List<String> partitionColumn, List<String> partitionValues)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            doUnregisterPartition(session, accessControl, schemaName, tableName, partitionColumn, partitionValues);
-        }
+        withClassLoaderOf(getClass(), () -> doUnregisterPartition(session, accessControl, schemaName, tableName, partitionColumn, partitionValues));
     }
 
     private void doUnregisterPartition(ConnectorSession session, ConnectorAccessControl accessControl, String schemaName, String tableName, List<String> partitionColumn, List<String> partitionValues)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -37,7 +37,6 @@ import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
@@ -106,6 +105,7 @@ import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.SESSION;
 import static io.trino.plugin.hive.HiveTestUtils.TYPE_MANAGER;
 import static io.trino.plugin.hive.acid.AcidTransaction.NO_ACID_TRANSACTION;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.sql.relational.Expressions.field;
 import static io.trino.testing.TestingHandles.TEST_TABLE_HANDLE;
@@ -725,7 +725,7 @@ public class TestOrcPageSourceMemoryTracking
 
     private static RecordWriter createRecordWriter(Path target, Configuration conf)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(FileSystem.class.getClassLoader())) {
+        return withClassLoaderOf(FileSystem.class, () -> {
             WriterOptions options = OrcFile.writerOptions(conf)
                     .memory(new NullMemoryManager())
                     .compress(ZLIB);
@@ -736,7 +736,7 @@ public class TestOrcPageSourceMemoryTracking
             catch (ReflectiveOperationException e) {
                 throw new RuntimeException(e);
             }
-        }
+        });
     }
 
     private static Constructor<? extends RecordWriter> getOrcWriterConstructor()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.bootstrap.LifeCycleManager;
 import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
 import io.trino.plugin.hive.HiveTransactionHandle;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorCapabilities;
@@ -39,6 +38,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.collect.Sets.immutableEnumSet;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static io.trino.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
 import static io.trino.spi.transaction.IsolationLevel.SERIALIZABLE;
 import static io.trino.spi.transaction.IsolationLevel.checkConnectorSupports;
@@ -187,9 +187,7 @@ public class IcebergConnector
     {
         checkConnectorSupports(SERIALIZABLE, isolationLevel);
         ConnectorTransactionHandle transaction = new HiveTransactionHandle();
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            transactionManager.put(transaction, metadataFactory.create());
-        }
+        withClassLoaderOf(getClass(), () -> transactionManager.put(transaction, metadataFactory.create()));
         return transaction;
     }
 
@@ -203,9 +201,7 @@ public class IcebergConnector
     public void rollback(ConnectorTransactionHandle transaction)
     {
         IcebergMetadata metadata = transactionManager.remove(transaction);
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            metadata.rollback();
-        }
+        withClassLoaderOf(getClass(), metadata::rollback);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
@@ -40,7 +40,6 @@ import io.trino.plugin.hive.s3.HiveS3Module;
 import io.trino.plugin.iceberg.testing.TrackingFileIoModule;
 import io.trino.spi.NodeManager;
 import io.trino.spi.PageIndexerFactory;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
@@ -56,6 +55,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.google.inject.Scopes.SINGLETON;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 
 public final class InternalIcebergConnectorFactory
 {
@@ -69,7 +69,7 @@ public final class InternalIcebergConnectorFactory
             boolean trackMetadataIo)
     {
         ClassLoader classLoader = InternalIcebergConnectorFactory.class.getClassLoader();
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+        return withClassLoader(classLoader, () -> {
             Bootstrap app = new Bootstrap(
                     new EventModule(),
                     new MBeanModule(),
@@ -125,6 +125,6 @@ public final class InternalIcebergConnectorFactory
                     icebergTableProperties.getTableProperties(),
                     new AllowAllAccessControl(),
                     procedures);
-        }
+        });
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ClassLoaderSafeSchemaRegistryClient.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/schema/confluent/ClassLoaderSafeSchemaRegistryClient.java
@@ -18,16 +18,14 @@ import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference;
 import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import org.apache.avro.Schema;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class ClassLoaderSafeSchemaRegistryClient
@@ -45,312 +43,210 @@ public class ClassLoaderSafeSchemaRegistryClient
     @Override
     public Optional<ParsedSchema> parseSchema(String schemaType, String schemaString, List<SchemaReference> references)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.parseSchema(schemaType, schemaString, references);
-        }
+        return withClassLoader(classLoader, () -> delegate.parseSchema(schemaType, schemaString, references));
     }
 
     @Override
     public int register(String subject, Schema schema)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.register(subject, schema);
-        }
+        return withClassLoader(classLoader, () -> delegate.register(subject, schema));
     }
 
     @Override
     public int register(String subject, ParsedSchema parsedSchema)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.register(subject, parsedSchema);
-        }
+        return withClassLoader(classLoader, () -> delegate.register(subject, parsedSchema));
     }
 
     @Override
     public int register(String subject, Schema schema, int version, int id)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.register(subject, schema, version, id);
-        }
+        return withClassLoader(classLoader, () -> delegate.register(subject, schema, version, id));
     }
 
     @Override
     public int register(String subject, ParsedSchema parsedSchema, int version, int id)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.register(subject, parsedSchema, version, id);
-        }
+        return withClassLoader(classLoader, () -> delegate.register(subject, parsedSchema, version, id));
     }
 
     @Override
     public Schema getByID(int id)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getByID(id);
-        }
+        return withClassLoader(classLoader, () -> delegate.getByID(id));
     }
 
     @Override
     public Schema getById(int id)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getById(id);
-        }
+        return withClassLoader(classLoader, () -> delegate.getById(id));
     }
 
     @Override
     public ParsedSchema getSchemaById(int id)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSchemaById(id);
-        }
+        return withClassLoader(classLoader, () -> delegate.getSchemaById(id));
     }
 
     @Override
     public Schema getBySubjectAndID(String subject, int id)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getBySubjectAndID(subject, id);
-        }
+        return withClassLoader(classLoader, () -> delegate.getBySubjectAndID(subject, id));
     }
 
     @Override
     public Schema getBySubjectAndId(String subject, int id)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getBySubjectAndId(subject, id);
-        }
+        return withClassLoader(classLoader, () -> delegate.getBySubjectAndId(subject, id));
     }
 
     @Override
     public ParsedSchema getSchemaBySubjectAndId(String subject, int id)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSchemaBySubjectAndId(subject, id);
-        }
+        return withClassLoader(classLoader, () -> delegate.getSchemaBySubjectAndId(subject, id));
     }
 
     @Override
     public Collection<String> getAllSubjectsById(int id)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getAllSubjectsById(id);
-        }
+        return withClassLoader(classLoader, () -> delegate.getAllSubjectsById(id));
     }
 
     @Override
     public Collection<SubjectVersion> getAllVersionsById(int id)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getAllVersionsById(id);
-        }
+        return withClassLoader(classLoader, () -> delegate.getAllVersionsById(id));
     }
 
     @Override
     public io.confluent.kafka.schemaregistry.client.rest.entities.Schema getByVersion(String subject, int version, boolean lookupDeletedSchema)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getByVersion(subject, version, lookupDeletedSchema);
-        }
+        return withClassLoader(classLoader, () -> delegate.getByVersion(subject, version, lookupDeletedSchema));
     }
 
     @Override
     public SchemaMetadata getLatestSchemaMetadata(String subject)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getLatestSchemaMetadata(subject);
-        }
+        return withClassLoader(classLoader, () -> delegate.getLatestSchemaMetadata(subject));
     }
 
     @Override
     public SchemaMetadata getSchemaMetadata(String subject, int version)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getSchemaMetadata(subject, version);
-        }
+        return withClassLoader(classLoader, () -> delegate.getSchemaMetadata(subject, version));
     }
 
     @Override
     public int getVersion(String subject, Schema schema)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getVersion(subject, schema);
-        }
+        return withClassLoader(classLoader, () -> delegate.getVersion(subject, schema));
     }
 
     @Override
     public int getVersion(String subject, ParsedSchema parsedSchema)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getVersion(subject, parsedSchema);
-        }
+        return withClassLoader(classLoader, () -> delegate.getVersion(subject, parsedSchema));
     }
 
     @Override
     public List<Integer> getAllVersions(String subject)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getAllVersions(subject);
-        }
+        return withClassLoader(classLoader, () -> delegate.getAllVersions(subject));
     }
 
     @Override
     public boolean testCompatibility(String subject, Schema schema)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.testCompatibility(subject, schema);
-        }
+        return withClassLoader(classLoader, () -> delegate.testCompatibility(subject, schema));
     }
 
     @Override
     public boolean testCompatibility(String subject, ParsedSchema parsedSchema)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.testCompatibility(subject, parsedSchema);
-        }
+        return withClassLoader(classLoader, () -> delegate.testCompatibility(subject, parsedSchema));
     }
 
     @Override
     public String updateCompatibility(String subject, String compatibility)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.updateCompatibility(subject, compatibility);
-        }
+        return withClassLoader(classLoader, () -> delegate.updateCompatibility(subject, compatibility));
     }
 
     @Override
     public String getCompatibility(String subject)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getCompatibility(subject);
-        }
+        return withClassLoader(classLoader, () -> delegate.getCompatibility(subject));
     }
 
     @Override
     public String setMode(String mode)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.setMode(mode);
-        }
+        return withClassLoader(classLoader, () -> delegate.setMode(mode));
     }
 
     @Override
     public String setMode(String mode, String subject)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.setMode(mode, subject);
-        }
+        return withClassLoader(classLoader, () -> delegate.setMode(mode, subject));
     }
 
     @Override
     public String getMode()
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getMode();
-        }
+        return withClassLoader(classLoader, () -> delegate.getMode());
     }
 
     @Override
     public String getMode(String subject)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getMode(subject);
-        }
+        return withClassLoader(classLoader, () -> delegate.getMode(subject));
     }
 
     @Override
     public Collection<String> getAllSubjects()
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getAllSubjects();
-        }
+        return withClassLoader(classLoader, () -> delegate.getAllSubjects());
     }
 
     @Override
     public int getId(String subject, Schema schema)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getId(subject, schema);
-        }
+        return withClassLoader(classLoader, () -> delegate.getId(subject, schema));
     }
 
     @Override
     public int getId(String subject, ParsedSchema parsedSchema)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getId(subject, parsedSchema);
-        }
+        return withClassLoader(classLoader, () -> delegate.getId(subject, parsedSchema));
     }
 
     @Override
     public List<Integer> deleteSubject(String subject)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.deleteSubject(subject);
-        }
+        return withClassLoader(classLoader, () -> delegate.deleteSubject(subject));
     }
 
     @Override
     public List<Integer> deleteSubject(Map<String, String> requestProperties, String subject)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.deleteSubject(subject);
-        }
+        return withClassLoader(classLoader, () -> delegate.deleteSubject(subject));
     }
 
     @Override
     public Integer deleteSchemaVersion(String subject, String version)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.deleteSchemaVersion(subject, version);
-        }
+        return withClassLoader(classLoader, () -> delegate.deleteSchemaVersion(subject, version));
     }
 
     @Override
     public Integer deleteSchemaVersion(Map<String, String> requestProperties, String subject, String version)
-            throws IOException, RestClientException
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.deleteSchemaVersion(requestProperties, subject, version);
-        }
+        return withClassLoader(classLoader, () -> delegate.deleteSchemaVersion(requestProperties, subject, version));
     }
 
     @Override
     public void reset()
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            delegate.reset();
-        }
+        withClassLoader(classLoader, delegate::reset);
     }
 }

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticator.java
@@ -21,7 +21,6 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.log.Logger;
 import io.trino.plugin.password.Credential;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.BasicPrincipal;
 import io.trino.spi.security.PasswordAuthenticator;
@@ -37,6 +36,7 @@ import java.util.Set;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -98,13 +98,15 @@ public class LdapAuthenticator
     @Override
     public Principal createAuthenticatedPrincipal(String user, String password)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
-            return authenticationCache.getUnchecked(new Credential(user, password));
-        }
-        catch (UncheckedExecutionException e) {
-            throwIfInstanceOf(e.getCause(), AccessDeniedException.class);
-            throw e;
-        }
+        return withClassLoaderOf(getClass(), () -> {
+            try {
+                return authenticationCache.getUnchecked(new Credential(user, password));
+            }
+            catch (UncheckedExecutionException e) {
+                throwIfInstanceOf(e.getCause(), AccessDeniedException.class);
+                throw e;
+            }
+        });
     }
 
     private Principal authenticateWithUserBind(Credential credential)

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixConnectorFactory.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixConnectorFactory.java
@@ -17,7 +17,6 @@ import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 import io.trino.plugin.base.CatalogName;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
@@ -26,6 +25,7 @@ import io.trino.spi.type.TypeManager;
 
 import java.util.Map;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class PhoenixConnectorFactory
@@ -55,7 +55,7 @@ public class PhoenixConnectorFactory
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
 
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+        return withClassLoader(classLoader, () -> {
             Bootstrap app = new Bootstrap(
                     new JsonModule(),
                     new PhoenixClientModule(),
@@ -71,6 +71,6 @@ public class PhoenixConnectorFactory
                     .initialize();
 
             return injector.getInstance(PhoenixConnector.class);
-        }
+        });
     }
 }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnectorFactory.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConnectorFactory.java
@@ -17,7 +17,6 @@ import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 import io.trino.plugin.base.CatalogName;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
@@ -26,6 +25,7 @@ import io.trino.spi.type.TypeManager;
 
 import java.util.Map;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class PhoenixConnectorFactory
@@ -55,7 +55,7 @@ public class PhoenixConnectorFactory
     {
         requireNonNull(requiredConfig, "requiredConfig is null");
 
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+        return withClassLoader(classLoader, () -> {
             Bootstrap app = new Bootstrap(
                     new JsonModule(),
                     new PhoenixClientModule(),
@@ -71,6 +71,6 @@ public class PhoenixConnectorFactory
                     .initialize();
 
             return injector.getInstance(PhoenixConnector.class);
-        }
+        });
     }
 }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/OrcFileWriter.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/OrcFileWriter.java
@@ -22,7 +22,6 @@ import io.airlift.slice.Slice;
 import io.trino.plugin.raptor.legacy.util.SyncingFileSystem;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeId;
@@ -69,6 +68,7 @@ import static io.trino.plugin.raptor.legacy.util.Types.isArrayType;
 import static io.trino.plugin.raptor.legacy.util.Types.isMapType;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoaderOf;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
@@ -87,9 +87,7 @@ public class OrcFileWriter
 {
     static {
         // make sure Hadoop version is loaded from correct class loader
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(VersionInfo.class.getClassLoader())) {
-            ShimLoader.getHadoopShims();
-        }
+        withClassLoaderOf(VersionInfo.class, ShimLoader::getHadoopShims);
     }
 
     private static final Configuration CONFIGURATION = new Configuration(false);

--- a/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2ResourceGroupConfigurationManagerFactory.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/resourcegroups/db/H2ResourceGroupConfigurationManagerFactory.java
@@ -18,7 +18,6 @@ import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 import io.airlift.node.NodeModule;
 import io.trino.plugin.resourcegroups.db.DbResourceGroupConfigurationManager;
-import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.memory.ClusterMemoryPoolManager;
 import io.trino.spi.resourcegroups.ResourceGroupConfigurationManager;
 import io.trino.spi.resourcegroups.ResourceGroupConfigurationManagerContext;
@@ -26,6 +25,7 @@ import io.trino.spi.resourcegroups.ResourceGroupConfigurationManagerFactory;
 
 import java.util.Map;
 
+import static io.trino.spi.classloader.ThreadContextClassLoader.withClassLoader;
 import static java.util.Objects.requireNonNull;
 
 public class H2ResourceGroupConfigurationManagerFactory
@@ -47,7 +47,7 @@ public class H2ResourceGroupConfigurationManagerFactory
     @Override
     public ResourceGroupConfigurationManager<?> create(Map<String, String> config, ResourceGroupConfigurationManagerContext context)
     {
-        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+        return withClassLoader(classLoader, () -> {
             Bootstrap app = new Bootstrap(
                     new JsonModule(),
                     new H2ResourceGroupsModule(),
@@ -62,6 +62,6 @@ public class H2ResourceGroupConfigurationManagerFactory
                     .initialize();
 
             return injector.getInstance(DbResourceGroupConfigurationManager.class);
-        }
+        });
     }
 }


### PR DESCRIPTION
Avoid C++-like RAII approach in favour of more Java-like lambda-friendly approach.

Just 

```
withClassLoader(classLoader, () -> doSomething());
```

instead of 

```
try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader) {
        doSomething();
}
```

`Runnable`, `Supplier<T>` and custom `ThrowingSupplier<T, E extends Exception>` are supported.