### PR TITLE
Increase chances of testLargeInFailureOnPartitionedColumns passing

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -627,20 +627,16 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testLargeInFailureOnPartitionedColumns()
     {
-        QualifiedObjectName tableName = new QualifiedObjectName("iceberg", "tpch", "test_large_in_failure");
-        assertUpdate(format(
-                "CREATE TABLE %s (col1 BIGINT, col2 BIGINT) WITH (partitioning = ARRAY['col2'])",
-                tableName));
-        assertUpdate(format("INSERT INTO %s VALUES (1, 10)", tableName), 1L);
-        assertUpdate(format("INSERT INTO %s VALUES (2, 20)", tableName), 1L);
+        assertUpdate("CREATE TABLE test_large_in_failure (col1 BIGINT, col2 BIGINT) WITH (partitioning = ARRAY['col2'])");
+        assertUpdate("INSERT INTO test_large_in_failure VALUES (1, 10)", 1L);
+        assertUpdate("INSERT INTO test_large_in_failure VALUES (2, 20)", 1L);
 
         List<String> predicates = IntStream.range(0, 5000).boxed()
                 .map(Object::toString)
                 .collect(toImmutableList());
 
         String filter = format("col2 IN (%s)", String.join(",", predicates));
-
-        assertThatThrownBy(() -> getQueryRunner().execute(format("SELECT * FROM %s WHERE %s", tableName, filter)))
+        assertThatThrownBy(() -> getQueryRunner().execute(format("SELECT * FROM test_large_in_failure WHERE %s", filter)))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("java.lang.StackOverflowError");
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -631,7 +631,7 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate("INSERT INTO test_large_in_failure VALUES (1, 10)", 1L);
         assertUpdate("INSERT INTO test_large_in_failure VALUES (2, 20)", 1L);
 
-        List<String> predicates = IntStream.range(0, 5000).boxed()
+        List<String> predicates = IntStream.range(0, 25_000).boxed()
                 .map(Object::toString)
                 .collect(toImmutableList());
 


### PR DESCRIPTION
With 5k or 15k expressions, the `StackOverflowError` expected by the
test does not always happen when running the test locally. While this is
obviously subject to JVM configuration, so no value is perfect, this
commit picks a value that is more likely to make the test pass under
"normal" circumstances.

Fixes https://github.com/trinodb/trino/issues/8644