### PR TITLE
Add option to define query preprocessing class

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -207,7 +207,8 @@ public class ClientOptions
                 toExtraCredentials(extraCredentials),
                 null,
                 clientRequestTimeout,
-                disableCompression);
+                disableCompression,
+                Optional.empty());
     }
 
     public static URI parseServer(String server)

--- a/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestQueryRunner.java
@@ -121,7 +121,8 @@ public class TestQueryRunner
                 ImmutableMap.of(),
                 null,
                 new Duration(2, MINUTES),
-                true);
+                true,
+                Optional.empty());
     }
 
     static String createResults(MockWebServer server)

--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -53,6 +53,7 @@ public class ClientSession
     private final String transactionId;
     private final Duration clientRequestTimeout;
     private final boolean compressionDisabled;
+    private final Optional<String> preprocessorClass;
 
     public static Builder builder(ClientSession clientSession)
     {
@@ -86,7 +87,8 @@ public class ClientSession
             Map<String, String> extraCredentials,
             String transactionId,
             Duration clientRequestTimeout,
-            boolean compressionDisabled)
+            boolean compressionDisabled,
+            Optional<String> preprocessorClass)
     {
         this.server = requireNonNull(server, "server is null");
         this.principal = principal;
@@ -108,6 +110,7 @@ public class ClientSession
         this.extraCredentials = ImmutableMap.copyOf(requireNonNull(extraCredentials, "extraCredentials is null"));
         this.clientRequestTimeout = clientRequestTimeout;
         this.compressionDisabled = compressionDisabled;
+        this.preprocessorClass = preprocessorClass;
 
         for (String clientTag : clientTags) {
             checkArgument(!clientTag.contains(","), "client tag cannot contain ','");
@@ -246,6 +249,11 @@ public class ClientSession
         return compressionDisabled;
     }
 
+    public Optional<String> getPreprocessorClass()
+    {
+        return preprocessorClass;
+    }
+
     @Override
     public String toString()
     {
@@ -263,6 +271,7 @@ public class ClientSession
                 .add("locale", locale)
                 .add("properties", properties)
                 .add("transactionId", transactionId)
+                .add("preprocessorClass", preprocessorClass.orElse(null))
                 .omitNullValues()
                 .toString();
     }
@@ -289,6 +298,7 @@ public class ClientSession
         private String transactionId;
         private Duration clientRequestTimeout;
         private boolean compressionDisabled;
+        private Optional<String> preprocessorClass;
 
         private Builder(ClientSession clientSession)
         {
@@ -313,6 +323,7 @@ public class ClientSession
             transactionId = clientSession.getTransactionId();
             clientRequestTimeout = clientSession.getClientRequestTimeout();
             compressionDisabled = clientSession.isCompressionDisabled();
+            preprocessorClass = clientSession.getPreprocessorClass();
         }
 
         public Builder withCatalog(String catalog)
@@ -397,7 +408,8 @@ public class ClientSession
                     credentials,
                     transactionId,
                     clientRequestTimeout,
-                    compressionDisabled);
+                    compressionDisabled,
+                    preprocessorClass);
         }
     }
 }

--- a/client/trino-client/src/main/java/io/trino/client/QueryPreprocessor.java
+++ b/client/trino-client/src/main/java/io/trino/client/QueryPreprocessor.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.client;
+
+public interface QueryPreprocessor
+{
+    String preprocess(String query);
+}

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -81,6 +81,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String> TRACE_TOKEN = new TraceToken();
     public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
     public static final ConnectionProperty<String> SOURCE = new Source();
+    public static final ConnectionProperty<String> PREPROCESSOR_CLASS = new PreprocessorClass();
 
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
             .add(USER)
@@ -117,6 +118,7 @@ final class ConnectionProperties
             .add(EXTERNAL_AUTHENTICATION)
             .add(EXTERNAL_AUTHENTICATION_TIMEOUT)
             .add(EXTERNAL_AUTHENTICATION_TOKEN_CACHE)
+            .add(PREPROCESSOR_CLASS)
             .build();
 
     private static final Map<String, ConnectionProperty<?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -527,6 +529,15 @@ final class ConnectionProperties
         public Source()
         {
             super("source", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class PreprocessorClass
+            extends AbstractConnectionProperty<String>
+    {
+        public PreprocessorClass()
+        {
+            super("preprocessorClass", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -107,6 +107,7 @@ public class TrinoConnection
     private final AtomicReference<String> transactionId = new AtomicReference<>();
     private final OkHttpClient httpClient;
     private final Set<TrinoStatement> statements = newSetFromMap(new ConcurrentHashMap<>());
+    private final Optional<String> preprocessorClass;
 
     TrinoConnection(TrinoDriverUri uri, OkHttpClient httpClient)
             throws SQLException
@@ -124,6 +125,7 @@ public class TrinoConnection
         this.compressionDisabled = uri.isCompressionDisabled();
         this.assumeLiteralNamesInMetadataCallsForNonConformingClients = uri.isAssumeLiteralNamesInMetadataCallsForNonConformingClients();
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.preprocessorClass = uri.getPreprocessorClass();
         uri.getClientInfo().ifPresent(tags -> clientInfo.put(CLIENT_INFO, tags));
         uri.getClientTags().ifPresent(tags -> clientInfo.put(CLIENT_TAGS, tags));
         uri.getTraceToken().ifPresent(tags -> clientInfo.put(TRACE_TOKEN, tags));
@@ -745,7 +747,8 @@ public class TrinoConnection
                 extraCredentials,
                 transactionId.get(),
                 timeout,
-                compressionDisabled);
+                compressionDisabled,
+                preprocessorClass);
 
         return newStatementClient(httpClient, session, sql);
     }

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -70,6 +70,7 @@ import static io.trino.jdbc.ConnectionProperties.KERBEROS_REMOTE_SERVICE_NAME;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_SERVICE_PRINCIPAL_PATTERN;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_USE_CANONICAL_HOSTNAME;
 import static io.trino.jdbc.ConnectionProperties.PASSWORD;
+import static io.trino.jdbc.ConnectionProperties.PREPROCESSOR_CLASS;
 import static io.trino.jdbc.ConnectionProperties.ROLES;
 import static io.trino.jdbc.ConnectionProperties.SESSION_PROPERTIES;
 import static io.trino.jdbc.ConnectionProperties.SESSION_USER;
@@ -235,6 +236,12 @@ public final class TrinoDriverUri
             throws SQLException
     {
         return DISABLE_COMPRESSION.getValue(properties).orElse(false);
+    }
+
+    public Optional<String> getPreprocessorClass()
+            throws SQLException
+    {
+        return PREPROCESSOR_CLASS.getValue(properties);
     }
 
     public boolean isAssumeLiteralNamesInMetadataCallsForNonConformingClients()

--- a/testing/trino-benchmark-driver/src/main/java/io/trino/benchmark/driver/BenchmarkDriverOptions.java
+++ b/testing/trino-benchmark-driver/src/main/java/io/trino/benchmark/driver/BenchmarkDriverOptions.java
@@ -120,7 +120,8 @@ public class BenchmarkDriverOptions
                         .collect(toImmutableMap(ClientExtraCredential::getName, ClientExtraCredential::getValue)),
                 null,
                 clientRequestTimeout,
-                disableCompression);
+                disableCompression,
+                Optional.empty());
     }
 
     private static URI parseServer(String server)

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestingTrinoClient.java
@@ -172,7 +172,8 @@ public abstract class AbstractTestingTrinoClient<T>
                 session.getIdentity().getExtraCredentials(),
                 session.getTransactionId().map(Object::toString).orElse(null),
                 clientRequestTimeout,
-                true);
+                true,
+                Optional.empty());
     }
 
     public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestFinalQueryInfo.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestFinalQueryInfo.java
@@ -83,7 +83,8 @@ public class TestFinalQueryInfo
                     ImmutableMap.of(),
                     null,
                     new Duration(2, MINUTES),
-                    true);
+                    true,
+                    Optional.empty());
 
             // start query
             StatementClient client = newStatementClient(httpClient, clientSession, sql);

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestUserImpersonationAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestUserImpersonationAccessControl.java
@@ -104,7 +104,8 @@ public class TestUserImpersonationAccessControl
                     ImmutableMap.of(),
                     null,
                     new Duration(2, MINUTES),
-                    true);
+                    true,
+                    Optional.empty());
 
             // start query
             StatementClient client = newStatementClient(httpClient, clientSession, "SELECT * FROM tpch.tiny.nation");


### PR DESCRIPTION
I've worked on several projects that would have benefitted from a preprocessor. Examples include 
* an electric car company that uses a complex partitioning scheme to accommodate late arriving sensor data, they rewrite the filter logic on every query to hide this complexity from their users. 
* rewriting end user's non-ANSI compliant SQL during migrations
* base32 encoding ElasticSearch DSL queries for our connector's pass through functionality
Today the common solution is to do rewriting in a proxy between the client and Trino. This PR introduces an extension point for defining a custom preprocessing class in the driver itself.