### PR TITLE
Add ALTER SCHEMA fragment to applicable connectors

### DIFF
--- a/docs/src/main/sphinx/connector/alter-schema-limitation.fragment
+++ b/docs/src/main/sphinx/connector/alter-schema-limitation.fragment
@@ -1,0 +1,5 @@
+ALTER SCHEMA
+^^^^^^^^^^^^
+
+The connector supports renaming a schema with the ``ALTER SCHEMA RENAME``
+statement. ``ALTER SCHEMA SET AUTHORIZATION`` is not supported.

--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -157,3 +157,6 @@ statements, the connector supports the following features:
 * :doc:`/sql/drop-table`
 * :doc:`/sql/create-schema`
 * :doc:`/sql/drop-schema`
+* :doc:`/sql/alter-schema`
+
+.. include:: alter-schema-limitation.fragment

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -106,5 +106,8 @@ statements, the connector supports the following features:
 * :doc:`/sql/drop-table`
 * :doc:`/sql/create-schema`
 * :doc:`/sql/drop-schema`
+* :doc:`/sql/alter-schema`
 
 .. include:: sql-delete-limitation.fragment
+
+.. include:: alter-schema-limitation.fragment

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -139,6 +139,8 @@ statements, the connector supports the following features:
 
 .. include:: sql-delete-limitation.fragment
 
+.. include:: alter-schema-limitation.fragment
+
 .. _postgresql-pushdown:
 
 Pushdown

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -134,6 +134,8 @@ supports the following features:
 
 .. include:: sql-delete-limitation.fragment
 
+.. include:: alter-schema-limitation.fragment
+
 .. _sqlserver-pushdown:
 
 Pushdown


### PR DESCRIPTION
Create a fragment discussing support for ALTER SCHEMA RENAME but not ALTER SCHEMA SET AUTHORIZATION, and added the fragment to the appropriate connectors.