### PR TITLE
Add .run directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test-output/
 test-reports/
 /atlassian-ide-plugin.xml
 .idea
+.run
 .DS_Store
 .classpath
 .settings


### PR DESCRIPTION
"Run/Debug Configurations" in IntelliJ is stored in `.run` directory by default. 

https://blog.jetbrains.com/idea/2020/03/intellij-idea-2020-1-beta2/