### PR TITLE
Pin selenium/standalone-chrome-debug docker image version

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/SeleniumChrome.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/SeleniumChrome.java
@@ -28,7 +28,7 @@ import static java.util.Objects.requireNonNull;
 public class SeleniumChrome
         implements EnvironmentExtender
 {
-    private static final DockerImageName CHROME_IMAGE = DockerImageName.parse("selenium/standalone-chrome-debug").withTag("3.141.59");
+    private static final DockerImageName CHROME_IMAGE = DockerImageName.parse("selenium/standalone-chrome-debug").withTag("3.141.59-20210804");
     private static final int SELENIUM_PORT = 7777;
     private static final Duration STARTUP_TIMEOUT = Duration.ofSeconds(15);
 


### PR DESCRIPTION
Pin selenium/standalone-chrome-debug docker image version

That way the image that is used in product tests will be more immutable,
and we can potentially avoid surprises in future.
