### PR TITLE
Set higher open files limit in init script

### DIFF
--- a/core/trino-server-rpm/src/main/resources/dist/etc/init.d/trino
+++ b/core/trino-server-rpm/src/main/resources/dist/etc/init.d/trino
@@ -37,6 +37,16 @@ CONFIGURATION=(
     --server-log-file "${SERVER_LOG_FILE:-/var/log/trino/server.log}"
 )
 
+# As defined in the requirements: https://trino.io/docs/current/installation/deployment.html#requirements
+files_limit=131072
+if current_limit=$(ulimit -Hn) && [ "${files_limit}" -lt "${current_limit}" ]; then
+    files_limit="${current_limit}"
+fi
+if max_limit=$(cat /proc/sys/fs/nr_open) && [ "${files_limit}" -gt "${max_limit}" ]; then
+    files_limit="${max_limit}"
+fi
+ulimit -n "${files_limit}"
+
 declare -A CONFIG_ENV
 # Don't need shellcheck to follow env.sh
 # shellcheck disable=1091

--- a/docs/src/main/sphinx/installation/deployment.rst
+++ b/docs/src/main/sphinx/installation/deployment.rst
@@ -26,6 +26,9 @@ Linux operating system
       trino soft nofile 131072
       trino hard nofile 131072
 
+..
+   These values are used in core/trino-server-rpm/src/main/resources/dist/etc/init.d/trino
+
 .. _requirements-java:
 
 Java runtime environment


### PR DESCRIPTION
#5066 added mention of `ulimit` to Trino's requirements. These recommended values should be used by default when installing Trino using the RPM package.

The reason to set these in the init script, not in a `/etc/security/limits.d/99-trino.conf` file is that it's a simpler change and at some point in time Trino might migrate from a SysV script to a SystemD unit file, which would ignore limits from `/etc/security` since those are only used by PAM (the `pam_limits.so` module). 

Defining these limits before sourcing the `env.sh` file allows users to adjust them further if required.