### PR TITLE
Disable oauth2 product tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,8 +384,9 @@ jobs:
           - config: default
             suite: suite-tpcds
           # this suite is not meant to be run with different configs
-          - config: default
-            suite: suite-oauth2
+          # TODO Re-enable oauth2 product tests - https://github.com/trinodb/trino/issues/8719
+          #- config: default
+          #  suite: suite-oauth2
           # this suite is not meant to be run with different configs
           - config: default
             suite: suite-compatibility


### PR DESCRIPTION
Disable oauth2 product tests

We started to hitting https://github.com/trinodb/trino/issues/8719
without any explicit change on our side (the world has changed).

Disabling oauth2 to not to distract other areas of development. While,
in the same time running investigation what has changed and
how to mitigate it.
