### PR TITLE
Handle Null Return When Materialized View is Missing

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1202,6 +1202,8 @@ public interface ConnectorMetadata
 
     /**
      * The method is used by the engine to determine if a materialized view is current with respect to the tables it depends on.
+     *
+     * @throws MaterializedViewNotFoundException when materialized view is not found
      */
     default MaterializedViewFreshness getMaterializedViewFreshness(ConnectorSession session, SchemaTableName name)
     {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -43,6 +43,7 @@ import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.DiscretePredicates;
 import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.MaterializedViewNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.SystemTable;
@@ -859,7 +860,12 @@ public class IcebergMetadata
             String schema = strings.get(0);
             String name = strings.get(1);
             SchemaTableName schemaTableName = new SchemaTableName(schema, name);
-            if (!isTableCurrent(session, getTableHandle(session, schemaTableName), entry.getValue())) {
+            IcebergTableHandle tableHandle = getTableHandle(session, schemaTableName);
+
+            if (tableHandle == null) {
+                throw new MaterializedViewNotFoundException(materializedViewName);
+            }
+            if (!isTableCurrent(session, tableHandle, entry.getValue())) {
                 return new MaterializedViewFreshness(false);
             }
         }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoCatalog.java
@@ -17,7 +17,6 @@ import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
-import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.security.TrinoPrincipal;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -78,7 +77,6 @@ public interface TrinoCatalog
      * @param session Trino session
      * @param schemaTableName Trino schema and table name
      * @return Iceberg table loaded
-     * @throws TableNotFoundException if table not found
      * @throws UnknownTableTypeException if table is not of Iceberg type in the metastore
      */
     Table loadTable(ConnectorSession session, SchemaTableName schemaTableName);


### PR DESCRIPTION
**Description**

Fixes: https://github.com/trinodb/trino/issues/9041

- Fixed null value exception when retrieving the freshness of a materialized view that does not exist in `IcebergMetadata`
- Skip displaying any materialized views whose "freshness" are missing in `MaterializedViewSystemTable`