### PR TITLE
Fix the result structure of DescribeInputRewrite and DescribeOutputRewrite

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/DescribeInputRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/DescribeInputRewrite.java
@@ -47,11 +47,13 @@ import static io.trino.execution.ParameterExtractor.getParameters;
 import static io.trino.sql.ParsingUtil.createParsingOptions;
 import static io.trino.sql.QueryUtil.aliased;
 import static io.trino.sql.QueryUtil.ascending;
-import static io.trino.sql.QueryUtil.identifier;
 import static io.trino.sql.QueryUtil.ordering;
+import static io.trino.sql.QueryUtil.query;
+import static io.trino.sql.QueryUtil.quotedIdentifier;
 import static io.trino.sql.QueryUtil.row;
 import static io.trino.sql.QueryUtil.selectList;
 import static io.trino.sql.QueryUtil.simpleQuery;
+import static io.trino.sql.QueryUtil.subquery;
 import static io.trino.sql.QueryUtil.values;
 import static io.trino.type.TypeUtils.getDisplayLabel;
 import static io.trino.type.UnknownType.UNKNOWN;
@@ -137,9 +139,9 @@ final class DescribeInputRewrite
             }
 
             return simpleQuery(
-                    selectList(identifier("Position"), identifier("Type")),
+                    selectList(quotedIdentifier("Position"), quotedIdentifier("Type")),
                     aliased(
-                            values(rows),
+                            subquery(query(values(rows))),
                             "Parameter Input",
                             ImmutableList.of("Position", "Type")),
                     Optional.empty(),

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/DescribeOutputRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/DescribeOutputRewrite.java
@@ -48,10 +48,12 @@ import java.util.Optional;
 import static io.trino.SystemSessionProperties.isOmitDateTimeTypePrecision;
 import static io.trino.sql.ParsingUtil.createParsingOptions;
 import static io.trino.sql.QueryUtil.aliased;
-import static io.trino.sql.QueryUtil.identifier;
+import static io.trino.sql.QueryUtil.query;
+import static io.trino.sql.QueryUtil.quotedIdentifier;
 import static io.trino.sql.QueryUtil.row;
 import static io.trino.sql.QueryUtil.selectList;
 import static io.trino.sql.QueryUtil.simpleQuery;
+import static io.trino.sql.QueryUtil.subquery;
 import static io.trino.sql.QueryUtil.values;
 import static io.trino.type.TypeUtils.getDisplayLabel;
 import static java.util.Objects.requireNonNull;
@@ -132,15 +134,15 @@ final class DescribeOutputRewrite
             }
             return simpleQuery(
                     selectList(
-                            identifier("Column Name"),
-                            identifier("Catalog"),
-                            identifier("Schema"),
-                            identifier("Table"),
-                            identifier("Type"),
-                            identifier("Type Size"),
-                            identifier("Aliased")),
+                            quotedIdentifier("Column Name"),
+                            quotedIdentifier("Catalog"),
+                            quotedIdentifier("Schema"),
+                            quotedIdentifier("Table"),
+                            quotedIdentifier("Type"),
+                            quotedIdentifier("Type Size"),
+                            quotedIdentifier("Aliased")),
                     aliased(
-                            values(rows),
+                            subquery(query(values(rows))),
                             "Statement Output",
                             ImmutableList.of("Column Name", "Catalog", "Schema", "Table", "Type", "Type Size", "Aliased")),
                     Optional.empty(),

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -125,6 +125,7 @@ import static io.trino.sql.QueryUtil.functionCall;
 import static io.trino.sql.QueryUtil.identifier;
 import static io.trino.sql.QueryUtil.logicalAnd;
 import static io.trino.sql.QueryUtil.ordering;
+import static io.trino.sql.QueryUtil.quotedIdentifier;
 import static io.trino.sql.QueryUtil.row;
 import static io.trino.sql.QueryUtil.selectAll;
 import static io.trino.sql.QueryUtil.selectList;
@@ -369,7 +370,7 @@ final class ShowQueriesRewrite
             }
             else if (node.getLikePattern().isPresent()) {
                 predicate = Optional.of(new LikePredicate(
-                        identifier("catalog"),
+                        quotedIdentifier("catalog"),
                         new StringLiteral(node.getLikePattern().get()),
                         node.getEscape().map(StringLiteral::new)));
             }

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -701,7 +701,7 @@ final class ShowQueriesRewrite
                     selectAll(columns.entrySet().stream()
                             .map(entry -> aliasedName(entry.getKey(), entry.getValue()))
                             .collect(toImmutableList())),
-                    aliased(new Values(rows), "functions", ImmutableList.copyOf(columns.keySet())),
+                    aliased(subquery(query(new Values(rows))), "functions", ImmutableList.copyOf(columns.keySet())),
                     node.getLikePattern().map(like ->
                             new LikePredicate(
                                     identifier("function_name"),

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -379,7 +379,7 @@ final class ShowQueriesRewrite
 
             return simpleQuery(
                     selectList(new AllColumns()),
-                    aliased(new Values(rows), "catalogs", ImmutableList.of("Catalog")),
+                    aliased(subquery(query(new Values(rows))), "catalogs", ImmutableList.of("Catalog")),
                     predicate,
                     Optional.of(ordering(ascending("Catalog"))));
         }

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -328,7 +328,7 @@ final class ShowQueriesRewrite
 
             return simpleQuery(
                     selectList(new AllColumns()),
-                    aliased(new Values(rows), "role_grants", ImmutableList.of("Role Grants")),
+                    aliased(subquery(query(new Values(rows))), "role_grants", ImmutableList.of("Role Grants")),
                     ordering(ascending("Role Grants")));
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -125,12 +125,14 @@ import static io.trino.sql.QueryUtil.functionCall;
 import static io.trino.sql.QueryUtil.identifier;
 import static io.trino.sql.QueryUtil.logicalAnd;
 import static io.trino.sql.QueryUtil.ordering;
+import static io.trino.sql.QueryUtil.query;
 import static io.trino.sql.QueryUtil.quotedIdentifier;
 import static io.trino.sql.QueryUtil.row;
 import static io.trino.sql.QueryUtil.selectAll;
 import static io.trino.sql.QueryUtil.selectList;
 import static io.trino.sql.QueryUtil.simpleQuery;
 import static io.trino.sql.QueryUtil.singleValueQuery;
+import static io.trino.sql.QueryUtil.subquery;
 import static io.trino.sql.QueryUtil.table;
 import static io.trino.sql.SqlFormatter.formatSql;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
@@ -774,7 +776,7 @@ final class ShowQueriesRewrite
                             aliasedName("type", "Type"),
                             aliasedName("description", "Description")),
                     aliased(
-                            new Values(rows.build()),
+                            subquery(query(new Values(rows.build()))),
                             "session",
                             ImmutableList.of("name", "value", "default", "type", "description", "include")),
                     predicate);

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowStatsRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowStatsRewrite.java
@@ -67,9 +67,11 @@ import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.sql.QueryUtil.aliased;
+import static io.trino.sql.QueryUtil.query;
 import static io.trino.sql.QueryUtil.selectAll;
 import static io.trino.sql.QueryUtil.selectList;
 import static io.trino.sql.QueryUtil.simpleQuery;
+import static io.trino.sql.QueryUtil.subquery;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static java.lang.Double.isFinite;
 import static java.lang.Math.round;
@@ -173,7 +175,7 @@ public class ShowStatsRewrite
             rowsBuilder.add(new Row(rowValues.build()));
             List<Expression> resultRows = rowsBuilder.build();
 
-            return simpleQuery(selectAll(selectItems), aliased(new Values(resultRows), "table_stats", statsColumnNames));
+            return simpleQuery(selectAll(selectItems), aliased(subquery(query(new Values(resultRows))), "table_stats", statsColumnNames));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -941,6 +941,21 @@ public class LocalQueryRunner
         return logicalPlanner.plan(analysis, stage);
     }
 
+    public QueryExplainer getQueryExplainer(boolean forceSingleNode)
+    {
+        return new QueryExplainer(
+                getPlanOptimizers(forceSingleNode),
+                planFragmenter,
+                metadata,
+                typeOperators,
+                groupProvider,
+                accessControl,
+                sqlParser,
+                statsCalculator,
+                costCalculator,
+                dataDefinitionTask);
+    }
+
     private static List<Split> getNextBatch(SplitSource splitSource)
     {
         return getFutureValue(splitSource.getNextBatch(NOT_PARTITIONED, Lifespan.taskWide(), 1000)).getSplits();

--- a/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
+++ b/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
@@ -44,6 +44,7 @@ import io.trino.sql.rewrite.StatementRewrite.Rewrite;
 import io.trino.sql.tree.DescribeInput;
 import io.trino.sql.tree.DescribeOutput;
 import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.ShowCatalogs;
 import io.trino.sql.tree.ShowFunctions;
 import io.trino.sql.tree.ShowSession;
 import io.trino.sql.tree.Statement;
@@ -177,6 +178,22 @@ public class TestStatementRewrite
                         ")  \"functions\" (\"function_name\", \"return_type\", \"argument_types\", \"function_type\", \"deterministic\", \"description\")\n" +
                         "WHERE (function_name LIKE '%' ESCAPE '$')\n" +
                         "ORDER BY lower(function_name) ASC, \"return_type\" ASC, \"argument_types\" ASC, \"function_type\" ASC\n");
+    }
+
+    @Test
+    public void testShowCatalogs()
+    {
+        assertFormatSql(
+                new ShowCatalogs(Optional.of("%"), Optional.of("$")),
+                SHOW_QUERIES_REWRITE,
+                "SELECT *\n" +
+                        "FROM\n" +
+                        "  (\n" +
+                        " VALUES \n" +
+                        "     ROW ('tpch')\n" +
+                        ")  \"catalogs\" (\"Catalog\")\n" +
+                        "WHERE (\"catalog\" LIKE '%' ESCAPE '$')\n" +
+                        "ORDER BY \"Catalog\" ASC");
     }
 
     private void assertFormatSql(Statement node, Rewrite rewriteProvider, String expected)

--- a/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
+++ b/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
@@ -163,7 +163,7 @@ public class TestStatementRewrite
     }
 
     @Test
-    public void testShowFunctions()
+    public void testShowFunctionsFormatSql()
     {
         assertFormatSqlWithMockMetadata(
                 new ShowFunctions(Optional.of("%"), Optional.of("$")),
@@ -186,7 +186,7 @@ public class TestStatementRewrite
     }
 
     @Test
-    public void testShowCatalogs()
+    public void testShowCatalogsFormatSql()
     {
         assertFormatSql(
                 new ShowCatalogs(Optional.of("%"), Optional.of("$")),
@@ -202,7 +202,7 @@ public class TestStatementRewrite
     }
 
     @Test
-    public void testShowRoleGrants()
+    public void testShowRoleGrantsFormatSql()
     {
         assertFormatSqlWithMockMetadata(
                 new ShowRoleGrants(Optional.empty()),

--- a/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
+++ b/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.rewrite;
+
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.connector.CatalogName;
+import io.trino.connector.informationschema.InformationSchemaConnector;
+import io.trino.connector.system.SystemConnector;
+import io.trino.metadata.Catalog;
+import io.trino.metadata.CatalogManager;
+import io.trino.metadata.InMemoryNodeManager;
+import io.trino.metadata.InternalNodeManager;
+import io.trino.metadata.Metadata;
+import io.trino.security.AccessControlConfig;
+import io.trino.security.AccessControlManager;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorMetadata;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.transaction.IsolationLevel;
+import io.trino.sql.SqlFormatterUtil;
+import io.trino.sql.analyzer.FeaturesConfig;
+import io.trino.sql.parser.ParsingOptions;
+import io.trino.sql.parser.SqlParser;
+import io.trino.sql.tree.Statement;
+import io.trino.testing.TestingMetadata;
+import io.trino.transaction.TransactionManager;
+import io.trino.sql.rewrite.StatementRewrite.Rewrite;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static io.trino.connector.CatalogName.createInformationSchemaCatalogName;
+import static io.trino.connector.CatalogName.createSystemTablesCatalogName;
+import static io.trino.cost.StatsCalculator.noopStatsCalculator;
+import static io.trino.execution.warnings.WarningCollector.NOOP;
+import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.operator.scalar.ApplyFunction.APPLY_FUNCTION;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingEventListenerManager.emptyEventListenerManager;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
+import static io.trino.transaction.TransactionBuilder.transaction;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+
+public class TestStatementRewrite
+{
+    private static final String TPCH_CATALOG = "tpch";
+    private static final CatalogName TPCH_CATALOG_NAME = new CatalogName(TPCH_CATALOG);
+    private static final Session.SessionBuilder CLIENT_SESSION_BUILDER = testSessionBuilder()
+            .setCatalog(TPCH_CATALOG)
+            .setSchema("s1")
+            .addPreparedStatement("q1", "SELECT a, ? as col2 FROM tpch.s1.t1");
+    private static final Session SETUP_SESSION = testSessionBuilder()
+            .setCatalog("c1")
+            .setSchema("s1")
+            .build();
+
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final DescribeOutputRewrite DESCRIBE_OUTPUT_REWRITE = new DescribeOutputRewrite();
+
+    private TransactionManager transactionManager;
+    private AccessControlManager accessControl;
+    private Metadata metadata;
+
+    @Test
+    public void testDescribeOutputFormatSql()
+    {
+        transaction(transactionManager, accessControl)
+                .readUncommitted()
+                .execute(beginTransaction(CLIENT_SESSION_BUILDER), session -> {
+                    Statement root = SQL_PARSER.createStatement("DESCRIBE OUTPUT q1", new ParsingOptions());
+                    Statement rewrittenNode = rewrite(session, root, DESCRIBE_OUTPUT_REWRITE);
+                    // SqlFormatterUtil#getFormattedSql will parse query and assert query round-trip inside.
+                    // We don't need to add extra asserting.
+                    SqlFormatterUtil.getFormattedSql(rewrittenNode, SQL_PARSER);
+                });
+    }
+
+    @Test
+    public void testDescribeInputFormatSql()
+    {
+        transaction(transactionManager, accessControl)
+                .readUncommitted()
+                .execute(beginTransaction(CLIENT_SESSION_BUILDER), session -> {
+                    Statement root = SQL_PARSER.createStatement("DESCRIBE INPUT q1", new ParsingOptions());
+                    Statement rewrittenNode = rewrite(session, root, DESCRIBE_OUTPUT_REWRITE);
+                    // SqlFormatterUtil#getFormattedSql will parse query and assert query round-trip inside.
+                    // We don't need to add extra asserting.
+                    SqlFormatterUtil.getFormattedSql(rewrittenNode, SQL_PARSER);
+                });
+    }
+
+    private Statement rewrite(Session session, Statement node, Rewrite rewriteProvider)
+    {
+        return rewriteProvider.rewrite(
+                session,
+                metadata,
+                SQL_PARSER,
+                Optional.empty(),
+                node,
+                emptyList(),
+                emptyMap(),
+                user -> ImmutableSet.of(),
+                accessControl,
+                NOOP,
+                noopStatsCalculator());
+    }
+
+    private Session beginTransaction(Session.SessionBuilder sessionBuilder)
+    {
+        return sessionBuilder.setTransactionId(transactionManager.beginTransaction(false)).build();
+    }
+
+    @BeforeClass
+    public void setup()
+    {
+        CatalogManager catalogManager = new CatalogManager();
+        transactionManager = createTestTransactionManager(catalogManager);
+        accessControl = new AccessControlManager(transactionManager,  emptyEventListenerManager(), new AccessControlConfig());
+        accessControl.loadSystemAccessControl();
+
+        metadata = createTestMetadataManager(transactionManager, new FeaturesConfig());
+        metadata.addFunctions(ImmutableList.of(APPLY_FUNCTION));
+
+        Catalog tpchTestCatalog = createTestingCatalog(TPCH_CATALOG, TPCH_CATALOG_NAME);
+        catalogManager.registerCatalog(tpchTestCatalog);
+        metadata.getTablePropertyManager().addProperties(TPCH_CATALOG_NAME, tpchTestCatalog.getConnector(TPCH_CATALOG_NAME).getTableProperties());
+        metadata.getAnalyzePropertyManager().addProperties(TPCH_CATALOG_NAME, tpchTestCatalog.getConnector(TPCH_CATALOG_NAME).getAnalyzeProperties());
+
+        SchemaTableName table1 = new SchemaTableName("s1", "t1");
+        inSetupTransaction(session -> metadata.createTable(session, TPCH_CATALOG,
+                new ConnectorTableMetadata(table1, ImmutableList.of(new ColumnMetadata("a", BIGINT))),
+                false));
+    }
+
+    private Catalog createTestingCatalog(String catalogName, CatalogName catalog)
+    {
+        CatalogName systemId = createSystemTablesCatalogName(catalog);
+        Connector connector = createTestingConnector();
+        InternalNodeManager nodeManager = new InMemoryNodeManager();
+        return new Catalog(
+                catalogName,
+                catalog,
+                connector,
+                createInformationSchemaCatalogName(catalog),
+                new InformationSchemaConnector(catalogName, nodeManager, metadata, accessControl),
+                systemId,
+                new SystemConnector(
+                        nodeManager,
+                        connector.getSystemTables(),
+                        transactionId -> transactionManager.getConnectorTransaction(transactionId, catalog)));
+    }
+
+    private void inSetupTransaction(Consumer<Session> consumer)
+    {
+        transaction(transactionManager, accessControl)
+                .singleStatement()
+                .readUncommitted()
+                .execute(SETUP_SESSION, consumer);
+    }
+
+    private static Connector createTestingConnector()
+    {
+        return new Connector()
+        {
+            private final ConnectorMetadata metadata = new TestingMetadata();
+
+            @Override
+            public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
+            {
+                return new ConnectorTransactionHandle() {};
+            }
+
+            @Override
+            public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
+            {
+                return metadata;
+            }
+
+            @Override
+            public List<PropertyMetadata<?>> getAnalyzeProperties()
+            {
+                return ImmutableList.of();
+            }
+        };
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
+++ b/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
@@ -40,6 +40,7 @@ import io.trino.sql.parser.SqlParser;
 import io.trino.sql.rewrite.StatementRewrite.Rewrite;
 import io.trino.sql.tree.DescribeInput;
 import io.trino.sql.tree.DescribeOutput;
+import io.trino.sql.tree.ShowSession;
 import io.trino.sql.tree.Statement;
 import io.trino.testing.TestingMetadata;
 import io.trino.transaction.TransactionManager;
@@ -124,6 +125,105 @@ public class TestStatementRewrite
                         "ORDER BY Position ASC\n");
     }
 
+    @Test
+    public void testShowSessionFormSql()
+    {
+        assertFormatSql(
+                new ShowSession(Optional.of("%"), Optional.of("$")),
+                new ShowQueriesRewrite(),
+                "SELECT\n" +
+                        "  \"name\" \"Name\"\n" +
+                        ", \"value\" \"Value\"\n" +
+                        ", \"default\" \"Default\"\n" +
+                        ", \"type\" \"Type\"\n" +
+                        ", \"description\" \"Description\"\n" +
+                        "FROM\n" +
+                        "  (\n" +
+                        " VALUES \n" +
+                        "     ROW ('aggregation_operator_unspill_memory_limit', '4MB', '4MB', 'varchar', 'How much memory should be allocated per aggregation operator in unspilling process', true)\n" +
+                        "   , ROW ('collect_plan_statistics_for_all_queries', 'false', 'false', 'boolean', 'Collect plan statistics for non-EXPLAIN queries', true)\n" +
+                        "   , ROW ('colocated_join', 'false', 'false', 'boolean', 'Experimental: Use a colocated join when possible', true)\n" +
+                        "   , ROW ('concurrent_lifespans_per_task', '0', '0', 'integer', 'Experimental: Run a fixed number of groups concurrently for eligible JOINs', true)\n" +
+                        "   , ROW ('default_filter_factor_enabled', 'false', 'false', 'boolean', 'use a default filter factor for unknown filters in a filter node', true)\n" +
+                        "   , ROW ('dictionary_aggregation', 'false', 'false', 'boolean', 'Enable optimization for aggregations on dictionaries', true)\n" +
+                        "   , ROW ('distributed_index_join', 'false', 'false', 'boolean', 'Distribute index joins on join keys instead of executing inline', true)\n" +
+                        "   , ROW ('distributed_sort', 'true', 'true', 'boolean', 'Parallelize sort across multiple nodes', true)\n" +
+                        "   , ROW ('dynamic_schedule_for_grouped_execution', 'false', 'false', 'boolean', 'Experimental: Use dynamic schedule for grouped execution when possible', true)\n" +
+                        "   , ROW ('enable_coordinator_dynamic_filters_distribution', 'true', 'true', 'boolean', 'Enable distribution of dynamic filters from coordinator to all workers', true)\n" +
+                        "   , ROW ('enable_dynamic_filtering', 'true', 'true', 'boolean', 'Enable dynamic filtering', true)\n" +
+                        "   , ROW ('enable_intermediate_aggregations', 'false', 'false', 'boolean', 'Enable the use of intermediate aggregations', true)\n" +
+                        "   , ROW ('enable_large_dynamic_filters', 'false', 'false', 'boolean', 'Enable collection of large dynamic filters', true)\n" +
+                        "   , ROW ('enable_stats_calculator', 'true', 'true', 'boolean', 'Enable statistics calculator', true)\n" +
+                        "   , ROW ('exchange_compression', 'false', 'false', 'boolean', 'Enable compression in exchanges', true)\n" +
+                        "   , ROW ('execution_policy', 'all-at-once', 'all-at-once', 'varchar', 'Policy used for scheduling query tasks', true)\n" +
+                        "   , ROW ('filter_and_project_min_output_page_row_count', '256', '256', 'integer', 'Experimental: Minimum output page row count for filter and project operators', true)\n" +
+                        "   , ROW ('filter_and_project_min_output_page_size', '500kB', '500kB', 'varchar', 'Experimental: Minimum output page size for filter and project operators', true)\n" +
+                        "   , ROW ('grouped_execution', 'false', 'false', 'boolean', 'Use grouped execution when possible', true)\n" +
+                        "   , ROW ('hash_partition_count', '100', '100', 'integer', 'Number of partitions for distributed joins and aggregations', true)\n" +
+                        "   , ROW ('ignore_downstream_preferences', 'false', 'false', 'boolean', 'Ignore Parent''s PreferredProperties in AddExchange optimizer', true)\n" +
+                        "   , ROW ('ignore_stats_calculator_failures', 'false', 'true', 'boolean', 'Ignore statistics calculator failures', true)\n" +
+                        "   , ROW ('initial_splits_per_node', '16', '16', 'integer', 'The number of splits each node will run per task, initially', true)\n" +
+                        "   , ROW ('iterative_optimizer_timeout', '3.00m', '3.00m', 'varchar', 'Timeout for plan optimization in iterative optimizer', true)\n" +
+                        "   , ROW ('iterative_rule_based_column_pruning', 'true', 'true', 'boolean', 'Use iterative rules to prune unreferenced columns', true)\n" +
+                        "   , ROW ('join_distribution_type', 'AUTOMATIC', 'AUTOMATIC', 'varchar', 'Join distribution type. Possible values: [BROADCAST, PARTITIONED, AUTOMATIC]', true)\n" +
+                        "   , ROW ('join_max_broadcast_table_size', '100MB', '100MB', 'varchar', 'Maximum estimated size of a table that can be broadcast when using automatic join type selection', true)\n" +
+                        "   , ROW ('join_reordering_strategy', 'AUTOMATIC', 'AUTOMATIC', 'varchar', 'Join reordering strategy. Possible values: [NONE, ELIMINATE_CROSS_JOINS, AUTOMATIC]', true)\n" +
+                        "   , ROW ('late_materialization', 'false', 'false', 'boolean', 'Experimental: Use late materialization (including WorkProcessor pipelines)', true)\n" +
+                        "   , ROW ('max_drivers_per_task', '', '', 'integer', 'Maximum number of drivers per task', true)\n" +
+                        "   , ROW ('max_recursion_depth', '10', '10', 'integer', 'Maximum recursion depth for recursive common table expression', true)\n" +
+                        "   , ROW ('max_reordered_joins', '9', '9', 'integer', 'The maximum number of joins to reorder as one group in cost-based join reordering', true)\n" +
+                        "   , ROW ('max_unacknowledged_splits_per_task', '500', '500', 'integer', 'Maximum number of leaf splits awaiting delivery to a given task', true)\n" +
+                        "   , ROW ('merge_project_with_values', 'true', 'true', 'boolean', 'Inline project expressions into values', true)\n" +
+                        "   , ROW ('omit_datetime_type_precision', 'false', 'false', 'boolean', 'Omit precision when rendering datetime type names with default precision', true)\n" +
+                        "   , ROW ('optimize_duplicate_insensitive_joins', 'true', 'true', 'boolean', 'Optimize duplicate insensitive joins', true)\n" +
+                        "   , ROW ('optimize_hash_generation', 'true', 'true', 'boolean', 'Compute hash codes for distribution, joins, and aggregations early in query plan', true)\n" +
+                        "   , ROW ('optimize_metadata_queries', 'false', 'false', 'boolean', 'Enable optimization for metadata queries', true)\n" +
+                        "   , ROW ('optimize_mixed_distinct_aggregations', 'false', 'false', 'boolean', 'Optimize mixed non-distinct and distinct aggregations', true)\n" +
+                        "   , ROW ('optimize_top_n_ranking', 'true', 'true', 'boolean', 'Use top N ranking optimization', true)\n" +
+                        "   , ROW ('parse_decimal_literals_as_double', 'false', 'false', 'boolean', 'Parse decimal literals as DOUBLE instead of DECIMAL', true)\n" +
+                        "   , ROW ('predicate_pushdown_use_table_properties', 'true', 'true', 'boolean', 'Use table properties in predicate pushdown', true)\n" +
+                        "   , ROW ('prefer_partial_aggregation', 'true', 'true', 'boolean', 'Prefer splitting aggregations into partial and final stages', true)\n" +
+                        "   , ROW ('prefer_streaming_operators', 'false', 'false', 'boolean', 'Prefer source table layouts that produce streaming operators', true)\n" +
+                        "   , ROW ('preferred_write_partitioning_min_number_of_partitions', '50', '50', 'integer', 'Use preferred write partitioning when the number of written partitions exceeds the configured threshold', true)\n" +
+                        "   , ROW ('push_aggregation_through_outer_join', 'true', 'true', 'boolean', 'Allow pushing aggregations below joins', true)\n" +
+                        "   , ROW ('push_partial_aggregation_through_join', 'false', 'false', 'boolean', 'Push partial aggregations below joins', true)\n" +
+                        "   , ROW ('push_table_write_through_union', 'true', 'true', 'boolean', 'Parallelize writes when using UNION ALL in queries that write data', true)\n" +
+                        "   , ROW ('query_max_cpu_time', '1000000000.00d', '1000000000.00d', 'varchar', 'Maximum CPU time of a query', true)\n" +
+                        "   , ROW ('query_max_execution_time', '100.00d', '100.00d', 'varchar', 'Maximum execution time of a query', true)\n" +
+                        "   , ROW ('query_max_planning_time', '10.00m', '10.00m', 'varchar', 'Maximum planning time of a query', true)\n" +
+                        "   , ROW ('query_max_run_time', '100.00d', '100.00d', 'varchar', 'Maximum run time of a query (includes the queueing time)', true)\n" +
+                        "   , ROW ('query_max_scan_physical_bytes', '', '', 'varchar', 'Maximum scan physical bytes of a query', true)\n" +
+                        "   , ROW ('query_priority', '1', '1', 'integer', 'The priority of queries. Larger numbers are higher priority', true)\n" +
+                        "   , ROW ('redistribute_writes', 'true', 'true', 'boolean', 'Force parallel distributed writes', true)\n" +
+                        "   , ROW ('required_workers_count', '1', '1', 'integer', 'Minimum number of active workers that must be available before the query will start', true)\n" +
+                        "   , ROW ('required_workers_max_wait_time', '5.00m', '5.00m', 'varchar', 'Maximum time to wait for minimum number of workers before the query is failed', true)\n" +
+                        "   , ROW ('resource_overcommit', 'false', 'false', 'boolean', 'Use resources which are not guaranteed to be available to the query', true)\n" +
+                        "   , ROW ('rewrite_filtering_semi_join_to_inner_join', 'true', 'true', 'boolean', 'Rewrite semi join in filtering context to inner join', true)\n" +
+                        "   , ROW ('scale_writers', 'false', 'false', 'boolean', 'Scale out writers based on throughput (use minimum necessary)', true)\n" +
+                        "   , ROW ('skip_redundant_sort', 'true', 'true', 'boolean', 'Skip redundant sort operations', true)\n" +
+                        "   , ROW ('spatial_join', 'true', 'true', 'boolean', 'Use spatial index for spatial join when possible', true)\n" +
+                        "   , ROW ('spatial_partitioning_table_name', '', '', 'varchar', 'Name of the table containing spatial partitioning scheme', true)\n" +
+                        "   , ROW ('spill_enabled', 'false', 'false', 'boolean', 'Enable spilling', true)\n" +
+                        "   , ROW ('spill_order_by', 'true', 'true', 'boolean', 'Spill in OrderBy if spill_enabled is also set', true)\n" +
+                        "   , ROW ('spill_window_operator', 'true', 'true', 'boolean', 'Spill in WindowOperator if spill_enabled is also set', true)\n" +
+                        "   , ROW ('split_concurrency_adjustment_interval', '100.00ms', '100.00ms', 'varchar', 'Experimental: Interval between changes to the number of concurrent splits per node', true)\n" +
+                        "   , ROW ('statistics_cpu_timer_enabled', 'true', 'true', 'boolean', 'Experimental: Enable cpu time tracking for automatic column statistics collection on write', true)\n" +
+                        "   , ROW ('statistics_precalculation_for_pushdown_enabled', 'false', 'false', 'boolean', 'Enable statistics precalculation for pushdown', true)\n" +
+                        "   , ROW ('table_scan_node_partitioning_min_bucket_to_task_ratio', '0.5', '0.5', 'double', 'Min table scan bucket to task ratio for which plan will be adopted to node pre-partitioned tables', true)\n" +
+                        "   , ROW ('task_concurrency', '16', '16', 'integer', 'Default number of local parallel jobs per worker', true)\n" +
+                        "   , ROW ('task_share_index_loading', 'false', 'false', 'boolean', 'Share index join lookups and caching within a task', true)\n" +
+                        "   , ROW ('task_writer_count', '1', '1', 'integer', 'Default number of local parallel table writer jobs per worker', true)\n" +
+                        "   , ROW ('unwrap_casts', 'true', 'true', 'boolean', 'Enable optimization to unwrap CAST expression', true)\n" +
+                        "   , ROW ('use_legacy_window_filter_pushdown', 'false', 'false', 'boolean', 'Use legacy window filter pushdown optimizer', true)\n" +
+                        "   , ROW ('use_mark_distinct', 'true', 'true', 'boolean', 'Implement DISTINCT aggregations using MarkDistinct', true)\n" +
+                        "   , ROW ('use_preferred_write_partitioning', 'true', 'true', 'boolean', 'Use preferred write partitioning', true)\n" +
+                        "   , ROW ('use_table_scan_node_partitioning', 'true', 'true', 'boolean', 'Adapt plan to node pre-partitioned tables', true)\n" +
+                        "   , ROW ('writer_min_size', '32MB', '32MB', 'varchar', 'Target minimum size of writer output when scaling writers', true)\n" +
+                        "   , ROW ('', '', '', '', '', false)\n" +
+                        ")  \"session\" (\"name\", \"value\", \"default\", \"type\", \"description\", \"include\")\n" +
+                        "WHERE (include AND (name LIKE '%' ESCAPE '$'))\n");
+    }
+
     private void assertFormatSql(Statement node, Rewrite rewriteProvider, String expected)
     {
         transaction(transactionManager, accessControl)
@@ -182,6 +282,7 @@ public class TestStatementRewrite
     {
         CatalogName systemId = createSystemTablesCatalogName(catalog);
         Connector connector = createTestingConnector();
+        metadata.getSessionPropertyManager().addConnectorSessionProperties(new CatalogName(catalogName), connector.getSessionProperties());
         InternalNodeManager nodeManager = new InMemoryNodeManager();
         return new Catalog(
                 catalogName,

--- a/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
+++ b/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
@@ -11,9 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.trino.sql.rewrite;
-
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -40,10 +38,10 @@ import io.trino.sql.SqlFormatterUtil;
 import io.trino.sql.analyzer.FeaturesConfig;
 import io.trino.sql.parser.ParsingOptions;
 import io.trino.sql.parser.SqlParser;
+import io.trino.sql.rewrite.StatementRewrite.Rewrite;
 import io.trino.sql.tree.Statement;
 import io.trino.testing.TestingMetadata;
 import io.trino.transaction.TransactionManager;
-import io.trino.sql.rewrite.StatementRewrite.Rewrite;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -139,7 +137,7 @@ public class TestStatementRewrite
     {
         CatalogManager catalogManager = new CatalogManager();
         transactionManager = createTestTransactionManager(catalogManager);
-        accessControl = new AccessControlManager(transactionManager,  emptyEventListenerManager(), new AccessControlConfig());
+        accessControl = new AccessControlManager(transactionManager, emptyEventListenerManager(), new AccessControlConfig());
         accessControl.loadSystemAccessControl();
 
         metadata = createTestMetadataManager(transactionManager, new FeaturesConfig());

--- a/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
+++ b/core/trino-main/src/test/java/io/trino/sql/rewrite/TestStatementRewrite.java
@@ -19,11 +19,13 @@ import io.trino.Session;
 import io.trino.connector.CatalogName;
 import io.trino.connector.informationschema.InformationSchemaConnector;
 import io.trino.connector.system.SystemConnector;
+import io.trino.metadata.AbstractMockMetadata;
 import io.trino.metadata.Catalog;
 import io.trino.metadata.CatalogManager;
 import io.trino.metadata.InMemoryNodeManager;
 import io.trino.metadata.InternalNodeManager;
 import io.trino.metadata.Metadata;
+import io.trino.metadata.SessionPropertyManager;
 import io.trino.security.AccessControlConfig;
 import io.trino.security.AccessControlManager;
 import io.trino.spi.connector.ColumnMetadata;
@@ -48,6 +50,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -57,6 +60,7 @@ import static io.trino.cost.StatsCalculator.noopStatsCalculator;
 import static io.trino.execution.warnings.WarningCollector.NOOP;
 import static io.trino.metadata.MetadataManager.createTestMetadataManager;
 import static io.trino.operator.scalar.ApplyFunction.APPLY_FUNCTION;
+import static io.trino.spi.session.PropertyMetadata.integerProperty;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.QueryUtil.identifier;
 import static io.trino.testing.TestingEventListenerManager.emptyEventListenerManager;
@@ -81,10 +85,12 @@ public class TestStatementRewrite
             .build();
 
     private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final ShowQueriesRewrite SHOW_QUERIES_REWRITE = new ShowQueriesRewrite();
 
     private TransactionManager transactionManager;
     private AccessControlManager accessControl;
     private Metadata metadata;
+    private Metadata mockMetadata;
 
     @Test
     public void testDescribeOutputFormatSql()
@@ -122,15 +128,15 @@ public class TestStatementRewrite
                         " VALUES \n" +
                         "     ROW (0, 'unknown')\n" +
                         ")  \"Parameter Input\" (\"Position\", \"Type\")\n" +
-                        "ORDER BY Position ASC\n");
+                        "ORDER BY \"Position\" ASC\n");
     }
 
     @Test
-    public void testShowSessionFormSql()
+    public void testShowSessionFormatSql()
     {
-        assertFormatSql(
+        assertFormatSqlWithMockMetadata(
                 new ShowSession(Optional.of("%"), Optional.of("$")),
-                new ShowQueriesRewrite(),
+                SHOW_QUERIES_REWRITE,
                 "SELECT\n" +
                         "  \"name\" \"Name\"\n" +
                         ", \"value\" \"Value\"\n" +
@@ -140,85 +146,8 @@ public class TestStatementRewrite
                         "FROM\n" +
                         "  (\n" +
                         " VALUES \n" +
-                        "     ROW ('aggregation_operator_unspill_memory_limit', '4MB', '4MB', 'varchar', 'How much memory should be allocated per aggregation operator in unspilling process', true)\n" +
-                        "   , ROW ('collect_plan_statistics_for_all_queries', 'false', 'false', 'boolean', 'Collect plan statistics for non-EXPLAIN queries', true)\n" +
-                        "   , ROW ('colocated_join', 'false', 'false', 'boolean', 'Experimental: Use a colocated join when possible', true)\n" +
-                        "   , ROW ('concurrent_lifespans_per_task', '0', '0', 'integer', 'Experimental: Run a fixed number of groups concurrently for eligible JOINs', true)\n" +
-                        "   , ROW ('default_filter_factor_enabled', 'false', 'false', 'boolean', 'use a default filter factor for unknown filters in a filter node', true)\n" +
-                        "   , ROW ('dictionary_aggregation', 'false', 'false', 'boolean', 'Enable optimization for aggregations on dictionaries', true)\n" +
-                        "   , ROW ('distributed_index_join', 'false', 'false', 'boolean', 'Distribute index joins on join keys instead of executing inline', true)\n" +
-                        "   , ROW ('distributed_sort', 'true', 'true', 'boolean', 'Parallelize sort across multiple nodes', true)\n" +
-                        "   , ROW ('dynamic_schedule_for_grouped_execution', 'false', 'false', 'boolean', 'Experimental: Use dynamic schedule for grouped execution when possible', true)\n" +
-                        "   , ROW ('enable_coordinator_dynamic_filters_distribution', 'true', 'true', 'boolean', 'Enable distribution of dynamic filters from coordinator to all workers', true)\n" +
-                        "   , ROW ('enable_dynamic_filtering', 'true', 'true', 'boolean', 'Enable dynamic filtering', true)\n" +
-                        "   , ROW ('enable_intermediate_aggregations', 'false', 'false', 'boolean', 'Enable the use of intermediate aggregations', true)\n" +
-                        "   , ROW ('enable_large_dynamic_filters', 'false', 'false', 'boolean', 'Enable collection of large dynamic filters', true)\n" +
-                        "   , ROW ('enable_stats_calculator', 'true', 'true', 'boolean', 'Enable statistics calculator', true)\n" +
-                        "   , ROW ('exchange_compression', 'false', 'false', 'boolean', 'Enable compression in exchanges', true)\n" +
-                        "   , ROW ('execution_policy', 'all-at-once', 'all-at-once', 'varchar', 'Policy used for scheduling query tasks', true)\n" +
-                        "   , ROW ('filter_and_project_min_output_page_row_count', '256', '256', 'integer', 'Experimental: Minimum output page row count for filter and project operators', true)\n" +
-                        "   , ROW ('filter_and_project_min_output_page_size', '500kB', '500kB', 'varchar', 'Experimental: Minimum output page size for filter and project operators', true)\n" +
-                        "   , ROW ('grouped_execution', 'false', 'false', 'boolean', 'Use grouped execution when possible', true)\n" +
-                        "   , ROW ('hash_partition_count', '100', '100', 'integer', 'Number of partitions for distributed joins and aggregations', true)\n" +
-                        "   , ROW ('ignore_downstream_preferences', 'false', 'false', 'boolean', 'Ignore Parent''s PreferredProperties in AddExchange optimizer', true)\n" +
-                        "   , ROW ('ignore_stats_calculator_failures', 'false', 'true', 'boolean', 'Ignore statistics calculator failures', true)\n" +
-                        "   , ROW ('initial_splits_per_node', '16', '16', 'integer', 'The number of splits each node will run per task, initially', true)\n" +
-                        "   , ROW ('iterative_optimizer_timeout', '3.00m', '3.00m', 'varchar', 'Timeout for plan optimization in iterative optimizer', true)\n" +
-                        "   , ROW ('iterative_rule_based_column_pruning', 'true', 'true', 'boolean', 'Use iterative rules to prune unreferenced columns', true)\n" +
-                        "   , ROW ('join_distribution_type', 'AUTOMATIC', 'AUTOMATIC', 'varchar', 'Join distribution type. Possible values: [BROADCAST, PARTITIONED, AUTOMATIC]', true)\n" +
-                        "   , ROW ('join_max_broadcast_table_size', '100MB', '100MB', 'varchar', 'Maximum estimated size of a table that can be broadcast when using automatic join type selection', true)\n" +
-                        "   , ROW ('join_reordering_strategy', 'AUTOMATIC', 'AUTOMATIC', 'varchar', 'Join reordering strategy. Possible values: [NONE, ELIMINATE_CROSS_JOINS, AUTOMATIC]', true)\n" +
-                        "   , ROW ('late_materialization', 'false', 'false', 'boolean', 'Experimental: Use late materialization (including WorkProcessor pipelines)', true)\n" +
-                        "   , ROW ('max_drivers_per_task', '', '', 'integer', 'Maximum number of drivers per task', true)\n" +
-                        "   , ROW ('max_recursion_depth', '10', '10', 'integer', 'Maximum recursion depth for recursive common table expression', true)\n" +
-                        "   , ROW ('max_reordered_joins', '9', '9', 'integer', 'The maximum number of joins to reorder as one group in cost-based join reordering', true)\n" +
-                        "   , ROW ('max_unacknowledged_splits_per_task', '500', '500', 'integer', 'Maximum number of leaf splits awaiting delivery to a given task', true)\n" +
-                        "   , ROW ('merge_project_with_values', 'true', 'true', 'boolean', 'Inline project expressions into values', true)\n" +
-                        "   , ROW ('omit_datetime_type_precision', 'false', 'false', 'boolean', 'Omit precision when rendering datetime type names with default precision', true)\n" +
-                        "   , ROW ('optimize_duplicate_insensitive_joins', 'true', 'true', 'boolean', 'Optimize duplicate insensitive joins', true)\n" +
-                        "   , ROW ('optimize_hash_generation', 'true', 'true', 'boolean', 'Compute hash codes for distribution, joins, and aggregations early in query plan', true)\n" +
-                        "   , ROW ('optimize_metadata_queries', 'false', 'false', 'boolean', 'Enable optimization for metadata queries', true)\n" +
-                        "   , ROW ('optimize_mixed_distinct_aggregations', 'false', 'false', 'boolean', 'Optimize mixed non-distinct and distinct aggregations', true)\n" +
-                        "   , ROW ('optimize_top_n_ranking', 'true', 'true', 'boolean', 'Use top N ranking optimization', true)\n" +
-                        "   , ROW ('parse_decimal_literals_as_double', 'false', 'false', 'boolean', 'Parse decimal literals as DOUBLE instead of DECIMAL', true)\n" +
-                        "   , ROW ('predicate_pushdown_use_table_properties', 'true', 'true', 'boolean', 'Use table properties in predicate pushdown', true)\n" +
-                        "   , ROW ('prefer_partial_aggregation', 'true', 'true', 'boolean', 'Prefer splitting aggregations into partial and final stages', true)\n" +
-                        "   , ROW ('prefer_streaming_operators', 'false', 'false', 'boolean', 'Prefer source table layouts that produce streaming operators', true)\n" +
-                        "   , ROW ('preferred_write_partitioning_min_number_of_partitions', '50', '50', 'integer', 'Use preferred write partitioning when the number of written partitions exceeds the configured threshold', true)\n" +
-                        "   , ROW ('push_aggregation_through_outer_join', 'true', 'true', 'boolean', 'Allow pushing aggregations below joins', true)\n" +
-                        "   , ROW ('push_partial_aggregation_through_join', 'false', 'false', 'boolean', 'Push partial aggregations below joins', true)\n" +
-                        "   , ROW ('push_table_write_through_union', 'true', 'true', 'boolean', 'Parallelize writes when using UNION ALL in queries that write data', true)\n" +
-                        "   , ROW ('query_max_cpu_time', '1000000000.00d', '1000000000.00d', 'varchar', 'Maximum CPU time of a query', true)\n" +
-                        "   , ROW ('query_max_execution_time', '100.00d', '100.00d', 'varchar', 'Maximum execution time of a query', true)\n" +
-                        "   , ROW ('query_max_planning_time', '10.00m', '10.00m', 'varchar', 'Maximum planning time of a query', true)\n" +
-                        "   , ROW ('query_max_run_time', '100.00d', '100.00d', 'varchar', 'Maximum run time of a query (includes the queueing time)', true)\n" +
-                        "   , ROW ('query_max_scan_physical_bytes', '', '', 'varchar', 'Maximum scan physical bytes of a query', true)\n" +
-                        "   , ROW ('query_priority', '1', '1', 'integer', 'The priority of queries. Larger numbers are higher priority', true)\n" +
-                        "   , ROW ('redistribute_writes', 'true', 'true', 'boolean', 'Force parallel distributed writes', true)\n" +
-                        "   , ROW ('required_workers_count', '1', '1', 'integer', 'Minimum number of active workers that must be available before the query will start', true)\n" +
-                        "   , ROW ('required_workers_max_wait_time', '5.00m', '5.00m', 'varchar', 'Maximum time to wait for minimum number of workers before the query is failed', true)\n" +
-                        "   , ROW ('resource_overcommit', 'false', 'false', 'boolean', 'Use resources which are not guaranteed to be available to the query', true)\n" +
-                        "   , ROW ('rewrite_filtering_semi_join_to_inner_join', 'true', 'true', 'boolean', 'Rewrite semi join in filtering context to inner join', true)\n" +
-                        "   , ROW ('scale_writers', 'false', 'false', 'boolean', 'Scale out writers based on throughput (use minimum necessary)', true)\n" +
-                        "   , ROW ('skip_redundant_sort', 'true', 'true', 'boolean', 'Skip redundant sort operations', true)\n" +
-                        "   , ROW ('spatial_join', 'true', 'true', 'boolean', 'Use spatial index for spatial join when possible', true)\n" +
-                        "   , ROW ('spatial_partitioning_table_name', '', '', 'varchar', 'Name of the table containing spatial partitioning scheme', true)\n" +
-                        "   , ROW ('spill_enabled', 'false', 'false', 'boolean', 'Enable spilling', true)\n" +
-                        "   , ROW ('spill_order_by', 'true', 'true', 'boolean', 'Spill in OrderBy if spill_enabled is also set', true)\n" +
-                        "   , ROW ('spill_window_operator', 'true', 'true', 'boolean', 'Spill in WindowOperator if spill_enabled is also set', true)\n" +
-                        "   , ROW ('split_concurrency_adjustment_interval', '100.00ms', '100.00ms', 'varchar', 'Experimental: Interval between changes to the number of concurrent splits per node', true)\n" +
-                        "   , ROW ('statistics_cpu_timer_enabled', 'true', 'true', 'boolean', 'Experimental: Enable cpu time tracking for automatic column statistics collection on write', true)\n" +
-                        "   , ROW ('statistics_precalculation_for_pushdown_enabled', 'false', 'false', 'boolean', 'Enable statistics precalculation for pushdown', true)\n" +
-                        "   , ROW ('table_scan_node_partitioning_min_bucket_to_task_ratio', '0.5', '0.5', 'double', 'Min table scan bucket to task ratio for which plan will be adopted to node pre-partitioned tables', true)\n" +
-                        "   , ROW ('task_concurrency', '16', '16', 'integer', 'Default number of local parallel jobs per worker', true)\n" +
-                        "   , ROW ('task_share_index_loading', 'false', 'false', 'boolean', 'Share index join lookups and caching within a task', true)\n" +
-                        "   , ROW ('task_writer_count', '1', '1', 'integer', 'Default number of local parallel table writer jobs per worker', true)\n" +
-                        "   , ROW ('unwrap_casts', 'true', 'true', 'boolean', 'Enable optimization to unwrap CAST expression', true)\n" +
-                        "   , ROW ('use_legacy_window_filter_pushdown', 'false', 'false', 'boolean', 'Use legacy window filter pushdown optimizer', true)\n" +
-                        "   , ROW ('use_mark_distinct', 'true', 'true', 'boolean', 'Implement DISTINCT aggregations using MarkDistinct', true)\n" +
-                        "   , ROW ('use_preferred_write_partitioning', 'true', 'true', 'boolean', 'Use preferred write partitioning', true)\n" +
-                        "   , ROW ('use_table_scan_node_partitioning', 'true', 'true', 'boolean', 'Adapt plan to node pre-partitioned tables', true)\n" +
-                        "   , ROW ('writer_min_size', '32MB', '32MB', 'varchar', 'Target minimum size of writer output when scaling writers', true)\n" +
+                        "     ROW ('prop1', '1', '1', 'integer', 'des1', true)\n" +
+                        "   , ROW ('prop2', '2', '2', 'integer', 'des2', true)\n" +
                         "   , ROW ('', '', '', '', '', false)\n" +
                         ")  \"session\" (\"name\", \"value\", \"default\", \"type\", \"description\", \"include\")\n" +
                         "WHERE (include AND (name LIKE '%' ESCAPE '$'))\n");
@@ -229,13 +158,24 @@ public class TestStatementRewrite
         transaction(transactionManager, accessControl)
                 .readUncommitted()
                 .execute(beginTransaction(CLIENT_SESSION_BUILDER), session -> {
-                    Statement rewrittenNode = rewrite(session, node, rewriteProvider);
+                    Statement rewrittenNode = rewrite(session, metadata, node, rewriteProvider);
                     String actual = SqlFormatterUtil.getFormattedSql(rewrittenNode, SQL_PARSER);
                     assertThat(actual).isEqualTo(expected);
                 });
     }
 
-    private Statement rewrite(Session session, Statement node, Rewrite rewriteProvider)
+    private void assertFormatSqlWithMockMetadata(Statement node, Rewrite rewriteProvider, String expected)
+    {
+        transaction(transactionManager, accessControl)
+                .readUncommitted()
+                .execute(beginTransaction(CLIENT_SESSION_BUILDER), session -> {
+                    Statement rewrittenNode = rewrite(session, mockMetadata, node, rewriteProvider);
+                    String actual = SqlFormatterUtil.getFormattedSql(rewrittenNode, SQL_PARSER);
+                    assertThat(actual).isEqualTo(expected);
+                });
+    }
+
+    private Statement rewrite(Session session, Metadata metadata, Statement node, Rewrite rewriteProvider)
     {
         return rewriteProvider.rewrite(
                 session,
@@ -267,6 +207,10 @@ public class TestStatementRewrite
         metadata = createTestMetadataManager(transactionManager, new FeaturesConfig());
         metadata.addFunctions(ImmutableList.of(APPLY_FUNCTION));
 
+        // Because the default system property and function could be changed if we implement new feature.
+        // Create a mock metadata to offer testing data for rewrite classes.
+        mockMetadata = new MockMetadata(metadata);
+
         Catalog tpchTestCatalog = createTestingCatalog(TPCH_CATALOG, TPCH_CATALOG_NAME);
         catalogManager.registerCatalog(tpchTestCatalog);
         metadata.getTablePropertyManager().addProperties(TPCH_CATALOG_NAME, tpchTestCatalog.getConnector(TPCH_CATALOG_NAME).getTableProperties());
@@ -283,6 +227,7 @@ public class TestStatementRewrite
         CatalogName systemId = createSystemTablesCatalogName(catalog);
         Connector connector = createTestingConnector();
         metadata.getSessionPropertyManager().addConnectorSessionProperties(new CatalogName(catalogName), connector.getSessionProperties());
+        mockMetadata.getSessionPropertyManager().addConnectorSessionProperties(new CatalogName(catalogName), connector.getSessionProperties());
         InternalNodeManager nodeManager = new InMemoryNodeManager();
         return new Catalog(
                 catalogName,
@@ -329,5 +274,34 @@ public class TestStatementRewrite
                 return ImmutableList.of();
             }
         };
+    }
+
+    private static class MockMetadata
+            extends AbstractMockMetadata
+    {
+        private final Metadata delegate;
+        private final SessionPropertyManager sessionPropertyManager;
+
+        public MockMetadata(Metadata delegate)
+        {
+            this.delegate = delegate;
+            sessionPropertyManager = new SessionPropertyManager(
+                    ImmutableList.of(
+                            integerProperty("prop1", "des1", 1, false),
+                            integerProperty("prop2", "des2", 2, false),
+                            integerProperty("hidden", "hidden", 3, true)));
+        }
+
+        @Override
+        public SessionPropertyManager getSessionPropertyManager()
+        {
+            return sessionPropertyManager;
+        }
+
+        @Override
+        public Map<String, CatalogName> getCatalogNames(Session session)
+        {
+            return delegate.getCatalogNames(session);
+        }
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
@@ -162,7 +162,7 @@ public final class QueryUtil
                 relation,
                 identifier(alias),
                 columnAliases.stream()
-                        .map(QueryUtil::identifier)
+                        .map(QueryUtil::quotedIdentifier)
                         .collect(Collectors.toList()));
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/QueryUtil.java
@@ -74,12 +74,12 @@ public final class QueryUtil
 
     public static SelectItem unaliasedName(String name)
     {
-        return new SingleColumn(identifier(name));
+        return new SingleColumn(quotedIdentifier(name));
     }
 
     public static SelectItem aliasedName(String name, String alias)
     {
-        return new SingleColumn(identifier(name), identifier(alias));
+        return new SingleColumn(quotedIdentifier(name), quotedIdentifier(alias));
     }
 
     public static Select selectList(Expression... expressions)
@@ -118,7 +118,7 @@ public final class QueryUtil
 
     public static SortItem ascending(String name)
     {
-        return new SortItem(identifier(name), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED);
+        return new SortItem(quotedIdentifier(name), SortItem.Ordering.ASCENDING, SortItem.NullOrdering.UNDEFINED);
     }
 
     public static Expression logicalAnd(Expression left, Expression right)
@@ -153,14 +153,14 @@ public final class QueryUtil
 
     public static Relation aliased(Relation relation, String alias)
     {
-        return new AliasedRelation(relation, identifier(alias), null);
+        return new AliasedRelation(relation, quotedIdentifier(alias), null);
     }
 
     public static Relation aliased(Relation relation, String alias, List<String> columnAliases)
     {
         return new AliasedRelation(
                 relation,
-                identifier(alias),
+                quotedIdentifier(alias),
                 columnAliases.stream()
                         .map(QueryUtil::quotedIdentifier)
                         .collect(Collectors.toList()));
@@ -168,7 +168,7 @@ public final class QueryUtil
 
     public static SelectItem aliasedNullToEmpty(String column, String alias)
     {
-        return new SingleColumn(new CoalesceExpression(identifier(column), new StringLiteral("")), identifier(alias));
+        return new SingleColumn(new CoalesceExpression(quotedIdentifier(column), new StringLiteral("")), quotedIdentifier(alias));
     }
 
     public static OrderBy ordering(SortItem... items)


### PR DESCRIPTION
I found the result of `DescribeInputRewrite` and `DescribeOutputRewrite` is wrong. If using `SqlFormatter` to format their result, the syntax of results is wrong.

For example:
1. Prepare a statement `select comment from tpch.tiny.orders` and name it `q1`.
2. Rewrite the sql `DESCRIBE OUTPUT q1`.
3. Formatted the rewrite result to SQL using `SqlFormatter`, and then we will get:
```sql
SELECT
  "Column Name"
, Catalog
, Schema
, Table
, Type
, "Type Size"
, Aliased
FROM
   VALUES 
  ROW ('comment', 'tpch', 'tiny', 'orders', 'varchar(79)', 0, false)
 "Statement Output" ("Column Name", Catalog, Schema, Table, Type, "Type Size", Aliased)
```

This SQL exists two syntax errors.
1. The name of some identifier are the reserved word of trino, such as `Catalog`, `Schema` and `Table`.
2. The part of `VALUES` is a subquery. It needs to be surround with parentheses.

To fix them, I tried to change the result structure of `DescribeInputRewrite` and `DescribeOutputRewrite` and added test cases for them.

After fixing, we can get the correct SQL:
```sql
SELECT
 "Column Name"
, "Catalog"
, "Schema"
, "Table"
, "Type"
, "Type Size"
, "Aliased"
FROM (
 VALUES 
 ROW ('comment', 'tpch', 'tiny', 'orders', 'varchar(79)', 0, false))
"Statement Output" ("Column Name", "Catalog", "Schema", "Table", "Type", "Type Size", "Aliased")
```