### PR TITLE
Fix Cassandra Range pushdown

### DIFF
--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClusteringPredicatesExtractor.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClusteringPredicatesExtractor.java
@@ -23,12 +23,13 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 
 public class CassandraClusteringPredicatesExtractor
 {
@@ -55,7 +56,7 @@ public class CassandraClusteringPredicatesExtractor
     {
         ImmutableSet.Builder<ColumnHandle> fullyPushedColumnPredicates = ImmutableSet.builder();
         ImmutableList.Builder<String> clusteringColumnSql = ImmutableList.builder();
-        int currentClusteringColumn = 0;
+        int allProcessedClusteringColumns = 0;
         for (CassandraColumnHandle columnHandle : clusteringColumns) {
             Domain domain = predicates.getDomains().get().get(columnHandle);
             if (domain == null) {
@@ -64,64 +65,46 @@ public class CassandraClusteringPredicatesExtractor
             if (domain.isNullAllowed()) {
                 break;
             }
+
+            int currentlyProcessedClusteringColumn = allProcessedClusteringColumns;
             String predicateString = domain.getValues().getValuesProcessor().transform(
                     ranges -> {
-                        List<Object> singleValues = new ArrayList<>();
-                        List<String> rangeConjuncts = new ArrayList<>();
-                        String predicate = null;
+                        if (ranges.getRangeCount() == 1) {
+                            fullyPushedColumnPredicates.add(columnHandle);
+                            return translateRangeIntoCql(columnHandle, getOnlyElement(ranges.getOrderedRanges()));
+                        }
+                        if (ranges.getOrderedRanges().stream().allMatch(Range::isSingleValue)) {
+                            if (isInExpressionNotAllowed(clusteringColumns, cassandraVersion, currentlyProcessedClusteringColumn)) {
+                                return translateRangeIntoCql(columnHandle, ranges.getSpan());
+                            }
 
-                        for (Range range : ranges.getOrderedRanges()) {
-                            if (range.isAll()) {
-                                return null;
-                            }
-                            if (range.isSingleValue()) {
-                                singleValues.add(columnHandle.getCassandraType().toCqlLiteral(range.getSingleValue()));
-                            }
-                            else {
-                                if (!range.isLowUnbounded()) {
-                                    String lowBound = columnHandle.getCassandraType().toCqlLiteral(range.getLowBoundedValue());
-                                    rangeConjuncts.add(format(
-                                            "%s %s %s",
-                                            CassandraCqlUtils.validColumnName(columnHandle.getName()),
-                                            range.isLowInclusive() ? ">=" : ">",
-                                            lowBound));
-                                }
-                                if (!range.isHighUnbounded()) {
-                                    String highBound = columnHandle.getCassandraType().toCqlLiteral(range.getHighBoundedValue());
-                                    rangeConjuncts.add(format(
-                                            "%s %s %s",
-                                            CassandraCqlUtils.validColumnName(columnHandle.getName()),
-                                            range.isHighInclusive() ? "<=" : "<",
-                                            highBound));
-                                }
-                            }
+                            String inValues = ranges.getOrderedRanges().stream()
+                                    .map(range -> toCqlLiteral(columnHandle, range.getSingleValue()))
+                                    .collect(joining(","));
+                            fullyPushedColumnPredicates.add(columnHandle);
+                            return CassandraCqlUtils.validColumnName(columnHandle.getName()) + " IN (" + inValues + ")";
                         }
-
-                        if (!singleValues.isEmpty() && !rangeConjuncts.isEmpty()) {
-                            return null;
-                        }
-                        if (!singleValues.isEmpty()) {
-                            if (singleValues.size() == 1) {
-                                predicate = CassandraCqlUtils.validColumnName(columnHandle.getName()) + " = " + singleValues.get(0);
-                            }
-                            else {
-                                predicate = CassandraCqlUtils.validColumnName(columnHandle.getName()) + " IN ("
-                                        + Joiner.on(",").join(singleValues) + ")";
-                            }
-                        }
-                        else if (!rangeConjuncts.isEmpty()) {
-                            predicate = Joiner.on(" AND ").join(rangeConjuncts);
-                        }
-                        return predicate;
+                        return translateRangeIntoCql(columnHandle, ranges.getSpan());
                     }, discreteValues -> {
                         if (discreteValues.isInclusive()) {
-                            ImmutableList.Builder<Object> discreteValuesList = ImmutableList.builder();
-                            for (Object discreteValue : discreteValues.getValues()) {
-                                discreteValuesList.add(columnHandle.getCassandraType().toCqlLiteral(discreteValue));
+                            if (discreteValues.getValuesCount() == 0) {
+                                return null;
                             }
-                            String predicate = CassandraCqlUtils.validColumnName(columnHandle.getName()) + " IN ("
-                                    + Joiner.on(",").join(discreteValuesList.build()) + ")";
-                            return predicate;
+                            if (discreteValues.getValuesCount() == 1) {
+                                fullyPushedColumnPredicates.add(columnHandle);
+                                return format("%s = %s",
+                                        CassandraCqlUtils.validColumnName(columnHandle.getName()),
+                                        toCqlLiteral(columnHandle, getOnlyElement(discreteValues.getValues())));
+                            }
+                            if (isInExpressionNotAllowed(clusteringColumns, cassandraVersion, currentlyProcessedClusteringColumn)) {
+                                return null;
+                            }
+
+                            String inValues = discreteValues.getValues().stream()
+                                    .map(columnHandle.getCassandraType()::toCqlLiteral)
+                                    .collect(joining(","));
+                            fullyPushedColumnPredicates.add(columnHandle);
+                            return CassandraCqlUtils.validColumnName(columnHandle.getName()) + " IN (" + inValues + " )";
                         }
                         return null;
                     }, allOrNone -> null);
@@ -129,21 +112,67 @@ public class CassandraClusteringPredicatesExtractor
             if (predicateString == null) {
                 break;
             }
-            // IN restriction only on last clustering column for Cassandra version = 2.1
-            if (predicateString.contains(" IN (") && cassandraVersion.compareTo(VersionNumber.parse("2.2.0")) < 0 && currentClusteringColumn != (clusteringColumns.size() - 1)) {
-                break;
-            }
             clusteringColumnSql.add(predicateString);
-            fullyPushedColumnPredicates.add(columnHandle);
             // Check for last clustering column should only be restricted by range condition
             if (predicateString.contains(">") || predicateString.contains("<")) {
                 break;
             }
-            currentClusteringColumn++;
+            allProcessedClusteringColumns++;
         }
         List<String> clusteringColumnPredicates = clusteringColumnSql.build();
 
         return new ClusteringPushDownResult(fullyPushedColumnPredicates.build(), Joiner.on(" AND ").join(clusteringColumnPredicates));
+    }
+
+    /**
+     * IN restriction allowed only on last clustering column for Cassandra version <= 2.2.0
+     */
+    private static boolean isInExpressionNotAllowed(List<CassandraColumnHandle> clusteringColumns, VersionNumber cassandraVersion, int currentlyProcessedClusteringColumn)
+    {
+        return cassandraVersion.compareTo(VersionNumber.parse("2.2.0")) < 0 && currentlyProcessedClusteringColumn != (clusteringColumns.size() - 1);
+    }
+
+    private static String toCqlLiteral(CassandraColumnHandle columnHandle, Object value)
+    {
+        return columnHandle.getCassandraType().toCqlLiteral(value);
+    }
+
+    private static String translateRangeIntoCql(CassandraColumnHandle columnHandle, Range range)
+    {
+        if (range.isAll()) {
+            return null;
+        }
+        if (range.isSingleValue()) {
+            return format("%s = %s",
+                    CassandraCqlUtils.validColumnName(columnHandle.getName()),
+                    toCqlLiteral(columnHandle, range.getSingleValue()));
+        }
+
+        String lowerBoundPredicate = null;
+        String upperBoundPredicate = null;
+        if (!range.isLowUnbounded()) {
+            String lowBound = toCqlLiteral(columnHandle, range.getLowBoundedValue());
+            lowerBoundPredicate = format(
+                    "%s %s %s",
+                    CassandraCqlUtils.validColumnName(columnHandle.getName()),
+                    range.isLowInclusive() ? ">=" : ">",
+                    lowBound);
+        }
+        if (!range.isHighUnbounded()) {
+            String highBound = toCqlLiteral(columnHandle, range.getHighBoundedValue());
+            upperBoundPredicate = format(
+                    "%s %s %s",
+                    CassandraCqlUtils.validColumnName(columnHandle.getName()),
+                    range.isHighInclusive() ? "<=" : "<",
+                    highBound);
+        }
+        if (lowerBoundPredicate != null && upperBoundPredicate != null) {
+            return format("%s AND %s ", lowerBoundPredicate, upperBoundPredicate);
+        }
+        if (lowerBoundPredicate != null) {
+            return lowerBoundPredicate;
+        }
+        return upperBoundPredicate;
     }
 
     private static class ClusteringPushDownResult

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -410,6 +410,19 @@ public class TestCassandraConnectorTest
     }
 
     @Test
+    public void testNotEqualPredicateOnClusteringColumn()
+    {
+        String sql = "SELECT * FROM " + TABLE_CLUSTERING_KEYS_INEQUALITY + " WHERE key='key_1' AND clust_one != 'clust_one'";
+        assertEquals(execute(sql).getRowCount(), 0);
+        sql = "SELECT * FROM " + TABLE_CLUSTERING_KEYS_INEQUALITY + " WHERE key='key_1' AND clust_one='clust_one' AND clust_two != 2";
+        assertEquals(execute(sql).getRowCount(), 3);
+        sql = "SELECT * FROM " + TABLE_CLUSTERING_KEYS_INEQUALITY + " WHERE key='key_1' AND clust_one='clust_one' AND clust_two >= 2 AND clust_two != 3";
+        assertEquals(execute(sql).getRowCount(), 2);
+        sql = "SELECT * FROM " + TABLE_CLUSTERING_KEYS_INEQUALITY + " WHERE key='key_1' AND clust_one='clust_one' AND clust_two > 2 AND clust_two != 3";
+        assertEquals(execute(sql).getRowCount(), 1);
+    }
+
+    @Test
     public void testClusteringKeyPushdownInequality()
     {
         String sql = "SELECT * FROM " + TABLE_CLUSTERING_KEYS_INEQUALITY + " WHERE key='key_1' AND clust_one='clust_one'";


### PR DESCRIPTION
It's a pr that tries to fix this issue #401. First by fixing the correctness (so disabling the pushdown all together).

It seems to me however that logic which drives ranges pushdown in [CassandraClusteringPredicatesExtractor](plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClusteringPredicatesExtractor.java) is trying to deal with generic ranges and joint them with AND operator, when in reality these ranges comes from SortedRangeSet and should be treat as a sum of Range rather than an intersection. Since Cassandra doesn't support OR operator, I think that we should only push single range values all the time - so in a simplest scenario we should only handle pushdown for  SortedRangeSets that size equals 1. 

I would like to quickly refactor CassandraClusteringPredicatesExtractor's range  handling to reflect that directly. 

Ok I've clearly forgotten about IN statement, which results in similar situation. I would stil refactor this though, just with a bit more subtle approach.