### PR TITLE
Move AggregateFunctionRewriter to plugin toolkit

### DIFF
--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -19,6 +19,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-matching</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>bootstrap</artifactId>
         </dependency>

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/AggregateFunctionPatterns.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/AggregateFunctionPatterns.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.jdbc.expression;
+package io.trino.plugin.base.expression;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.matching.Captures;

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/AggregateFunctionRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/expression/AggregateFunctionRule.java
@@ -11,11 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.jdbc.expression;
+package io.trino.plugin.base.expression;
 
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
-import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
@@ -27,11 +26,11 @@ import java.util.function.Function;
 import static com.google.common.base.Verify.verifyNotNull;
 import static java.util.Objects.requireNonNull;
 
-public interface AggregateFunctionRule
+public interface AggregateFunctionRule<Result>
 {
     Pattern<AggregateFunction> getPattern();
 
-    Optional<JdbcExpression> rewrite(AggregateFunction aggregateFunction, Captures captures, RewriteContext context);
+    Optional<Result> rewrite(AggregateFunction aggregateFunction, Captures captures, RewriteContext context);
 
     interface RewriteContext
     {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementAvgDecimal.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementAvgDecimal.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -26,18 +27,18 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static java.lang.String.format;
 
 /**
  * Implements {@code avg(decimal(p, s)}
  */
 public class ImplementAvgDecimal
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementAvgFloatingPoint.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementAvgFloatingPoint.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -25,11 +26,11 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
 import static java.lang.String.format;
@@ -38,7 +39,7 @@ import static java.lang.String.format;
  * Implements {@code avg(float)}
  */
 public class ImplementAvgFloatingPoint
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCorr.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCorr.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -26,17 +27,17 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionTypes;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.inputs;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variables;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionTypes;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.inputs;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variables;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
 import static java.lang.String.format;
 
 public class ImplementCorr
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<List<Variable>> INPUTS = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCount.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCount.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
@@ -28,10 +29,10 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -40,7 +41,7 @@ import static java.util.Objects.requireNonNull;
  * Implements {@code count(x)}.
  */
 public class ImplementCount
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCountAll.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCountAll.java
@@ -15,6 +15,7 @@ package io.trino.plugin.jdbc.expression;
 
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
@@ -25,9 +26,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.inputs;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.inputs;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static java.util.Objects.requireNonNull;
 
@@ -35,7 +36,7 @@ import static java.util.Objects.requireNonNull;
  * Implements {@code count(*)}.
  */
 public class ImplementCountAll
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private final JdbcTypeHandle bigintTypeHandle;
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCovariancePop.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCovariancePop.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -26,17 +27,17 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionTypes;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.inputs;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variables;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionTypes;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.inputs;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variables;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
 import static java.lang.String.format;
 
 public class ImplementCovariancePop
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<List<Variable>> INPUTS = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCovarianceSamp.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementCovarianceSamp.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -26,17 +27,17 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionTypes;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.inputs;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variables;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionTypes;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.inputs;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variables;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
 import static java.lang.String.format;
 
 public class ImplementCovarianceSamp
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<List<Variable>> INPUTS = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementMinMax.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementMinMax.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -26,17 +27,17 @@ import java.util.Set;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static java.lang.String.format;
 
 /**
  * Implements {@code min(x)}, {@code max(x)}.
  */
 public class ImplementMinMax
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementRegrIntercept.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementRegrIntercept.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -26,17 +27,17 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionTypes;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.inputs;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variables;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionTypes;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.inputs;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variables;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
 import static java.lang.String.format;
 
 public class ImplementRegrIntercept
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<List<Variable>> INPUTS = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementRegrSlope.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementRegrSlope.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -26,17 +27,17 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionTypes;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.inputs;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variables;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionTypes;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.inputs;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variables;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
 import static java.lang.String.format;
 
 public class ImplementRegrSlope
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<List<Variable>> INPUTS = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementStddevPop.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementStddevPop.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -26,15 +27,15 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static java.lang.String.format;
 
 public class ImplementStddevPop
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementStddevSamp.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementStddevSamp.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -26,15 +27,15 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static java.lang.String.format;
 
 public class ImplementStddevSamp
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementSum.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementSum.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
@@ -27,10 +28,10 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -38,7 +39,7 @@ import static java.util.Objects.requireNonNull;
  * Implements {@code sum(x)}
  */
 public class ImplementSum
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementVariancePop.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementVariancePop.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -26,15 +27,15 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static java.lang.String.format;
 
 public class ImplementVariancePop
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementVarianceSamp.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/expression/ImplementVarianceSamp.java
@@ -16,6 +16,7 @@ package io.trino.plugin.jdbc.expression;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.spi.connector.AggregateFunction;
@@ -26,15 +27,15 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static java.lang.String.format;
 
 public class ImplementVarianceSamp
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
@@ -14,7 +14,7 @@
 package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableSet;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRewriter;
+import io.trino.plugin.base.expression.AggregateFunctionRewriter;
 import io.trino.plugin.jdbc.expression.ImplementCountAll;
 import io.trino.plugin.jdbc.mapping.DefaultIdentifierMapping;
 import io.trino.spi.TrinoException;
@@ -85,7 +85,7 @@ class TestingH2JdbcClient
     @Override
     public Optional<JdbcExpression> implementAggregation(ConnectorSession session, AggregateFunction aggregate, Map<String, ColumnHandle> assignments)
     {
-        return new AggregateFunctionRewriter(this::quoted, ImmutableSet.of(new ImplementCountAll(BIGINT_TYPE_HANDLE)))
+        return new AggregateFunctionRewriter<>(this::quoted, ImmutableSet.of(new ImplementCountAll(BIGINT_TYPE_HANDLE)))
                 .rewrite(session, aggregate, assignments);
     }
 

--- a/plugin/trino-clickhouse/pom.xml
+++ b/plugin/trino-clickhouse/pom.xml
@@ -27,6 +27,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-matching</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -16,6 +16,8 @@ package io.trino.plugin.clickhouse;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
+import io.trino.plugin.base.expression.AggregateFunctionRewriter;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.BaseJdbcClient;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ColumnMapping;
@@ -27,8 +29,6 @@ import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.SliceWriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRewriter;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.expression.ImplementAvgFloatingPoint;
 import io.trino.plugin.jdbc.expression.ImplementCount;
 import io.trino.plugin.jdbc.expression.ImplementCountAll;
@@ -123,7 +123,7 @@ public class ClickHouseClient
     static final int CLICKHOUSE_MAX_DECIMAL_PRECISION = 76;
 
     private final boolean mapStringAsVarchar;
-    private final AggregateFunctionRewriter aggregateFunctionRewriter;
+    private final AggregateFunctionRewriter<JdbcExpression> aggregateFunctionRewriter;
     private final Type uuidType;
 
     @Inject
@@ -139,9 +139,9 @@ public class ClickHouseClient
         // TODO (https://github.com/trinodb/trino/issues/7102) define session property
         this.mapStringAsVarchar = clickHouseConfig.isMapStringAsVarchar();
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-        this.aggregateFunctionRewriter = new AggregateFunctionRewriter(
+        this.aggregateFunctionRewriter = new AggregateFunctionRewriter<>(
                 this::quoted,
-                ImmutableSet.<AggregateFunctionRule>builder()
+                ImmutableSet.<AggregateFunctionRule<JdbcExpression>>builder()
                         .add(new ImplementCountAll(bigintTypeHandle))
                         .add(new ImplementCount(bigintTypeHandle))
                         .add(new ImplementMinMax())

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ImplementAvgBigint.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ImplementAvgBigint.java
@@ -16,10 +16,10 @@ package io.trino.plugin.clickhouse;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.expression.Variable;
 
@@ -28,17 +28,17 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static java.lang.String.format;
 
 public class ImplementAvgBigint
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ImplementAvgDecimal.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ImplementAvgDecimal.java
@@ -16,9 +16,9 @@ package io.trino.plugin.clickhouse;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.type.DecimalType;
@@ -27,19 +27,19 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static io.trino.plugin.clickhouse.ClickHouseClient.CLICKHOUSE_MAX_DECIMAL_PRECISION;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
 import static java.lang.String.format;
 
 /**
  * Implements {@code avg(decimal(p, s)}
  */
 public class ImplementAvgDecimal
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/ImplementAvgBigint.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/ImplementAvgBigint.java
@@ -16,10 +16,10 @@ package io.trino.plugin.mysql;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.expression.Variable;
 
@@ -28,17 +28,17 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static java.lang.String.format;
 
 public class ImplementAvgBigint
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -15,6 +15,8 @@ package io.trino.plugin.mysql;
 
 import com.google.common.collect.ImmutableSet;
 import com.mysql.cj.jdbc.JdbcStatement;
+import io.trino.plugin.base.expression.AggregateFunctionRewriter;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.BaseJdbcClient;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ColumnMapping;
@@ -27,8 +29,6 @@ import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.WriteMapping;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRewriter;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.expression.ImplementAvgDecimal;
 import io.trino.plugin.jdbc.expression.ImplementAvgFloatingPoint;
 import io.trino.plugin.jdbc.expression.ImplementCount;
@@ -143,7 +143,7 @@ public class MySqlClient
     private static final int ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE = 19;
 
     private final Type jsonType;
-    private final AggregateFunctionRewriter aggregateFunctionRewriter;
+    private final AggregateFunctionRewriter<JdbcExpression> aggregateFunctionRewriter;
 
     @Inject
     public MySqlClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, TypeManager typeManager, IdentifierMapping identifierMapping)
@@ -152,9 +152,9 @@ public class MySqlClient
         this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
 
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-        this.aggregateFunctionRewriter = new AggregateFunctionRewriter(
+        this.aggregateFunctionRewriter = new AggregateFunctionRewriter<>(
                 this::quoted,
-                ImmutableSet.<AggregateFunctionRule>builder()
+                ImmutableSet.<AggregateFunctionRule<JdbcExpression>>builder()
                         .add(new ImplementCountAll(bigintTypeHandle))
                         .add(new ImplementCount(bigintTypeHandle))
                         .add(new ImplementMinMax())

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/ImplementAvgBigint.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/ImplementAvgBigint.java
@@ -16,10 +16,10 @@ package io.trino.plugin.postgresql;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.expression.Variable;
 
@@ -28,17 +28,17 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static java.lang.String.format;
 
 public class ImplementAvgBigint
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -19,6 +19,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.math.LongMath;
 import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
+import io.trino.plugin.base.expression.AggregateFunctionRewriter;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.BaseJdbcClient;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.BooleanReadFunction;
@@ -43,8 +45,6 @@ import io.trino.plugin.jdbc.SliceReadFunction;
 import io.trino.plugin.jdbc.SliceWriteFunction;
 import io.trino.plugin.jdbc.UnsupportedTypeHandling;
 import io.trino.plugin.jdbc.WriteMapping;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRewriter;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.expression.ImplementAvgDecimal;
 import io.trino.plugin.jdbc.expression.ImplementAvgFloatingPoint;
 import io.trino.plugin.jdbc.expression.ImplementCorr;
@@ -226,7 +226,7 @@ public class PostgreSqlClient
     private final Type uuidType;
     private final MapType varcharMapType;
     private final List<String> tableTypes;
-    private final AggregateFunctionRewriter aggregateFunctionRewriter;
+    private final AggregateFunctionRewriter<JdbcExpression> aggregateFunctionRewriter;
 
     private static final PredicatePushdownController POSTGRESQL_CHARACTER_PUSHDOWN = (session, domain) -> {
         checkArgument(
@@ -265,9 +265,9 @@ public class PostgreSqlClient
         this.tableTypes = tableTypes.build();
 
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-        this.aggregateFunctionRewriter = new AggregateFunctionRewriter(
+        this.aggregateFunctionRewriter = new AggregateFunctionRewriter<>(
                 this::quoted,
-                ImmutableSet.<AggregateFunctionRule>builder()
+                ImmutableSet.<AggregateFunctionRule<JdbcExpression>>builder()
                         .add(new ImplementCountAll(bigintTypeHandle))
                         .add(new ImplementCount(bigintTypeHandle))
                         .add(new ImplementMinMax())

--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -29,6 +29,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementAvgBigint.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementAvgBigint.java
@@ -16,10 +16,10 @@ package io.trino.plugin.sqlserver;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.expression.Variable;
 
@@ -28,17 +28,17 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static java.lang.String.format;
 
 public class ImplementAvgBigint
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerStddevPop.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerStddevPop.java
@@ -16,9 +16,9 @@ package io.trino.plugin.sqlserver;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.type.DoubleType;
@@ -27,16 +27,16 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static java.lang.String.format;
 
 public class ImplementSqlServerStddevPop
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerStdev.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerStdev.java
@@ -16,9 +16,9 @@ package io.trino.plugin.sqlserver;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.type.DoubleType;
@@ -27,16 +27,16 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static java.lang.String.format;
 
 public class ImplementSqlServerStdev
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerVariance.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerVariance.java
@@ -16,9 +16,9 @@ package io.trino.plugin.sqlserver;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.type.DoubleType;
@@ -27,16 +27,16 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static java.lang.String.format;
 
 public class ImplementSqlServerVariance
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerVariancePop.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/ImplementSqlServerVariancePop.java
@@ -16,9 +16,9 @@ package io.trino.plugin.sqlserver;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.expression.Variable;
 import io.trino.spi.type.DoubleType;
@@ -27,16 +27,16 @@ import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
 import static io.trino.matching.Capture.newCapture;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.basicAggregation;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.expressionType;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.functionName;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.singleInput;
-import static io.trino.plugin.jdbc.expression.AggregateFunctionPatterns.variable;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.basicAggregation;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.expressionType;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.functionName;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.singleInput;
+import static io.trino.plugin.base.expression.AggregateFunctionPatterns.variable;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static java.lang.String.format;
 
 public class ImplementSqlServerVariancePop
-        implements AggregateFunctionRule
+        implements AggregateFunctionRule<JdbcExpression>
 {
     private static final Capture<Variable> INPUT = newCapture();
 

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -20,6 +20,8 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
+import io.trino.plugin.base.expression.AggregateFunctionRewriter;
+import io.trino.plugin.base.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.BaseJdbcClient;
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ColumnMapping;
@@ -37,8 +39,6 @@ import io.trino.plugin.jdbc.LongWriteFunction;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.SliceWriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRewriter;
-import io.trino.plugin.jdbc.expression.AggregateFunctionRule;
 import io.trino.plugin.jdbc.expression.ImplementAvgDecimal;
 import io.trino.plugin.jdbc.expression.ImplementAvgFloatingPoint;
 import io.trino.plugin.jdbc.expression.ImplementCount;
@@ -151,7 +151,7 @@ public class SqlServerClient
             .expireAfterWrite(ofMinutes(5))
             .build();
 
-    private final AggregateFunctionRewriter aggregateFunctionRewriter;
+    private final AggregateFunctionRewriter<JdbcExpression> aggregateFunctionRewriter;
 
     private static final int MAX_SUPPORTED_TEMPORAL_PRECISION = 7;
 
@@ -164,9 +164,9 @@ public class SqlServerClient
         snapshotIsolationDisabled = sqlServerConfig.isSnapshotIsolationDisabled();
 
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());
-        this.aggregateFunctionRewriter = new AggregateFunctionRewriter(
+        this.aggregateFunctionRewriter = new AggregateFunctionRewriter<>(
                 this::quoted,
-                ImmutableSet.<AggregateFunctionRule>builder()
+                ImmutableSet.<AggregateFunctionRule<JdbcExpression>>builder()
                         .add(new ImplementCountAll(bigintTypeHandle))
                         .add(new ImplementCount(bigintTypeHandle))
                         .add(new ImplementMinMax())


### PR DESCRIPTION
This is to make it reusable between connectors based on base-jdbc and
the Pinot connector.

For https://github.com/trinodb/trino/pull/6069