### PR TITLE
Add type mapping fragment to applicable connectors

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -115,6 +115,13 @@ Property Name               Default Value    Description
 Currently the connector only supports ``Log`` and ``MergeTree`` table engines
 in create table statement. ``ReplicatedMergeTree`` engine is not yet supported.
 
+.. _clickhouse-type-mapping:
+
+Type mapping
+------------
+
+.. include:: jdbc-type-mapping.fragment
+
 Pushdown
 --------
 

--- a/docs/src/main/sphinx/connector/druid.rst
+++ b/docs/src/main/sphinx/connector/druid.rst
@@ -42,6 +42,13 @@ secured by basic authentication by updating the URL and adding credentials:
 Now you can access your Druid database in Trino with the ``druiddb`` catalog
 name from the properties file.
 
+.. _druid-type-mapping:
+
+Type mapping
+------------
+
+.. include:: jdbc-type-mapping.fragment
+
 .. _druid-sql-support:
 
 SQL support

--- a/docs/src/main/sphinx/connector/phoenix.rst
+++ b/docs/src/main/sphinx/connector/phoenix.rst
@@ -87,8 +87,10 @@ Finally, you can access the ``clicks`` table in the ``web`` schema::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``phoenix`` in the above examples.
 
-Data types
-----------
+.. _phoenix-type-mapping:
+
+Type mapping
+------------
 
 The data type mappings are as follows:
 
@@ -116,6 +118,7 @@ variable length ``VARBINARY`` data type. There is no way to create a
 Phoenix table in Trino that uses the ``BINARY`` data type, as Trino
 does not have an equivalent type.
 
+.. include:: jdbc-type-mapping.fragment
 
 Table properties - Phoenix
 --------------------------

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -112,6 +112,8 @@ SQL Server Type                     Trino Type
 Complete list of `SQL Server data types
 <https://msdn.microsoft.com/en-us/library/ms187752.aspx>`_.
 
+.. include:: jdbc-type-mapping.fragment
+
 .. _sqlserver-sql-support:
 
 SQL support


### PR DESCRIPTION
Add standard type mapping fragment to connector documentation for applicable JDBC connectors

Cherry-picked from https://github.com/trinodb/trino/pull/8643/commits/fca12fcba5b3ec3538fc42fb505d199dd902f0c9