### PR TITLE
Remove unnecessary config

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/iceberg.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/iceberg.properties
@@ -1,4 +1,2 @@
 connector.name=iceberg
 hive.metastore.uri=thrift://hadoop-master:9083
-# TODO: Remove this config to test default read behavior once Spark writer version is fixed. See https://github.com/trinodb/trino/issues/6369 for details
-iceberg.use-file-size-from-metadata=false


### PR DESCRIPTION
Product tests use spark runtime 0.11.0 now, which
has fixes for the bugs causing incorrect file size
metadata