### PR TITLE
Improve performance of InCodeGenerator and ExpressionInterpreter

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
@@ -88,10 +88,9 @@ public class InCodeGenerator
     @VisibleForTesting
     static SwitchGenerationCase checkSwitchGenerationCase(Type type, List<RowExpression> values)
     {
-        if ((type.getJavaType() != long.class && values.size() >= 8) || (type.getJavaType() == long.class && values.size() >= 16)) {
+        if (values.size() >= 8) {
             // SET_CONTAINS is generally faster for not super tiny IN lists.
-            // Tipping point for types based on long (benchmarked with BIGINT) (where DIRECT_SWITCH can be used) is between 10 and 20 (using round 16)
-            // Tipping point for other types (benchmarked with VARCHAR/DOUBLE) is between 5 and 10 (using round 8)
+            // Tipping point is between 5 and 10 (using round 8)
             return SwitchGenerationCase.SET_CONTAINS;
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/InCodeGenerator.java
@@ -25,11 +25,11 @@ import io.airlift.bytecode.control.IfStatement;
 import io.airlift.bytecode.control.SwitchStatement.SwitchBuilder;
 import io.airlift.bytecode.instruction.LabelNode;
 import io.trino.metadata.ResolvedFunction;
-import io.trino.plugin.base.util.FastutilSetHelper;
 import io.trino.spi.type.Type;
 import io.trino.sql.relational.ConstantExpression;
 import io.trino.sql.relational.RowExpression;
 import io.trino.sql.relational.SpecialForm;
+import io.trino.util.FastutilSetHelper;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Collection;
@@ -43,7 +43,6 @@ import static io.airlift.bytecode.expression.BytecodeExpressions.constantFalse;
 import static io.airlift.bytecode.expression.BytecodeExpressions.constantTrue;
 import static io.airlift.bytecode.expression.BytecodeExpressions.invokeStatic;
 import static io.airlift.bytecode.instruction.JumpInstruction.jump;
-import static io.trino.plugin.base.util.FastutilSetHelper.toFastutilHashSet;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.NEVER_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
@@ -54,6 +53,7 @@ import static io.trino.spi.function.OperatorType.INDETERMINATE;
 import static io.trino.sql.gen.BytecodeUtils.ifWasNullPopAndGoto;
 import static io.trino.sql.gen.BytecodeUtils.invoke;
 import static io.trino.sql.gen.BytecodeUtils.loadConstant;
+import static io.trino.util.FastutilSetHelper.toFastutilHashSet;
 import static java.lang.Math.toIntExact;
 
 public class InCodeGenerator

--- a/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/ExpressionInterpreter.java
@@ -24,7 +24,6 @@ import io.trino.metadata.FunctionMetadata;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.ResolvedFunction;
 import io.trino.operator.scalar.ArraySubscriptOperator;
-import io.trino.plugin.base.util.FastutilSetHelper;
 import io.trino.security.AccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.spi.block.Block;
@@ -98,6 +97,7 @@ import io.trino.type.FunctionType;
 import io.trino.type.JoniRegexp;
 import io.trino.type.LikeFunctions;
 import io.trino.type.TypeCoercion;
+import io.trino.util.FastutilSetHelper;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;

--- a/core/trino-main/src/main/java/io/trino/type/BlockTypeOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/BlockTypeOperators.java
@@ -38,8 +38,8 @@ import static io.trino.spi.function.InvocationConvention.InvocationArgumentConve
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
 import static io.trino.spi.function.InvocationConvention.simpleConvention;
-import static io.trino.type.SingleAccessMethodCompiler.compileSingleAccessMethod;
 import static io.trino.type.TypeUtils.NULL_HASH_CODE;
+import static io.trino.util.SingleAccessMethodCompiler.compileSingleAccessMethod;
 import static java.util.Objects.requireNonNull;
 
 public final class BlockTypeOperators

--- a/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
+++ b/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
@@ -13,7 +13,9 @@
  */
 package io.trino.util;
 
-import io.trino.spi.TrinoException;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.trino.spi.type.Type;
 import it.unimi.dsi.fastutil.Hash;
 import it.unimi.dsi.fastutil.booleans.BooleanOpenHashSet;
@@ -23,13 +25,18 @@ import it.unimi.dsi.fastutil.longs.LongHash;
 import it.unimi.dsi.fastutil.longs.LongOpenCustomHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
 
+import javax.annotation.concurrent.GuardedBy;
+
 import java.lang.invoke.MethodHandle;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
-import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.base.Verify.verifyNotNull;
-import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static io.trino.util.SingleAccessMethodCompiler.compileSingleAccessMethod;
 import static java.lang.Boolean.TRUE;
 import static java.lang.invoke.MethodType.methodType;
 import static java.util.Objects.requireNonNull;
@@ -49,16 +56,16 @@ public final class FastutilSetHelper
         // The performance of InCodeGenerator heavily depends on the load factor being small.
         Class<?> javaElementType = type.getJavaType();
         if (javaElementType == long.class) {
-            return new LongOpenCustomHashSet((Collection<Long>) set, 0.25f, new LongStrategy(hashCodeHandle, equalsHandle));
+            return new LongOpenCustomHashSet((Collection<Long>) set, 0.25f, new LongStrategy(hashCodeHandle, equalsHandle, type));
         }
         if (javaElementType == double.class) {
-            return new DoubleOpenCustomHashSet((Collection<Double>) set, 0.25f, new DoubleStrategy(hashCodeHandle, equalsHandle));
+            return new DoubleOpenCustomHashSet((Collection<Double>) set, 0.25f, new DoubleStrategy(hashCodeHandle, equalsHandle, type));
         }
         if (javaElementType == boolean.class) {
             return new BooleanOpenHashSet((Collection<Boolean>) set, 0.25f);
         }
         else if (!type.getJavaType().isPrimitive()) {
-            return new ObjectOpenCustomHashSet<>(set, 0.25f, new ObjectStrategy(hashCodeHandle, equalsHandle));
+            return new ObjectOpenCustomHashSet<>(set, 0.25f, new ObjectStrategy(hashCodeHandle, equalsHandle, type));
         }
         else {
             throw new UnsupportedOperationException("Unsupported native type in set: " + type.getJavaType() + " with type " + type.getTypeSignature());
@@ -88,97 +95,123 @@ public final class FastutilSetHelper
     private static final class LongStrategy
             implements LongHash.Strategy
     {
-        private final MethodHandle hashCodeHandle;
-        private final MethodHandle equalsHandle;
+        private final LongHashCode longHashCode;
+        private final LongEquals longEquals;
 
-        public LongStrategy(MethodHandle hashCodeHandle, MethodHandle equalsHandle)
+        public LongStrategy(MethodHandle hashCodeHandle, MethodHandle equalsHandle, Type type)
         {
-            this.hashCodeHandle = requireNonNull(hashCodeHandle, "hashCodeHandle is null");
-            this.equalsHandle = requireNonNull(equalsHandle, "equalsHandle is null");
+            requireNonNull(hashCodeHandle, "hashCodeHandle is null");
+            requireNonNull(equalsHandle, "equalsHandle is null");
+            requireNonNull(type, "type is null");
+
+            this.longHashCode = MethodGenerator.getGeneratedMethod(type, LongHashCode.class, hashCodeHandle);
+            this.longEquals = MethodGenerator.getGeneratedMethod(type, LongEquals.class, equalsHandle);
+        }
+
+        // Needs to be public for compileSingleAccessMethod
+        public interface LongHashCode
+        {
+            long hashCode(long value);
+        }
+
+        // Needs to be public for compileSingleAccessMethod
+        public interface LongEquals
+        {
+            Boolean equals(long a, long b);
         }
 
         @Override
         public int hashCode(long value)
         {
-            try {
-                return Long.hashCode((long) hashCodeHandle.invokeExact(value));
-            }
-            catch (Throwable t) {
-                throwIfInstanceOf(t, Error.class);
-                throwIfInstanceOf(t, TrinoException.class);
-                throw new TrinoException(GENERIC_INTERNAL_ERROR, t);
-            }
+            return Long.hashCode(longHashCode.hashCode(value));
         }
 
         @Override
         public boolean equals(long a, long b)
         {
-            try {
-                Boolean result = (Boolean) equalsHandle.invokeExact(a, b);
-                // FastutilHashSet is not intended be used for indeterminate values lookup
-                verifyNotNull(result, "result is null");
-                return TRUE.equals(result);
-            }
-            catch (Throwable t) {
-                throwIfInstanceOf(t, Error.class);
-                throwIfInstanceOf(t, TrinoException.class);
-                throw new TrinoException(GENERIC_INTERNAL_ERROR, t);
-            }
+            Boolean result = longEquals.equals(a, b);
+            // FastutilHashSet is not intended be used for indeterminate values lookup
+            verifyNotNull(result, "result is null");
+            return TRUE.equals(result);
         }
     }
 
     private static final class DoubleStrategy
             implements DoubleHash.Strategy
     {
-        private final MethodHandle hashCodeHandle;
-        private final MethodHandle equalsHandle;
+        private final DoubleHashCode doubleHashCode;
+        private final DoubleEquals doubleEquals;
 
-        public DoubleStrategy(MethodHandle hashCodeHandle, MethodHandle equalsHandle)
+        public DoubleStrategy(MethodHandle hashCodeHandle, MethodHandle equalsHandle, Type type)
         {
-            this.hashCodeHandle = requireNonNull(hashCodeHandle, "hashCodeHandle is null");
-            this.equalsHandle = requireNonNull(equalsHandle, "equalsHandle is null");
+            requireNonNull(hashCodeHandle, "hashCodeHandle is null");
+            requireNonNull(equalsHandle, "equalsHandle is null");
+            requireNonNull(type, "type is null");
+
+            this.doubleHashCode = MethodGenerator.getGeneratedMethod(type, DoubleHashCode.class, hashCodeHandle);
+            this.doubleEquals = MethodGenerator.getGeneratedMethod(type, DoubleEquals.class, equalsHandle);
+        }
+
+        // Needs to be public for compileSingleAccessMethod
+        public interface DoubleHashCode
+        {
+            long hashCode(double value);
+        }
+
+        // Needs to be public for compileSingleAccessMethod
+        public interface DoubleEquals
+        {
+            Boolean equals(double a, double b);
         }
 
         @Override
         public int hashCode(double value)
         {
-            try {
-                return Long.hashCode((long) hashCodeHandle.invokeExact(value));
-            }
-            catch (Throwable t) {
-                throwIfInstanceOf(t, Error.class);
-                throwIfInstanceOf(t, TrinoException.class);
-                throw new TrinoException(GENERIC_INTERNAL_ERROR, t);
-            }
+            return Long.hashCode(doubleHashCode.hashCode(value));
         }
 
         @Override
         public boolean equals(double a, double b)
         {
-            try {
-                Boolean result = (Boolean) equalsHandle.invokeExact(a, b);
-                // FastutilHashSet is not intended be used for indeterminate values lookup
-                verifyNotNull(result, "result is null");
-                return TRUE.equals(result);
-            }
-            catch (Throwable t) {
-                throwIfInstanceOf(t, Error.class);
-                throwIfInstanceOf(t, TrinoException.class);
-                throw new TrinoException(GENERIC_INTERNAL_ERROR, t);
-            }
+            Boolean result = doubleEquals.equals(a, b);
+            // FastutilHashSet is not intended be used for indeterminate values lookup
+            verifyNotNull(result, "result is null");
+            return TRUE.equals(result);
         }
     }
 
     private static final class ObjectStrategy
             implements Hash.Strategy<Object>
     {
-        private final MethodHandle hashCodeHandle;
-        private final MethodHandle equalsHandle;
+        private final ObjectHashCode objectHashCode;
+        private final ObjectEquals objectEquals;
 
-        public ObjectStrategy(MethodHandle hashCodeHandle, MethodHandle equalsHandle)
+        public ObjectStrategy(MethodHandle hashCodeHandle, MethodHandle equalsHandle, Type type)
         {
-            this.hashCodeHandle = requireNonNull(hashCodeHandle, "hashCodeHandle is null").asType(methodType(long.class, Object.class));
-            this.equalsHandle = requireNonNull(equalsHandle, "equalsHandle is null").asType(methodType(Boolean.class, Object.class, Object.class));
+            requireNonNull(hashCodeHandle, "hashCodeHandle is null");
+            requireNonNull(equalsHandle, "equalsHandle is null");
+            requireNonNull(type, "type is null");
+
+            this.objectHashCode = MethodGenerator.getGeneratedMethod(
+                    type,
+                    ObjectHashCode.class,
+                    hashCodeHandle.asType(methodType(long.class, Object.class)));
+            this.objectEquals = MethodGenerator.getGeneratedMethod(
+                    type,
+                    ObjectEquals.class,
+                    equalsHandle.asType(methodType(Boolean.class, Object.class, Object.class)));
+        }
+
+        // Needs to be public for compileSingleAccessMethod
+        public interface ObjectHashCode
+        {
+            long hashCode(Object value);
+        }
+
+        // Needs to be public for compileSingleAccessMethod
+        public interface ObjectEquals
+        {
+            Boolean equals(Object a, Object b);
         }
 
         @Override
@@ -187,14 +220,7 @@ public final class FastutilSetHelper
             if (value == null) {
                 return 0;
             }
-            try {
-                return Long.hashCode((long) hashCodeHandle.invokeExact(value));
-            }
-            catch (Throwable t) {
-                throwIfInstanceOf(t, Error.class);
-                throwIfInstanceOf(t, TrinoException.class);
-                throw new TrinoException(GENERIC_INTERNAL_ERROR, t);
-            }
+            return Long.hashCode(objectHashCode.hashCode(value));
         }
 
         @Override
@@ -203,16 +229,93 @@ public final class FastutilSetHelper
             if (b == null || a == null) {
                 return a == null && b == null;
             }
+            Boolean result = objectEquals.equals(a, b);
+            // FastutilHashSet is not intended be used for indeterminate values lookup
+            verifyNotNull(result, "result is null");
+            return TRUE.equals(result);
+        }
+    }
+
+    private static class MethodGenerator
+    {
+        private static final Cache<MethodKey<?>, GeneratedMethod<?>> generatedMethodCache = CacheBuilder.newBuilder()
+                .maximumSize(1_000)
+                .expireAfterWrite(2, TimeUnit.HOURS)
+                .build();
+
+        private static <T> T getGeneratedMethod(Type type, Class<T> operatorInterface, MethodHandle methodHandle)
+        {
             try {
-                Boolean result = (Boolean) equalsHandle.invokeExact(a, b);
-                // FastutilHashSet is not intended be used for indeterminate values lookup
-                verifyNotNull(result, "result is null");
-                return TRUE.equals(result);
+                @SuppressWarnings("unchecked")
+                GeneratedMethod<T> generatedMethod = (GeneratedMethod<T>) generatedMethodCache.get(
+                        new MethodKey<>(type, operatorInterface),
+                        () -> new GeneratedMethod<>(type, operatorInterface, methodHandle));
+                return generatedMethod.get();
             }
-            catch (Throwable t) {
-                throwIfInstanceOf(t, Error.class);
-                throwIfInstanceOf(t, TrinoException.class);
-                throw new TrinoException(GENERIC_INTERNAL_ERROR, t);
+            catch (ExecutionException | UncheckedExecutionException e) {
+                throwIfUnchecked(e.getCause());
+                throw new RuntimeException(e.getCause());
+            }
+        }
+
+        private static class MethodKey<T>
+        {
+            private final Type type;
+            private final Class<T> singleMethodInterface;
+
+            public MethodKey(Type type, Class<T> singleMethodInterface)
+            {
+                this.type = requireNonNull(type, "type is null");
+                this.singleMethodInterface = requireNonNull(singleMethodInterface, "singleMethodInterface is null");
+            }
+
+            @Override
+            public boolean equals(Object o)
+            {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+                MethodKey<?> that = (MethodKey<?>) o;
+                return type.equals(that.type) && singleMethodInterface.equals(that.singleMethodInterface);
+            }
+
+            @Override
+            public int hashCode()
+            {
+                return Objects.hash(type, singleMethodInterface);
+            }
+        }
+
+        private static class GeneratedMethod<T>
+        {
+            private Type type;
+            private Class<T> singleMethodInterface;
+            private MethodHandle methodHandle;
+            @GuardedBy("this")
+            private T operator;
+
+            public GeneratedMethod(Type type, Class<T> singleMethodInterface, MethodHandle methodHandle)
+            {
+                this.type = requireNonNull(type, "type is null");
+                this.singleMethodInterface = requireNonNull(singleMethodInterface, "singleMethodInterface is null");
+                this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");
+            }
+
+            public synchronized T get()
+            {
+                if (operator != null) {
+                    return operator;
+                }
+                String suggestedClassName = singleMethodInterface.getSimpleName() + "_" + type.getDisplayName();
+                operator = compileSingleAccessMethod(suggestedClassName, singleMethodInterface, methodHandle);
+                // Free up memory by removing references to the objects that we won't need anymore
+                type = null;
+                singleMethodInterface = null;
+                methodHandle = null;
+                return operator;
             }
         }
     }

--- a/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
+++ b/core/trino-main/src/main/java/io/trino/util/FastutilSetHelper.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.base.util;
+package io.trino.util;
 
 import io.trino.spi.TrinoException;
 import io.trino.spi.type.Type;

--- a/core/trino-main/src/main/java/io/trino/util/SingleAccessMethodCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/util/SingleAccessMethodCompiler.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.type;
+package io.trino.util;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.bytecode.ClassDefinition;
@@ -39,7 +39,7 @@ import static io.trino.util.CompilerUtils.defineClass;
 import static io.trino.util.CompilerUtils.makeClassName;
 import static java.lang.invoke.MethodType.methodType;
 
-final class SingleAccessMethodCompiler
+public final class SingleAccessMethodCompiler
 {
     private SingleAccessMethodCompiler() {}
 

--- a/core/trino-main/src/test/java/io/trino/sql/gen/TestInCodeGenerator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/gen/TestInCodeGenerator.java
@@ -56,12 +56,11 @@ public class TestInCodeGenerator
                 Collections.singletonList(constant(12345678901234.0, DOUBLE))));
         assertEquals(checkSwitchGenerationCase(INTEGER, values), DIRECT_SWITCH);
 
-        for (int i = 6; i <= 15; ++i) {
-            values.add(constant(i, INTEGER));
-        }
+        values.add(constant(6, BIGINT));
+        values.add(constant(7, BIGINT));
         assertEquals(checkSwitchGenerationCase(INTEGER, values), DIRECT_SWITCH);
 
-        values.add(constant(16, INTEGER));
+        values.add(constant(8, INTEGER));
         assertEquals(checkSwitchGenerationCase(INTEGER, values), SET_CONTAINS);
     }
 
@@ -81,12 +80,11 @@ public class TestInCodeGenerator
                 Collections.singletonList(constant(12345678901234.0, DOUBLE))));
         assertEquals(checkSwitchGenerationCase(BIGINT, values), HASH_SWITCH);
 
-        for (long i = 6; i <= 15; ++i) {
-            values.add(constant(i, BIGINT));
-        }
+        values.add(constant(6L, BIGINT));
+        values.add(constant(7L, BIGINT));
         assertEquals(checkSwitchGenerationCase(BIGINT, values), HASH_SWITCH);
 
-        values.add(constant(16L, BIGINT));
+        values.add(constant(8L, BIGINT));
         assertEquals(checkSwitchGenerationCase(BIGINT, values), SET_CONTAINS);
     }
 
@@ -99,7 +97,7 @@ public class TestInCodeGenerator
         values.add(constant(3L, DATE));
         assertEquals(checkSwitchGenerationCase(DATE, values), DIRECT_SWITCH);
 
-        for (long i = 4; i <= 15; ++i) {
+        for (long i = 4; i <= 7; ++i) {
             values.add(constant(i, DATE));
         }
         assertEquals(checkSwitchGenerationCase(DATE, values), DIRECT_SWITCH);

--- a/core/trino-main/src/test/java/io/trino/type/TestSingleAccessMethodCompiler.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSingleAccessMethodCompiler.java
@@ -19,7 +19,7 @@ import java.lang.invoke.MethodType;
 import java.util.function.LongFunction;
 import java.util.function.LongUnaryOperator;
 
-import static io.trino.type.SingleAccessMethodCompiler.compileSingleAccessMethod;
+import static io.trino.util.SingleAccessMethodCompiler.compileSingleAccessMethod;
 import static java.lang.invoke.MethodHandles.lookup;
 import static org.testng.Assert.assertEquals;
 

--- a/lib/trino-plugin-toolkit/pom.xml
+++ b/lib/trino-plugin-toolkit/pom.xml
@@ -90,11 +90,6 @@
         </dependency>
 
         <dependency>
-            <groupId>it.unimi.dsi</groupId>
-            <artifactId>fastutil</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/lib/trino-rcfile/pom.xml
+++ b/lib/trino-rcfile/pom.xml
@@ -98,6 +98,12 @@
         </dependency>
 
         <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
Going through MethodHandle for hashCode and equals operations is much slower than direct method access.
Using compileSingleAccessMethod to generate the required interface from method handles results in around 50% improvement on BenchmarkInCodeGenerator for long and double.