### PR TITLE
Iceberg: throw TableNotFoundException when desc table in iceberg connector if metadata is null

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
@@ -296,6 +296,10 @@ public class HiveTableOperations
                 .run(metadataLocation -> newMetadata.set(
                         TableMetadataParser.read(this, io().newInputFile(metadataLocation))));
 
+        if (newMetadata.get() == null) {
+            throw new TableNotFoundException(getSchemaTableName(), "Table metadata is missing.");
+        }
+
         String newUUID = newMetadata.get().uuid();
         if (currentMetadata != null) {
             checkState(newUUID == null || newUUID.equals(currentMetadata.uuid()),

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
@@ -297,7 +297,7 @@ public class HiveTableOperations
                         TableMetadataParser.read(this, io().newInputFile(metadataLocation))));
 
         if (newMetadata.get() == null) {
-            throw new TableNotFoundException(getSchemaTableName(), "Table metadata is missing.");
+            throw new TrinoException(ICEBERG_INVALID_METADATA, "Table metadata is missing or invalid: " + getSchemaTableName());
         }
 
         String newUUID = newMetadata.get().uuid();

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -41,6 +41,7 @@ import io.trino.plugin.hive.metastore.HivePrincipal;
 import io.trino.plugin.hive.metastore.PrincipalPrivileges;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.plugin.hive.util.HiveUtil;
+import io.trino.spi.ErrorType;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.connector.CatalogSchemaTableName;
@@ -483,8 +484,10 @@ public class IcebergMetadata
             catch (TableNotFoundException e) {
                 // table disappeared during listing operation
             }
-            catch (UnknownTableTypeException e) {
-                // ignore table of unknown type
+            catch (TrinoException e) {
+                if (!e.getErrorCode().getType().equals(ErrorType.EXTERNAL)) {
+                    throw e;
+                }
             }
         }
         return columns.build();


### PR DESCRIPTION
Fix NPE when desc table in iceberg connector. The json file (metadata) of some iceberg table might be missing during listing tables, so we could throw a TableNotFoundException here (The exception thrown would be handled in listing table functions).