### PR TITLE
Avoid re-checking Iceberg table existence

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -730,12 +730,12 @@ public class IcebergMetadata
         icebergTable.updateSchema().renameColumn(columnHandle.getName(), target).commit();
     }
 
+    /**
+     * @throws TableNotFoundException when table cannot be found
+     */
     private ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName table)
     {
-        if (metastore.getTable(new HiveIdentity(session), table.getSchemaName(), table.getTableName()).isEmpty()) {
-            throw new TableNotFoundException(table);
-        }
-
+        // getIcebergTable throws TableNotFoundException when table not found
         org.apache.iceberg.Table icebergTable = getIcebergTable(session, table);
 
         List<ColumnMetadata> columns = getColumnMetadatas(icebergTable);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -105,7 +105,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("SELECT * FROM test_select_from",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 8)
+                        .addCopies(GET_TABLE, 4)
                         .build());
     }
 
@@ -116,7 +116,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("SELECT * FROM test_select_from_where WHERE age = 2",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 8)
+                        .addCopies(GET_TABLE, 4)
                         .build());
     }
 
@@ -128,7 +128,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 16)
+                        .addCopies(GET_TABLE, 8)
                         .build());
     }
 
@@ -139,7 +139,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("EXPLAIN SELECT * FROM test_explain",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 7)
+                        .addCopies(GET_TABLE, 4)
                         .build());
     }
 
@@ -150,7 +150,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("SHOW STATS FOR test_show_stats",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 5)
+                        .addCopies(GET_TABLE, 4)
                         .build());
     }
 
@@ -161,7 +161,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("SHOW STATS FOR (SELECT * FROM test_show_stats_with_filter where age >= 2)",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 5)
+                        .addCopies(GET_TABLE, 4)
                         .build());
     }
 


### PR DESCRIPTION
This is to avoid unnecessary communication with metastore and thus to
improve query planning time.

For https://github.com/trinodb/trino/issues/8675

cc @electrum 