### PR TITLE
Change CassandraType enum to class

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClusteringPredicatesExtractor.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClusteringPredicatesExtractor.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static io.trino.plugin.cassandra.CassandraType.toCqlLiteral;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -76,11 +77,11 @@ public class CassandraClusteringPredicatesExtractor
                                 return null;
                             }
                             if (range.isSingleValue()) {
-                                singleValues.add(columnHandle.getCassandraType().toCqlLiteral(range.getSingleValue()));
+                                singleValues.add(toCqlLiteral(columnHandle.getCassandraType(), range.getSingleValue()));
                             }
                             else {
                                 if (!range.isLowUnbounded()) {
-                                    String lowBound = columnHandle.getCassandraType().toCqlLiteral(range.getLowBoundedValue());
+                                    String lowBound = toCqlLiteral(columnHandle.getCassandraType(), range.getLowBoundedValue());
                                     rangeConjuncts.add(format(
                                             "%s %s %s",
                                             CassandraCqlUtils.validColumnName(columnHandle.getName()),
@@ -88,7 +89,7 @@ public class CassandraClusteringPredicatesExtractor
                                             lowBound));
                                 }
                                 if (!range.isHighUnbounded()) {
-                                    String highBound = columnHandle.getCassandraType().toCqlLiteral(range.getHighBoundedValue());
+                                    String highBound = toCqlLiteral(columnHandle.getCassandraType(), range.getHighBoundedValue());
                                     rangeConjuncts.add(format(
                                             "%s %s %s",
                                             CassandraCqlUtils.validColumnName(columnHandle.getName()),
@@ -118,7 +119,7 @@ public class CassandraClusteringPredicatesExtractor
                         if (discreteValues.isInclusive()) {
                             ImmutableList.Builder<Object> discreteValuesList = ImmutableList.builder();
                             for (Object discreteValue : discreteValues.getValues()) {
-                                discreteValuesList.add(columnHandle.getCassandraType().toCqlLiteral(discreteValue));
+                                discreteValuesList.add(toCqlLiteral(columnHandle.getCassandraType(), discreteValue));
                             }
                             String predicate = CassandraCqlUtils.validColumnName(columnHandle.getName()) + " IN ("
                                     + Joiner.on(",").join(discreteValuesList.build()) + ")";

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraColumnHandle.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraColumnHandle.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.cassandra;
 
+import com.datastax.driver.core.DataType;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
@@ -25,6 +26,7 @@ import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.cassandra.CassandraType.toTrinoType;
 import static java.util.Objects.requireNonNull;
 
 public class CassandraColumnHandle
@@ -32,7 +34,7 @@ public class CassandraColumnHandle
 {
     private final String name;
     private final int ordinalPosition;
-    private final CassandraType cassandraType;
+    private final DataType.Name cassandraType;
     private final boolean partitionKey;
     private final boolean clusteringKey;
     private final boolean indexed;
@@ -42,7 +44,7 @@ public class CassandraColumnHandle
     public CassandraColumnHandle(
             @JsonProperty("name") String name,
             @JsonProperty("ordinalPosition") int ordinalPosition,
-            @JsonProperty("cassandraType") CassandraType cassandraType,
+            @JsonProperty("cassandraType") DataType.Name cassandraType,
             @JsonProperty("partitionKey") boolean partitionKey,
             @JsonProperty("clusteringKey") boolean clusteringKey,
             @JsonProperty("indexed") boolean indexed,
@@ -71,7 +73,7 @@ public class CassandraColumnHandle
     }
 
     @JsonProperty
-    public CassandraType getCassandraType()
+    public DataType.Name getCassandraType()
     {
         return cassandraType;
     }
@@ -104,14 +106,14 @@ public class CassandraColumnHandle
     {
         return ColumnMetadata.builder()
                 .setName(CassandraCqlUtils.cqlNameToSqlName(name))
-                .setType(cassandraType.getTrinoType())
+                .setType(toTrinoType(cassandraType))
                 .setHidden(hidden)
                 .build();
     }
 
     public Type getType()
     {
-        return cassandraType.getTrinoType();
+        return toTrinoType(cassandraType);
     }
 
     @Override

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraMetadata.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.cassandra;
 
+import com.datastax.driver.core.DataType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
@@ -54,6 +55,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static io.trino.plugin.cassandra.CassandraType.toCassandraType;
+import static io.trino.plugin.cassandra.CassandraType.toTrinoType;
 import static io.trino.plugin.cassandra.util.CassandraCqlUtils.ID_COLUMN_NAME;
 import static io.trino.plugin.cassandra.util.CassandraCqlUtils.cqlNameToSqlName;
 import static io.trino.plugin.cassandra.util.CassandraCqlUtils.quoteStringLiteral;
@@ -341,7 +343,7 @@ public class CassandraMetadata
                 .collect(Collectors.toList());
         List<Type> columnTypes = columns.stream()
                 .filter(columnHandle -> !isHiddenIdColumn(columnHandle))
-                .map(CassandraColumnHandle::getType)
+                .map(columnHandle -> toTrinoType(columnHandle.getCassandraType()))
                 .collect(Collectors.toList());
         boolean generateUuid = columns.stream()
                 .filter(CassandraMetadata::isHiddenIdColumn)
@@ -370,7 +372,7 @@ public class CassandraMetadata
     @Override
     public ColumnHandle getDeleteRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        return new CassandraColumnHandle("$update_row_id", 0, CassandraType.TEXT, false, false, false, true);
+        return new CassandraColumnHandle("$update_row_id", 0, DataType.Name.TEXT, false, false, false, true);
     }
 
     @Override

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraPartitionManager.java
@@ -33,6 +33,8 @@ import java.util.Set;
 
 import static com.google.common.base.Predicates.in;
 import static com.google.common.base.Predicates.not;
+import static io.trino.plugin.cassandra.CassandraType.isSupportedPartitionKey;
+import static io.trino.plugin.cassandra.CassandraType.toCqlLiteral;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
@@ -86,7 +88,7 @@ public class CassandraPartitionManager
                 if (column.isIndexed() && domain.isSingleValue()) {
                     sb.append(CassandraCqlUtils.validColumnName(column.getName()))
                             .append(" = ")
-                            .append(column.getCassandraType().toCqlLiteral(entry.getValue().getSingleValue()));
+                            .append(toCqlLiteral(column.getCassandraType(), entry.getValue().getSingleValue()));
                     indexedColumns.add(column);
                     // Only one indexed column predicate can be pushed down.
                     break;
@@ -146,8 +148,7 @@ public class CassandraPartitionManager
                             }
                             Object value = range.getSingleValue();
 
-                            CassandraType valueType = columnHandle.getCassandraType();
-                            if (valueType.isSupportedPartitionKey()) {
+                            if (isSupportedPartitionKey(columnHandle.getCassandraType())) {
                                 columnValues.add(value);
                             }
                         }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraColumnHandle.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraColumnHandle.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.cassandra;
 
+import com.datastax.driver.core.DataType;
 import io.airlift.json.JsonCodec;
 import org.testng.annotations.Test;
 
@@ -26,7 +27,7 @@ public class TestCassandraColumnHandle
     @Test
     public void testRoundTrip()
     {
-        CassandraColumnHandle expected = new CassandraColumnHandle("name", 42, CassandraType.FLOAT, true, false, false, false);
+        CassandraColumnHandle expected = new CassandraColumnHandle("name", 42, DataType.Name.FLOAT, true, false, false, false);
 
         String json = codec.toJson(expected);
         CassandraColumnHandle actual = codec.fromJson(json);
@@ -44,7 +45,7 @@ public class TestCassandraColumnHandle
         CassandraColumnHandle expected = new CassandraColumnHandle(
                 "name2",
                 1,
-                CassandraType.MAP,
+                DataType.Name.MAP,
                 false,
                 true,
                 false,

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnector.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnector.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.cassandra;
 
+import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.utils.Bytes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -301,8 +302,8 @@ public class TestCassandraConnector
 
     private CassandraPartition createPartition(long value1, long value2)
     {
-        CassandraColumnHandle column1 = new CassandraColumnHandle("partition_one", 1, CassandraType.BIGINT, true, false, false, false);
-        CassandraColumnHandle column2 = new CassandraColumnHandle("partition_two", 2, CassandraType.INT, true, false, false, false);
+        CassandraColumnHandle column1 = new CassandraColumnHandle("partition_one", 1, DataType.Name.BIGINT, true, false, false, false);
+        CassandraColumnHandle column2 = new CassandraColumnHandle("partition_two", 2, DataType.Name.INT, true, false, false, false);
         TupleDomain<ColumnHandle> tupleDomain = TupleDomain.withColumnDomains(
                 ImmutableMap.of(
                         column1, Domain.singleValue(BIGINT, value1),

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestJsonCassandraHandles.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestJsonCassandraHandles.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.cassandra;
 
+import com.datastax.driver.core.DataType;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
@@ -132,7 +133,7 @@ public class TestJsonCassandraHandles
     public void testColumnHandleSerialize()
             throws Exception
     {
-        CassandraColumnHandle columnHandle = new CassandraColumnHandle("column", 42, CassandraType.BIGINT, false, true, false, false);
+        CassandraColumnHandle columnHandle = new CassandraColumnHandle("column", 42, DataType.Name.BIGINT, false, true, false, false);
 
         assertTrue(OBJECT_MAPPER.canSerialize(CassandraColumnHandle.class));
         String json = OBJECT_MAPPER.writeValueAsString(columnHandle);
@@ -146,7 +147,7 @@ public class TestJsonCassandraHandles
         CassandraColumnHandle columnHandle = new CassandraColumnHandle(
                 "column2",
                 0,
-                CassandraType.SET,
+                DataType.Name.SET,
                 false,
                 false,
                 false,
@@ -167,7 +168,7 @@ public class TestJsonCassandraHandles
 
         assertEquals(columnHandle.getName(), "column");
         assertEquals(columnHandle.getOrdinalPosition(), 42);
-        assertEquals(columnHandle.getCassandraType(), CassandraType.BIGINT);
+        assertEquals(columnHandle.getCassandraType(), DataType.Name.BIGINT);
         assertEquals(columnHandle.isPartitionKey(), false);
         assertEquals(columnHandle.isClusteringKey(), true);
     }
@@ -182,7 +183,7 @@ public class TestJsonCassandraHandles
 
         assertEquals(columnHandle.getName(), "column2");
         assertEquals(columnHandle.getOrdinalPosition(), 0);
-        assertEquals(columnHandle.getCassandraType(), CassandraType.SET);
+        assertEquals(columnHandle.getCassandraType(), DataType.Name.SET);
         assertEquals(columnHandle.isPartitionKey(), false);
         assertEquals(columnHandle.isClusteringKey(), false);
     }

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/util/TestCassandraClusteringPredicatesExtractor.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/util/TestCassandraClusteringPredicatesExtractor.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.cassandra.util;
 
+import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.VersionNumber;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -20,7 +21,6 @@ import io.trino.plugin.cassandra.CassandraClusteringPredicatesExtractor;
 import io.trino.plugin.cassandra.CassandraColumnHandle;
 import io.trino.plugin.cassandra.CassandraTable;
 import io.trino.plugin.cassandra.CassandraTableHandle;
-import io.trino.plugin.cassandra.CassandraType;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
@@ -42,10 +42,10 @@ public class TestCassandraClusteringPredicatesExtractor
     @BeforeTest
     void setUp()
     {
-        col1 = new CassandraColumnHandle("partitionKey1", 1, CassandraType.BIGINT, true, false, false, false);
-        col2 = new CassandraColumnHandle("clusteringKey1", 2, CassandraType.BIGINT, false, true, false, false);
-        col3 = new CassandraColumnHandle("clusteringKey2", 3, CassandraType.BIGINT, false, true, false, false);
-        col4 = new CassandraColumnHandle("clusteringKe3", 4, CassandraType.BIGINT, false, true, false, false);
+        col1 = new CassandraColumnHandle("partitionKey1", 1, DataType.Name.BIGINT, true, false, false, false);
+        col2 = new CassandraColumnHandle("clusteringKey1", 2, DataType.Name.BIGINT, false, true, false, false);
+        col3 = new CassandraColumnHandle("clusteringKey2", 3, DataType.Name.BIGINT, false, true, false, false);
+        col4 = new CassandraColumnHandle("clusteringKe3", 4, DataType.Name.BIGINT, false, true, false, false);
 
         cassandraTable = new CassandraTable(
                 new CassandraTableHandle("test", "records"), ImmutableList.of(col1, col2, col3, col4));


### PR DESCRIPTION
We should avoid enum for complex type mapping (e.g. UDT in Cassandra). 