### PR TITLE
Iceberg: add new fields in files system table

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/PageListBuilder.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/util/PageListBuilder.java
@@ -114,6 +114,16 @@ public final class PageListBuilder
         VARBINARY.writeSlice(nextColumn(), value);
     }
 
+    public void appendIntegerArray(Iterable<Integer> values)
+    {
+        BlockBuilder column = nextColumn();
+        BlockBuilder array = column.beginBlockEntry();
+        for (Integer value : values) {
+            INTEGER.writeLong(array, value);
+        }
+        column.closeEntry();
+    }
+
     public void appendBigintArray(Iterable<Long> values)
     {
         BlockBuilder column = nextColumn();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcMetricsCollection.java
@@ -33,6 +33,7 @@ import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
+import org.apache.iceberg.FileContent;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -98,6 +99,9 @@ public class TestIcebergOrcMetricsCollection
         assertEquals(materializedResult.getRowCount(), 1);
         DataFileRecord datafile = toDataFileRecord(materializedResult.getMaterializedRows().get(0));
 
+        // check content
+        assertEquals(datafile.getContent(), FileContent.DATA.id());
+
         // Check file format
         assertEquals(datafile.getFileFormat(), "ORC");
 
@@ -109,6 +113,10 @@ public class TestIcebergOrcMetricsCollection
 
         // Check per-column null value count
         datafile.getNullValueCounts().values().forEach(nullValueCount -> assertEquals(nullValueCount, (Long) 0L));
+
+        // Check NaN value count
+        // TODO: add more checks after NaN info is collected
+        assertNull(datafile.getNanValueCounts());
 
         // Check per-column lower bound
         Map<Integer, String> lowerBounds = datafile.getLowerBounds();
@@ -181,6 +189,28 @@ public class TestIcebergOrcMetricsCollection
     }
 
     @Test
+    public void testWithNaNs()
+    {
+        assertUpdate("CREATE TABLE test_with_nans (_int INTEGER, _real REAL, _double DOUBLE)");
+        assertUpdate("INSERT INTO test_with_nans VALUES (1, 1.1, 1.1), (2, nan(), 4.5), (3, 4.6, -nan())", 3);
+        MaterializedResult materializedResult = computeActual("SELECT * FROM \"test_with_nans$files\"");
+        assertEquals(materializedResult.getRowCount(), 1);
+        DataFileRecord datafile = toDataFileRecord(materializedResult.getMaterializedRows().get(0));
+
+        // Check per-column value count
+        datafile.getValueCounts().values().forEach(valueCount -> assertEquals(valueCount, (Long) 3L));
+
+        // TODO: add more checks after NaN info is collected
+        assertNull(datafile.getNanValueCounts());
+        assertNull(datafile.getLowerBounds().get(2));
+        assertNull(datafile.getLowerBounds().get(3));
+        assertNull(datafile.getUpperBounds().get(2));
+        assertNull(datafile.getUpperBounds().get(3));
+
+        assertUpdate("DROP TABLE test_with_nans");
+    }
+
+    @Test
     public void testNestedTypes()
     {
         assertUpdate("CREATE TABLE test_nested_types (col1 INTEGER, col2 ROW (f1 INTEGER, f2 ARRAY(INTEGER), f3 DOUBLE))");
@@ -220,6 +250,7 @@ public class TestIcebergOrcMetricsCollection
 
     public static class DataFileRecord
     {
+        private final int content;
         private final String filePath;
         private final String fileFormat;
         private final long recordCount;
@@ -227,25 +258,29 @@ public class TestIcebergOrcMetricsCollection
         private final Map<Integer, Long> columnSizes;
         private final Map<Integer, Long> valueCounts;
         private final Map<Integer, Long> nullValueCounts;
+        private final Map<Integer, Long> nanValueCounts;
         private final Map<Integer, String> lowerBounds;
         private final Map<Integer, String> upperBounds;
 
         public static DataFileRecord toDataFileRecord(MaterializedRow row)
         {
-            assertEquals(row.getFieldCount(), 11);
+            assertEquals(row.getFieldCount(), 14);
             return new DataFileRecord(
-                    (String) row.getField(0),
+                    (int) row.getField(0),
                     (String) row.getField(1),
-                    (long) row.getField(2),
+                    (String) row.getField(2),
                     (long) row.getField(3),
-                    row.getField(4) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(4)) : null,
+                    (long) row.getField(4),
                     row.getField(5) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(5)) : null,
                     row.getField(6) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(6)) : null,
-                    row.getField(7) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(7)) : null,
-                    row.getField(8) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(8)) : null);
+                    row.getField(7) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(7)) : null,
+                    row.getField(8) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(8)) : null,
+                    row.getField(9) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(9)) : null,
+                    row.getField(10) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(10)) : null);
         }
 
         private DataFileRecord(
+                int content,
                 String filePath,
                 String fileFormat,
                 long recordCount,
@@ -253,9 +288,11 @@ public class TestIcebergOrcMetricsCollection
                 Map<Integer, Long> columnSizes,
                 Map<Integer, Long> valueCounts,
                 Map<Integer, Long> nullValueCounts,
+                Map<Integer, Long> nanValueCounts,
                 Map<Integer, String> lowerBounds,
                 Map<Integer, String> upperBounds)
         {
+            this.content = content;
             this.filePath = filePath;
             this.fileFormat = fileFormat;
             this.recordCount = recordCount;
@@ -263,8 +300,14 @@ public class TestIcebergOrcMetricsCollection
             this.columnSizes = columnSizes;
             this.valueCounts = valueCounts;
             this.nullValueCounts = nullValueCounts;
+            this.nanValueCounts = nanValueCounts;
             this.lowerBounds = lowerBounds;
             this.upperBounds = upperBounds;
+        }
+
+        public int getContent()
+        {
+            return content;
         }
 
         public String getFilePath()
@@ -300,6 +343,11 @@ public class TestIcebergOrcMetricsCollection
         public Map<Integer, Long> getNullValueCounts()
         {
             return nullValueCounts;
+        }
+
+        public Map<Integer, Long> getNanValueCounts()
+        {
+            return nanValueCounts;
         }
 
         public Map<Integer, String> getLowerBounds()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSystemTables.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSystemTables.java
@@ -167,17 +167,20 @@ public class TestIcebergSystemTables
     public void testFilesTable()
     {
         assertQuery("SHOW COLUMNS FROM test_schema.\"test_table$files\"",
-                "VALUES ('file_path', 'varchar', '', '')," +
+                "VALUES ('content', 'integer', '', '')," +
+                        "('file_path', 'varchar', '', '')," +
                         "('file_format', 'varchar', '', '')," +
                         "('record_count', 'bigint', '', '')," +
                         "('file_size_in_bytes', 'bigint', '', '')," +
                         "('column_sizes', 'map(integer, bigint)', '', '')," +
                         "('value_counts', 'map(integer, bigint)', '', '')," +
                         "('null_value_counts', 'map(integer, bigint)', '', '')," +
+                        "('nan_value_counts', 'map(integer, bigint)', '', '')," +
                         "('lower_bounds', 'map(integer, varchar)', '', '')," +
                         "('upper_bounds', 'map(integer, varchar)', '', '')," +
                         "('key_metadata', 'varbinary', '', '')," +
-                        "('split_offsets', 'array(bigint)', '', '')");
+                        "('split_offsets', 'array(bigint)', '', '')," +
+                        "('equality_ids', 'array(integer)', '', '')");
         assertQuerySucceeds("SELECT * FROM test_schema.\"test_table$files\"");
     }
 


### PR DESCRIPTION
Add new fields introduced in Iceberg in files table, to match:

https://github.com/apache/iceberg/blob/0.11.x/api/src/main/java/org/apache/iceberg/DataFile.java#L72-L88