### PR TITLE
Improve MarkDistinctHash

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/MarkDistinctHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MarkDistinctHash.java
@@ -17,7 +17,8 @@ import com.google.common.annotations.VisibleForTesting;
 import io.trino.Session;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
-import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.RunLengthEncodedBlock;
+import io.trino.spi.type.BooleanType;
 import io.trino.spi.type.Type;
 import io.trino.sql.gen.JoinCompiler;
 import io.trino.type.BlockTypeOperators;
@@ -25,9 +26,9 @@ import io.trino.type.BlockTypeOperators;
 import java.util.List;
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkState;
 import static io.trino.SystemSessionProperties.isDictionaryAggregationEnabled;
 import static io.trino.operator.GroupByHash.createGroupByHash;
-import static io.trino.spi.type.BooleanType.BOOLEAN;
 
 public class MarkDistinctHash
 {
@@ -51,26 +52,41 @@ public class MarkDistinctHash
 
     public Work<Block> markDistinctRows(Page page)
     {
-        return new TransformWork<>(
-                groupByHash.getGroupIds(page),
-                ids -> {
-                    BlockBuilder blockBuilder = BOOLEAN.createBlockBuilder(null, ids.getPositionCount());
-                    for (int i = 0; i < ids.getPositionCount(); i++) {
-                        if (ids.getGroupId(i) == nextDistinctId) {
-                            BOOLEAN.writeBoolean(blockBuilder, true);
-                            nextDistinctId++;
-                        }
-                        else {
-                            BOOLEAN.writeBoolean(blockBuilder, false);
-                        }
-                    }
-                    return blockBuilder.build();
-                });
+        return new TransformWork<>(groupByHash.getGroupIds(page), this::processNextGroupIds);
     }
 
     @VisibleForTesting
     public int getCapacity()
     {
         return groupByHash.getCapacity();
+    }
+
+    private Block processNextGroupIds(GroupByIdBlock ids)
+    {
+        int positions = ids.getPositionCount();
+        if (positions > 1) {
+            // must have > 1 positions to benefit from using a RunLengthEncoded block
+            if (nextDistinctId == ids.getGroupCount()) {
+                // no new distinct positions
+                return new RunLengthEncodedBlock(BooleanType.createBlockForSingleNonNullValue(false), positions);
+            }
+            if (nextDistinctId + positions == ids.getGroupCount()) {
+                // all positions are distinct
+                nextDistinctId = ids.getGroupCount();
+                return new RunLengthEncodedBlock(BooleanType.createBlockForSingleNonNullValue(true), positions);
+            }
+        }
+        byte[] distinctMask = new byte[positions];
+        for (int position = 0; position < distinctMask.length; position++) {
+            if (ids.getGroupId(position) == nextDistinctId) {
+                distinctMask[position] = 1;
+                nextDistinctId++;
+            }
+            else {
+                distinctMask[position] = 0;
+            }
+        }
+        checkState(nextDistinctId == ids.getGroupCount());
+        return BooleanType.wrapByteArrayAsBooleanBlockWithoutNulls(distinctMask);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestBooleanType.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestBooleanType.java
@@ -15,8 +15,14 @@ package io.trino.type;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.ByteArrayBlock;
+import io.trino.spi.type.BooleanType;
+import org.testng.annotations.Test;
 
+import static io.trino.block.BlockAssertions.assertBlockEquals;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestBooleanType
         extends AbstractTestType
@@ -24,6 +30,39 @@ public class TestBooleanType
     public TestBooleanType()
     {
         super(BOOLEAN, Boolean.class, createTestBlock());
+    }
+
+    @Test
+    public void testBooleanBlockWithoutNullsFromByteArray()
+    {
+        byte[] booleanBytes = new byte[4];
+        BlockBuilder builder = BOOLEAN.createFixedSizeBlockBuilder(booleanBytes.length);
+        for (int i = 0; i < booleanBytes.length; i++) {
+            boolean value = i % 2 == 0;
+            booleanBytes[i] = value ? (byte) 1 : 0;
+            BOOLEAN.writeBoolean(builder, value);
+        }
+        Block wrappedBlock = BooleanType.wrapByteArrayAsBooleanBlockWithoutNulls(booleanBytes);
+        Block builderBlock = builder.build();
+        // wrapped instances have no nulls
+        assertFalse(wrappedBlock.mayHaveNull());
+        // wrapped byte array instances and builder based instances both produce ByteArrayBlock
+        assertTrue(wrappedBlock instanceof ByteArrayBlock);
+        assertTrue(builderBlock instanceof ByteArrayBlock);
+        assertBlockEquals(BOOLEAN, wrappedBlock, builderBlock);
+        // the wrapping instance does not copy the byte array defensively
+        assertTrue(BOOLEAN.getBoolean(wrappedBlock, 0));
+        booleanBytes[0] = 0;
+        assertFalse(BOOLEAN.getBoolean(wrappedBlock, 0));
+    }
+
+    @Test
+    public void testBooleanBlockWithSingleNonNullValue()
+    {
+        assertTrue(BooleanType.createBlockForSingleNonNullValue(true) instanceof ByteArrayBlock);
+        assertTrue(BOOLEAN.getBoolean(BooleanType.createBlockForSingleNonNullValue(true), 0));
+        assertFalse(BOOLEAN.getBoolean(BooleanType.createBlockForSingleNonNullValue(false), 0));
+        assertFalse(BooleanType.createBlockForSingleNonNullValue(false).mayHaveNull());
     }
 
     public static Block createTestBlock()

--- a/core/trino-spi/src/main/java/io/trino/spi/type/BooleanType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/BooleanType.java
@@ -17,10 +17,13 @@ import io.airlift.slice.XxHash64;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.block.BlockBuilderStatus;
+import io.trino.spi.block.ByteArrayBlock;
 import io.trino.spi.block.ByteArrayBlockBuilder;
 import io.trino.spi.block.PageBuilderStatus;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.function.ScalarOperator;
+
+import java.util.Optional;
 
 import static io.trino.spi.function.OperatorType.COMPARISON;
 import static io.trino.spi.function.OperatorType.EQUAL;
@@ -40,6 +43,23 @@ public final class BooleanType
     private static final long FALSE_XX_HASH = XxHash64.hash(0);
 
     public static final BooleanType BOOLEAN = new BooleanType();
+
+    /**
+     * This method signifies a contract to callers that as an optimization, they can encode BooleanType blocks as a byte[] directly
+     * and potentially bypass the BlockBuilder / BooleanType abstraction in the name of efficiency. If in the future BooleanType
+     * encoding changes such that {@link ByteArrayBlock} is not always a valid or efficient representation, then this method must be
+     * removed and any usages changed
+     */
+    public static Block wrapByteArrayAsBooleanBlockWithoutNulls(byte[] booleansAsBytes)
+    {
+        return new ByteArrayBlock(booleansAsBytes.length, Optional.empty(), booleansAsBytes);
+    }
+
+    public static Block createBlockForSingleNonNullValue(boolean value)
+    {
+        byte byteValue = value ? (byte) 1 : 0;
+        return new ByteArrayBlock(1, Optional.empty(), new byte[]{byteValue});
+    }
 
     private BooleanType()
     {


### PR DESCRIPTION
Improves performance of MarkDistinctHash (and therefore, MarkDistinctOperator) by:
- Detecting when no positions or all positions of the input are distinct and emitting a RunLengthEncoded block for the output mask (so long as the input position count is > 1).
- Building `BooleanType` mask blocks directly from `byte[]` instead of via a `BlockBuilder`, reducing allocation overhead per built mask by 1/2 since we know in advance no nulls will be present in the created block