### PR TITLE
Throw schema not accessible exception for hive system schemas

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -243,6 +243,7 @@ public class IcebergMetadata
     @Override
     public Map<String, Object> getSchemaProperties(ConnectorSession session, CatalogSchemaName schemaName)
     {
+        checkState(isHiveSystemSchema(schemaName.getSchemaName()), "Schema is not accessible: %s", schemaName);
         Optional<Database> db = metastore.getDatabase(schemaName.getSchemaName());
         if (db.isPresent()) {
             return HiveSchemaProperties.fromDatabase(db.get());
@@ -254,6 +255,7 @@ public class IcebergMetadata
     @Override
     public Optional<TrinoPrincipal> getSchemaOwner(ConnectorSession session, CatalogSchemaName schemaName)
     {
+        checkState(isHiveSystemSchema(schemaName.getSchemaName()), "Schema is not accessible: %s", schemaName);
         Optional<Database> database = metastore.getDatabase(schemaName.getSchemaName());
         if (database.isPresent()) {
             return database.flatMap(db -> Optional.of(new TrinoPrincipal(db.getOwnerType(), db.getOwnerName())));


### PR DESCRIPTION
Currently if we execute 'show create schema information_schema' we will get 'schema not found' exception:
```
trino:iceberg_db> show create schema information_schema;
Query 20210719_035035_00006_mr4jk failed: Schema information_schema not found
io.trino.spi.connector.SchemaNotFoundException: Schema information_schema not found
	at io.trino.plugin.iceberg.IcebergMetadata.getSchemaProperties(IcebergMetadata.java:218)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.getSchemaProperties(ClassLoaderSafeConnectorMetadata.java:564)
	at io.trino.metadata.MetadataManager.getSchemaProperties(MetadataManager.java:1158)
	at io.trino.sql.rewrite.ShowQueriesRewrite$Visitor.visitShowCreate(ShowQueriesRewrite.java:604)
	at io.trino.sql.rewrite.ShowQueriesRewrite$Visitor.visitShowCreate(ShowQueriesRewrite.java:171)
	at io.trino.sql.tree.ShowCreate.accept(ShowCreate.java:70)
	at io.trino.sql.tree.AstVisitor.process(AstVisitor.java:27)
	at io.trino.sql.rewrite.ShowQueriesRewrite.rewrite(ShowQueriesRewrite.java:168)
	at io.trino.sql.rewrite.StatementRewrite.rewrite(StatementRewrite.java:61)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:88)
	at io.trino.sql.analyzer.Analyzer.analyze(Analyzer.java:83)
	at io.trino.execution.SqlQueryExecution.analyze(SqlQueryExecution.java:269)
	at io.trino.execution.SqlQueryExecution.<init>(SqlQueryExecution.java:190)
	at io.trino.execution.SqlQueryExecution$SqlQueryExecutionFactory.createQueryExecution(SqlQueryExecution.java:806)
	at io.trino.dispatcher.LocalDispatchQueryFactory.lambda$createDispatchQuery$0(LocalDispatchQueryFactory.java:132)
	at io.trino.$gen.Trino_358_2_g669f6ea_dirty____20210706_143456_2.call(Unknown Source)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:69)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
```
This is misleading since information_schema actually exist. So we should throw 'schema is not accessible exception' instead.