### PR TITLE
Leverage Block#mayHaveNull() in HashSemiJoinOperator

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/Page.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Page.java
@@ -292,6 +292,22 @@ public final class Page
         return wrapBlocksWithoutCopy(positionCount, loadedBlocks);
     }
 
+    public Page getLoadedPage(int column)
+    {
+        return wrapBlocksWithoutCopy(positionCount, new Block[]{this.blocks[column].getLoadedBlock()});
+    }
+
+    public Page getLoadedPage(int... columns)
+    {
+        requireNonNull(columns, "columns is null");
+
+        Block[] blocks = new Block[columns.length];
+        for (int i = 0; i < columns.length; i++) {
+            blocks[i] = this.blocks[columns[i]].getLoadedBlock();
+        }
+        return wrapBlocksWithoutCopy(positionCount, blocks);
+    }
+
     @Override
     public String toString()
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/LazyBlock.java
@@ -254,6 +254,12 @@ public class LazyBlock
     }
 
     @Override
+    public boolean mayHaveNull()
+    {
+        return getBlock().mayHaveNull();
+    }
+
+    @Override
     public final List<Block> getChildren()
     {
         return singletonList(getBlock());


### PR DESCRIPTION
Comparable changes to https://github.com/prestodb/presto/pull/16459

Consults `Block#mayHaveNull()` outside of the main processing loop in `HashSemiJoinOperator` so that `Block#isNull` checks can be skipped inside the loop when none are necessary.

Also adds:
- `LazyBlock#mayHaveNull()` implementation to make the `Block#mayHaveNull()` checks like this one more effective
- `Page#getLoadedPage(int... columns)` helper methods to support simultaneous column extraction and `LazyBlock` unwrapping