### PR TITLE
Support extending elasticsearch AWS Request Signer

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorFactory.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.elasticsearch;
 
 import com.google.inject.Injector;
+import com.google.inject.Module;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 import io.trino.plugin.base.TypeDeserializerModule;
@@ -33,7 +34,17 @@ import static java.util.Objects.requireNonNull;
 public class ElasticsearchConnectorFactory
         implements ConnectorFactory
 {
-    ElasticsearchConnectorFactory() {}
+    private final Module extension;
+
+    public ElasticsearchConnectorFactory()
+    {
+        this(new ElasticsearchDefaultExtensionModule());
+    }
+
+    public ElasticsearchConnectorFactory(Module extension)
+    {
+        this.extension = requireNonNull(extension, "extension is null");
+    }
 
     @Override
     public String getName()
@@ -62,7 +73,8 @@ public class ElasticsearchConnectorFactory
                 new ElasticsearchConnectorModule(),
                 binder -> {
                     binder.bind(NodeManager.class).toInstance(context.getNodeManager());
-                });
+                },
+                extension);
 
         Injector injector = app.strictConfig()
                 .doNotInitializeLogging()

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorModule.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchConnectorModule.java
@@ -16,12 +16,12 @@ package io.trino.plugin.elasticsearch;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.elasticsearch.aws.AwsSignerCredentialsProvider;
 import io.trino.plugin.elasticsearch.client.ElasticsearchClient;
 
 import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.airlift.configuration.ConfigBinder.configBinder;
-import static io.trino.plugin.elasticsearch.ElasticsearchConfig.Security.AWS;
 import static io.trino.plugin.elasticsearch.ElasticsearchConfig.Security.PASSWORD;
 import static java.util.function.Predicate.isEqual;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
@@ -43,15 +43,8 @@ public class ElasticsearchConnectorModule
 
         configBinder(binder).bindConfig(ElasticsearchConfig.class);
 
-        newOptionalBinder(binder, AwsSecurityConfig.class);
+        newOptionalBinder(binder, AwsSignerCredentialsProvider.class);
         newOptionalBinder(binder, PasswordConfig.class);
-
-        install(conditionalModule(
-                ElasticsearchConfig.class,
-                config -> config.getSecurity()
-                        .filter(isEqual(AWS))
-                        .isPresent(),
-                conditionalBinder -> configBinder(conditionalBinder).bindConfig(AwsSecurityConfig.class)));
 
         install(conditionalModule(
                 ElasticsearchConfig.class,

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchDefaultExtensionModule.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/ElasticsearchDefaultExtensionModule.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch;
+
+import com.google.inject.Binder;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.elasticsearch.aws.ElasticsearchAwsModule;
+
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.trino.plugin.elasticsearch.ElasticsearchConfig.Security.AWS;
+import static java.util.function.Predicate.isEqual;
+
+public class ElasticsearchDefaultExtensionModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        install(conditionalModule(
+                ElasticsearchConfig.class,
+                config -> config.getSecurity()
+                        .filter(isEqual(AWS))
+                        .isPresent(),
+                new ElasticsearchAwsModule()));
+    }
+}

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aws/AwsRequestSigner.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aws/AwsRequestSigner.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.elasticsearch.client;
+package io.trino.plugin.elasticsearch.aws;
 
 import com.amazonaws.DefaultRequest;
 import com.amazonaws.auth.AWS4Signer;
@@ -42,7 +42,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static org.apache.http.protocol.HttpCoreContext.HTTP_TARGET_HOST;
 
-class AwsRequestSigner
+public class AwsRequestSigner
         implements HttpRequestInterceptor
 {
     private static final String SERVICE_NAME = "es";

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aws/AwsSecurityConfig.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aws/AwsSecurityConfig.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.elasticsearch;
+package io.trino.plugin.elasticsearch.aws;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigSecuritySensitive;

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aws/AwsSignerCredentialsProvider.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aws/AwsSignerCredentialsProvider.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch.aws;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+
+public interface AwsSignerCredentialsProvider
+{
+    String getAwsRegion();
+
+    AWSCredentialsProvider getCredentialsProvider();
+}

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aws/ElasticsearchAwsModule.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aws/ElasticsearchAwsModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch.aws;
+
+import com.google.inject.Binder;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+import static io.airlift.configuration.ConfigBinder.configBinder;
+
+public class ElasticsearchAwsModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(AwsSecurityConfig.class);
+        newOptionalBinder(binder, AwsSignerCredentialsProvider.class)
+                .setDefault().to(IamUserCredentialsProvider.class);
+    }
+}

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aws/IamUserCredentialsProvider.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/aws/IamUserCredentialsProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch.aws;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.google.inject.Inject;
+
+public class IamUserCredentialsProvider
+        implements AwsSignerCredentialsProvider
+{
+    private final AwsSecurityConfig awsSecurityConfig;
+
+    @Inject
+    public IamUserCredentialsProvider(AwsSecurityConfig awsSecurityConfig)
+    {
+        this.awsSecurityConfig = awsSecurityConfig;
+    }
+
+    @Override
+    public String getAwsRegion()
+    {
+        return awsSecurityConfig.getRegion();
+    }
+
+    @Override
+    public AWSCredentialsProvider getCredentialsProvider()
+    {
+        if (awsSecurityConfig.getAccessKey().isPresent() && awsSecurityConfig.getSecretKey().isPresent()) {
+            return new AWSStaticCredentialsProvider(new BasicAWSCredentials(
+                    awsSecurityConfig.getAccessKey().get(),
+                    awsSecurityConfig.getSecretKey().get()));
+        }
+        return DefaultAWSCredentialsProviderChain.getInstance();
+    }
+}

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -129,7 +129,7 @@ public abstract class BaseElasticsearchConnectorTest
     public final void destroy()
             throws IOException
     {
-        elasticsearch.stop();
+        elasticsearch.close();
         client.close();
     }
 

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -162,6 +162,7 @@ public abstract class BaseElasticsearchConnectorTest
                 "TopNPartial\\[5 by \\(nationkey DESC");
     }
 
+    @Test
     @Override
     public void testShowCreateTable()
     {

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
@@ -14,6 +14,9 @@
 package io.trino.plugin.elasticsearch;
 
 import com.google.common.net.HostAndPort;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -74,5 +77,11 @@ public class ElasticsearchServer
     public HostAndPort getAddress()
     {
         return HostAndPort.fromString(container.getHttpHostAddress());
+    }
+
+    public RestHighLevelClient createClient()
+    {
+        HostAndPort address = getAddress();
+        return new RestHighLevelClient(RestClient.builder(new HttpHost(address.getHost(), address.getPort())));
     }
 }

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
@@ -18,6 +18,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -30,6 +31,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
 public class ElasticsearchServer
+        implements Closeable
 {
     private final Path configurationPath;
     private final ElasticsearchContainer container;
@@ -61,7 +63,8 @@ public class ElasticsearchServer
         container.start();
     }
 
-    public void stop()
+    @Override
+    public void close()
             throws IOException
     {
         container.close();

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch6ConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch6ConnectorTest.java
@@ -14,21 +14,37 @@
 package io.trino.plugin.elasticsearch;
 
 import com.google.common.collect.ImmutableMap;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 
+import static io.trino.plugin.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
 import static java.lang.String.format;
 
 public class TestElasticsearch6ConnectorTest
         extends BaseElasticsearchConnectorTest
 {
-    public TestElasticsearch6ConnectorTest()
+    private RestHighLevelClient client;
+
+    @Override
+    protected RestHighLevelClient getClient()
     {
-        super("docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0");
+        return client;
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        ElasticsearchServer elasticsearch = closeAfterClass(new ElasticsearchServer("docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0", ImmutableMap.of()));
+        client = closeAfterClass(elasticsearch.createClient());
+        return createElasticsearchQueryRunner(elasticsearch.getAddress(), TpchTable.getTables(), ImmutableMap.of(), ImmutableMap.of(), 3);
     }
 
     @Test

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch7ConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearch7ConnectorTest.java
@@ -13,14 +13,32 @@
  */
 package io.trino.plugin.elasticsearch;
 
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.QueryRunner;
+import io.trino.tpch.TpchTable;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import static io.trino.plugin.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
 import static java.lang.String.format;
 
 public class TestElasticsearch7ConnectorTest
         extends BaseElasticsearchConnectorTest
 {
-    public TestElasticsearch7ConnectorTest()
+    private RestHighLevelClient client;
+
+    @Override
+    protected RestHighLevelClient getClient()
     {
-        super("elasticsearch:7.0.0");
+        return client;
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        ElasticsearchServer elasticsearch = closeAfterClass(new ElasticsearchServer("elasticsearch:7.0.0", ImmutableMap.of()));
+        client = closeAfterClass(elasticsearch.createClient());
+        return createElasticsearchQueryRunner(elasticsearch.getAddress(), TpchTable.getTables(), ImmutableMap.of(), ImmutableMap.of(), 3);
     }
 
     @Override

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchBackpressure.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestElasticsearchBackpressure.java
@@ -57,7 +57,7 @@ public class TestElasticsearchBackpressure
             throws IOException
     {
         elasticsearchNginxProxy.stop();
-        elasticsearch.stop();
+        elasticsearch.close();
     }
 
     @Test

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestPasswordAuthentication.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestPasswordAuthentication.java
@@ -83,11 +83,7 @@ public class TestPasswordAuthentication
     public final void destroy()
             throws IOException
     {
-        closeAll(
-                () -> assertions.close(),
-                () -> elasticsearch.stop(),
-                () -> client.close());
-
+        closeAll(assertions, elasticsearch, client);
         assertions = null;
         elasticsearch = null;
         client = null;

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/aws/TestAwsSecurityConfig.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/aws/TestAwsSecurityConfig.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.elasticsearch;
+package io.trino.plugin.elasticsearch.aws;
 
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/aws/TestIamUserCredentialsProvider.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/aws/TestIamUserCredentialsProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.elasticsearch.aws;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestIamUserCredentialsProvider
+{
+    @Test
+    public void testGetAwsRegion()
+    {
+        String awsRegion = "us-east-2";
+        AwsSecurityConfig awsConfig = new AwsSecurityConfig().setRegion(awsRegion);
+        IamUserCredentialsProvider instance = new IamUserCredentialsProvider(awsConfig);
+
+        assertThat(instance.getAwsRegion()).isEqualTo(awsRegion);
+    }
+
+    @Test
+    public void testGetCredentialsProviderWithConfiguredCredentials()
+    {
+        AwsSecurityConfig awsConfig = new AwsSecurityConfig()
+                .setAccessKey("access")
+                .setSecretKey("secret");
+        IamUserCredentialsProvider instance = new IamUserCredentialsProvider(awsConfig);
+
+        assertThat(instance.getCredentialsProvider()).isInstanceOf(AWSStaticCredentialsProvider.class);
+        assertThat(instance.getCredentialsProvider().getCredentials().getAWSAccessKeyId()).isEqualTo("access");
+        assertThat(instance.getCredentialsProvider().getCredentials().getAWSSecretKey()).isEqualTo("secret");
+    }
+
+    @Test
+    public void testGetCredentialsProviderWithNoConfiguredCredentials()
+    {
+        AwsSecurityConfig awsConfig = new AwsSecurityConfig();
+        IamUserCredentialsProvider instance = new IamUserCredentialsProvider(awsConfig);
+
+        assertThat(instance.getCredentialsProvider()).isInstanceOf(DefaultAWSCredentialsProviderChain.class);
+    }
+}


### PR DESCRIPTION
- Support adding an additional module to `ElasticsearchConnectorFactory`
- Extract a new `ElasticsearchAwsModule` that provides a default implementation for the `AwsSignerCredentialsProvider` interface
- Change `ElasticsearchClient` to inject `Optional<AwsSignerCredentialsProvider>` rather than the AWS config, to allow extending AWS authentication with different credential providers