### PR TITLE
Iceberg: support Iceberg native catalog, initial refactoring

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CatalogType.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/CatalogType.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+public enum CatalogType
+{
+    HIVE,
+    HADOOP,
+
+    /**/;
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -22,6 +22,7 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import static io.trino.plugin.hive.HiveCompressionCodec.GZIP;
+import static io.trino.plugin.iceberg.CatalogType.HIVE;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 
 public class IcebergConfig
@@ -30,6 +31,19 @@ public class IcebergConfig
     private HiveCompressionCodec compressionCodec = GZIP;
     private boolean useFileSizeFromMetadata = true;
     private int maxPartitionsPerWriter = 100;
+    private CatalogType catalogType = HIVE;
+
+    public CatalogType getCatalogType()
+    {
+        return catalogType;
+    }
+
+    @Config("iceberg.catalog.type")
+    public IcebergConfig setCatalogType(CatalogType catalogType)
+    {
+        this.catalogType = catalogType;
+        return this;
+    }
 
     @NotNull
     public FileFormat getFileFormat()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -129,11 +129,11 @@ public class IcebergMetadata
     public IcebergMetadata(
             TypeManager typeManager,
             JsonCodec<CommitTaskData> commitTaskCodec,
-            TrinoCatalogFactory catalogFactory)
+            TrinoCatalog catalog)
     {
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
-        this.catalog = requireNonNull(catalogFactory, "catalogFactory is null").create();
+        this.catalog = requireNonNull(catalog, "catalog is null");
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -20,22 +20,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.airlift.json.JsonCodec;
-import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
-import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.base.classloader.ClassLoaderSafeSystemTable;
-import io.trino.plugin.hive.HdfsEnvironment;
-import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
-import io.trino.plugin.hive.HiveSchemaProperties;
 import io.trino.plugin.hive.HiveWrittenPartitions;
-import io.trino.plugin.hive.TableAlreadyExistsException;
-import io.trino.plugin.hive.authentication.HiveIdentity;
-import io.trino.plugin.hive.metastore.Column;
-import io.trino.plugin.hive.metastore.Database;
-import io.trino.plugin.hive.metastore.HiveMetastore;
-import io.trino.plugin.hive.metastore.HivePrincipal;
-import io.trino.plugin.hive.metastore.PrincipalPrivileges;
-import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
@@ -55,8 +42,6 @@ import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.DiscretePredicates;
 import io.trino.spi.connector.MaterializedViewFreshness;
-import io.trino.spi.connector.MaterializedViewNotFoundException;
-import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SystemTable;
@@ -68,166 +53,107 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ComputedStatistics;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.TypeManager;
-import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.AppendFiles;
-import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFiles;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionField;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Snapshot;
-import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.TypeUtil;
-import org.apache.iceberg.types.Types;
-import org.apache.iceberg.types.Types.NestedField;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
-import static io.trino.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
-import static io.trino.plugin.hive.HiveMetadata.STORAGE_TABLE;
-import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
-import static io.trino.plugin.hive.HiveType.HIVE_STRING;
-import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
-import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
-import static io.trino.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
-import static io.trino.plugin.hive.util.HiveWriteUtils.getTableDefaultLocation;
 import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
-import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.decodeMaterializedViewData;
-import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.encodeMaterializedViewData;
-import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.fromConnectorMaterializedViewDefinition;
-import static io.trino.plugin.iceberg.IcebergSchemaProperties.getSchemaLocation;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
-import static io.trino.plugin.iceberg.IcebergTableProperties.getFileFormat;
-import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
-import static io.trino.plugin.iceberg.IcebergTableProperties.getTableLocation;
 import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
 import static io.trino.plugin.iceberg.IcebergUtil.getColumns;
 import static io.trino.plugin.iceberg.IcebergUtil.getDataPath;
 import static io.trino.plugin.iceberg.IcebergUtil.getFileFormat;
-import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableWithMetadata;
+import static io.trino.plugin.iceberg.IcebergUtil.getNewCreateTableTransaction;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
 import static io.trino.plugin.iceberg.IcebergUtil.getTableComment;
-import static io.trino.plugin.iceberg.IcebergUtil.isIcebergTable;
-import static io.trino.plugin.iceberg.IcebergUtil.loadIcebergTable;
-import static io.trino.plugin.iceberg.PartitionFields.parsePartitionFields;
+import static io.trino.plugin.iceberg.IcebergUtil.toNamespace;
+import static io.trino.plugin.iceberg.IcebergUtil.toTableId;
 import static io.trino.plugin.iceberg.PartitionFields.toPartitionFields;
 import static io.trino.plugin.iceberg.TableType.DATA;
 import static io.trino.plugin.iceberg.TypeConverter.toIcebergType;
 import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
-import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
-import static io.trino.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
-import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
-import static org.apache.hadoop.hive.metastore.TableType.VIRTUAL_VIEW;
-import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
-import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
-import static org.apache.iceberg.TableMetadata.newTableMetadata;
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
-import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
-import static org.apache.iceberg.Transactions.createTableTransaction;
 
 public class IcebergMetadata
         implements ConnectorMetadata
 {
-    private static final Logger log = Logger.get(IcebergMetadata.class);
-    private static final String ICEBERG_MATERIALIZED_VIEW_COMMENT = "Presto Materialized View";
+    public static final String ICEBERG_MATERIALIZED_VIEW_COMMENT = "Presto Materialized View";
     public static final String DEPENDS_ON_TABLES = "dependsOnTables";
 
-    private final CatalogName catalogName;
-    private final HiveMetastore metastore;
-    private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
     private final JsonCodec<CommitTaskData> commitTaskCodec;
-    private final HiveTableOperationsProvider tableOperationsProvider;
+    private final TrinoCatalog catalog;
 
     private final Map<String, Optional<Long>> snapshotIds = new ConcurrentHashMap<>();
-    private final Map<SchemaTableName, TableMetadata> tableMetadataCache = new ConcurrentHashMap<>();
 
     private Transaction transaction;
 
     public IcebergMetadata(
-            CatalogName catalogName,
-            HiveMetastore metastore,
-            HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
             JsonCodec<CommitTaskData> commitTaskCodec,
-            HiveTableOperationsProvider tableOperationsProvider)
+            TrinoCatalogFactory catalogFactory)
     {
-        this.catalogName = requireNonNull(catalogName, "catalogName is null");
-        this.metastore = requireNonNull(metastore, "metastore is null");
-        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
-        this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
+        this.catalog = requireNonNull(catalogFactory, "catalogFactory is null").create();
     }
 
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
-        return metastore.getAllDatabases();
+        return catalog.listNamespaces(session).stream()
+                .map(Namespace::toString)
+                .collect(toImmutableList());
     }
 
     @Override
     public Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName)
     {
-        Optional<Database> db = metastore.getDatabase(schemaName.getSchemaName());
-        if (db.isPresent()) {
-            return HiveSchemaProperties.fromDatabase(db.get());
-        }
-
-        throw new SchemaNotFoundException(schemaName.getSchemaName());
+        return catalog.loadNamespaceMetadataObjects(toNamespace(schemaName), session);
     }
 
     @Override
     public Optional<TrinoPrincipal> getSchemaOwner(ConnectorSession session, CatalogSchemaName schemaName)
     {
-        Optional<Database> database = metastore.getDatabase(schemaName.getSchemaName());
-        if (database.isPresent()) {
-            return database.flatMap(db -> Optional.of(new TrinoPrincipal(db.getOwnerType(), db.getOwnerName())));
-        }
-
-        throw new SchemaNotFoundException(schemaName.getSchemaName());
+        return catalog.getNamespacePrincipal(toNamespace(schemaName), session);
     }
 
     @Override
@@ -236,18 +162,12 @@ public class IcebergMetadata
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
         verify(name.getTableType() == DATA, "Wrong table type: " + name.getTableType());
 
-        Optional<Table> hiveTable = metastore.getTable(new HiveIdentity(session), tableName.getSchemaName(), name.getTableName());
-        if (hiveTable.isEmpty()) {
+        TableIdentifier tableId = toTableId(tableName);
+        if (!catalog.tableExists(tableId, session)) {
             return null;
-        }
-        if (isMaterializedView(hiveTable.get())) {
-            return null;
-        }
-        if (!isIcebergTable(hiveTable.get())) {
-            throw new UnknownTableTypeException(tableName);
         }
 
-        org.apache.iceberg.Table table = getIcebergTable(session, hiveTable.get().getSchemaTableName());
+        Table table = catalog.loadTable(tableId, session);
         Optional<Long> snapshotId = getSnapshotId(table, name.getSnapshotId());
 
         return new IcebergTableHandle(
@@ -270,12 +190,12 @@ public class IcebergMetadata
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
 
-        Optional<Table> hiveTable = metastore.getTable(new HiveIdentity(session), tableName.getSchemaName(), name.getTableName());
-        if (hiveTable.isEmpty() || !isIcebergTable(hiveTable.get())) {
+        TableIdentifier tableId = TableIdentifier.of(tableName.getSchemaName(), name.getTableName());
+        if (!catalog.tableExists(tableId, session)) {
             return Optional.empty();
         }
 
-        org.apache.iceberg.Table table = getIcebergTable(session, hiveTable.get().getSchemaTableName());
+        Table table = catalog.loadTable(tableId, session);
 
         SchemaTableName systemTableName = new SchemaTableName(tableName.getSchemaName(), name.getTableNameWithType());
         switch (name.getTableType()) {
@@ -312,7 +232,7 @@ public class IcebergMetadata
             return new ConnectorTableProperties(TupleDomain.none(), Optional.empty(), Optional.empty(), Optional.empty(), ImmutableList.of());
         }
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
+        Table icebergTable = catalog.loadTable(toTableId(table.getSchemaTableName()), session);
 
         // Extract identity partition fields that are present in all partition specs, for creating the discrete predicates.
         Set<Integer> partitionSourceIds = identityPartitionColumnsInAllSpecs(icebergTable);
@@ -392,30 +312,16 @@ public class IcebergMetadata
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
-        ImmutableList.Builder<SchemaTableName> tablesListBuilder = ImmutableList.builder();
-        schemaName.map(Collections::singletonList)
-                .orElseGet(metastore::getAllDatabases)
-                .stream()
-                .flatMap(schema -> Stream.concat(
-                        // Get tables with parameter table_type set to  "ICEBERG" or "iceberg". This is required because
-                        // Trino uses lowercase value whereas Spark and Flink use uppercase.
-                        // TODO: use one metastore call to pass both the filters: https://github.com/trinodb/trino/issues/7710
-                        metastore.getTablesWithParameter(schema, TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toLowerCase(Locale.ENGLISH)).stream()
-                                .map(table -> new SchemaTableName(schema, table)),
-                        metastore.getTablesWithParameter(schema, TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH)).stream()
-                                .map(table -> new SchemaTableName(schema, table)))
-                        .distinct())  // distinct() to avoid duplicates for case-insensitive HMS backends
-                .forEach(tablesListBuilder::add);
-
-        tablesListBuilder.addAll(listMaterializedViews(session, schemaName));
-        return tablesListBuilder.build();
+        return catalog.listTables(schemaName.map(Namespace::of).orElse(null), session).stream()
+                .map(IcebergUtil::fromTableId)
+                .collect(toImmutableList());
     }
 
     @Override
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
+        Table icebergTable = catalog.loadTable(toTableId(table.getSchemaTableName()), session);
         return getColumns(icebergTable.schema(), typeManager).stream()
                 .collect(toImmutableMap(IcebergColumnHandle::getName, identity()));
     }
@@ -456,47 +362,25 @@ public class IcebergMetadata
     @Override
     public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, TrinoPrincipal owner)
     {
-        Optional<String> location = getSchemaLocation(properties).map(uri -> {
-            try {
-                hdfsEnvironment.getFileSystem(new HdfsContext(session), new Path(uri));
-            }
-            catch (IOException | IllegalArgumentException e) {
-                throw new TrinoException(INVALID_SCHEMA_PROPERTY, "Invalid location URI: " + uri, e);
-            }
-            return uri;
-        });
-
-        Database database = Database.builder()
-                .setDatabaseName(schemaName)
-                .setLocation(location)
-                .setOwnerType(owner.getType())
-                .setOwnerName(owner.getName())
-                .build();
-
-        metastore.createDatabase(new HiveIdentity(session), database);
+        catalog.createNamespaceWithPrincipal(Namespace.of(schemaName), properties, owner, session);
     }
 
     @Override
     public void dropSchema(ConnectorSession session, String schemaName)
     {
-        // basic sanity check to provide a better error message
-        if (!listTables(session, Optional.of(schemaName)).isEmpty() ||
-                !listViews(session, Optional.of(schemaName)).isEmpty()) {
-            throw new TrinoException(SCHEMA_NOT_EMPTY, "Schema not empty: " + schemaName);
-        }
-        metastore.dropDatabase(new HiveIdentity(session), schemaName);
+        catalog.dropNamespace(Namespace.of(schemaName), session);
     }
 
     @Override
     public void renameSchema(ConnectorSession session, String source, String target)
     {
-        metastore.renameDatabase(new HiveIdentity(session), source, target);
+        catalog.renameNamespace(Namespace.of(source), Namespace.of(target), session);
     }
 
     @Override
     public void setSchemaAuthorization(ConnectorSession session, String source, TrinoPrincipal principal)
     {
-        metastore.setDatabaseOwner(new HiveIdentity(session), source, HivePrincipal.from(principal));
+        catalog.setNamespacePrincipal(Namespace.of(source), principal, session);
     }
 
     @Override
@@ -510,69 +394,21 @@ public class IcebergMetadata
     public void setTableComment(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<String> comment)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        metastore.commentTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), comment);
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
-        if (comment.isEmpty()) {
-            icebergTable.updateProperties().remove(TABLE_COMMENT).commit();
-        }
-        else {
-            icebergTable.updateProperties().set(TABLE_COMMENT, comment.get()).commit();
-        }
+        catalog.updateTableComment(TableIdentifier.of(handle.getSchemaName(), handle.getTableName()), comment, session);
     }
 
     @Override
     public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
     {
-        SchemaTableName schemaTableName = tableMetadata.getTable();
-        String schemaName = schemaTableName.getSchemaName();
-        String tableName = schemaTableName.getTableName();
-
-        Schema schema = toIcebergSchema(tableMetadata.getColumns());
-
-        PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
-
-        Database database = metastore.getDatabase(schemaName)
-                .orElseThrow(() -> new SchemaNotFoundException(schemaName));
-
-        HdfsContext hdfsContext = new HdfsContext(session);
-        HiveIdentity identity = new HiveIdentity(session);
-        String targetPath = getTableLocation(tableMetadata.getProperties());
-        if (targetPath == null) {
-            targetPath = getTableDefaultLocation(database, hdfsContext, hdfsEnvironment, schemaName, tableName).toString();
-        }
-
-        TableOperations operations = tableOperationsProvider.createTableOperations(
-                hdfsContext,
-                session.getQueryId(),
-                identity,
-                schemaName,
-                tableName,
-                Optional.of(session.getUser()),
-                Optional.of(targetPath));
-
-        if (operations.current() != null) {
-            throw new TableAlreadyExistsException(schemaTableName);
-        }
-
-        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(2);
-        FileFormat fileFormat = getFileFormat(tableMetadata.getProperties());
-        propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toString());
-        if (tableMetadata.getComment().isPresent()) {
-            propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
-        }
-
-        TableMetadata metadata = newTableMetadata(schema, partitionSpec, targetPath, propertiesBuilder.build());
-
-        transaction = createTableTransaction(tableName, operations, metadata);
-
+        transaction = getNewCreateTableTransaction(catalog, tableMetadata, session);
         return new IcebergWritableTableHandle(
-                schemaName,
-                tableName,
-                SchemaParser.toJson(metadata.schema()),
-                PartitionSpecParser.toJson(metadata.spec()),
-                getColumns(metadata.schema(), typeManager),
-                targetPath,
-                fileFormat);
+                tableMetadata.getTable().getSchemaName(),
+                tableMetadata.getTable().getTableName(),
+                SchemaParser.toJson(transaction.table().schema()),
+                PartitionSpecParser.toJson(transaction.table().spec()),
+                getColumns(transaction.table().schema(), typeManager),
+                transaction.table().location(),
+                getFileFormat(transaction.table()));
     }
 
     @Override
@@ -585,7 +421,7 @@ public class IcebergMetadata
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
+        Table icebergTable = catalog.loadTable(toTableId(table.getSchemaTableName()), session);
 
         transaction = icebergTable.newTransaction();
 
@@ -603,7 +439,7 @@ public class IcebergMetadata
     public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
         IcebergWritableTableHandle table = (IcebergWritableTableHandle) insertHandle;
-        org.apache.iceberg.Table icebergTable = transaction.table();
+        Table icebergTable = transaction.table();
 
         List<CommitTaskData> commitTasks = fragments.stream()
                 .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
@@ -615,11 +451,10 @@ public class IcebergMetadata
                 .toArray(Type[]::new);
 
         AppendFiles appendFiles = transaction.newFastAppend();
+        FileIO fileIO = transaction.table().io();
         for (CommitTaskData task : commitTasks) {
-            HdfsContext context = new HdfsContext(session);
-
             DataFiles.Builder builder = DataFiles.builder(icebergTable.spec())
-                    .withInputFile(new HdfsInputFile(new Path(task.getPath()), hdfsEnvironment, context))
+                    .withInputFile(fileIO.newInputFile(task.getPath()))
                     .withFormat(table.getFileFormat())
                     .withMetrics(task.getMetrics().metrics());
 
@@ -656,50 +491,46 @@ public class IcebergMetadata
     @Override
     public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        metastore.dropTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), true);
+        catalog.dropTable(toTableId(tableHandle), true, session);
     }
 
     @Override
     public void renameTable(ConnectorSession session, ConnectorTableHandle tableHandle, SchemaTableName newTable)
     {
-        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        metastore.renameTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName(), newTable.getSchemaName(), newTable.getTableName());
+        catalog.renameTable(toTableId(tableHandle), toTableId(newTable), session);
     }
 
     @Override
     public void addColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnMetadata column)
     {
-        IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
+        Table icebergTable = catalog.loadTable(toTableId(tableHandle), session);
         icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType())).commit();
     }
 
     @Override
     public void dropColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle column)
     {
-        IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
         IcebergColumnHandle handle = (IcebergColumnHandle) column;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, icebergTableHandle.getSchemaTableName());
+        Table icebergTable = catalog.loadTable(toTableId(tableHandle), session);
         icebergTable.updateSchema().deleteColumn(handle.getName()).commit();
     }
 
     @Override
     public void renameColumn(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle source, String target)
     {
-        IcebergTableHandle icebergTableHandle = (IcebergTableHandle) tableHandle;
         IcebergColumnHandle columnHandle = (IcebergColumnHandle) source;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, icebergTableHandle.getSchemaTableName());
+        Table icebergTable = catalog.loadTable(toTableId(tableHandle), session);
         icebergTable.updateSchema().renameColumn(columnHandle.getName(), target).commit();
     }
 
     private ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName table)
     {
-        if (metastore.getTable(new HiveIdentity(session), table.getSchemaName(), table.getTableName()).isEmpty()) {
+        TableIdentifier tableId = toTableId(table);
+        if (!catalog.tableExists(tableId, session)) {
             throw new TableNotFoundException(table);
         }
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table);
+        Table icebergTable = catalog.loadTable(tableId, session);
 
         List<ColumnMetadata> columns = getColumnMetadatas(icebergTable);
 
@@ -712,7 +543,7 @@ public class IcebergMetadata
         return new ConnectorTableMetadata(table, columns, properties.build(), getTableComment(icebergTable));
     }
 
-    private List<ColumnMetadata> getColumnMetadatas(org.apache.iceberg.Table table)
+    private List<ColumnMetadata> getColumnMetadatas(Table table)
     {
         return table.schema().columns().stream()
                 .map(column -> {
@@ -724,25 +555,6 @@ public class IcebergMetadata
                             .build();
                 })
                 .collect(toImmutableList());
-    }
-
-    private static Schema toIcebergSchema(List<ColumnMetadata> columns)
-    {
-        List<NestedField> icebergColumns = new ArrayList<>();
-        for (ColumnMetadata column : columns) {
-            if (!column.isHidden()) {
-                int index = icebergColumns.size();
-                Type type = toIcebergType(column.getType());
-                NestedField field = column.isNullable()
-                        ? NestedField.optional(index, column.getName(), type, column.getComment())
-                        : NestedField.required(index, column.getName(), type, column.getComment());
-                icebergColumns.add(field);
-            }
-        }
-        Type icebergSchema = Types.StructType.of(icebergColumns);
-        AtomicInteger nextFieldId = new AtomicInteger(1);
-        icebergSchema = TypeUtil.assignFreshIds(icebergSchema, nextFieldId::getAndIncrement);
-        return new Schema(icebergSchema.asStructType().fields());
     }
 
     @Override
@@ -762,7 +574,7 @@ public class IcebergMetadata
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
+        Table icebergTable = catalog.loadTable(toTableId(handle.getSchemaTableName()), session);
 
         icebergTable.newDelete()
                 .deleteFromRowFilter(toIcebergExpression(handle.getEnforcedPredicate()))
@@ -787,7 +599,7 @@ public class IcebergMetadata
     public Optional<ConstraintApplicationResult<ConnectorTableHandle>> applyFilter(ConnectorSession session, ConnectorTableHandle handle, Constraint constraint)
     {
         IcebergTableHandle table = (IcebergTableHandle) handle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
+        Table icebergTable = catalog.loadTable(toTableId(table.getSchemaTableName()), session);
 
         Set<Integer> partitionSourceIds = identityPartitionColumnsInAllSpecs(icebergTable);
         BiPredicate<IcebergColumnHandle, Domain> isIdentityPartition = (column, domain) -> partitionSourceIds.contains(column.getId());
@@ -820,7 +632,7 @@ public class IcebergMetadata
                 false));
     }
 
-    private static Set<Integer> identityPartitionColumnsInAllSpecs(org.apache.iceberg.Table table)
+    private static Set<Integer> identityPartitionColumnsInAllSpecs(Table table)
     {
         // Extract identity partition column source ids common to ALL specs
         return table.spec().fields().stream()
@@ -834,113 +646,32 @@ public class IcebergMetadata
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, handle.getSchemaTableName());
+        Table icebergTable = catalog.loadTable(toTableId(handle.getSchemaTableName()), session);
         return TableStatisticsMaker.getTableStatistics(typeManager, constraint, handle, icebergTable);
     }
 
-    private Optional<Long> getSnapshotId(org.apache.iceberg.Table table, Optional<Long> snapshotId)
+    private Optional<Long> getSnapshotId(Table table, Optional<Long> snapshotId)
     {
         return snapshotIds.computeIfAbsent(table.toString(), ignored -> snapshotId
                 .map(id -> IcebergUtil.resolveSnapshotId(table, id))
                 .or(() -> Optional.ofNullable(table.currentSnapshot()).map(Snapshot::snapshotId)));
     }
 
-    org.apache.iceberg.Table getIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
+    Table getIcebergTable(ConnectorSession session, SchemaTableName schemaTableName)
     {
-        TableMetadata metadata = tableMetadataCache.computeIfAbsent(
-                schemaTableName,
-                ignore -> ((BaseTable) loadIcebergTable(tableOperationsProvider, session, schemaTableName)).operations().current());
-
-        return getIcebergTableWithMetadata(tableOperationsProvider, session, schemaTableName, metadata);
+        return catalog.loadTable(toTableId(schemaTableName), session);
     }
 
     @Override
     public void createMaterializedView(ConnectorSession session, SchemaTableName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
     {
-        HiveIdentity identity = new HiveIdentity(session);
-        Optional<Table> existing = metastore.getTable(identity, viewName.getSchemaName(), viewName.getTableName());
-
-        // It's a create command where the materialized view already exists and 'if not exists' clause is not specified
-        if (!replace && existing.isPresent()) {
-            if (ignoreExisting) {
-                return;
-            }
-            throw new TrinoException(ALREADY_EXISTS, "Materialized view already exists: " + viewName);
-        }
-
-        // Generate a storage table name and create a storage table. The properties in the definition are table properties for the
-        // storage table as indicated in the materialized view definition.
-        String storageTableName = "st_" + UUID.randomUUID().toString().replace("-", "");
-        Map<String, Object> storageTableProperties = new HashMap<>(definition.getProperties());
-        storageTableProperties.putIfAbsent(FILE_FORMAT_PROPERTY, DEFAULT_FILE_FORMAT_DEFAULT);
-
-        SchemaTableName storageTable = new SchemaTableName(viewName.getSchemaName(), storageTableName);
-        List<ColumnMetadata> columns = definition.getColumns().stream()
-                .map(column -> new ColumnMetadata(column.getName(), typeManager.getType(column.getType())))
-                .collect(toImmutableList());
-
-        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(storageTable, columns, storageTableProperties, Optional.empty());
-        Optional<ConnectorNewTableLayout> layout = getNewTableLayout(session, tableMetadata);
-        finishCreateTable(session, beginCreateTable(session, tableMetadata, layout), ImmutableList.of(), ImmutableList.of());
-
-        // Create a view indicating the storage table
-        Map<String, String> viewProperties = ImmutableMap.<String, String>builder()
-                .put(PRESTO_QUERY_ID_NAME, session.getQueryId())
-                .put(STORAGE_TABLE, storageTableName)
-                .put(PRESTO_VIEW_FLAG, "true")
-                .put(TABLE_COMMENT, ICEBERG_MATERIALIZED_VIEW_COMMENT)
-                .build();
-
-        Column dummyColumn = new Column("dummy", HIVE_STRING, Optional.empty());
-
-        String schemaName = viewName.getSchemaName();
-        String tableName = viewName.getTableName();
-        Table.Builder tableBuilder = Table.builder()
-                .setDatabaseName(schemaName)
-                .setTableName(tableName)
-                .setOwner(session.getUser())
-                .setTableType(VIRTUAL_VIEW.name())
-                .setDataColumns(ImmutableList.of(dummyColumn))
-                .setPartitionColumns(ImmutableList.of())
-                .setParameters(viewProperties)
-                .withStorage(storage -> storage.setStorageFormat(VIEW_STORAGE_FORMAT))
-                .withStorage(storage -> storage.setLocation(""))
-                .setViewOriginalText(Optional.of(
-                        encodeMaterializedViewData(fromConnectorMaterializedViewDefinition(definition))))
-                .setViewExpandedText(Optional.of("/* Presto Materialized View */"));
-        Table table = tableBuilder.build();
-        PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(session.getUser());
-        if (existing.isPresent() && replace) {
-            // drop the current storage table
-            String oldStorageTable = existing.get().getParameters().get(STORAGE_TABLE);
-            if (oldStorageTable != null) {
-                metastore.dropTable(identity, viewName.getSchemaName(), oldStorageTable, true);
-            }
-            // Replace the existing view definition
-            metastore.replaceTable(identity, viewName.getSchemaName(), viewName.getTableName(), table, principalPrivileges);
-            return;
-        }
-        // create the view definition
-        metastore.createTable(identity, table, principalPrivileges);
+        catalog.createMaterializedView(toTableId(viewName), definition, replace, ignoreExisting, session);
     }
 
     @Override
     public void dropMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
-        final HiveIdentity identity = new HiveIdentity(session);
-        Table view = metastore.getTable(identity, viewName.getSchemaName(), viewName.getTableName())
-                .orElseThrow(() -> new MaterializedViewNotFoundException(viewName));
-
-        String storageTableName = view.getParameters().get(STORAGE_TABLE);
-        if (storageTableName != null) {
-            try {
-                metastore.dropTable(identity, viewName.getSchemaName(), storageTableName, true);
-            }
-            catch (TrinoException e) {
-                log.warn(e, "Failed to drop storage table '%s' for materialized view '%s'", storageTableName, viewName);
-            }
-        }
-        metastore.dropTable(identity, viewName.getSchemaName(), viewName.getTableName(), true);
+        catalog.dropMaterializedView(toTableId(viewName), session);
     }
 
     @Override
@@ -953,7 +684,7 @@ public class IcebergMetadata
     public ConnectorInsertTableHandle beginRefreshMaterializedView(ConnectorSession session, ConnectorTableHandle tableHandle, List<ConnectorTableHandle> sourceTableHandles)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
+        Table icebergTable = catalog.loadTable(toTableId(table.getSchemaTableName()), session);
         transaction = icebergTable.newTransaction();
 
         return new IcebergWritableTableHandle(
@@ -980,7 +711,7 @@ public class IcebergMetadata
 
         IcebergWritableTableHandle table = (IcebergWritableTableHandle) insertHandle;
 
-        org.apache.iceberg.Table icebergTable = transaction.table();
+        Table icebergTable = transaction.table();
         List<CommitTaskData> commitTasks = fragments.stream()
                 .map(slice -> commitTaskCodec.fromJson(slice.getBytes()))
                 .collect(toImmutableList());
@@ -991,10 +722,10 @@ public class IcebergMetadata
                 .toArray(Type[]::new);
 
         AppendFiles appendFiles = transaction.newFastAppend();
+        FileIO fileIO = transaction.table().io();
         for (CommitTaskData task : commitTasks) {
-            HdfsContext context = new HdfsContext(session);
             DataFiles.Builder builder = DataFiles.builder(icebergTable.spec())
-                    .withInputFile(new HdfsInputFile(new Path(task.getPath()), hdfsEnvironment, context))
+                    .withInputFile(fileIO.newInputFile(task.getPath()))
                     .withFormat(table.getFileFormat())
                     .withMetrics(task.getMetrics().metrics());
 
@@ -1023,63 +754,24 @@ public class IcebergMetadata
                 .collect(toImmutableList())));
     }
 
-    private boolean isMaterializedView(Table table)
-    {
-        return table.getTableType().equals(VIRTUAL_VIEW.name())
-                && "true".equals(table.getParameters().get(PRESTO_VIEW_FLAG))
-                && table.getParameters().containsKey(STORAGE_TABLE);
-    }
-
     @Override
     public List<SchemaTableName> listMaterializedViews(ConnectorSession session, Optional<String> schemaName)
     {
-        // Iceberg does not support VIEWs
-        // Filter on ICEBERG_MATERIALIZED_VIEW_COMMENT is used to avoid listing hive views in case of a shared HMS
-        return schemaName.map(Collections::singletonList)
-                .orElseGet(metastore::getAllDatabases).stream()
-                .flatMap(schema -> metastore.getTablesWithParameter(schema, TABLE_COMMENT, ICEBERG_MATERIALIZED_VIEW_COMMENT).stream()
-                        .map(table -> new SchemaTableName(schema, table)))
+        return catalog.listMaterializedViews(schemaName.map(Namespace::of).orElse(null), session).stream()
+                .map(IcebergUtil::fromTableId)
                 .collect(toImmutableList());
     }
 
     @Override
     public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(ConnectorSession session, SchemaTableName viewName)
     {
-        Optional<Table> tableOptional = metastore.getTable(new HiveIdentity(session), viewName.getSchemaName(), viewName.getTableName());
-        if (tableOptional.isEmpty()) {
-            return Optional.empty();
-        }
-
-        if (!isMaterializedView(tableOptional.get())) {
-            return Optional.empty();
-        }
-
-        Table materializedView = tableOptional.get();
-        String storageTable = materializedView.getParameters().get(STORAGE_TABLE);
-        checkState(storageTable != null, "Storage table missing in definition of materialized view " + viewName);
-
-        IcebergMaterializedViewDefinition definition = decodeMaterializedViewData(materializedView.getViewOriginalText()
-                .orElseThrow(() -> new TrinoException(HIVE_INVALID_METADATA, "No view original text: " + viewName)));
-
-        SchemaTableName storageTableName = new SchemaTableName(viewName.getSchemaName(), storageTable);
-        ConnectorTableMetadata tableMetadata = getTableMetadata(session, storageTableName);
-        return Optional.of(new ConnectorMaterializedViewDefinition(
-                definition.getOriginalSql(),
-                Optional.of(new CatalogSchemaTableName(catalogName.toString(), storageTableName)),
-                definition.getCatalog(),
-                definition.getSchema(),
-                definition.getColumns().stream()
-                        .map(column -> new ConnectorMaterializedViewDefinition.Column(column.getName(), column.getType()))
-                        .collect(toImmutableList()),
-                definition.getComment(),
-                materializedView.getOwner(),
-                ImmutableMap.copyOf(tableMetadata.getProperties())));
+        return catalog.getMaterializedView(toTableId(viewName), session);
     }
 
     public Optional<TableToken> getTableToken(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, table.getSchemaTableName());
+        Table icebergTable = catalog.loadTable(toTableId(table.getSchemaTableName()), session);
         return Optional.ofNullable(icebergTable.currentSnapshot())
                 .map(snapshot -> new TableToken(snapshot.snapshotId()));
     }
@@ -1134,7 +826,7 @@ public class IcebergMetadata
                 .map(CatalogSchemaTableName::getSchemaTableName)
                 .orElseThrow(() -> new IllegalStateException("Storage table missing in definition of materialized view " + name));
 
-        org.apache.iceberg.Table icebergTable = getIcebergTable(session, storageTableName);
+        Table icebergTable = catalog.loadTable(toTableId(storageTableName), session);
         String dependsOnTables = icebergTable.currentSnapshot().summary().getOrDefault(DEPENDS_ON_TABLES, "");
         if (!dependsOnTables.isEmpty()) {
             Map<String, String> tableToSnapshotIdMap = Splitter.on(',').withKeyValueSeparator('=').split(dependsOnTables);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
@@ -14,9 +14,6 @@
 package io.trino.plugin.iceberg;
 
 import io.airlift.json.JsonCodec;
-import io.trino.plugin.base.CatalogName;
-import io.trino.plugin.hive.HdfsEnvironment;
-import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.spi.type.TypeManager;
 
 import javax.inject.Inject;
@@ -25,44 +22,23 @@ import static java.util.Objects.requireNonNull;
 
 public class IcebergMetadataFactory
 {
-    private final CatalogName catalogName;
-    private final HiveMetastore metastore;
-    private final HdfsEnvironment hdfsEnvironment;
     private final TypeManager typeManager;
     private final JsonCodec<CommitTaskData> commitTaskCodec;
-    private final HiveTableOperationsProvider tableOperationsProvider;
+    private final TrinoCatalogFactory catalogFactory;
 
     @Inject
     public IcebergMetadataFactory(
-            CatalogName catalogName,
-            IcebergConfig config,
-            HiveMetastore metastore,
-            HdfsEnvironment hdfsEnvironment,
-            TypeManager typeManager,
-            JsonCodec<CommitTaskData> commitTaskDataJsonCodec,
-            HiveTableOperationsProvider tableOperationsProvider)
-    {
-        this(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskDataJsonCodec, tableOperationsProvider);
-    }
-
-    public IcebergMetadataFactory(
-            CatalogName catalogName,
-            HiveMetastore metastore,
-            HdfsEnvironment hdfsEnvironment,
             TypeManager typeManager,
             JsonCodec<CommitTaskData> commitTaskCodec,
-            HiveTableOperationsProvider tableOperationsProvider)
+            TrinoCatalogFactory catalogFactory)
     {
-        this.catalogName = requireNonNull(catalogName, "catalogName is null");
-        this.metastore = requireNonNull(metastore, "metastore is null");
-        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.commitTaskCodec = requireNonNull(commitTaskCodec, "commitTaskCodec is null");
-        this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
+        this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
     }
 
     public IcebergMetadata create()
     {
-        return new IcebergMetadata(catalogName, metastore, hdfsEnvironment, typeManager, commitTaskCodec, tableOperationsProvider);
+        return new IcebergMetadata(typeManager, commitTaskCodec, catalogFactory);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadataFactory.java
@@ -39,6 +39,6 @@ public class IcebergMetadataFactory
 
     public IcebergMetadata create()
     {
-        return new IcebergMetadata(typeManager, commitTaskCodec, catalogFactory);
+        return new IcebergMetadata(typeManager, commitTaskCodec, catalogFactory.create());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -62,6 +62,7 @@ public class IcebergModule
         configBinder(binder).bindConfig(ParquetReaderConfig.class);
         configBinder(binder).bindConfig(ParquetWriterConfig.class);
 
+        binder.bind(TrinoCatalogFactory.class).in(Scopes.SINGLETON);
         binder.bind(IcebergMetadataFactory.class).in(Scopes.SINGLETON);
 
         jsonCodecBinder(binder).bindJsonCodec(CommitTaskData.class);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -38,7 +38,7 @@ public class IcebergSplitManager
     private final IcebergTransactionManager transactionManager;
 
     @Inject
-    public IcebergSplitManager(IcebergTransactionManager transactionManager, HiveTableOperationsProvider tableOperationsProvider)
+    public IcebergSplitManager(IcebergTransactionManager transactionManager)
     {
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceUtf8;
 import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.trino.plugin.hive.TableAlreadyExistsException;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
@@ -46,7 +47,6 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
@@ -364,7 +364,7 @@ final class IcebergUtil
         TableIdentifier tableId = toTableId(schemaTableName);
 
         if (catalog.tableExists(tableId, session)) {
-            throw new AlreadyExistsException("Table already exists: %s", tableId);
+            throw new TableAlreadyExistsException(schemaTableName);
         }
 
         Schema schema = toIcebergSchema(tableMetadata.getColumns());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RollbackToSnapshotProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RollbackToSnapshotProcedure.java
@@ -24,7 +24,7 @@ import javax.inject.Provider;
 
 import java.lang.invoke.MethodHandle;
 
-import static io.trino.plugin.iceberg.IcebergUtil.loadIcebergTable;
+import static io.trino.plugin.iceberg.IcebergUtil.toTableId;
 import static io.trino.spi.block.MethodHandleUtil.methodHandle;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -41,12 +41,12 @@ public class RollbackToSnapshotProcedure
             String.class,
             Long.class);
 
-    private final HiveTableOperationsProvider tableOperationsProvider;
+    private final TrinoCatalog catalog;
 
     @Inject
-    public RollbackToSnapshotProcedure(HiveTableOperationsProvider tableOperationsProvider)
+    public RollbackToSnapshotProcedure(TrinoCatalogFactory catalogFactory)
     {
-        this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
+        this.catalog = requireNonNull(catalogFactory, "catalogFactory is null").create();
     }
 
     @Override
@@ -65,7 +65,7 @@ public class RollbackToSnapshotProcedure
     public void rollbackToSnapshot(ConnectorSession clientSession, String schema, String table, Long snapshotId)
     {
         SchemaTableName schemaTableName = new SchemaTableName(schema, table);
-        Table icebergTable = loadIcebergTable(tableOperationsProvider, clientSession, schemaTableName);
+        Table icebergTable = catalog.loadTable(toTableId(schemaTableName), clientSession);
         icebergTable.rollback().toSnapshotId(snapshotId).commit();
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoCatalog.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.security.TrinoPrincipal;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public interface TrinoCatalog
+{
+    String getName(ConnectorSession session);
+
+    List<Namespace> listNamespaces(ConnectorSession session);
+
+    boolean dropNamespace(Namespace namespace, ConnectorSession session);
+
+    Map<String, Object> loadNamespaceMetadataObjects(Namespace namespace, ConnectorSession session);
+
+    Optional<TrinoPrincipal> getNamespacePrincipal(Namespace namespace, ConnectorSession session);
+
+    void createNamespaceWithPrincipal(Namespace namespace, Map<String, Object> map, TrinoPrincipal owner, ConnectorSession session);
+
+    void setNamespacePrincipal(Namespace namespace, TrinoPrincipal principal, ConnectorSession session);
+
+    void renameNamespace(Namespace source, Namespace target, ConnectorSession session);
+
+    List<TableIdentifier> listTables(Namespace namespace, ConnectorSession session);
+
+    Transaction newCreateTableTransaction(TableIdentifier tableIdentifier, Schema schema, PartitionSpec partitionSpec, String location,
+            Map<String, String> properties, ConnectorSession session);
+
+    boolean tableExists(TableIdentifier identifier, ConnectorSession session);
+
+    boolean dropTable(TableIdentifier identifier, boolean purge, ConnectorSession session);
+
+    void renameTable(TableIdentifier from, TableIdentifier to, ConnectorSession session);
+
+    Table loadTable(TableIdentifier identifier, ConnectorSession session);
+
+    void updateTableComment(TableIdentifier tableIdentifier, Optional<String> comment, ConnectorSession session);
+
+    String defaultTableLocation(TableIdentifier tableIdentifier, ConnectorSession session);
+
+    void createMaterializedView(TableIdentifier viewIdentifier, ConnectorMaterializedViewDefinition definition,
+            boolean replace, boolean ignoreExisting, ConnectorSession session);
+
+    void dropMaterializedView(TableIdentifier viewIdentifier, ConnectorSession session);
+
+    Optional<ConnectorMaterializedViewDefinition> getMaterializedView(TableIdentifier viewIdentifier, ConnectorSession session);
+
+    List<TableIdentifier> listViews(Namespace namespace, ConnectorSession session);
+
+    List<TableIdentifier> listMaterializedViews(Namespace namespace, ConnectorSession session);
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoCatalogFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.trino.plugin.base.CatalogName;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.spi.TrinoException;
+import io.trino.spi.type.TypeManager;
+
+import javax.inject.Inject;
+
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.util.Objects.requireNonNull;
+
+class TrinoCatalogFactory
+{
+    private final IcebergConfig config;
+    private final CatalogName catalogName;
+    private final HiveMetastore metastore;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final TypeManager typeManager;
+    private final HiveTableOperationsProvider tableOperationsProvider;
+
+    @Inject
+    public TrinoCatalogFactory(
+            CatalogName catalogName,
+            IcebergConfig config,
+            HiveMetastore metastore,
+            HdfsEnvironment hdfsEnvironment,
+            TypeManager typeManager,
+            HiveTableOperationsProvider tableOperationsProvider)
+    {
+        this.config = requireNonNull(config, "config is null");
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.metastore = requireNonNull(metastore, "metastore is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationProvider is null");
+    }
+
+    public TrinoCatalog create()
+    {
+        switch (config.getCatalogType()) {
+            case HIVE:
+                return new TrinoHiveCatalog(catalogName, metastore, hdfsEnvironment, typeManager, tableOperationsProvider);
+            default:
+                throw new TrinoException(NOT_SUPPORTED, "Unsupported Trino Iceberg catalog type " + config.getCatalogType());
+        }
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
@@ -1,0 +1,501 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.trino.plugin.base.CatalogName;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HiveSchemaProperties;
+import io.trino.plugin.hive.authentication.HiveIdentity;
+import io.trino.plugin.hive.metastore.Column;
+import io.trino.plugin.hive.metastore.Database;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.HivePrincipal;
+import io.trino.plugin.hive.metastore.PrincipalPrivileges;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.MaterializedViewNotFoundException;
+import io.trino.spi.connector.SchemaNotFoundException;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.security.TrinoPrincipal;
+import io.trino.spi.type.TypeManager;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_METADATA;
+import static io.trino.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
+import static io.trino.plugin.hive.HiveMetadata.STORAGE_TABLE;
+import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
+import static io.trino.plugin.hive.HiveType.HIVE_STRING;
+import static io.trino.plugin.hive.ViewReaderUtil.PRESTO_VIEW_FLAG;
+import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
+import static io.trino.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
+import static io.trino.plugin.hive.util.HiveWriteUtils.getTableDefaultLocation;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.decodeMaterializedViewData;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.encodeMaterializedViewData;
+import static io.trino.plugin.iceberg.IcebergMaterializedViewDefinition.fromConnectorMaterializedViewDefinition;
+import static io.trino.plugin.iceberg.IcebergMetadata.ICEBERG_MATERIALIZED_VIEW_COMMENT;
+import static io.trino.plugin.iceberg.IcebergSchemaProperties.getSchemaLocation;
+import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergUtil.fromTableId;
+import static io.trino.plugin.iceberg.IcebergUtil.getIcebergTableWithMetadata;
+import static io.trino.plugin.iceberg.IcebergUtil.getNewCreateTableTransaction;
+import static io.trino.plugin.iceberg.IcebergUtil.loadIcebergTable;
+import static io.trino.plugin.iceberg.IcebergUtil.schemaFromTableId;
+import static io.trino.plugin.iceberg.PartitionFields.toPartitionFields;
+import static io.trino.spi.StandardErrorCode.ALREADY_EXISTS;
+import static io.trino.spi.StandardErrorCode.INVALID_SCHEMA_PROPERTY;
+import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
+import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.hive.metastore.TableType.VIRTUAL_VIEW;
+import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
+import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static org.apache.iceberg.TableMetadata.newTableMetadata;
+import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+import static org.apache.iceberg.Transactions.createTableTransaction;
+
+class TrinoHiveCatalog
+        implements TrinoCatalog
+{
+    private static final Logger log = Logger.get(IcebergMetadata.class);
+
+    private final String catalogName;
+    private final HiveMetastore metastore;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final TypeManager typeManager;
+    private final HiveTableOperationsProvider tableOperationsProvider;
+
+    private final Map<SchemaTableName, TableMetadata> tableMetadataCache = new ConcurrentHashMap<>();
+
+    public TrinoHiveCatalog(
+            CatalogName catalogName,
+            HiveMetastore metastore,
+            HdfsEnvironment hdfsEnvironment,
+            TypeManager typeManager,
+            HiveTableOperationsProvider tableOperationsProvider)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null").toString();
+        this.metastore = requireNonNull(metastore, "metastore is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.tableOperationsProvider = requireNonNull(tableOperationsProvider, "tableOperationsProvider is null");
+    }
+
+    @Override
+    public String getName(ConnectorSession session)
+    {
+        return catalogName;
+    }
+
+    @Override
+    public List<Namespace> listNamespaces(ConnectorSession session)
+    {
+        return metastore.getAllDatabases().stream().map(Namespace::of).collect(Collectors.toList());
+    }
+
+    @Override
+    public Map<String, Object> loadNamespaceMetadataObjects(Namespace namespace, ConnectorSession session)
+    {
+        Optional<Database> db = metastore.getDatabase(namespace.toString());
+        if (db.isPresent()) {
+            return HiveSchemaProperties.fromDatabase(db.get());
+        }
+
+        throw new SchemaNotFoundException(namespace.toString());
+    }
+
+    @Override
+    public Optional<TrinoPrincipal> getNamespacePrincipal(Namespace namespace, ConnectorSession session)
+    {
+        Optional<Database> database = metastore.getDatabase(namespace.toString());
+        if (database.isPresent()) {
+            return database.flatMap(db -> Optional.of(new TrinoPrincipal(db.getOwnerType(), db.getOwnerName())));
+        }
+
+        throw new SchemaNotFoundException(namespace.toString());
+    }
+
+    @Override
+    public void createNamespaceWithPrincipal(Namespace namespace, Map<String, Object> map, TrinoPrincipal owner, ConnectorSession session)
+    {
+        Optional<String> location = getSchemaLocation(map).map(uri -> {
+            try {
+                hdfsEnvironment.getFileSystem(new HdfsEnvironment.HdfsContext(session), new Path(uri));
+            }
+            catch (IOException | IllegalArgumentException e) {
+                throw new TrinoException(INVALID_SCHEMA_PROPERTY, "Invalid location URI: " + uri, e);
+            }
+            return uri;
+        });
+
+        Database database = Database.builder()
+                .setDatabaseName(namespace.toString())
+                .setLocation(location)
+                .setOwnerType(owner.getType())
+                .setOwnerName(owner.getName())
+                .build();
+
+        metastore.createDatabase(new HiveIdentity(session), database);
+    }
+
+    @Override
+    public boolean dropNamespace(Namespace namespace, ConnectorSession session)
+            throws NamespaceNotEmptyException
+    {
+        // basic sanity check to provide a better error message
+        if (!listTables(namespace, session).isEmpty() ||
+                !listViews(namespace, session).isEmpty()) {
+            throw new TrinoException(SCHEMA_NOT_EMPTY, "Schema not empty: " + namespace);
+        }
+        metastore.dropDatabase(new HiveIdentity(session), namespace.toString());
+        return true;
+    }
+
+    @Override
+    public void renameNamespace(Namespace source, Namespace target, ConnectorSession session)
+    {
+        metastore.renameDatabase(new HiveIdentity(session), source.toString(), target.toString());
+    }
+
+    @Override
+    public void setNamespacePrincipal(Namespace namespace, TrinoPrincipal principal, ConnectorSession session)
+    {
+        metastore.setDatabaseOwner(new HiveIdentity(session), namespace.toString(), HivePrincipal.from(principal));
+    }
+
+    @Override
+    public Transaction newCreateTableTransaction(TableIdentifier tableIdentifier, Schema schema, PartitionSpec partitionSpec, String location,
+            Map<String, String> properties, ConnectorSession session)
+    {
+        TableMetadata metadata = newTableMetadata(schema, partitionSpec, location, properties);
+        TableOperations ops = tableOperationsProvider.createTableOperations(
+                new HdfsEnvironment.HdfsContext(session),
+                session.getQueryId(),
+                new HiveIdentity(session),
+                schemaFromTableId(tableIdentifier),
+                tableIdentifier.name(),
+                Optional.of(session.getUser()),
+                Optional.of(location));
+        return createTableTransaction(tableIdentifier.toString(), ops, metadata);
+    }
+
+    @Override
+    public Table loadTable(TableIdentifier tableIdentifier, ConnectorSession session)
+    {
+        SchemaTableName schemaTableName = fromTableId(tableIdentifier);
+        TableMetadata metadata = tableMetadataCache.computeIfAbsent(
+                schemaTableName,
+                ignore -> ((BaseTable) loadIcebergTable(tableOperationsProvider, session, schemaTableName)).operations().current());
+
+        return getIcebergTableWithMetadata(tableOperationsProvider, session, schemaTableName, metadata);
+    }
+
+    @Override
+    public boolean tableExists(TableIdentifier identifier, ConnectorSession session)
+    {
+        SchemaTableName name = fromTableId(identifier);
+        Optional<io.trino.plugin.hive.metastore.Table> table = metastore.getTable(new HiveIdentity(session), name.getSchemaName(), name.getTableName());
+        if (table.isEmpty()) {
+            return false;
+        }
+        if (isMaterializedView(table.get())) {
+            return false;
+        }
+        if (!isIcebergTable(table.get())) {
+            throw new UnknownTableTypeException(name);
+        }
+        return true;
+    }
+
+    @Override
+    public List<TableIdentifier> listTables(Namespace namespace, ConnectorSession session)
+    {
+        ImmutableList.Builder<TableIdentifier> tablesListBuilder = ImmutableList.builder();
+        Optional.ofNullable(namespace)
+                .map(ns -> (List<String>) ImmutableList.of(ns.toString()))
+                .orElseGet(metastore::getAllDatabases)
+                .stream()
+                .flatMap(schema -> Stream.concat(
+                        // Get tables with parameter table_type set to  "ICEBERG" or "iceberg". This is required because
+                        // Trino uses lowercase value whereas Spark and Flink use uppercase.
+                        // TODO: use one metastore call to pass both the filters: https://github.com/trinodb/trino/issues/7710
+                        metastore.getTablesWithParameter(schema, TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toLowerCase(Locale.ENGLISH)).stream()
+                                .map(table -> TableIdentifier.of(schema, table)),
+                        metastore.getTablesWithParameter(schema, TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH)).stream()
+                                .map(table -> TableIdentifier.of(schema, table)))
+                        .distinct())  // distinct() to avoid duplicates for case-insensitive HMS backends
+                .forEach(tablesListBuilder::add);
+
+        tablesListBuilder.addAll(listMaterializedViews(namespace, session));
+        return tablesListBuilder.build();
+    }
+
+    @Override
+    public void updateTableComment(TableIdentifier tableIdentifier, Optional<String> comment, ConnectorSession session)
+    {
+        metastore.commentTable(new HiveIdentity(session), schemaFromTableId(tableIdentifier), tableIdentifier.name(), comment);
+        Table icebergTable = loadTable(tableIdentifier, session);
+        if (comment.isEmpty()) {
+            icebergTable.updateProperties().remove(TABLE_COMMENT).commit();
+        }
+        else {
+            icebergTable.updateProperties().set(TABLE_COMMENT, comment.get()).commit();
+        }
+    }
+
+    @Override
+    public String defaultTableLocation(TableIdentifier tableIdentifier, ConnectorSession session)
+    {
+        String schemaName = schemaFromTableId(tableIdentifier);
+        Database database = metastore.getDatabase(schemaName)
+                .orElseThrow(() -> new SchemaNotFoundException(schemaName));
+        return getTableDefaultLocation(database, new HdfsEnvironment.HdfsContext(session), hdfsEnvironment, schemaName, tableIdentifier.name()).toString();
+    }
+
+    @Override
+    public List<TableIdentifier> listViews(Namespace namespace, ConnectorSession session)
+    {
+        return emptyList();
+    }
+
+    @Override
+    public List<TableIdentifier> listMaterializedViews(Namespace namespace, ConnectorSession session)
+    {
+        // Iceberg does not support VIEWs
+        // Filter on ICEBERG_MATERIALIZED_VIEW_COMMENT is used to avoid listing hive views in case of a shared HMS
+        return Optional.ofNullable(namespace).map(ns -> (List<String>) ImmutableList.of(ns.toString()))
+                .orElseGet(metastore::getAllDatabases).stream()
+                .flatMap(schema -> metastore.getTablesWithParameter(schema, TABLE_COMMENT, ICEBERG_MATERIALIZED_VIEW_COMMENT).stream()
+                        .map(table -> TableIdentifier.of(schema, table)))
+                .collect(toImmutableList());
+    }
+
+    @Override
+    public void createMaterializedView(TableIdentifier viewIdentifier, ConnectorMaterializedViewDefinition definition,
+            boolean replace, boolean ignoreExisting, ConnectorSession session)
+    {
+        String schemaName = schemaFromTableId(viewIdentifier);
+        String tableName = viewIdentifier.name();
+        HiveIdentity identity = new HiveIdentity(session);
+        Optional<io.trino.plugin.hive.metastore.Table> existing = metastore.getTable(identity, schemaName, tableName);
+
+        // It's a create command where the materialized view already exists and 'if not exists' clause is not specified
+        if (!replace && existing.isPresent()) {
+            if (ignoreExisting) {
+                return;
+            }
+            throw new TrinoException(ALREADY_EXISTS, "Materialized view already exists: " + viewIdentifier);
+        }
+
+        // Generate a storage table name and create a storage table. The properties in the definition are table properties for the
+        // storage table as indicated in the materialized view definition.
+        String storageTableName = "st_" + UUID.randomUUID().toString().replace("-", "");
+        Map<String, Object> storageTableProperties = new HashMap<>(definition.getProperties());
+        storageTableProperties.putIfAbsent(FILE_FORMAT_PROPERTY, DEFAULT_FILE_FORMAT_DEFAULT);
+
+        SchemaTableName storageTable = new SchemaTableName(schemaName, storageTableName);
+        List<ColumnMetadata> columns = definition.getColumns().stream()
+                .map(column -> new ColumnMetadata(column.getName(), typeManager.getType(column.getType())))
+                .collect(toImmutableList());
+
+        ConnectorTableMetadata tableMetadata = new ConnectorTableMetadata(storageTable, columns, storageTableProperties, Optional.empty());
+        Transaction transaction = getNewCreateTableTransaction(this, tableMetadata, session);
+        transaction.newAppend().commit();
+        transaction.commitTransaction();
+
+        // Create a view indicating the storage table
+        Map<String, String> viewProperties = ImmutableMap.<String, String>builder()
+                .put(PRESTO_QUERY_ID_NAME, session.getQueryId())
+                .put(STORAGE_TABLE, storageTableName)
+                .put(PRESTO_VIEW_FLAG, "true")
+                .put(TABLE_COMMENT, ICEBERG_MATERIALIZED_VIEW_COMMENT)
+                .build();
+
+        Column dummyColumn = new Column("dummy", HIVE_STRING, Optional.empty());
+
+        io.trino.plugin.hive.metastore.Table.Builder tableBuilder = io.trino.plugin.hive.metastore.Table.builder()
+                .setDatabaseName(schemaName)
+                .setTableName(tableName)
+                .setOwner(session.getUser())
+                .setTableType(VIRTUAL_VIEW.name())
+                .setDataColumns(ImmutableList.of(dummyColumn))
+                .setPartitionColumns(ImmutableList.of())
+                .setParameters(viewProperties)
+                .withStorage(storage -> storage.setStorageFormat(VIEW_STORAGE_FORMAT))
+                .withStorage(storage -> storage.setLocation(""))
+                .setViewOriginalText(Optional.of(
+                        encodeMaterializedViewData(fromConnectorMaterializedViewDefinition(definition))))
+                .setViewExpandedText(Optional.of("/* Presto Materialized View */"));
+        io.trino.plugin.hive.metastore.Table table = tableBuilder.build();
+        PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(session.getUser());
+        if (existing.isPresent() && replace) {
+            // drop the current storage table
+            String oldStorageTable = existing.get().getParameters().get(STORAGE_TABLE);
+            if (oldStorageTable != null) {
+                metastore.dropTable(identity, schemaName, oldStorageTable, true);
+            }
+            // Replace the existing view definition
+            metastore.replaceTable(identity, schemaName, tableName, table, principalPrivileges);
+            return;
+        }
+        // create the view definition
+        metastore.createTable(identity, table, principalPrivileges);
+    }
+
+    @Override
+    public void dropMaterializedView(TableIdentifier viewIdentifier, ConnectorSession session)
+    {
+        String schemaName = schemaFromTableId(viewIdentifier);
+        String tableName = viewIdentifier.name();
+        final HiveIdentity identity = new HiveIdentity(session);
+        io.trino.plugin.hive.metastore.Table view = metastore.getTable(identity, schemaName, tableName)
+                .orElseThrow(() -> new MaterializedViewNotFoundException(new SchemaTableName(schemaName, tableName)));
+
+        String storageTableName = view.getParameters().get(STORAGE_TABLE);
+        if (storageTableName != null) {
+            try {
+                metastore.dropTable(identity, schemaName, storageTableName, true);
+            }
+            catch (TrinoException e) {
+                log.warn(e, "Failed to drop storage table '%s' for materialized view '%s'", storageTableName, viewIdentifier);
+            }
+        }
+        metastore.dropTable(identity, schemaName, tableName, true);
+    }
+
+    @Override
+    public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(TableIdentifier viewIdentifier, ConnectorSession session)
+    {
+        String schemaName = schemaFromTableId(viewIdentifier);
+        String tableName = viewIdentifier.name();
+        Optional<io.trino.plugin.hive.metastore.Table> tableOptional = metastore.getTable(new HiveIdentity(session), schemaName, tableName);
+        if (tableOptional.isEmpty()) {
+            return Optional.empty();
+        }
+
+        if (!isMaterializedView(tableOptional.get())) {
+            return Optional.empty();
+        }
+
+        io.trino.plugin.hive.metastore.Table materializedView = tableOptional.get();
+        String storageTable = materializedView.getParameters().get(STORAGE_TABLE);
+        checkState(storageTable != null, "Storage table missing in definition of materialized view " + viewIdentifier);
+
+        IcebergMaterializedViewDefinition definition = decodeMaterializedViewData(materializedView.getViewOriginalText()
+                .orElseThrow(() -> new TrinoException(HIVE_INVALID_METADATA, "No view original text: " + viewIdentifier)));
+
+        Table icebergTable = loadTable(TableIdentifier.of(schemaName, storageTable), session);
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+        properties.put(FILE_FORMAT_PROPERTY, IcebergUtil.getFileFormat(icebergTable));
+        if (!icebergTable.spec().fields().isEmpty()) {
+            properties.put(PARTITIONING_PROPERTY, toPartitionFields(icebergTable.spec()));
+        }
+
+        return Optional.of(new ConnectorMaterializedViewDefinition(
+                definition.getOriginalSql(),
+                Optional.of(new CatalogSchemaTableName(catalogName.toString(), new SchemaTableName(schemaName, storageTable))),
+                definition.getCatalog(),
+                definition.getSchema(),
+                definition.getColumns().stream()
+                        .map(column -> new ConnectorMaterializedViewDefinition.Column(column.getName(), column.getType()))
+                        .collect(toImmutableList()),
+                definition.getComment(),
+                materializedView.getOwner(),
+                ImmutableMap.copyOf(properties.build())));
+    }
+
+    @Override
+    public boolean dropTable(TableIdentifier tableIdentifier, boolean purge, ConnectorSession session)
+    {
+        metastore.dropTable(new HiveIdentity(session), schemaFromTableId(tableIdentifier), tableIdentifier.name(), purge);
+        return true;
+    }
+
+    @Override
+    public void renameTable(TableIdentifier tableIdentifier, TableIdentifier newTableIdentifier, ConnectorSession session)
+    {
+        metastore.renameTable(new HiveIdentity(session), schemaFromTableId(tableIdentifier), tableIdentifier.name(),
+                schemaFromTableId(newTableIdentifier), newTableIdentifier.name());
+    }
+
+    private static boolean isIcebergTable(io.trino.plugin.hive.metastore.Table hiveTable)
+    {
+        return ICEBERG_TABLE_TYPE_VALUE.equalsIgnoreCase(hiveTable.getParameters().get(TABLE_TYPE_PROP));
+    }
+
+    private boolean isMaterializedView(io.trino.plugin.hive.metastore.Table table)
+    {
+        return table.getTableType().equals(VIRTUAL_VIEW.name())
+                && "true".equals(table.getParameters().get(PRESTO_VIEW_FLAG))
+                && table.getParameters().containsKey(STORAGE_TABLE);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
@@ -74,7 +74,6 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
@@ -209,7 +209,6 @@ class TrinoHiveCatalog
 
     @Override
     public boolean dropNamespace(Namespace namespace, ConnectorSession session)
-            throws NamespaceNotEmptyException
     {
         // basic sanity check to provide a better error message
         if (!listTables(namespace, session).isEmpty() ||

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -23,6 +23,8 @@ import static io.airlift.configuration.testing.ConfigAssertions.assertFullMappin
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.trino.plugin.hive.HiveCompressionCodec.GZIP;
+import static io.trino.plugin.iceberg.CatalogType.HADOOP;
+import static io.trino.plugin.iceberg.CatalogType.HIVE;
 import static io.trino.plugin.iceberg.IcebergFileFormat.ORC;
 import static io.trino.plugin.iceberg.IcebergFileFormat.PARQUET;
 
@@ -35,7 +37,8 @@ public class TestIcebergConfig
                 .setFileFormat(ORC)
                 .setCompressionCodec(GZIP)
                 .setUseFileSizeFromMetadata(true)
-                .setMaxPartitionsPerWriter(100));
+                .setMaxPartitionsPerWriter(100)
+                .setCatalogType(HIVE));
     }
 
     @Test
@@ -46,13 +49,15 @@ public class TestIcebergConfig
                 .put("iceberg.compression-codec", "NONE")
                 .put("iceberg.use-file-size-from-metadata", "false")
                 .put("iceberg.max-partitions-per-writer", "222")
+                .put("iceberg.catalog.type", "HADOOP")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
                 .setFileFormat(PARQUET)
                 .setCompressionCodec(HiveCompressionCodec.NONE)
                 .setUseFileSizeFromMetadata(false)
-                .setMaxPartitionsPerWriter(222);
+                .setMaxPartitionsPerWriter(222)
+                .setCatalogType(HADOOP);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
based on #6977

Because it's pulling code out of `IcebergMetadata` to `TrinoHiveCatalog`, the change is messy in those 2 classes. I have tried best to keep as much code blocks the same as possible.

Will also add some inline comments for some major changes.

@losipiuk @phd3 @electrum 