### PR TITLE
Extract common JDBC configurations into their own fragment

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -115,6 +115,13 @@ Property Name               Default Value    Description
 Currently the connector only supports ``Log`` and ``MergeTree`` table engines
 in create table statement. ``ReplicatedMergeTree`` engine is not yet supported.
 
+.. _clickhouse-type-mapping:
+
+Type mapping
+------------
+
+.. include:: jdbc-type-mapping.fragment
+
 Pushdown
 --------
 

--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -34,6 +34,8 @@ appropriate for your setup:
     connection-user=exampleuser
     connection-password=examplepassword
 
+.. include:: jdbc-common-configurations.fragment
+
 Multiple ClickHouse servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/druid.rst
+++ b/docs/src/main/sphinx/connector/druid.rst
@@ -42,6 +42,8 @@ secured by basic authentication by updating the URL and adding credentials:
 Now you can access your Druid database in Trino with the ``druiddb`` catalog
 name from the properties file.
 
+.. include:: jdbc-common-configurations.fragment
+
 .. _druid-type-mapping:
 
 Type mapping

--- a/docs/src/main/sphinx/connector/druid.rst
+++ b/docs/src/main/sphinx/connector/druid.rst
@@ -42,6 +42,13 @@ secured by basic authentication by updating the URL and adding credentials:
 Now you can access your Druid database in Trino with the ``druiddb`` catalog
 name from the properties file.
 
+.. _druid-type-mapping:
+
+Type mapping
+------------
+
+.. include:: jdbc-type-mapping.fragment
+
 .. _druid-sql-support:
 
 SQL support

--- a/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
@@ -1,0 +1,27 @@
+General configuration properties
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following table describes general configuration properties for the
+connector:
+
+.. list-table::
+  :widths: 30, 40, 30
+  :header-rows: 1
+
+  * - Property name
+    - Description
+    - Default value
+  * - ``case-insensitive-name-matching``
+    - Support case insensitive database and collection names
+    - False
+  * - ``case-insensitive-name-matching.cache-ttl``
+    -
+    - 1 minute
+  * - ``metadata.cache-ttl``
+    - Duration for which metadata, including table and column statistics, is
+      cached
+    - 0 (disabled caching)
+  * - ``metadata.cache-missing``
+    - Cache the fact that metadata, including table and column statistics, is
+      not available
+    - False

--- a/docs/src/main/sphinx/connector/jdbc-type-mapping.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-type-mapping.fragment
@@ -24,17 +24,3 @@ cached in Trino.
     - Allow forced mapping of comma separated lists of data types to convert to
       unbounded ``VARCHAR``
     -
-  * - ``case-insensitive-name-matching``
-    - Support case insensitive database and collection names
-    - False
-  * - ``case-insensitive-name-matching.cache-ttl``
-    -
-    - 1 minute
-  * - ``metadata.cache-ttl``
-    - Duration for which metadata, including table and column statistics, is
-      cached
-    - 0 (disabled caching)
-  * - ``metadata.cache-missing``
-    - Cache the fact that metadata, including table and column statistics, is
-      not available
-    - False

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -32,6 +32,8 @@ connection properties as appropriate for your setup:
     connection-user=root
     connection-password=secret
 
+.. include:: jdbc-common-configurations.fragment
+
 Multiple SingleStore servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -50,6 +50,8 @@ determine the user credentials for the connection, often a service user. You can
 use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
 properties files.
 
+.. include:: jdbc-common-configurations.fragment
+
 Multiple MySQL servers
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -51,6 +51,8 @@ To disable connection pooling, update properties to include the following:
 
     oracle.connection-pool.enabled=false
 
+.. include:: jdbc-common-configurations.fragment
+
 Multiple Oracle servers
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/phoenix.rst
+++ b/docs/src/main/sphinx/connector/phoenix.rst
@@ -87,8 +87,10 @@ Finally, you can access the ``clicks`` table in the ``web`` schema::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``phoenix`` in the above examples.
 
-Data types
-----------
+.. _phoenix-type-mapping:
+
+Type mapping
+------------
 
 The data type mappings are as follows:
 
@@ -116,6 +118,7 @@ variable length ``VARBINARY`` data type. There is no way to create a
 Phoenix table in Trino that uses the ``BINARY`` data type, as Trino
 does not have an equivalent type.
 
+.. include:: jdbc-type-mapping.fragment
 
 Table properties - Phoenix
 --------------------------

--- a/docs/src/main/sphinx/connector/phoenix.rst
+++ b/docs/src/main/sphinx/connector/phoenix.rst
@@ -44,10 +44,7 @@ For HBase 2.x and Phoenix 5.x (5.1.0 or later) use:
 
     connector.name=phoenix5
 
-Configuration properties
-------------------------
-
-The following configuration properties are available:
+The following Phoenix-specific configuration properties are available:
 
 ================================================== ========== ===================================================================================
 Property Name                                      Required   Description
@@ -60,6 +57,8 @@ Property Name                                      Required   Description
 ``phoenix.config.resources``                       No         Comma-separated list of configuration files (e.g. ``hbase-site.xml``) to use for
                                                               connection properties.  These files must exist on the machines running Trino.
 ================================================== ========== ===================================================================================
+
+.. include:: jdbc-common-configurations.fragment
 
 Querying Phoenix tables
 -------------------------

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -46,6 +46,8 @@ determine the user credentials for the connection, often a service user. You can
 use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
 properties files.
 
+.. include:: jdbc-common-configurations.fragment
+
 Multiple PostgreSQL databases or servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -31,6 +31,8 @@ connection properties as appropriate for your setup:
     connection-user=root
     connection-password=secret
 
+.. include:: jdbc-common-configurations.fragment
+
 Multiple Redshift databases or clusters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -44,6 +44,8 @@ determine the user credentials for the connection, often a service user. You can
 use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
 properties files.
 
+.. include:: jdbc-common-configurations.fragment
+
 Multiple SQL Server databases or servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -112,6 +112,8 @@ SQL Server Type                     Trino Type
 Complete list of `SQL Server data types
 <https://msdn.microsoft.com/en-us/library/ms187752.aspx>`_.
 
+.. include:: jdbc-type-mapping.fragment
+
 .. _sqlserver-sql-support:
 
 SQL support


### PR DESCRIPTION
Split jdbc-type-mapping fragment into two. One for common JDBC connector configs and other for type mapping.

This will give a place to document common JDBC connector configurations as a follow-up.