### PR TITLE
Add write batch size documentation to applicable JDBC connectors

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -146,3 +146,5 @@ statements, the connector supports the following features:
 * :doc:`/sql/drop-table`
 * :doc:`/sql/create-schema`
 * :doc:`/sql/drop-schema`
+
+.. include:: jdbc-batch-size.fragment

--- a/docs/src/main/sphinx/connector/jdbc-batch-size.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-batch-size.fragment
@@ -1,0 +1,20 @@
+Manage write batch size
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The connector supports manual control of the JDBC batch size used during write
+operations, which can be increased or decreased to improve performance. Set the
+batch size with the following connection property, where ``<size>`` is the
+maximum number of rows to write in a single batch:
+
+.. code-block:: none
+
+    write.batch-size=<size>
+
+You can also control the write batch size for a single session with the
+``write_batch_size`` session property.
+
+.. caution::
+
+    Only set this property if it's explicitly needed. Setting this property can
+    dramatically impact performance and memory usage on the target database,
+    because Trino can use multiple workers to write data at once.

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -104,3 +104,5 @@ statements, the connector supports the following features:
 * :doc:`/sql/drop-schema`
 
 .. include:: sql-delete-limitation.fragment
+
+.. include:: jdbc-batch-size.fragment

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -150,3 +150,5 @@ the following statements:
 * :doc:`/sql/drop-schema`
 
 .. include:: sql-delete-limitation.fragment
+
+.. include:: jdbc-batch-size.fragment

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -388,3 +388,5 @@ supports the following statements:
 * :doc:`/sql/comment`
 
 .. include:: sql-delete-limitation.fragment
+
+.. include:: jdbc-batch-size.fragment

--- a/docs/src/main/sphinx/connector/phoenix.rst
+++ b/docs/src/main/sphinx/connector/phoenix.rst
@@ -183,3 +183,5 @@ SQL support
 -----------
 
 .. include:: sql-delete-limitation.fragment
+
+.. include:: jdbc-batch-size.fragment

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -135,6 +135,8 @@ statements, the connector supports the following features:
 
 .. include:: sql-delete-limitation.fragment
 
+.. include:: jdbc-batch-size.fragment
+
 .. _postgresql-pushdown:
 
 Pushdown

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -97,3 +97,5 @@ statements, the connector supports the following features:
 * :doc:`/sql/comment`
 
 .. include:: sql-delete-limitation.fragment
+
+.. include:: jdbc-batch-size.fragment

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -128,6 +128,8 @@ supports the following features:
 
 .. include:: sql-delete-limitation.fragment
 
+.. include:: jdbc-batch-size.fragment
+
 .. _sqlserver-pushdown:
 
 Pushdown


### PR DESCRIPTION
For 360 release, add documentation discussing the `write.batch-size` connector and session property to the appropriate JDBC connectors.