### PR TITLE
Allow disabling of Iceberg table statistics

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -36,6 +36,7 @@ public class IcebergConfig
     private boolean uniqueTableLocation;
     private CatalogType catalogType = HIVE_METASTORE;
     private Duration dynamicFilteringWaitTimeout = new Duration(0, SECONDS);
+    private boolean tableStatisticsEnabled = true;
 
     public CatalogType getCatalogType()
     {
@@ -135,5 +136,21 @@ public class IcebergConfig
     {
         this.dynamicFilteringWaitTimeout = dynamicFilteringWaitTimeout;
         return this;
+    }
+
+    // In case of some queries / tables, retrieving table statistics from Iceberg
+    // can take 20+ seconds. This config allows the user / operator the option
+    // to opt out of retrieving table statistics in those cases to speed up query planning.
+    @Config("iceberg.table-statistics-enabled")
+    @ConfigDescription("Enable use of table statistics")
+    public IcebergConfig setTableStatisticsEnabled(boolean tableStatisticsEnabled)
+    {
+        this.tableStatisticsEnabled = tableStatisticsEnabled;
+        return this;
+    }
+
+    public boolean isTableStatisticsEnabled()
+    {
+        return tableStatisticsEnabled;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -90,6 +90,7 @@ import static io.trino.plugin.hive.util.HiveUtil.isStructuralType;
 import static io.trino.plugin.iceberg.ExpressionConverter.toIcebergExpression;
 import static io.trino.plugin.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
 import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.isStatisticsEnabled;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
@@ -688,6 +689,10 @@ public class IcebergMetadata
     @Override
     public TableStatistics getTableStatistics(ConnectorSession session, ConnectorTableHandle tableHandle, Constraint constraint)
     {
+        if (!isStatisticsEnabled(session)) {
+            return TableStatistics.empty();
+        }
+
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
         Table icebergTable = catalog.loadTable(session, handle.getSchemaTableName());
         return TableStatisticsMaker.getTableStatistics(typeManager, constraint, handle, icebergTable);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -67,6 +67,7 @@ public final class IcebergSessionProperties
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
     private static final String DYNAMIC_FILTERING_WAIT_TIMEOUT = "dynamic_filtering_wait_timeout";
+    private static final String STATISTICS_ENABLED = "statistics_enabled";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -198,6 +199,11 @@ public final class IcebergSessionProperties
                         "Duration to wait for completion of dynamic filters during split generation",
                         icebergConfig.getDynamicFilteringWaitTimeout(),
                         false))
+                .add(booleanProperty(
+                        STATISTICS_ENABLED,
+                        "Expose table statistics",
+                        icebergConfig.isTableStatisticsEnabled(),
+                        false))
                 .build();
     }
 
@@ -322,5 +328,10 @@ public final class IcebergSessionProperties
     public static Duration getDynamicFilteringWaitTimeout(ConnectorSession session)
     {
         return session.getProperty(DYNAMIC_FILTERING_WAIT_TIMEOUT, Duration.class);
+    }
+
+    public static boolean isStatisticsEnabled(ConnectorSession session)
+    {
+        return session.getProperty(STATISTICS_ENABLED, Boolean.class);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -42,7 +42,8 @@ public class TestIcebergConfig
                 .setMaxPartitionsPerWriter(100)
                 .setUniqueTableLocation(false)
                 .setCatalogType(HIVE_METASTORE)
-                .setDynamicFilteringWaitTimeout(new Duration(0, MINUTES)));
+                .setDynamicFilteringWaitTimeout(new Duration(0, MINUTES))
+                .setTableStatisticsEnabled(true));
     }
 
     @Test
@@ -56,6 +57,7 @@ public class TestIcebergConfig
                 .put("iceberg.unique-table-location", "true")
                 .put("iceberg.catalog.type", "GLUE")
                 .put("iceberg.dynamic-filtering.wait-timeout", "1h")
+                .put("iceberg.table-statistics-enabled", "false")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -65,7 +67,8 @@ public class TestIcebergConfig
                 .setMaxPartitionsPerWriter(222)
                 .setUniqueTableLocation(true)
                 .setCatalogType(GLUE)
-                .setDynamicFilteringWaitTimeout(Duration.valueOf("1h"));
+                .setDynamicFilteringWaitTimeout(Duration.valueOf("1h"))
+                .setTableStatisticsEnabled(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This change adds support to wrap the lookup of Iceberg's table statistics behind a config flag / session property. This gets the Iceberg connector to a similar state as the Hive connector regarding stats retrieval (as we gate that behind `hive.table-statistics-enabled`). 
cc @findepi / @raunaqmorarka - as we discussed this a few days back on the Trino slack channel. 