### PR TITLE
Use table name as cache key explicitly

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -1011,7 +1011,8 @@ public class IcebergMetadata
 
     private Optional<Long> getSnapshotId(org.apache.iceberg.Table table, Optional<Long> snapshotId)
     {
-        return snapshotIds.computeIfAbsent(table.toString(), ignored -> snapshotId
+        // table.name() is an encoded version of SchemaTableName
+        return snapshotIds.computeIfAbsent(table.name(), ignored -> snapshotId
                 .map(id -> IcebergUtil.resolveSnapshotId(table, id))
                 .or(() -> Optional.ofNullable(table.currentSnapshot()).map(Snapshot::snapshotId)));
     }


### PR DESCRIPTION
`toString()` is not guaranteed to be implemented for an implementation
of the `Table` interface, however all found implementations return
`name()`. This is sufficient for the cache key here, because it contains
schema name and table name.