### PR TITLE
Propagate exception when reading metadata fails

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/HiveTableOperations.java
@@ -298,7 +298,6 @@ public class HiveTableOperations
         Tasks.foreach(newLocation)
                 .retry(20)
                 .exponentialBackoff(100, 5000, 600000, 4.0)
-                .suppressFailureWhenFinished()
                 .run(metadataLocation -> newMetadata.set(
                         TableMetadataParser.read(this, io().newInputFile(metadataLocation))));
 


### PR DESCRIPTION
`.suppressFailureWhenFinished()` causes the `run` method return `false`
on failure, instead of throwing. This behavior was not desirable here,
leading to NPE when trying to access the result.

For https://github.com/trinodb/trino/issues/8873 