### PR TITLE
Support pushdown of `count` aggregation with distinct

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -485,7 +485,6 @@ public class PlanOptimizers
                                         new RemoveRedundantExists(),
                                         new ImplementFilteredAggregations(metadata),
                                         new SingleDistinctAggregationToGroupBy(),
-                                        new MultipleDistinctAggregationToMarkDistinct(),
                                         new MergeLimitWithDistinct(),
                                         new PruneCountAggregationOverScalar(metadata),
                                         new PruneOrderByInAggregation(metadata),
@@ -675,7 +674,8 @@ public class PlanOptimizers
                                 new RemoveEmptyExceptBranches(),
                                 new RemoveRedundantIdentityProjections(),
                                 new PushAggregationThroughOuterJoin(),
-                                new ReplaceRedundantJoinWithSource())), // Run this after PredicatePushDown optimizer as it inlines filter constants
+                                new ReplaceRedundantJoinWithSource(), // Run this after PredicatePushDown optimizer as it inlines filter constants
+                                new MultipleDistinctAggregationToMarkDistinct())), // Run this after aggregation pushdown so that multiple distinct aggregations can be pushed into a connector
                 inlineProjections,
                 simplifyOptimizer, // Re-run the SimplifyExpressions to simplify any recomposed expressions from other optimizations
                 pushProjectionIntoTableScanOptimizer,

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/StandardColumnMappings.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/StandardColumnMappings.java
@@ -262,9 +262,7 @@ public final class StandardColumnMappings
 
     public static SliceWriteFunction charWriteFunction()
     {
-        return (statement, index, value) -> {
-            statement.setString(index, value.toStringUtf8());
-        };
+        return (statement, index, value) -> statement.setString(index, value.toStringUtf8());
     }
 
     public static ColumnMapping defaultVarcharColumnMapping(int columnSize, boolean isRemoteCaseSensitive)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCountDistinct.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCountDistinct.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc.expression;
+
+import io.trino.matching.Capture;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcExpression;
+import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.expression.Variable;
+import io.trino.spi.type.BigintType;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.VarcharType;
+
+import java.util.Optional;
+
+import static com.google.common.base.Verify.verify;
+import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.distinct;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.hasFilter;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Implements {@code count(DISTINCT x)}.
+ */
+public class ImplementCountDistinct
+        implements AggregateFunctionRule
+{
+    private static final Capture<Variable> INPUT = newCapture();
+
+    private final JdbcTypeHandle bigintTypeHandle;
+    private final boolean isRemoteCollationSensitive;
+
+    /**
+     * @param bigintTypeHandle A {@link JdbcTypeHandle} that will be mapped to {@link BigintType} by {@link JdbcClient#toColumnMapping}.
+     */
+    public ImplementCountDistinct(JdbcTypeHandle bigintTypeHandle, boolean isRemoteCollationSensitive)
+    {
+        this.bigintTypeHandle = requireNonNull(bigintTypeHandle, "bigintTypeHandle is null");
+        this.isRemoteCollationSensitive = isRemoteCollationSensitive;
+    }
+
+    @Override
+    public Pattern<AggregateFunction> getPattern()
+    {
+        return Pattern.typeOf(AggregateFunction.class)
+                .with(distinct().equalTo(true))
+                .with(hasFilter().equalTo(false))
+                .with(functionName().equalTo("count"))
+                .with(singleInput().matching(variable().capturedAs(INPUT)));
+    }
+
+    @Override
+    public Optional<JdbcExpression> rewrite(AggregateFunction aggregateFunction, Captures captures, RewriteContext context)
+    {
+        Variable input = captures.get(INPUT);
+        JdbcColumnHandle columnHandle = (JdbcColumnHandle) context.getAssignment(input.getName());
+        verify(aggregateFunction.getOutputType() == BIGINT);
+
+        boolean isCaseSensitiveType = columnHandle.getColumnType() instanceof CharType || columnHandle.getColumnType() instanceof VarcharType;
+        if (aggregateFunction.isDistinct() && !isRemoteCollationSensitive && isCaseSensitiveType) {
+            // Remote database is case insensitive or compares values differently from Trino
+            return Optional.empty();
+        }
+
+        return Optional.of(new JdbcExpression(
+                format("count(DISTINCT %s)", context.getIdentifierQuote().apply(columnHandle.getColumnName())),
+                bigintTypeHandle));
+    }
+}

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -230,7 +230,7 @@ public abstract class BaseJdbcConnectorTest
             return;
         }
 
-        boolean expectAggregationPushdown = hasBehavior(SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY);
+        boolean supportsPushdownWithVarcharInequality = hasBehavior(SUPPORTS_PREDICATE_PUSHDOWN_WITH_VARCHAR_INEQUALITY);
         PlanMatchPattern aggregationOverTableScan = node(AggregationNode.class, node(TableScanNode.class));
         PlanMatchPattern groupingAggregationOverTableScan = node(AggregationNode.class, node(ProjectNode.class, node(TableScanNode.class)));
         try (TestTable table = new TestTable(
@@ -246,7 +246,7 @@ public abstract class BaseJdbcConnectorTest
             assertConditionallyPushedDown(
                     getSession(),
                     "SELECT max(a_string), min(a_string), max(a_char), min(a_char) FROM " + table.getName(),
-                    expectAggregationPushdown,
+                    supportsPushdownWithVarcharInequality,
                     aggregationOverTableScan)
                     .skippingTypesCheck()
                     .matches("VALUES ('b', 'A', 'b', 'A')");
@@ -254,27 +254,27 @@ public abstract class BaseJdbcConnectorTest
             assertConditionallyPushedDown(
                     getSession(),
                     "SELECT distinct a_string FROM " + table.getName(),
-                    expectAggregationPushdown,
+                    supportsPushdownWithVarcharInequality,
                     groupingAggregationOverTableScan)
                     .skippingTypesCheck()
                     .matches("VALUES 'A', 'B', 'a', 'b'");
             assertConditionallyPushedDown(
                     getSession(),
                     "SELECT distinct a_char FROM " + table.getName(),
-                    expectAggregationPushdown,
+                    supportsPushdownWithVarcharInequality,
                     groupingAggregationOverTableScan)
                     .skippingTypesCheck()
                     .matches("VALUES 'A', 'B', 'a', 'b'");
             // case-sensitive grouping sets prevent pushdown
             assertConditionallyPushedDown(getSession(),
                     "SELECT a_string, count(*) FROM " + table.getName() + " GROUP BY a_string",
-                    expectAggregationPushdown,
+                    supportsPushdownWithVarcharInequality,
                     groupingAggregationOverTableScan)
                     .skippingTypesCheck()
                     .matches("VALUES ('A', BIGINT '1'), ('a', BIGINT '1'), ('b', BIGINT '1'), ('B', BIGINT '1')");
             assertConditionallyPushedDown(getSession(),
                     "SELECT a_char, count(*) FROM " + table.getName() + " GROUP BY a_char",
-                    expectAggregationPushdown,
+                    supportsPushdownWithVarcharInequality,
                     groupingAggregationOverTableScan)
                     .skippingTypesCheck()
                     .matches("VALUES ('A', BIGINT '1'), ('B', BIGINT '1'), ('a', BIGINT '1'), ('b', BIGINT '1')");
@@ -286,13 +286,13 @@ public abstract class BaseJdbcConnectorTest
             // DISTINCT over case-sensitive columns prevents pushdown
             assertConditionallyPushedDown(getSession(),
                     "SELECT count(DISTINCT a_string) FROM " + table.getName(),
-                    expectAggregationPushdown,
+                    supportsPushdownWithVarcharInequality,
                     groupingAggregationOverTableScan)
                     .skippingTypesCheck()
                     .matches("VALUES BIGINT '4'");
             assertConditionallyPushedDown(getSession(),
                     "SELECT count(DISTINCT a_char) FROM " + table.getName(),
-                    expectAggregationPushdown,
+                    supportsPushdownWithVarcharInequality,
                     groupingAggregationOverTableScan)
                     .skippingTypesCheck()
                     .matches("VALUES BIGINT '4'");

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -15,6 +15,7 @@ package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
 import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
 import io.trino.plugin.jdbc.UnsupportedTypeHandling;
@@ -32,6 +33,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.UNSUPPORTED_TYPE_HANDLING;
@@ -52,6 +54,7 @@ import static io.trino.sql.tree.SortItem.NullOrdering.FIRST;
 import static io.trino.sql.tree.SortItem.NullOrdering.LAST;
 import static io.trino.sql.tree.SortItem.Ordering.ASCENDING;
 import static io.trino.sql.tree.SortItem.Ordering.DESCENDING;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -263,6 +266,23 @@ public class TestPhoenixConnectorTest
                     "SELECT k, v FROM " + table.getName() + " WHERE v = CAST('x ' AS char(2))",
                     // The 3-spaces value is included because both sides of the comparison are coerced to char(3)
                     "VALUES (4, 'x'), (5, 'x '), (6, 'x  ')");
+        }
+    }
+
+    // Overridden because Phoenix requires a ROWID column
+    @Override
+    public void testCountDistinctWithStringTypes()
+    {
+        assertThatThrownBy(super::testCountDistinctWithStringTypes).hasStackTraceContaining("Illegal data. CHAR types may only contain single byte characters");
+        // Skipping the ą test case because it is not supported
+        List<String> rows = Streams.mapWithIndex(Stream.of("a", "b", "A", "B", " a ", "a", "b", " b "), (value, idx) -> String.format("%d, '%2$s', '%2$s'", idx, value))
+                .collect(toImmutableList());
+        String tableName = "count_distinct_strings" + randomTableSuffix();
+
+        try (TestTable testTable = new TestTable(getQueryRunner()::execute, tableName, "(id int, t_char CHAR(5), t_varchar VARCHAR(5)) WITH (ROWKEYS='id')", rows)) {
+            assertQuery("SELECT count(DISTINCT t_varchar) FROM " + testTable.getName(), "VALUES 6");
+            assertQuery("SELECT count(DISTINCT t_char) FROM " + testTable.getName(), "VALUES 6");
+            assertQuery("SELECT count(DISTINCT t_char), count(DISTINCT t_varchar) FROM " + testTable.getName(), "VALUES (6, 6)");
         }
     }
 

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -50,6 +50,7 @@ import io.trino.plugin.jdbc.expression.ImplementAvgFloatingPoint;
 import io.trino.plugin.jdbc.expression.ImplementCorr;
 import io.trino.plugin.jdbc.expression.ImplementCount;
 import io.trino.plugin.jdbc.expression.ImplementCountAll;
+import io.trino.plugin.jdbc.expression.ImplementCountDistinct;
 import io.trino.plugin.jdbc.expression.ImplementCovariancePop;
 import io.trino.plugin.jdbc.expression.ImplementCovarianceSamp;
 import io.trino.plugin.jdbc.expression.ImplementMinMax;
@@ -282,8 +283,9 @@ public class PostgreSqlClient
                 this::quoted,
                 ImmutableSet.<AggregateFunctionRule<JdbcExpression>>builder()
                         .add(new ImplementCountAll(bigintTypeHandle))
-                        .add(new ImplementCount(bigintTypeHandle))
                         .add(new ImplementMinMax(false))
+                        .add(new ImplementCount(bigintTypeHandle))
+                        .add(new ImplementCountDistinct(bigintTypeHandle, false))
                         .add(new ImplementSum(PostgreSqlClient::toTypeHandle))
                         .add(new ImplementAvgFloatingPoint())
                         .add(new ImplementAvgDecimal())

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -97,7 +97,7 @@ public class TestPostgreSqlClient
         testImplementAggregation(
                 new AggregateFunction("count", BIGINT, List.of(bigintVariable), List.of(), true, Optional.empty()),
                 Map.of(bigintVariable.getName(), BIGINT_COLUMN),
-                Optional.empty());
+                Optional.of("count(DISTINCT \"c_bigint\")"));
 
         // count() FILTER (WHERE ...)
 

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -93,6 +93,7 @@ public class TestPostgreSqlConnectorTest
             case SUPPORTS_AGGREGATION_PUSHDOWN_COVARIANCE:
             case SUPPORTS_AGGREGATION_PUSHDOWN_CORRELATION:
             case SUPPORTS_AGGREGATION_PUSHDOWN_REGRESSION:
+            case SUPPORTS_AGGREGATION_PUSHDOWN_COUNT_DISTINCT:
                 return true;
 
             case SUPPORTS_JOIN_PUSHDOWN:

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
@@ -35,6 +35,7 @@ public enum TestingConnectorBehavior
     SUPPORTS_AGGREGATION_PUSHDOWN_COVARIANCE(false),
     SUPPORTS_AGGREGATION_PUSHDOWN_CORRELATION(false),
     SUPPORTS_AGGREGATION_PUSHDOWN_REGRESSION(false),
+    SUPPORTS_AGGREGATION_PUSHDOWN_COUNT_DISTINCT(false),
 
     SUPPORTS_JOIN_PUSHDOWN(
             // Currently no connector supports Join pushdown by default. JDBC connectors may support Join pushdown and BaseJdbcConnectorTest


### PR DESCRIPTION
Moves the distinct aggregation rewriting optimizers to after PushAggregationIntoTableScan.

TODO: I'm not as familiar with testing around PlanOptimizers, is there a good way to test this?

https://github.com/trinodb/trino/issues/4323