### PR TITLE
Support reading from/writing to Iceberg table after partition field dropped

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
@@ -100,6 +100,7 @@ public final class PartitionFields
             case "month":
             case "day":
             case "hour":
+            case "void":
                 return format("%s(%s)", transform, name);
         }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
@@ -40,6 +40,7 @@ public final class PartitionFields
     private static final Pattern HOUR_PATTERN = Pattern.compile("hour" + FUNCTION_ARGUMENT_NAME);
     private static final Pattern BUCKET_PATTERN = Pattern.compile("bucket" + FUNCTION_ARGUMENT_NAME_AND_INT);
     private static final Pattern TRUNCATE_PATTERN = Pattern.compile("truncate" + FUNCTION_ARGUMENT_NAME_AND_INT);
+    private static final Pattern VOID_PATTERN = Pattern.compile("void" + FUNCTION_ARGUMENT_NAME);
 
     private static final Pattern ICEBERG_BUCKET_PATTERN = Pattern.compile("bucket\\[(\\d+)]");
     private static final Pattern ICEBERG_TRUNCATE_PATTERN = Pattern.compile("truncate\\[(\\d+)]");
@@ -65,7 +66,9 @@ public final class PartitionFields
                 tryMatch(field, DAY_PATTERN, match -> builder.day(match.group(1))) ||
                 tryMatch(field, HOUR_PATTERN, match -> builder.hour(match.group(1))) ||
                 tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(match.group(1), parseInt(match.group(2)))) ||
-                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(match.group(1), parseInt(match.group(2))));
+                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(match.group(1), parseInt(match.group(2)))) ||
+                tryMatch(field, VOID_PATTERN, match -> builder.alwaysNull(match.group(1))) ||
+                false;
         if (!matched) {
             throw new IllegalArgumentException("Invalid partition field declaration: " + field);
         }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
@@ -46,6 +46,7 @@ public class TestPartitionFields
         assertParse("bucket(order_key, 42)", partitionSpec(builder -> builder.bucket("order_key", 42)));
         assertParse("truncate(comment, 13)", partitionSpec(builder -> builder.truncate("comment", 13)));
         assertParse("truncate(order_key, 88)", partitionSpec(builder -> builder.truncate("order_key", 88)));
+        assertParse("void(order_key)", partitionSpec(builder -> builder.alwaysNull("order_key")));
 
         assertInvalid("bucket()", "Invalid partition field declaration: bucket()");
         assertInvalid("abc", "Cannot find source column: abc");

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/spark-defaults.conf
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/spark-defaults.conf
@@ -5,6 +5,7 @@ spark.sql.hive.thriftServer.singleSession=false
 spark.sql.catalog.iceberg_test=org.apache.iceberg.spark.SparkCatalog
 spark.sql.catalog.iceberg_test.type=hive
 spark.sql.catalog.iceberg_test.uri=thrift://hadoop-master:9083
+spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
 
 spark.hadoop.fs.defaultFS=hdfs://hadoop-master:9000
 spark.hive.metastore.uris=thrift://hadoop-master:9083

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.iceberg;
+
+import io.trino.tempto.ProductTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tests.product.TestGroups.ICEBERG;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.utils.QueryExecutors.onSpark;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+
+public class TestIcebergPartitionEvolution
+        extends ProductTest
+{
+    @Test(groups = {ICEBERG, PROFILE_SPECIFIC_TESTS}, dataProvider = "testDroppedPartitionFieldDataProvider")
+    public void testDroppedPartitionField(boolean dropFirst)
+    {
+        onTrino().executeQuery("USE iceberg.default");
+        onTrino().executeQuery("DROP TABLE IF EXISTS test_dropped_partition_field");
+        onTrino().executeQuery("CREATE TABLE test_dropped_partition_field(a varchar, b varchar, c varchar) WITH (partitioning = ARRAY['a','b'])");
+        onTrino().executeQuery("INSERT INTO test_dropped_partition_field VALUES " +
+                "('one', 'small', 'snake')," +
+                "('one', 'small', 'rabbit')," +
+                "('one', 'big', 'rabbit')," +
+                "('another', 'small', 'snake')," +
+                "('something', 'completely', 'else')," +
+                "(NULL, NULL, 'nothing')");
+
+        onSpark().executeQuery("ALTER TABLE iceberg_test.default.test_dropped_partition_field DROP PARTITION FIELD " + (dropFirst ? "a" : "b"));
+
+        assertThat(onTrino().executeQuery("SHOW CREATE TABLE test_dropped_partition_field"))
+                .containsOnly(
+                        row("CREATE TABLE iceberg.default.test_dropped_partition_field (\n" +
+                                "   a varchar,\n" +
+                                "   b varchar,\n" +
+                                "   c varchar\n" +
+                                ")\n" +
+                                "WITH (\n" +
+                                "   format = 'ORC',\n" +
+                                "   partitioning = ARRAY[" + (dropFirst ? "'void(a)','b'" : "'a','void(b)'") + "]\n" +
+                                ")"));
+
+        assertThat(onTrino().executeQuery("SELECT * FROM test_dropped_partition_field"))
+                .containsOnly(
+                        row("one", "small", "snake"),
+                        row("one", "small", "rabbit"),
+                        row("one", "big", "rabbit"),
+                        row("another", "small", "snake"),
+                        row("something", "completely", "else"),
+                        row(null, null, "nothing"));
+
+        assertThat(onTrino().executeQuery("SHOW STATS FOR test_dropped_partition_field"))
+                .containsOnly(
+                        row("a", null, null, 1. / 6, null, null, null),
+                        row("b", null, null, 1. / 6, null, null, null),
+                        row("c", null, null, 0., null, null, null),
+                        row(null, null, null, null, 6., null, null));
+
+        assertThat(onTrino().executeQuery("SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'test_dropped_partition_field$partitions'"))
+                .containsOnly(
+                        row("a", "varchar"),
+                        row("b", "varchar"),
+                        // A/B is now partitioning column in the first partitioning spec, and non-partitioning in new one
+                        // TODO (https://github.com/trinodb/trino/issues/8729): $partitions table (as every other table) cannot have duplicate column names
+                        row(dropFirst ? "a" : "b", "row(min varchar, max varchar, null_count bigint)"),
+                        row("row_count", "bigint"),
+                        row("file_count", "bigint"),
+                        row("total_size", "bigint"),
+                        row("c", "row(min varchar, max varchar, null_count bigint)"));
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT a, b, c.min, c.max, row_count FROM \"test_dropped_partition_field$partitions\""))
+                // TODO (https://github.com/trinodb/trino/issues/8729): cannot read from $partitions table because of duplicate column names
+                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Multiple entries with same key: " + (dropFirst ? "a=a and a=a" : "b=b and b=b"));
+    }
+
+    @DataProvider
+    public Object[][] testDroppedPartitionFieldDataProvider()
+    {
+        return new Object[][] {{true}, {false}};
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
@@ -86,6 +86,17 @@ public class TestIcebergPartitionEvolution
         assertQueryFailure(() -> onTrino().executeQuery("SELECT a, b, c.min, c.max, row_count FROM \"test_dropped_partition_field$partitions\""))
                 // TODO (https://github.com/trinodb/trino/issues/8729): cannot read from $partitions table because of duplicate column names
                 .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Multiple entries with same key: " + (dropFirst ? "a=a and a=a" : "b=b and b=b"));
+
+        onTrino().executeQuery("INSERT INTO test_dropped_partition_field VALUES ('yet', 'another', 'row')");
+        assertThat(onTrino().executeQuery("SELECT * FROM test_dropped_partition_field"))
+                .containsOnly(
+                        row("one", "small", "snake"),
+                        row("one", "small", "rabbit"),
+                        row("one", "big", "rabbit"),
+                        row("another", "small", "snake"),
+                        row("something", "completely", "else"),
+                        row(null, null, "nothing"),
+                        row("yet", "another", "row"));
     }
 
     @DataProvider


### PR DESCRIPTION
Before the change, Trino was not able to read from an Iceberg v1 table
in which a partitioning field was removed via Spark. In v1 tables,
removed partitioning fields are replaced with `void` transformation to
keep field ordinal numbers unchanged, and `void` transformation was not
supported.

fixes https://github.com/trinodb/trino/issues/8284