### PR TITLE
Mark TestMemoryConnectorTest.testCustomMetricsScanFilter as flaky

### DIFF
--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -151,6 +151,8 @@ public class TestMemoryConnectorTest
     }
 
     @Test
+    // TODO (https://github.com/trinodb/trino/issues/8691) fix the test
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/8691", match = "ComparisonFailure: expected:<LongCount\\{total=\\[\\d+]}> but was:<LongCount\\{total=\\[\\d+]}>")
     public void testCustomMetricsScanFilter()
     {
         Metrics metrics = collectCustomMetrics("SELECT partkey FROM part WHERE partkey % 1000 > 0");


### PR DESCRIPTION
for https://github.com/trinodb/trino/issues/8691 