### PR TITLE
Fix connection URL example and link to Oracle docs

### DIFF
--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -25,13 +25,27 @@ properties in the file:
 .. code-block:: text
 
     connector.name=oracle
-    connection-url=jdbc:oracle:thin:@example.net:1521/ORCLCDB
+    // The exact format of connection-url varies by Oracle version. Refer to
+    // the Oracle Database documentation for version-specific information on the
+    // JDBC Thin driver.
+    connection-url=jdbc:oracle:thin:@//example.net:1521/ORCLCDB
     connection-user=root
     connection-password=secret
 
+The ``connection-url`` defines the connection information and parameters to pass
+to the Oracle JDBC Thin driver. See the `Oracle Database JDBC driver
+documentation <https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm#BEIDHCBA>`_
+for more information.
+
+The ``connection-user`` and ``connection-password`` are typically required and
+determine the user credentials for the connection, often a service user. You can
+use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
+properties files.
+
 .. note::
     Oracle does not expose metadata comment via ``REMARKS`` column by default
-    in JDBC driver. You can enable it using ``oracle.remarks-reporting.enabled`` config option. See `Additional Oracle Performance Extensions
+    in JDBC driver. You can enable it using ``oracle.remarks-reporting.enabled``
+    config option. See `Additional Oracle Performance Extensions
     <https://docs.oracle.com/en/database/oracle/oracle-database/19/jjdbc/performance-extensions.html#GUID-96A38C6D-A288-4E0B-9F03-E711C146632B>`_
     for more details.
 
@@ -278,8 +292,8 @@ to Trino ``TIMESTAMP``.
 Mapping character types
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Trino's ``VARCHAR(n)`` maps to ``VARCHAR2(n CHAR)`` if ``n`` is no greater than
-4000. A larger or unbounded ``VARCHAR`` maps to ``NCLOB``.
+Trino's ``VARCHAR(n)`` maps to ``VARCHAR2(n CHAR)`` if ``n`` is no greater
+than 4000. A larger or unbounded ``VARCHAR`` maps to ``NCLOB``.
 
 Trino's ``CHAR(n)`` maps to ``CHAR(n CHAR)`` if ``n`` is no greater than 2000.
 A larger ``CHAR`` maps to ``NCLOB``.


### PR DESCRIPTION
Address an incorrect `connection-url` example, and link to the corresponding Oracle doc for more info.