### PR TITLE
Add IN operator limit

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
@@ -40,7 +40,7 @@ public class JdbcMetadataConfig
     // between performance and pushdown capabilities
     private int domainCompactionThreshold = 32;
 
-    // The limit of the vales per IN operator depends on the database. 
+    // The limit of the values per IN operator depends on the database. 
     // E.g. Oracle allows only up to 1,000 IN list values in a SQL statement.
     // A value of 0 means no limit
     private int inOperatorLimit = 0;

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataConfig.java
@@ -40,6 +40,11 @@ public class JdbcMetadataConfig
     // between performance and pushdown capabilities
     private int domainCompactionThreshold = 32;
 
+    // The limit of the vales per IN operator depends on the database. 
+    // E.g. Oracle allows only up to 1,000 IN list values in a SQL statement.
+    // A value of 0 means no limit
+    private int inOperatorLimit = 0;
+
     public boolean isAllowDropTable()
     {
         return allowDropTable;
@@ -107,4 +112,18 @@ public class JdbcMetadataConfig
         this.domainCompactionThreshold = domainCompactionThreshold;
         return this;
     }
+
+    @Min(0)
+    public int getInOperatorLimit()
+    {
+        return inOperatorLimit;
+    }    
+
+    @Config("in-operator-limit")
+    @ConfigDescription("Maximum number of values per IN operator. A value of 0 means no limit")
+    public JdbcMetadataConfig setInOperatorLimit(int inOperatorLimit)
+    {
+        this.inOperatorLimit = inOperatorLimit;
+        return this;
+    }    
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataSessionProperties.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcMetadataSessionProperties.java
@@ -36,6 +36,7 @@ public class JdbcMetadataSessionProperties
     public static final String AGGREGATION_PUSHDOWN_ENABLED = "aggregation_pushdown_enabled";
     public static final String TOPN_PUSHDOWN_ENABLED = "topn_pushdown_enabled";
     public static final String DOMAIN_COMPACTION_THRESHOLD = "domain_compaction_threshold";
+    public static final String IN_OPERATOR_LIMIT = "in_operator_limit";
 
     private final List<PropertyMetadata<?>> properties;
 
@@ -64,6 +65,12 @@ public class JdbcMetadataSessionProperties
                         TOPN_PUSHDOWN_ENABLED,
                         "Enable TopN pushdown",
                         jdbcMetadataConfig.isTopNPushdownEnabled(),
+                        false))
+                .add(integerProperty(
+                		IN_OPERATOR_LIMIT,
+                        "Maximum number of values per IN operator. A value of 0 means no limit",
+                        jdbcMetadataConfig.getInOperatorLimit(),
+                        value -> validateInOperatorLimit(value),
                         false))
                 .build();
     }
@@ -94,6 +101,11 @@ public class JdbcMetadataSessionProperties
         return session.getProperty(DOMAIN_COMPACTION_THRESHOLD, Integer.class);
     }
 
+    public static int getInOperatorLimit(ConnectorSession session)
+    {
+        return session.getProperty(IN_OPERATOR_LIMIT, Integer.class);
+    }
+
     private static void validateDomainCompactionThreshold(int domainCompactionThreshold, Optional<Integer> maxDomainCompactionThreshold)
     {
         if (domainCompactionThreshold < 1) {
@@ -105,5 +117,12 @@ public class JdbcMetadataSessionProperties
                 throw new TrinoException(INVALID_SESSION_PROPERTY, format("Domain compaction threshold (%s) cannot exceed %s", domainCompactionThreshold, max));
             }
         });
+    }
+
+    private static void validateInOperatorLimit(int inOperatorLimit)
+    {
+        if (inOperatorLimit < 0) {
+            throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s must be greater than or equal to 0: %s", IN_OPERATOR_LIMIT, inOperatorLimit));
+        }
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
@@ -329,7 +329,7 @@ public class QueryBuilder
                 disjuncts.add(client.quoted(column.getColumnName()) + " IN (" + values + ")");
             }
             else {
-                // The limit of the vales per IN operator depends on the database. E.g. Oracle allows only up to 1,000 IN list values in a SQL statement. 
+                // The limit of the values per IN operator depends on the database. E.g. Oracle allows only up to 1,000 IN list values in a SQL statement. 
             	int remainder = singleValues.size() % getInOperatorLimit(session);
             	for (int i = 0; i < (singleValues.size() - remainder) / getInOperatorLimit(session); i++) {
 	                String values = Joiner.on(",").join(nCopies(getInOperatorLimit(session), writeFunction.getBindExpression()));


### PR DESCRIPTION
The limit of the values per IN operator depends on the database. E.g. Oracle allows only up to 1,000 IN list values in a SQL statement.