### PR TITLE
fix Stage state transitionToRunning on schedulingComplete()

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlStageExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlStageExecution.java
@@ -252,9 +252,6 @@ public final class SqlStageExecution
             return;
         }
 
-        if (getAllTasks().stream().anyMatch(task -> getState() == StageState.RUNNING)) {
-            stateMachine.transitionToRunning();
-        }
         if (isFlushing()) {
             stateMachine.transitionToFlushing();
         }


### PR DESCRIPTION
fix Stage state transitionToRunning on schedulingComplete(), origin is dead code.

It would be possible to make Stage transition to RUNNING on schedulingComplete(), 
which maybe earlier than StageTaskListener#stateChanged()