### PR TITLE
Rename ExtraCredentialsBasedJdbcIdentityCacheMappingModule

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ExtraCredentialsBasedIdentityCacheMappingModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ExtraCredentialsBasedIdentityCacheMappingModule.java
@@ -17,7 +17,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 
-public class ExtraCredentialsBasedJdbcIdentityCacheMappingModule
+public class ExtraCredentialsBasedIdentityCacheMappingModule
         implements Module
 {
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPlugin.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcPlugin.java
@@ -44,7 +44,7 @@ public class JdbcPlugin
                 name,
                 combine(
                         new CredentialProviderModule(),
-                        new ExtraCredentialsBasedJdbcIdentityCacheMappingModule(),
+                        new ExtraCredentialsBasedIdentityCacheMappingModule(),
                         module)));
     }
 }


### PR DESCRIPTION
This is a final part of commit 63ca924f772b1b984afcb695c46517f4f9e3998f, where `JdbcIdentity` was removed and all related classes were renamed to remove the `Jdbc`.