### PR TITLE
Get ObjectId from timestamp

### DIFF
--- a/docs/src/main/sphinx/connector/mongodb.rst
+++ b/docs/src/main/sphinx/connector/mongodb.rst
@@ -294,6 +294,41 @@ You can render the ``_id`` field to readable values with a cast to ``VARCHAR``:
      55b151633864d6438c61a9ce  |        1 | bad         |       50.0 | 2015-07-23
     (1 row)
 
+ObjectId timestamp functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The first four bytes of each `ObjectId <https://docs.mongodb.com/manual/reference/method/ObjectId>`_ represent
+an embedded timestamp of its creation time. Trino provides a couple of functions to take advantage of this MongoDB feature.
+
+.. function:: objectid_timestamp(ObjectId) -> timestamp
+
+    Extracts the timestamp with time zone from a given ObjectId::
+
+        SELECT objectid_timestamp(ObjectId('507f191e810c19729de860ea'));
+        -- 2012-10-17 20:46:22.000 UTC
+
+.. function:: timestamp_objectid(timestamp) -> ObjectId
+
+    Creates an ObjectId from a timestamp with time zone::
+
+        SELECT timestamp_objectid(TIMESTAMP '2021-08-07 17:51:36 +00:00');
+        -- 61 0e c8 28 00 00 00 00 00 00 00 00
+
+In MongoDB, you can filter all the documents created after ``2021-08-07 17:51:36``
+with a query like this:
+
+.. code-block:: text
+
+    db.collection.find({"_id": {"$gt": ObjectId("610ec8280000000000000000")}})
+
+In Trino, the same can be achieved with this query:
+
+.. code-block:: sql
+
+    SELECT *
+    FROM collection
+    WHERE _id > timestamp_objectid(TIMESTAMP '2021-08-07 17:51:36 +00:00');
+
 Limitations
 -----------
 

--- a/docs/src/main/sphinx/functions/list.rst
+++ b/docs/src/main/sphinx/functions/list.rst
@@ -462,6 +462,7 @@ T
 - :func:`tan`
 - :func:`tanh`
 - :func:`tdigest_agg`
+- :func:`timestamp_objectid`
 - :func:`timezone_hour`
 - :func:`timezone_minute`
 - :func:`to_base`
@@ -546,4 +547,3 @@ Z
 
 - :func:`zip`
 - :func:`zip_with`
-

--- a/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestObjectIdFunctions.java
+++ b/plugin/trino-mongodb/src/test/java/io/trino/plugin/mongodb/TestObjectIdFunctions.java
@@ -15,12 +15,15 @@ package io.trino.plugin.mongodb;
 
 import io.trino.operator.scalar.AbstractTestFunctions;
 import io.trino.spi.type.SqlTimestampWithTimeZone;
+import io.trino.spi.type.SqlVarbinary;
 import io.trino.spi.type.TimeZoneKey;
+import org.bson.types.ObjectId;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.time.ZonedDateTime;
 
+import static io.trino.plugin.mongodb.ObjectIdType.OBJECT_ID;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static java.time.ZoneOffset.UTC;
 
@@ -40,6 +43,24 @@ public class TestObjectIdFunctions
                 "objectid_timestamp(ObjectId('1234567890abcdef12345678'))",
                 TIMESTAMP_TZ_MILLIS,
                 toTimestampWithTimeZone(ZonedDateTime.of(1979, 9, 5, 22, 51, 36, 0, UTC)));
+    }
+
+    @Test
+    public void testTimestampObjectid()
+    {
+        assertFunction(
+                "timestamp_objectid(TIMESTAMP '1979-09-05 22:51:36 +00:00')",
+                OBJECT_ID,
+                new SqlVarbinary(new ObjectId("123456780000000000000000").toByteArray()));
+    }
+
+    @Test
+    public void testTimestampObjectidNull()
+    {
+        assertFunction(
+                "timestamp_objectid(null)",
+                OBJECT_ID,
+                null);
     }
 
     private SqlTimestampWithTimeZone toTimestampWithTimeZone(ZonedDateTime zonedDateTime)


### PR DESCRIPTION
As mentioned [here](https://steveridout.github.io/).

# Why generate an ObjectId from a timestamp?

To query documents by creation date.

e.g. to find all comments created after 2013-11-01:

 ```
 db.comments.find({_id: {$gt: ObjectId("5272e0f00000000000000000")}})
 ```
 The intention is to use the new function in SQL like:
  ```
  SELECT * 
  FROM comments 
  WHERE '_id' > timestamp_objectid(TIMESTAMP '2013-11-01 00:00:00 +00:00')
  ```
  
  (`_id` being the ObjectId of the document collection)
 