### PR TITLE
Add JDBC driver resultset buffer size property

### DIFF
--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -88,6 +88,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String> TRACE_TOKEN = new TraceToken();
     public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
     public static final ConnectionProperty<String> SOURCE = new Source();
+    public static final ConnectionProperty<Integer> RESULT_SET_BUFFER_SIZE = new ResultSetBufferSize();
 
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
             .add(USER)
@@ -128,6 +129,7 @@ final class ConnectionProperties
             .add(EXTERNAL_AUTHENTICATION_TIMEOUT)
             .add(EXTERNAL_AUTHENTICATION_TOKEN_CACHE)
             .add(EXTERNAL_AUTHENTICATION_REDIRECT_HANDLERS)
+            .add(RESULT_SET_BUFFER_SIZE)
             .build();
 
     private static final Map<String, ConnectionProperty<?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -579,6 +581,30 @@ final class ConnectionProperties
         public static Map<String, String> parseExtraCredentials(String extraCredentialString)
         {
             return new MapPropertyParser("extraCredentials").parse(extraCredentialString);
+        }
+    }
+
+    private static class ResultSetBufferSize
+            extends AbstractConnectionProperty<Integer>
+    {
+        public ResultSetBufferSize()
+        {
+            super("resultSetBufferSize", Optional.of("50000"), NOT_REQUIRED, ALLOWED, ResultSetBufferSize::parseBufferSize);
+        }
+
+        public static Integer parseBufferSize(String value)
+        {
+            int valueAsInt;
+            try {
+                valueAsInt = Integer.parseInt(value);
+            }
+            catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("value must be a positive integer");
+            }
+            if (valueAsInt <= 0) {
+                throw new IllegalArgumentException("value must be a positive integer");
+            }
+            return valueAsInt;
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoConnection.java
@@ -112,6 +112,7 @@ public class TrinoConnection
     private final AtomicReference<String> transactionId = new AtomicReference<>();
     private final OkHttpClient httpClient;
     private final Set<TrinoStatement> statements = newSetFromMap(new ConcurrentHashMap<>());
+    private final int resultSetBufferSize;
 
     TrinoConnection(TrinoDriverUri uri, OkHttpClient httpClient)
             throws SQLException
@@ -137,6 +138,7 @@ public class TrinoConnection
         this.assumeLiteralUnderscoreInMetadataCallsForNonConformingClients = uri.isAssumeLiteralUnderscoreInMetadataCallsForNonConformingClients();
 
         this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.resultSetBufferSize = uri.getResultSetBufferSize();
         uri.getClientInfo().ifPresent(tags -> clientInfo.put(CLIENT_INFO, tags));
         uri.getClientTags().ifPresent(tags -> clientInfo.put(CLIENT_TAGS, tags));
         uri.getTraceToken().ifPresent(tags -> clientInfo.put(TRACE_TOKEN, tags));
@@ -717,6 +719,11 @@ public class TrinoConnection
                 "START TRANSACTION ISOLATION LEVEL %s, READ %s",
                 getIsolationLevel(isolationLevel.get()),
                 readOnly.get() ? "ONLY" : "WRITE");
+    }
+
+    int resultSetBufferSize()
+    {
+        return resultSetBufferSize;
     }
 
     StatementClient startQuery(String sql, Map<String, String> sessionPropertiesOverride)

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java
@@ -73,6 +73,7 @@ import static io.trino.jdbc.ConnectionProperties.KERBEROS_REMOTE_SERVICE_NAME;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_SERVICE_PRINCIPAL_PATTERN;
 import static io.trino.jdbc.ConnectionProperties.KERBEROS_USE_CANONICAL_HOSTNAME;
 import static io.trino.jdbc.ConnectionProperties.PASSWORD;
+import static io.trino.jdbc.ConnectionProperties.RESULT_SET_BUFFER_SIZE;
 import static io.trino.jdbc.ConnectionProperties.ROLES;
 import static io.trino.jdbc.ConnectionProperties.SESSION_PROPERTIES;
 import static io.trino.jdbc.ConnectionProperties.SESSION_USER;
@@ -232,6 +233,12 @@ public final class TrinoDriverUri
             throws SQLException
     {
         return SESSION_PROPERTIES.getValue(properties).orElse(ImmutableMap.of());
+    }
+
+    public int getResultSetBufferSize()
+            throws SQLException
+    {
+        return RESULT_SET_BUFFER_SIZE.getRequiredValue(properties);
     }
 
     public Optional<String> getSource()

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoDriverUri.java
@@ -182,6 +182,11 @@ public class TestTrinoDriverUri
         // legacy url
         assertInvalid("jdbc:presto://localhost:8080", "Invalid JDBC URL: jdbc:presto://localhost:8080");
 
+        //invalid result buffer sizes
+        assertInvalid("jdbc:trino://localhost:8080?resultSetBufferSize=0", "Connection property 'resultSetBufferSize' value is invalid:");
+        assertInvalid("jdbc:trino://localhost:8080?resultSetBufferSize=-1", "Connection property 'resultSetBufferSize' value is invalid:");
+        assertInvalid("jdbc:trino://localhost:8080?resultSetBufferSize=abc", "Connection property 'resultSetBufferSize' value is invalid:");
+
         // cannot set mutually exclusive properties for non-conforming clients to true
         assertInvalid("jdbc:trino://localhost:8080?assumeLiteralNamesInMetadataCallsForNonConformingClients=true&assumeLiteralUnderscoreInMetadataCallsForNonConformingClients=true", "Connection property 'assumeLiteralNamesInMetadataCallsForNonConformingClients' is not allowed");
     }
@@ -420,6 +425,20 @@ public class TestTrinoDriverUri
         TrinoDriverUri parameters = createDriverUri("jdbc:trino://localhost:8080?assumeLiteralUnderscoreInMetadataCallsForNonConformingClients=true");
         assertThat(parameters.isAssumeLiteralUnderscoreInMetadataCallsForNonConformingClients()).isTrue();
         assertThat(parameters.isAssumeLiteralNamesInMetadataCallsForNonConformingClients()).isFalse();
+    }
+
+    @Test
+    public void testUriWithResultSetBufferSize() throws SQLException
+    {
+        TrinoDriverUri parameters = createDriverUri("jdbc:trino://localhost:8080?resultSetBufferSize=1000");
+        assertEquals(1_000, parameters.getResultSetBufferSize());
+    }
+
+    @Test
+    public void testDefaultResultSetBufferSize() throws SQLException
+    {
+        TrinoDriverUri parameters = createDriverUri("jdbc:trino://localhost:8080");
+        assertEquals(50_000, parameters.getResultSetBufferSize());
     }
 
     private static void assertUriPortScheme(TrinoDriverUri parameters, int port, String scheme)

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoResultSet.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestTrinoResultSet.java
@@ -266,7 +266,7 @@ public class TestTrinoResultSet
                             // do nothing
                         }
                     },
-                    Optional.of(queue));
+                    queue);
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/trinodb/trino/issues/8360

Rather than hard coding 50k for MAX_QUEUED_ROWS, create jdbc property (defaulted to 50k) which controls the value.