### PR TITLE
Test system.runtime.nodes explicitly

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/connector/system/runtime/TestSystemConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/connector/system/runtime/TestSystemConnector.java
@@ -108,6 +108,17 @@ public class TestSystemConnector
         executor.shutdownNow();
     }
 
+    @Test
+    public void testRuntimeNodes()
+    {
+        assertQuery(
+                "SELECT node_version, coordinator, state FROM system.runtime.nodes",
+                "VALUES " +
+                        "('testversion', true, 'active')," +
+                        "('testversion', true, 'active')," + // backup coordinator
+                        "('testversion', false, 'active')");
+    }
+
     // Test is run multiple times because it is vulnerable to OS clock adjustment. See https://github.com/trinodb/trino/issues/5608
     @Test(invocationCount = 10, successPercentage = 80)
     public void testRuntimeQueriesTimestamps()


### PR DESCRIPTION
The table is tested implicitly in some places, but should be tested
explicitly in `TestSystemConnector`.