### PR TITLE
Fix query failure of predicate pushdown to BigQuery DATETIME type

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
@@ -39,6 +39,7 @@ import io.trino.spi.type.Type;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
 
+import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -51,6 +52,7 @@ import java.util.Map;
 
 import static com.google.cloud.bigquery.Field.Mode.REPEATED;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.math.LongMath.divide;
 import static io.trino.plugin.bigquery.BigQueryMetadata.NUMERIC_DATA_TYPE_PRECISION;
 import static io.trino.plugin.bigquery.BigQueryMetadata.NUMERIC_DATA_TYPE_SCALE;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -62,7 +64,6 @@ import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.lang.Integer.parseInt;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
-import static java.time.ZoneOffset.systemDefault;
 import static java.util.stream.Collectors.toList;
 
 public enum BigQueryType
@@ -147,7 +148,7 @@ public enum BigQueryType
 
     static String datetimeToStringConverter(Object value)
     {
-        return formatTimestamp(((Long) value).longValue(), systemDefault());
+        return formatTimestamp(divide(((long) value), MICROSECONDS_PER_MILLISECOND, RoundingMode.UNNECESSARY), UTC);
     }
 
     static String timeToStringConverter(Object value)


### PR DESCRIPTION
The query having filter on BigQuery `DATETIME` type caused below error before this change:
```
trino> select * from bigquery.test.test_datetime where col = cast('0001-01-01 00:00:00.999' as timestamp(3));
Query 20210827_070648_00014_u3ikv failed: 
io.grpc.StatusRuntimeException: INVALID_ARGUMENT: request failed: 
Row filter for xxx.test.test_datetime is invalid. Filter is '(`col` = '+1967030-04-28 09:35:38.000')'
...
```

- [x] Run all BigQuery tests locally (passed)