### PR TITLE
Add dbref field support for mongodb connector;

### DIFF
--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoPageSource.java
@@ -15,6 +15,7 @@ package io.trino.plugin.mongodb;
 
 import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
+import com.mongodb.DBRef;
 import com.mongodb.client.MongoCursor;
 import io.airlift.slice.Slice;
 import io.trino.spi.Page;
@@ -314,6 +315,18 @@ public class MongoPageSource
                 for (int index = 0; index < type.getTypeParameters().size(); index++) {
                     appendTo(type.getTypeParameters().get(index), mapValue.get(fieldNames.get(index)), builder);
                 }
+                output.closeEntry();
+                return;
+            }
+            else if (value instanceof DBRef) {
+                DBRef dbRefValue = (DBRef) value;
+                BlockBuilder builder = output.beginBlockEntry();
+
+                checkState(type.getTypeParameters().size() == 3, "DBRef should have 3 fields : %s", type);
+                appendTo(type.getTypeParameters().get(0), dbRefValue.getDatabaseName(), builder);
+                appendTo(type.getTypeParameters().get(1), dbRefValue.getCollectionName(), builder);
+                appendTo(type.getTypeParameters().get(2), dbRefValue.getId(), builder);
+
                 output.closeEntry();
                 return;
             }

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestMongoIntegrationSmokeTest.java
@@ -15,6 +15,7 @@ package io.trino.plugin.mongodb;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.mongodb.DBRef;
 import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
 import io.trino.sql.planner.plan.LimitNode;
@@ -23,6 +24,7 @@ import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import org.bson.Document;
+import org.bson.types.ObjectId;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -189,6 +191,25 @@ public class TestMongoIntegrationSmokeTest
         Document document2 = new Document("col", new Document("key1", null));
         client.getDatabase("test").getCollection("tmp_guess_schema2").insertOne(document2);
         assertQueryReturnsEmptyResult("SHOW COLUMNS FROM test.tmp_guess_schema2");
+    }
+
+    @Test
+    public void testDBRef()
+    {
+        Document document = Document.parse("{\"_id\":ObjectId(\"5126bbf64aed4daf9e2ab771\"),\"col1\":\"foo\"}");
+
+        ObjectId objectId = new ObjectId("5126bc054aed4daf9e2ab772");
+        DBRef dbRef = new DBRef("test", "creators", objectId);
+        document.append("creator", dbRef);
+
+        client.getDatabase("test").getCollection("test_dbref").insertOne(document);
+
+        assertQuery(
+                "SELECT creator.databaseName, creator.collectionName, CAST(creator.id AS VARCHAR) FROM test.test_dbref",
+                "SELECT 'test', 'creators', '5126bc054aed4daf9e2ab772'");
+        assertQuery(
+                "SELECT typeof(creator) FROM test.test_dbref",
+                "SELECT 'row(databaseName varchar, collectionName varchar, id ObjectId)'");
     }
 
     @Test


### PR DESCRIPTION
Fixes #3134.

Description: Added explicit case for handling if the type of a field is DBRef. In such case, we extract the id, database name and collection name from the object and convert that into a row. This change enables support at the MongoSession level. With this change, the column starts showing up in the information schema. However, all the values come as null because the writeBlock() method still needs to add the support.

To do this, we need add support at the MongoPageSource. This is done by aadding a case in the writeBlock() method.