### PR TITLE
Optimize array_distinct(array_sort(…))

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayDistinctFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayDistinctFunction.java
@@ -41,6 +41,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 @Description("Remove duplicate values from the given array")
 public final class ArrayDistinctFunction
 {
+    public static final String NAME = "array_distinct";
     private final PageBuilder pageBuilder;
 
     @TypeParameter("E")

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySortFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArraySortFunction.java
@@ -35,6 +35,7 @@ import static io.trino.spi.function.OperatorType.COMPARISON_UNORDERED_LAST;
 @Description("Sorts the given array in ascending order according to the natural ordering of its elements.")
 public final class ArraySortFunction
 {
+    public static final String NAME = "array_sort";
     private final PageBuilder pageBuilder;
     private static final int INITIAL_LENGTH = 128;
     private final IntArrayList positions = new IntArrayList(INITIAL_LENGTH);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -36,6 +36,7 @@ import io.trino.sql.planner.iterative.rule.AddIntermediateAggregations;
 import io.trino.sql.planner.iterative.rule.ApplyPreferredTableExecutePartitioning;
 import io.trino.sql.planner.iterative.rule.ApplyPreferredTableWriterPartitioning;
 import io.trino.sql.planner.iterative.rule.ApplyTableScanRedirection;
+import io.trino.sql.planner.iterative.rule.ArraySortAfterArrayDistinct;
 import io.trino.sql.planner.iterative.rule.CanonicalizeExpressions;
 import io.trino.sql.planner.iterative.rule.CreatePartialTopN;
 import io.trino.sql.planner.iterative.rule.DecorrelateInnerUnnestWithGlobalAggregation;
@@ -363,6 +364,7 @@ public class PlanOptimizers
                 .addAll(new UnwrapCastInComparison(plannerContext, typeAnalyzer).rules())
                 .addAll(new RemoveDuplicateConditions(metadata).rules())
                 .addAll(new CanonicalizeExpressions(plannerContext, typeAnalyzer).rules())
+                .addAll(new ArraySortAfterArrayDistinct(plannerContext).rules())
                 .add(new RemoveTrivialFilters())
                 .build();
         IterativeOptimizer simplifyOptimizer = new IterativeOptimizer(

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ArraySortAfterArrayDistinct.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ArraySortAfterArrayDistinct.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.ResolvedFunction;
+import io.trino.operator.scalar.ArrayDistinctFunction;
+import io.trino.operator.scalar.ArraySortFunction;
+import io.trino.spi.type.Type;
+import io.trino.sql.PlannerContext;
+import io.trino.sql.planner.FunctionCallBuilder;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.ExpressionTreeRewriter;
+import io.trino.sql.tree.FunctionCall;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.SymbolReference;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+public class ArraySortAfterArrayDistinct
+        extends ExpressionRewriteRuleSet
+{
+    public ArraySortAfterArrayDistinct(PlannerContext plannerContext)
+    {
+        super((expression, context) -> rewrite(expression, context, plannerContext.getMetadata()));
+    }
+
+    @Override
+    public Set<Rule<?>> rules()
+    {
+        return ImmutableSet.of(
+                projectExpressionRewrite(),
+                filterExpressionRewrite(),
+                joinExpressionRewrite(),
+                valuesExpressionRewrite(),
+                patternRecognitionExpressionRewrite());
+    }
+
+    private static Expression rewrite(Expression expression, Rule.Context context, Metadata metadata)
+    {
+        if (expression instanceof SymbolReference) {
+            return expression;
+        }
+        Session session = context.getSession();
+        return ExpressionTreeRewriter.rewriteWith(new Visitor(metadata, session), expression);
+    }
+
+    private static class Visitor
+            extends io.trino.sql.tree.ExpressionRewriter<Void>
+    {
+        private final Metadata metadata;
+        private final Session session;
+
+        public Visitor(Metadata metadata, Session session)
+        {
+            this.metadata = metadata;
+            this.session = session;
+        }
+
+        @Override
+        public Expression rewriteFunctionCall(FunctionCall node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+        {
+            FunctionCall rewritten = treeRewriter.defaultRewrite(node, context);
+            if (metadata.decodeFunction(rewritten.getName()).getSignature().getName().equals(ArrayDistinctFunction.NAME) &&
+                    getOnlyElement(rewritten.getArguments()) instanceof FunctionCall) {
+                Expression expression = getOnlyElement(rewritten.getArguments());
+                FunctionCall functionCall = (FunctionCall) expression;
+                ResolvedFunction resolvedFunction = metadata.decodeFunction(functionCall.getName());
+                if (resolvedFunction.getSignature().getName().equals(ArraySortFunction.NAME)) {
+                    List<Expression> arraySortArguments = functionCall.getArguments();
+                    List<Type> arraySortArgumentsTypes = resolvedFunction.getSignature().getArgumentTypes();
+
+                    FunctionCall arrayDistinctCall = FunctionCallBuilder.resolve(session, metadata)
+                            .setName(QualifiedName.of(ArrayDistinctFunction.NAME))
+                            .setArguments(
+                                    ImmutableList.of(arraySortArgumentsTypes.get(0)),
+                                    ImmutableList.of(arraySortArguments.get(0)))
+                            .build();
+
+                    FunctionCallBuilder arraySortCallBuilder = FunctionCallBuilder.resolve(session, metadata)
+                            .setName(QualifiedName.of(ArraySortFunction.NAME))
+                            .addArgument(arraySortArgumentsTypes.get(0), arrayDistinctCall);
+
+                    if (arraySortArguments.size() == 2) {
+                        arraySortCallBuilder.addArgument(arraySortArgumentsTypes.get(1), arraySortArguments.get(1));
+                    }
+                    return arraySortCallBuilder.build();
+                }
+            }
+            return rewritten;
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestArraySortAfterArrayDistinct.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestArraySortAfterArrayDistinct.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import io.trino.sql.ExpressionTestUtils;
+import io.trino.sql.planner.TypeProvider;
+import io.trino.sql.planner.assertions.PlanMatchPattern;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.tree.Expression;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestArraySortAfterArrayDistinct
+        extends BaseRuleTest
+{
+    @Test
+    public void testArrayDistinctAfterArraySort()
+    {
+        test("ARRAY_DISTINCT(ARRAY_SORT(ARRAY['a']))", "ARRAY_SORT(ARRAY_DISTINCT(ARRAY['a']))");
+    }
+
+    @Test
+    public void testArrayDistinctAfterArraySortWithLambda()
+    {
+        test("ARRAY_DISTINCT(ARRAY_SORT(ARRAY['a'], (a, b) -> 1))", "ARRAY_SORT(ARRAY_DISTINCT(ARRAY['a']), (a, b) -> 1)");
+    }
+
+    private void test(String original, String rewritten)
+    {
+        tester().assertThat(new ArraySortAfterArrayDistinct(tester().getPlannerContext()).projectExpressionRewrite())
+                .on(p -> p.project(
+                        Assignments.builder()
+                                .put(p.symbol("output"), expression(original))
+                                .build(),
+                        p.values()))
+                .matches(
+                        project(Map.of("output", PlanMatchPattern.expression(expression(rewritten))),
+                                values()));
+    }
+
+    private Expression expression(String sql)
+    {
+        return ExpressionTestUtils.planExpression(tester().getPlannerContext(), tester().getSession(), TypeProvider.empty(), PlanBuilder.expression(sql));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestArraySortAfterArrayDistinct.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestArraySortAfterArrayDistinct.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+public class TestArraySortAfterArrayDistinct
+{
+    private QueryAssertions assertions;
+
+    @BeforeAll
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterAll
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testArrayDistinctAfterArraySort()
+    {
+        assertThat(assertions.query(
+                "SELECT ARRAY_DISTINCT(ARRAY_SORT(items)) as result from (VALUES (ARRAY ['elephant', 'dog', 'cat', 'dog'])) t(items)"))
+                .matches("VALUES (ARRAY  ['cat', 'dog', 'elephant'])");
+    }
+
+    @Test
+    public void testArrayDistinctAfterArraySortWithLambda()
+    {
+        assertThat(assertions.query(
+                "SELECT ARRAY_DISTINCT(ARRAY_SORT(items, (x, y) -> IF(x < y, 1, IF(x = y, 0, -1)))) as result from (VALUES (ARRAY ['elephant', 'dog', 'cat', 'dog'])) t(items)"))
+                .matches("VALUES (ARRAY  ['elephant', 'dog', 'cat'])");
+    }
+}


### PR DESCRIPTION
Fixes #8777 

As I'm using ArrayConstructor in my test, I had to add the transactionID in the test suite, however I think this broke some other tests. Need some advice on best approach to override the session only for this test or not require a transactionid.