### PR TITLE
Avoid redundant metastore calls for non-system Iceberg tables

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -303,6 +303,9 @@ public class IcebergMetadata
     private Optional<SystemTable> getRawSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
+        if (name.getTableType() == DATA) {
+            return Optional.empty();
+        }
 
         Optional<Table> hiveTable = metastore.getTable(new HiveIdentity(session), tableName.getSchemaName(), name.getTableName());
         if (hiveTable.isEmpty() || !isIcebergTable(hiveTable.get())) {
@@ -314,6 +317,7 @@ public class IcebergMetadata
         SchemaTableName systemTableName = new SchemaTableName(tableName.getSchemaName(), name.getTableNameWithType());
         switch (name.getTableType()) {
             case DATA:
+                // Handled above.
                 break;
             case HISTORY:
                 if (name.getSnapshotId().isPresent()) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -83,7 +83,7 @@ public class TestIcebergMetastoreAccessOperations
                 ImmutableMultiset.builder()
                         .add(CREATE_TABLE)
                         .add(GET_DATABASE)
-                        .addCopies(GET_TABLE, 2)
+                        .add(GET_TABLE)
                         .build());
     }
 
@@ -94,7 +94,7 @@ public class TestIcebergMetastoreAccessOperations
                 ImmutableMultiset.builder()
                         .add(GET_DATABASE)
                         .add(CREATE_TABLE)
-                        .addCopies(GET_TABLE, 2)
+                        .add(GET_TABLE)
                         .build());
     }
 
@@ -105,7 +105,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("SELECT * FROM test_select_from",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 12)
+                        .addCopies(GET_TABLE, 8)
                         .build());
     }
 
@@ -116,7 +116,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("SELECT * FROM test_select_from_where WHERE age = 2",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 12)
+                        .addCopies(GET_TABLE, 8)
                         .build());
     }
 
@@ -128,7 +128,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("SELECT name, age FROM test_join_t1 JOIN test_join_t2 ON test_join_t2.id = test_join_t1.id",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 24)
+                        .addCopies(GET_TABLE, 16)
                         .build());
     }
 
@@ -139,7 +139,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("EXPLAIN SELECT * FROM test_explain",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 11)
+                        .addCopies(GET_TABLE, 7)
                         .build());
     }
 
@@ -150,7 +150,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("SHOW STATS FOR test_show_stats",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 9)
+                        .addCopies(GET_TABLE, 5)
                         .build());
     }
 
@@ -161,7 +161,7 @@ public class TestIcebergMetastoreAccessOperations
 
         assertMetastoreInvocations("SHOW STATS FOR (SELECT * FROM test_show_stats_with_filter where age >= 2)",
                 ImmutableMultiset.builder()
-                        .addCopies(GET_TABLE, 9)
+                        .addCopies(GET_TABLE, 5)
                         .build());
     }
 


### PR DESCRIPTION
When table name doesn't look like a system table, we can exit early.

For https://github.com/trinodb/trino/issues/8675