### PR TITLE
Improve error message for DROP/RENAME TABLE on MV

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
@@ -20,6 +20,8 @@ import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
+import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
+import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameTable;
 import io.trino.transaction.TransactionManager;
@@ -56,6 +58,29 @@ public class RenameTableTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getSource());
+
+        Optional<ConnectorMaterializedViewDefinition> materializedView = metadata.getMaterializedView(session, tableName);
+        if (materializedView.isPresent()) {
+            if (!statement.isExists()) {
+                throw semanticException(
+                        TABLE_NOT_FOUND,
+                        statement,
+                        "Table '%s' does not exist, but a materialized view with that name exists.", tableName);
+            }
+            return immediateVoidFuture();
+        }
+
+        Optional<ConnectorViewDefinition> view = metadata.getView(session, tableName);
+        if (view.isPresent()) {
+            if (!statement.isExists()) {
+                throw semanticException(
+                        TABLE_NOT_FOUND,
+                        statement,
+                        "Table '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME ...?", tableName, tableName);
+            }
+            return immediateVoidFuture();
+        }
+
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (tableHandle.isEmpty()) {
             if (!statement.isExists()) {

--- a/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
+++ b/core/trino-main/src/test/java/io/trino/execution/BaseDataDefinitionTaskTest.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.connector.CatalogName;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.AbstractMockMetadata;
+import io.trino.metadata.Catalog;
+import io.trino.metadata.CatalogManager;
+import io.trino.metadata.MaterializedViewPropertyManager;
+import io.trino.metadata.MetadataManager;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.TableHandle;
+import io.trino.metadata.TableMetadata;
+import io.trino.metadata.TablePropertyManager;
+import io.trino.metadata.TableSchema;
+import io.trino.security.AccessControl;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.TestingColumnHandle;
+import io.trino.spi.resourcegroups.ResourceGroupId;
+import io.trino.sql.planner.TestingConnectorTransactionHandle;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.testing.TestingMetadata.TestingTableHandle;
+import io.trino.transaction.TransactionManager;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verifyNotNull;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.testing.TestingSession.createBogusTestingCatalog;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.transaction.InMemoryTransactionManager.createTestTransactionManager;
+import static java.util.Objects.requireNonNull;
+
+@Test
+public abstract class BaseDataDefinitionTaskTest
+{
+    protected static final String CATALOG_NAME = "catalog";
+    public static final String SCHEMA = "schema";
+    protected Session testSession;
+    protected MockMetadata metadata;
+    protected TransactionManager transactionManager;
+    protected QueryStateMachine queryStateMachine;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        CatalogManager catalogManager = new CatalogManager();
+        transactionManager = createTestTransactionManager(catalogManager);
+        TablePropertyManager tablePropertyManager = new TablePropertyManager();
+        MaterializedViewPropertyManager materializedViewPropertyManager = new MaterializedViewPropertyManager();
+        Catalog testCatalog = createBogusTestingCatalog(CATALOG_NAME);
+        catalogManager.registerCatalog(testCatalog);
+        testSession = testSessionBuilder()
+                .setTransactionId(transactionManager.beginTransaction(false))
+                .build();
+        metadata = new MockMetadata(
+                tablePropertyManager,
+                materializedViewPropertyManager,
+                testCatalog.getConnectorCatalogName());
+        queryStateMachine = stateMachine(transactionManager, createTestMetadataManager(), new AllowAllAccessControl(), testSession);
+    }
+
+    protected static QualifiedObjectName qualifiedObjectName(String objectName)
+    {
+        return new QualifiedObjectName(CATALOG_NAME, SCHEMA, objectName);
+    }
+
+    protected static QualifiedName qualifiedName(String name)
+    {
+        return QualifiedName.of(CATALOG_NAME, SCHEMA, name);
+    }
+
+    protected static QualifiedObjectName asQualifiedObjectName(QualifiedName viewName)
+    {
+        return QualifiedObjectName.valueOf(viewName.toString());
+    }
+
+    protected static QualifiedName asQualifiedName(QualifiedObjectName qualifiedObjectName)
+    {
+        return QualifiedName.of(qualifiedObjectName.getCatalogName(), qualifiedObjectName.getSchemaName(), qualifiedObjectName.getObjectName());
+    }
+
+    protected ConnectorMaterializedViewDefinition someMaterializedView()
+    {
+        return someMaterializedView("select * from some_table", ImmutableList.of(new ConnectorMaterializedViewDefinition.Column("test", BIGINT.getTypeId())));
+    }
+
+    protected ConnectorMaterializedViewDefinition someMaterializedView(
+            String sql,
+            List<ConnectorMaterializedViewDefinition.Column> columns)
+    {
+        return new ConnectorMaterializedViewDefinition(
+                sql,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                columns,
+                Optional.empty(),
+                "owner",
+                ImmutableMap.of());
+    }
+
+    protected static ConnectorTableMetadata someTable(QualifiedObjectName tableName)
+    {
+        return new ConnectorTableMetadata(tableName.asSchemaTableName(), ImmutableList.of(new ColumnMetadata("test", BIGINT)));
+    }
+
+    protected static ConnectorViewDefinition someView()
+    {
+        return viewDefinition("SELECT 1", ImmutableList.of(new ConnectorViewDefinition.ViewColumn("test", BIGINT.getTypeId())));
+    }
+
+    protected static ConnectorViewDefinition viewDefinition(String sql, ImmutableList<ConnectorViewDefinition.ViewColumn> columns)
+    {
+        return new ConnectorViewDefinition(
+                sql,
+                Optional.empty(),
+                Optional.empty(),
+                columns,
+                Optional.empty(),
+                Optional.empty(),
+                true);
+    }
+
+    private static QueryStateMachine stateMachine(TransactionManager transactionManager, MetadataManager metadata, AccessControl accessControl, Session session)
+    {
+        return QueryStateMachine.begin(
+                "test",
+                Optional.empty(),
+                session,
+                URI.create("fake://uri"),
+                new ResourceGroupId("test"),
+                false,
+                transactionManager,
+                accessControl,
+                directExecutor(),
+                metadata,
+                WarningCollector.NOOP,
+                Optional.empty());
+    }
+
+    protected static class MockMetadata
+            extends AbstractMockMetadata
+    {
+        private final TablePropertyManager tablePropertyManager;
+        private final MaterializedViewPropertyManager materializedViewPropertyManager;
+        private final CatalogName catalogHandle;
+        private final Map<SchemaTableName, ConnectorTableMetadata> tables = new ConcurrentHashMap<>();
+        private final Map<SchemaTableName, ConnectorViewDefinition> views = new ConcurrentHashMap<>();
+        private final Map<SchemaTableName, ConnectorMaterializedViewDefinition> materializedViews = new ConcurrentHashMap<>();
+
+        public MockMetadata(
+                TablePropertyManager tablePropertyManager,
+                MaterializedViewPropertyManager materializedViewPropertyManager,
+                CatalogName catalogHandle)
+        {
+            this.tablePropertyManager = requireNonNull(tablePropertyManager, "tablePropertyManager is null");
+            this.materializedViewPropertyManager = requireNonNull(materializedViewPropertyManager, "materializedViewPropertyManager is null");
+            this.catalogHandle = requireNonNull(catalogHandle, "catalogHandle is null");
+        }
+
+        @Override
+        public TablePropertyManager getTablePropertyManager()
+        {
+            return tablePropertyManager;
+        }
+
+        @Override
+        public MaterializedViewPropertyManager getMaterializedViewPropertyManager()
+        {
+            return materializedViewPropertyManager;
+        }
+
+        @Override
+        public Optional<CatalogName> getCatalogHandle(Session session, String catalogName)
+        {
+            if (catalogHandle.getCatalogName().equals(catalogName)) {
+                return Optional.of(catalogHandle);
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public TableSchema getTableSchema(Session session, TableHandle tableHandle)
+        {
+            return new TableSchema(tableHandle.getCatalogName(), getTableMetadata(tableHandle).getTableSchema());
+        }
+
+        @Override
+        public Optional<TableHandle> getTableHandle(Session session, QualifiedObjectName tableName)
+        {
+            return Optional.ofNullable(tables.get(tableName.asSchemaTableName()))
+                    .map(tableMetadata -> new TableHandle(
+                            new CatalogName(CATALOG_NAME),
+                            new TestingTableHandle(tableName.asSchemaTableName()),
+                            TestingConnectorTransactionHandle.INSTANCE,
+                            Optional.empty()));
+        }
+
+        @Override
+        public TableMetadata getTableMetadata(Session session, TableHandle tableHandle)
+        {
+            return new TableMetadata(new CatalogName("catalog"), getTableMetadata(tableHandle));
+        }
+
+        @Override
+        public void createTable(Session session, String catalogName, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
+        {
+            checkArgument(ignoreExisting || !tables.containsKey(tableMetadata.getTable()));
+            tables.put(tableMetadata.getTable(), tableMetadata);
+        }
+
+        @Override
+        public void dropTable(Session session, TableHandle tableHandle)
+        {
+            tables.remove(getTableName(tableHandle));
+        }
+
+        @Override
+        public void renameTable(Session session, TableHandle tableHandle, QualifiedObjectName newTableName)
+        {
+            SchemaTableName oldTableName = getTableName(tableHandle);
+            tables.put(newTableName.asSchemaTableName(), verifyNotNull(tables.get(oldTableName), "Table not found %s", oldTableName));
+            tables.remove(oldTableName);
+        }
+
+        private ConnectorTableMetadata getTableMetadata(TableHandle tableHandle)
+        {
+            return tables.get(getTableName(tableHandle));
+        }
+
+        private SchemaTableName getTableName(TableHandle tableHandle)
+        {
+            return ((TestingTableHandle) tableHandle.getConnectorHandle()).getTableName();
+        }
+
+        @Override
+        public Map<String, ColumnHandle> getColumnHandles(Session session, TableHandle tableHandle)
+        {
+            return getTableMetadata(tableHandle).getColumns().stream()
+                    .collect(toImmutableMap(
+                            ColumnMetadata::getName,
+                            column -> new TestingColumnHandle(column.getName())));
+        }
+
+        @Override
+        public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
+        {
+            return Optional.ofNullable(materializedViews.get(viewName.asSchemaTableName()));
+        }
+
+        @Override
+        public void createMaterializedView(Session session, QualifiedObjectName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+        {
+            checkArgument(ignoreExisting || !materializedViews.containsKey(viewName.asSchemaTableName()));
+            materializedViews.put(viewName.asSchemaTableName(), definition);
+        }
+
+        @Override
+        public void dropMaterializedView(Session session, QualifiedObjectName viewName)
+        {
+            materializedViews.remove(viewName.asSchemaTableName());
+        }
+
+        @Override
+        public Optional<ConnectorViewDefinition> getView(Session session, QualifiedObjectName viewName)
+        {
+            return Optional.ofNullable(views.get(viewName.asSchemaTableName()));
+        }
+
+        @Override
+        public void createView(Session session, QualifiedObjectName viewName, ConnectorViewDefinition definition, boolean replace)
+        {
+            checkArgument(replace || !views.containsKey(viewName.asSchemaTableName()));
+            views.put(viewName.asSchemaTableName(), definition);
+        }
+
+        @Override
+        public void dropView(Session session, QualifiedObjectName viewName)
+        {
+            views.remove(viewName.asSchemaTableName());
+        }
+
+        @Override
+        public void renameView(Session session, QualifiedObjectName source, QualifiedObjectName target)
+        {
+            SchemaTableName oldViewName = source.asSchemaTableName();
+            views.put(target.asSchemaTableName(), verifyNotNull(views.get(oldViewName), "View not found %s", oldViewName));
+            views.remove(oldViewName);
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropMaterializedViewTask.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.sql.tree.DropMaterializedView;
+import io.trino.sql.tree.QualifiedName;
+import org.testng.annotations.Test;
+
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestDropMaterializedViewTask
+        extends BaseDataDefinitionTaskTest
+{
+    @Test
+    public void testDropExistingMaterializedView()
+    {
+        QualifiedObjectName viewName = qualifiedObjectName("existing_materialized_view");
+        metadata.createMaterializedView(testSession, viewName, someMaterializedView(), false, false);
+        assertThat(metadata.getMaterializedView(testSession, viewName)).isPresent();
+
+        getFutureValue(executeDropMaterializedView(asQualifiedName(viewName), false));
+        assertThat(metadata.getMaterializedView(testSession, viewName)).isEmpty();
+    }
+
+    @Test
+    public void testDropNotExistingMaterializedView()
+    {
+        QualifiedName viewName = qualifiedName("not_existing_materialized_view");
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropMaterializedView(viewName, false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("Materialized view '%s' does not exist", viewName);
+    }
+
+    @Test
+    public void testDropNotExistingMaterializedViewIfExists()
+    {
+        QualifiedName viewName = qualifiedName("not_existing_materialized_view");
+
+        getFutureValue(executeDropMaterializedView(viewName, true));
+        // no exception
+    }
+
+    @Test
+    public void testDropMaterializedViewOnTable()
+    {
+        QualifiedObjectName tableName = qualifiedObjectName("existing_table");
+        metadata.createTable(testSession, CATALOG_NAME, someTable(tableName), false);
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropMaterializedView(asQualifiedName(tableName), false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("Materialized view '%s' does not exist, but a table with that name exists. Did you mean DROP TABLE %s?", tableName, tableName);
+    }
+
+    @Test
+    public void testDropMaterializedViewOnTableIfExists()
+    {
+        QualifiedObjectName tableName = qualifiedObjectName("existing_table");
+        metadata.createTable(testSession, CATALOG_NAME, someTable(tableName), false);
+
+        getFutureValue(executeDropMaterializedView(asQualifiedName(tableName), true));
+        // no exception
+    }
+
+    @Test
+    public void testDropMaterializedViewOnView()
+    {
+        QualifiedName viewName = qualifiedName("existing_view");
+        metadata.createView(testSession, asQualifiedObjectName(viewName), someView(), false);
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropMaterializedView(viewName, false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("Materialized view '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", viewName, viewName);
+    }
+
+    @Test
+    public void testDropMaterializedViewOnViewIfExists()
+    {
+        QualifiedName viewName = qualifiedName("existing_view");
+        metadata.createView(testSession, asQualifiedObjectName(viewName), someView(), false);
+
+        getFutureValue(executeDropMaterializedView(viewName, true));
+        // no exception
+    }
+
+    private ListenableFuture<Void> executeDropMaterializedView(QualifiedName viewName, boolean exists)
+    {
+        return new DropMaterializedViewTask().execute(new DropMaterializedView(viewName, exists), transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropTableTask.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.sql.tree.DropTable;
+import io.trino.sql.tree.QualifiedName;
+import org.testng.annotations.Test;
+
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestDropTableTask
+        extends BaseDataDefinitionTaskTest
+{
+    @Test
+    public void testDropExistingTable()
+    {
+        QualifiedObjectName tableName = qualifiedObjectName("not_existing_table");
+        metadata.createTable(testSession, CATALOG_NAME, someTable(tableName), false);
+        assertThat(metadata.getTableHandle(testSession, tableName)).isPresent();
+
+        getFutureValue(executeDropTable(asQualifiedName(tableName), false));
+        assertThat(metadata.getTableHandle(testSession, tableName)).isEmpty();
+    }
+
+    @Test
+    public void testDropNotExistingTable()
+    {
+        QualifiedName tableName = qualifiedName("not_existing_table");
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropTable(tableName, false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("Table '%s' does not exist", tableName);
+    }
+
+    @Test
+    public void testDropNotExistingTableIfExists()
+    {
+        QualifiedName tableName = qualifiedName("not_existing_table");
+
+        getFutureValue(executeDropTable(tableName, true));
+        // no exception
+    }
+
+    @Test
+    public void testDropTableOnView()
+    {
+        QualifiedName viewName = qualifiedName("existing_view");
+        metadata.createView(testSession, asQualifiedObjectName(viewName), someView(), false);
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropTable(viewName, false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("Table '%s' does not exist, but a view with that name exists. Did you mean DROP VIEW %s?", viewName, viewName);
+    }
+
+    @Test
+    public void testDropTableOnViewIfExists()
+    {
+        QualifiedName viewName = qualifiedName("existing_view");
+        metadata.createView(testSession, asQualifiedObjectName(viewName), someView(), false);
+
+        getFutureValue(executeDropTable(viewName, true));
+        // no exception
+    }
+
+    @Test
+    public void testDropTableOnMaterializedView()
+    {
+        QualifiedName viewName = qualifiedName("existing_materialized_view");
+        metadata.createMaterializedView(testSession, asQualifiedObjectName(viewName), someMaterializedView(), false, false);
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropTable(viewName, false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("Table '%s' does not exist, but a materialized view with that name exists. Did you mean DROP MATERIALIZED VIEW %s?", viewName, viewName);
+    }
+
+    @Test
+    public void testDropTableOnMaterializedViewIfExists()
+    {
+        QualifiedName viewName = qualifiedName("existing_materialized_view");
+        metadata.createMaterializedView(testSession, asQualifiedObjectName(viewName), someMaterializedView(), false, false);
+
+        getFutureValue(executeDropTable(viewName, true));
+        // no exception
+    }
+
+    private ListenableFuture<Void> executeDropTable(QualifiedName tableName, boolean exists)
+    {
+        return new DropTableTask().execute(new DropTable(tableName, exists), transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropViewTask.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.sql.tree.DropView;
+import io.trino.sql.tree.QualifiedName;
+import org.testng.annotations.Test;
+
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestDropViewTask
+        extends BaseDataDefinitionTaskTest
+{
+    @Test
+    public void testDropExistingView()
+    {
+        QualifiedObjectName viewName = qualifiedObjectName("existing_view");
+        metadata.createView(testSession, viewName, someView(), false);
+        assertThat(metadata.getView(testSession, viewName)).isPresent();
+
+        getFutureValue(executeDropView(asQualifiedName(viewName), false));
+        assertThat(metadata.getView(testSession, viewName)).isEmpty();
+    }
+
+    @Test
+    public void testDropNotExistingView()
+    {
+        QualifiedName viewName = qualifiedName("not_existing_view");
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropView(viewName, false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("View '%s' does not exist", viewName);
+    }
+
+    @Test
+    public void testDropNotExistingViewIfExists()
+    {
+        QualifiedName viewName = qualifiedName("not_existing_view");
+
+        getFutureValue(executeDropView(viewName, true));
+        // no exception
+    }
+
+    @Test
+    public void testDropViewOnTable()
+    {
+        QualifiedObjectName tableName = qualifiedObjectName("existing_table");
+        metadata.createTable(testSession, CATALOG_NAME, someTable(tableName), false);
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropView(asQualifiedName(tableName), false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("View '%s' does not exist, but a table with that name exists. Did you mean DROP TABLE %s?", tableName, tableName);
+    }
+
+    @Test
+    public void testDropViewOnTableIfExists()
+    {
+        QualifiedObjectName tableName = qualifiedObjectName("existing_table");
+        metadata.createTable(testSession, CATALOG_NAME, someTable(tableName), false);
+
+        getFutureValue(executeDropView(asQualifiedName(tableName), true));
+        // no exception
+    }
+
+    @Test
+    public void testDropViewOnMaterializedView()
+    {
+        QualifiedName viewName = qualifiedName("existing_materialized_view");
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeDropView(viewName, false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("View '%s' does not exist, but a materialized view with that name exists. Did you mean DROP MATERIALIZED VIEW %s?", viewName, viewName);
+    }
+
+    @Test
+    public void testDropViewOnMaterializedViewIfExists()
+    {
+        QualifiedName viewName = qualifiedName("existing_materialized_view");
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
+
+        getFutureValue(executeDropView(viewName, true));
+        // no exception
+    }
+
+    private ListenableFuture<Void> executeDropView(QualifiedName viewName, boolean exists)
+    {
+        return new DropViewTask().execute(new DropView(viewName, exists), transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.RenameTable;
+import org.testng.annotations.Test;
+
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestRenameTableTask
+        extends BaseDataDefinitionTaskTest
+{
+    @Test
+    public void testRenameExistingTable()
+    {
+        QualifiedObjectName tableName = qualifiedObjectName("existing_table");
+        QualifiedObjectName newTableName = qualifiedObjectName("existing_view_new");
+        metadata.createTable(testSession, CATALOG_NAME, someTable(tableName), false);
+
+        getFutureValue(executeRenameTable(asQualifiedName(tableName), asQualifiedName(newTableName), false));
+        assertThat(metadata.getTableHandle(testSession, tableName)).isEmpty();
+        assertThat(metadata.getTableHandle(testSession, newTableName)).isPresent();
+    }
+
+    @Test
+    public void testRenameNotExistingTable()
+    {
+        QualifiedName tableName = qualifiedName("not_existing_table");
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(tableName, qualifiedName("not_existing_table_new"), false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("Table '%s' does not exist", tableName);
+    }
+
+    @Test
+    public void testRenameNotExistingTableIfExists()
+    {
+        QualifiedName tableName = qualifiedName("not_existing_table");
+
+        getFutureValue(executeRenameTable(tableName, qualifiedName("not_existing_table_new"), true));
+        // no exception
+    }
+
+    @Test
+    public void testRenameTableOnView()
+    {
+        QualifiedObjectName viewName = qualifiedObjectName("existing_view");
+        metadata.createView(testSession, viewName, someView(), false);
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(asQualifiedName(viewName), qualifiedName("existing_view_new"), false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("Table '%s' does not exist, but a view with that name exists. Did you mean ALTER VIEW %s RENAME ...?", viewName, viewName);
+    }
+
+    @Test
+    public void testRenameTableOnViewIfExists()
+    {
+        QualifiedObjectName viewName = qualifiedObjectName("existing_view");
+        metadata.createView(testSession, viewName, someView(), false);
+
+        getFutureValue(executeRenameTable(asQualifiedName(viewName), qualifiedName("existing_view_new"), true));
+        // no exception
+    }
+
+    @Test
+    public void testRenameTableOnMaterializedView()
+    {
+        QualifiedName viewName = qualifiedName("existing_materialized_view");
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameTable(viewName, qualifiedName("existing_materialized_view_new"), false)))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("Table '%s' does not exist, but a materialized view with that name exists.", viewName);
+    }
+
+    @Test
+    public void testRenameTableOnMaterializedViewIfExists()
+    {
+        QualifiedName viewName = qualifiedName("existing_materialized_view");
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
+
+        getFutureValue(executeRenameTable(viewName, qualifiedName("existing_materialized_view_new"), true));
+        // no exception
+    }
+
+    private ListenableFuture<Void> executeRenameTable(QualifiedName source, QualifiedName target, boolean exists)
+    {
+        return new RenameTableTask().execute(new RenameTable(source, target, exists), transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.security.AllowAllAccessControl;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.RenameView;
+import org.testng.annotations.Test;
+
+import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
+import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Test(singleThreaded = true)
+public class TestRenameViewTask
+        extends BaseDataDefinitionTaskTest
+{
+    @Test
+    public void testRenameExistingView()
+    {
+        QualifiedObjectName viewName = qualifiedObjectName("existing_view");
+        QualifiedObjectName newViewName = qualifiedObjectName("existing_view_new");
+        metadata.createView(testSession, viewName, someView(), false);
+
+        getFutureValue(executeRenameView(asQualifiedName(viewName), asQualifiedName(newViewName)));
+        assertThat(metadata.getView(testSession, viewName)).isEmpty();
+        assertThat(metadata.getView(testSession, newViewName)).isPresent();
+    }
+
+    @Test
+    public void testRenameNotExistingView()
+    {
+        QualifiedName viewName = qualifiedName("not_existing_view");
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameView(viewName, qualifiedName("not_existing_view_new"))))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("View '%s' does not exist", viewName);
+    }
+
+    @Test
+    public void testRenameViewOnTable()
+    {
+        QualifiedObjectName tableName = qualifiedObjectName("existing_table");
+        metadata.createTable(testSession, CATALOG_NAME, someTable(tableName), false);
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameView(asQualifiedName(tableName), qualifiedName("existing_table_new"))))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("View '%s' does not exist, but a table with that name exists. Did you mean ALTER TABLE %s RENAME ...?", tableName, tableName);
+    }
+
+    @Test
+    public void testRenameViewOnMaterializedView()
+    {
+        QualifiedName viewName = qualifiedName("existing_materialized_view");
+        metadata.createMaterializedView(testSession, QualifiedObjectName.valueOf(viewName.toString()), someMaterializedView(), false, false);
+
+        assertTrinoExceptionThrownBy(() -> getFutureValue(executeRenameView(viewName, qualifiedName("existing_materialized_view_new"))))
+                .hasErrorCode(TABLE_NOT_FOUND)
+                .hasMessage("View '%s' does not exist, but a materialized view with that name exists.", viewName);
+    }
+
+    private ListenableFuture<Void> executeRenameView(QualifiedName source, QualifiedName target)
+    {
+        return new RenameViewTask().execute(new RenameView(source, target), transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+    }
+}


### PR DESCRIPTION
Add information that operation fails due to action on a materialized view.
Add tests that confirm DROP/RENAME TABLE/VIEW does not work on MATERIALIZED VIEW