### PR TITLE
Use Kerberos ticket cache if keytab is not provided

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/auth/kerberos/LoginBasedSubjectProvider.java
+++ b/client/trino-client/src/main/java/io/trino/client/auth/kerberos/LoginBasedSubjectProvider.java
@@ -95,9 +95,12 @@ public class LoginBasedSubjectProvider
 
                 credentialCache.ifPresent(file -> {
                     options.put("ticketCache", file.getAbsolutePath());
-                    options.put("useTicketCache", "true");
                     options.put("renewTGT", "true");
                 });
+
+                if (!keytab.isPresent() || credentialCache.isPresent()) {
+                    options.put("useTicketCache", "true");
+                }
 
                 principal.ifPresent(value -> options.put("principal", value));
 


### PR DESCRIPTION
On Windows, when using the native libs for GSSAPI (enforce by ` -Dsun.security.jgss.native=true`), there's no way to specify the cache location. But it should be possible not to specify the keytab and rely on the cache to be populated by the OS.

I tested this manually by running `java "-Dtrino.client.debugKerberos=true" "-Djavax.security.auth.useSubjectCredsOnly=false" "-Dsun.security.jgss.native=true" "-Dsun.security.krb5.debug=true" -jar .\trino-cli-361-SNAPSHOT-executable.jar --
server https://x:8443 --insecure --krb5-config-path=C:\Windows\krb5.ini --krb5-principal=y --krb5-remote-service-name=z --user y --debug --network-logging=BODY --execute 'show catalogs'` which produces (cut and anonimized):

```
...
>>> KrbCreds found the default ticket granting ticket in credential cache.
>>> Obtained TGT from LSA: Credentials:
      client=y
      server=krbtgt/REALM@REALM
    authTime=20210826085446Z
   startTime=20210826085446Z
     endTime=20210826185446Z
   renewTill=null
       flags=FORWARDABLE;INITIAL;PRE-AUTHENT
EType (skey)=18
   (tkt key)=18
Principal is y
Commit Succeeded
...
```

This also should be valid, according to https://docs.oracle.com/javase/8/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/Krb5LoginModule.html