### PR TITLE
Unwrap lazy blocks before expensive remote and local exchange operations

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSinkOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSinkOperator.java
@@ -149,8 +149,8 @@ public class LocalExchangeSinkOperator
     {
         requireNonNull(page, "page is null");
         page = pagePreprocessor.apply(page);
-        sink.addPage(page);
         operatorContext.recordOutput(page.getSizeInBytes(), page.getPositionCount());
+        sink.addPage(page);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PageChannelSelector.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PageChannelSelector.java
@@ -24,6 +24,9 @@ import static java.util.Objects.requireNonNull;
 public class PageChannelSelector
         implements Function<Page, Page>
 {
+    // No channels need to be remapped, only ensure that all page blocks are loaded
+    private static final Function<Page, Page> GET_LOADED_PAGE = Page::getLoadedPage;
+
     private final int[] channels;
 
     public PageChannelSelector(int... channels)
@@ -35,6 +38,12 @@ public class PageChannelSelector
     @Override
     public Page apply(Page page)
     {
-        return requireNonNull(page, "page is null").getColumns(channels);
+        // Ensure the channels that are emitted are fully loaded and in the correct order
+        return requireNonNull(page, "page is null").getLoadedPage(channels);
+    }
+
+    public static Function<Page, Page> identitySelection()
+    {
+        return GET_LOADED_PAGE;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PartitioningExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PartitioningExchanger.java
@@ -19,7 +19,6 @@ import io.trino.operator.PartitionFunction;
 import io.trino.operator.exchange.PageReference.PageReleasedListener;
 import io.trino.spi.Page;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -56,28 +55,37 @@ class PartitioningExchanger
     }
 
     @Override
-    public synchronized void accept(Page page)
+    public void accept(Page page)
     {
-        // reset the assignment lists
-        for (IntList partitionAssignment : partitionAssignments) {
-            partitionAssignment.clear();
-        }
+        partitionPage(page, partitionedPagePreparer.apply(page));
+    }
 
-        // assign each row to a partition
-        Page partitionPage = partitionedPagePreparer.apply(page);
+    private synchronized void partitionPage(Page page, Page partitionPage)
+    {
+        // assign each row to a partition. The assignments lists are all expected to cleared by the previous iterations
         for (int position = 0; position < partitionPage.getPositionCount(); position++) {
             int partition = partitionFunction.getPartition(partitionPage, position);
             partitionAssignments[partition].add(position);
         }
 
         // build a page for each partition
-        for (int partition = 0; partition < buffers.size(); partition++) {
+        for (int partition = 0; partition < partitionAssignments.length; partition++) {
             IntArrayList positions = partitionAssignments[partition];
-            if (!positions.isEmpty()) {
-                Page pageSplit = page.copyPositions(positions.elements(), 0, positions.size());
-                memoryManager.updateMemoryUsage(pageSplit.getRetainedSizeInBytes());
-                buffers.get(partition).accept(new PageReference(pageSplit, 1, onPageReleased));
+            int partitionSize = positions.size();
+            if (partitionSize == 0) {
+                continue;
             }
+            Page pageSplit;
+            if (partitionSize == page.getPositionCount()) {
+                pageSplit = page; // entire page will be sent to this partition, no copies necessary
+            }
+            else {
+                pageSplit = page.copyPositions(positions.elements(), 0, partitionSize);
+            }
+            // clear the assigned positions list for the next iteration to start empty
+            positions.clear();
+            memoryManager.updateMemoryUsage(pageSplit.getRetainedSizeInBytes());
+            buffers.get(partition).accept(new PageReference(pageSplit, 1, onPageReleased));
         }
     }
 


### PR DESCRIPTION
Comparable changes extracted from https://github.com/prestodb/presto/pull/16617

Ensures that pages are fully loaded and `LazyBlock` instances are unwrapped as part of the page pre-processing function passed to `LocalExchangeSinkOperator` and `OutputOperatorFactory` (used by most output operators) . This ensures that all columns that will be emitted as part of output operator (and therefore, can no longer potentially benefit from laziness) will incur that overhead on the producing operator, before they might be accessed inside of a synchronized critical section or inside of a relatively expensive inner loop like partitioning.

Also includes minor improvements to local `PartitioningExchanger` that avoids boxing and reduces work that occurs inside of the synchronized critical section.