### PR TITLE
Accept that transaction is cancelled early in TestJdbcConnection

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcConnection.java
@@ -495,7 +495,7 @@ public class TestJdbcConnection
             // verify that the query was cancelled
             assertThatThrownBy(future::get).isNotNull();
             assertThat(listQueryErrorCodes(sql))
-                    .containsExactly("USER_CANCELED")
+                    .allMatch(errorCode -> "TRANSACTION_ALREADY_ABORTED".equals(errorCode) || "USER_CANCELED".equals(errorCode))
                     .hasSize(1);
         }
     }
@@ -535,7 +535,7 @@ public class TestJdbcConnection
         futures.forEach(future -> assertThatThrownBy(future::get).isNotNull());
         assertThat(listQueryErrorCodes(sql))
                 .hasSize(futures.size())
-                .containsOnly("USER_CANCELED");
+                .allMatch(errorCode -> "TRANSACTION_ALREADY_ABORTED".equals(errorCode) || "USER_CANCELED".equals(errorCode));
     }
 
     private Connection createConnection()


### PR DESCRIPTION
Accept that transaction is cancelled early in TestJdbcConnection

So query fails to start as transaction is already cancelled.
This is one of expected outcome (but rare) of query cancellation.

The one test that is not updated makes sure that user is able to read
data, so surely query has started there so `TRANSACTION_ALREADY_ABORTED`
is not expected there.

Fixes https://github.com/trinodb/trino/issues/8611