### PR TITLE
Allow assuming an AWS IAM Role in Elasticsearch connector

### DIFF
--- a/docs/src/main/sphinx/connector/elasticsearch.rst
+++ b/docs/src/main/sphinx/connector/elasticsearch.rst
@@ -324,8 +324,17 @@ Additionally, the following options need to be configured appropriately:
 Property Name                                    Description
 ================================================ ==================================================================
 ``elasticsearch.aws.region``                     AWS region or the Elasticsearch endpoint. This option is required.
+
 ``elasticsearch.aws.access-key``                 AWS access key to use to connect to the Elasticsearch domain.
+                                                 If not set, the Default AWS Credentials Provider chain will be used.
+
 ``elasticsearch.aws.secret-key``                 AWS secret key to use to connect to the Elasticsearch domain.
+                                                 If not set, the Default AWS Credentials Provider chain will be used.
+
+``elasticsearch.aws.iam-role``                   Optional ARN of an IAM Role to assume to connect to the Elasticsearch domain.
+                                                 Note: the configured IAM user has to be able to assume this role.
+
+``elasticsearch.aws.external-id``                Optional external ID to pass while assuming an AWS IAM Role.
 ================================================ ==================================================================
 
 Password authentication

--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -83,6 +83,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
         </dependency>

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/AwsSecurityConfig.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/AwsSecurityConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.elasticsearch;
 
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.DefunctConfig;
 
@@ -27,6 +28,8 @@ public class AwsSecurityConfig
     private String accessKey;
     private String secretKey;
     private String region;
+    private String iamRole;
+    private String externalId;
 
     @NotNull
     public Optional<String> getAccessKey()
@@ -64,6 +67,34 @@ public class AwsSecurityConfig
     public AwsSecurityConfig setRegion(String region)
     {
         this.region = region;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getIamRole()
+    {
+        return Optional.ofNullable(iamRole);
+    }
+
+    @Config("elasticsearch.aws.iam-role")
+    @ConfigDescription("Optional AWS IAM role to assume for authenticating. If set, this role will be used to get credentials to sign requests to ES.")
+    public AwsSecurityConfig setIamRole(String iamRole)
+    {
+        this.iamRole = iamRole;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getExternalId()
+    {
+        return Optional.ofNullable(externalId);
+    }
+
+    @Config("elasticsearch.aws.external-id")
+    @ConfigDescription("Optional external id to pass to AWS STS while assuming a role")
+    public AwsSecurityConfig setExternalId(String externalId)
+    {
+        this.externalId = externalId;
         return this;
     }
 }

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestAwsSecurityConfig.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/TestAwsSecurityConfig.java
@@ -30,7 +30,9 @@ public class TestAwsSecurityConfig
         assertRecordedDefaults(recordDefaults(AwsSecurityConfig.class)
                 .setAccessKey(null)
                 .setSecretKey(null)
-                .setRegion(null));
+                .setRegion(null)
+                .setIamRole(null)
+                .setExternalId(null));
     }
 
     @Test
@@ -40,12 +42,16 @@ public class TestAwsSecurityConfig
                 .put("elasticsearch.aws.access-key", "access")
                 .put("elasticsearch.aws.secret-key", "secret")
                 .put("elasticsearch.aws.region", "region")
+                .put("elasticsearch.aws.iam-role", "iamRole")
+                .put("elasticsearch.aws.external-id", "externalId")
                 .build();
 
         AwsSecurityConfig expected = new AwsSecurityConfig()
                 .setAccessKey("access")
                 .setSecretKey("secret")
-                .setRegion("region");
+                .setRegion("region")
+                .setIamRole("iamRole")
+                .setExternalId("externalId");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
- Add optional configuration to allow assuming an IAM Role in the Elasticsearch connector
- Update connector documentation to mention the new configs