### PR TITLE
Improve LookupJoin Performance

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinProbe.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinProbe.java
@@ -13,11 +13,13 @@
  */
 package io.trino.operator.join;
 
+import com.google.common.primitives.Ints;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
-import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.google.common.base.Verify.verify;
@@ -28,43 +30,40 @@ public class JoinProbe
     public static class JoinProbeFactory
     {
         private final int[] probeOutputChannels;
-        private final List<Integer> probeJoinChannels;
-        private final OptionalInt probeHashChannel;
+        private final int[] probeJoinChannels;
+        private final int probeHashChannel; // only valid when >= 0
 
         public JoinProbeFactory(int[] probeOutputChannels, List<Integer> probeJoinChannels, OptionalInt probeHashChannel)
         {
             this.probeOutputChannels = probeOutputChannels;
-            this.probeJoinChannels = probeJoinChannels;
-            this.probeHashChannel = probeHashChannel;
+            this.probeJoinChannels = Ints.toArray(probeJoinChannels);
+            this.probeHashChannel = probeHashChannel.orElse(-1);
         }
 
         public JoinProbe createJoinProbe(Page page)
         {
-            return new JoinProbe(probeOutputChannels, page, probeJoinChannels, probeHashChannel);
+            Page probePage = page.getLoadedPage(probeJoinChannels);
+            return new JoinProbe(probeOutputChannels, page, probePage, probeHashChannel >= 0 ? page.getBlock(probeHashChannel).getLoadedBlock() : null);
         }
     }
 
     private final int[] probeOutputChannels;
     private final int positionCount;
-    private final Block[] probeBlocks;
     private final Page page;
     private final Page probePage;
-    private final Optional<Block> probeHashBlock;
-
+    @Nullable
+    private final Block probeHashBlock;
+    private final boolean probeMayHaveNull;
     private int position = -1;
 
-    private JoinProbe(int[] probeOutputChannels, Page page, List<Integer> probeJoinChannels, OptionalInt probeHashChannel)
+    private JoinProbe(int[] probeOutputChannels, Page page, Page probePage, @Nullable Block probeHashBlock)
     {
         this.probeOutputChannels = probeOutputChannels;
         this.positionCount = page.getPositionCount();
-        this.probeBlocks = new Block[probeJoinChannels.size()];
-
-        for (int i = 0; i < probeJoinChannels.size(); i++) {
-            probeBlocks[i] = page.getBlock(probeJoinChannels.get(i)).getLoadedBlock();
-        }
         this.page = page;
-        this.probePage = new Page(page.getPositionCount(), probeBlocks);
-        this.probeHashBlock = probeHashChannel.isPresent() ? Optional.of(page.getBlock(probeHashChannel.getAsInt()).getLoadedBlock()) : Optional.empty();
+        this.probePage = probePage;
+        this.probeHashBlock = probeHashBlock;
+        this.probeMayHaveNull = probeMayHaveNull(probePage);
     }
 
     public int[] getOutputChannels()
@@ -74,8 +73,7 @@ public class JoinProbe
 
     public boolean advanceNextPosition()
     {
-        verify(position < positionCount, "already finished");
-        position++;
+        verify(++position <= positionCount, "already finished");
         return !isFinished();
     }
 
@@ -86,11 +84,11 @@ public class JoinProbe
 
     public long getCurrentJoinPosition(LookupSource lookupSource)
     {
-        if (currentRowContainsNull()) {
+        if (probeMayHaveNull && currentRowContainsNull()) {
             return -1;
         }
-        if (probeHashBlock.isPresent()) {
-            long rawHash = BIGINT.getLong(probeHashBlock.get(), position);
+        if (probeHashBlock != null) {
+            long rawHash = BIGINT.getLong(probeHashBlock, position);
             return lookupSource.getJoinPosition(position, probePage, page, rawHash);
         }
         return lookupSource.getJoinPosition(position, probePage, page);
@@ -108,8 +106,18 @@ public class JoinProbe
 
     private boolean currentRowContainsNull()
     {
-        for (Block probeBlock : probeBlocks) {
-            if (probeBlock.isNull(position)) {
+        for (int i = 0; i < probePage.getChannelCount(); i++) {
+            if (probePage.getBlock(i).isNull(position)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean probeMayHaveNull(Page probePage)
+    {
+        for (int i = 0; i < probePage.getChannelCount(); i++) {
+            if (probePage.getBlock(i).mayHaveNull()) {
                 return true;
             }
         }

--- a/core/trino-spi/src/main/java/io/trino/spi/PageBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/PageBuilder.java
@@ -93,7 +93,7 @@ public class PageBuilder
 
         declaredPositions = 0;
 
-        for (int i = 0; i < types.size(); i++) {
+        for (int i = 0; i < blockBuilders.length; i++) {
             blockBuilders[i] = blockBuilders[i].newBlockBuilderLike(pageBuilderStatus.createBlockBuilderStatus());
         }
     }


### PR DESCRIPTION
Improves lookup join performance via changes in `LookupJoinPageBuilder` and `JoinProbe`.

Improves `JoinProbe` by:
- Avoiding boxing the hash channel Block, preferring a `@Nullable` field instead
- Avoiding boxing of the `probeJoinChannels` and probeHashChannel arguments in `JoinProbeFactory`
- Using the `Page#getLoadedPage(int...channels)` helper directly to avoid an intermediate Block[] copy
- Leveraging `Block#mayHaveNull()` to bypass `Block#isNull()` checks on the probe page blocks

Improves LookupJoinPageBuilder by:
- Storing the previous join probe position directly to avoid repeating `probeIndexBuilder.getInt(probeIndexBuilder.size() - 1)` calls
- Unswitching the `LookupJoinPageBuilder#build(JoinProbe)` loop so that sequential probe position joins can bypass copying the probeIndexBuilder contents into a new int[] when it won't be used
- Bypassing `buildPageBuilder.build()` in favor of using each individual `BlockBuilder#build()`. This avoids an unnecessary intermediate page creation that is quickly discarded

Benchmarks for [BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/4433598a243df755ba13138e67c7005d/raw/ae11a47d63e71c0cd5f4a71a4422b4202b000320/baseline_join.json,https://gist.githubusercontent.com/pettyjamesm/4433598a243df755ba13138e67c7005d/raw/ae11a47d63e71c0cd5f4a71a4422b4202b000320/improved_join.json) improve by 0-10% depending on the scenario.

