### PR TITLE
Resolve issue with OAuth2 product tests and reenable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,9 +384,8 @@ jobs:
           - config: default
             suite: suite-tpcds
           # this suite is not meant to be run with different configs
-          # TODO Re-enable oauth2 product tests - https://github.com/trinodb/trino/issues/8719
-          #- config: default
-          #  suite: suite-oauth2
+          - config: default
+            suite: suite-oauth2
           # this suite is not meant to be run with different configs
           - config: default
             suite: suite-compatibility


### PR DESCRIPTION
Apparently there is an issue with Chrome 92 when running inside a Docker container. This PR implements the workaround suggested in the following links and reenables the OAuth2 product tests.

See:
* https://github.com/SeleniumHQ/docker-selenium/issues/1346
* https://github.com/SeleniumHQ/docker-selenium/issues/1351
* https://bugs.chromium.org/p/chromium/issues/detail?id=1228625

An alternate solution is to pin `selenium/standalone-chrome-debug` to tag `3.141.59-20210713` (in `SeleniumChrome`).

Related to https://github.com/trinodb/trino/pull/8756