### PR TITLE
Add session refresh interval in Cassandra connector

### DIFF
--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -104,6 +104,9 @@ Property Name                                                 Description
 
 ``cassandra.batch-size``                                      Maximum number of statements to execute in one batch.
 
+``cassandra.session-refresh-interval``                        Refresh interval for initializing a session. New keyspaces or tables
+                                                              created in Yugabyte CQL won't appear until the next interval.
+
 ``cassandra.client.read-timeout``                             Maximum time the Cassandra driver waits for an
                                                               answer to a query from one Cassandra node. Note that the underlying
                                                               Cassandra driver may retry a query against more than one node in

--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -93,7 +93,7 @@ Property Name                                                 Description
 ``cassandra.fetch-size``                                      Number of rows fetched at a time in a Cassandra query.
 
 ``cassandra.partition-size-for-batch-select``                 Number of partitions batched together into a single select for a
-                                                              single partion key column table.
+                                                              single partition key column table.
 
 ``cassandra.split-size``                                      Number of keys per split when querying Cassandra.
 

--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -104,7 +104,7 @@ Property Name                                                 Description
 
 ``cassandra.batch-size``                                      Maximum number of statements to execute in one batch.
 
-``cassandra.session-refresh-interval``                        Refresh interval for initializing a session. New keyspaces or tables
+``cassandra.session-refresh-interval``                        Refresh interval for initializing a metadata. New keyspaces or tables
                                                               created in Yugabyte CQL won't appear until the next interval.
 
 ``cassandra.client.read-timeout``                             Maximum time the Cassandra driver waits for an

--- a/plugin/trino-cassandra/pom.xml
+++ b/plugin/trino-cassandra/pom.xml
@@ -190,6 +190,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClientConfig.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClientConfig.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -58,6 +59,7 @@ public class CassandraClientConfig
     private boolean allowDropTable;
     private String username;
     private String password;
+    private Duration sessionRefreshInterval = new Duration(Long.MAX_VALUE, DAYS);
     private Duration clientReadTimeout = new Duration(SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS, MILLISECONDS);
     private Duration clientConnectTimeout = new Duration(SocketOptions.DEFAULT_CONNECT_TIMEOUT_MILLIS, MILLISECONDS);
     private Integer clientSoLinger;
@@ -224,6 +226,19 @@ public class CassandraClientConfig
     public CassandraClientConfig setPassword(String password)
     {
         this.password = password;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getSessionRefreshInterval()
+    {
+        return sessionRefreshInterval;
+    }
+
+    @Config("cassandra.session-refresh-interval")
+    public CassandraClientConfig setSessionRefreshInterval(Duration sessionRefreshInterval)
+    {
+        this.sessionRefreshInterval = sessionRefreshInterval;
         return this;
     }
 

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClientModule.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClientModule.java
@@ -201,7 +201,8 @@ public class CassandraClientModule
                 new ReopeningCluster(() -> {
                     contactPoints.forEach(clusterBuilder::addContactPoint);
                     return clusterBuilder.build();
-                }),
+                }, config.getSessionRefreshInterval()),
+                config.getSessionRefreshInterval(),
                 config.getNoHostAvailableRetryTimeout());
     }
 

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
@@ -39,6 +39,7 @@ import static com.google.common.io.Resources.getResource;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -80,10 +81,11 @@ public class CassandraServer
                         new InetSocketAddress(this.dockerContainer.getContainerIpAddress(), this.dockerContainer.getMappedPort(PORT))))
                 .withMaxSchemaAgreementWaitSeconds(30);
 
-        ReopeningCluster cluster = new ReopeningCluster(clusterBuilder::build);
+        ReopeningCluster cluster = new ReopeningCluster(clusterBuilder::build, new Duration(Long.MAX_VALUE, DAYS));
         CassandraSession session = new CassandraSession(
                 JsonCodec.listJsonCodec(ExtraColumnMetadata.class),
                 cluster,
+                new Duration(Long.MAX_VALUE, DAYS),
                 new Duration(1, MINUTES));
 
         try {

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraClientConfig.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraClientConfig.java
@@ -28,6 +28,7 @@ import static com.datastax.driver.core.ProtocolVersion.V2;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -49,6 +50,7 @@ public class TestCassandraClientConfig
                 .setAllowDropTable(false)
                 .setUsername(null)
                 .setPassword(null)
+                .setSessionRefreshInterval(new Duration(Long.MAX_VALUE, DAYS))
                 .setClientReadTimeout(new Duration(SocketOptions.DEFAULT_READ_TIMEOUT_MILLIS, MILLISECONDS))
                 .setClientConnectTimeout(new Duration(SocketOptions.DEFAULT_CONNECT_TIMEOUT_MILLIS, MILLISECONDS))
                 .setClientSoLinger(null)
@@ -90,6 +92,7 @@ public class TestCassandraClientConfig
                 .put("cassandra.allow-drop-table", "true")
                 .put("cassandra.username", "my_username")
                 .put("cassandra.password", "my_password")
+                .put("cassandra.session-refresh-interval", "5m")
                 .put("cassandra.client.read-timeout", "11ms")
                 .put("cassandra.client.connect-timeout", "22ms")
                 .put("cassandra.client.so-linger", "33")
@@ -124,6 +127,7 @@ public class TestCassandraClientConfig
                 .setAllowDropTable(true)
                 .setUsername("my_username")
                 .setPassword("my_password")
+                .setSessionRefreshInterval(new Duration(5, MINUTES))
                 .setClientReadTimeout(new Duration(11, MILLISECONDS))
                 .setClientConnectTimeout(new Duration(22, MILLISECONDS))
                 .setClientSoLinger(33)

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestYugabyteDatabase.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestYugabyteDatabase.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.cassandra;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.cassandra.CassandraTestingUtils.createKeyspace;
+import static io.trino.plugin.cassandra.YugabyteQueryRunner.createYugabyteQueryRunner;
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TestYugabyteDatabase
+        extends AbstractTestQueryFramework
+{
+    private static final String KEYSPACE = "smoke_test";
+
+    private CassandraSession session;
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        TestingYugabyteServer server = closeAfterClass(new TestingYugabyteServer());
+        session = server.getSession();
+        createKeyspace(session, KEYSPACE);
+        return createYugabyteQueryRunner(
+                server,
+                ImmutableMap.of(),
+                ImmutableMap.of("cassandra.session-refresh-interval", "5s"));
+    }
+
+    @Test
+    public void testNewSchemaInYugabyte()
+            throws Exception
+    {
+        String schemaName = "test_new_schema";
+
+        onYugabyte("DROP KEYSPACE IF EXISTS " + schemaName);
+        assertQueryReturnsEmptyResult(format("SHOW SCHEMAS FROM yugabyte LIKE '%s'", schemaName));
+
+        onYugabyte("CREATE SCHEMA " + schemaName);
+
+        assertQueryEventually(getSession(),
+                format("SHOW SCHEMAS FROM yugabyte LIKE '%s'", schemaName),
+                format("VALUES ('%s')", schemaName),
+                new Duration(10, SECONDS));
+
+        onYugabyte("DROP KEYSPACE " + schemaName);
+    }
+
+    @Test
+    public void testNewTableInYugabyte()
+            throws Exception
+    {
+        String tableName = "test_new_table";
+
+        onYugabyte("DROP TABLE IF EXISTS smoke_test." + tableName);
+        assertQueryReturnsEmptyResult(format("SHOW TABLES FROM smoke_test LIKE '%s'", tableName));
+
+        onYugabyte(format("CREATE TABLE smoke_test.%s (id INT PRIMARY KEY)", tableName));
+
+        assertQueryEventually(getSession(),
+                format("SHOW TABLES FROM smoke_test LIKE '%s'", tableName),
+                format("VALUES ('%s')", tableName),
+                new Duration(10, SECONDS));
+
+        onYugabyte("DROP TABLE smoke_test." + tableName);
+    }
+
+    private void onYugabyte(@Language("SQL") String sql)
+    {
+        session.execute(sql);
+    }
+}

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestingScyllaServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestingScyllaServer.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeoutException;
 import static com.datastax.driver.core.ProtocolVersion.V3;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -65,7 +66,8 @@ public class TestingScyllaServer
 
         session = new CassandraSession(
                 JsonCodec.listJsonCodec(ExtraColumnMetadata.class),
-                new ReopeningCluster(clusterBuilder::build),
+                new ReopeningCluster(clusterBuilder::build, new io.airlift.units.Duration(Long.MAX_VALUE, DAYS)),
+                new io.airlift.units.Duration(Long.MAX_VALUE, DAYS),
                 new Duration(1, MINUTES));
     }
 

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestingYugabyteServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestingYugabyteServer.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.google.common.collect.ImmutableList;
+import io.airlift.json.JsonCodec;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+
+import static com.datastax.driver.core.ProtocolVersion.V3;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+public class TestingYugabyteServer
+        implements Closeable
+{
+    public static final Integer PORT = 9042;
+    public static final String SCHEMA = "tpch";
+
+    private final GenericContainer<?> dockerContainer;
+    private final CassandraSession session;
+
+    public TestingYugabyteServer()
+    {
+        this("yugabytedb/yugabyte:latest");
+    }
+
+    public TestingYugabyteServer(String dockerImageName)
+    {
+        dockerContainer = new GenericContainer<>(DockerImageName.parse(dockerImageName))
+                .withCommand("bin/yugabyted", "start", "--daemon=false")
+                .withStartupTimeout(Duration.ofMinutes(3))
+                .withExposedPorts(PORT);
+        dockerContainer.start();
+
+        Cluster.Builder clusterBuilder = Cluster.builder()
+                .withProtocolVersion(V3)
+                .withClusterName("TestCluster")
+                .addContactPointsWithPorts(ImmutableList.of(
+                        new InetSocketAddress(dockerContainer.getContainerIpAddress(), dockerContainer.getMappedPort(PORT))))
+                .withMaxSchemaAgreementWaitSeconds(30);
+
+        ReopeningCluster cluster = new ReopeningCluster(clusterBuilder::build, new io.airlift.units.Duration(Long.MAX_VALUE, DAYS));
+        session = new CassandraSession(
+                JsonCodec.listJsonCodec(ExtraColumnMetadata.class),
+                cluster,
+                new io.airlift.units.Duration(Long.MAX_VALUE, DAYS),
+                new io.airlift.units.Duration(1, MINUTES));
+    }
+
+    public CassandraSession getSession()
+    {
+        return requireNonNull(session, "session is null");
+    }
+
+    public String getHost()
+    {
+        return dockerContainer.getHost();
+    }
+
+    public int getPort()
+    {
+        return dockerContainer.getMappedPort(PORT);
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        dockerContainer.close();
+    }
+}

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/YugabyteQueryRunner.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/YugabyteQueryRunner.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.cassandra;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.log.Logger;
+import io.airlift.log.Logging;
+import io.trino.Session;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.DistributedQueryRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.airlift.testing.Closeables.closeAllSuppress;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public final class YugabyteQueryRunner
+{
+    private YugabyteQueryRunner() {}
+
+    private static final String TPCH_SCHEMA = "tpch";
+
+    public static DistributedQueryRunner createYugabyteQueryRunner(
+            TestingYugabyteServer server,
+            Map<String, String> extraProperties,
+            Map<String, String> connectorProperties)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(createSession())
+                .setExtraProperties(extraProperties)
+                .build();
+        try {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+
+            connectorProperties = new HashMap<>(ImmutableMap.copyOf(connectorProperties));
+            connectorProperties.putIfAbsent("cassandra.contact-points", server.getHost());
+            connectorProperties.putIfAbsent("cassandra.native-protocol-port", Integer.toString(server.getPort()));
+            connectorProperties.putIfAbsent("cassandra.allow-drop-table", "true");
+
+            queryRunner.installPlugin(new CassandraPlugin());
+            queryRunner.createCatalog("yugabyte", "cassandra", connectorProperties);
+
+            return queryRunner;
+        }
+        catch (Throwable e) {
+            closeAllSuppress(e, queryRunner, server);
+            throw e;
+        }
+    }
+
+    public static Session createSession()
+    {
+        return testSessionBuilder()
+                .setCatalog("yugabyte")
+                .setSchema(TPCH_SCHEMA)
+                .build();
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        Logging.initialize();
+
+        DistributedQueryRunner queryRunner = createYugabyteQueryRunner(
+                new TestingYugabyteServer(),
+                ImmutableMap.of("http-server.http.port", "8080"),
+                ImmutableMap.of("cassandra.session-refresh-interval", "30s"));
+
+        Logger log = Logger.get(YugabyteQueryRunner.class);
+        log.info("======== SERVER STARTED ========");
+        log.info("\n====\n%s\n====", queryRunner.getCoordinator().getBaseUrl());
+    }
+}


### PR DESCRIPTION
Fixes #4838

I considered extending BaseConnectorTest and BaseConnectorSmokeTest for Yugabyte tests at first, but there were some failures due to lack of `comment` table properties in Yugabyte. Cassandra connector uses `comment` to mange hidden columns. 

Also, excluded the logic to populate TPCH data in Yugabyte query runner because it was flaky, returning the wrong row number just after insert.

