### PR TITLE
Remove incorrect useless code from Iceberg TableStatisticsMaker

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
@@ -28,7 +29,6 @@ import io.trino.spi.predicate.Domain;
 import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.ColumnStatistics;
-import io.trino.spi.statistics.DoubleRange;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.testing.BaseConnectorTest;
 import io.trino.testing.MaterializedResult;
@@ -1556,24 +1556,28 @@ public abstract class BaseIcebergConnectorTest
         String insertStart = "INSERT INTO iceberg.tpch.test_simple_partitioned_table_statistics";
         assertUpdate(insertStart + " VALUES (1, 101), (2, 102), (3, 103), (4, 104)", 4);
         TableStatistics tableStatistics = getTableStatistics(tableName, new Constraint(TupleDomain.all()));
-
-        // TODO Change to use SHOW STATS FOR table_name when Iceberg applyFilter allows pushdown.
-        // Then I can get rid of the helper methods and direct use of TableStatistics
-
-        Predicate<Map<ColumnHandle, NullableValue>> predicate = new TestRelationalNumberPredicate("col1", 3, i -> i >= 0);
         IcebergColumnHandle col1Handle = getColumnHandleFromStatistics(tableStatistics, "col1");
-        Constraint constraint = new Constraint(TupleDomain.all(), Optional.of(predicate), Optional.of(ImmutableSet.of(col1Handle)));
-        tableStatistics = getTableStatistics(tableName, constraint);
-        assertEquals(tableStatistics.getRowCount().getValue(), 2.0);
-        ColumnStatistics columnStatistics = getStatisticsForColumn(tableStatistics, "col1");
-        assertThat(columnStatistics.getRange()).hasValue(new DoubleRange(3, 4));
 
-        // This shows that Predicate<ColumnHandle, NullableValue> only filters rows for partitioned columns.
-        predicate = new TestRelationalNumberPredicate("col2", 102, i -> i >= 0);
-        tableStatistics = getTableStatistics(tableName, new Constraint(TupleDomain.all(), Optional.of(predicate), Optional.empty()));
-        assertEquals(tableStatistics.getRowCount().getValue(), 4.0);
-        columnStatistics = getStatisticsForColumn(tableStatistics, "col2");
-        assertThat(columnStatistics.getRange()).hasValue(new DoubleRange(101, 104));
+        // Constraint.predicate is currently not supported, because it's never provided by the engine.
+        // TODO add (restore) test coverage when this changes.
+
+        // predicate on a partition column
+        assertThatThrownBy(() ->
+                getTableStatistics(tableName, new Constraint(
+                        TupleDomain.all(),
+                        Optional.of(new TestRelationalNumberPredicate("col1", 3, i1 -> i1 >= 0)),
+                        Optional.of(ImmutableSet.of(col1Handle)))))
+                .isInstanceOf(VerifyException.class)
+                .hasMessage("Unexpected Constraint predicate");
+
+        // predicate on an unspecified set of columns column
+        assertThatThrownBy(() ->
+                getTableStatistics(tableName, new Constraint(
+                        TupleDomain.all(),
+                        Optional.of(new TestRelationalNumberPredicate("col2", 102, i -> i >= 0)),
+                        Optional.empty())))
+                .isInstanceOf(VerifyException.class)
+                .hasMessage("Unexpected Constraint predicate");
 
         dropTable(tableName);
     }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -788,6 +788,11 @@ public abstract class BaseIcebergConnectorTest
 
         assertQuery("SELECT d_hour, row_count, d.min, d.max, b.min, b.max FROM \"test_hour_transform$partitions\"", expected);
 
+        // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
+        assertQuery(
+                "SELECT * FROM test_hour_transform WHERE day_of_week(d) = 3 AND b % 7 = 3",
+                "VALUES (TIMESTAMP '1969-12-31 23:44:55.567890', 10)");
+
         assertThat(query("SHOW STATS FOR test_hour_transform"))
                 .projected(0, 2, 3, 4, 5, 6) // ignore data size which is available for Parquet, but not for ORC
                 .skippingTypesCheck()
@@ -830,6 +835,11 @@ public abstract class BaseIcebergConnectorTest
                         "(DATE '2015-01-13', 2, DATE '2015-01-13', DATE '2015-01-13', 4, 5), " +
                         "(DATE '2015-05-15', 2, DATE '2015-05-15', DATE '2015-05-15', 6, 7), " +
                         "(DATE '2020-02-21', 2, DATE '2020-02-21', DATE '2020-02-21', 8, 9)");
+
+        // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
+        assertQuery(
+                "SELECT * FROM test_day_transform_date WHERE day_of_week(d) = 3 AND b % 7 = 3",
+                "VALUES (DATE '1969-01-01', 10)");
 
         assertThat(query("SHOW STATS FOR test_day_transform_date"))
                 .projected(0, 2, 3, 4, 5, 6) // ignore data size which is available for Parquet, but not for ORC
@@ -885,6 +895,11 @@ public abstract class BaseIcebergConnectorTest
 
         assertQuery("SELECT d_day, row_count, d.min, d.max, b.min, b.max FROM \"test_day_transform_timestamp$partitions\"", expected);
 
+        // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
+        assertQuery(
+                "SELECT * FROM test_day_transform_timestamp WHERE day_of_week(d) = 3 AND b % 7 = 3",
+                "VALUES (TIMESTAMP '1969-12-31 00:00:00.000000', 10)");
+
         assertThat(query("SHOW STATS FOR test_day_transform_timestamp"))
                 .projected(0, 2, 3, 4, 5, 6) // ignore data size which is available for Parquet, but not for ORC
                 .skippingTypesCheck()
@@ -931,6 +946,11 @@ public abstract class BaseIcebergConnectorTest
                         "(605, 3, DATE '2020-06-06', DATE '2020-06-28', 9, 11), " +
                         "(606, 2, DATE '2020-07-18', DATE '2020-07-28', 12, 13), " +
                         "(611, 1, DATE '2020-12-31', DATE '2020-12-31', 14, 14)");
+
+        // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
+        assertQuery(
+                "SELECT * FROM test_month_transform_date WHERE day_of_week(d) = 7 AND b % 7 = 3",
+                "VALUES (DATE '2020-06-28', 10)");
 
         assertThat(query("SHOW STATS FOR test_month_transform_date"))
                 .projected(0, 2, 3, 4, 5, 6) // ignore data size which is available for Parquet, but not for ORC
@@ -983,6 +1003,11 @@ public abstract class BaseIcebergConnectorTest
 
         assertQuery("SELECT d_month, row_count, d.min, d.max, b.min, b.max FROM \"test_month_transform_timestamp$partitions\"", expected);
 
+        // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
+        assertQuery(
+                "SELECT * FROM test_month_transform_timestamp WHERE day_of_week(d) = 1 AND b % 7 = 3",
+                "VALUES (TIMESTAMP '1969-12-01 00:00:00.000000', 10)");
+
         assertThat(query("SHOW STATS FOR test_month_transform_timestamp"))
                 .projected(0, 2, 3, 4, 5, 6) // ignore data size which is available for Parquet, but not for ORC
                 .skippingTypesCheck()
@@ -1024,6 +1049,11 @@ public abstract class BaseIcebergConnectorTest
                         "(45, 3, DATE '2015-01-01', DATE '2015-07-28', 6, 8), " +
                         "(46, 2, DATE '2016-05-15', DATE '2016-06-06', 9, 10), " +
                         "(50, 2, DATE '2020-02-21', DATE '2020-11-10', 11, 12)");
+
+        // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
+        assertQuery(
+                "SELECT * FROM test_year_transform_date WHERE day_of_week(d) = 1 AND b % 7 = 3",
+                "VALUES (DATE '2016-06-06', 10)");
 
         assertThat(query("SHOW STATS FOR test_year_transform_date"))
                 .projected(0, 2, 3, 4, 5, 6) // ignore data size which is available for Parquet, but not for ORC
@@ -1074,6 +1104,11 @@ public abstract class BaseIcebergConnectorTest
 
         assertQuery("SELECT d_year, row_count, d.min, d.max, b.min, b.max FROM \"test_year_transform_timestamp$partitions\"", expected);
 
+        // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
+        assertQuery(
+                "SELECT * FROM test_year_transform_timestamp WHERE day_of_week(d) = 2 AND b % 7 = 3",
+                "VALUES (TIMESTAMP '2015-09-15 14:21:02.345678', 10)");
+
         assertThat(query("SHOW STATS FOR test_year_transform_timestamp"))
                 .projected(0, 2, 3, 4, 5, 6) // ignore data size which is available for Parquet, but not for ORC
                 .skippingTypesCheck()
@@ -1110,6 +1145,11 @@ public abstract class BaseIcebergConnectorTest
 
         assertQuery("SELECT b FROM test_truncate_text_transform WHERE substring(d, 1, 2) = 'Gr'", "VALUES 6, 7");
         assertQuery(select + " WHERE d_trunc = 'Gr'", "VALUES ('Gr', 2, 'Greece', 'Grozny', 6, 7)");
+
+        // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
+        assertQuery(
+                "SELECT * FROM test_truncate_text_transform WHERE length(d) = 4 AND b % 7 = 2",
+                "VALUES ('abxy', 2)");
 
         assertThat(query("SHOW STATS FOR test_truncate_text_transform"))
                 .projected(0, 2, 3, 4, 5, 6) // ignore data size which is available for Parquet, but not for ORC
@@ -1166,6 +1206,11 @@ public abstract class BaseIcebergConnectorTest
         assertQuery("SELECT b FROM " + table + " WHERE d IN (-123, -130)", "VALUES 14, 15");
         assertQuery(select + " WHERE d_trunc = -130", "VALUES (-130, 2, -130, -123, 14, 15)");
 
+        // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
+        assertQuery(
+                "SELECT * FROM " + table + " WHERE d % 10 = -1 AND b % 7 = 3",
+                "VALUES (-1, 10)");
+
         assertThat(query("SHOW STATS FOR " + table))
                 .projected(0, 2, 3, 4, 5, 6) // ignore data size which is available for Parquet, but not for ORC
                 .skippingTypesCheck()
@@ -1213,6 +1258,11 @@ public abstract class BaseIcebergConnectorTest
         assertQuery("SELECT b FROM test_truncate_decimal_transform WHERE d = -0.05", "VALUES 5");
         assertQuery(select + " WHERE d_trunc = -0.10", "VALUES (-0.10, 1, -0.05, -0.05, 5, 5)");
 
+        // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
+        assertQuery(
+                "SELECT * FROM test_truncate_decimal_transform WHERE d * 100 % 10 = 9 AND b % 7 = 3",
+                "VALUES (12.29, 3)");
+
         assertThat(query("SHOW STATS FOR test_truncate_decimal_transform"))
                 .projected(0, 2, 3, 4, 5, 6) // ignore data size which is available for Parquet, but not for ORC
                 .skippingTypesCheck()
@@ -1245,6 +1295,11 @@ public abstract class BaseIcebergConnectorTest
         assertQuery(select + " WHERE d_bucket = 0", "VALUES(0, 3, 'Grozny', 'mommy', 1, 7)");
 
         assertQuery(select + " WHERE d_bucket = 1", "VALUES(1, 4, 'Greece', 'moscow', 2, 6)");
+
+        // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
+        assertQuery(
+                "SELECT * FROM test_bucket_transform WHERE length(d) = 4 AND b % 7 = 2",
+                "VALUES ('abxy', 2)");
 
         assertThat(query("SHOW STATS FOR test_bucket_transform"))
                 .projected(0, 2, 3, 4, 5, 6) // ignore data size which is available for Parquet, but not for ORC


### PR DESCRIPTION
The code used to extract partition values was useless, because
`Constraint#predicate` is never present there.

The code was also incorrect, because it would assign transformation
value to transformation's source column. For example, it would
instantiate a map like

    a_string_column: 2 (bucket number)