### PR TITLE
Add getCompletedPositions to ConnectorPageSource

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -78,6 +78,7 @@ public class ScanFilterAndProjectOperator
     private long processedPositions;
     private long processedBytes;
     private long physicalBytes;
+    private long physicalPositions;
     private long readTimeNanos;
     private long dynamicFilterSplitsProcessed;
     private Metrics metrics = Metrics.EMPTY;
@@ -135,7 +136,7 @@ public class ScanFilterAndProjectOperator
     @Override
     public long getPhysicalInputPositions()
     {
-        return processedPositions;
+        return physicalPositions;
     }
 
     @Override
@@ -339,6 +340,7 @@ public class ScanFilterAndProjectOperator
                 // TODO: derive better values for cursors
                 processedBytes = cursor.getCompletedBytes();
                 physicalBytes = cursor.getCompletedBytes();
+                physicalPositions = processedPositions;
                 readTimeNanos = cursor.getReadTimeNanos();
                 if (output.isNoMoreRows()) {
                     finished = true;
@@ -402,6 +404,7 @@ public class ScanFilterAndProjectOperator
             // update operator stats
             processedPositions += page.getPositionCount();
             physicalBytes = pageSource.getCompletedBytes();
+            physicalPositions = pageSource.getCompletedPositions().orElse(processedPositions);
             readTimeNanos = pageSource.getReadTimeNanos();
             metrics = pageSource.getMetrics();
 

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanWorkProcessorOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanWorkProcessorOperator.java
@@ -217,7 +217,10 @@ public class TableScanWorkProcessorOperator
 
         long getPhysicalInputPositions()
         {
-            return processedPositions;
+            if (source == null) {
+                return 0;
+            }
+            return source.getCompletedPositions().orElse(processedPositions);
         }
 
         DataSize getInputDataSize()

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSource.java
@@ -18,6 +18,7 @@ import io.trino.spi.metrics.Metrics;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 
 public interface ConnectorPageSource
@@ -30,6 +31,16 @@ public interface ConnectorPageSource
      * If size is not available, this method should return zero.
      */
     long getCompletedBytes();
+
+    /**
+     * Gets the number of input rows processed by this page source so far.
+     * By default, the positions count of the page returned from getNextPage
+     * is used to calculate the number of input rows.
+     */
+    default OptionalLong getCompletedPositions()
+    {
+        return OptionalLong.empty();
+    }
 
     /**
      * Gets the wall time this page source spent reading data from the input.

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -58,6 +58,7 @@ import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -255,6 +256,12 @@ public class HivePageSource
     public long getCompletedBytes()
     {
         return delegate.getCompletedBytes();
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return delegate.getCompletedPositions();
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcPageSource.java
@@ -76,6 +76,8 @@ public class OrcPageSource
     // Row ID relative to all the original files of the same bucket ID before this file in lexicographic order
     private Optional<Long> originalFileRowId = Optional.empty();
 
+    private long completedPositions;
+
     public OrcPageSource(
             OrcRecordReader recordReader,
             List<ColumnAdaptation> columnAdaptations,
@@ -98,6 +100,12 @@ public class OrcPageSource
     public long getCompletedBytes()
     {
         return orcDataSource.getReadBytes();
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return OptionalLong.of(completedPositions);
     }
 
     @Override
@@ -133,6 +141,8 @@ public class OrcPageSource
             close();
             return null;
         }
+
+        completedPositions += page.getPositionCount();
 
         OptionalLong startRowId = originalFileRowId.isPresent() ?
                 OptionalLong.of(originalFileRowId.get() + recordReader.getFilePosition()) : OptionalLong.empty();

--- a/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPageSourceProvider.java
+++ b/plugin/trino-memory/src/main/java/io/trino/plugin/memory/MemoryPageSourceProvider.java
@@ -35,6 +35,7 @@ import javax.inject.Inject;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalDouble;
+import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Objects.requireNonNull;
@@ -93,6 +94,7 @@ public final class MemoryPageSourceProvider
         private final DynamicFilter dynamicFilter;
         private final boolean enableLazyDynamicFiltering;
         private long rows;
+        private long completedPositions;
 
         private DynamicFilteringPageSource(FixedPageSource delegate, List<ColumnHandle> columns, DynamicFilter dynamicFilter, boolean enableLazyDynamicFiltering)
         {
@@ -106,6 +108,12 @@ public final class MemoryPageSourceProvider
         public long getCompletedBytes()
         {
             return delegate.getCompletedBytes();
+        }
+
+        @Override
+        public OptionalLong getCompletedPositions()
+        {
+            return OptionalLong.of(completedPositions);
         }
 
         @Override
@@ -132,12 +140,15 @@ public final class MemoryPageSourceProvider
                 return null;
             }
             Page page = delegate.getNextPage();
-            if (page != null && !predicate.isAll()) {
+            if (page == null) {
+                return null;
+            }
+            completedPositions += page.getPositionCount();
+
+            if (!predicate.isAll()) {
                 page = applyFilter(page, predicate.transformKeys(columns::indexOf).getDomains().get());
             }
-            if (page != null) {
-                rows += page.getPositionCount();
-            }
+            rows += page.getPositionCount();
             return page;
         }
 


### PR DESCRIPTION
This allows connectors to report input rows processed
by ConnectorPageSource rather than relying solely on
the positions count of the page returned from getNextPage