### PR TITLE
Update airbase to 112

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/LuhnCheckFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/LuhnCheckFunction.java
@@ -29,7 +29,7 @@ public final class LuhnCheckFunction
     @Description("Checks that a string of digits is valid according to the Luhn algorithm")
     @ScalarFunction("luhn_check")
     @SqlType(StandardTypes.BOOLEAN)
-    public static boolean LuhnCheck(@SqlType(StandardTypes.VARCHAR) Slice slice)
+    public static boolean luhnCheck(@SqlType(StandardTypes.VARCHAR) Slice slice)
     {
         if (slice.length() == 0) {
             return false;

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -1186,7 +1186,7 @@ public final class MathFunctions
     @Description("Constant representing not-a-number")
     @ScalarFunction("nan")
     @SqlType(StandardTypes.DOUBLE)
-    public static double NaN()
+    public static double nan()
     {
         return Double.NaN;
     }

--- a/core/trino-main/src/test/java/io/trino/metadata/TestInternalBlockEncodingSerde.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestInternalBlockEncodingSerde.java
@@ -38,7 +38,7 @@ public class TestInternalBlockEncodingSerde
     private final BlockEncodingSerde blockEncodingSerde = new InternalBlockEncodingSerde(blockEncodings::get, testingTypeManager::getType);
 
     @Test
-    public void BlockRoundTrip()
+    public void blockRoundTrip()
     {
         BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 2);
         VARCHAR.writeSlice(blockBuilder, Slices.utf8Slice("hello"));

--- a/core/trino-server-main/pom.xml
+++ b/core/trino-server-main/pom.xml
@@ -29,5 +29,11 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/trino-server-main/src/test/java/io/trino/server/TestDummy.java
+++ b/core/trino-server-main/src/test/java/io/trino/server/TestDummy.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import org.testng.annotations.Test;
+
+public class TestDummy
+{
+    @Test
+    public void buildRequiresTestToExist() {}
+}

--- a/plugin/trino-accumulo-iterators/pom.xml
+++ b/plugin/trino-accumulo-iterators/pom.xml
@@ -43,5 +43,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/plugin/trino-accumulo-iterators/src/test/java/io/trino/server/TestDummy.java
+++ b/plugin/trino-accumulo-iterators/src/test/java/io/trino/server/TestDummy.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import org.testng.annotations.Test;
+
+public class TestDummy
+{
+    @Test
+    public void buildRequiresTestToExist() {}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>110</version>
+        <version>112</version>
     </parent>
 
     <groupId>io.trino</groupId>

--- a/testing/trino-product-tests/src/test/java/io/trino/server/TestDummy.java
+++ b/testing/trino-product-tests/src/test/java/io/trino/server/TestDummy.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import org.testng.annotations.Test;
+
+public class TestDummy
+{
+    @Test
+    public void buildRequiresTestToExist() {}
+}

--- a/testing/trino-testing-kafka/pom.xml
+++ b/testing/trino-testing-kafka/pom.xml
@@ -62,5 +62,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/testing/trino-testing-kafka/src/test/java/io/trino/server/TestDummy.java
+++ b/testing/trino-testing-kafka/src/test/java/io/trino/server/TestDummy.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server;
+
+import org.testng.annotations.Test;
+
+public class TestDummy
+{
+    @Test
+    public void buildRequiresTestToExist() {}
+}


### PR DESCRIPTION
Update airbase to 112

Code style changes:
- method names must now match pattern '^[a-z][a-zA-Z0-9_]*$'

Do not run tests for modules without tests:
 - trino-server-main
 - trino-accumulo-iterators
 - trino-testing-kafka
 - trino-product-tests