### PR TITLE
Fix system.jdbc.column queries with uppercase filters

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMetadataManager.java
@@ -189,6 +189,23 @@ public class TestMetadataManager
                 .isEmpty();
     }
 
+    @Test
+    public void testColumnsQueryWithUpperCaseFilter()
+    {
+        // TODO (https://github.com/trinodb/trino/issues/17) this should return no rows
+        assertThat(queryRunner.execute("SELECT * FROM system.jdbc.columns WHERE table_schem = 'upper_case_schema' AND table_name = 'upper_case_table'"))
+                .hasSize(100);
+        // TODO (https://github.com/trinodb/trino/issues/17) this should return 100 rows
+        assertThat(queryRunner.execute("SELECT * FROM system.jdbc.columns WHERE table_schem = 'UPPER_CASE_SCHEMA'"))
+                .isEmpty();
+        // TODO (https://github.com/trinodb/trino/issues/17) this should return 100 rows
+        assertThat(queryRunner.execute("SELECT * FROM system.jdbc.columns WHERE table_name = 'UPPER_CASE_TABLE'"))
+                .isEmpty();
+        // TODO (https://github.com/trinodb/trino/issues/17) this should return 100 rows
+        assertThat(queryRunner.execute("SELECT * FROM system.jdbc.columns WHERE table_schem = 'UPPER_CASE_TABLE' AND table_name = 'UPPER_CASE_TABLE'"))
+                .isEmpty();
+    }
+
     private static ConnectorViewDefinition getConnectorViewDefinition()
     {
         return new ConnectorViewDefinition(


### PR DESCRIPTION
Queries on system.jdbc.columns with filter on  table_name containing uppercase characters fails 

```
trino:jdbc> select * from columns where table_name like 'Abcd';
Query 20210825_142926_00019_5qsmu failed: tableName is not lowercase: Abcd
```

stack trace fragment:
```
java.lang.IllegalArgumentException: tableName is not lowercase: SelectPartnerAbletoTourRate8B1
at com.google.common.base.Preconditions.checkArgument(Preconditions.java:443)
at io.trino.metadata.MetadataUtil.checkLowerCase(MetadataUtil.java:89)
at io.trino.metadata.MetadataUtil.checkTableName(MetadataUtil.java:74)
at io.trino.metadata.QualifiedTablePrefix.<init>(QualifiedTablePrefix.java:55)
at io.trino.connector.system.jdbc.FilterUtil.tablePrefix(FilterUtil.java:45)
at io.trino.connector.system.jdbc.ColumnJdbcTable.cursor(ColumnJdbcTable.java:256)
at io.trino.connector.system.SystemPageSourceProvider$1.cursor(SystemPageSourceProvider.java:129)
at io.trino.split.MappedRecordSet.cursor(MappedRecordSet.java:53)
at io.trino.spi.connector.RecordPageSource.<init>(RecordPageSource.java:37)
at io.trino.connector.system.SystemPageSourceProvider.createPageSource(SystemPageSourceProvider.java:108)
```

This PR fixes this in similar way to the system.jdbc.tables and adds tests for such cases. 
