### PR TITLE
Add SQL support content to ClickHouse connector

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -130,14 +130,19 @@ The connector supports pushdown for a number of operations:
 * :func:`min`
 * :func:`sum`
 
-Limitations
+.. _clickhouse-sql-support:
+
+SQL support
 -----------
 
-The following SQL statements aren't  supported:
+The connector provides read and write access to data and metadata in
+a ClickHouse catalog. In addition to the :ref:`globally available
+<sql-globally-available>` and :ref:`read operation <sql-read-operations>`
+statements, the connector supports the following features:
 
-* :doc:`/sql/delete`
-* :doc:`/sql/grant`
-* :doc:`/sql/revoke`
-* :doc:`/sql/show-grants`
-* :doc:`/sql/show-roles`
-* :doc:`/sql/show-role-grants`
+* :doc:`/sql/insert`
+* :doc:`/sql/create-table`
+* :doc:`/sql/create-table-as`
+* :doc:`/sql/drop-table`
+* :doc:`/sql/create-schema`
+* :doc:`/sql/drop-schema`


### PR DESCRIPTION
Update the ClickHouse connector doc with a standardized SQL support section.