### PR TITLE
Correct getRetainedBytes() in SliceDictionaryColumnWriter

### DIFF
--- a/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
+++ b/lib/trino-orc/src/main/java/io/trino/orc/writer/SliceDictionaryColumnWriter.java
@@ -535,7 +535,7 @@ public class SliceDictionaryColumnWriter
                 (directColumnWriter == null ? 0 : directColumnWriter.getRetainedBytes());
 
         for (DictionaryRowGroup rowGroup : rowGroups) {
-            retainedBytes += rowGroup.getColumnStatistics().getRetainedSizeInBytes();
+            retainedBytes += rowGroup.getColumnStatistics().getRetainedSizeInBytes() + rowGroup.getDictionaryIndexes().sizeOf();
         }
         return retainedBytes;
     }


### PR DESCRIPTION
The dictionaryIndexes in DictionaryRowGroup is an IntBigArray object, which needs to be counted when counting memory.