### PR TITLE
Upgrade google-http-client and google-oauth-client version

### DIFF
--- a/plugin/trino-google-sheets/pom.xml
+++ b/plugin/trino-google-sheets/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client</artifactId>
-            <version>1.23.0</version>
+            <version>1.35.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>com.google.oauth-client</groupId>
             <artifactId>google-oauth-client</artifactId>
-            <version>1.23.0</version>
+            <version>1.31.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes #8784

`google-http-client` also needs upgrade because of upper bound dependencies. 