### PR TITLE
Allow mock connector to return data

### DIFF
--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorEntities.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorEntities.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.connector.ColumnMetadata;
+
+import java.util.List;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+
+public final class MockConnectorEntities
+{
+    private MockConnectorEntities() {}
+
+    public static final List<ColumnMetadata> TPCH_NATION_SCHEMA = ImmutableList.<ColumnMetadata>builder()
+            .add(new ColumnMetadata("nationkey", BIGINT))
+            .add(new ColumnMetadata("name", createUnboundedVarcharType()))
+            .add(new ColumnMetadata("regionkey", BIGINT))
+            .add(new ColumnMetadata("comment", createUnboundedVarcharType()))
+            .build();
+
+    public static final List<List<?>> TPCH_NATION_DATA = ImmutableList.<List<?>>builder()
+            .add(ImmutableList.of(0, "ALGERIA", 0, " haggle. carefully final deposits detect slyly agai"))
+            .add(ImmutableList.of(1, "ARGENTINA", 1, "al foxes promise slyly according to the regular accounts. bold requests alon"))
+            .add(ImmutableList.of(2, "BRAZIL", 1, "y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special "))
+            .add(ImmutableList.of(3, "CANADA", 1, "eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold"))
+            .add(ImmutableList.of(4, "EGYPT", 4, "y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d"))
+            .add(ImmutableList.of(5, "ETHIOPIA", 0, "ven packages wake quickly. regu"))
+            .add(ImmutableList.of(6, "FRANCE", 3, "refully final requests. regular, ironi"))
+            .add(ImmutableList.of(7, "GERMANY", 3, "l platelets. regular accounts x-ray: unusual, regular acco"))
+            .add(ImmutableList.of(8, "INDIA", 2, "ss excuses cajole slyly across the packages. deposits print aroun"))
+            .add(ImmutableList.of(9, "INDONESIA", 2, " slyly express asymptotes. regular deposits haggle slyly. carefully ironic hockey players sleep blithely. carefull"))
+            .add(ImmutableList.of(10, "IRAN", 4, "efully alongside of the slyly final dependencies. "))
+            .add(ImmutableList.of(11, "IRAQ", 4, "nic deposits boost atop the quickly final requests? quickly regula"))
+            .add(ImmutableList.of(12, "JAPAN", 2, "ously. final, express gifts cajole a"))
+            .add(ImmutableList.of(13, "JORDAN", 4, "ic deposits are blithely about the carefully regular pa"))
+            .add(ImmutableList.of(14, "KENYA", 0, " pending excuses haggle furiously deposits. pending, express pinto beans wake fluffily past t"))
+            .add(ImmutableList.of(15, "MOROCCO", 0, "rns. blithely bold courts among the closely regular packages use furiously bold platelets?"))
+            .add(ImmutableList.of(16, "MOZAMBIQUE", 0, "s. ironic, unusual asymptotes wake blithely r"))
+            .add(ImmutableList.of(17, "PERU", 1, "platelets. blithely pending dependencies use fluffily across the even pinto beans. carefully silent accoun"))
+            .add(ImmutableList.of(18, "CHINA", 2, "c dependencies. furiously express notornis sleep slyly regular accounts. ideas sleep. depos"))
+            .add(ImmutableList.of(19, "ROMANIA", 3, "ular asymptotes are about the furious multipliers. express dependencies nag above the ironically ironic account"))
+            .add(ImmutableList.of(20, "SAUDI ARABIA", 4, "ts. silent requests haggle. closely express packages sleep across the blithely"))
+            .add(ImmutableList.of(21, "VIETNAM", 2, "hely enticingly express accounts. even, final "))
+            .add(ImmutableList.of(22, "RUSSIA", 3, " requests against the platelets use never according to the quickly regular pint"))
+            .add(ImmutableList.of(23, "UNITED KINGDOM", 3, "eans boost carefully special requests. accounts are. carefull"))
+            .add(ImmutableList.of(24, "UNITED STATES", 1, "y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be"))
+            .build();
+}

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -90,6 +90,7 @@ public class MockConnectorFactory
     private final Supplier<Iterable<EventListener>> eventListeners;
     private final ListRoleGrants roleGrants;
     private final MockConnectorAccessControl accessControl;
+    private final Function<SchemaTableName, List<List<?>>> data;
 
     private MockConnectorFactory(
             Function<ConnectorSession, List<String>> listSchemaNames,
@@ -113,7 +114,7 @@ public class MockConnectorFactory
             BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties,
             Supplier<Iterable<EventListener>> eventListeners,
             ListRoleGrants roleGrants,
-            MockConnectorAccessControl accessControl)
+            MockConnectorAccessControl accessControl, Function<SchemaTableName, List<List<?>>> data)
     {
         this.listSchemaNames = requireNonNull(listSchemaNames, "listSchemaNames is null");
         this.listTables = requireNonNull(listTables, "listTables is null");
@@ -137,6 +138,7 @@ public class MockConnectorFactory
         this.eventListeners = requireNonNull(eventListeners, "eventListeners is null");
         this.roleGrants = requireNonNull(roleGrants, "roleGrants is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.data = requireNonNull(data, "data is null");
     }
 
     @Override
@@ -176,7 +178,8 @@ public class MockConnectorFactory
                 getTableProperties,
                 eventListeners,
                 roleGrants,
-                accessControl);
+                accessControl,
+                data);
     }
 
     public static Builder builder()
@@ -274,6 +277,7 @@ public class MockConnectorFactory
         private Function<SchemaTableName, ViewExpression> rowFilter = (tableName) -> null;
         private BiFunction<SchemaTableName, String, ViewExpression> columnMask = (tableName, columnName) -> null;
         private BiFunction<ConnectorSession, SchemaTableName, Optional<CatalogSchemaTableName>> redirectTable = (session, tableName) -> Optional.empty();
+        private Function<SchemaTableName, List<List<?>>> data = schemaTableName -> ImmutableList.of();
 
         public Builder withListSchemaNames(Function<ConnectorSession, List<String>> listSchemaNames)
         {
@@ -435,6 +439,12 @@ public class MockConnectorFactory
             return this;
         }
 
+        public Builder withData(Function<SchemaTableName, List<List<?>>> data)
+        {
+            this.data = requireNonNull(data, "data is null");
+            return this;
+        }
+
         public MockConnectorFactory build()
         {
             return new MockConnectorFactory(
@@ -459,7 +469,8 @@ public class MockConnectorFactory
                     getTableProperties,
                     eventListeners,
                     roleGrants,
-                    new MockConnectorAccessControl(schemaGrants, tableGrants, rowFilter, columnMask));
+                    new MockConnectorAccessControl(schemaGrants, tableGrants, rowFilter, columnMask),
+                    data);
         }
 
         public static Function<ConnectorSession, List<String>> defaultListSchemaNames()

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorHandleResolver.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorHandleResolver.java
@@ -13,10 +13,12 @@
  */
 package io.trino.connector;
 
+import io.trino.connector.MockConnector.MockConnectorSplit;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorHandleResolver;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
+import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 
@@ -39,6 +41,12 @@ public class MockConnectorHandleResolver
     public Class<? extends ColumnHandle> getColumnHandleClass()
     {
         return MockConnectorColumnHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorSplit> getSplitClass()
+    {
+        return MockConnectorSplit.class;
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorPageSource.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorPageSource.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.Page;
+import io.trino.spi.block.Block;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.UpdatablePageSource;
+import io.trino.spi.metrics.Metrics;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public class MockConnectorPageSource
+        implements UpdatablePageSource
+{
+    private final ConnectorPageSource delegate;
+
+    public MockConnectorPageSource(ConnectorPageSource delegate)
+    {
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return delegate.getCompletedBytes();
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return delegate.getCompletedPositions();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return delegate.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return delegate.isFinished();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        return delegate.getNextPage();
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return delegate.getSystemMemoryUsage();
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        delegate.close();
+    }
+
+    @Override
+    public CompletableFuture<?> isBlocked()
+    {
+        return delegate.isBlocked();
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        return delegate.getMetrics();
+    }
+
+    @Override
+    public void deleteRows(Block rowIds) {}
+
+    @Override
+    public void updateRows(Page page, List<Integer> columnValueAndRowIdChannels) {}
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        return completedFuture(Collections.emptyList());
+    }
+
+    @Override
+    public void abort()
+    {
+        UpdatablePageSource.super.abort();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/connector/TestMockConnectorPageSource.java
+++ b/core/trino-main/src/test/java/io/trino/connector/TestMockConnectorPageSource.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import io.trino.spi.connector.ConnectorPageSource;
+import org.testng.annotations.Test;
+
+import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
+
+public class TestMockConnectorPageSource
+{
+    @Test
+    public void testEverythingImplemented()
+    {
+        assertAllMethodsOverridden(ConnectorPageSource.class, MockConnectorPageSource.class);
+    }
+}

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
@@ -31,8 +31,11 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.trino.connector.MockConnectorEntities.TPCH_NATION_DATA;
+import static io.trino.connector.MockConnectorEntities.TPCH_NATION_SCHEMA;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestMockConnector
         extends AbstractTestQueryFramework
@@ -49,7 +52,12 @@ public class TestMockConnector
                 new MockConnectorPlugin(
                         MockConnectorFactory.builder()
                                 .withListSchemaNames(connectionSession -> ImmutableList.of("default"))
-                                .withGetColumns(schemaTableName -> ImmutableList.of(new ColumnMetadata("nationkey", BIGINT)))
+                                .withGetColumns(schemaTableName -> {
+                                    if (schemaTableName.equals(new SchemaTableName("default", "nation"))) {
+                                        return TPCH_NATION_SCHEMA;
+                                    }
+                                    return ImmutableList.of(new ColumnMetadata("nationkey", BIGINT));
+                                })
                                 .withGetTableHandle((session, tableName) -> new MockConnectorTableHandle(tableName))
                                 .withGetMaterializedViews((session, schemaTablePrefix) -> ImmutableMap.of(
                                         new SchemaTableName("default", "test_materialized_view"),
@@ -62,6 +70,12 @@ public class TestMockConnector
                                                 Optional.empty(),
                                                 "alice",
                                                 ImmutableMap.of())))
+                                .withData(schemaTableName -> {
+                                    if (schemaTableName.equals(new SchemaTableName("default", "nation"))) {
+                                        return TPCH_NATION_DATA;
+                                    }
+                                    throw new UnsupportedOperationException();
+                                })
                                 .build()));
         queryRunner.createCatalog("mock", "mock");
         return queryRunner;
@@ -101,5 +115,55 @@ public class TestMockConnector
     public void testDropMaterializedView()
     {
         assertUpdate("DROP MATERIALIZED VIEW mock.default.test_materialized_view");
+    }
+
+    @Test
+    public void testDataGeneration()
+    {
+        assertQuery(
+                "SELECT * FROM mock.default.nation",
+                "SELECT * FROM nation");
+        assertQuery(
+                "SELECT nationkey FROM mock.default.nation",
+                "SELECT nationkey FROM nation");
+        assertQuery(
+                "SELECT nationkey, regionkey FROM mock.default.nation",
+                "SELECT nationkey, regionkey FROM nation");
+        assertQuery(
+                "SELECT regionkey FROM mock.default.nation",
+                "SELECT regionkey FROM nation");
+    }
+
+    @Test
+    public void testInsert()
+    {
+        assertQuery("SELECT count(*) FROM mock.default.nation", "SELECT 25");
+        assertUpdate("INSERT INTO mock.default.nation VALUES (101, 'POLAND', 0, 'No comment')", 1);
+        // Mock connector only pretends support for INSERT, it does not manipulate any data
+        assertQuery("SELECT count(*) FROM mock.default.nation", "SELECT 25");
+    }
+
+    @Test
+    public void testDelete()
+    {
+        assertQuery("SELECT count(*) FROM mock.default.nation", "SELECT 25");
+        assertUpdate("DELETE FROM mock.default.nation", 25);
+        assertUpdate("DELETE FROM mock.default.nation WHERE nationkey = 1", 1);
+        assertUpdate("DELETE FROM mock.default.nation WHERE false", 0);
+        // Mock connector only pretends support for DELETE, it does not manipulate any data
+        assertQuery("SELECT count(*) FROM mock.default.nation", "SELECT 25");
+    }
+
+    @Test
+    public void testUpdate()
+    {
+        assertQuery("SELECT count(*) FROM mock.default.nation WHERE name = 'ALGERIA'", "SELECT 1");
+        assertUpdate("UPDATE mock.default.nation SET name = 'ALGERIA'", 25);
+        assertUpdate("UPDATE mock.default.nation SET name = 'ALGERIA' WHERE nationkey = 1", 1);
+        assertThatThrownBy(() -> assertUpdate("UPDATE mock.default.nation SET name = 'x' WHERE false", 0))
+                // TODO https://github.com/trinodb/trino/issues/8855 - UPDATE with WHERE false currently is not supported
+                .hasMessage("Invalid descendant for DeleteNode or UpdateNode: io.trino.sql.planner.plan.ExchangeNode");
+        // Mock connector only pretends support for UPDATE, it does not manipulate any data
+        assertQuery("SELECT count(*) FROM mock.default.nation WHERE name = 'ALGERIA'", "SELECT 1");
     }
 }


### PR DESCRIPTION
Allow mock connector to return data

Mock connector just pretends that it supports INSERT, DELETE and UPDATE.
It does not modify any data. Added tests for that.