### PR TITLE
Make CredentialPropertiesProvider generic

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/CredentialPropertiesProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/CredentialPropertiesProvider.java
@@ -20,7 +20,7 @@ import java.util.Map;
 /**
  * Extracts properties needed for authentication for a JDBC connection.
  */
-public interface CredentialPropertiesProvider
+public interface CredentialPropertiesProvider<K, V>
 {
-    Map<String, String> getCredentialProperties(ConnectorIdentity identity);
+    Map<K, V> getCredentialProperties(ConnectorIdentity identity);
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/DefaultCredentialPropertiesProvider.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/credential/DefaultCredentialPropertiesProvider.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import static java.util.Objects.requireNonNull;
 
 public class DefaultCredentialPropertiesProvider
-        implements CredentialPropertiesProvider
+        implements CredentialPropertiesProvider<String, String>
 {
     private final CredentialProvider provider;
 


### PR DESCRIPTION
Certain drivers require non-string key and value pair