### PR TITLE
Map unsupported types to VARCHAR in Druid connector

### DIFF
--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -135,6 +135,11 @@ public class DruidJdbcClient
     @Override
     public Optional<ColumnMapping> toColumnMapping(ConnectorSession session, Connection connection, JdbcTypeHandle typeHandle)
     {
+        Optional<ColumnMapping> mapping = getForcedMappingToVarchar(typeHandle);
+        if (mapping.isPresent()) {
+            return mapping;
+        }
+
         switch (typeHandle.getJdbcType()) {
             case Types.VARCHAR:
                 int columnSize = typeHandle.getRequiredColumnSize();


### PR DESCRIPTION
Fix https://github.com/trinodb/trino/issues/8886