### PR TITLE
Avoid hard-coded http scheme for Pinot controller url

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/client/PinotClient.java
@@ -68,6 +68,7 @@ import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
 import static io.airlift.json.JsonCodec.listJsonCodec;
 import static io.airlift.json.JsonCodec.mapJsonCodec;
@@ -96,7 +97,7 @@ public class PinotClient
     private static final String REQUEST_PAYLOAD_TEMPLATE = "{\"sql\" : \"%s\" }";
     private static final String QUERY_URL_TEMPLATE = "http://%s/query/sql";
 
-    private final List<String> controllerUrls;
+    private final List<URI> controllerUrls;
     private final HttpClient httpClient;
     private final PinotHostMapper pinotHostMapper;
 
@@ -178,7 +179,7 @@ public class PinotClient
     private <T> T sendHttpGetToControllerJson(String path, JsonCodec<T> codec)
     {
         return doHttpActionWithHeadersJson(
-                Request.Builder.prepareGet().setUri(URI.create(format("http://%s/%s", getControllerUrl(), path))),
+                Request.Builder.prepareGet().setUri(uriBuilderFrom(getControllerUrl()).appendPath(path).build()),
                 Optional.empty(),
                 codec);
     }
@@ -191,7 +192,7 @@ public class PinotClient
                 codec);
     }
 
-    private String getControllerUrl()
+    private URI getControllerUrl()
     {
         return controllerUrls.get(ThreadLocalRandom.current().nextInt(controllerUrls.size()));
     }


### PR DESCRIPTION
Fixes #8617

Pinot docs says the scheme is optional, but the config with `http(s)://` generates invalid url. 

https://trino.io/docs/current/connector/pinot.html#configuration
> This can be the ip or the FDQN, the url scheme (http://) is optional.