### PR TITLE
Iceberg: remove useless todo list for residual expression

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitManager.java
@@ -68,9 +68,6 @@ public class IcebergSplitManager
                                 // (See AbstractTestIcebergSmoke#testLargeInFailureOnPartitionedColumns)
                                 .intersect(table.getUnenforcedPredicate().simplify(ICEBERG_DOMAIN_COMPACTION_THRESHOLD))))
                 .useSnapshot(table.getSnapshotId().get());
-
-        // TODO Use residual. Right now there is no way to propagate residual to Trino but at least we can
-        //      propagate it at split level so the parquet pushdown can leverage it.
         IcebergSplitSource splitSource = new IcebergSplitSource(table.getSchemaTableName(), tableScan.planTasks());
 
         return new ClassLoaderSafeConnectorSplitSource(splitSource, Thread.currentThread().getContextClassLoader());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -91,11 +91,6 @@ public class IcebergSplitSource
 
     private ConnectorSplit toIcebergSplit(FileScanTask task)
     {
-        // TODO: We should leverage residual expression and convert that to TupleDomain.
-        //       The predicate here is used by readers for predicate push down at reader level,
-        //       so when we do not use residual expression, we are just wasting CPU cycles
-        //       on reader side evaluating a condition that we know will always be true.
-
         return new IcebergSplit(
                 task.file().path().toString(),
                 task.start(),


### PR DESCRIPTION
Since 'applyFilter' has been implemented for Iceberg Connector, so the todo list is useless now