### PR TITLE
Reject Glue and Alluxio metastores from Iceberg

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
@@ -35,7 +35,6 @@ import io.trino.plugin.hive.authentication.HdfsAuthenticationModule;
 import io.trino.plugin.hive.azure.HiveAzureModule;
 import io.trino.plugin.hive.gcs.HiveGcsModule;
 import io.trino.plugin.hive.metastore.HiveMetastore;
-import io.trino.plugin.hive.metastore.HiveMetastoreModule;
 import io.trino.plugin.hive.s3.HiveS3Module;
 import io.trino.plugin.iceberg.testing.TrackingFileIoModule;
 import io.trino.spi.NodeManager;
@@ -76,13 +75,12 @@ public final class InternalIcebergConnectorFactory
                     new ConnectorObjectNameGeneratorModule(catalogName, "io.trino.plugin.iceberg", "trino.plugin.iceberg"),
                     new JsonModule(),
                     new IcebergModule(),
-                    new IcebergMetastoreModule(),
+                    new IcebergMetastoreModule(metastore),
                     new HiveHdfsModule(),
                     new HiveS3Module(),
                     new HiveGcsModule(),
                     new HiveAzureModule(),
                     new HdfsAuthenticationModule(),
-                    new HiveMetastoreModule(metastore),
                     new MBeanServerModule(),
                     trackMetadataIo
                             ? new TrackingFileIoModule()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -15,38 +15,15 @@ package io.trino.plugin.iceberg;
 
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.testing.TestingConnectorContext;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Map;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.common.io.MoreFiles.deleteRecursively;
-import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
-import static java.nio.file.Files.createTempDirectory;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestIcebergPlugin
 {
-    private Path tempDirectory;
-
-    @BeforeClass
-    public void setup()
-            throws IOException
-    {
-        tempDirectory = createTempDirectory(getClass().getSimpleName());
-    }
-
-    @AfterClass(alwaysRun = true)
-    public void tearDown()
-            throws IOException
-    {
-        deleteRecursively(tempDirectory, ALLOW_INSECURE);
-    }
-
     @Test
     public void testCreateConnector()
     {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -51,13 +51,11 @@ public class TestIcebergPlugin
     {
         ConnectorFactory factory = getConnectorFactory();
 
-        factory.create(
+        assertThatThrownBy(() -> factory.create(
                 "test",
-                Map.of(
-                        "hive.metastore", "glue",
-                        "hive.metastore.glue.region", "us-east-2"),
-                new TestingConnectorContext())
-                .shutdown();
+                Map.of("hive.metastore", "glue"),
+                new TestingConnectorContext()))
+                .hasMessageContaining("Explicit bindings are required and HiveMetastore is not explicitly bound");
 
         assertThatThrownBy(() -> factory.create(
                 "test",
@@ -84,14 +82,15 @@ public class TestIcebergPlugin
                 .shutdown();
 
         // recording with glue
-        factory.create(
+        assertThatThrownBy(() -> factory.create(
                 "test",
                 Map.of(
                         "hive.metastore", "glue",
                         "hive.metastore.glue.region", "us-east-2",
                         "hive.metastore-recording-path", "/tmp"),
-                new TestingConnectorContext())
-                .shutdown();
+                new TestingConnectorContext()))
+                .hasMessageContaining("Configuration property 'hive.metastore-recording-path' was not used")
+                .hasMessageContaining("Configuration property 'hive.metastore.glue.region' was not used");
     }
 
     private static ConnectorFactory getConnectorFactory()


### PR DESCRIPTION
They are currently not supported.

Previously, Iceberg would use `HiveMetastoreModule` and thus inherited
metastore configuration from Hive connector. `IcebergMetastoreModule`
existed for validation purposes. Besides thrift and file, Iceberg
inherited 'support' for glue (which actually didn't work at runtime) and
alluxio metastores (which was not intentional).

The commit copies `HiveMetastoreModule` into `IcebergMetastoreModule`
so that the latter class defines metastore configuration for Iceberg.
The Glue metastore option is currently not supported, but will be added
in the future. The Alluxio metastore option is dropped.

