### PR TITLE
Add querylog implementation and tests

### DIFF
--- a/plugin/trino-querylog/pom.xml
+++ b/plugin/trino-querylog/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.trino</groupId>
+        <artifactId>trino-root</artifactId>
+        <version>359-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>trino-querylog</artifactId>
+    <description>Trino - Querylog</description>
+    <packaging>trino-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>1.17.2</version>
+        </dependency>
+
+
+        <!-- Trino SPI -->
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- TEST -->
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/plugin/trino-querylog/src/main/java/io/trino/plugin/querylog/QuerylogListener.java
+++ b/plugin/trino-querylog/src/main/java/io/trino/plugin/querylog/QuerylogListener.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.querylog;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.airlift.log.Logger;
+import io.trino.spi.eventlistener.EventListener;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+import io.trino.spi.eventlistener.SplitCompletedEvent;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class QuerylogListener
+        implements EventListener
+{
+    private final Logger log = Logger.get(QuerylogListener.class);
+
+    private final ObjectWriter objectWriter = new ObjectMapper().registerModule(new Jdk8Module()).registerModule(new JavaTimeModule()).writer();
+
+    private final boolean shouldLogCreated;
+    private final boolean shouldLogCompleted;
+    private final boolean shouldLogSplit;
+
+    private final InetAddress inetAddress;
+    private final int port;
+    private final String scheme;
+
+    private final Map<String, String> httpHeaders;
+
+    /**
+     * Create a HTTP logger of query events
+     * @param inetAddress Hostname to destination
+     * @param port Port
+     * @param scheme Scheme to use, either HTTP or HTTPS
+     * @param httpHeaders Map of custom HTTP headers
+     * @param shouldLogCreated Enable logging of {@link io.trino.spi.eventlistener.QueryCreatedEvent}
+     * @param shouldLogCompleted Enable logging of {@link io.trino.spi.eventlistener.QueryCompletedEvent}
+     * @param shouldLogSplit Enable logging of {@link io.trino.spi.eventlistener.SplitCompletedEvent}
+     * @throws UnknownHostException When it can't parse InetAddress
+     */
+    public QuerylogListener(String inetAddress, int port, String scheme, Map<String, String> httpHeaders, boolean shouldLogCreated, boolean shouldLogCompleted, boolean shouldLogSplit)
+            throws UnknownHostException
+    {
+        this.shouldLogCreated = shouldLogCreated;
+        this.shouldLogCompleted = shouldLogCompleted;
+        this.shouldLogSplit = shouldLogSplit;
+        this.httpHeaders = requireNonNull(httpHeaders, "HTTP headers cannot be null");
+
+        if (inetAddress == null || inetAddress.isBlank()) {
+            throw new UnknownHostException("Address is empty or blank");
+        }
+        this.inetAddress = InetAddress.getByName(inetAddress);
+        this.scheme = requireNonNull(scheme, "scheme must be either https or http, not null");
+        this.port = port;
+    }
+
+    @Override
+    public void queryCreated(QueryCreatedEvent queryCreatedEvent)
+    {
+        if (shouldLogCreated) {
+            sendLog(queryCreatedEvent);
+        }
+    }
+
+    @Override
+    public void queryCompleted(QueryCompletedEvent queryCompletedEvent)
+    {
+        if (shouldLogCompleted) {
+            sendLog(queryCompletedEvent);
+        }
+    }
+
+    @Override
+    public void splitCompleted(SplitCompletedEvent splitCompletedEvent)
+    {
+        if (shouldLogSplit) {
+            sendLog(splitCompletedEvent);
+        }
+    }
+
+    private <T> void sendLog(T event)
+    {
+        String logJson;
+
+        try {
+            logJson = objectWriter.writeValueAsString(event);
+        }
+        catch (JsonProcessingException e) {
+            log.error("Could not parse %s as JSON: %s", event.toString(), e.getMessage());
+            return;
+        }
+
+        OkHttpClient client = new OkHttpClient();
+
+        RequestBody body = RequestBody.create(MediaType.get("application/json; charset=UTF-8"), logJson);
+        Request.Builder requestBuilder = new Request.Builder()
+                .url(new HttpUrl.Builder()
+                        .host(inetAddress.getHostAddress())
+                        .port(port)
+                        .scheme(scheme)
+                        .build())
+                .post(body);
+        httpHeaders.forEach(requestBuilder::addHeader);
+        Request request = requestBuilder.build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (response.code() != 200) {
+                log.warn("Received status code %d from ingest server URL %s when logging %s; expecting status 200", response.code(), request.url().toString(), event.toString());
+            }
+        }
+        catch (IOException e) {
+            log.error("Error connecting to ingest sever with URL %s: %s", request.url().toString(), e.getMessage());
+        }
+    }
+}

--- a/plugin/trino-querylog/src/main/java/io/trino/plugin/querylog/QuerylogListenerFactory.java
+++ b/plugin/trino-querylog/src/main/java/io/trino/plugin/querylog/QuerylogListenerFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.querylog;
+
+import io.airlift.log.Logger;
+import io.trino.spi.eventlistener.EventListener;
+import io.trino.spi.eventlistener.EventListenerFactory;
+
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class QuerylogListenerFactory
+        implements EventListenerFactory
+{
+    private final Logger log = Logger.get(QuerylogListenerFactory.class);
+
+    public static final String QUERYLOG_SEND_CREATED = "trino.querylog.log.created";
+    public static final String QUERYLOG_SEND_COMPLETED = "trino.querylog.log.completed";
+    public static final String QUERYLOG_SEND_SPLIT = "trino.querylog.log.split";
+    public static final String QUERYLOG_CONNECT_INET_ADDRESS = "trino.querylog.connect.inet.address";
+    public static final String QUERYLOG_CONNECT_SCHEME = "trino.querylog.connect.scheme";
+    public static final String QUERYLOG_CONNECT_PORT = "trino.querylog.connect.port";
+    public static final String QUERYLOG_CONNECT_HEADERS_PREFIX = "trino.querylog.connect.headers.";
+
+    @Override
+    public String getName()
+    {
+        return "trino-querylog";
+    }
+
+    @Override
+    public EventListener create(Map<String, String> config)
+    {
+        boolean sendCreated = getBooleanConfig(config, QUERYLOG_SEND_CREATED, false);
+        boolean sendCompleted = getBooleanConfig(config, QUERYLOG_SEND_COMPLETED, false);
+        boolean sendSplit = getBooleanConfig(config, QUERYLOG_SEND_SPLIT, false);
+
+        Optional<String> scheme = Optional.ofNullable(config.get(QUERYLOG_CONNECT_SCHEME));
+        Optional<String> inetAddress = Optional.ofNullable(config.get(QUERYLOG_CONNECT_INET_ADDRESS));
+        Optional<String> portConfig = Optional.ofNullable(config.get(QUERYLOG_CONNECT_PORT));
+
+        if (inetAddress.isEmpty()) {
+            throw new IllegalArgumentException(String.format("%s must be present", QUERYLOG_CONNECT_INET_ADDRESS));
+        }
+
+        if (portConfig.isEmpty()) {
+            throw new IllegalArgumentException(String.format("%s must be present", QUERYLOG_CONNECT_PORT));
+        }
+
+        int port;
+        try {
+            port = Integer.parseUnsignedInt(portConfig.get());
+        }
+        catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format("%s must be a positive integer value", QUERYLOG_CONNECT_PORT), e);
+        }
+
+        if (scheme.isEmpty() || !List.of("http", "https").contains(scheme.get().toLowerCase(Locale.ENGLISH))) {
+            throw new IllegalArgumentException(String.format("%s must be either https or http, but not %s", QUERYLOG_CONNECT_SCHEME, scheme.orElse("empty")));
+        }
+
+        Map<String, String> httpHeaders = config.keySet().stream()
+                .filter(key -> key.startsWith(QUERYLOG_CONNECT_HEADERS_PREFIX))
+                .collect(Collectors.toMap(
+                        key -> key.replaceFirst("^" + QUERYLOG_CONNECT_HEADERS_PREFIX, ""),
+                        config::get));
+
+        try {
+            return new QuerylogListener(inetAddress.get(), port, scheme.get().toLowerCase(Locale.ENGLISH), httpHeaders, sendCreated, sendCompleted, sendSplit);
+        }
+        catch (UnknownHostException e) {
+            throw new IllegalArgumentException(String.format("%s is not a valid hostname or it could not be resolved", QUERYLOG_CONNECT_INET_ADDRESS), e);
+        }
+    }
+
+    /**
+     * Get {@code boolean} parameter value, or return default.
+     *
+     * @param params       Map of parameters
+     * @param paramName    Parameter name
+     * @param paramDefault Parameter default value
+     * @return Parameter value or default.
+     */
+    private static boolean getBooleanConfig(Map<String, String> params, String paramName, boolean paramDefault)
+    {
+        String value = params.get(paramName);
+        if (value != null) {
+            if (value.trim().isEmpty()) {
+                return true;
+            }
+            return Boolean.parseBoolean(value);
+        }
+        return paramDefault;
+    }
+}

--- a/plugin/trino-querylog/src/main/java/io/trino/plugin/querylog/QuerylogPlugin.java
+++ b/plugin/trino-querylog/src/main/java/io/trino/plugin/querylog/QuerylogPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.querylog;
+
+import io.trino.spi.Plugin;
+import io.trino.spi.eventlistener.EventListenerFactory;
+
+import java.util.Collections;
+
+public class QuerylogPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<EventListenerFactory> getEventListenerFactories()
+    {
+        return Collections.singletonList(new QuerylogListenerFactory());
+    }
+}

--- a/plugin/trino-querylog/src/test/java/io/trino/plugin/querylog/TestQuerylogListener.java
+++ b/plugin/trino-querylog/src/test/java/io/trino/plugin/querylog/TestQuerylogListener.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.querylog;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.trino.spi.eventlistener.QueryCompletedEvent;
+import io.trino.spi.eventlistener.QueryContext;
+import io.trino.spi.eventlistener.QueryCreatedEvent;
+import io.trino.spi.eventlistener.QueryIOMetadata;
+import io.trino.spi.eventlistener.QueryMetadata;
+import io.trino.spi.eventlistener.QueryStatistics;
+import io.trino.spi.eventlistener.SplitCompletedEvent;
+import io.trino.spi.eventlistener.SplitStatistics;
+import io.trino.spi.resourcegroups.QueryType;
+import io.trino.spi.resourcegroups.ResourceGroupId;
+import io.trino.spi.session.ResourceEstimates;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static java.time.Duration.ofMillis;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+@Test(singleThreaded = true)
+public class TestQuerylogListener
+{
+    private MockWebServer server;
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new Jdk8Module()).registerModule(new JavaTimeModule());
+
+    private static final QueryIOMetadata queryIOMetadata;
+    private static final QueryContext queryContext;
+    private static final QueryMetadata queryMetadata;
+    private static final SplitStatistics splitStatistics;
+    private static final QueryStatistics queryStatistics;
+    private static final SplitCompletedEvent splitCompleteEvent;
+    private static final QueryCreatedEvent queryCreatedEvent;
+    private static final QueryCompletedEvent queryCompleteEvent;
+
+    static {
+        queryIOMetadata = new QueryIOMetadata(Collections.emptyList(), Optional.empty());
+
+        queryContext = new QueryContext(
+                "user",
+                Optional.of("principal"),
+                Set.of(), // groups
+                Optional.empty(), // traceToken
+                Optional.empty(), // remoteClientAddress
+                Optional.empty(), // userAgent
+                Optional.empty(), // clientInfo
+                new HashSet<>(), // clientTags
+                new HashSet<>(), // clientCapabilities
+                Optional.of("source"),
+                Optional.of("catalog"),
+                Optional.of("schema"),
+                Optional.of(new ResourceGroupId("name")),
+                new HashMap<>(), // sessionProperties
+                new ResourceEstimates(Optional.empty(), Optional.empty(), Optional.of(1000L)),
+                "serverAddress", "serverVersion", "environment",
+                Optional.of(QueryType.SELECT));
+
+        queryMetadata = new QueryMetadata(
+                "queryId",
+                Optional.empty(),
+                "query",
+                Optional.of("updateType"),
+                Optional.of("preparedQuery"),
+                "queryState",
+                List.of(),
+                List.of(),
+                URI.create("http://localhost"),
+                Optional.empty(), Optional.empty());
+
+        splitStatistics = new SplitStatistics(
+                ofMillis(1000),
+                ofMillis(2000),
+                ofMillis(3000),
+                ofMillis(4000),
+                1,
+                2,
+                Optional.of(Duration.ofMillis(100)),
+                Optional.of(Duration.ofMillis(200)));
+
+        queryStatistics = new QueryStatistics(
+                ofMillis(1000),
+                ofMillis(1000),
+                ofMillis(1000),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                Collections.emptyList(),
+                0,
+                true,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Optional.empty());
+
+        splitCompleteEvent = new SplitCompletedEvent(
+                "queryId",
+                "stageId",
+                "taskId",
+                Optional.of("catalogName"),
+                Instant.now(),
+                Optional.of(Instant.now()),
+                Optional.of(Instant.now()),
+                splitStatistics,
+                Optional.empty(),
+                "payload");
+
+        queryCreatedEvent = new QueryCreatedEvent(
+                Instant.now(),
+                queryContext,
+                queryMetadata);
+
+        queryCompleteEvent = new QueryCompletedEvent(
+                queryMetadata,
+                queryStatistics,
+                queryContext,
+                queryIOMetadata,
+                Optional.empty(),
+                Collections.emptyList(),
+                Instant.now(),
+                Instant.now(),
+                Instant.now());
+    }
+
+    @BeforeMethod
+    public void setup()
+            throws IOException
+    {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardown()
+            throws IOException
+    {
+        server.close();
+    }
+
+    /**
+     * Querylog created without exceptions but not requests sent
+     */
+    @Test
+    public void testAllLoggingDisabled_Should_Timeout()
+            throws Exception
+    {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200));
+
+        QuerylogListener querylogListener = new QuerylogListener(server.getHostName(), server.getPort(), "http", new HashMap<>(), false, false, false);
+
+        querylogListener.queryCreated(null);
+        querylogListener.queryCompleted(null);
+        querylogListener.splitCompleted(null);
+
+        assertNull(server.takeRequest(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testAllLoggingEnabled_Should_SendCorrectEvent()
+            throws Exception
+    {
+        Map<String, String> headers = new HashMap<>() {{
+                put("Authorization", "trust me");
+                put("Cache-Control", "no-cache");
+            }};
+
+        QuerylogListener querylogListener = new QuerylogListener(server.getHostName(), server.getPort(), "http", headers, true, true, true);
+
+        server.enqueue(new MockResponse().setResponseCode(200));
+        server.enqueue(new MockResponse().setResponseCode(200));
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        querylogListener.queryCreated(queryCreatedEvent);
+        querylogListener.queryCompleted(queryCompleteEvent);
+        querylogListener.splitCompleted(splitCompleteEvent);
+
+        checkRequest(server.takeRequest(1, TimeUnit.SECONDS), headers, queryCreatedEvent);
+        checkRequest(server.takeRequest(1, TimeUnit.SECONDS), headers, queryCompleteEvent);
+        checkRequest(server.takeRequest(1, TimeUnit.SECONDS), headers, splitCompleteEvent);
+    }
+
+    @Test
+    public void testContentTypeDefaultHeader_Should_AlwaysBeSet()
+            throws Exception
+    {
+        QuerylogListener querylogListener = new QuerylogListener(server.getHostName(), server.getPort(), "http", new HashMap<>(), true, true, true);
+
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        querylogListener.queryCompleted(queryCompleteEvent);
+
+        assertEquals(server.takeRequest(1, TimeUnit.SECONDS).getHeader("Content-Type"), "application/json; charset=UTF-8");
+    }
+
+    @Test
+    public void testBadHostName_ShouldThrow_UnknownHostException()
+    {
+        Exception e = expectThrows(UnknownHostException.class,
+                () -> new QuerylogListener("this-is+not_a+hostname", 8090, "http", new HashMap<>(), true, true, true));
+
+        assertTrue(e.getMessage().contains("this-is+not_a+hostname"));
+    }
+
+    @Test
+    public void testEmptyHeaders_ShouldThrow_NullPointerException()
+    {
+        Exception e = expectThrows(NullPointerException.class,
+                () -> new QuerylogListener("google.com", 8090, "http", null, true, true, true));
+        assertTrue(e.getMessage().contains("headers"), String.format("\"%s\" should contain the word headers", e.getMessage()));
+    }
+
+    @Test
+    public void testEmptyScheme_ShouldThrow_NullPointerException()
+    {
+        Exception e = expectThrows(NullPointerException.class,
+                () -> new QuerylogListener("google.com", 8090, null, new HashMap<>(), true, true, true));
+        assertTrue(e.getMessage().contains("scheme"), String.format("\"%s\" should contain the word scheme", e.getMessage()));
+    }
+
+    private void checkRequest(RecordedRequest recordedRequest, Map<String, String> customHeaders, Object event)
+            throws JsonProcessingException
+    {
+        assertNotNull(recordedRequest, String.format("No request sent when logging is enabled for %s", event));
+        for (String key : customHeaders.keySet()) {
+            assertNotNull(recordedRequest.getHeader(key), String.format("Custom header %s not present in request for %s event", key, event));
+            assertEquals(recordedRequest.getHeader(key), customHeaders.get(key),
+                    String.format("Expected value %s for header %s but got %s for %s event", customHeaders.get(key), key, recordedRequest.getHeader(key), event));
+        }
+        String body = recordedRequest.getBody().readUtf8();
+        assertFalse(body.isEmpty(), String.format("Body is empty for %s event", event));
+        String eventJson = objectMapper.writeValueAsString(event);
+        assertTrue(objectMapper.readTree(eventJson).equals(objectMapper.readTree(body)), String.format("Json value is wrong for event %s", event));
+    }
+}

--- a/plugin/trino-querylog/src/test/java/io/trino/plugin/querylog/TestQuerylogListenerFactory.java
+++ b/plugin/trino-querylog/src/test/java/io/trino/plugin/querylog/TestQuerylogListenerFactory.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.querylog;
+
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+@Test(singleThreaded = true)
+public class TestQuerylogListenerFactory
+{
+    private final QuerylogListenerFactory factory = new QuerylogListenerFactory();
+
+    @Test
+    public void testGoodConfig_ShouldReturn_EventListener()
+    {
+        factory.create(
+                new HashMap<>() {{
+                    put("trino.querylog.connect.port", "8090");
+                    put("trino.querylog.connect.inet.address", "google.com");
+                    put("trino.querylog.connect.scheme", "http");
+                }});
+    }
+
+    @Test
+    public void testNameNotEmptyOrNull()
+    {
+        assertTrue(factory.getName() != null && !factory.getName().trim().isEmpty(), "plugin name cannot be null or empty");
+    }
+
+    @Test
+    public void testBadIngestURLConfig_ShouldThrow_IllegalArgumentException()
+    {
+        inetConfigTestUtil(null);
+        inetConfigTestUtil("");
+        inetConfigTestUtil("this_is-not*an+url");
+    }
+
+    private void inetConfigTestUtil(String inetAddress)
+    {
+        Exception missingInetException = expectThrows(IllegalArgumentException.class, () -> factory.create(
+                new HashMap<>() {{
+                    put("trino.querylog.connect.port", "8090");
+                    put("trino.querylog.connect.inet.address", inetAddress);
+                    put("trino.querylog.connect.scheme", "http");
+                }}));
+        assertTrue(missingInetException.getMessage().contains("trino.querylog.connect.inet.address"), String.format("error message should reference the config field: %s", missingInetException.getMessage()));
+    }
+
+    @Test
+    public void testBadPortConfig_ShouldThrow_IllegalArgumentException()
+    {
+        portConfigTestUtil("NAN");
+        portConfigTestUtil("-100");
+        portConfigTestUtil("");
+        portConfigTestUtil(null);
+    }
+
+    private void portConfigTestUtil(String port)
+    {
+        Exception e = expectThrows(IllegalArgumentException.class, () -> factory.create(
+                new HashMap<>() {{
+                    put("trino.querylog.connect.inet.address", "google.com");
+                    put("trino.querylog.connect.port", port);
+                    put("trino.querylog.connect.scheme", "http");
+                }}));
+        assertTrue(e.getMessage().contains("trino.querylog.connect.port"));
+    }
+
+    @Test
+    public void testBadSchemeConfig_ShouldThrow_IllegalArgumentException()
+    {
+        schemeConfigTestUtil(null);
+        schemeConfigTestUtil("");
+        schemeConfigTestUtil("not a valid scheme");
+    }
+
+    private void schemeConfigTestUtil(String scheme)
+    {
+        Exception e = expectThrows(IllegalArgumentException.class, () -> factory.create(
+                new HashMap<>() {{
+                    put("trino.querylog.connect.inet.address", "google.com");
+                    put("trino.querylog.connect.port", "8090");
+                    put("trino.querylog.connect.scheme", scheme);
+                }}));
+        assertTrue(e.getMessage().contains("trino.querylog.connect.scheme"));
+    }
+
+    @Test
+    public void testHttpHeadersConfig_ShouldReturn_CorrectHeaders()
+            throws Exception
+    {
+        PrivateObjectFieldAccessor<Map<String, String>> httpHeadersFieldAccessor = new PrivateObjectFieldAccessor<>("httpHeaders");
+
+        QuerylogListener querylogListener = (QuerylogListener) factory.create(new HashMap<>() {{
+                put("trino.querylog.connect.inet.address", "google.com");
+                put("trino.querylog.connect.port", "8090");
+                put("trino.querylog.connect.scheme", "http");
+                put("trino.querylog.connect.headers.Authorization", "trust-me");
+                put("trino.querylog.connect.headers.Cache-Control", "no-cache");
+            }});
+        assertEquals(httpHeadersFieldAccessor.getPrivateFieldFrom(querylogListener).get("Authorization"), "trust-me", "http header not set from configuration");
+        assertEquals(httpHeadersFieldAccessor.getPrivateFieldFrom(querylogListener).get("Cache-Control"), "no-cache", "http header not set from configuration");
+
+        querylogListener = (QuerylogListener) factory.create(new HashMap<>() {{
+                put("trino.querylog.connect.inet.address", "google.com");
+                put("trino.querylog.connect.port", "8090");
+                put("trino.querylog.connect.scheme", "http");
+            }});
+        assertNotNull(httpHeadersFieldAccessor.getPrivateFieldFrom(querylogListener), "http headers must not be null, even when no configuration was given");
+    }
+
+    @Test
+    public void testEnabledEventsConfig_ShouldReturn_CorrectEnables()
+            throws Exception
+    {
+        PrivateBooleanFieldAccessor completedFieldAccessor = new PrivateBooleanFieldAccessor("shouldLogCompleted");
+        PrivateBooleanFieldAccessor createdFieldAccessor = new PrivateBooleanFieldAccessor("shouldLogCreated");
+        PrivateBooleanFieldAccessor splitFieldAccessor = new PrivateBooleanFieldAccessor("shouldLogSplit");
+
+        QuerylogListener querylogListener = (QuerylogListener) factory.create(new HashMap<>() {{
+                put("trino.querylog.connect.inet.address", "google.com");
+                put("trino.querylog.connect.port", "8090");
+                put("trino.querylog.connect.scheme", "http");
+                put("trino.querylog.log.created", "");
+                put("trino.querylog.log.completed", "true");
+                put("trino.querylog.log.split", "True");
+            }});
+        assertTrue(createdFieldAccessor.getPrivateFieldFrom(querylogListener), "NOT logging created events when configuration is \"\"");
+        assertTrue(completedFieldAccessor.getPrivateFieldFrom(querylogListener), "NOT logging completed events when configuration is \"true\"");
+        assertTrue(splitFieldAccessor.getPrivateFieldFrom(querylogListener), "NOT logging split events when configuration is \"True\"");
+
+        querylogListener = (QuerylogListener) factory.create(new HashMap<>() {{
+                put("trino.querylog.connect.inet.address", "google.com");
+                put("trino.querylog.connect.port", "8090");
+                put("trino.querylog.connect.scheme", "http");
+                put("trino.querylog.log.created", "false");
+                put("trino.querylog.log.completed", "FALSE");
+            }});
+        assertFalse(createdFieldAccessor.getPrivateFieldFrom(querylogListener), "logging created events when configuration is \"false\"");
+        assertFalse(completedFieldAccessor.getPrivateFieldFrom(querylogListener), "logging completed events when configuration is \"FALSE\"");
+        assertFalse(splitFieldAccessor.getPrivateFieldFrom(querylogListener), "logging split events when configuration is not present");
+    }
+
+    private class PrivateObjectFieldAccessor<T>
+    {
+        private final String fieldName;
+
+        public PrivateObjectFieldAccessor(String fieldName)
+        {
+            this.fieldName = fieldName;
+        }
+
+        public T getPrivateFieldFrom(Object obj)
+                throws Exception
+        {
+            Field field = obj.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return (T) field.get(obj);
+        }
+    }
+
+    private class PrivateBooleanFieldAccessor
+    {
+        private final String fieldName;
+
+        public PrivateBooleanFieldAccessor(String fieldName)
+        {
+            this.fieldName = fieldName;
+        }
+
+        public boolean getPrivateFieldFrom(Object obj)
+                throws Exception
+        {
+            Field field = obj.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return field.getBoolean(obj);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
         <module>plugin/trino-pinot</module>
         <module>plugin/trino-postgresql</module>
         <module>plugin/trino-prometheus</module>
+        <module>plugin/trino-querylog</module>
         <module>plugin/trino-raptor-legacy</module>
         <module>plugin/trino-redis</module>
         <module>plugin/trino-redshift</module>

--- a/testing/trino-server-dev/etc/config.properties
+++ b/testing/trino-server-dev/etc/config.properties
@@ -48,6 +48,7 @@ plugin.bundles=\
   ../../plugin/trino-tpcds/pom.xml, \
   ../../plugin/trino-google-sheets/pom.xml, \
   ../../plugin/trino-druid/pom.xml, \
-  ../../plugin/trino-geospatial/pom.xml
+  ../../plugin/trino-geospatial/pom.xml, \
+  ../../plugin/trino-querylog/pom.xml
 
 node-scheduler.include-coordinator=true

--- a/testing/trino-server-dev/etc/event-listener.properties
+++ b/testing/trino-server-dev/etc/event-listener.properties
@@ -1,0 +1,5 @@
+event-listener.name=trino-querylog
+trino.querylog.log.completed
+trino.querylog.connect.http
+trino.querylog.connect.inet.address=localhost
+trino.querylog.connect.headers.Authorization = "trust-me"


### PR DESCRIPTION
Update plugin

Change event enables variable names
Remove listener getters and use reflection in factory tests
Add server crash on plugin fail to load
Make port required value with no default
Remove sum type class for events
Remove isInsecureHttp to explicit http/s config

Make sendLog function generic, remove unused function

Signed-off-by: Alex Brisan <abrisan1@bloomberg.net>