### PR TITLE
Add tests counting metastore accesses for Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/CountingAccessFileHiveMetastore.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/CountingAccessFileHiveMetastore.java
@@ -1,0 +1,335 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import io.trino.plugin.hive.HiveType;
+import io.trino.plugin.hive.PartitionStatistics;
+import io.trino.plugin.hive.acid.AcidTransaction;
+import io.trino.plugin.hive.authentication.HiveIdentity;
+import io.trino.plugin.hive.metastore.Database;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.HivePrincipal;
+import io.trino.plugin.hive.metastore.HivePrivilegeInfo;
+import io.trino.plugin.hive.metastore.Partition;
+import io.trino.plugin.hive.metastore.PartitionWithStatistics;
+import io.trino.plugin.hive.metastore.PrincipalPrivileges;
+import io.trino.plugin.hive.metastore.Table;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.security.RoleGrant;
+import io.trino.spi.statistics.ColumnStatisticType;
+import io.trino.spi.type.Type;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+@ThreadSafe
+public class CountingAccessFileHiveMetastore
+        implements HiveMetastore
+{
+    public enum Methods
+    {
+        CREATE_DATABASE,
+        CREATE_TABLE,
+        GET_ALL_DATABASES,
+        GET_DATABASE,
+        GET_TABLE,
+        GET_TABLE_WITH_PARAMETER,
+        GET_TABLE_STATISTICS,
+    }
+
+    private final HiveMetastore delegate;
+    private final ConcurrentHashMultiset<Methods> methodInvocations = ConcurrentHashMultiset.create();
+
+    public CountingAccessFileHiveMetastore(HiveMetastore delegate)
+    {
+        this.delegate = delegate;
+    }
+
+    public Multiset<Methods> getMethodInvocations()
+    {
+        return ImmutableMultiset.copyOf(methodInvocations);
+    }
+
+    public void resetCounters()
+    {
+        methodInvocations.clear();
+    }
+
+    @Override
+    public Optional<Table> getTable(HiveIdentity identity, String databaseName, String tableName)
+    {
+        methodInvocations.add(Methods.GET_TABLE);
+        return delegate.getTable(identity, databaseName, tableName);
+    }
+
+    @Override
+    public Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> getAllDatabases()
+    {
+        methodInvocations.add(Methods.GET_ALL_DATABASES);
+        return delegate.getAllDatabases();
+    }
+
+    @Override
+    public Optional<Database> getDatabase(String databaseName)
+    {
+        methodInvocations.add(Methods.GET_DATABASE);
+        return delegate.getDatabase(databaseName);
+    }
+
+    @Override
+    public List<String> getTablesWithParameter(String databaseName, String parameterKey, String parameterValue)
+    {
+        methodInvocations.add(Methods.GET_TABLE_WITH_PARAMETER);
+        return delegate.getTablesWithParameter(databaseName, parameterKey, parameterValue);
+    }
+
+    @Override
+    public List<String> getAllViews(String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createDatabase(HiveIdentity identity, Database database)
+    {
+        methodInvocations.add(Methods.CREATE_DATABASE);
+        delegate.createDatabase(identity, database);
+    }
+
+    @Override
+    public void dropDatabase(HiveIdentity identity, String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void renameDatabase(HiveIdentity identity, String databaseName, String newDatabaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDatabaseOwner(HiveIdentity identity, String databaseName, HivePrincipal principal)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createTable(HiveIdentity identity, Table table, PrincipalPrivileges principalPrivileges)
+    {
+        methodInvocations.add(Methods.CREATE_TABLE);
+        delegate.createTable(identity, table, principalPrivileges);
+    }
+
+    @Override
+    public void dropTable(HiveIdentity identity, String databaseName, String tableName, boolean deleteData)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void replaceTable(HiveIdentity identity, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void renameTable(HiveIdentity identity, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void commentTable(HiveIdentity identity, String databaseName, String tableName, Optional<String> comment)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTableOwner(HiveIdentity identity, String databaseName, String tableName, HivePrincipal principal)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void commentColumn(HiveIdentity identity, String databaseName, String tableName, String columnName, Optional<String> comment)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addColumn(HiveIdentity identity, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void renameColumn(HiveIdentity identity, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dropColumn(HiveIdentity identity, String databaseName, String tableName, String columnName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Partition> getPartition(HiveIdentity identity, Table table, List<String> partitionValues)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<String>> getPartitionNamesByFilter(HiveIdentity identity, String databaseName, String tableName, List<String> columnNames, TupleDomain<String> partitionKeysFilter)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Optional<Partition>> getPartitionsByNames(HiveIdentity identity, Table table, List<String> partitionNames)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addPartitions(HiveIdentity identity, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dropPartition(HiveIdentity identity, String databaseName, String tableName, List<String> parts, boolean deleteData)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void alterPartition(HiveIdentity identity, String databaseName, String tableName, PartitionWithStatistics partition)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void createRole(String role, String grantor)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void dropRole(String role)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<String> listRoles()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void grantRoles(Set<String> roles, Set<HivePrincipal> grantees, boolean adminOption, HivePrincipal grantor)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void revokeRoles(Set<String> roles, Set<HivePrincipal> grantees, boolean adminOption, HivePrincipal grantor)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<RoleGrant> listGrantedPrincipals(String role)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<RoleGrant> listRoleGrants(HivePrincipal principal)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void grantTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void revokeTablePrivileges(String databaseName, String tableName, String tableOwner, HivePrincipal grantee, Set<HivePrivilegeInfo> privileges)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<HivePrivilegeInfo> listTablePrivileges(String databaseName, String tableName, String tableOwner, Optional<HivePrincipal> principal)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isImpersonationEnabled()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PartitionStatistics getTableStatistics(HiveIdentity identity, Table table)
+    {
+        methodInvocations.add(Methods.GET_TABLE_STATISTICS);
+        return delegate.getTableStatistics(identity, table);
+    }
+
+    @Override
+    public Map<String, PartitionStatistics> getPartitionStatistics(HiveIdentity identity, Table table, List<Partition> partitions)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateTableStatistics(HiveIdentity identity, String databaseName, String tableName, AcidTransaction transaction, Function<PartitionStatistics, PartitionStatistics> update)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updatePartitionStatistics(HiveIdentity identity, Table table, String partitionName, Function<PartitionStatistics, PartitionStatistics> update)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> getAllTables(String databaseName)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multiset;
+import io.trino.Session;
+import io.trino.plugin.hive.HdfsConfig;
+import io.trino.plugin.hive.HdfsConfiguration;
+import io.trino.plugin.hive.HdfsConfigurationInitializer;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HiveHdfsConfiguration;
+import io.trino.plugin.hive.NodeVersion;
+import io.trino.plugin.hive.authentication.NoHdfsAuthentication;
+import io.trino.plugin.hive.metastore.HiveMetastore;
+import io.trino.plugin.hive.metastore.MetastoreConfig;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastore;
+import io.trino.plugin.hive.metastore.file.FileHiveMetastoreConfig;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+import static io.trino.plugin.iceberg.CountingAccessFileHiveMetastore.Methods.CREATE_TABLE;
+import static io.trino.plugin.iceberg.CountingAccessFileHiveMetastore.Methods.GET_DATABASE;
+import static io.trino.plugin.iceberg.CountingAccessFileHiveMetastore.Methods.GET_TABLE;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true) // metastore invocation counters shares mutable state so can't be run from many threads simultaneously
+public class TestIcebergMetastoreAccessOperations
+        extends AbstractTestQueryFramework
+{
+    private static final Session TEST_SESSION = testSessionBuilder()
+            .setCatalog("iceberg")
+            .setSchema("test_schema")
+            .build();
+
+    private CountingAccessFileHiveMetastore metastore;
+
+    @Override
+    protected DistributedQueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(TEST_SESSION).build();
+
+        File baseDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").toFile();
+        HdfsConfig hdfsConfig = new HdfsConfig();
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hdfsConfig), ImmutableSet.of());
+        HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, hdfsConfig, new NoHdfsAuthentication());
+        HiveMetastore hiveMetastore = new FileHiveMetastore(
+                new NodeVersion("testversion"),
+                hdfsEnvironment,
+                new MetastoreConfig(),
+                new FileHiveMetastoreConfig()
+                        .setCatalogDirectory(baseDir.toURI().toString())
+                        .setMetastoreUser("test"));
+        metastore = new CountingAccessFileHiveMetastore(hiveMetastore);
+        queryRunner.installPlugin(new TestingIcebergPlugin(metastore, true));
+        queryRunner.createCatalog("iceberg", "iceberg");
+
+        queryRunner.execute("CREATE SCHEMA test_schema");
+        return queryRunner;
+    }
+
+    @Test
+    public void testCreateTable()
+    {
+        assertMetastoreInvocations("CREATE TABLE test_create (id VARCHAR, age INT)",
+                ImmutableMultiset.builder()
+                        .add(CREATE_TABLE)
+                        .add(GET_DATABASE)
+                        .addCopies(GET_TABLE, 2)
+                        .build());
+    }
+
+    @Test
+    public void testCreateTableAsSelect()
+    {
+        assertMetastoreInvocations("CREATE TABLE test_ctas AS SELECT 1 AS age",
+                ImmutableMultiset.builder()
+                        .add(GET_DATABASE)
+                        .add(CREATE_TABLE)
+                        .addCopies(GET_TABLE, 2)
+                        .build());
+    }
+
+    @Test
+    public void testSelect()
+    {
+        assertUpdate("CREATE TABLE test_select_from (id VARCHAR, age INT)");
+
+        assertMetastoreInvocations("SELECT * FROM test_select_from",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_TABLE, 12)
+                        .build());
+    }
+
+    @Test
+    public void testSelectWithFilter()
+    {
+        assertUpdate("CREATE TABLE test_select_from_where AS SELECT 2 as age", 1);
+
+        assertMetastoreInvocations("SELECT * FROM test_select_from_where WHERE age = 2",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_TABLE, 12)
+                        .build());
+    }
+
+    @Test
+    public void testJoin()
+    {
+        assertUpdate("CREATE TABLE test_join_t1 AS SELECT 2 as age, 'id1' AS id", 1);
+        assertUpdate("CREATE TABLE test_join_t2 AS SELECT 'name1' as name, 'id1' AS id", 1);
+
+        assertMetastoreInvocations("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_TABLE, 24)
+                        .build());
+    }
+
+    @Test
+    public void testExplainSelect()
+    {
+        assertUpdate("CREATE TABLE test_explain AS SELECT 2 as age", 1);
+
+        assertMetastoreInvocations("EXPLAIN SELECT * FROM test_explain",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_TABLE, 11)
+                        .build());
+    }
+
+    @Test
+    public void testShowStatsForTable()
+    {
+        assertUpdate("CREATE TABLE test_show_stats AS SELECT 2 as age", 1);
+
+        assertMetastoreInvocations("SHOW STATS FOR test_show_stats",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_TABLE, 9)
+                        .build());
+    }
+
+    @Test
+    public void testShowStatsForTableWithFilter()
+    {
+        assertUpdate("CREATE TABLE test_show_stats_with_filter AS SELECT 2 as age", 1);
+
+        assertMetastoreInvocations("SHOW STATS FOR (SELECT * FROM test_show_stats_with_filter where age >= 2)",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_TABLE, 9)
+                        .build());
+    }
+
+    private void assertMetastoreInvocations(String query, Multiset expectedInvocations)
+    {
+        metastore.resetCounters();
+        getQueryRunner().execute(query);
+        assertThat(metastore.getMethodInvocations()).containsExactlyInAnyOrderElementsOf(expectedInvocations);
+    }
+}


### PR DESCRIPTION
Accessing metastore is expensive so in order
to prevent performance regressions test will now
count how many times metastore is accessed
for specific queries.
In case this number changes the test will fail
preventing from introducing performance regression.