### PR TITLE
Updates CLI to default protocol to HTTPS if port is 443

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -219,7 +219,9 @@ public class ClientOptions
 
         HostAndPort host = HostAndPort.fromString(server);
         try {
-            return new URI("http", null, host.getHost(), host.getPortOrDefault(80), null, null, null);
+            int port = host.getPortOrDefault(80);
+            String scheme = port == 443 ? "https" : "http";
+            return new URI(scheme, null, host.getHost(), port, null, null, null);
         }
         catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -92,6 +92,30 @@ public class TestClientOptions
         assertEquals(session.getServer().toString(), "https://test/foo");
     }
 
+    @Test
+    public void testServer443Port()
+    {
+        Console console = createConsole("--server=test:443");
+        ClientSession session = console.clientOptions.toClientSession();
+        assertEquals(session.getServer().toString(), "https://test:443");
+    }
+
+    @Test
+    public void testServerHttpsHostPort()
+    {
+        Console console = createConsole("--server=https://test:443");
+        ClientSession session = console.clientOptions.toClientSession();
+        assertEquals(session.getServer().toString(), "https://test:443");
+    }
+
+    @Test
+    public void testServerHttpWithPort443()
+    {
+        Console console = createConsole("--server=http://test:443");
+        ClientSession session = console.clientOptions.toClientSession();
+        assertEquals(session.getServer().toString(), "http://test:443");
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Unparseable port number: x:y")
     public void testInvalidServer()
     {


### PR DESCRIPTION
If a user passes in a port that is 443, but they do not pass in
a protocol, we can assume that the user is using the HTTPS protocol.

Fixes #8798