### PR TITLE
Treat table as unbucketed if bucketed on unsupported data type

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketing.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveBucketing.java
@@ -37,6 +37,7 @@ import io.trino.spi.predicate.NullableValue;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.predicate.ValueSet;
 import io.trino.spi.type.TypeManager;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
@@ -64,7 +65,6 @@ import static java.lang.String.format;
 import static java.util.Map.Entry;
 import static java.util.function.Function.identity;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_BUCKETING_VERSION;
-import static org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory.TIMESTAMP;
 
 public final class HiveBucketing
 {
@@ -191,6 +191,10 @@ public final class HiveBucketing
             return Optional.empty();
         }
 
+        if (!isSupportedBucketing(table)) {
+            return Optional.empty();
+        }
+
         HiveTimestampPrecision timestampPrecision = getTimestampPrecision(session);
         Map<String, HiveColumnHandle> map = getRegularColumnHandles(table, typeManager, timestampPrecision).stream()
                 .collect(Collectors.toMap(HiveColumnHandle::getName, identity()));
@@ -222,9 +226,6 @@ public final class HiveBucketing
         List<Column> dataColumns = hiveTable.getDataColumns().stream()
                 .map(HiveColumnHandle::toMetastoreColumn)
                 .collect(toImmutableList());
-        if (bucketedOnTimestamp(hiveBucketProperty, dataColumns, hiveTable.getTableName())) {
-            return Optional.empty();
-        }
 
         Optional<Map<ColumnHandle, List<NullableValue>>> bindings = TupleDomain.extractDiscreteValues(effectivePredicate);
         if (bindings.isEmpty()) {
@@ -319,36 +320,57 @@ public final class HiveBucketing
         }
     }
 
-    public static boolean bucketedOnTimestamp(HiveBucketProperty bucketProperty, Table table)
+    public static boolean isSupportedBucketing(Table table)
     {
-        return bucketedOnTimestamp(bucketProperty, table.getDataColumns(), table.getTableName());
+        return isSupportedBucketing(table.getStorage().getBucketProperty().orElseThrow(), table.getDataColumns(), table.getTableName());
     }
 
-    public static boolean bucketedOnTimestamp(HiveBucketProperty bucketProperty, List<Column> dataColumns, String tableName)
+    public static boolean isSupportedBucketing(HiveBucketProperty bucketProperty, List<Column> dataColumns, String tableName)
     {
         return bucketProperty.getBucketedBy().stream()
                 .map(columnName -> dataColumns.stream().filter(column -> column.getName().equals(columnName)).findFirst()
                         .orElseThrow(() -> new IllegalArgumentException(format("Cannot find column '%s' in %s", columnName, tableName))))
                 .map(Column::getType)
                 .map(HiveType::getTypeInfo)
-                .anyMatch(HiveBucketing::bucketedOnTimestamp);
+                .allMatch(HiveBucketing::isTypeSupportedForBucketing);
     }
 
-    private static boolean bucketedOnTimestamp(TypeInfo type)
+    private static boolean isTypeSupportedForBucketing(TypeInfo type)
     {
         switch (type.getCategory()) {
             case PRIMITIVE:
-                return ((PrimitiveTypeInfo) type).getPrimitiveCategory() == TIMESTAMP;
+                PrimitiveTypeInfo typeInfo = (PrimitiveTypeInfo) type;
+                PrimitiveObjectInspector.PrimitiveCategory primitiveCategory = typeInfo.getPrimitiveCategory();
+                switch (primitiveCategory) {
+                    case BOOLEAN:
+                    case BYTE:
+                    case SHORT:
+                    case INT:
+                    case LONG:
+                    case FLOAT:
+                    case DOUBLE:
+                    case STRING:
+                    case VARCHAR:
+                    case DATE:
+                        return true;
+                    case BINARY:
+                    case TIMESTAMP:
+                    case DECIMAL:
+                    case CHAR:
+                        return false;
+                    default:
+                        throw new UnsupportedOperationException("Unknown type " + type);
+                }
             case LIST:
-                return bucketedOnTimestamp(((ListTypeInfo) type).getListElementTypeInfo());
+                return isTypeSupportedForBucketing(((ListTypeInfo) type).getListElementTypeInfo());
             case MAP:
                 MapTypeInfo mapTypeInfo = (MapTypeInfo) type;
-                return bucketedOnTimestamp(mapTypeInfo.getMapKeyTypeInfo()) ||
-                        bucketedOnTimestamp(mapTypeInfo.getMapValueTypeInfo());
-            default:
-                // TODO: support more types, e.g. ROW
-                throw new UnsupportedOperationException("Computation of Hive bucket hashCode is not supported for Hive category: " + type.getCategory());
+                return isTypeSupportedForBucketing(mapTypeInfo.getMapKeyTypeInfo()) && isTypeSupportedForBucketing(mapTypeInfo.getMapValueTypeInfo());
+            case STRUCT:
+            case UNION:
+                return false;
         }
+        throw new UnsupportedOperationException("Unknown type " + type);
     }
 
     public static class HiveBucketFilter

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -131,7 +131,7 @@ import static io.trino.plugin.hive.metastore.SortingColumn.Order.ASCENDING;
 import static io.trino.plugin.hive.metastore.SortingColumn.Order.DESCENDING;
 import static io.trino.plugin.hive.util.ConfigurationUtils.copy;
 import static io.trino.plugin.hive.util.ConfigurationUtils.toJobConf;
-import static io.trino.plugin.hive.util.HiveBucketing.bucketedOnTimestamp;
+import static io.trino.plugin.hive.util.HiveBucketing.isSupportedBucketing;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -845,7 +845,7 @@ public final class HiveUtil
         // add hidden columns
         columns.add(pathColumnHandle());
         if (table.getStorage().getBucketProperty().isPresent()) {
-            if (!bucketedOnTimestamp(table.getStorage().getBucketProperty().get(), table)) {
+            if (isSupportedBucketing(table)) {
                 columns.add(bucketColumnHandle());
             }
         }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBucketedTables.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBucketedTables.java
@@ -39,6 +39,9 @@ import static io.trino.tempto.query.QueryExecutor.param;
 import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.BIG_QUERY;
 import static io.trino.tests.product.TpchTableResults.PRESTO_NATION_RESULT;
+import static io.trino.tests.product.hive.BucketingType.BUCKETED_DEFAULT;
+import static io.trino.tests.product.hive.BucketingType.BUCKETED_V1;
+import static io.trino.tests.product.hive.BucketingType.BUCKETED_V2;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static io.trino.tests.product.utils.TableDefinitionUtils.mutableTableInstanceOf;
@@ -289,13 +292,13 @@ public class TestHiveBucketedTables
         List<String> bucketV1NameOptions = ImmutableList.of(bucketV1);
         List<String> bucketV2NameOptions = ImmutableList.of(bucketV2Standard, bucketV2DirectInsert);
 
-        testBucketingVersion(BucketingType.BUCKETED_DEFAULT, value, false, (getHiveVersionMajor() < 3) ? bucketV1NameOptions : bucketV2NameOptions);
-        testBucketingVersion(BucketingType.BUCKETED_DEFAULT, value, true, (getHiveVersionMajor() < 3) ? bucketV1NameOptions : bucketV2NameOptions);
-        testBucketingVersion(BucketingType.BUCKETED_V1, value, false, bucketV1NameOptions);
-        testBucketingVersion(BucketingType.BUCKETED_V1, value, true, bucketV1NameOptions);
+        testBucketingVersion(BUCKETED_DEFAULT, value, false, (getHiveVersionMajor() < 3) ? bucketV1NameOptions : bucketV2NameOptions);
+        testBucketingVersion(BUCKETED_DEFAULT, value, true, (getHiveVersionMajor() < 3) ? bucketV1NameOptions : bucketV2NameOptions);
+        testBucketingVersion(BUCKETED_V1, value, false, bucketV1NameOptions);
+        testBucketingVersion(BUCKETED_V1, value, true, bucketV1NameOptions);
         if (getHiveVersionMajor() >= 3) {
-            testBucketingVersion(BucketingType.BUCKETED_V2, value, false, bucketV2NameOptions);
-            testBucketingVersion(BucketingType.BUCKETED_V2, value, true, bucketV2NameOptions);
+            testBucketingVersion(BUCKETED_V2, value, false, bucketV2NameOptions);
+            testBucketingVersion(BUCKETED_V2, value, true, bucketV2NameOptions);
         }
     }
 


### PR DESCRIPTION
This would unblock reads for table which are bucketed by columns having unsupported datatype.  