### PR TITLE
Minor updates to JDBC caching client

### DIFF
--- a/plugin/trino-base-jdbc/pom.xml
+++ b/plugin/trino-base-jdbc/pom.xml
@@ -45,6 +45,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>jmx</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>log</artifactId>
         </dependency>
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -19,6 +19,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheStats;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import io.airlift.jmx.CacheStatsMBean;
 import io.airlift.units.Duration;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.jdbc.IdentityCacheMapping.IdentityCacheKey;
@@ -39,6 +40,7 @@ import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.Type;
 import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
 import javax.inject.Inject;
 
@@ -697,5 +699,40 @@ public class CachingJdbcClient
         {
             return Objects.hash(tableHandle, tupleDomain);
         }
+    }
+
+    @Managed
+    @Nested
+    public CacheStatsMBean getSchemaNamesStats()
+    {
+        return new CacheStatsMBean(schemaNamesCache);
+    }
+
+    @Managed
+    @Nested
+    public CacheStatsMBean getTableNamesCache()
+    {
+        return new CacheStatsMBean(tableNamesCache);
+    }
+
+    @Managed
+    @Nested
+    public CacheStatsMBean getTableHandleCache()
+    {
+        return new CacheStatsMBean(tableHandleCache);
+    }
+
+    @Managed
+    @Nested
+    public CacheStatsMBean getColumnsCache()
+    {
+        return new CacheStatsMBean(columnsCache);
+    }
+
+    @Managed
+    @Nested
+    public CacheStatsMBean getStatisticsCache()
+    {
+        return new CacheStatsMBean(statisticsCache);
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -38,6 +38,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.type.Type;
+import org.weakref.jmx.Managed;
 
 import javax.inject.Inject;
 
@@ -458,6 +459,16 @@ public class CachingJdbcClient
         OptionalLong deletedRowsCount = delegate.delete(session, handle);
         onDataChanged(handle.getRequiredNamedRelation().getSchemaTableName());
         return deletedRowsCount;
+    }
+
+    @Managed
+    public void flushCache()
+    {
+        schemaNamesCache.invalidateAll();
+        tableNamesCache.invalidateAll();
+        tableHandleCache.invalidateAll();
+        columnsCache.invalidateAll();
+        statisticsCache.invalidateAll();
     }
 
     private IdentityCacheKey getIdentityKey(ConnectorSession session)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadataFactory.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadataFactory.java
@@ -45,7 +45,9 @@ public class DefaultJdbcMetadataFactory
                         jdbcClient,
                         Set.of(),
                         new SingletonIdentityCacheMapping(),
-                        new Duration(1, DAYS), true),
+                        new Duration(1, DAYS),
+                        true,
+                        Integer.MAX_VALUE),
                 allowDropTable);
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDiagnosticModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcDiagnosticModule.java
@@ -46,6 +46,8 @@ public class JdbcDiagnosticModule
                 .as(generator -> generator.generatedNameOf(JdbcClient.class, catalogName.get().toString()));
         newExporter(binder).export(Key.get(ConnectionFactory.class, StatsCollecting.class))
                 .as(generator -> generator.generatedNameOf(ConnectionFactory.class, catalogName.get().toString()));
+        newExporter(binder).export(JdbcClient.class)
+                .as(generator -> generator.generatedNameOf(CachingJdbcClient.class, catalogName.get().toString()));
     }
 
     @Provides

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestBaseJdbcConfig.java
@@ -31,14 +31,17 @@ import static org.testng.Assert.assertEquals;
 
 public class TestBaseJdbcConfig
 {
+    private static final Duration ZERO = Duration.succinctDuration(0, MINUTES);
+
     @Test
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(BaseJdbcConfig.class)
                 .setConnectionUrl(null)
                 .setJdbcTypesMappedToVarchar("")
-                .setMetadataCacheTtl(new Duration(0, MINUTES))
-                .setCacheMissing(false));
+                .setMetadataCacheTtl(ZERO)
+                .setCacheMissing(false)
+                .setCacheMaximumSize(10000));
     }
 
     @Test
@@ -49,13 +52,15 @@ public class TestBaseJdbcConfig
                 .put("jdbc-types-mapped-to-varchar", "mytype,struct_type1")
                 .put("metadata.cache-ttl", "1s")
                 .put("metadata.cache-missing", "true")
+                .put("metadata.cache-maximum-size", "5000")
                 .build();
 
         BaseJdbcConfig expected = new BaseJdbcConfig()
                 .setConnectionUrl("jdbc:h2:mem:config")
                 .setJdbcTypesMappedToVarchar("mytype, struct_type1")
                 .setMetadataCacheTtl(new Duration(1, SECONDS))
-                .setCacheMissing(true);
+                .setCacheMissing(true)
+                .setCacheMaximumSize(5000);
 
         assertFullMapping(properties, expected);
 
@@ -71,6 +76,24 @@ public class TestBaseJdbcConfig
                 .hasMessageContaining("must match the following regular expression: ^jdbc:[a-z0-9]+:(?s:.*)$");
         buildConfig(ImmutableMap.of("connection-url", "jdbc:protocol:uri"));
         buildConfig(ImmutableMap.of("connection-url", "jdbc:protocol:"));
+    }
+
+    @Test
+    public void testCacheConfigValidation()
+    {
+        BaseJdbcConfig explicitCacheSize = new BaseJdbcConfig()
+                .setMetadataCacheTtl(new Duration(1, SECONDS))
+                .setCacheMaximumSize(5000);
+        explicitCacheSize.validate();
+        BaseJdbcConfig defaultCacheSize = new BaseJdbcConfig()
+                .setMetadataCacheTtl(new Duration(1, SECONDS));
+        defaultCacheSize.validate();
+        assertThatThrownBy(() -> new BaseJdbcConfig()
+                .setMetadataCacheTtl(ZERO)
+                .setCacheMaximumSize(100000)
+                .validate())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageMatching("metadata.cache-ttl must be set to a non-zero value when metadata.cache-maximum-size is set");
     }
 
     private static void buildConfig(Map<String, String> properties)


### PR DESCRIPTION
Some minor updates to the JDBC caching client that are useful for cluster admins:

* add a default size limit of 10,000 for the cache
* add a new config option to specify a size for the number of objects to cache
* expose cache statistics through JMX
* add a MBean method `flushCache` to allow invalidating of the cache