### PR TITLE
query-level caching for hive tables and iceberg table statistics

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -237,7 +237,7 @@ public class IcebergMetadata
                 .expireAfterWrite(5, TimeUnit.MINUTES)
                 .build(new TableStatisticsCacheLoader());
     }
-    
+
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1364,7 +1364,7 @@ public class IcebergMetadata
         }
     }
 
-    private final class TableCacheLoader
+    private static final class TableCacheLoader
             extends CacheLoader<String, ConcurrentHashMap<SchemaTableName, Table>>
     {
         @Override
@@ -1375,7 +1375,7 @@ public class IcebergMetadata
         }
     }
 
-    private final class TableStatisticsCacheLoader
+    private static final class TableStatisticsCacheLoader
             extends CacheLoader<String, ConcurrentHashMap<SchemaTableName, TableStatistics>>
     {
         @Override


### PR DESCRIPTION
We experienced long planning times due to expensive calls to hive metastore and s3 (during BaseTableScans). Caching of statistics and hive tables on the query-level reduced planning times by around 50% for us.

fixes https://github.com/trinodb/trino/issues/8675