### PR TITLE
Add column positional mode to InterpretedHashGenerator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/MergeHashSort.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MergeHashSort.java
@@ -52,7 +52,7 @@ public class MergeHashSort
      */
     public WorkProcessor<Page> merge(List<Type> keyTypes, List<Type> allTypes, List<WorkProcessor<Page>> channels, DriverYieldSignal driverYieldSignal)
     {
-        InterpretedHashGenerator hashGenerator = createHashGenerator(keyTypes);
+        InterpretedHashGenerator hashGenerator = InterpretedHashGenerator.createPositionalWithTypes(keyTypes, blockTypeOperators);
         return mergeSortedPages(
                 channels,
                 createHashPageWithPositionComparator(hashGenerator),
@@ -88,14 +88,5 @@ public class MergeHashSort
 
             return Long.compare(leftHash, rightHash);
         };
-    }
-
-    private InterpretedHashGenerator createHashGenerator(List<Type> keyTypes)
-    {
-        int[] hashChannels = new int[keyTypes.size()];
-        for (int i = 0; i < keyTypes.size(); i++) {
-            hashChannels[i] = i;
-        }
-        return new InterpretedHashGenerator(keyTypes, hashChannels, blockTypeOperators);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/join/PartitionedLookupSource.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/PartitionedLookupSource.java
@@ -96,11 +96,7 @@ public class PartitionedLookupSource
 
         // this generator is only used for getJoinPosition without a rawHash and in this case
         // the hash channels are always packed in a page without extra columns
-        int[] hashChannels = new int[hashChannelTypes.size()];
-        for (int i = 0; i < hashChannels.length; i++) {
-            hashChannels[i] = i;
-        }
-        this.partitionGenerator = new LocalPartitionGenerator(new InterpretedHashGenerator(hashChannelTypes, hashChannels, blockTypeOperators), lookupSources.size());
+        this.partitionGenerator = new LocalPartitionGenerator(InterpretedHashGenerator.createPositionalWithTypes(hashChannelTypes, blockTypeOperators), lookupSources.size());
 
         this.partitionMask = lookupSources.size() - 1;
         this.shiftSize = numberOfTrailingZeros(lookupSources.size()) + 1;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SystemPartitioningHandle.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SystemPartitioningHandle.java
@@ -186,12 +186,8 @@ public final class SystemPartitioningHandle
                 if (isHashPrecomputed) {
                     return new HashBucketFunction(new PrecomputedHashGenerator(0), bucketCount);
                 }
-                int[] hashChannels = new int[partitionChannelTypes.size()];
-                for (int i = 0; i < partitionChannelTypes.size(); i++) {
-                    hashChannels[i] = i;
-                }
 
-                return new HashBucketFunction(new InterpretedHashGenerator(partitionChannelTypes, hashChannels, blockTypeOperators), bucketCount);
+                return new HashBucketFunction(InterpretedHashGenerator.createPositionalWithTypes(partitionChannelTypes, blockTypeOperators), bucketCount);
             }
         },
         ROUND_ROBIN {

--- a/core/trino-main/src/test/java/io/trino/type/TypeTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/type/TypeTestUtils.java
@@ -36,11 +36,7 @@ public final class TypeTestUtils
     public static Block getHashBlock(List<? extends Type> hashTypes, Block... hashBlocks)
     {
         checkArgument(hashTypes.size() == hashBlocks.length);
-        int[] hashChannels = new int[hashBlocks.length];
-        for (int i = 0; i < hashBlocks.length; i++) {
-            hashChannels[i] = i;
-        }
-        HashGenerator hashGenerator = new InterpretedHashGenerator(ImmutableList.copyOf(hashTypes), hashChannels, TYPE_OPERATOR_FACTORY);
+        HashGenerator hashGenerator = InterpretedHashGenerator.createPositionalWithTypes(ImmutableList.copyOf(hashTypes), TYPE_OPERATOR_FACTORY);
         int positionCount = hashBlocks[0].getPositionCount();
         BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(positionCount);
         Page page = new Page(hashBlocks);


### PR DESCRIPTION
Adds support for creating `InterpretedHashGenerator` instances that read blocks out of the input page sequentially starting from `0`. This allows a couple benefits:
- This is a very common idiom as evidenced by the usage sites changed. Those places no longer need to manufacture a redundant channels array.
- The JIT can identify and specialize code for when the block accesses are sequential, which is more predictable in terms of access patterns than the `int[]` indirection form.

Also changed in this PR:
- Removed per invocation lambda creation in `InterpretedHashGenerator#hashPosition(int position, Page page)` in favor of slight duplication
- Switched from using `List<BlockPositionHashCode>` to `BlockPositionHashCode[]` to avoid an extra indirection

Benchmarks: [jmh.morethan.io](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/5b5313e06b9126d274efa9b9b0dea65c/raw/6237ea7b089e646f27bb6d12709a33251f2c1e43/baseline_hash_v3.json,https://gist.githubusercontent.com/pettyjamesm/5b5313e06b9126d274efa9b9b0dea65c/raw/6237ea7b089e646f27bb6d12709a33251f2c1e43/improved_hash_v3.json)