### PR TITLE
Throw by default in Connector::rollback()

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
@@ -183,7 +183,10 @@ public interface Connector
      * {@link #commit(ConnectorTransactionHandle)} is called.
      * Note: calls to this method may race with calls to the ConnectorMetadata.
      */
-    default void rollback(ConnectorTransactionHandle transactionHandle) {}
+    default void rollback(ConnectorTransactionHandle transactionHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * True if the connector only supports write statements in independent transactions.


### PR DESCRIPTION
Throw by default in Connector::rollback()

So far rolback() method was not a no-op. That could lead to a false
impression that connector supports `ROLLBACK` statement while it is
be not true, as this implementation does not differ from commit() method
implementation.
