### PR TITLE
Iceberg: support row-level delete and update

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -112,7 +112,7 @@ public class RowBlock
     }
 
     @Override
-    protected Block[] getRawFieldBlocks()
+    public Block[] getRawFieldBlocks()
     {
         return fieldBlocks;
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CommitTaskData.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class CommitTaskData
@@ -25,16 +26,20 @@ public class CommitTaskData
     private final String path;
     private final MetricsWrapper metrics;
     private final Optional<String> partitionDataJson;
+    private final int content;
 
     @JsonCreator
     public CommitTaskData(
             @JsonProperty("path") String path,
             @JsonProperty("metrics") MetricsWrapper metrics,
-            @JsonProperty("partitionDataJson") Optional<String> partitionDataJson)
+            @JsonProperty("partitionDataJson") Optional<String> partitionDataJson,
+            @JsonProperty("content") int content)
     {
         this.path = requireNonNull(path, "path is null");
         this.metrics = requireNonNull(metrics, "metrics is null");
         this.partitionDataJson = requireNonNull(partitionDataJson, "partitionDataJson is null");
+        this.content = content;
+        checkArgument(content >= 0, "content id must be positive");
     }
 
     @JsonProperty
@@ -53,5 +58,11 @@ public class CommitTaskData
     public Optional<String> getPartitionDataJson()
     {
         return partitionDataJson;
+    }
+
+    @JsonProperty
+    public int getContent()
+    {
+        return content;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.types.Types;
 
 import java.util.Objects;
@@ -28,10 +30,14 @@ import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
 import static io.trino.plugin.iceberg.ColumnIdentity.primitiveColumnIdentity;
 import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
 import static java.util.Objects.requireNonNull;
+import static org.apache.iceberg.types.Types.NestedField.required;
 
 public class IcebergColumnHandle
         implements ColumnHandle
 {
+    public static final int ROW_ID_COLUMN_INDEX = Integer.MIN_VALUE;
+    public static final String ROW_ID_COLUMN_NAME = "$row_id";
+
     private final ColumnIdentity columnIdentity;
     private final Type type;
     private final Optional<String> comment;
@@ -115,5 +121,10 @@ public class IcebergColumnHandle
                 createColumnIdentity(column),
                 toTrinoType(column.type(), typeManager),
                 Optional.ofNullable(column.doc()));
+    }
+
+    public static IcebergColumnHandle createUpdateRowIdColumnHandle(Schema tableSchema, TypeManager typeManager)
+    {
+        return create(required(ROW_ID_COLUMN_INDEX, ROW_ID_COLUMN_NAME, DeleteSchemaUtil.posDeleteSchema(tableSchema).asStruct()), typeManager);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -23,6 +23,7 @@ import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
@@ -86,6 +87,7 @@ public class IcebergPageSinkProvider
                 jsonCodec,
                 session,
                 tableHandle.getFileFormat(),
+                FileContent.DATA,
                 maxOpenPartitions);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceUpdate.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceUpdate.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.RowBlock;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.connector.ConnectorPageSink;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.UpdatablePageSource;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static io.trino.plugin.iceberg.IcebergColumnHandle.ROW_ID_COLUMN_NAME;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class IcebergPageSourceUpdate
+        implements UpdatablePageSource
+{
+    private final Slice filePathSlice;
+    private final List<IcebergColumnHandle> queriedColumns;
+    private final List<IcebergColumnHandle> allTableColumns;
+    private final List<IcebergColumnHandle> updateColumns;
+    private final ConnectorPageSource source;
+    private final ConnectorPageSink posDeleteSink;
+    private final ConnectorPageSink updateRowSink;
+
+    public IcebergPageSourceUpdate(
+            String filePath,
+            List<IcebergColumnHandle> queriedColumns,
+            List<IcebergColumnHandle> allTableColumns,
+            List<IcebergColumnHandle> updateColumns,
+            ConnectorPageSource source,
+            ConnectorPageSink posDeleteSink,
+            ConnectorPageSink updateRowSink)
+    {
+        this.filePathSlice = Slices.utf8Slice(requireNonNull(filePath, "filePath is null"));
+        this.queriedColumns = requireNonNull(queriedColumns, "queriedColumns is null");
+        this.allTableColumns = requireNonNull(allTableColumns, "allTableColumns is null");
+        this.updateColumns = requireNonNull(updateColumns, "updateColumns is null");
+        this.source = requireNonNull(source, "source is null");
+        this.posDeleteSink = requireNonNull(posDeleteSink, "posDeleteSink is null");
+        this.updateRowSink = requireNonNull(updateRowSink, "updateRowSink is null");
+    }
+
+    @Override
+    public void deleteRows(Block rowIds)
+    {
+        RowBlock rows = (RowBlock) rowIds;
+        // TODO: need to use proper way to get blocks inside the row block instead of using getRawFieldBlocks(), this is just for POC purpose
+        posDeleteSink.appendPage(new Page(rows.getPositionCount(), rows.getRawFieldBlocks()));
+    }
+
+    @Override
+    public void updateRows(Page page, List<Integer> columnValueAndRowIdChannels)
+    {
+        RowBlock rowIdBlock = (RowBlock) page.getBlock(columnValueAndRowIdChannels.get(columnValueAndRowIdChannels.size() - 1));
+        deleteRows(rowIdBlock);
+        Map<Integer, Block> updatedColumnBlocks = new HashMap<>();
+        for (int i = 0; i < columnValueAndRowIdChannels.size() - 1; i++) {
+            IcebergColumnHandle updatedColumn = updateColumns.get(i);
+            Block updatedValues = page.getBlock(columnValueAndRowIdChannels.get(i));
+            updatedColumnBlocks.put(updatedColumn.getId(), updatedValues);
+        }
+
+        Block[] updatedRows = new Block[allTableColumns.size()];
+        Block[] oldRows = ((RowBlock) rowIdBlock.getRawFieldBlocks()[2]).getRawFieldBlocks();
+        for (int i = 0; i < allTableColumns.size(); i++) {
+            int columnId = allTableColumns.get(i).getId();
+            if (updatedColumnBlocks.containsKey(columnId)) {
+                updatedRows[i] = updatedColumnBlocks.get(columnId);
+            }
+            else {
+                updatedRows[i] = oldRows[i];
+            }
+        }
+
+        updateRowSink.appendPage(new Page(page.getPositionCount(), updatedRows));
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        try {
+            Collection<Slice> slices = posDeleteSink.finish().get();
+            slices.addAll(updateRowSink.finish().get());
+            return CompletableFuture.completedFuture(slices);
+        }
+        catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        Page sourcePage = source.getNextPage();
+        if (sourcePage == null) {
+            return null;
+        }
+        Block[] rowIdComponentBlocks = new Block[3];
+        int channelCount = sourcePage.getChannelCount();
+        int pageSize = sourcePage.getPositionCount();
+        // file_path
+        rowIdComponentBlocks[0] = RunLengthEncodedBlock.create(VARCHAR, filePathSlice, pageSize);
+        rowIdComponentBlocks[1] = sourcePage.getBlock(channelCount - 2);
+        Block[] fieldBlocks = new Block[allTableColumns.size()];
+        for (int i = 0; i < allTableColumns.size(); i++) {
+            fieldBlocks[i] = sourcePage.getBlock(i);
+        }
+        rowIdComponentBlocks[2] = RowBlock.fromFieldBlocks(pageSize, Optional.empty(), fieldBlocks);
+
+        Block[] resultBlocks = new Block[queriedColumns.size()];
+        for (int i = 0; i < queriedColumns.size(); i++) {
+            IcebergColumnHandle columnHandle = queriedColumns.get(i);
+            if (ROW_ID_COLUMN_NAME.equals(columnHandle.getName())) {
+                resultBlocks[i] = RowBlock.fromFieldBlocks(pageSize, Optional.empty(), rowIdComponentBlocks);
+            }
+            else {
+                resultBlocks[i] = sourcePage.getBlock(allTableColumns.indexOf(columnHandle));
+            }
+        }
+        return new Page(sourcePage.getPositionCount(), resultBlocks);
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return source.getSystemMemoryUsage();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        source.close();
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return source.getCompletedBytes();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return source.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return source.isFinished();
+    }
+}


### PR DESCRIPTION
This PR adds support for writing Iceberg position delete. Similar to #8534 , I first present our working internal implementation backported to Trino, some parts might not work because of internal differences, but once we agree with the general approach I will make the fix and add unit tests. 

Also, there is a missing piece that has to be added after #8534 is first merged, so that the `IcebergPageSource` has the ability to retain the row position channel and pass it to the updatable page source.

A few key points:
1. we choose to support row level delete through position delete spec instead of equality delete, this is based on the general guidance from Iceberg that position delete is preferred when possible. Plus the delete write mechanism in Trino fits perfectly with the position delete spec, as data is first scanned and filtered anyway, recording equality wastes the computation effort comparing to recording positions.
2. Trino delete row ID column has Trino type `ROW(string file_path, long pos, row(table schema))`, which matches Iceberg's position delete file schema.
3. update and delete share exactly the same row id type and also `beginXXX` and `finishXXX` operation implementation. The only difference is that update writes new data files after writing the delete files. This is because update in Iceberg is modelled as delete + insert.
4. In the page source provider, if it detects the operation is for DELETE or UPDATE (columns contain row id column), it will automatically read all the table columns (except for the identity partition columns), because the entire row is a part of the position delete schema anyway.
5. I directly reused the current Iceberg sink implementation to write back the position delete rows and updated rows. It's probably not the most optimal, but simple enough for the first iteration.

This is a bare minimum backport, I left some inline TODOs, and also there are many optimizaitons we can make after the base version is checked in, I tried to keep this as simple as possible to avoid too many disagreements around optimization related changes. Please let me know if this looks good or not, thanks!

@phd3 @electrum @findepi @losipiuk @caneGuy @rdblue @hashhar




