### PR TITLE
Correct getRetainedSize() in ChunkedSliceOutput

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
@@ -367,7 +367,8 @@ public final class ChunkedSliceOutput
         public void reset()
         {
             bufferPool.addAll(0, usedBuffers);
-            for (byte b[]: bufferPool){
+            for (byte[] b : bufferPool)
+            {
                 bufferPollSize += SizeOf.sizeOf(b);
             }
             usedBuffers.clear();
@@ -391,7 +392,7 @@ public final class ChunkedSliceOutput
 
         public long getBufferPollSize()
         {
-            return bufferPollSize ;
+            return bufferPollSize;
         }
     }
 }

--- a/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
@@ -367,7 +367,7 @@ public final class ChunkedSliceOutput
         public void reset()
         {
             bufferPool.addAll(0, usedBuffers);
-            for (byte[] b : bufferPool) {
+            for (byte[] b : usedBuffers) {
                 bufferPoolSize += SizeOf.sizeOf(b);
             }
             usedBuffers.clear();

--- a/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
@@ -14,6 +14,7 @@
 package io.trino.orc;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.slice.SizeOf;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
@@ -107,7 +108,7 @@ public final class ChunkedSliceOutput
     @Override
     public long getRetainedSize()
     {
-        return slice.getRetainedSize() + closedSlicesRetainedSize + INSTANCE_SIZE;
+        return slice.getRetainedSize() + chunkSupplier.getBufferPollSize() + closedSlicesRetainedSize + INSTANCE_SIZE;
     }
 
     @Override
@@ -351,6 +352,7 @@ public final class ChunkedSliceOutput
         private final List<byte[]> usedBuffers = new ArrayList<>();
 
         private int currentSize;
+        private long bufferPollSize;
 
         public ChunkSupplier(int minChunkSize, int maxChunkSize)
         {
@@ -365,6 +367,9 @@ public final class ChunkedSliceOutput
         public void reset()
         {
             bufferPool.addAll(0, usedBuffers);
+            for (byte b[]: bufferPool){
+                bufferPollSize += SizeOf.sizeOf(b);
+            }
             usedBuffers.clear();
         }
 
@@ -377,10 +382,16 @@ public final class ChunkedSliceOutput
             }
             else {
                 buffer = bufferPool.remove(0);
+                bufferPollSize -= SizeOf.sizeOf(buffer);
                 currentSize = buffer.length;
             }
             usedBuffers.add(buffer);
             return buffer;
+        }
+
+        public long getBufferPollSize()
+        {
+            return bufferPollSize;
         }
     }
 }

--- a/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
@@ -108,7 +108,7 @@ public final class ChunkedSliceOutput
     @Override
     public long getRetainedSize()
     {
-        return slice.getRetainedSize() + chunkSupplier.getBufferPollSize() + closedSlicesRetainedSize + INSTANCE_SIZE;
+        return slice.getRetainedSize() + chunkSupplier.getBufferPoolSize() + closedSlicesRetainedSize + INSTANCE_SIZE;
     }
 
     @Override
@@ -352,7 +352,7 @@ public final class ChunkedSliceOutput
         private final List<byte[]> usedBuffers = new ArrayList<>();
 
         private int currentSize;
-        private long bufferPollSize;
+        private long bufferPoolSize;
 
         public ChunkSupplier(int minChunkSize, int maxChunkSize)
         {
@@ -368,7 +368,7 @@ public final class ChunkedSliceOutput
         {
             bufferPool.addAll(0, usedBuffers);
             for (byte[] b : bufferPool) {
-                bufferPollSize += SizeOf.sizeOf(b);
+                bufferPoolSize += SizeOf.sizeOf(b);
             }
             usedBuffers.clear();
         }
@@ -382,16 +382,16 @@ public final class ChunkedSliceOutput
             }
             else {
                 buffer = bufferPool.remove(0);
-                bufferPollSize -= SizeOf.sizeOf(buffer);
+                bufferPoolSize -= SizeOf.sizeOf(buffer);
                 currentSize = buffer.length;
             }
             usedBuffers.add(buffer);
             return buffer;
         }
 
-        public long getBufferPollSize()
+        public long getBufferPoolSize()
         {
-            return bufferPollSize;
+            return bufferPoolSize;
         }
     }
 }

--- a/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
@@ -367,8 +367,7 @@ public final class ChunkedSliceOutput
         public void reset()
         {
             bufferPool.addAll(0, usedBuffers);
-            for (byte[] b : bufferPool)
-            {
+            for (byte[] b : bufferPool) {
                 bufferPollSize += SizeOf.sizeOf(b);
             }
             usedBuffers.clear();

--- a/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/ChunkedSliceOutput.java
@@ -391,7 +391,7 @@ public final class ChunkedSliceOutput
 
         public long getBufferPollSize()
         {
-            return bufferPollSize;
+            return bufferPollSize ;
         }
     }
 }


### PR DESCRIPTION
When ChunkedSliceOutput.reset() is called, the memory of usedBuffers in ChunkSupplier will be moved to ChunkSupplier.bufferPool. Since ChunkedSliceOutput.getRetainedSize does not take into account the memory of ChunkSupplier.bufferPool, the memory that ChunkedSupplier.bufferPool tracks the larger gap between ChunkedSliceOutput.getRetainedSize .