### PR TITLE
Add SQL support section to Memory connector

### DIFF
--- a/docs/src/main/sphinx/connector/memory.rst
+++ b/docs/src/main/sphinx/connector/memory.rst
@@ -56,11 +56,33 @@ For the Memory connector, a table scan is delayed until the collection of dynami
 This can be disabled by using the configuration property ``memory.enable-lazy-dynamic-filtering``
 in the catalog file.
 
+.. _memory-sql-support:
+
+SQL support
+-----------
+
+The connector provides read and write access to temporary data and metadata
+stored in memory. In addition to the :ref:`globally available
+<sql-globally-available>` and :ref:`read operation <sql-read-operations>`
+statements, the connector supports the following features:
+
+* :ref:`sql-data-management`
+* :doc:`/sql/create-table`
+* :doc:`/sql/create-table-as`
+* :doc:`/sql/drop-table`
+* :doc:`/sql/create-schema`
+* :doc:`/sql/drop-schema`
+
+DROP TABLE
+^^^^^^^^^^
+
+Upon execution of a ``DROP TABLE`` operation, memory is not released
+immediately. It is instead released after the next write operation to the
+connector.
+
 Limitations
 -----------
 
-* After ``DROP TABLE`` memory is not released immediately. It is
-  released after the next write access to memory connector.
 * When one worker fails/restarts, all data that was stored in its
   memory is lost. To prevent silent data loss the
   connector throws an error on any read access to such


### PR DESCRIPTION
Create a standard SQL support section in the Memory connector doc, including moving a SQL statement behavior limitation out as a sub section.