### PR TITLE
Fix cli auto completion

### DIFF
--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -109,6 +109,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/client/trino-cli/src/main/java/io/trino/cli/Completion.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Completion.java
@@ -13,42 +13,42 @@
  */
 package io.trino.cli;
 
-import com.google.common.collect.ImmutableSet;
 import org.jline.reader.Completer;
+import org.jline.reader.impl.completer.AggregateCompleter;
+import org.jline.reader.impl.completer.ArgumentCompleter;
+import org.jline.reader.impl.completer.NullCompleter;
 import org.jline.reader.impl.completer.StringsCompleter;
 
-import java.util.Set;
+import java.util.List;
 
-import static java.util.Locale.ENGLISH;
-import static java.util.stream.Collectors.toSet;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 public final class Completion
 {
-    private static final Set<String> COMMANDS = ImmutableSet.of(
-            "SELECT",
-            "SHOW CATALOGS",
-            "SHOW COLUMNS",
-            "SHOW FUNCTIONS",
-            "SHOW SCHEMAS",
-            "SHOW SESSION",
-            "SHOW TABLES",
-            "CREATE TABLE",
-            "DROP TABLE",
-            "EXPLAIN",
-            "DESCRIBE",
-            "USE",
-            "HELP",
-            "QUIT");
-
     private Completion() {}
 
     public static Completer commandCompleter()
     {
-        return new StringsCompleter(ImmutableSet.<String>builder()
-                .addAll(COMMANDS)
-                .addAll(COMMANDS.stream()
-                        .map(value -> value.toLowerCase(ENGLISH))
-                        .collect(toSet()))
-                .build());
+        return new AggregateCompleter(buildArgumentCompleter("CREATE", singletonList("TABLE")),
+                buildArgumentCompleter("DESCRIBE"),
+                buildArgumentCompleter("DROP", singletonList("TABLE")),
+                buildArgumentCompleter("EXPLAIN"),
+                buildArgumentCompleter("HELP"),
+                buildArgumentCompleter("QUIT"),
+                buildArgumentCompleter("SELECT"),
+                buildArgumentCompleter("SHOW", asList("CATALOGS", "COLUMNS", "FUNCTIONS", "SCHEMAS", "SESSION", "TABLES")),
+                buildArgumentCompleter("USE"));
+    }
+
+    private static Completer buildArgumentCompleter(String command)
+    {
+        // NullCompleter is used to indicate the command is complete and the last word should not be repeated
+        return new ArgumentCompleter(new StringsCompleter(command), NullCompleter.INSTANCE);
+    }
+
+    private static Completer buildArgumentCompleter(String command, List<String> options)
+    {
+        return new ArgumentCompleter(new StringsCompleter(command), new StringsCompleter(options), NullCompleter.INSTANCE);
     }
 }

--- a/client/trino-cli/src/main/java/io/trino/cli/Completion.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/Completion.java
@@ -22,7 +22,6 @@ import org.jline.reader.impl.completer.StringsCompleter;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 
 public final class Completion
 {
@@ -30,9 +29,10 @@ public final class Completion
 
     public static Completer commandCompleter()
     {
-        return new AggregateCompleter(buildArgumentCompleter("CREATE", singletonList("TABLE")),
+        return new AggregateCompleter(buildArgumentCompleter("ALTER", asList("SCHEMA", "TABLE")),
+                buildArgumentCompleter("CREATE", asList("SCHEMA", "TABLE")),
                 buildArgumentCompleter("DESCRIBE"),
-                buildArgumentCompleter("DROP", singletonList("TABLE")),
+                buildArgumentCompleter("DROP", asList("SCHEMA", "TABLE")),
                 buildArgumentCompleter("EXPLAIN"),
                 buildArgumentCompleter("HELP"),
                 buildArgumentCompleter("QUIT"),

--- a/client/trino-cli/src/main/java/io/trino/cli/InputParser.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/InputParser.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import static com.google.common.base.CharMatcher.whitespace;
 import static io.trino.cli.Console.STATEMENT_DELIMITERS;
 import static java.util.Locale.ENGLISH;
+import static org.jline.reader.Parser.ParseContext.COMPLETE;
 
 public class InputParser
         implements Parser
@@ -37,7 +38,7 @@ public class InputParser
             throws SyntaxError
     {
         String command = whitespace().trimFrom(line);
-        if (command.isEmpty() || SPECIAL.contains(command.toLowerCase(ENGLISH))) {
+        if (command.isEmpty() || SPECIAL.contains(command.toLowerCase(ENGLISH)) || context == COMPLETE) {
             return new DefaultParser().parse(line, cursor, context);
         }
 

--- a/client/trino-cli/src/test/java/io/trino/cli/TestInputParser.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestInputParser.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.cli;
+
+import org.jline.reader.EOFError;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.jline.reader.Parser.ParseContext.ACCEPT_LINE;
+import static org.jline.reader.Parser.ParseContext.COMPLETE;
+import static org.testng.Assert.assertNotNull;
+
+public class TestInputParser
+{
+    @Test
+    public void testParseIncompleteStatements()
+    {
+        InputParser instance = new InputParser();
+        // assert an incomplete statement throws an error if the ParseContext is not COMPLETE
+        assertThatThrownBy(() -> instance.parse("show", 4, ACCEPT_LINE)).isInstanceOf(EOFError.class);
+        assertNotNull(instance.parse("show", 4, COMPLETE));
+    }
+}


### PR DESCRIPTION
- The cli auto completion feature was silently broken for a while and, recently, started printing an error to stdout when an user presses `tab`.
- This PR fixes it by handling the `COMPLETE` ParseContext
- Additionally fixes completion for commands with multiple words
- Fixes #8481 and #8495