### PR TITLE
Only support single statement writes by default

### DIFF
--- a/core/trino-main/src/main/java/io/trino/transaction/InMemoryTransactionManager.java
+++ b/core/trino-main/src/main/java/io/trino/transaction/InMemoryTransactionManager.java
@@ -465,7 +465,7 @@ public class InMemoryTransactionManager
                 throw new TrinoException(MULTI_CATALOG_WRITE_CONFLICT, "Multi-catalog writes not supported in a single transaction. Already wrote to catalog " + writtenConnectorId.get());
             }
             if (transactionMetadata.isSingleStatementWritesOnly() && !autoCommitContext) {
-                throw new TrinoException(AUTOCOMMIT_WRITE_CONFLICT, "Catalog " + catalogName + " only supports writes using autocommit");
+                throw new TrinoException(AUTOCOMMIT_WRITE_CONFLICT, "Catalog only supports writes using autocommit: " + catalogName);
             }
         }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
@@ -190,7 +190,7 @@ public interface Connector
      */
     default boolean isSingleStatementWritesOnly()
     {
-        return false;
+        return true;
     }
 
     /**

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnector.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnector.java
@@ -87,12 +87,6 @@ public class JdbcConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        return true;
-    }
-
-    @Override
     public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
     {
         checkConnectorSupports(READ_COMMITTED, isolationLevel);

--- a/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleConnector.java
+++ b/plugin/trino-blackhole/src/main/java/io/trino/plugin/blackhole/BlackHoleConnector.java
@@ -81,13 +81,6 @@ public class BlackHoleConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        // TODO: support transactional metadata
-        return true;
-    }
-
-    @Override
     public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle)
     {
         return metadata;

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraConnector.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraConnector.java
@@ -66,12 +66,6 @@ public class CassandraConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        return true;
-    }
-
-    @Override
     public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle)
     {
         return metadata;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorSmokeTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorSmokeTest.java
@@ -48,6 +48,9 @@ public class TestHiveConnectorSmokeTest
             case SUPPORTS_DELETE:
                 return true;
 
+            case SUPPORTS_MULTI_STATEMENT_WRITES:
+                return true;
+
             default:
                 return super.hasBehavior(connectorBehavior);
         }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
@@ -215,6 +215,9 @@ public class TestHiveConnectorTest
             case SUPPORTS_DELETE:
                 return true;
 
+            case SUPPORTS_MULTI_STATEMENT_WRITES:
+                return true;
+
             default:
                 return super.hasBehavior(connectorBehavior);
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
@@ -102,12 +102,6 @@ public class IcebergConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        return true;
-    }
-
-    @Override
     public Set<ConnectorCapabilities> getCapabilities()
     {
         return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -36,7 +36,6 @@ import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import io.trino.testing.sql.TestTable;
-import io.trino.transaction.TransactionBuilder;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.file.DataFileWriter;
@@ -1696,11 +1695,6 @@ public abstract class BaseIcebergConnectorTest
                                 .collect(toImmutableMap(entry -> columns.get(entry.getKey()), Map.Entry::getValue))));
             }
         });
-    }
-
-    private TransactionBuilder newTransaction()
-    {
-        return transaction(getQueryRunner().getTransactionManager(), getQueryRunner().getAccessControl());
     }
 
     private static class TestRelationalNumberPredicate

--- a/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnector.java
+++ b/plugin/trino-mongodb/src/main/java/io/trino/plugin/mongodb/MongoConnector.java
@@ -64,12 +64,6 @@ public class MongoConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        return true;
-    }
-
-    @Override
     public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
     {
         MongoMetadata metadata = transactions.get(transaction);

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorConnector.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorConnector.java
@@ -117,12 +117,6 @@ public class RaptorConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        return true;
-    }
-
-    @Override
     public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
     {
         checkConnectorSupports(READ_COMMITTED, isolationLevel);

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -50,6 +50,7 @@ import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.query.QueryAssertions.QueryAssert;
 import io.trino.sql.tree.ExplainType;
 import io.trino.testing.TestingAccessControlManager.TestingPrivilege;
+import io.trino.transaction.TransactionBuilder;
 import io.trino.util.AutoCloseableCloser;
 import org.assertj.core.api.AssertProvider;
 import org.intellij.lang.annotations.Language;
@@ -125,6 +126,16 @@ public abstract class AbstractTestQueryFramework
     protected final int getNodeCount()
     {
         return queryRunner.getNodeCount();
+    }
+
+    protected TransactionBuilder newTransaction()
+    {
+        return transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl());
+    }
+
+    protected void inTransaction(Consumer<Session> callback)
+    {
+        newTransaction().execute(getSession(), callback);
     }
 
     protected MaterializedResult computeActual(@Language("SQL") String sql)
@@ -398,7 +409,7 @@ public abstract class AbstractTestQueryFramework
     protected String getExplainPlan(String query, ExplainType.Type planType)
     {
         QueryExplainer explainer = getQueryExplainer();
-        return transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
+        return newTransaction()
                 .singleStatement()
                 .execute(getSession(), session -> {
                     return explainer.getPlan(session, sqlParser.createStatement(query, createParsingOptions(session)), planType, emptyList(), WarningCollector.NOOP);
@@ -408,7 +419,7 @@ public abstract class AbstractTestQueryFramework
     protected String getGraphvizExplainPlan(String query, ExplainType.Type planType)
     {
         QueryExplainer explainer = getQueryExplainer();
-        return transaction(queryRunner.getTransactionManager(), queryRunner.getAccessControl())
+        return newTransaction()
                 .singleStatement()
                 .execute(queryRunner.getDefaultSession(), session -> {
                     return explainer.getGraphvizPlan(session, sqlParser.createStatement(query, createParsingOptions(session)), planType, emptyList(), WarningCollector.NOOP);

--- a/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/TestingConnectorBehavior.java
@@ -73,6 +73,8 @@ public enum TestingConnectorBehavior
 
     SUPPORTS_CANCELLATION(false),
 
+    SUPPORTS_MULTI_STATEMENT_WRITES(false),
+
     /**/;
 
     private final Predicate<Predicate<TestingConnectorBehavior>> hasBehaviorByDefault;


### PR DESCRIPTION
This changes the default behavior of `Connector.isSingleStatementWritesOnly()` to return `true` by default, since most connectors do not support multi-statement writes. This also fixes the behavior of many connectors that did not override this
method and thus pretended to support transactions, but would execute the operations immediately and silently ignore rollback.