### PR TITLE
Fix flaky TestMySqlCaseInsensitiveMapping

### DIFF
--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlCaseInsensitiveMapping.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlCaseInsensitiveMapping.java
@@ -71,4 +71,12 @@ public class TestMySqlCaseInsensitiveMapping
         name = name.replace(identifierQuote, identifierQuote + identifierQuote);
         return identifierQuote + name + identifierQuote;
     }
+
+    @Test
+    public void forceTestNgToRespectSingleThreaded()
+    {
+        // TODO: Remove after updating TestNG to 7.4.0+ (https://github.com/trinodb/trino/issues/8571)
+        // TestNG doesn't enforce @Test(singleThreaded = true) when tests are defined in base class. According to
+        // https://github.com/cbeust/testng/issues/2361#issuecomment-688393166 a workaround it to add a dummy test to the leaf test class.
+    }
 }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlCaseInsensitiveMapping.java
@@ -62,4 +62,12 @@ public class TestPostgreSqlCaseInsensitiveMapping
     {
         return requireNonNull(postgreSqlServer, "postgreSqlServer is null")::execute;
     }
+
+    @Test
+    public void forceTestNgToRespectSingleThreaded()
+    {
+        // TODO: Remove after updating TestNG to 7.4.0+ (https://github.com/trinodb/trino/issues/8571)
+        // TestNG doesn't enforce @Test(singleThreaded = true) when tests are defined in base class. According to
+        // https://github.com/cbeust/testng/issues/2361#issuecomment-688393166 a workaround it to add a dummy test to the leaf test class.
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/8477

According to https://github.com/cbeust/testng/issues/2361#issuecomment-688393166, the workaround is to add a dummy test method to the leaf test class. While the dummy method must be `public`, protected / private methods still let tests run in parallel mode.

Run `./mvnw test -pl :trino-mysql -Dtest=TestMySqlCaseInsensitiveMapping` fail frequently on my laptop, after adding a dummy public test, TestMySqlCaseInsensitiveMapping stop reporting failures.