### PR TITLE
Explain statistic bean conflicts in Elastic tests

### DIFF
--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -462,7 +462,8 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
-                                <!-- This test must be run in isolation  -->
+                                <!-- You can only bind one statistics bean per JVM, otherwise you'll see problems with statistics being 0 despite backpressure handling -->
+                                <!-- This test should be run in isolation, to avoid the possibility of some other test also registering statistic beans -->
                                 <exclude>**/TestElasticsearchBackpressure*</exclude>
                             </excludes>
                         </configuration>


### PR DESCRIPTION
Statistics sometimes returned 0 as if they were not being updated.
Apparently if more than one stats bean gets registered in the JVM,
it can lead to stats not being updated/read properly.

The test @kokosing mentioned as an example had a similar kind of isolation
in place, presumably to avoid multiple stats bean registrations.