### PR TITLE
Update code not to use QueryAssert.containsExactly and use containsEx…

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestAlterTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestAlterTable.java
@@ -67,7 +67,7 @@ public class TestAlterTable
         assertThat(query(format("ALTER TABLE %s RENAME COLUMN n_nationkey TO nationkey", TABLE_NAME)))
                 .hasRowsCount(1);
         assertThat(query(format("SELECT count(nationkey) FROM %s", TABLE_NAME)))
-                .containsExactly(row(25));
+                .containsExactlyInOrder(row(25));
         assertQueryFailure(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO nATIoNkEy", TABLE_NAME)))
                 .hasMessageContaining("Column 'nationkey' already exists");
         assertQueryFailure(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_regionkeY", TABLE_NAME)))
@@ -82,7 +82,7 @@ public class TestAlterTable
         query(format("CREATE TABLE %s AS SELECT * FROM nation", TABLE_NAME));
 
         assertThat(query(format("SELECT count(1) FROM %s", TABLE_NAME)))
-                .containsExactly(row(25));
+                .containsExactlyInOrder(row(25));
         assertThat(query(format("ALTER TABLE %s ADD COLUMN some_new_column BIGINT", TABLE_NAME)))
                 .hasRowsCount(1);
         assertQueryFailure(() -> query(format("ALTER TABLE %s ADD COLUMN n_nationkey BIGINT", TABLE_NAME)))
@@ -97,7 +97,7 @@ public class TestAlterTable
         query(format("CREATE TABLE %s AS SELECT n_nationkey, n_regionkey, n_name FROM nation", TABLE_NAME));
 
         assertThat(query(format("SELECT count(n_nationkey) FROM %s", TABLE_NAME)))
-                .containsExactly(row(25));
+                .containsExactlyInOrder(row(25));
         assertThat(query(format("ALTER TABLE %s DROP COLUMN n_name", TABLE_NAME)))
                 .hasRowsCount(1);
         assertThat(query(format("ALTER TABLE %s DROP COLUMN n_nationkey", TABLE_NAME)))

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/blackhole/TestBlackHoleConnector.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/blackhole/TestBlackHoleConnector.java
@@ -32,7 +32,7 @@ public class TestBlackHoleConnector
         String nullTable = "\"blackhole\".default.nation_" + UUID.randomUUID().toString().replace("-", "");
         String table = "tpch.tiny.nation";
 
-        assertThat(query(format("SELECT count(*) from %s", table))).containsExactly(row(25));
+        assertThat(query(format("SELECT count(*) from %s", table))).containsExactlyInOrder(row(25));
         QueryResult result = query(format("CREATE TABLE %s AS SELECT * FROM %s", nullTable, table));
         try {
             assertThat(result).updatedRowsCountIsEqualTo(25);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/TestFunctions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/TestFunctions.java
@@ -27,12 +27,12 @@ public class TestFunctions
     @Test(groups = JSON_FUNCTIONS)
     public void testScalarFunction()
     {
-        assertThat(query("SELECT upper('value')")).containsExactly(row("VALUE"));
+        assertThat(query("SELECT upper('value')")).containsExactlyInOrder(row("VALUE"));
     }
 
     @Test(groups = JSON_FUNCTIONS)
     public void testAggregate()
     {
-        assertThat(query("SELECT min(x) FROM (VALUES 1,2,3,4) t(x)")).containsExactly(row(1));
+        assertThat(query("SELECT min(x) FROM (VALUES 1,2,3,4) t(x)")).containsExactlyInOrder(row(1));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/operators/TestComparison.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/operators/TestComparison.java
@@ -46,41 +46,41 @@ public class TestComparison
     public void testLessThanOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
         assertThat(query(format("select cast(%s as %s) < cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
-                .containsExactly(row(true));
+                .containsExactlyInOrder(row(true));
     }
 
     @Test(groups = {COMPARISON, QUERY_ENGINE}, dataProvider = "operands")
     public void testGreaterThanOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
         assertThat(query(format("select cast(%s as %s) > cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
-                .containsExactly(row(false));
+                .containsExactlyInOrder(row(false));
     }
 
     @Test(groups = {COMPARISON, QUERY_ENGINE}, dataProvider = "operands")
     public void testLessThanOrEqualOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
         assertThat(query(format("select cast(%s as %s) <= cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
-                .containsExactly(row(true));
+                .containsExactlyInOrder(row(true));
     }
 
     @Test(groups = {COMPARISON, QUERY_ENGINE}, dataProvider = "operands")
     public void testGreaterThanOrEqualOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
         assertThat(query(format("select cast(%s as %s) >= cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
-                .containsExactly(row(false));
+                .containsExactlyInOrder(row(false));
     }
 
     @Test(groups = {COMPARISON, QUERY_ENGINE}, dataProvider = "operands")
     public void testEqualOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
         assertThat(query(format("select cast(%s as %s) = cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
-                .containsExactly(row(false));
+                .containsExactlyInOrder(row(false));
     }
 
     @Test(groups = {COMPARISON, QUERY_ENGINE}, dataProvider = "operands")
     public void testBetweenOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
         assertThat(query(format("select cast(%s as %s) BETWEEN cast(%s as %s) AND cast(%s as %s)", leftOperand, typeName, leftOperand, typeName, rightOperand, typeName)))
-                .containsExactly(row(true));
+                .containsExactlyInOrder(row(true));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/operators/TestLogical.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/operators/TestLogical.java
@@ -28,11 +28,11 @@ public class TestLogical
     @Test(groups = {LOGICAL, QUERY_ENGINE})
     public void testLogicalOperatorsExists()
     {
-        assertThat(query("select true AND true")).containsExactly(row(true));
-        assertThat(query("select true OR false")).containsExactly(row(true));
-        assertThat(query("select 1 in (1, 2, 3)")).containsExactly(row(true));
-        assertThat(query("select 'ala ma kota' like 'ala%'")).containsExactly(row(true));
-        assertThat(query("select NOT true")).containsExactly(row(false));
-        assertThat(query("select null is null")).containsExactly(row(true));
+        assertThat(query("select true AND true")).containsExactlyInOrder(row(true));
+        assertThat(query("select true OR false")).containsExactlyInOrder(row(true));
+        assertThat(query("select 1 in (1, 2, 3)")).containsExactlyInOrder(row(true));
+        assertThat(query("select 'ala ma kota' like 'ala%'")).containsExactlyInOrder(row(true));
+        assertThat(query("select NOT true")).containsExactlyInOrder(row(false));
+        assertThat(query("select null is null")).containsExactlyInOrder(row(true));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAllDatatypesFromHiveConnector.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAllDatatypesFromHiveConnector.java
@@ -237,7 +237,7 @@ public class TestAllDatatypesFromHiveConnector
                         ")",
                 tableName));
 
-        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactly(
+        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
                 row("c_int", "integer"),
                 row("c_bigint", "bigint"),
                 row("c_float", "real"),
@@ -290,7 +290,7 @@ public class TestAllDatatypesFromHiveConnector
 
     private void assertProperAllDatatypesSchema(String tableName)
     {
-        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactly(
+        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
                 row("c_tinyint", "tinyint"),
                 row("c_smallint", "smallint"),
                 row("c_int", "integer"),
@@ -370,7 +370,7 @@ public class TestAllDatatypesFromHiveConnector
                 "'kot binarny'" +
                 ")", tableName));
 
-        assertThat(query(format("SHOW COLUMNS FROM %s", tableName)).project(1, 2)).containsExactly(
+        assertThat(query(format("SHOW COLUMNS FROM %s", tableName)).project(1, 2)).containsExactlyInOrder(
                 row("c_tinyint", "tinyint"),
                 row("c_smallint", "smallint"),
                 row("c_int", "integer"),

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaEvolution.java
@@ -65,14 +65,14 @@ public class TestAvroSchemaEvolution
     public void testSelectTable()
     {
         assertThat(query(format("SELECT string_col FROM %s", TABLE_NAME)))
-                .containsExactly(row("string0"));
+                .containsExactlyInOrder(row("string0"));
     }
 
     @Test(groups = AVRO)
     public void testInsertAfterSchemaEvolution()
     {
         assertThat(query(SELECT_STAR))
-                .containsExactly(row("string0", 0));
+                .containsExactlyInOrder(row("string0", 0));
 
         alterTableSchemaTo(ADDED_COLUMN_SCHEMA);
         query(format("INSERT INTO %s VALUES ('string1', 1, 101)", TABLE_NAME));
@@ -86,11 +86,11 @@ public class TestAvroSchemaEvolution
     public void testSchemaEvolutionWithIncompatibleType()
     {
         assertThat(query(COLUMNS_IN_TABLE))
-                .containsExactly(
+                .containsExactlyInOrder(
                         row("string_col", "varchar", "", ""),
                         row("int_col", "integer", "", ""));
         assertThat(query(SELECT_STAR))
-                .containsExactly(row("string0", 0));
+                .containsExactlyInOrder(row("string0", 0));
 
         alterTableSchemaTo(INCOMPATIBLE_TYPE_SCHEMA);
         assertQueryFailure(() -> query(SELECT_STAR))
@@ -101,57 +101,57 @@ public class TestAvroSchemaEvolution
     public void testSchemaEvolution()
     {
         assertThat(query(COLUMNS_IN_TABLE))
-                .containsExactly(
+                .containsExactlyInOrder(
                         row("string_col", "varchar", "", ""),
                         row("int_col", "integer", "", ""));
         assertThat(query(SELECT_STAR))
-                .containsExactly(row("string0", 0));
+                .containsExactlyInOrder(row("string0", 0));
 
         alterTableSchemaTo(CHANGE_COLUMN_TYPE_SCHEMA);
         assertThat(query(COLUMNS_IN_TABLE))
-                .containsExactly(
+                .containsExactlyInOrder(
                         row("string_col", "varchar", "", ""),
                         row("int_col", "bigint", "", ""));
         assertThat(query(SELECT_STAR))
-                .containsExactly(row("string0", 0));
+                .containsExactlyInOrder(row("string0", 0));
 
         alterTableSchemaTo(ADDED_COLUMN_SCHEMA);
         assertThat(query(COLUMNS_IN_TABLE))
-                .containsExactly(
+                .containsExactlyInOrder(
                         row("string_col", "varchar", "", ""),
                         row("int_col", "integer", "", ""),
                         row("int_col_added", "integer", "", ""));
         assertThat(query(SELECT_STAR))
-                .containsExactly(row("string0", 0, 100));
+                .containsExactlyInOrder(row("string0", 0, 100));
 
         alterTableSchemaTo(REMOVED_COLUMN_SCHEMA);
         assertThat(query(COLUMNS_IN_TABLE))
-                .containsExactly(row("int_col", "integer", "", ""));
+                .containsExactlyInOrder(row("int_col", "integer", "", ""));
         assertThat(query(SELECT_STAR))
-                .containsExactly(row(0));
+                .containsExactlyInOrder(row(0));
 
         alterTableSchemaTo(RENAMED_COLUMN_SCHEMA);
         assertThat(query(COLUMNS_IN_TABLE))
-                .containsExactly(
+                .containsExactlyInOrder(
                         row("string_col", "varchar", "", ""),
                         row("int_col_renamed", "integer", "", ""));
         assertThat(query(SELECT_STAR))
-                .containsExactly(row("string0", null));
+                .containsExactlyInOrder(row("string0", null));
     }
 
     @Test(groups = AVRO)
     public void testSchemaWhenUrlIsUnset()
     {
         assertThat(query(COLUMNS_IN_TABLE))
-                .containsExactly(
+                .containsExactlyInOrder(
                         row("string_col", "varchar", "", ""),
                         row("int_col", "integer", "", ""));
         assertThat(query(SELECT_STAR))
-                .containsExactly(row("string0", 0));
+                .containsExactlyInOrder(row("string0", 0));
 
         onHive().executeQuery(format("ALTER TABLE %s UNSET TBLPROPERTIES('avro.schema.url')", TABLE_NAME));
         assertThat(query(COLUMNS_IN_TABLE))
-                .containsExactly(
+                .containsExactlyInOrder(
                         row("dummy_col", "varchar", "", ""));
     }
 
@@ -167,7 +167,7 @@ public class TestAvroSchemaEvolution
         query(format("INSERT INTO %s VALUES ('string0', 0)", createTableLikeName));
 
         assertThat(query(format("SELECT string_col FROM %s", createTableLikeName)))
-                .containsExactly(row("string0"));
+                .containsExactlyInOrder(row("string0"));
         query("DROP TABLE IF EXISTS " + createTableLikeName);
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaUrl.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaUrl.java
@@ -98,8 +98,8 @@ public class TestAvroSchemaUrl
                 schemaLocation));
         onHive().executeQuery("INSERT INTO test_avro_schema_url_hive VALUES ('some text', 123042)");
 
-        assertThat(onHive().executeQuery("SELECT * FROM test_avro_schema_url_hive")).containsExactly(row("some text", 123042));
-        assertThat(onTrino().executeQuery("SELECT * FROM test_avro_schema_url_hive")).containsExactly(row("some text", 123042));
+        assertThat(onHive().executeQuery("SELECT * FROM test_avro_schema_url_hive")).containsExactlyInOrder(row("some text", 123042));
+        assertThat(onTrino().executeQuery("SELECT * FROM test_avro_schema_url_hive")).containsExactlyInOrder(row("some text", 123042));
 
         onHive().executeQuery("DROP TABLE test_avro_schema_url_hive");
     }
@@ -122,7 +122,7 @@ public class TestAvroSchemaUrl
                 schemaLocationOnHdfs));
 
         assertThat(onTrino().executeQuery("SHOW COLUMNS FROM test_avro_schema_url_in_serde_properties"))
-                .containsExactly(
+                .containsExactlyInOrder(
                         row("string_col", "varchar", "", ""),
                         row("int_col", "integer", "", ""));
 
@@ -136,12 +136,12 @@ public class TestAvroSchemaUrl
         saveResourceOnHdfs("avro/change_column_type_schema.avsc", schemaLocationOnHdfs);
 
         assertThat(onTrino().executeQuery("SHOW COLUMNS FROM test_avro_schema_url_in_serde_properties"))
-                .containsExactly(
+                .containsExactlyInOrder(
                         row("string_col", "varchar", "", ""),
                         row("int_col", "bigint", "", ""));
 
         assertThat(onTrino().executeQuery("SELECT * FROM test_avro_schema_url_in_serde_properties"))
-                .containsExactly(row("some text", 2147483635L));
+                .containsExactlyInOrder(row("some text", 2147483635L));
 
         onHive().executeQuery("DROP TABLE test_avro_schema_url_in_serde_properties");
     }
@@ -153,8 +153,8 @@ public class TestAvroSchemaUrl
         onTrino().executeQuery(format("CREATE TABLE test_avro_schema_url_presto (dummy_col VARCHAR) WITH (format='AVRO', avro_schema_url='%s')", schemaLocation));
         onTrino().executeQuery("INSERT INTO test_avro_schema_url_presto VALUES ('some text', 123042)");
 
-        assertThat(onHive().executeQuery("SELECT * FROM test_avro_schema_url_presto")).containsExactly(row("some text", 123042));
-        assertThat(onTrino().executeQuery("SELECT * FROM test_avro_schema_url_presto")).containsExactly(row("some text", 123042));
+        assertThat(onHive().executeQuery("SELECT * FROM test_avro_schema_url_presto")).containsExactlyInOrder(row("some text", 123042));
+        assertThat(onTrino().executeQuery("SELECT * FROM test_avro_schema_url_presto")).containsExactlyInOrder(row("some text", 123042));
 
         onTrino().executeQuery("DROP TABLE test_avro_schema_url_presto");
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSymlinkInputFormat.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSymlinkInputFormat.java
@@ -71,7 +71,7 @@ public class TestAvroSymlinkInputFormat
         saveResourceOnHdfs("avro/original_data.avro", dataDir + "/original_data.avro");
         hdfsClient.saveFile(dataDir + "/dontread.txt", "This file will cause an error if read as avro.");
         hdfsClient.saveFile(tableRoot + "/symlink.txt", format("hdfs:%s/original_data.avro", dataDir));
-        assertThat(onTrino().executeQuery("SELECT * FROM " + table)).containsExactly(row("someValue", 1));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + table)).containsExactlyInOrder(row("someValue", 1));
 
         onHive().executeQuery("DROP TABLE " + table);
         hdfsClient.delete(dataDir);
@@ -107,7 +107,7 @@ public class TestAvroSymlinkInputFormat
         saveResourceOnHdfs("avro/original_data.avro", anotherDataDir + "/more_data.avro");
         hdfsClient.saveFile(dataDir + "/dontread.txt", "This file will cause an error if read as avro.");
         hdfsClient.saveFile(tableRoot + "/symlink.txt", format("hdfs:%s/original_data.avro\nhdfs:%s/more_data.avro", dataDir, anotherDataDir));
-        assertThat(onTrino().executeQuery("SELECT COUNT(*) as cnt FROM " + table)).containsExactly(row(2));
+        assertThat(onTrino().executeQuery("SELECT COUNT(*) as cnt FROM " + table)).containsExactlyInOrder(row(2));
 
         onHive().executeQuery("DROP TABLE " + table);
         hdfsClient.delete(dataDir);
@@ -140,7 +140,7 @@ public class TestAvroSymlinkInputFormat
         String dataDir = warehouseDirectory + "/data_test_avro_symlink_with_nested_directory";
         saveResourceOnHdfs("avro/original_data.avro", dataDir + "/original_data.avro");
         hdfsClient.saveFile(tableRoot + "/symlink.txt", format("hdfs://%s/", dataDir));
-        assertThat(onTrino().executeQuery("SELECT * FROM " + table)).containsExactly(row("someValue", 1));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + table)).containsExactlyInOrder(row("someValue", 1));
 
         onHive().executeQuery("DROP TABLE " + table);
         hdfsClient.delete(dataDir);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCompression.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCompression.java
@@ -70,9 +70,9 @@ public class TestCompression
             onHive().executeQuery("CREATE TABLE test_read_compressed " + tableStorageDefinition + " AS SELECT * FROM orders");
 
             assertThat(onTrino().executeQuery("SELECT count(*) FROM test_read_compressed"))
-                    .containsExactly(row(1500000));
+                    .containsExactlyInOrder(row(1500000));
             assertThat(onTrino().executeQuery("SELECT sum(o_orderkey) FROM test_read_compressed"))
-                    .containsExactly(row(4499987250000L));
+                    .containsExactlyInOrder(row(4499987250000L));
 
             assertThat((String) onTrino().executeQuery("SELECT regexp_replace(\"$path\", '.*/') FROM test_read_compressed LIMIT 1").row(0).get(0))
                     .matches(expectedFileNamePattern);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestExternalHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestExternalHiveTable.java
@@ -90,7 +90,7 @@ public class TestExternalHiveTable
         insertNationPartition(nation, 1);
 
         // Running ANALYZE on an external table is allowed as long as the user has the privileges.
-        assertThat(query("ANALYZE hive.default." + EXTERNAL_TABLE_NAME)).containsExactly(row(5));
+        assertThat(query("ANALYZE hive.default." + EXTERNAL_TABLE_NAME)).containsExactlyInOrder(row(5));
     }
 
     @Test

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBucketedTables.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBucketedTables.java
@@ -117,7 +117,7 @@ public class TestHiveBucketedTables
                 .contains(row(25, 50));
 
         assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
-                .containsExactly(row(2));
+                .containsExactlyInOrder(row(2));
     }
 
     @Test(groups = BIG_QUERY)
@@ -134,7 +134,7 @@ public class TestHiveBucketedTables
                 .contains(row(25, 75));
 
         assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
-                .containsExactly(row(3));
+                .containsExactlyInOrder(row(3));
     }
 
     @Test
@@ -146,13 +146,13 @@ public class TestHiveBucketedTables
         populateHiveTable(tableName, NATION.getName());
 
         assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
-                .containsExactly(row(2));
+                .containsExactlyInOrder(row(2));
         assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
-                .containsExactly(row(10));
+                .containsExactlyInOrder(row(10));
         assertThat(query(format("SELECT n_regionkey, count(*) FROM %s GROUP BY n_regionkey", tableName)))
                 .containsOnly(row(0, 10), row(1, 10), row(2, 10), row(3, 10), row(4, 10));
         assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
-                .containsExactly(row(500));
+                .containsExactlyInOrder(row(500));
     }
 
     @Test
@@ -164,13 +164,13 @@ public class TestHiveBucketedTables
         populateHiveTable(tableName, NATION.getName());
 
         assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
-                .containsExactly(row(2));
+                .containsExactlyInOrder(row(2));
         assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
-                .containsExactly(row(10));
+                .containsExactlyInOrder(row(10));
         assertThat(query(format("SELECT n_regionkey, count(*) FROM %s GROUP BY n_regionkey", tableName)))
                 .containsOnly(row(0, 10), row(1, 10), row(2, 10), row(3, 10), row(4, 10));
         assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
-                .containsExactly(row(500));
+                .containsExactlyInOrder(row(500));
     }
 
     @Test
@@ -184,18 +184,18 @@ public class TestHiveBucketedTables
         populateHivePartitionedTable(tableName, NATION.getName(), "part_key = 'insert_2'");
 
         assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
-                .containsExactly(row(4));
+                .containsExactlyInOrder(row(4));
         assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
-                .containsExactly(row(20));
+                .containsExactlyInOrder(row(20));
         assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1 AND part_key = 'insert_1'", tableName)))
                 .hasRowsCount(1)
-                .containsExactly(row(10));
+                .containsExactlyInOrder(row(10));
         assertThat(query(format("SELECT n_regionkey, count(*) FROM %s WHERE part_key = 'insert_2' GROUP BY n_regionkey", tableName)))
                 .containsOnly(row(0, 10), row(1, 10), row(2, 10), row(3, 10), row(4, 10));
         assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
-                .containsExactly(row(2000));
+                .containsExactlyInOrder(row(2000));
         assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey WHERE n.part_key = 'insert_1'", tableName, tableName)))
-                .containsExactly(row(1000));
+                .containsExactlyInOrder(row(1000));
     }
 
     @Test
@@ -204,7 +204,7 @@ public class TestHiveBucketedTables
     {
         String tableName = mutableTableInstanceOf(BUCKETED_NATION).getNameInDatabase();
         assertThat(query(format("SELECT count(*) FROM %s", tableName)))
-                .containsExactly(row(0));
+                .containsExactlyInOrder(row(0));
     }
 
     @Test
@@ -215,9 +215,9 @@ public class TestHiveBucketedTables
         populateRowToHiveTable(tableName, ImmutableList.of("2", "'name'", "2", "'comment'"), Optional.empty());
         // insert one row into nation
         assertThat(query(format("SELECT count(*) from %s", tableName)))
-                .containsExactly(row(1));
+                .containsExactlyInOrder(row(1));
         assertThat(query(format("select n_nationkey from %s where n_regionkey = 2", tableName)))
-                .containsExactly(row(2));
+                .containsExactlyInOrder(row(2));
     }
 
     @Test
@@ -230,10 +230,10 @@ public class TestHiveBucketedTables
                 "AS SELECT n_nationkey, n_name, n_regionkey, n_comment, n_name as part_key FROM %s";
         query(format(ctasQuery, tableName, NATION.getName()));
 
-        assertThat(query(format("SELECT count(*) FROM %s", tableName))).containsExactly(row(25));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactly(row(5));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE part_key='ALGERIA'", tableName))).containsExactly(row(1));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0 AND part_key='ALGERIA'", tableName))).containsExactly(row(1));
+        assertThat(query(format("SELECT count(*) FROM %s", tableName))).containsExactlyInOrder(row(25));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(5));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0 AND part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
     }
 
     @Test
@@ -244,10 +244,10 @@ public class TestHiveBucketedTables
 
         query(format("INSERT INTO %s SELECT n_nationkey, n_name, n_regionkey, n_comment, n_name FROM %s", tableName, NATION.getName()));
 
-        assertThat(query(format("SELECT count(*) FROM %s", tableName))).containsExactly(row(25));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactly(row(5));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE part_key='ALGERIA'", tableName))).containsExactly(row(1));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0 AND part_key='ALGERIA'", tableName))).containsExactly(row(1));
+        assertThat(query(format("SELECT count(*) FROM %s", tableName))).containsExactlyInOrder(row(25));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(5));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0 AND part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
     }
 
     @Test
@@ -260,8 +260,8 @@ public class TestHiveBucketedTables
         // make sure that insert will not overwrite existing data
         query(format("INSERT INTO %s SELECT * FROM %s", tableName, NATION.getName()));
 
-        assertThat(query(format("SELECT count(*) FROM %s", tableName))).containsExactly(row(50));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactly(row(10));
+        assertThat(query(format("SELECT count(*) FROM %s", tableName))).containsExactlyInOrder(row(50));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(10));
     }
 
     @Test
@@ -274,7 +274,7 @@ public class TestHiveBucketedTables
         query(format("CREATE TABLE %s WITH (bucket_count = 10, bucketed_by = ARRAY['n_regionkey']) AS SELECT * FROM %s", tableName, NATION.getName()));
 
         assertThat(query(format("SELECT * FROM %s", tableName))).matches(PRESTO_NATION_RESULT);
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactly(row(5));
+        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(5));
     }
 
     @Test

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCaching.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCaching.java
@@ -60,7 +60,7 @@ public class TestHiveCaching
         long initialAsyncDownloadedMb = beforeCacheStats.getAsyncDownloadedMb();
 
         assertThat(query("SELECT * FROM " + cachedTableName))
-                .containsExactly(tableData);
+                .containsExactlyInOrder(tableData);
 
         assertEventually(
                 new Duration(20, SECONDS),
@@ -82,7 +82,7 @@ public class TestHiveCaching
                     long beforeQueryNonLocalReads = beforeQueryCacheStats.getNonLocalReads();
 
                     assertThat(query("SELECT * FROM " + cachedTableName))
-                            .containsExactly(tableData);
+                            .containsExactlyInOrder(tableData);
 
                     // query via caching catalog should read exclusively from cache
                     CacheStats afterQueryCacheStats = getCacheStats();

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercion.java
@@ -261,7 +261,7 @@ public class TestHiveCoercion
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN int_to_bigint int_to_bigint bigint", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN float_to_double float_to_double double", tableName));
 
-        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactly(
+        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
                 row("int_to_bigint", "bigint"),
                 row("float_to_double", "double"),
                 row("id", "bigint"));
@@ -618,7 +618,7 @@ public class TestHiveCoercion
     {
         String floatType = tableName.toLowerCase(Locale.ENGLISH).contains("parquet") ? "double" : "real";
 
-        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactly(
+        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
                 row("row_to_row", "row(keep varchar, ti2si smallint, si2int integer, int2bi bigint, bi2vc varchar)"),
                 row("list_to_list", "array(row(ti2int integer, si2bi bigint, bi2vc varchar))"),
                 row("map_to_map", "map(integer, row(ti2bi bigint, int2bi bigint, float2double double, add tinyint))"),

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePartitionsTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePartitionsTable.java
@@ -112,11 +112,11 @@ public class TestHivePartitionsTable
         QueryResult partitionListResult;
 
         partitionListResult = query("SELECT * FROM " + partitionsTable);
-        assertThat(partitionListResult).containsExactly(row(1), row(2));
+        assertThat(partitionListResult).containsExactlyInOrder(row(1), row(2));
         assertColumnNames(partitionListResult, "part_col");
 
         partitionListResult = query(format("SELECT * FROM %s WHERE part_col = 1", partitionsTable));
-        assertThat(partitionListResult).containsExactly(row(1));
+        assertThat(partitionListResult).containsExactlyInOrder(row(1));
         assertColumnNames(partitionListResult, "part_col");
 
         assertQueryFailure(() -> query(format("SELECT * FROM %s WHERE no_such_column = 1", partitionsTable)))
@@ -148,17 +148,17 @@ public class TestHivePartitionsTable
         QueryResult partitionListResult;
 
         partitionListResult = query(format("SELECT * FROM %s WHERE part_col < 7", partitionsTable));
-        assertThat(partitionListResult).containsExactly(row(0), row(1), row(2), row(3), row(4), row(5), row(6));
+        assertThat(partitionListResult).containsExactlyInOrder(row(0), row(1), row(2), row(3), row(4), row(5), row(6));
         assertColumnNames(partitionListResult, "part_col");
 
         partitionListResult = query(format("SELECT a.part_col FROM (SELECT * FROM %s WHERE part_col = 1) a, (SELECT * FROM %s WHERE part_col = 1) b WHERE a.col = b.col", tableName, tableName));
-        assertThat(partitionListResult).containsExactly(row(1));
+        assertThat(partitionListResult).containsExactlyInOrder(row(1));
 
         partitionListResult = query(format("SELECT * FROM %s WHERE part_col < -10", partitionsTable));
         assertThat(partitionListResult).hasNoRows();
 
         partitionListResult = query(format("SELECT * FROM %s ORDER BY part_col LIMIT 7", partitionsTable));
-        assertThat(partitionListResult).containsExactly(row(0), row(1), row(2), row(3), row(4), row(5), row(6));
+        assertThat(partitionListResult).containsExactlyInOrder(row(0), row(1), row(2), row(3), row(4), row(5), row(6));
     }
 
     private void createPartitions(String tableName, int partitionsToCreate)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -476,7 +476,7 @@ public class TestHiveStorageFormats
 
         onHive().executeQuery(format("INSERT INTO %s VALUES(1, 'test data')", tableName));
 
-        assertThat(query("SELECT * FROM " + tableName)).containsExactly(row(1, "test data"));
+        assertThat(query("SELECT * FROM " + tableName)).containsExactlyInOrder(row(1, "test data"));
 
         onHive().executeQuery("DROP TABLE " + tableName);
     }
@@ -750,7 +750,7 @@ public class TestHiveStorageFormats
         QueryResult actual = query(format(query, tableName));
         assertThat(actual)
                 .hasColumns(expected.getColumnTypes())
-                .containsExactly(expectedRows);
+                .containsExactlyInOrder(expectedRows);
     }
 
     private void setAdminRole()

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTableStatistics.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTableStatistics.java
@@ -700,7 +700,7 @@ public class TestHiveTableStatistics
                 row("c_int", null, null, null, null, null, null),
                 row(null, null, null, null, 2.0, null, null));
 
-        assertThat(query("ANALYZE " + tableName)).containsExactly(row(2));
+        assertThat(query("ANALYZE " + tableName)).containsExactlyInOrder(row(2));
         assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
                 row("c_string", 4.0, 1.0, 0.0, null, null, null),
                 row("c_int", null, 2.0, 0.0, null, "1", "2"),
@@ -733,7 +733,7 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, 0.0, null, null));
         }
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(25));
+        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(25));
 
         assertThat(query(showStatsWholeTable)).containsOnly(
                 row("n_nationkey", null, 25.0, 0.0, null, "0", "24"),
@@ -771,7 +771,7 @@ public class TestHiveTableStatistics
 
         // analyze for single partition
 
-        assertThat(query("ANALYZE " + tableNameInDatabase + " WITH (partitions = ARRAY[ARRAY['1']])")).containsExactly(row(5));
+        assertThat(query("ANALYZE " + tableNameInDatabase + " WITH (partitions = ARRAY[ARRAY['1']])")).containsExactlyInOrder(row(5));
 
         assertThat(query(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
@@ -796,7 +796,7 @@ public class TestHiveTableStatistics
 
         // analyze for all partitions
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(15));
+        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(15));
 
         assertThat(query(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
@@ -848,7 +848,7 @@ public class TestHiveTableStatistics
 
         // analyze for single partition
 
-        assertThat(query("ANALYZE " + tableNameInDatabase + " WITH (partitions = ARRAY[ARRAY['AMERICA']])")).containsExactly(row(5));
+        assertThat(query("ANALYZE " + tableNameInDatabase + " WITH (partitions = ARRAY[ARRAY['AMERICA']])")).containsExactlyInOrder(row(5));
 
         assertThat(query(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
@@ -873,7 +873,7 @@ public class TestHiveTableStatistics
 
         // column analysis for all partitions
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(15));
+        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(15));
 
         assertThat(query(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
@@ -943,7 +943,7 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, 0.0, null, null));
         }
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(2));
+        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(2));
 
         // SHOW STATS FORMAT: column_name, data_size, distinct_values_count, nulls_fraction, row_count
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
@@ -1012,7 +1012,7 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, 0.0, null, null));
         }
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(0));
+        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(0));
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", 0.0, 0.0, 1.0, null, null, null),
@@ -1060,7 +1060,7 @@ public class TestHiveTableStatistics
                 row("c_binary", null, null, null, null, null, null),
                 row(null, null, null, null, 1.0, null, null));
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactly(row(1));
+        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(1));
 
         assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", 0.0, 0.0, 1.0, null, null, null),

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -152,7 +152,7 @@ public class TestHiveTransactionalTable
             assertThat(query(selectFromOnePartitionsSql)).containsOnly(row(21, 1));
 
             onHive().executeQuery("INSERT INTO TABLE " + tableName + hivePartitionString + " VALUES (22, 2)");
-            assertThat(query(selectFromOnePartitionsSql)).containsExactly(row(21, 1), row(22, 2));
+            assertThat(query(selectFromOnePartitionsSql)).containsExactlyInOrder(row(21, 1), row(22, 2));
 
             // test filtering
             assertThat(query("SELECT col, fcol FROM " + tableName + " WHERE fcol = 1 ORDER BY col")).containsOnly(row(21, 1));
@@ -166,27 +166,27 @@ public class TestHiveTransactionalTable
             // test minor compacted data read
             onHive().executeQuery("INSERT INTO TABLE " + tableName + hivePartitionString + " VALUES (20, 3)");
 
-            assertThat(query("SELECT col, fcol FROM " + tableName + " WHERE col=20")).containsExactly(row(20, 3));
+            assertThat(query("SELECT col, fcol FROM " + tableName + " WHERE col=20")).containsExactlyInOrder(row(20, 3));
 
             compactTableAndWait(MINOR, tableName, hivePartitionString, new Duration(6, MINUTES));
-            assertThat(query(selectFromOnePartitionsSql)).containsExactly(row(20, 3), row(21, 1), row(22, 2));
+            assertThat(query(selectFromOnePartitionsSql)).containsExactlyInOrder(row(20, 3), row(21, 1), row(22, 2));
 
             // delete a row
             onHive().executeQuery("DELETE FROM " + tableName + " WHERE fcol=2");
-            assertThat(query(selectFromOnePartitionsSql)).containsExactly(row(20, 3), row(21, 1));
+            assertThat(query(selectFromOnePartitionsSql)).containsExactlyInOrder(row(20, 3), row(21, 1));
 
-            assertThat(query("SELECT col, fcol FROM " + tableName + " WHERE col=20")).containsExactly(row(20, 3));
+            assertThat(query("SELECT col, fcol FROM " + tableName + " WHERE col=20")).containsExactlyInOrder(row(20, 3));
 
             // update the existing row
             String predicate = "fcol = 1" + (isPartitioned ? " AND part_col = 2 " : "");
             onHive().executeQuery("UPDATE " + tableName + " SET col = 23 WHERE " + predicate);
-            assertThat(query(selectFromOnePartitionsSql)).containsExactly(row(20, 3), row(23, 1));
+            assertThat(query(selectFromOnePartitionsSql)).containsExactlyInOrder(row(20, 3), row(23, 1));
 
-            assertThat(query("SELECT col, fcol FROM " + tableName + " WHERE col=20")).containsExactly(row(20, 3));
+            assertThat(query("SELECT col, fcol FROM " + tableName + " WHERE col=20")).containsExactlyInOrder(row(20, 3));
 
             // test major compaction
             compactTableAndWait(MAJOR, tableName, hivePartitionString, new Duration(6, MINUTES));
-            assertThat(query(selectFromOnePartitionsSql)).containsExactly(row(20, 3), row(23, 1));
+            assertThat(query(selectFromOnePartitionsSql)).containsExactlyInOrder(row(20, 3), row(23, 1));
         }
     }
 
@@ -246,14 +246,14 @@ public class TestHiveTransactionalTable
             assertThat(query(selectFromOnePartitionsSql)).containsOnly(row(1));
 
             onHive().executeQuery("INSERT INTO TABLE " + tableName + hivePartitionString + " SELECT 2");
-            assertThat(query(selectFromOnePartitionsSql)).containsExactly(row(1), row(2));
+            assertThat(query(selectFromOnePartitionsSql)).containsExactlyInOrder(row(1), row(2));
 
-            assertThat(query("SELECT col FROM " + tableName + " WHERE col=2")).containsExactly(row(2));
+            assertThat(query("SELECT col FROM " + tableName + " WHERE col=2")).containsExactlyInOrder(row(2));
 
             // test minor compacted data read
             compactTableAndWait(MINOR, tableName, hivePartitionString, new Duration(6, MINUTES));
-            assertThat(query(selectFromOnePartitionsSql)).containsExactly(row(1), row(2));
-            assertThat(query("SELECT col FROM " + tableName + " WHERE col=2")).containsExactly(row(2));
+            assertThat(query(selectFromOnePartitionsSql)).containsExactlyInOrder(row(1), row(2));
+            assertThat(query("SELECT col FROM " + tableName + " WHERE col=2")).containsExactlyInOrder(row(2));
 
             onHive().executeQuery("INSERT OVERWRITE TABLE " + tableName + hivePartitionString + " SELECT 3");
             assertThat(query(selectFromOnePartitionsSql)).containsOnly(row(3));
@@ -1648,7 +1648,7 @@ public class TestHiveTransactionalTable
             // Create `delta-A` file
             onHive().executeQuery("INSERT INTO TABLE " + tableName + " VALUES (1),(2)");
             QueryResult onePartitionQueryResult = query(selectFromOnePartitionsSql);
-            assertThat(onePartitionQueryResult).containsExactly(row(1), row(2));
+            assertThat(onePartitionQueryResult).containsExactlyInOrder(row(1), row(2));
 
             String tableLocation = getTablePath(tableName);
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestInsertIntoHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestInsertIntoHiveTable.java
@@ -120,7 +120,7 @@ public class TestInsertIntoHiveTable
     {
         String tableNameInDatabase = mutableTablesState().get(TABLE_NAME).getNameInDatabase();
         assertThat(query("SELECT * FROM " + tableNameInDatabase)).hasNoRows();
-        assertThat(query("INSERT INTO " + tableNameInDatabase + " SELECT * from textfile_all_types")).containsExactly(row(1));
+        assertThat(query("INSERT INTO " + tableNameInDatabase + " SELECT * from textfile_all_types")).containsExactlyInOrder(row(1));
         assertThat(query("SELECT * FROM " + tableNameInDatabase)).containsOnly(
                 row(
                         127,
@@ -144,7 +144,7 @@ public class TestInsertIntoHiveTable
     public void testInsertIntoPartitionedWithSerdeProperty()
     {
         String tableNameInDatabase = mutableTablesState().get(PARTITIONED_TABLE_WITH_SERDE).getNameInDatabase();
-        assertThat(query("INSERT INTO " + tableNameInDatabase + " SELECT 1, 'Trino', '2018-01-01'")).containsExactly(row(1));
-        assertThat(query("SELECT * FROM " + tableNameInDatabase)).containsExactly(row(1, "Trino", "2018-01-01"));
+        assertThat(query("INSERT INTO " + tableNameInDatabase + " SELECT 1, 'Trino', '2018-01-01'")).containsExactlyInOrder(row(1));
+        assertThat(query("SELECT * FROM " + tableNameInDatabase)).containsExactlyInOrder(row(1, "Trino", "2018-01-01"));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestParquetSymlinkInputFormat.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestParquetSymlinkInputFormat.java
@@ -61,7 +61,7 @@ public class TestParquetSymlinkInputFormat
 
         saveResourceOnHdfs("data.parquet", dataDir + "/data.parquet");
         hdfsClient.saveFile(tableRoot + "/symlink.txt", format("hdfs:%s/data.parquet", dataDir));
-        assertThat(onTrino().executeQuery("SELECT * FROM " + table)).containsExactly(row(42));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + table)).containsExactlyInOrder(row(42));
 
         onHive().executeQuery("DROP TABLE " + table);
         hdfsClient.delete(dataDir);
@@ -90,7 +90,7 @@ public class TestParquetSymlinkInputFormat
         saveResourceOnHdfs("data.parquet", anotherDataDir + "/data.parquet");
         hdfsClient.saveFile(dataDir + "/dontread.txt", "This file will cause an error if read as avro.");
         hdfsClient.saveFile(tableRoot + "/symlink.txt", format("hdfs:%s/data.parquet\nhdfs:%s/data.parquet", dataDir, anotherDataDir));
-        assertThat(onTrino().executeQuery("SELECT COUNT(*) as cnt FROM " + table)).containsExactly(row(2));
+        assertThat(onTrino().executeQuery("SELECT COUNT(*) as cnt FROM " + table)).containsExactlyInOrder(row(2));
 
         onHive().executeQuery("DROP TABLE " + table);
         hdfsClient.delete(dataDir);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSyncPartitionMetadata.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSyncPartitionMetadata.java
@@ -177,12 +177,12 @@ public class TestSyncPartitionMetadata
     private static void assertPartitions(String tableName, QueryAssert.Row... rows)
     {
         QueryResult partitionListResult = query("SELECT * FROM \"" + tableName + "$partitions\" ORDER BY 1, 2");
-        assertThat(partitionListResult).containsExactly(rows);
+        assertThat(partitionListResult).containsExactlyInOrder(rows);
     }
 
     private static void assertData(String tableName, QueryAssert.Row... rows)
     {
         QueryResult dataResult = query("SELECT payload, col_x, col_y FROM " + tableName + " ORDER BY 1, 2, 3 ASC");
-        assertThat(dataResult).containsExactly(rows);
+        assertThat(dataResult).containsExactlyInOrder(rows);
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestTextFileHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestTextFileHiveTable.java
@@ -98,7 +98,7 @@ public class TestTextFileHiveTable
                         "   skip_footer_line_count = 1 " +
                         ")",
                 warehouseDirectory));
-        assertThat(query("SELECT * FROM test_create_textfile_skip_header_footer")).containsExactly(row("value"));
+        assertThat(query("SELECT * FROM test_create_textfile_skip_header_footer")).containsExactlyInOrder(row("value"));
         onHive().executeQuery("DROP TABLE test_create_textfile_skip_header_footer");
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaPushdownSmokeTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaPushdownSmokeTest.java
@@ -89,7 +89,7 @@ public class TestKafkaPushdownSmokeTest
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
                 PUSHDOWN_PARTITION_TABLE_NAME)))
-                .containsExactly(row(NUM_MESSAGES / 2));
+                .containsExactlyInOrder(row(NUM_MESSAGES / 2));
     }
 
     private static class PushdownOffsetTable
@@ -124,42 +124,42 @@ public class TestKafkaPushdownSmokeTest
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
                 PUSHDOWN_OFFSET_TABLE_NAME)))
-                .containsExactly(row(10));
+                .containsExactlyInOrder(row(10));
 
         assertThat(query(format(
                 "SELECT COUNT(*) FROM %s.%s.%s WHERE _partition_offset > 5 AND _partition_offset < 10",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
                 PUSHDOWN_OFFSET_TABLE_NAME)))
-                .containsExactly(row(8));
+                .containsExactlyInOrder(row(8));
 
         assertThat(query(format(
                 "SELECT COUNT(*) FROM %s.%s.%s WHERE _partition_offset >= 5 AND _partition_offset <= 10",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
                 PUSHDOWN_OFFSET_TABLE_NAME)))
-                .containsExactly(row(12));
+                .containsExactlyInOrder(row(12));
 
         assertThat(query(format(
                 "SELECT COUNT(*) FROM %s.%s.%s WHERE _partition_offset >= 5 AND _partition_offset < 10",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
                 PUSHDOWN_OFFSET_TABLE_NAME)))
-                .containsExactly(row(10));
+                .containsExactlyInOrder(row(10));
 
         assertThat(query(format(
                 "SELECT COUNT(*) FROM %s.%s.%s WHERE _partition_offset > 5 AND _partition_offset <= 10",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
                 PUSHDOWN_OFFSET_TABLE_NAME)))
-                .containsExactly(row(10));
+                .containsExactlyInOrder(row(10));
 
         assertThat(query(format(
                 "SELECT COUNT(*) FROM %s.%s.%s WHERE _partition_offset = 5",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
                 PUSHDOWN_OFFSET_TABLE_NAME)))
-                .containsExactly(row(2));
+                .containsExactlyInOrder(row(2));
     }
 
     @Test(groups = {KAFKA, PROFILE_SPECIFIC_TESTS})
@@ -187,6 +187,6 @@ public class TestKafkaPushdownSmokeTest
         assertThat(query(format(
                 "SELECT COUNT(*) FROM %s.%s.%s WHERE _timestamp >= TIMESTAMP '%s' AND _timestamp < TIMESTAMP '%s'",
                 KAFKA_CATALOG, SCHEMA_NAME, PUSHDOWN_CREATE_TIME_TABLE_NAME, startTime, endTime)))
-                .containsExactly(row(endKey - startKey));
+                .containsExactlyInOrder(row(endKey - startKey));
     }
 }


### PR DESCRIPTION
+ for all the tests which used io.trino.tempto.assertions.QueryAssert instance, use containsExactlyInOrder to replace the deprecated containsExactly method
+ Two artifacts depend on tempto-core
      - trino-testing-services (no case used deprecated methods)
      - trino-product-tests (replace all the deprecated methods)
+ mvn test passed on trino-product-tests
