### PR TITLE
Remove note about connector-specific ANALYZE support

### DIFF
--- a/docs/src/main/sphinx/sql/analyze.rst
+++ b/docs/src/main/sphinx/sql/analyze.rst
@@ -19,9 +19,6 @@ To list all available properties, run the following query::
 
     SELECT * FROM system.metadata.analyze_properties
 
-Currently, this statement is only supported by the
-:ref:`Hive connector <hive_analyze>`.
-
 Examples
 --------
 


### PR DESCRIPTION
SQL statement support is now being documented in each connector doc, so having this content in the SQL statement page is unnecessary overhead