### PR TITLE
Add test counting accesses to files for iceberg

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataFileOperations.java
@@ -13,12 +13,18 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
 import io.trino.Session;
 import io.trino.plugin.hive.metastore.HiveMetastore;
-import io.trino.plugin.iceberg.testing.TrackingFileIoProvider;
 import io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationContext;
+import io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType;
+import io.trino.plugin.tpch.TpchPlugin;
 import io.trino.testing.AbstractTestQueryFramework;
 import io.trino.testing.DistributedQueryRunner;
+import io.trino.tpch.TpchTable;
+import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
 import javax.management.MBeanServer;
@@ -27,24 +33,33 @@ import javax.management.ObjectName;
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.util.Map;
-import java.util.Optional;
-import java.util.function.Predicate;
+import java.util.Objects;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
-import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.INPUT_FILE_EXISTS;
+import static io.trino.plugin.iceberg.TestIcebergMetadataFileOperations.FileType.MANIFEST;
+import static io.trino.plugin.iceberg.TestIcebergMetadataFileOperations.FileType.METADATA_JSON;
+import static io.trino.plugin.iceberg.TestIcebergMetadataFileOperations.FileType.SNAPSHOT;
+import static io.trino.plugin.iceberg.TestIcebergMetadataFileOperations.FileType.fromFilePath;
 import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.INPUT_FILE_GET_LENGTH;
 import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.INPUT_FILE_NEW_STREAM;
+import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.OUTPUT_FILE_CREATE;
+import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.OUTPUT_FILE_CREATE_OR_OVERWRITE;
+import static io.trino.plugin.iceberg.testing.TrackingFileIoProvider.OperationType.OUTPUT_FILE_LOCATION;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.QueryAssertions.copyTpchTables;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
-import static org.testng.Assert.assertEquals;
+import static java.util.stream.Collectors.toCollection;
+import static org.assertj.core.api.Assertions.assertThat;
 
+@Test(singleThreaded = true)
 public class TestIcebergMetadataFileOperations
         extends AbstractTestQueryFramework
 {
     private static final MBeanServer BEAN_SERVER = ManagementFactory.getPlatformMBeanServer();
     private static final String BEAN_NAME = "trino.plugin.iceberg.testing:type=TrackingFileIoProvider,name=iceberg";
-    private static final String OPERATION_COUNTS_ATTRIBUTE = "OperationCounts";
     private static final Session TEST_SESSION = testSessionBuilder()
             .setCatalog("iceberg")
             .setSchema("test_schema")
@@ -69,96 +84,270 @@ public class TestIcebergMetadataFileOperations
         HiveMetastore metastore = createTestingFileHiveMetastore(baseDir);
         queryRunner.installPlugin(new TestingIcebergPlugin(metastore, true));
         queryRunner.createCatalog("iceberg", "iceberg");
+        queryRunner.installPlugin(new TpchPlugin());
+        queryRunner.createCatalog("tpch", "tpch");
 
         queryRunner.execute("CREATE SCHEMA test_schema");
+
+        queryRunner.execute("CREATE SCHEMA tpch");
+
+        copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, session, TpchTable.getTables());
         return queryRunner;
     }
 
     @Test
-    public void testOperations()
+    public void testCreateTable()
             throws Exception
     {
-        assertUpdate("CREATE TABLE test_select_from AS SELECT 1 col0", 1);
-        String queryId = runAndGetId("SELECT * FROM test_select_from");
-
-        OperationCounts counts = getCounts().forQueryId(queryId);
-
-        // The table contains exactly one metadata, snapshot and manifest files, so file-naming based filters are sufficient
-        // for assertions.
-
-        String metadataFileSuffix = "metadata.json";
-        assertEquals(counts.forPathContaining(metadataFileSuffix).forOperation(INPUT_FILE_NEW_STREAM).sum(), 1);
-        // getLength is cached, so only assert number of different InputFile instances for a file
-        assertEquals(counts.forPathContaining(metadataFileSuffix).forOperation(INPUT_FILE_GET_LENGTH).get().size(), 0);
-        assertEquals(counts.forPathContaining(metadataFileSuffix).forOperation(INPUT_FILE_EXISTS).sum(), 0);
-
-        String snapshotFilePrefix = "/snap-";
-        assertEquals(counts.forPathContaining(snapshotFilePrefix).forOperation(INPUT_FILE_NEW_STREAM).sum(), 1);
-        // getLength is cached, so only assert number of different InputFile instances for a file
-        assertEquals(counts.forPathContaining(snapshotFilePrefix).forOperation(INPUT_FILE_GET_LENGTH).get().size(), 1);
-        assertEquals(counts.forPathContaining(snapshotFilePrefix).forOperation(INPUT_FILE_EXISTS).sum(), 0);
-
-        String manifestFileSuffix = "-m0.avro";
-        // Iceberg seems to read manifest files twice during Streams.stream(combinedScanIterable) call in IcebergSplitSource
-        assertEquals(counts.forPathContaining(manifestFileSuffix).forOperation(INPUT_FILE_NEW_STREAM).sum(), 2);
-        // getLength is cached, so only assert number of different InputFile instances for a file
-        assertEquals(counts.forPathContaining(manifestFileSuffix).forOperation(INPUT_FILE_GET_LENGTH).get().size(), 1);
-        assertEquals(counts.forPathContaining(manifestFileSuffix).forOperation(INPUT_FILE_EXISTS).sum(), 0);
+        assertFileSystemAccesses("CREATE TABLE test_create (id VARCHAR, age INT)",
+                ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(METADATA_JSON, OUTPUT_FILE_CREATE), 1)
+                        .addCopies(new FileOperation(METADATA_JSON, OUTPUT_FILE_LOCATION), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, OUTPUT_FILE_CREATE_OR_OVERWRITE), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, OUTPUT_FILE_LOCATION), 2)
+                        .build());
     }
 
-    private String runAndGetId(String query)
-    {
-        return getDistributedQueryRunner().executeWithQueryId(TEST_SESSION, query).getQueryId().getId();
-    }
-
-    private static OperationCounts getCounts()
+    @Test
+    public void testCreateTableAsSelect()
             throws Exception
     {
-        return new OperationCounts((Map<OperationContext, Integer>) BEAN_SERVER.getAttribute(new ObjectName(BEAN_NAME), OPERATION_COUNTS_ATTRIBUTE));
+        assertFileSystemAccesses("CREATE TABLE test_create_as_select AS SELECT 1 col_name",
+                ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, OUTPUT_FILE_CREATE_OR_OVERWRITE), 1)
+                        .addCopies(new FileOperation(MANIFEST, OUTPUT_FILE_LOCATION), 1)
+                        .addCopies(new FileOperation(METADATA_JSON, OUTPUT_FILE_CREATE), 1)
+                        .addCopies(new FileOperation(METADATA_JSON, OUTPUT_FILE_LOCATION), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, OUTPUT_FILE_CREATE_OR_OVERWRITE), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, OUTPUT_FILE_LOCATION), 2)
+                        .build());
     }
 
-    private static class OperationCounts
+    @Test
+    public void testSelect()
+            throws Exception
     {
-        private final Map<OperationContext, Integer> allCounts;
-        private Optional<String> queryId = Optional.empty();
-        private Predicate<String> pathPredicate = path -> true;
-        private Optional<TrackingFileIoProvider.OperationType> type = Optional.empty();
+        assertUpdate("CREATE TABLE test_select AS SELECT 1 col_name", 1);
+        assertFileSystemAccesses("SELECT * FROM test_select",
+                ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 2)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 2)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
+                        .build());
+    }
 
-        public OperationCounts(Map<OperationContext, Integer> allCounts)
+    @Test
+    public void testSelectWithFilter()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_select_with_filter AS SELECT 1 col_name", 1);
+        assertFileSystemAccesses("SELECT * FROM test_select_with_filter WHERE col_name = 1",
+                ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 2)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 2)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
+                        .build());
+    }
+
+    @Test
+    public void testJoin()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_join_t1 AS SELECT 2 as age, 'id1' AS id", 1);
+        assertUpdate("CREATE TABLE test_join_t2 AS SELECT 'name1' as name, 'id1' AS id", 1);
+
+        assertFileSystemAccesses("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
+                ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 12)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 12)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 2)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 2)
+                        .build());
+    }
+
+    @Test
+    public void testJoinWithPartitionedTable()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_join_partitioned_t1 (a BIGINT, b TIMESTAMP(6) with time zone) WITH (partitioning = ARRAY['a', 'day(b)'])");
+        assertUpdate("CREATE TABLE test_join_partitioned_t2 (foo BIGINT)");
+        assertUpdate("INSERT INTO test_join_partitioned_t2 VALUES(123)", 1);
+        assertUpdate("INSERT INTO test_join_partitioned_t1 VALUES(123, current_date)", 1);
+
+        assertFileSystemAccesses("SELECT COUNT(*) FROM test_join_partitioned_t1 t1 join test_join_partitioned_t2 t2 on t1.a = t2.foo",
+                ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 12)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 12)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 2)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 2)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 2)
+                        .build());
+    }
+
+    @Test
+    public void testExplainSelect()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_explain AS SELECT 2 as age", 1);
+
+        assertFileSystemAccesses("EXPLAIN SELECT * FROM test_explain",
+                ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 2)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 2)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
+                        .build());
+    }
+
+    @Test
+    public void testShowStatsForTable()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_show_stats AS SELECT 2 as age", 1);
+
+        assertFileSystemAccesses("SHOW STATS FOR test_show_stats",
+                ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 4)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 4)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
+                        .build());
+    }
+
+    @Test
+    public void testShowStatsForPartitionedTable()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_show_stats_partitioned " +
+                "WITH (partitioning = ARRAY['regionkey']) " +
+                "AS SELECT * FROM tpch.tiny.nation", 25);
+
+        assertFileSystemAccesses("SHOW STATS FOR test_show_stats_partitioned",
+                ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 4)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 4)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
+                        .build());
+    }
+
+    @Test
+    public void testShowStatsForTableWithFilter()
+            throws Exception
+    {
+        assertUpdate("CREATE TABLE test_show_stats_with_filter AS SELECT 2 as age", 1);
+
+        assertFileSystemAccesses("SHOW STATS FOR (SELECT * FROM test_show_stats_with_filter WHERE age >= 2)",
+                ImmutableMultiset.builder()
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_GET_LENGTH), 4)
+                        .addCopies(new FileOperation(MANIFEST, INPUT_FILE_NEW_STREAM), 4)
+                        .addCopies(new FileOperation(METADATA_JSON, INPUT_FILE_NEW_STREAM), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_GET_LENGTH), 1)
+                        .addCopies(new FileOperation(SNAPSHOT, INPUT_FILE_NEW_STREAM), 1)
+                        .build());
+    }
+
+    private void assertFileSystemAccesses(@Language("SQL") String query, Multiset<Object> expectedAccesses)
+            throws Exception
+    {
+        resetCounts();
+        getDistributedQueryRunner().executeWithQueryId(TEST_SESSION, query);
+        assertThat(ImmutableMultiset.<Object>copyOf(getOperations())).containsExactlyInAnyOrderElementsOf(expectedAccesses);
+    }
+
+    private static void resetCounts()
+            throws Exception
+    {
+        BEAN_SERVER.invoke(new ObjectName(BEAN_NAME), "reset", null, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Multiset<FileOperation> getOperations()
+            throws Exception
+    {
+        return ((Map<OperationContext, Integer>) BEAN_SERVER.getAttribute(new ObjectName(BEAN_NAME), "OperationCounts"))
+                .entrySet().stream()
+                .flatMap(entry -> nCopies(entry.getValue(), new FileOperation(entry.getKey())).stream())
+                .collect(toCollection(HashMultiset::create));
+    }
+
+    static class FileOperation
+    {
+        private final FileType fileType;
+        private final OperationType operationType;
+
+        public FileOperation(OperationContext operationContext)
         {
-            this.allCounts = requireNonNull(allCounts, "allCounts is null");
+            this(fromFilePath(operationContext.getFilePath()), operationContext.getOperationType());
         }
 
-        public OperationCounts forQueryId(String queryId)
+        public FileOperation(FileType fileType, OperationType operationType)
         {
-            this.queryId = Optional.of(queryId);
-            return this;
+            this.fileType = requireNonNull(fileType, "fileType is null");
+            this.operationType = requireNonNull(operationType, "operationType is null");
         }
 
-        public OperationCounts forPathContaining(String value)
+        @Override
+        public boolean equals(Object o)
         {
-            this.pathPredicate = path -> path.contains(value);
-            return this;
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            FileOperation that = (FileOperation) o;
+            return fileType == that.fileType &&
+                    operationType == that.operationType;
         }
 
-        public OperationCounts forOperation(TrackingFileIoProvider.OperationType type)
+        @Override
+        public int hashCode()
         {
-            this.type = Optional.of(type);
-            return this;
+            return Objects.hash(fileType, operationType);
         }
 
-        public Map<OperationContext, Integer> get()
+        @Override
+        public String toString()
         {
-            return allCounts.entrySet().stream()
-                    .filter(entry -> queryId.map(id -> entry.getKey().getQueryId().equals(id)).orElse(true))
-                    .filter(entry -> pathPredicate.test(entry.getKey().getFilePath()))
-                    .filter(entry -> type.map(value -> value == entry.getKey().getOperationType()).orElse(true))
-                    .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+            return toStringHelper(this)
+                    .add("fileType", fileType)
+                    .add("operationType", operationType)
+                    .toString();
         }
+    }
 
-        public int sum()
+    enum FileType
+    {
+        METADATA_JSON,
+        MANIFEST,
+        SNAPSHOT,
+        /**/;
+
+        public static FileType fromFilePath(String path)
         {
-            return get().values().stream().mapToInt(Integer::intValue).sum();
+            if (path.endsWith("metadata.json")) {
+                return METADATA_JSON;
+            }
+            if (path.contains("/snap-")) {
+                return SNAPSHOT;
+            }
+            if (path.endsWith("-m0.avro")) {
+                return MANIFEST;
+            }
+            throw new IllegalArgumentException("File not recognized: " + path);
         }
     }
 }


### PR DESCRIPTION
In order to prevent introducing regressions a test that counts
accesses to file system is added. The test differentiate between
different files and accesses types. Additioanlly this pr removes
queryId from information provided by TrackingFileIoProvider as
it is no longer needed