### PR TITLE
Fix handling of timestamps in avro files created in hive 3.1

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/GenericHiveRecordCursor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/GenericHiveRecordCursor.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.RecordReader;
+import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -84,7 +85,6 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.joda.time.DateTimeZone.UTC;
 
 public class GenericHiveRecordCursor<K, V extends Writable>
         implements RecordCursor
@@ -124,7 +124,8 @@ public class GenericHiveRecordCursor<K, V extends Writable>
             RecordReader<K, V> recordReader,
             long totalBytes,
             Properties splitSchema,
-            List<HiveColumnHandle> columns)
+            List<HiveColumnHandle> columns,
+            DateTimeZone dateTimeZone)
     {
         requireNonNull(path, "path is null");
         requireNonNull(recordReader, "recordReader is null");
@@ -166,7 +167,7 @@ public class GenericHiveRecordCursor<K, V extends Writable>
             Type columnType = column.getType();
             types[i] = columnType;
             if (columnType instanceof TimestampType) {
-                timestampEncoders[i] = createTimestampEncoder((TimestampType) columnType, UTC);
+                timestampEncoders[i] = createTimestampEncoder((TimestampType) columnType, dateTimeZone);
             }
             hiveTypes[i] = column.getHiveType();
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/GenericHiveRecordCursorProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/GenericHiveRecordCursorProvider.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapreduce.lib.input.LineRecordReader;
+import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
 
@@ -71,7 +72,8 @@ public class GenericHiveRecordCursorProvider
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
             TypeManager typeManager,
-            boolean s3SelectPushdownEnabled)
+            boolean s3SelectPushdownEnabled,
+            DateTimeZone dateTimeZone)
     {
         configuration.setInt(LineRecordReader.MAX_LINE_LENGTH, textMaxLineLengthBytes);
 
@@ -107,7 +109,8 @@ public class GenericHiveRecordCursorProvider
                         genericRecordReader(recordReader),
                         length,
                         schema,
-                        readerColumns);
+                        readerColumns,
+                        dateTimeZone);
             }
             catch (Exception e) {
                 try {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConfig.java
@@ -40,6 +40,7 @@ import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.plugin.hive.HiveSessionProperties.InsertExistingPartitionsBehavior.APPEND;
 import static io.trino.plugin.hive.HiveSessionProperties.InsertExistingPartitionsBehavior.ERROR;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.joda.time.DateTimeZone.UTC;
 
 @DefunctConfig({
         "dfs.domain-socket-path",
@@ -99,6 +100,9 @@ public class HiveConfig
 
     private String parquetTimeZone = TimeZone.getDefault().getID();
     private boolean useParquetColumnNames = true;
+
+    //This is set to UTC by default to be backward compatible
+    private String avroTimeZone = UTC.getID();
 
     private String rcfileTimeZone = TimeZone.getDefault().getID();
     private boolean rcfileWriterValidate;
@@ -660,6 +664,25 @@ public class HiveConfig
     public HiveConfig setUseParquetColumnNames(boolean useParquetColumnNames)
     {
         this.useParquetColumnNames = useParquetColumnNames;
+        return this;
+    }
+
+    public DateTimeZone getAvroDateTimeZone()
+    {
+        return DateTimeZone.forID(avroTimeZone);
+    }
+
+    @NotNull
+    public String getAvroTimeZone()
+    {
+        return avroTimeZone;
+    }
+
+    @Config("hive.avro.time-zone")
+    @ConfigDescription("Time zone for Avro read and write")
+    public HiveConfig setAvroTimeZone(String avroTimeZone)
+    {
+        this.avroTimeZone = avroTimeZone;
         return this;
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
@@ -70,6 +70,7 @@ public class HivePageSinkProvider
     private final HiveWriterStats hiveWriterStats;
     private final long perTransactionMetastoreCacheMaximumSize;
     private final DateTimeZone parquetTimeZone;
+    private final DateTimeZone avroTimeZone;
 
     @Inject
     public HivePageSinkProvider(
@@ -105,6 +106,7 @@ public class HivePageSinkProvider
         this.hiveWriterStats = requireNonNull(hiveWriterStats, "hiveWriterStats is null");
         this.perTransactionMetastoreCacheMaximumSize = config.getPerTransactionMetastoreCacheMaximumSize();
         this.parquetTimeZone = config.getParquetDateTimeZone();
+        this.avroTimeZone = config.getAvroDateTimeZone();
     }
 
     @Override
@@ -156,6 +158,7 @@ public class HivePageSinkProvider
                 writerSortBufferSize,
                 maxOpenSortFiles,
                 parquetTimeZone,
+                avroTimeZone,
                 session,
                 nodeManager,
                 eventClient,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveRecordCursorProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveRecordCursorProvider.java
@@ -19,6 +19,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.TypeManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTimeZone;
 
 import java.util.List;
 import java.util.Optional;
@@ -39,7 +40,8 @@ public interface HiveRecordCursorProvider
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
             TypeManager typeManager,
-            boolean s3SelectPushdownEnabled);
+            boolean s3SelectPushdownEnabled,
+            DateTimeZone dateTimeZone);
 
     /**
      * A wrapper class for

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
@@ -145,6 +145,7 @@ public class HiveWriterFactory
     private final String sortedWritingTempStagingPath;
     private final InsertExistingPartitionsBehavior insertExistingPartitionsBehavior;
     private final DateTimeZone parquetTimeZone;
+    private final DateTimeZone avroTimeZone;
 
     private final ConnectorSession session;
     private final OptionalInt bucketCount;
@@ -178,6 +179,7 @@ public class HiveWriterFactory
             DataSize sortBufferSize,
             int maxOpenSortFiles,
             DateTimeZone parquetTimeZone,
+            DateTimeZone avroTimeZone,
             ConnectorSession session,
             NodeManager nodeManager,
             EventClient eventClient,
@@ -207,6 +209,7 @@ public class HiveWriterFactory
         this.sortedWritingTempStagingPath = getTemporaryStagingDirectoryPath(session);
         this.insertExistingPartitionsBehavior = getInsertExistingPartitionsBehavior(session);
         this.parquetTimeZone = requireNonNull(parquetTimeZone, "parquetTimeZone is null");
+        this.avroTimeZone = requireNonNull(avroTimeZone, "avroTimeZone is null");
 
         // divide input columns into partition and data columns
         requireNonNull(inputColumns, "inputColumns is null");
@@ -491,6 +494,7 @@ public class HiveWriterFactory
                     conf,
                     typeManager,
                     parquetTimeZone,
+                    avroTimeZone,
                     session);
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RecordFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RecordFileWriter.java
@@ -15,6 +15,7 @@ package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
+import io.trino.plugin.hive.avro.AvroRecordWriter;
 import io.trino.plugin.hive.metastore.StorageFormat;
 import io.trino.plugin.hive.parquet.ParquetRecordWriter;
 import io.trino.plugin.hive.util.FieldSetterFactory;
@@ -86,6 +87,7 @@ public class RecordFileWriter
             JobConf conf,
             TypeManager typeManager,
             DateTimeZone parquetTimeZone,
+            DateTimeZone avroTimeZone,
             ConnectorSession session)
     {
         this.path = requireNonNull(path, "path is null");
@@ -120,7 +122,13 @@ public class RecordFileWriter
 
         row = tableInspector.create();
 
-        DateTimeZone timeZone = (recordWriter instanceof ParquetRecordWriter) ? parquetTimeZone : DateTimeZone.UTC;
+        DateTimeZone timeZone = DateTimeZone.UTC;
+        if (recordWriter instanceof ParquetRecordWriter) {
+            timeZone = parquetTimeZone;
+        }
+        else if (recordWriter instanceof AvroRecordWriter) {
+            timeZone = avroTimeZone;
+        }
         FieldSetterFactory fieldSetterFactory = new FieldSetterFactory(timeZone);
 
         setters = new FieldSetter[structFields.size()];

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectRecordCursor.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectRecordCursor.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapred.RecordReader;
+import org.joda.time.DateTimeZone;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,9 +51,10 @@ class S3SelectRecordCursor<K, V extends Writable>
             RecordReader<K, V> recordReader,
             long totalBytes,
             Properties splitSchema,
-            List<HiveColumnHandle> columns)
+            List<HiveColumnHandle> columns,
+            DateTimeZone dateTimeZone)
     {
-        super(configuration, path, recordReader, totalBytes, updateSplitSchema(splitSchema, columns), columns);
+        super(configuration, path, recordReader, totalBytes, updateSplitSchema(splitSchema, columns), columns, dateTimeZone);
     }
 
     // since s3select only returns the required column, not the whole columns

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectRecordCursorProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3select/S3SelectRecordCursorProvider.java
@@ -26,6 +26,7 @@ import io.trino.spi.type.TypeManager;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
+import org.joda.time.DateTimeZone;
 
 import javax.inject.Inject;
 
@@ -67,7 +68,8 @@ public class S3SelectRecordCursorProvider
             List<HiveColumnHandle> columns,
             TupleDomain<HiveColumnHandle> effectivePredicate,
             TypeManager typeManager,
-            boolean s3SelectPushdownEnabled)
+            boolean s3SelectPushdownEnabled,
+            DateTimeZone dateTimeZone)
     {
         if (!s3SelectPushdownEnabled) {
             return Optional.empty();
@@ -95,7 +97,7 @@ public class S3SelectRecordCursorProvider
             String ionSqlQuery = queryBuilder.buildSql(readerColumns, effectivePredicate);
             S3SelectLineRecordReader recordReader = new S3SelectCsvRecordReader(configuration, path, start, length, schema, ionSqlQuery, s3ClientFactory);
 
-            RecordCursor cursor = new S3SelectRecordCursor<>(configuration, path, recordReader, length, schema, readerColumns);
+            RecordCursor cursor = new S3SelectRecordCursor<>(configuration, path, recordReader, length, schema, readerColumns, dateTimeZone);
             return Optional.of(new ReaderRecordCursorWithProjections(cursor, projectedReaderColumns));
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConfig.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.DataSize.Unit;
 import io.airlift.units.Duration;
+import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -73,6 +74,7 @@ public class TestHiveConfig
                 .setOrcLegacyTimeZone(TimeZone.getDefault().getID())
                 .setParquetTimeZone(TimeZone.getDefault().getID())
                 .setUseParquetColumnNames(true)
+                .setAvroTimeZone(DateTimeZone.UTC.getID())
                 .setRcfileTimeZone(TimeZone.getDefault().getID())
                 .setRcfileWriterValidate(false)
                 .setSkipDeletionForAlter(false)
@@ -143,6 +145,7 @@ public class TestHiveConfig
                 .put("hive.orc.time-zone", nonDefaultTimeZone().getID())
                 .put("hive.parquet.time-zone", nonDefaultTimeZone().getID())
                 .put("hive.parquet.use-column-names", "false")
+                .put("hive.avro.time-zone", nonDefaultTimeZone().getID())
                 .put("hive.rcfile.time-zone", nonDefaultTimeZone().getID())
                 .put("hive.rcfile.writer.validate", "true")
                 .put("hive.skip-deletion-for-alter", "true")
@@ -212,6 +215,7 @@ public class TestHiveConfig
                 .setOrcLegacyTimeZone(nonDefaultTimeZone().getID())
                 .setParquetTimeZone(nonDefaultTimeZone().getID())
                 .setUseParquetColumnNames(false)
+                .setAvroTimeZone(nonDefaultTimeZone().getID())
                 .setRcfileTimeZone(nonDefaultTimeZone().getID())
                 .setRcfileWriterValidate(true)
                 .setSkipDeletionForAlter(true)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -945,7 +945,8 @@ public class TestHiveFileFormats
                 false,
                 Optional.empty(),
                 false,
-                NO_ACID_TRANSACTION);
+                NO_ACID_TRANSACTION,
+                UTC);
 
         return pageSource.get();
     }
@@ -1015,7 +1016,8 @@ public class TestHiveFileFormats
                 false,
                 Optional.empty(),
                 false,
-                NO_ACID_TRANSACTION);
+                NO_ACID_TRANSACTION,
+                UTC);
 
         assertTrue(pageSource.isPresent());
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestOrcPageSourceMemoryTracking.java
@@ -574,7 +574,8 @@ public class TestOrcPageSourceMemoryTracking
                     false,
                     Optional.empty(),
                     false,
-                    NO_ACID_TRANSACTION)
+                    NO_ACID_TRANSACTION,
+                    UTC)
                     .orElseThrow();
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/avro/TestHiveAvroTable.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/avro/TestHiveAvroTable.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.avro;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.HiveQueryRunner;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static io.trino.tpch.TpchTable.NATION;
+
+public class TestHiveAvroTable
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.builder()
+                .setHiveProperties(ImmutableMap.of("hive.avro.time-zone", "Asia/Kamchatka"))
+                .setInitialTables(ImmutableList.of(NATION))
+                .build();
+    }
+
+    @Test
+    public void testWritingAndReadingTimestampFromAvroTable()
+    {
+        assertUpdate("CREATE TABLE test_avro (id BIGINT, ts TIMESTAMP) WITH (format = 'AVRO')");
+        String timestamp = "2020-05-11T11:15:05";
+        assertUpdate("INSERT INTO test_avro VALUES(1, from_iso8601_timestamp('" + timestamp + "'))", 1);
+        assertQuery("SELECT ts FROM test_avro WHERE id = 1", "VALUES('" + timestamp + "')");
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/AbstractFileFormat.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/AbstractFileFormat.java
@@ -64,6 +64,7 @@ import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.FILE_
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_COLUMNS;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_COLUMN_TYPES;
 import static org.apache.hadoop.hive.serde.serdeConstants.SERIALIZATION_LIB;
+import static org.joda.time.DateTimeZone.UTC;
 
 public abstract class AbstractFileFormat
         implements FileFormat
@@ -192,7 +193,8 @@ public abstract class AbstractFileFormat
                 readColumns,
                 TupleDomain.all(),
                 TYPE_MANAGER,
-                false);
+                false,
+                UTC);
 
         checkState(recordCursorWithProjections.isPresent(), "readerPageSourceWithProjections is not present");
         checkState(recordCursorWithProjections.get().getProjectedReaderColumns().isEmpty(), "projection should not be required");

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
@@ -417,6 +417,7 @@ public final class StandardFileFormats
                     config,
                     TYPE_MANAGER,
                     UTC,
+                    UTC,
                     session);
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/orc/TestOrcPredicates.java
@@ -227,7 +227,8 @@ public class TestOrcPredicates
                 false,
                 Optional.empty(),
                 false,
-                NO_ACID_TRANSACTION);
+                NO_ACID_TRANSACTION,
+                UTC);
 
         assertTrue(pageSource.isPresent());
         return pageSource.get();

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard/presto-init-hdp3.sh
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/standard/presto-init-hdp3.sh
@@ -6,5 +6,6 @@ for hive_properties in $(find '/docker/presto-product-tests/conf/presto/etc/cata
     echo "Updating $hive_properties for HDP3"
     # Add file format time zone properties
     echo "hive.parquet.time-zone=UTC" >> "${hive_properties}"
+    echo "hive.avro.time-zone=UTC" >> "${hive_properties}"
     echo "hive.rcfile.time-zone=UTC" >> "${hive_properties}"
 done

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroFileHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroFileHiveTable.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+import io.trino.tempto.ProductTest;
+import org.testng.annotations.Test;
+
+import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tests.product.utils.QueryExecutors.onHive;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+
+public class TestAvroFileHiveTable
+        extends ProductTest
+{
+    @Test
+    public void testWritingAndReadingAvroTableWithTimestampColumn()
+    {
+        onHive().executeQuery("DROP TABLE IF EXISTS test_avro_table");
+        onTrino().executeQuery("CREATE TABLE test_avro_table (id BIGINT, ts TIMESTAMP) WITH (format = 'AVRO')");
+        onHive().executeQuery("INSERT INTO test_avro_table VALUES(1, '2020-01-01 12:34:56.123')");
+        assertThat(onHive().executeQuery("SELECT CAST(ts as VARCHAR(100)) FROM test_avro_table")).containsOnly(row("2020-01-01 12:34:56.123"));
+        assertThat(onTrino().executeQuery("SELECT CAST(ts as VARCHAR(100)) FROM test_avro_table")).containsOnly(row("2020-01-01 12:34:56.123"));
+    }
+}


### PR DESCRIPTION
https://github.com/trinodb/trino/issues/5144
Previously timestamps from avro were always read with UTC timezone.
Now this timezone is extracted to configuration and can be set per catalog.