### PR TITLE
Add SQL support content to Redshift connector

### DIFF
--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -77,13 +77,23 @@ Type mapping
 
 .. include:: jdbc-type-mapping.fragment
 
+.. _redshift-sql-support:
+
 SQL support
 -----------
 
-The following SQL statements are not yet supported:
+The connector provides read access and write access to data and metadata in
+Redshift. In addition to the :ref:`globally available
+<sql-globally-available>` and :ref:`read operation <sql-read-operations>`
+statements, the connector supports the following features:
 
-* :doc:`/sql/grant`
-* :doc:`/sql/revoke`
-* :doc:`/sql/show-grants`
+* :doc:`/sql/insert`
+* :doc:`/sql/delete`
+* :doc:`/sql/create-table`
+* :doc:`/sql/create-table-as`
+* :doc:`/sql/drop-table`
+* :doc:`/sql/create-schema`
+* :doc:`/sql/drop-schema`
+* :doc:`/sql/comment`
 
 .. include:: sql-delete-limitation.fragment


### PR DESCRIPTION
Update the Redshift connector doc with a standardized SQL support section.