### PR TITLE
Remove ignored DROP SCHEMA clause

### DIFF
--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -45,7 +45,7 @@ statement
     | CREATE SCHEMA (IF NOT EXISTS)? qualifiedName
         (AUTHORIZATION principal)?
         (WITH properties)?                                             #createSchema
-    | DROP SCHEMA (IF EXISTS)? qualifiedName (CASCADE | RESTRICT)?     #dropSchema
+    | DROP SCHEMA (IF EXISTS)? qualifiedName (CASCADE)?                #dropSchema
     | ALTER SCHEMA qualifiedName RENAME TO identifier                  #renameSchema
     | ALTER SCHEMA qualifiedName SET AUTHORIZATION principal           #setSchemaAuthorization
     | CREATE TABLE (IF NOT EXISTS)? qualifiedName columnAliases?


### PR DESCRIPTION
This is part of the grammar, but currently ignored in AstBuilder.

cc @martint 