### PR TITLE
Fix incorrect result about BigQuery TIME type

### DIFF
--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -248,6 +248,27 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-main</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-spi</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-testing</artifactId>
             <scope>test</scope>
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryResultPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryResultPageSource.java
@@ -64,6 +64,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
+import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -171,7 +172,7 @@ public class BigQueryResultPageSource
                     type.writeLong(output, toTrinoTimestamp(((Utf8) value).toString()));
                 }
                 else if (type.equals(TIME_WITH_TIME_ZONE)) {
-                    type.writeLong(output, DateTimeEncoding.packDateTimeWithZone(((Long) value).longValue() / 1000, TimeZoneKey.UTC_KEY));
+                    type.writeLong(output, DateTimeEncoding.packTimeWithTimeZone(((Long) value).longValue() * MICROSECONDS_PER_MILLISECOND, 0));
                 }
                 else if (type.equals(TIMESTAMP_TZ_MILLIS)) {
                     type.writeLong(output, DateTimeEncoding.packDateTimeWithZone(((Long) value).longValue() / 1000, TimeZoneKey.UTC_KEY));

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
@@ -384,6 +384,25 @@ public class TestBigQueryIntegrationSmokeTest
                         ")");
     }
 
+    @Test
+    public void testTimeType()
+    {
+        String tableName = "test.test_time_type";
+
+        onBigQuery("DROP TABLE IF EXISTS " + tableName);
+        onBigQuery("CREATE TABLE " + tableName + " (a TIME)");
+        onBigQuery("INSERT INTO " + tableName + " VALUES ('01:02:03.123'), ('23:59:59.999')");
+
+        assertThat(query("SELECT a FROM " + tableName))
+                .containsAll("VALUES (TIME '01:02:03.123+00:00'), (TIME '23:59:59.999+00:00')");
+        assertThat(query("SELECT a FROM " + tableName + " WHERE a = TIME '01:02:03.123+00:00'"))
+                .containsAll("VALUES (TIME '01:02:03.123+00:00')");
+        assertThat(query("SELECT a FROM " + tableName + " WHERE rand() = 42 OR a = TIME '01:02:03.123+00:00'"))
+                .containsAll("VALUES (TIME '01:02:03.123+00:00')");
+
+        onBigQuery("DROP TABLE " + tableName);
+    }
+
     private void onBigQuery(String sql)
     {
         bigQuerySqlExecutor.execute(sql);

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryType.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryType.java
@@ -28,7 +28,7 @@ public class TestBigQueryType
     {
         assertThat(BigQueryType.timeToStringConverter(
                 Long.valueOf(303497217825L)))
-                .isEqualTo("'12:34:56'");
+                .isEqualTo("'16:00:00.148'");
     }
 
     @Test


### PR DESCRIPTION
Before this change:

BigQuery
```sql
DROP TABLE IF EXISTS test.test_time;
CREATE TABLE test.test_time (c1 time);
INSERT INTO test.test_time VALUES ('01:02:03');

SELECT * FROM test.test_time;
-- 01:02:03
```

Trino
```sql
trino> SELECT * FROM bigquery.test.test_time;
         c1         
--------------------
 00:00:00.007+00:00
```

We should add all type mapping tests later. 