### PR TITLE
Only set default schema if default catalog is used

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/QuerySessionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/server/QuerySessionSupplier.java
@@ -96,15 +96,15 @@ public class QuerySessionSupplier
                 .setResourceEstimates(context.getResourceEstimates())
                 .setProtocolHeaders(context.getProtocolHeaders());
 
-        defaultCatalog.ifPresent(sessionBuilder::setCatalog);
-        defaultSchema.ifPresent(sessionBuilder::setSchema);
-
         if (context.getCatalog() != null) {
             sessionBuilder.setCatalog(context.getCatalog());
+            if (context.getSchema() != null) {
+                sessionBuilder.setSchema(context.getSchema());
+            }
         }
-
-        if (context.getSchema() != null) {
-            sessionBuilder.setSchema(context.getSchema());
+        else {
+            defaultCatalog.ifPresent(sessionBuilder::setCatalog);
+            defaultSchema.ifPresent(sessionBuilder::setSchema);
         }
 
         if (context.getPath() != null) {


### PR DESCRIPTION
The default schema is expected to be relative to the default catalog.

We could choose to set the default schema if the explicitly set session catalog matches the default catalog, but that would be somewhat magic behavior, and likely override the user's intent to leave the session schema unset.