### PR TITLE
Implement getSystemMemoryUsage in GenericHiveRecordCursor

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/GenericHiveRecordCursor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/GenericHiveRecordCursor.java
@@ -568,6 +568,12 @@ public class GenericHiveRecordCursor<K, V extends Writable>
     }
 
     @Override
+    public long getSystemMemoryUsage()
+    {
+        return totalBytes;
+    }
+
+    @Override
     public void close()
     {
         // some hive input formats are broken and bad things can happen if you close them multiple times


### PR DESCRIPTION
In our cluster, most of the input source comes from hadoop. If GenericHiveRecordCursor implements getSystemMemoryUsage, query memory reservation will be more accurate