### PR TITLE
Improve support for correlated subqueries with GROUP BY or LIMIT

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeDecorrelator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PlanNodeDecorrelator.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import io.trino.metadata.Metadata;
 import io.trino.spi.connector.SortOrder;
+import io.trino.spi.type.Type;
 import io.trino.sql.ExpressionUtils;
 import io.trino.sql.planner.OrderingScheme;
 import io.trino.sql.planner.Symbol;
@@ -43,9 +44,11 @@ import io.trino.sql.planner.plan.RowNumberNode;
 import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
 import io.trino.sql.planner.plan.WindowNode.Specification;
+import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.SymbolReference;
+import io.trino.type.TypeCoercion;
 
 import java.util.List;
 import java.util.Map;
@@ -57,6 +60,8 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.analyzer.TypeSignatureTranslator.toTypeSignature;
+import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
 import static io.trino.sql.planner.optimizations.SymbolMapper.symbolMapper;
 import static io.trino.sql.planner.plan.AggregationNode.singleGroupingSet;
 import static io.trino.sql.planner.plan.TopNRankingNode.RankingType.ROW_NUMBER;
@@ -69,12 +74,14 @@ public class PlanNodeDecorrelator
     private final Metadata metadata;
     private final SymbolAllocator symbolAllocator;
     private final Lookup lookup;
+    private final TypeCoercion typeCoercion;
 
     public PlanNodeDecorrelator(Metadata metadata, SymbolAllocator symbolAllocator, Lookup lookup)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.symbolAllocator = requireNonNull(symbolAllocator, "symbolAllocator is null");
         this.lookup = requireNonNull(lookup, "lookup is null");
+        this.typeCoercion = new TypeCoercion(metadata::getType);
     }
 
     public Optional<DecorrelatedNode> decorrelateFilters(PlanNode node, List<Symbol> correlation)
@@ -113,6 +120,7 @@ public class PlanNodeDecorrelator
                     ImmutableSet.of(),
                     ImmutableList.of(),
                     ImmutableMultimap.of(),
+                    ImmutableSet.of(),
                     false));
         }
 
@@ -130,6 +138,7 @@ public class PlanNodeDecorrelator
                     ImmutableSet.of(),
                     ImmutableList.of(),
                     ImmutableMultimap.of(),
+                    ImmutableSet.of(),
                     false));
 
             // try to decorrelate filters down the tree
@@ -164,6 +173,10 @@ public class PlanNodeDecorrelator
                     ImmutableMultimap.<Symbol, Symbol>builder()
                             .putAll(childDecorrelationResult.correlatedSymbolsMapping)
                             .putAll(extractCorrelatedSymbolsMapping(correlatedPredicates))
+                            .build(),
+                    ImmutableSet.<Symbol>builder()
+                            .addAll(childDecorrelationResult.constantSymbols)
+                            .addAll(extractConstantSymbols(correlatedPredicates))
                             .build(),
                     childDecorrelationResult.atMostSingleRow));
         }
@@ -230,6 +243,7 @@ public class PlanNodeDecorrelator
                     childDecorrelationResult.symbolsToPropagate,
                     childDecorrelationResult.correlatedPredicates,
                     childDecorrelationResult.correlatedSymbolsMapping,
+                    childDecorrelationResult.constantSymbols,
                     true));
         }
 
@@ -244,6 +258,7 @@ public class PlanNodeDecorrelator
                         childDecorrelationResult.symbolsToPropagate,
                         childDecorrelationResult.correlatedPredicates,
                         childDecorrelationResult.correlatedSymbolsMapping,
+                        childDecorrelationResult.constantSymbols,
                         false));
             }
 
@@ -267,6 +282,7 @@ public class PlanNodeDecorrelator
                     childDecorrelationResult.symbolsToPropagate,
                     childDecorrelationResult.correlatedPredicates,
                     childDecorrelationResult.correlatedSymbolsMapping,
+                    childDecorrelationResult.constantSymbols,
                     false));
         }
 
@@ -300,6 +316,7 @@ public class PlanNodeDecorrelator
                                 childDecorrelationResult.symbolsToPropagate,
                                 childDecorrelationResult.correlatedPredicates,
                                 childDecorrelationResult.correlatedSymbolsMapping,
+                                childDecorrelationResult.constantSymbols,
                                 node.getCount() == 1))
                         .or(() -> Optional.of(new DecorrelationResult(
                                 // no ordering symbols are left - convert to LimitNode
@@ -307,6 +324,7 @@ public class PlanNodeDecorrelator
                                 childDecorrelationResult.symbolsToPropagate,
                                 childDecorrelationResult.correlatedPredicates,
                                 childDecorrelationResult.correlatedSymbolsMapping,
+                                childDecorrelationResult.constantSymbols,
                                 node.getCount() == 1)));
             }
 
@@ -334,6 +352,7 @@ public class PlanNodeDecorrelator
                                 childDecorrelationResult.symbolsToPropagate,
                                 childDecorrelationResult.correlatedPredicates,
                                 childDecorrelationResult.correlatedSymbolsMapping,
+                                childDecorrelationResult.constantSymbols,
                                 node.getCount() == 1));
                     })
                     .orElseGet(() -> {
@@ -352,6 +371,7 @@ public class PlanNodeDecorrelator
                                 childDecorrelationResult.symbolsToPropagate,
                                 childDecorrelationResult.correlatedPredicates,
                                 childDecorrelationResult.correlatedSymbolsMapping,
+                                childDecorrelationResult.constantSymbols,
                                 node.getCount() == 1));
                     });
         }
@@ -436,6 +456,7 @@ public class PlanNodeDecorrelator
                     childDecorrelationResult.symbolsToPropagate,
                     childDecorrelationResult.correlatedPredicates,
                     childDecorrelationResult.correlatedSymbolsMapping,
+                    childDecorrelationResult.constantSymbols,
                     constantSymbols.containsAll(newAggregation.getGroupingKeys())));
         }
 
@@ -463,12 +484,12 @@ public class PlanNodeDecorrelator
                     childDecorrelationResult.symbolsToPropagate,
                     childDecorrelationResult.correlatedPredicates,
                     childDecorrelationResult.correlatedSymbolsMapping,
+                    childDecorrelationResult.constantSymbols,
                     childDecorrelationResult.atMostSingleRow));
         }
 
         private Multimap<Symbol, Symbol> extractCorrelatedSymbolsMapping(List<Expression> correlatedConjuncts)
         {
-            // TODO: handle coercions and non-direct column references
             ImmutableMultimap.Builder<Symbol, Symbol> mapping = ImmutableMultimap.builder();
             for (Expression conjunct : correlatedConjuncts) {
                 if (!(conjunct instanceof ComparisonExpression)) {
@@ -497,6 +518,63 @@ public class PlanNodeDecorrelator
             return mapping.build();
         }
 
+        private Set<Symbol> extractConstantSymbols(List<Expression> correlatedConjuncts)
+        {
+            ImmutableSet.Builder<Symbol> constants = ImmutableSet.builder();
+
+            correlatedConjuncts.stream()
+                    .filter(ComparisonExpression.class::isInstance)
+                    .map(ComparisonExpression.class::cast)
+                    .filter(comparison -> comparison.getOperator() == EQUAL)
+                    .forEach(comparison -> {
+                        Expression left = comparison.getLeft();
+                        Expression right = comparison.getRight();
+
+                        if (!isCorrelated(left) && (left instanceof SymbolReference || isSimpleInjectiveCast(left)) && isConstant(right)) {
+                            constants.add(getSymbol(left));
+                        }
+
+                        if (!isCorrelated(right) && (right instanceof SymbolReference || isSimpleInjectiveCast(right)) && isConstant(left)) {
+                            constants.add(getSymbol(right));
+                        }
+                    });
+
+            return constants.build();
+        }
+
+        // checks whether the expression is a deterministic combination of correlation symbols
+        private boolean isConstant(Expression expression)
+        {
+            return isDeterministic(expression, metadata) &&
+                    ImmutableSet.copyOf(correlation).containsAll(SymbolsExtractor.extractUnique(expression));
+        }
+
+        // checks whether the expression is an injective cast over a symbol
+        private boolean isSimpleInjectiveCast(Expression expression)
+        {
+            if (!(expression instanceof Cast)) {
+                return false;
+            }
+            Cast cast = (Cast) expression;
+            if (!(cast.getExpression() instanceof SymbolReference)) {
+                return false;
+            }
+            Symbol sourceSymbol = Symbol.from(cast.getExpression());
+
+            Type sourceType = symbolAllocator.getTypes().get(sourceSymbol);
+            Type targetType = metadata.getType(toTypeSignature(((Cast) expression).getType()));
+
+            return typeCoercion.isInjectiveCoercion(sourceType, targetType);
+        }
+
+        private Symbol getSymbol(Expression expression)
+        {
+            if (expression instanceof SymbolReference) {
+                return Symbol.from(expression);
+            }
+            return Symbol.from(((Cast) expression).getExpression());
+        }
+
         private boolean isCorrelated(Expression expression)
         {
             return correlation.stream().anyMatch(SymbolsExtractor.extractUnique(expression)::contains);
@@ -511,17 +589,27 @@ public class PlanNodeDecorrelator
 
         // mapping from correlated symbols to their uncorrelated equivalence
         final Multimap<Symbol, Symbol> correlatedSymbolsMapping;
+
+        // local (uncorrelated) symbols known to be constant based on their dependency on correlation symbols
+        // they are derived from the filter predicate, e.g.
+        // a = corr --> a is constant
+        // b = f(corr_1, corr_2, ...) --> b is constant provided that f is deterministic
+        // cast(c AS ...) = corr --> c is constant provided that cast is injective
+        final Set<Symbol> constantSymbols;
+
         // If a subquery has at most single row for any correlation values?
         final boolean atMostSingleRow;
 
-        DecorrelationResult(PlanNode node, Set<Symbol> symbolsToPropagate, List<Expression> correlatedPredicates, Multimap<Symbol, Symbol> correlatedSymbolsMapping, boolean atMostSingleRow)
+        DecorrelationResult(PlanNode node, Set<Symbol> symbolsToPropagate, List<Expression> correlatedPredicates, Multimap<Symbol, Symbol> correlatedSymbolsMapping, Set<Symbol> constantSymbols, boolean atMostSingleRow)
         {
             this.node = node;
             this.symbolsToPropagate = symbolsToPropagate;
             this.correlatedPredicates = correlatedPredicates;
             this.atMostSingleRow = atMostSingleRow;
             this.correlatedSymbolsMapping = correlatedSymbolsMapping;
-            checkState(symbolsToPropagate.containsAll(correlatedSymbolsMapping.values()), "Expected symbols to propagate to contain all constant symbols");
+            this.constantSymbols = constantSymbols;
+            checkState(constantSymbols.containsAll(correlatedSymbolsMapping.values()), "Expected constant symbols to contain all correlated symbols local equivalents");
+            checkState(symbolsToPropagate.containsAll(constantSymbols), "Expected symbols to propagate to contain all constant symbols");
         }
 
         SymbolMapper getCorrelatedSymbolMapper()
@@ -535,7 +623,7 @@ public class PlanNodeDecorrelator
          */
         Set<Symbol> getConstantSymbols()
         {
-            return ImmutableSet.copyOf(correlatedSymbolsMapping.values());
+            return constantSymbols;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
+++ b/core/trino-main/src/main/java/io/trino/type/TypeCoercion.java
@@ -128,6 +128,30 @@ public final class TypeCoercion
         return false;
     }
 
+    // based on `UnwrapCastInComparison.Visitor.hasInjectiveImplicitCoercion()`
+    public boolean isInjectiveCoercion(Type source, Type result)
+    {
+        if ((source.equals(BIGINT) && result.equals(DOUBLE)) ||
+                (source.equals(BIGINT) && result.equals(REAL)) ||
+                (source.equals(INTEGER) && result.equals(REAL)) ||
+                result instanceof TimestampWithTimeZoneType ||
+                result instanceof TimeWithTimeZoneType) {
+            return false;
+        }
+
+        if (source instanceof DecimalType) {
+            int precision = ((DecimalType) source).getPrecision();
+            if (precision > 15 && result.equals(DOUBLE)) {
+                return false;
+            }
+            if (precision > 7 && result.equals(REAL)) {
+                return false;
+            }
+        }
+
+        return canCoerce(source, result);
+    }
+
     public Optional<Type> getCommonSuperType(Type firstType, Type secondType)
     {
         TypeCompatibility compatibility = compatibility(firstType, secondType);


### PR DESCRIPTION
This change introduces a new policy of determining which subquery
symbols are constant.
Before, only symbols equal to some correlation symbols were recognized
as constant.
After this change, also deterministic combinations of correlation
symbols and coerced subquery symbols are recognized as constant.

Recognizing more subquery symbols as constant helps decorrelate
or improves plans for correlated queries with: GROUP BY, LIMIT,
ORDER BY + LIMIT.