### PR TITLE
Fix incorrect pushdown of simplified domain

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -779,7 +779,7 @@ public final class SortedRangeSet
         SortedRangeSet other = (SortedRangeSet) obj;
         return hashCode() == other.hashCode() && // compare hash codes because they are cached, so this is cheap and efficient
                 Objects.equals(this.type, other.type) &&
-                Arrays.equals(inclusive, inclusive) &&
+                Arrays.equals(this.inclusive, other.inclusive) &&
                 blocksEqual(this.sortedRanges, other.sortedRanges);
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/PredicatePushdownController.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/PredicatePushdownController.java
@@ -47,14 +47,19 @@ public interface PredicatePushdownController
             return FULL_PUSHDOWN.apply(session, domain);
         }
 
-        if (domain.getValues().isDiscreteSet()) {
-            return new DomainPushdownResult(
-                    domain.simplify(getDomainCompactionThreshold(session)),
-                    domain);
+        if (!domain.getValues().isDiscreteSet()) {
+            // case insensitive predicate pushdown could return incorrect results for operators like `!=`, `<` or `>`
+            return DISABLE_PUSHDOWN.apply(session, domain);
         }
 
-        // case insensitive predicate pushdown could return incorrect results for operators like `!=`, `<` or `>`
-        return DISABLE_PUSHDOWN.apply(session, domain);
+        Domain simplifiedDomain = domain.simplify(getDomainCompactionThreshold(session));
+        if (!simplifiedDomain.getValues().isDiscreteSet()) {
+            // Domain#simplify can turn a discrete set into a range predicate
+            // Push down of range predicate for varchar/char types could lead to incorrect results
+            // when the remote database is case insensitive
+            return DISABLE_PUSHDOWN.apply(session, domain);
+        }
+        return new DomainPushdownResult(simplifiedDomain, domain);
     };
 
     DomainPushdownResult apply(ConnectorSession session, Domain domain);

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/BaseSqlServerConnectorTest.java
@@ -13,8 +13,15 @@
  */
 package io.trino.plugin.sqlserver;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
 import io.trino.plugin.jdbc.BaseJdbcConnectorTest;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcTableHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.TupleDomain;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
@@ -24,9 +31,14 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.plugin.sqlserver.DataCompression.NONE;
 import static io.trino.plugin.sqlserver.DataCompression.PAGE;
 import static io.trino.plugin.sqlserver.DataCompression.ROW;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.node;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
@@ -152,6 +164,54 @@ public abstract class BaseSqlServerConnectorTest
                 .matches("VALUES (BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25)))")
                 // SQL Server is case insensitive by default
                 .isNotFullyPushedDown(FilterNode.class);
+
+        // varchar IN without domain compaction
+        assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name IN ('POLAND', 'ROMANIA', 'VIETNAM')"))
+                .matches("VALUES " +
+                        "(BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25))), " +
+                        "(BIGINT '2', BIGINT '21', CAST('VIETNAM' AS varchar(25)))")
+                // SQL Server is case insensitive by default
+                .isNotFullyPushedDown(
+                        node(
+                                FilterNode.class,
+                                // verify that pushed down constraint is applied by the connector
+                                tableScan(
+                                        tableHandle -> {
+                                            TupleDomain<ColumnHandle> constraint = ((JdbcTableHandle) tableHandle).getConstraint();
+                                            ColumnHandle nameColumn = constraint.getDomains().orElseThrow()
+                                                    .keySet().stream()
+                                                    .map(JdbcColumnHandle.class::cast)
+                                                    .filter(column -> column.getColumnName().equals("name"))
+                                                    .collect(onlyElement());
+                                            return constraint.getDomains().get().get(nameColumn)
+                                                    .equals(Domain.multipleValues(
+                                                            createVarcharType(25),
+                                                            ImmutableList.of(
+                                                                    utf8Slice("POLAND"),
+                                                                    utf8Slice("ROMANIA"),
+                                                                    utf8Slice("VIETNAM"))));
+                                        },
+                                        TupleDomain.all(),
+                                        ImmutableMap.of())));
+
+        // varchar IN with small compaction threshold
+        assertThat(query(
+                Session.builder(getSession())
+                        .setCatalogSessionProperty("sqlserver", "domain_compaction_threshold", "1")
+                        .build(),
+                "SELECT regionkey, nationkey, name FROM nation WHERE name IN ('POLAND', 'ROMANIA', 'VIETNAM')"))
+                .matches("VALUES " +
+                        "(BIGINT '3', BIGINT '19', CAST('ROMANIA' AS varchar(25))), " +
+                        "(BIGINT '2', BIGINT '21', CAST('VIETNAM' AS varchar(25)))")
+                // SQL Server is case insensitive by default
+                .isNotFullyPushedDown(
+                        node(
+                                FilterNode.class,
+                                // verify that no constraint is applied by the connector
+                                tableScan(
+                                        tableHandle -> ((JdbcTableHandle) tableHandle).getConstraint().isAll(),
+                                        TupleDomain.all(),
+                                        ImmutableMap.of())));
 
         // varchar different case
         assertThat(query("SELECT regionkey, nationkey, name FROM nation WHERE name = 'romania'"))


### PR DESCRIPTION
For varchar/char types if the remote database is
case insensitive, a simplified domain should not be
pushed down if it is not a discrete set.