### PR TITLE
Add Time Travel support and Syntax

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -734,4 +734,19 @@ public interface Metadata
      * Get the target table handle after performing redirection.
      */
     RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName);
+
+    /**
+     * Get the target table handle after performing redirection with a table version.
+     */
+    RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion);
+
+    /**
+     * Verifies that a version is valid for a given table
+     */
+    boolean isValidTableVersion(Session session, QualifiedObjectName tableName, TableVersion version);
+
+    /**
+     * Returns a table handle for the specified table name with a specified version
+     */
+    Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion);
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/TableVersion.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableVersion.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import io.trino.spi.connector.PointerType;
+import io.trino.spi.type.Type;
+
+public class TableVersion
+{
+    private final PointerType pointerType;
+    private final Type objectType;
+    private final Object pointer;
+
+    public TableVersion(PointerType pointerType, Type objectType, Object pointer)
+    {
+        this.pointerType = pointerType;
+        this.objectType = objectType;
+        this.pointer = pointer;
+    }
+
+    public PointerType getPointerType()
+    {
+        return pointerType;
+    }
+
+    public Type getObjectType()
+    {
+        return objectType;
+    }
+
+    public Object getPointer()
+    {
+        return pointer;
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -974,4 +974,22 @@ public abstract class AbstractMockMetadata
     {
         return noRedirection(getTableHandle(session, tableName));
     }
+
+    @Override
+    public RedirectionAwareTableHandle getRedirectionAwareTableHandle(Session session, QualifiedObjectName tableName, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isValidTableVersion(Session session, QualifiedObjectName tableName, TableVersion version)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName table, Optional<TableVersion> startVersion, Optional<TableVersion> endVersion)
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -384,7 +384,7 @@ columnAliases
     ;
 
 relationPrimary
-    : qualifiedName                                                   #tableName
+    : qualifiedName queryPeriod?                                      #tableName
     | '(' query ')'                                                   #subqueryRelation
     | UNNEST '(' expression (',' expression)* ')' (WITH ORDINALITY)?  #unnest
     | LATERAL '(' query ')'                                           #lateral
@@ -653,6 +653,15 @@ qualifiedName
     : identifier ('.' identifier)*
     ;
 
+queryPeriod
+    : FOR rangeType AS OF end=valueExpression
+    ;
+
+rangeType
+    : TIMESTAMP
+    | VERSION
+    ;
+
 grantor
     : principal             #specifiedPrincipal
     | CURRENT_USER          #currentUserGrantor
@@ -698,14 +707,14 @@ nonReserved
     | LAST | LATERAL | LEVEL | LIMIT | LOCAL | LOGICAL
     | MAP | MATCH | MATCHED | MATCHES | MATCH_RECOGNIZE | MATERIALIZED | MEASURES | MERGE | MINUTE | MONTH
     | NEXT | NFC | NFD | NFKC | NFKD | NO | NONE | NULLIF | NULLS
-    | OFFSET | OMIT | ONE | ONLY | OPTION | ORDINALITY | OUTPUT | OVER | OVERFLOW
+    | OF | OFFSET | OMIT | ONE | ONLY | OPTION | ORDINALITY | OUTPUT | OVER | OVERFLOW
     | PARTITION | PARTITIONS | PAST | PATH | PATTERN | PER | PERMUTE | POSITION | PRECEDING | PRECISION | PRIVILEGES | PROPERTIES
     | RANGE | READ | REFRESH | RENAME | REPEATABLE | REPLACE | RESET | RESPECT | RESTRICT | REVOKE | ROLE | ROLES | ROLLBACK | ROW | ROWS | RUNNING
     | SCHEMA | SCHEMAS | SECOND | SECURITY | SEEK | SERIALIZABLE | SESSION | SET | SETS
     | SHOW | SOME | START | STATS | SUBSET | SUBSTRING | SYSTEM
     | TABLES | TABLESAMPLE | TEXT | TIES | TIME | TIMESTAMP | TO | TRANSACTION | TRUNCATE | TRY_CAST | TYPE
     | UNBOUNDED | UNCOMMITTED | UNMATCHED | UPDATE | USE | USER
-    | VALIDATE | VERBOSE | VIEW
+    | VALIDATE | VERBOSE | VERSION | VIEW
     | WINDOW | WITHIN | WITHOUT | WORK | WRITE
     | YEAR
     | ZONE
@@ -848,6 +857,7 @@ NULLIF: 'NULLIF';
 NULLS: 'NULLS';
 OFFSET: 'OFFSET';
 OMIT: 'OMIT';
+OF: 'OF';
 ON: 'ON';
 ONE: 'ONE';
 ONLY: 'ONLY';
@@ -935,6 +945,7 @@ USING: 'USING';
 VALIDATE: 'VALIDATE';
 VALUES: 'VALUES';
 VERBOSE: 'VERBOSE';
+VERSION: 'VERSION';
 VIEW: 'VIEW';
 WHEN: 'WHEN';
 WHERE: 'WHERE';

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -79,6 +79,7 @@ import io.trino.sql.tree.PrincipalSpecification;
 import io.trino.sql.tree.Property;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.Query;
+import io.trino.sql.tree.QueryPeriod;
 import io.trino.sql.tree.QuerySpecification;
 import io.trino.sql.tree.RefreshMaterializedView;
 import io.trino.sql.tree.Relation;
@@ -462,7 +463,16 @@ public final class SqlFormatter
         protected Void visitTable(Table node, Integer indent)
         {
             builder.append(formatName(node.getName()));
+            if (node.getQueryPeriod().isPresent()) {
+                builder.append(" " + node.getQueryPeriod().get().toString());
+            }
+            return null;
+        }
 
+        @Override
+        protected Void visitQueryPeriod(QueryPeriod node, Integer indent)
+        {
+            builder.append("FOR " + node.getRangeType().name() + " AS OF " + formatExpression(node.getEnd().get()));
             return null;
         }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -154,6 +154,7 @@ import io.trino.sql.tree.QuantifiedComparisonExpression;
 import io.trino.sql.tree.QuantifiedPattern;
 import io.trino.sql.tree.Query;
 import io.trino.sql.tree.QueryBody;
+import io.trino.sql.tree.QueryPeriod;
 import io.trino.sql.tree.QuerySpecification;
 import io.trino.sql.tree.RangeQuantifier;
 import io.trino.sql.tree.RefreshMaterializedView;
@@ -1697,6 +1698,9 @@ class AstBuilder
     @Override
     public Node visitTableName(SqlBaseParser.TableNameContext context)
     {
+        if (context.queryPeriod() != null) {
+            return new Table(getLocation(context), getQualifiedName(context.qualifiedName()), (QueryPeriod) visit(context.queryPeriod()));
+        }
         return new Table(getLocation(context), getQualifiedName(context.qualifiedName()));
     }
 
@@ -2778,6 +2782,14 @@ class AstBuilder
                 ImmutableList.of(new TypeParameter((DataType) visit(context.type()))));
     }
 
+    @Override
+    public Node visitQueryPeriod(SqlBaseParser.QueryPeriodContext context)
+    {
+        QueryPeriod.RangeType type = getRangeType((Token) context.rangeType().getChild(0).getPayload());
+        Expression marker = (Expression) visit(context.valueExpression());
+        return new QueryPeriod(getLocation(context), type, marker);
+    }
+
     // ***************** helpers *****************
 
     @Override
@@ -3203,5 +3215,16 @@ class AstBuilder
     private static ParsingException parseError(String message, ParserRuleContext context)
     {
         return new ParsingException(message, null, context.getStart().getLine(), context.getStart().getCharPositionInLine() + 1);
+    }
+
+    private static QueryPeriod.RangeType getRangeType(Token token)
+    {
+        switch (token.getType()) {
+            case SqlBaseLexer.TIMESTAMP:
+                return QueryPeriod.RangeType.TIMESTAMP;
+            case SqlBaseLexer.VERSION:
+                return QueryPeriod.RangeType.VERSION;
+        }
+        throw new IllegalArgumentException("Unsupported query period range type: " + token.getText());
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -1071,4 +1071,9 @@ public abstract class AstVisitor<R, C>
     {
         return visitPatternQuantifier(node, context);
     }
+
+    protected R visitQueryPeriod(QueryPeriod node, C context)
+    {
+        return visitNode(node, context);
+    }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/QueryPeriod.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/QueryPeriod.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueryPeriod
+        extends Node
+{
+    private final Optional<Expression> start;
+    private final Optional<Expression> end;
+    private final RangeType rangeType;
+
+    public enum RangeType {
+        TIMESTAMP,
+        VERSION
+    }
+
+    public QueryPeriod(NodeLocation location, RangeType rangeType, Expression end)
+    {
+        this(location, rangeType, Optional.empty(), Optional.of(end));
+    }
+
+    private QueryPeriod(NodeLocation location, RangeType rangeType, Optional<Expression> start, Optional<Expression> end)
+    {
+        super(Optional.of(location));
+        this.rangeType = requireNonNull(rangeType, "rangeType is null");
+        this.start = start;
+        this.end = end;
+    }
+
+    @Override
+    public List<Node> getChildren()
+    {
+        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
+        if (start.isPresent()) {
+            nodes.add(start.get());
+        }
+        if (end.isPresent()) {
+            nodes.add(end.get());
+        }
+        return nodes.build();
+    }
+
+    public Optional<Expression> getStart()
+    {
+        return start;
+    }
+
+    public Optional<Expression> getEnd()
+    {
+        return end;
+    }
+
+    public RangeType getRangeType()
+    {
+        return rangeType;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitQueryPeriod(this, context);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        QueryPeriod o = (QueryPeriod) obj;
+        return Objects.equals(rangeType, o.rangeType) &&
+                Objects.equals(start, o.start) &&
+                Objects.equals(end, o.end);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(rangeType, start, end);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "FOR " + rangeType.toString() + " AS OF " + end.get().toString();
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Table.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Table.java
@@ -25,21 +25,28 @@ public class Table
         extends QueryBody
 {
     private final QualifiedName name;
+    private final Optional<QueryPeriod> queryPeriod;
 
     public Table(QualifiedName name)
     {
-        this(Optional.empty(), name);
+        this(Optional.empty(), name, Optional.empty());
     }
 
     public Table(NodeLocation location, QualifiedName name)
     {
-        this(Optional.of(location), name);
+        this(Optional.of(location), name, Optional.empty());
     }
 
-    private Table(Optional<NodeLocation> location, QualifiedName name)
+    public Table(NodeLocation location, QualifiedName name, QueryPeriod queryPeriod)
+    {
+        this(Optional.of(location), name, Optional.of(queryPeriod));
+    }
+
+    private Table(Optional<NodeLocation> location, QualifiedName name, Optional<QueryPeriod> queryPeriod)
     {
         super(location);
         this.name = name;
+        this.queryPeriod = queryPeriod;
     }
 
     public QualifiedName getName()
@@ -56,6 +63,9 @@ public class Table
     @Override
     public List<Node> getChildren()
     {
+        if (queryPeriod.isPresent()) {
+            return ImmutableList.of(queryPeriod.get());
+        }
         return ImmutableList.of();
     }
 
@@ -64,6 +74,7 @@ public class Table
     {
         return toStringHelper(this)
                 .addValue(name)
+                .addValue(queryPeriod)
                 .toString();
     }
 
@@ -78,13 +89,14 @@ public class Table
         }
 
         Table table = (Table) o;
-        return Objects.equals(name, table.name);
+        return Objects.equals(name, table.name) &&
+                Objects.equals(queryPeriod, table.getQueryPeriod());
     }
 
     @Override
     public int hashCode()
     {
-        return name.hashCode();
+        return Objects.hash(name, queryPeriod);
     }
 
     @Override
@@ -96,5 +108,10 @@ public class Table
 
         Table otherTable = (Table) other;
         return name.equals(otherTable.name);
+    }
+
+    public Optional<QueryPeriod> getQueryPeriod()
+    {
+        return queryPeriod;
     }
 }

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -127,6 +127,7 @@ import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.QuantifiedComparisonExpression;
 import io.trino.sql.tree.QuantifiedPattern;
 import io.trino.sql.tree.Query;
+import io.trino.sql.tree.QueryPeriod;
 import io.trino.sql.tree.QuerySpecification;
 import io.trino.sql.tree.RangeQuantifier;
 import io.trino.sql.tree.RefreshMaterializedView;
@@ -3541,6 +3542,70 @@ public class TestSqlParser
                         ImmutableList.of(
                                 new UpdateAssignment(new Identifier("bar"), new LongLiteral("23"))),
                         Optional.empty()));
+    }
+
+    @Test
+    public void testQueryPeriod()
+    {
+        Expression rangeValue = new TimestampLiteral(location(1, 37), "2021-03-01 00:00:01");
+        QueryPeriod queryPeriod = new QueryPeriod(location(1, 17), QueryPeriod.RangeType.TIMESTAMP, rangeValue);
+        Table table = new Table(location(1, 15), qualifiedName(location(1, 15), "t"), queryPeriod);
+        assertThat(statement("SELECT * FROM t FOR TIMESTAMP AS OF TIMESTAMP '2021-03-01 00:00:01'"))
+                .isEqualTo(
+                        new Query(
+                                location(1, 1),
+                                Optional.empty(),
+                                new QuerySpecification(
+                                        location(1, 1),
+                                        new Select(
+                                                location(1, 1),
+                                                false,
+                                                ImmutableList.of(
+                                                        new AllColumns(
+                                                                location(1, 8),
+                                                                Optional.empty(),
+                                                                ImmutableList.of()))),
+                                        Optional.of(table),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        ImmutableList.of(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty()),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()));
+
+        rangeValue = new StringLiteral(location(1, 35), "version1");
+        queryPeriod = new QueryPeriod(new NodeLocation(1, 17), QueryPeriod.RangeType.VERSION, rangeValue);
+        table = new Table(location(1, 15), qualifiedName(location(1, 15), "t"), queryPeriod);
+        assertThat(statement("SELECT * FROM t FOR VERSION AS OF 'version1'"))
+                .isEqualTo(
+                        new Query(
+                                location(1, 1),
+                                Optional.empty(),
+                                new QuerySpecification(
+                                        location(1, 1),
+                                        new Select(
+                                                location(1, 1),
+                                                false,
+                                                ImmutableList.of(
+                                                        new AllColumns(
+                                                                location(1, 8),
+                                                                Optional.empty(),
+                                                                ImmutableList.of()))),
+                                        Optional.of(table),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        ImmutableList.of(),
+                                        Optional.empty(),
+                                        Optional.empty(),
+                                        Optional.empty()),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()));
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParserErrorHandling.java
@@ -48,7 +48,7 @@ public class TestSqlParserErrorHandling
                 {"select * from 'oops",
                         "line 1:15: mismatched input '''. Expecting: '(', 'LATERAL', 'UNNEST', <identifier>"},
                 {"select *\nfrom x\nfrom",
-                        "line 3:1: mismatched input 'from'. Expecting: ',', '.', 'AS', 'CROSS', 'EXCEPT', 'FETCH', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', " +
+                        "line 3:1: mismatched input 'from'. Expecting: ',', '.', 'AS', 'CROSS', 'EXCEPT', 'FETCH', 'FOR', 'FULL', 'GROUP', 'HAVING', 'INNER', 'INTERSECT', 'JOIN', 'LEFT', " +
                                 "'LIMIT', 'MATCH_RECOGNIZE', 'NATURAL', 'OFFSET', 'ORDER', 'RIGHT', 'TABLESAMPLE', 'UNION', 'WHERE', 'WINDOW', <EOF>, <identifier>"},
                 {"select *\nfrom x\nwhere from",
                         "line 3:7: mismatched input 'from'. Expecting: <expression>"},
@@ -142,7 +142,13 @@ public class TestSqlParserErrorHandling
                 {"SHOW FUNCTIONS LIKE '%$_%' ESCAPE",
                         "line 1:34: mismatched input '<EOF>'. Expecting: <string>"},
                 {"SHOW SESSION LIKE '%$_%' ESCAPE",
-                        "line 1:32: mismatched input '<EOF>'. Expecting: <string>"}
+                        "line 1:32: mismatched input '<EOF>'. Expecting: <string>"},
+                {"SELECT * FROM t FOR TIMESTAMP ",
+                        "line 1:31: mismatched input '<EOF>'. Expecting: 'AS'"},
+                {"SELECT * FROM t FOR TIMESTAMP AS OF TIMESTAMP WHERE",
+                        "line 1:52: mismatched input '<EOF>'. Expecting: <expression>"},
+                {"SELECT * FROM t FOR VERSION AS OF TIMESTAMP WHERE",
+                        "line 1:50: mismatched input '<EOF>'. Expecting: <expression>"}
         };
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -26,6 +26,7 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ComputedStatistics;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.statistics.TableStatisticsMetadata;
+import io.trino.spi.type.Type;
 
 import javax.annotation.Nullable;
 
@@ -1294,5 +1295,21 @@ public interface ConnectorMetadata
     default Optional<CatalogSchemaTableName> redirectTable(ConnectorSession session, SchemaTableName tableName)
     {
         return Optional.empty();
+    }
+
+    /**
+     * Returns a table handle representing a versioned table. A versioned table differs by having an additional specifier for version.
+     */
+    default ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<ConnectorTableVersion> startVersion, Optional<ConnectorTableVersion> endVersion)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support versioned tables");
+    }
+
+    /**
+     * Returns whether a specified version type is supported by the connector for a given travel type and table name
+     */
+    default boolean isSupportedVersionType(ConnectorSession session, SchemaTableName tableName, PointerType pointerType, Type versioning)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not support versioned tables");
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableVersion.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableVersion.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.spi.connector;
+
+import io.trino.spi.type.Type;
+
+import static java.util.Objects.requireNonNull;
+
+public class ConnectorTableVersion
+{
+    private final PointerType pointerType;
+    private final Type versionType;
+    private final Object version;
+
+    public ConnectorTableVersion(PointerType pointerType, Type versionType, Object version)
+    {
+        requireNonNull(pointerType, "travelType is null");
+        requireNonNull(versionType, "versionType is null");
+        requireNonNull(version, "version is null");
+        this.pointerType = pointerType;
+        this.versionType = versionType;
+        this.version = version;
+    }
+
+    public PointerType getPointerType()
+    {
+        return pointerType;
+    }
+
+    public Type getVersionType()
+    {
+        return versionType;
+    }
+
+    public Object getVersion()
+    {
+        return version;
+    }
+
+    @Override
+    public String toString()
+    {
+        return new StringBuilder("ConnectorTableVersion{")
+                .append("travelType=").append(pointerType)
+                .append(", versionType=").append(versionType)
+                .append(", version=").append(version)
+                .append('}')
+                .toString();
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/PointerType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/PointerType.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+/**
+ * This enum represents the type of pointer used in TableVersion.
+ * Temporal pointers are used in TIMESTAMP based query periods.
+ * Snapshot id pointers are used in VERSION based query periods.
+ */
+public enum PointerType
+{
+    TEMPORAL,
+    TARGET_ID
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -39,6 +39,7 @@ import io.trino.spi.connector.ConnectorTableLayoutResult;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTableProperties;
 import io.trino.spi.connector.ConnectorTableSchema;
+import io.trino.spi.connector.ConnectorTableVersion;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
@@ -48,6 +49,7 @@ import io.trino.spi.connector.JoinStatistics;
 import io.trino.spi.connector.JoinType;
 import io.trino.spi.connector.LimitApplicationResult;
 import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.PointerType;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.SampleApplicationResult;
 import io.trino.spi.connector.SampleType;
@@ -67,6 +69,7 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.statistics.ComputedStatistics;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.statistics.TableStatisticsMetadata;
+import io.trino.spi.type.Type;
 
 import javax.inject.Inject;
 
@@ -1007,6 +1010,22 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.redirectTable(session, tableName);
+        }
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<ConnectorTableVersion> startVersion, Optional<ConnectorTableVersion> endVersion)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableHandle(session, tableName, startVersion, endVersion);
+        }
+    }
+
+    @Override
+    public boolean isSupportedVersionType(ConnectorSession session, SchemaTableName tableName, PointerType pointerType, Type versioning)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.isSupportedVersionType(session, tableName, pointerType, versioning);
         }
     }
 }


### PR DESCRIPTION
This PR adds support for time travel as described in https://github.com/trinodb/trino/issues/6988. This commit primarily contains:
- Adds new time travel syntax to trino-parser
- New SPIs to support time travel in trino-spi
- Engine support for time travel in trino-main

Iceberg implementation of the time travel SPIs will be contained in another PR.