### PR TITLE
Fix side effect in decimal addition operator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DecimalOperators.java
@@ -131,7 +131,8 @@ public final class DecimalOperators
             Slice right;
 
             if (rescaleLeft) {
-                left = rescale(a, rescale);
+                left = unscaledDecimal();
+                rescale(a, rescale, left);
                 right = unscaledDecimal(b);
             }
             else {

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalOperators.java
@@ -13,6 +13,7 @@
  */
 package io.trino.type;
 
+import io.airlift.slice.Slice;
 import io.trino.operator.scalar.AbstractTestFunctions;
 import org.testng.annotations.Test;
 
@@ -21,6 +22,9 @@ import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.OperatorType.INDETERMINATE;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
+import static io.trino.type.DecimalOperators.addShortLongLong;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestDecimalOperators
         extends AbstractTestFunctions
@@ -848,5 +852,19 @@ public class TestDecimalOperators
         assertOperator(INDETERMINATE, "DECIMAL '18'", BOOLEAN, false);
         assertOperator(INDETERMINATE, "DECIMAL '9.0'", BOOLEAN, false);
         assertOperator(INDETERMINATE, "DECIMAL '12345678901234567.89012345678901234567'", BOOLEAN, false);
+    }
+
+    @Test
+    public void testArgumentsNotModified()
+    {
+        Slice value = unscaledDecimal(2);
+
+        addShortLongLong(1, value, 0, false);
+        assertThat(value.getBytes())
+                .isEqualTo(unscaledDecimal(2).getBytes());
+
+        addShortLongLong(1, value, 0, false);
+        assertThat(value.getBytes())
+                .isEqualTo(unscaledDecimal(2).getBytes());
     }
 }


### PR DESCRIPTION
`addLongShortLong` performs an in-place addition that mutates the value of
the Slice associated with `left`. This is based on the assumption that
`rescale` always returns a new Slice, which would avoid modifications
to the input arguments to the operator. However, when the rescale factor
is 0, rescale just returns its input argument.

Fixes https://github.com/trinodb/trino/issues/8968