### PR TITLE
Iceberg: support Parquet read with delete filter

### DIFF
--- a/plugin/trino-iceberg/pom.xml
+++ b/plugin/trino-iceberg/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.iceberg.version>0.11.0</dep.iceberg.version>
+        <dep.iceberg.version>0.11.1</dep.iceberg.version>
     </properties>
 
     <dependencies>
@@ -142,6 +142,12 @@
                     <artifactId>avro</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-data</artifactId>
+            <version>${dep.iceberg.version}</version>
         </dependency>
 
         <dependency>

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.types.Types;
 
 import java.util.Objects;
@@ -27,11 +28,15 @@ import java.util.Optional;
 import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
 import static io.trino.plugin.iceberg.ColumnIdentity.primitiveColumnIdentity;
 import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergColumnHandle
         implements ColumnHandle
 {
+    public static final IcebergColumnHandle ROW_POSITION_COLUMN = new IcebergColumnHandle(
+            createColumnIdentity(MetadataColumns.ROW_POSITION), BIGINT, Optional.of(MetadataColumns.ROW_POSITION.doc()));
+
     private final ColumnIdentity columnIdentity;
     private final Type type;
     private final Optional<String> comment;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -166,6 +166,7 @@ import static org.apache.iceberg.TableMetadata.newTableMetadata;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
 import static org.apache.iceberg.Transactions.createTableTransaction;
+import static org.apache.iceberg.util.SerializationUtil.serializeToBytes;
 
 public class IcebergMetadata
         implements ConnectorMetadata
@@ -255,6 +256,7 @@ public class IcebergMetadata
                 name.getTableName(),
                 name.getTableType(),
                 snapshotId,
+                serializeToBytes(table.schema()),
                 TupleDomain.all(),
                 TupleDomain.all());
     }
@@ -814,6 +816,7 @@ public class IcebergMetadata
                         table.getTableName(),
                         table.getTableType(),
                         table.getSnapshotId(),
+                        serializeToBytes(icebergTable.schema()),
                         newUnenforcedConstraint,
                         newEnforcedConstraint),
                 newUnenforcedConstraint.transformKeys(ColumnHandle.class::cast),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -59,6 +59,7 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.StandardTypes;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -66,6 +67,9 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.BlockMissingException;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
@@ -78,6 +82,7 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -96,6 +101,7 @@ import static io.trino.parquet.ParquetTypeUtils.getParquetTypeByName;
 import static io.trino.parquet.predicate.PredicateUtils.buildPredicate;
 import static io.trino.parquet.predicate.PredicateUtils.predicateMatches;
 import static io.trino.plugin.hive.parquet.ParquetColumnIOConverter.constructField;
+import static io.trino.plugin.iceberg.IcebergColumnHandle.ROW_POSITION_COLUMN;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_CANNOT_OPEN_SPLIT;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_CURSOR_ERROR;
@@ -111,12 +117,14 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetMaxRead
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcBloomFiltersEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcNestedLazy;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isUseFileSizeFromMetadata;
+import static io.trino.plugin.iceberg.IcebergUtil.getColumns;
 import static io.trino.plugin.iceberg.TypeConverter.ORC_ICEBERG_ID_KEY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static org.joda.time.DateTimeZone.UTC;
 
@@ -127,18 +135,24 @@ public class IcebergPageSourceProvider
     private final FileFormatDataSourceStats fileFormatDataSourceStats;
     private final OrcReaderOptions orcReaderOptions;
     private final ParquetReaderOptions parquetReaderOptions;
+    private final FileIoProvider fileIoProvider;
+    private final TypeManager typeManager;
 
     @Inject
     public IcebergPageSourceProvider(
             HdfsEnvironment hdfsEnvironment,
             FileFormatDataSourceStats fileFormatDataSourceStats,
             OrcReaderConfig orcReaderConfig,
-            ParquetReaderConfig parquetReaderConfig)
+            ParquetReaderConfig parquetReaderConfig,
+            FileIoProvider fileIoProvider,
+            TypeManager typeManager)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.fileFormatDataSourceStats = requireNonNull(fileFormatDataSourceStats, "fileFormatDataSourceStats is null");
         this.orcReaderOptions = requireNonNull(orcReaderConfig, "orcReaderConfig is null").toOrcReaderOptions();
         this.parquetReaderOptions = requireNonNull(parquetReaderConfig, "parquetReaderConfig is null").toParquetReaderOptions();
+        this.fileIoProvider = requireNonNull(fileIoProvider, "fileIoProvider is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
     @Override
@@ -159,12 +173,22 @@ public class IcebergPageSourceProvider
 
         Map<Integer, String> partitionKeys = split.getPartitionKeys();
 
-        List<IcebergColumnHandle> regularColumns = columns.stream()
+        LinkedHashSet<IcebergColumnHandle> regularColumns = columns.stream()
                 .map(IcebergColumnHandle.class::cast)
                 .filter(column -> !partitionKeys.containsKey(column.getId()))
-                .collect(toImmutableList());
+                .collect(toCollection(LinkedHashSet::new));
 
         HdfsContext hdfsContext = new HdfsContext(session);
+        FileIO fileIo = fileIoProvider.createFileIo(hdfsContext, null);
+        List<Types.NestedField> deleteReadFields = icebergColumns.stream()
+                .map(column -> table.getSchema().findField(column.getId()))
+                .collect(toImmutableList());
+        Schema deleteReadSchema = new Schema(deleteReadFields);
+        TrinoDeleteFilter deleteFilter = new TrinoDeleteFilter(fileIo, split.getTask(), deleteReadSchema, deleteReadSchema);
+        getColumns(deleteFilter.requiredSchema(), typeManager).stream()
+                .filter(column -> !partitionKeys.containsKey(column.getId()))
+                .forEachOrdered(regularColumns::add);
+
         ConnectorPageSource dataPageSource = createDataPageSource(
                 session,
                 hdfsContext,
@@ -173,10 +197,10 @@ public class IcebergPageSourceProvider
                 split.getLength(),
                 split.getFileSize(),
                 split.getFileFormat(),
-                regularColumns,
+                ImmutableList.copyOf(regularColumns),
                 table.getUnenforcedPredicate());
 
-        return new IcebergPageSource(icebergColumns, partitionKeys, dataPageSource, session.getTimeZoneKey());
+        return new IcebergPageSource(icebergColumns, partitionKeys, dataPageSource, deleteFilter, session.getTimeZoneKey());
     }
 
     private ConnectorPageSource createDataPageSource(
@@ -201,8 +225,14 @@ public class IcebergPageSourceProvider
             }
         }
 
+        List<Boolean> rowIndexPositions = dataColumns.stream().map(ROW_POSITION_COLUMN::equals).collect(toImmutableList());
+
         switch (fileFormat) {
             case ORC:
+                if (rowIndexPositions.stream().anyMatch(v -> v)) {
+                    throw new UnsupportedOperationException("positional delete is not supported by ORC");
+                }
+
                 return createOrcPageSource(
                         hdfsEnvironment,
                         session.getUser(),
@@ -233,6 +263,7 @@ public class IcebergPageSourceProvider
                         length,
                         fileSize,
                         dataColumns,
+                        rowIndexPositions,
                         parquetReaderOptions
                                 .withMaxReadBlockSize(getParquetMaxReadBlockSize(session)),
                         predicate,
@@ -433,6 +464,7 @@ public class IcebergPageSourceProvider
             long length,
             long fileSize,
             List<IcebergColumnHandle> regularColumns,
+            List<Boolean> rowIndexLocations,
             ParquetReaderOptions options,
             TupleDomain<IcebergColumnHandle> effectivePredicate,
             FileFormatDataSourceStats fileFormatDataSourceStats)
@@ -507,7 +539,7 @@ public class IcebergPageSourceProvider
                 }
             }
 
-            return new ParquetPageSource(parquetReader, trinoTypes.build(), internalFields.build());
+            return new ParquetPageSource(parquetReader, trinoTypes.build(), rowIndexLocations, internalFields.build());
         }
         catch (IOException | RuntimeException e) {
             try {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -34,6 +34,7 @@ import static com.google.common.collect.Iterators.limit;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.apache.iceberg.util.SerializationUtil.serializeToBytes;
 
 public class IcebergSplitSource
         implements ConnectorSplitSource
@@ -89,11 +90,7 @@ public class IcebergSplitSource
         //       on reader side evaluating a condition that we know will always be true.
 
         return new IcebergSplit(
-                task.file().path().toString(),
-                task.start(),
-                task.length(),
-                task.file().fileSizeInBytes(),
-                task.file().format(),
+                serializeToBytes(task),
                 ImmutableList.of(),
                 getPartitionKeys(task));
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoDeleteFilter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoDeleteFilter.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.data.DeleteFilter;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+
+public class TrinoDeleteFilter
+        extends DeleteFilter<TrinoRow>
+{
+    private final FileIO fileIO;
+
+    public TrinoDeleteFilter(FileIO fileIO, FileScanTask task, Schema tableSchema, Schema requestedSchema)
+    {
+        super(task, tableSchema, requestedSchema);
+        this.fileIO = fileIO;
+    }
+
+    @Override
+    protected StructLike asStructLike(TrinoRow trinoRow)
+    {
+        return trinoRow;
+    }
+
+    @Override
+    protected InputFile getInputFile(String s)
+    {
+        return fileIO.newInputFile(s);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoRow.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoRow.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.DateType;
+import io.trino.spi.type.DecimalType;
+import io.trino.spi.type.DoubleType;
+import io.trino.spi.type.IntegerType;
+import io.trino.spi.type.RealType;
+import io.trino.spi.type.SmallintType;
+import io.trino.spi.type.TinyintType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarbinaryType;
+import io.trino.spi.type.VarcharType;
+import org.apache.iceberg.StructLike;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.trino.plugin.iceberg.util.Timestamps.getTimestampTz;
+import static io.trino.plugin.iceberg.util.Timestamps.timestampTzToMicros;
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.Decimals.readBigDecimal;
+import static io.trino.spi.type.TimeType.TIME_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_MICROSECOND;
+import static java.lang.Float.intBitsToFloat;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class TrinoRow
+        implements StructLike
+{
+    private final List<Type> types;
+    private final Block[] blocks;
+    private final int position;
+
+    public TrinoRow(List<Type> types, Block[] blocks, int position)
+    {
+        this.types = requireNonNull(types, "types list is null");
+        this.blocks = requireNonNull(blocks, "blocks array is null");
+        checkArgument(position >= 0, "page position must be positive: %s", position);
+        this.position = position;
+    }
+
+    public int getPosition()
+    {
+        return position;
+    }
+
+    @Override
+    public int size()
+    {
+        return blocks.length;
+    }
+
+    @Override
+    public <T> T get(int i, Class<T> aClass)
+    {
+        Block block = blocks[i].getLoadedBlock();
+        Type type = types.get(i);
+        T value;
+        // TODO: can refactor with IcebergPageSink.getIcebergValue
+        if (block.isNull(position)) {
+            value = null;
+        }
+        else if (type instanceof BigintType) {
+            value = aClass.cast(type.getLong(block, position));
+        }
+        else if (type instanceof IntegerType || type instanceof SmallintType || type instanceof TinyintType || type instanceof DateType) {
+            value = aClass.cast(toIntExact(type.getLong(block, position)));
+        }
+        else if (type instanceof BooleanType) {
+            value = aClass.cast(type.getBoolean(block, position));
+        }
+        else if (type instanceof DecimalType) {
+            value = aClass.cast(readBigDecimal((DecimalType) type, block, position));
+        }
+        else if (type instanceof RealType) {
+            value = aClass.cast(intBitsToFloat(toIntExact(type.getLong(block, position))));
+        }
+        else if (type instanceof DoubleType) {
+            value = aClass.cast(type.getDouble(block, position));
+        }
+        else if (type.equals(TIME_MICROS)) {
+            value = aClass.cast(type.getLong(block, position) / PICOSECONDS_PER_MICROSECOND);
+        }
+        else if (type.equals(TIMESTAMP_MICROS)) {
+            value = aClass.cast(type.getLong(block, position));
+        }
+        else if (type.equals(TIMESTAMP_TZ_MICROS)) {
+            value = aClass.cast(timestampTzToMicros(getTimestampTz(block, position)));
+        }
+        else if (type instanceof VarbinaryType) {
+            value = aClass.cast(type.getSlice(block, position).getBytes());
+        }
+        else if (type instanceof VarcharType) {
+            value = aClass.cast(type.getSlice(block, position).toStringUtf8());
+        }
+        else {
+            // will most likely throw unsupported exception
+            value = block.getObject(position, aClass);
+        }
+
+        return value;
+    }
+
+    @Override
+    public <T> void set(int i, T t)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "writing to TrinoRow is not supported");
+    }
+}


### PR DESCRIPTION
support using Iceberg's DeleteFilter to filter delete files in the read path, this implementation only supports Parquet first because it already has the ability to generate row id channel. Will add ORC later if this impl is accepted. The general idea is that:

1. express Trino `Page` as an iterable of `TrinoRow` s, where each row is defined by the underlying the block array and the position in the page.
2. `TrinoRow`s are implemented as Iceberg `StructLike` so that it can be used to directly leverage Iceberg's `DeleteFilter`
3. `DeleteFilter` is used to filter pages produced by the Parquet page source.
4. the result filtered rows can be used to derive the positions to keep in a page
5. `Page.getPositions` is used to only retain rows in the particular positions and complete the merge-on-read process

I have not added unit tests yet, only tested with internal Trino installation that supports multi-catalog against tables in Glue catalog. There might be some backport error I missed. Once we agree upon the general implementation idea, I will add back tests and fix performance issues if any.

@phd3 @electrum @findepi @losipiuk @caneGuy @rdblue 
