### PR TITLE
Remove unnecessary locking

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlStageExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlStageExecution.java
@@ -297,7 +297,7 @@ public final class SqlStageExecution
         return stateMachine.getTotalMemoryReservation();
     }
 
-    public synchronized Duration getTotalCpuTime()
+    public Duration getTotalCpuTime()
     {
         long millis = getAllTasks().stream()
                 .mapToLong(task -> task.getTaskInfo().getStats().getTotalCpuTime().toMillis())


### PR DESCRIPTION
The lock on getTotalCputime adds unnecessary contention through periodic CPU updates
 in InternalResourceGroupManager. The method does not access any variables
that need to be guarded by the intrinsic lock.