### PR TITLE
Generate temporary directory name in HDFS

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -142,6 +142,7 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -295,7 +296,6 @@ import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.Files.createTempDirectory;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -652,7 +652,7 @@ public abstract class AbstractTestHive
         executor = newCachedThreadPool(daemonThreadsNamed("hive-%s"));
         heartbeatService = newScheduledThreadPool(1);
         // Use separate staging directory for each test class to prevent intermittent failures coming from test parallelism
-        temporaryStagingDirectory = createTempDirectory("trino-staging-");
+        temporaryStagingDirectory = Paths.get("/tmp/" + UUID.randomUUID());
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
temporaryStagingDirectory is a directory in the HDFS so using locally generated tmp directory path
is incorrect on MacOS (as java.io.tmpdir points to /var/folders/ss/.../T which doesn't exist on HDFS).