### PR TITLE
Iceberg: use LocationProvider instead of hardcoded path

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.FileOutputFormat;
-import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
@@ -54,6 +53,7 @@ import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.HiveType.toHiveType;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
+import static io.trino.plugin.iceberg.IcebergUtil.getLocationProvider;
 import static io.trino.plugin.iceberg.IcebergUtil.isIcebergTable;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
@@ -255,7 +255,7 @@ public class HiveTableOperations
     public LocationProvider locationProvider()
     {
         TableMetadata metadata = current();
-        return LocationProviders.locationsFor(metadata.location(), metadata.properties());
+        return getLocationProvider(getSchemaTableName(), metadata.location(), metadata.properties());
     }
 
     private Table getTable()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -145,7 +145,6 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getTableLocation;
 import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumns;
-import static io.trino.plugin.iceberg.IcebergUtil.getDataPath;
 import static io.trino.plugin.iceberg.IcebergUtil.getFileFormat;
 import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableWithMetadata;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
@@ -607,7 +606,8 @@ public class IcebergMetadata
             propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
         }
 
-        TableMetadata metadata = newTableMetadata(schema, partitionSpec, targetPath, propertiesBuilder.build());
+        Map<String, String> properties = propertiesBuilder.build();
+        TableMetadata metadata = newTableMetadata(schema, partitionSpec, targetPath, properties);
 
         transaction = createTableTransaction(tableName, operations, metadata);
 
@@ -618,7 +618,8 @@ public class IcebergMetadata
                 PartitionSpecParser.toJson(metadata.spec()),
                 getColumns(metadata.schema(), typeManager),
                 targetPath,
-                fileFormat);
+                fileFormat,
+                properties);
     }
 
     @Override
@@ -641,8 +642,9 @@ public class IcebergMetadata
                 SchemaParser.toJson(icebergTable.schema()),
                 PartitionSpecParser.toJson(icebergTable.spec()),
                 getColumns(icebergTable.schema(), typeManager),
-                getDataPath(icebergTable.location()),
-                getFileFormat(icebergTable));
+                icebergTable.location(),
+                getFileFormat(icebergTable),
+                icebergTable.properties());
     }
 
     @Override
@@ -1147,8 +1149,9 @@ public class IcebergMetadata
                 SchemaParser.toJson(icebergTable.schema()),
                 PartitionSpecParser.toJson(icebergTable.spec()),
                 getColumns(icebergTable.schema(), typeManager),
-                getDataPath(icebergTable.location()),
-                getFileFormat(icebergTable));
+                icebergTable.location(),
+                getFileFormat(icebergTable),
+                icebergTable.properties());
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSink.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.transforms.Transform;
 
 import java.util.ArrayList;
@@ -84,7 +85,7 @@ public class IcebergPageSink
     private final int maxOpenWriters;
     private final Schema outputSchema;
     private final PartitionSpec partitionSpec;
-    private final String outputPath;
+    private final LocationProvider locationProvider;
     private final IcebergFileWriterFactory fileWriterFactory;
     private final HdfsEnvironment hdfsEnvironment;
     private final HdfsContext hdfsContext;
@@ -103,7 +104,7 @@ public class IcebergPageSink
     public IcebergPageSink(
             Schema outputSchema,
             PartitionSpec partitionSpec,
-            String outputPath,
+            LocationProvider locationProvider,
             IcebergFileWriterFactory fileWriterFactory,
             PageIndexerFactory pageIndexerFactory,
             HdfsEnvironment hdfsEnvironment,
@@ -117,11 +118,11 @@ public class IcebergPageSink
         requireNonNull(inputColumns, "inputColumns is null");
         this.outputSchema = requireNonNull(outputSchema, "outputSchema is null");
         this.partitionSpec = requireNonNull(partitionSpec, "partitionSpec is null");
-        this.outputPath = requireNonNull(outputPath, "outputPath is null");
+        this.locationProvider = requireNonNull(locationProvider, "locationProvider is null");
         this.fileWriterFactory = requireNonNull(fileWriterFactory, "fileWriterFactory is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.hdfsContext = requireNonNull(hdfsContext, "hdfsContext is null");
-        this.jobConf = toJobConf(hdfsEnvironment.getConfiguration(hdfsContext, new Path(outputPath)));
+        this.jobConf = toJobConf(hdfsEnvironment.getConfiguration(hdfsContext, new Path(locationProvider.newDataLocation("data-file"))));
         this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
         this.session = requireNonNull(session, "session is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
@@ -287,9 +288,7 @@ public class IcebergPageSink
             }
 
             Optional<PartitionData> partitionData = getPartitionData(pagePartitioner.getColumns(), page, position);
-            Optional<String> partitionPath = partitionData.map(partitionSpec::partitionToPath);
-
-            WriteContext writer = createWriter(partitionPath, partitionData);
+            WriteContext writer = createWriter(partitionData);
 
             writers.set(writerIndex, writer);
         }
@@ -299,14 +298,11 @@ public class IcebergPageSink
         return writerIndexes;
     }
 
-    private WriteContext createWriter(Optional<String> partitionPath, Optional<PartitionData> partitionData)
+    private WriteContext createWriter(Optional<PartitionData> partitionData)
     {
-        Path outputPath = new Path(this.outputPath);
-        if (partitionPath.isPresent()) {
-            outputPath = new Path(outputPath, partitionPath.get());
-        }
-        outputPath = new Path(outputPath, randomUUID().toString());
-        outputPath = new Path(fileFormat.addExtension(outputPath.toString()));
+        String fileName = fileFormat.addExtension(randomUUID().toString());
+        Path outputPath = partitionData.map(partition -> new Path(locationProvider.newDataLocation(partitionSpec, partition, fileName)))
+                .orElse(new Path(locationProvider.newDataLocation(fileName)));
 
         IcebergFileWriter writer = fileWriterFactory.createFileWriter(
                 outputPath,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSinkProvider.java
@@ -23,13 +23,16 @@ import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.SchemaTableName;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.io.LocationProvider;
 
 import javax.inject.Inject;
 
+import static io.trino.plugin.iceberg.IcebergUtil.getLocationProvider;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergPageSinkProvider
@@ -74,10 +77,12 @@ public class IcebergPageSinkProvider
         HdfsContext hdfsContext = new HdfsContext(session);
         Schema schema = SchemaParser.fromJson(tableHandle.getSchemaAsJson());
         PartitionSpec partitionSpec = PartitionSpecParser.fromJson(schema, tableHandle.getPartitionSpecAsJson());
+        LocationProvider locationProvider = getLocationProvider(new SchemaTableName(tableHandle.getSchemaName(), tableHandle.getTableName()),
+                tableHandle.getOutputPath(), tableHandle.getStorageProperties());
         return new IcebergPageSink(
                 schema,
                 partitionSpec,
-                tableHandle.getOutputPath(),
+                locationProvider,
                 fileWriterFactory,
                 pageIndexerFactory,
                 hdfsEnvironment,

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergWritableTableHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergWritableTableHandle.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.ConnectorOutputTableHandle;
 import org.apache.iceberg.FileFormat;
 
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
@@ -34,6 +35,7 @@ public class IcebergWritableTableHandle
     private final List<IcebergColumnHandle> inputColumns;
     private final String outputPath;
     private final FileFormat fileFormat;
+    private final Map<String, String> storageProperties;
 
     @JsonCreator
     public IcebergWritableTableHandle(
@@ -43,7 +45,8 @@ public class IcebergWritableTableHandle
             @JsonProperty("partitionSpecAsJson") String partitionSpecAsJson,
             @JsonProperty("inputColumns") List<IcebergColumnHandle> inputColumns,
             @JsonProperty("outputPath") String outputPath,
-            @JsonProperty("fileFormat") FileFormat fileFormat)
+            @JsonProperty("fileFormat") FileFormat fileFormat,
+            @JsonProperty("properties") Map<String, String> storageProperties)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -52,6 +55,7 @@ public class IcebergWritableTableHandle
         this.inputColumns = ImmutableList.copyOf(requireNonNull(inputColumns, "inputColumns is null"));
         this.outputPath = requireNonNull(outputPath, "outputPath is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
+        this.storageProperties = requireNonNull(storageProperties, "storageProperties is null");
     }
 
     @JsonProperty
@@ -94,6 +98,12 @@ public class IcebergWritableTableHandle
     public FileFormat getFileFormat()
     {
         return fileFormat;
+    }
+
+    @JsonProperty
+    public Map<String, String> getStorageProperties()
+    {
+        return storageProperties;
     }
 
     @Override

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -22,6 +22,7 @@ import java.sql.Timestamp;
 
 import static io.trino.tempto.assertions.QueryAssert.Row;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.ICEBERG;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
@@ -446,6 +447,9 @@ public class TestIcebergSparkCompatibility
         assertThat(queryResult).hasRowsCount(1).hasColumnsCount(1);
         assertTrue(((String) queryResult.row(0).get(0)).contains(dataPath));
 
+        // TODO: support path override in Iceberg table creation: https://github.com/trinodb/trino/issues/8861
+        assertQueryFailure(() -> onTrino().executeQuery("DROP TABLE " + trinoTableName))
+                .hasMessageContaining("contains Iceberg path override properties and cannot be dropped from Trino");
         onSpark().executeQuery("DROP TABLE " + sparkTableName);
     }
 


### PR DESCRIPTION
Use Iceberg's `LocationProvider` instead of hard-coding file paths. With the current hard-coded Hive-based file paths to write data files, users on cloud storage cannot enjoy the benefit of Iceberg's `ObjectStorageLocationProvider`. This PR fixes this issue.