### PR TITLE
Clarify SHOW STATS and where to expect NULL values

### DIFF
--- a/docs/src/main/sphinx/sql/show-stats.rst
+++ b/docs/src/main/sphinx/sql/show-stats.rst
@@ -13,18 +13,24 @@ Synopsis
 Description
 -----------
 
-Returns approximated statistics for the named table or for the results of a query.
+Returns approximated statistics for the named table or for the results of a
+query. Returns ``NULL`` for any statistics that are not populated or
+unavailable on the data source.
 
-Statistics are returned for each column, along with a summary row.
+Statistics are returned as a row for each column, plus a summary row for
+the table (identifiable by a ``NULL`` value for ``column_name``). The following
+table lists the returned columns and what statistics they represent. Any
+additional statistics collected on the data source, other than those listed
+here, are not included.
 
-==========================  =============================================================
-Column                      Description
-==========================  =============================================================
-``column_name``             The name of the column (``NULL`` for the summary row)
-``data_size``               The total size in bytes of all of the values in the column
-``distinct_values_count``   The number of distinct values in the column
-``nulls_fractions``         The portion of the values in the column that are ``NULL``
-``row_count``               The number of rows (only returned for the summary row)
-``low_value``               The lowest value found in this column (only for some types)
-``high_value``              The highest value found in this column (only for some types)
-==========================  =============================================================
+==========================  ============================================================= =================================
+Column                      Description                                                   Notes
+==========================  ============================================================= =================================
+``column_name``             The name of the column                                        ``NULL`` in the table summary row
+``data_size``               The total size in bytes of all of the values in the column    ``NULL`` in the table summary row. Available for columns of textual types (``CHAR``, ``VARCHAR``, etc)
+``distinct_values_count``   The estimated number of distinct values in the column m       ``NULL`` in the table summary row
+``nulls_fractions``         The portion of the values in the column that are ``NULL``     ``NULL`` in the table summary row.
+``row_count``               The estimated number of rows in the table                     ``NULL`` in column statistic rows
+``low_value``               The lowest value found in this column                         ``NULL`` in the table summary row. Available for columns of numeric types (``BIGINT``, ``DECIMAL``, etc)
+``high_value``              The highest value found in this column                        ``NULL`` in the table summary row. Available for columns of numeric types (``BIGINT``, ``DECIMAL``, etc)
+==========================  ============================================================= =================================


### PR DESCRIPTION
Update the SHOW STATS article to better describe describe when the statement may return NULL values. Including what statistics are accounted for in column vs. summary rows, and that additional statistics at the data source aren't included as part of the returned stats table.