### PR TITLE
Minor code cleanup around analyzer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/RelationType.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/RelationType.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkElementIndex;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
@@ -80,7 +79,6 @@ public class RelationType
      */
     public Field getFieldByIndex(int fieldIndex)
     {
-        checkElementIndex(fieldIndex, allFields.size(), "fieldIndex");
         return allFields.get(fieldIndex);
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -445,14 +445,14 @@ class QueryPlanner
                 outerContext);
     }
 
-    private boolean hasExpressionsToUnfold(List<SelectExpression> selectExpressions)
+    private static boolean hasExpressionsToUnfold(List<SelectExpression> selectExpressions)
     {
         return selectExpressions.stream()
                 .map(SelectExpression::getUnfoldedExpressions)
                 .anyMatch(Optional::isPresent);
     }
 
-    private List<Expression> outputExpressions(List<SelectExpression> selectExpressions)
+    private static List<Expression> outputExpressions(List<SelectExpression> selectExpressions)
     {
         ImmutableList.Builder<Expression> result = ImmutableList.builder();
         for (SelectExpression selectExpression : selectExpressions) {
@@ -570,7 +570,7 @@ class QueryPlanner
                 outputs);
     }
 
-    private Optional<PlanNodeId> getIdForLeftTableScan(PlanNode node)
+    private static Optional<PlanNodeId> getIdForLeftTableScan(PlanNode node)
     {
         if (node instanceof TableScanNode) {
             return Optional.of(node.getId());
@@ -835,7 +835,7 @@ class QueryPlanner
                 .collect(toImmutableList());
     }
 
-    private OrderingScheme translateOrderingScheme(List<SortItem> items, Function<Expression, Symbol> coercions)
+    private static OrderingScheme translateOrderingScheme(List<SortItem> items, Function<Expression, Symbol> coercions)
     {
         List<Symbol> coerced = items.stream()
                 .map(SortItem::getSortKey)
@@ -857,7 +857,7 @@ class QueryPlanner
         return new OrderingScheme(symbols.build(), orders);
     }
 
-    private List<Set<FieldId>> enumerateGroupingSets(GroupingSetAnalysis groupingSetAnalysis)
+    private static List<Set<FieldId>> enumerateGroupingSets(GroupingSetAnalysis groupingSetAnalysis)
     {
         List<List<Set<FieldId>>> partialSets = new ArrayList<>();
 
@@ -1066,7 +1066,7 @@ class QueryPlanner
         // Then, coerce the sortKey so that we can add / subtract the offset.
         // Note: for that we cannot rely on the usual mechanism of using the coerce() method. The coerce() method can only handle one coercion for a node,
         // while the sortKey node might require several different coercions, e.g. one for frame start and one for frame end.
-        Expression sortKey = Iterables.getOnlyElement(window.getOrderBy().get().getSortItems()).getSortKey();
+        Expression sortKey = Iterables.getOnlyElement(window.getOrderBy().orElseThrow().getSortItems()).getSortKey();
         Symbol sortKeyCoercedForFrameBoundCalculation = coercions.get(sortKey);
         Optional<Type> coercion = frameOffset.map(analysis::getSortKeyCoercionForFrameBoundCalculation);
         if (coercion.isPresent()) {
@@ -1213,7 +1213,7 @@ class QueryPlanner
         return new FrameOffsetPlanAndSymbol(subPlan, Optional.of(coercedOffsetSymbol));
     }
 
-    private Expression zeroOfType(Type type)
+    private static Expression zeroOfType(Type type)
     {
         if (isNumericType(type)) {
             return new Cast(new LongLiteral("0"), toSqlType(type));
@@ -1313,8 +1313,8 @@ class QueryPlanner
         WindowNode.Specification specification = planWindowSpecification(window.getPartitionBy(), window.getOrderBy(), coercions::get);
 
         // in window frame with pattern recognition, the frame extent is specified as `ROWS BETWEEN CURRENT ROW AND ... `
-        WindowFrame frame = window.getFrame().get();
-        FrameBound frameEnd = frame.getEnd().get();
+        WindowFrame frame = window.getFrame().orElseThrow();
+        FrameBound frameEnd = frame.getEnd().orElseThrow();
         WindowNode.Frame baseFrame = new WindowNode.Frame(
                 WindowFrame.Type.ROWS,
                 FrameBound.Type.CURRENT_ROW,
@@ -1351,7 +1351,7 @@ class QueryPlanner
                         ImmutableList.of(),
                         frame.getAfterMatchSkipTo(),
                         frame.getPatternSearchMode(),
-                        frame.getPattern().get(),
+                        frame.getPattern().orElseThrow(),
                         frame.getVariableDefinitions());
 
         // create pattern recognition node
@@ -1417,8 +1417,8 @@ class QueryPlanner
                     .addAll(getSortItemsFromOrderBy(window.getOrderBy()).stream()
                             .map(SortItem::getSortKey)
                             .iterator());
-            WindowFrame frame = window.getFrame().get();
-            Optional<Expression> endValue = frame.getEnd().get().getValue();
+            WindowFrame frame = window.getFrame().orElseThrow();
+            Optional<Expression> endValue = frame.getEnd().orElseThrow().getValue();
             endValue.ifPresent(inputsBuilder::add);
 
             List<Expression> inputs = inputsBuilder.build();
@@ -1462,8 +1462,8 @@ class QueryPlanner
         WindowNode.Specification specification = planWindowSpecification(window.getPartitionBy(), window.getOrderBy(), subPlan::translate);
 
         // in window frame with pattern recognition, the frame extent is specified as `ROWS BETWEEN CURRENT ROW AND ... `
-        WindowFrame frame = window.getFrame().get();
-        FrameBound frameEnd = frame.getEnd().get();
+        WindowFrame frame = window.getFrame().orElseThrow();
+        FrameBound frameEnd = frame.getEnd().orElseThrow();
         WindowNode.Frame baseFrame = new WindowNode.Frame(
                 WindowFrame.Type.ROWS,
                 FrameBound.Type.CURRENT_ROW,
@@ -1482,7 +1482,7 @@ class QueryPlanner
                         ImmutableList.of(analysis.getMeasureDefinition(windowMeasure)),
                         frame.getAfterMatchSkipTo(),
                         frame.getPatternSearchMode(),
-                        frame.getPattern().get(),
+                        frame.getPattern().orElseThrow(),
                         frame.getVariableDefinitions());
 
         Symbol measureSymbol = getOnlyElement(components.getMeasures().keySet());

--- a/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/RelationPlanner.java
@@ -287,7 +287,7 @@ class RelationPlanner
         for (int i = 0; i < plan.getDescriptor().getAllFieldCount(); i++) {
             Field field = plan.getDescriptor().getFieldByIndex(i);
 
-            for (Expression mask : columnMasks.getOrDefault(field.getName().get(), ImmutableList.of())) {
+            for (Expression mask : columnMasks.getOrDefault(field.getName().orElseThrow(), ImmutableList.of())) {
                 planBuilder = subqueryPlanner.handleSubqueries(planBuilder, mask, analysis.getSubqueries(mask));
 
                 Map<Symbol, Expression> assignments = new LinkedHashMap<>();
@@ -416,7 +416,7 @@ class RelationPlanner
         for (SubsetDefinition subsetDefinition : subsets) {
             IrLabel label = irLabel(subsetDefinition.getName());
             Set<IrLabel> elements = subsetDefinition.getIdentifiers().stream()
-                    .map(this::irLabel)
+                    .map(RelationPlanner::irLabel)
                     .collect(toImmutableSet());
             rewrittenSubsets.put(label, elements);
         }
@@ -453,19 +453,19 @@ class RelationPlanner
                 rewrittenSubsets.build(),
                 rewrittenMeasures.build(),
                 measureOutputs.build(),
-                skipTo.flatMap(SkipTo::getIdentifier).map(this::irLabel),
+                skipTo.flatMap(SkipTo::getIdentifier).map(RelationPlanner::irLabel),
                 skipTo.map(SkipTo::getPosition).orElse(PAST_LAST),
                 searchMode.map(mode -> mode.getMode() == INITIAL).orElse(TRUE),
                 rewrittenPattern,
                 rewrittenVariableDefinitions.build());
     }
 
-    private IrLabel irLabel(Identifier identifier)
+    private static IrLabel irLabel(Identifier identifier)
     {
         return new IrLabel(identifier.getCanonicalValue());
     }
 
-    private IrLabel irLabel(String label)
+    private static IrLabel irLabel(String label)
     {
         return new IrLabel(label);
     }
@@ -714,7 +714,7 @@ class RelationPlanner
             they will be removed by optimization passes.
         */
 
-        List<Identifier> joinColumns = ((JoinUsing) node.getCriteria().get()).getColumns();
+        List<Identifier> joinColumns = ((JoinUsing) node.getCriteria().orElseThrow()).getColumns();
 
         Analysis.JoinUsingAnalysis joinAnalysis = analysis.getJoinUsing(node);
 
@@ -807,7 +807,7 @@ class RelationPlanner
                 outerContext);
     }
 
-    private Optional<Unnest> getUnnest(Relation relation)
+    private static Optional<Unnest> getUnnest(Relation relation)
     {
         if (relation instanceof AliasedRelation) {
             return getUnnest(((AliasedRelation) relation).getRelation());
@@ -818,7 +818,7 @@ class RelationPlanner
         return Optional.empty();
     }
 
-    private Optional<Lateral> getLateral(Relation relation)
+    private static Optional<Lateral> getLateral(Relation relation)
     {
         if (relation instanceof AliasedRelation) {
             return getLateral(((AliasedRelation) relation).getRelation());
@@ -1103,7 +1103,7 @@ class RelationPlanner
                 Optional.empty());
     }
 
-    private static class SetOperationPlan
+    private static final class SetOperationPlan
     {
         private final List<PlanNode> sources;
         private final ListMultimap<Symbol, Symbol> symbolMapping;

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -70,7 +70,7 @@ public class MockConnectorFactory
 {
     private final Function<ConnectorSession, List<String>> listSchemaNames;
     private final BiFunction<ConnectorSession, String, List<SchemaTableName>> listTables;
-    Optional<BiFunction<ConnectorSession, SchemaTablePrefix, Stream<TableColumnsMetadata>>> streamTableColumns;
+    private final Optional<BiFunction<ConnectorSession, SchemaTablePrefix, Stream<TableColumnsMetadata>>> streamTableColumns;
     private final BiFunction<ConnectorSession, SchemaTablePrefix, Map<SchemaTableName, ConnectorViewDefinition>> getViews;
     private final BiFunction<ConnectorSession, SchemaTablePrefix, Map<SchemaTableName, ConnectorMaterializedViewDefinition>> getMaterializedViews;
     private final BiFunction<ConnectorSession, SchemaTableName, Boolean> delegateMaterializedViewRefreshToConnector;


### PR DESCRIPTION
Minor code cleanup around analyzer

- make fields private final where possible
- make inner classes static where possible
- use Optional.orElseThrow() instead of Optional.get() when called
  without checking the presence of the object
- remove redundant semicolons
- using method reference instead of lambda
