### PR TITLE
Check if Kerberos config exists and is readable

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/auth/kerberos/LoginBasedSubjectProvider.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/kerberos/LoginBasedSubjectProvider.java
@@ -61,6 +61,11 @@ public class LoginBasedSubjectProvider
                     "Refusing to set system property 'java.security.krb5.conf' to '%s', it is already set to '%s'",
                     newValue,
                     currentValue);
+            checkState(
+                    file.exists() && !file.isDirectory(),
+                    "Kerberos config file '%s' does not exist or is a directory",
+                    newValue);
+            checkState(file.canRead(), "Kerberos config file '%s' is not readable", newValue);
             System.setProperty("java.security.krb5.conf", newValue);
         });
     }


### PR DESCRIPTION
If a user provides an invalid Kerberos config file, its value is saved in the `java.security.krb5.conf` system property and cannot be changed, unless the application using the JDBC driver restarts.

Closes #8952 