### PR TITLE
Mark TestHiveStorageFormats:: testTimestampCreatedFromTrino as flaky

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -534,6 +534,7 @@ public class TestHiveStorageFormats
     }
 
     @Test(dataProvider = "storageFormatsWithNanosecondPrecision")
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/8662", match = "Object 'table_dropped' not found within 'hive.test_list_failing_views'")
     public void testTimestampCreatedFromTrino(StorageFormat storageFormat)
     {
         String tableName = createSimpleTimestampTable("timestamps_from_trino", storageFormat);


### PR DESCRIPTION
Test fails with "Failed to translate Hive view 'test_list_failing_views.failing_view': At line 0, column 0: Object 'table_dropped' not found within 'hive.test_list_failing_views'"

Not sure how to set up the stress tests on this one. Since the test does not have a group assigned I'm not sure if its a product test or if it runs in another section of the ci