### PR TITLE
Change date/time precision in BigQuery from 3 to 6

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -158,15 +158,15 @@ BigQuery       Trino                           Notes
 ``BOOLEAN``    ``BOOLEAN``
 ``BYTES``      ``VARBINARY``
 ``DATE``       ``DATE``
-``DATETIME``   ``TIMESTAMP``
+``DATETIME``   ``TIMESTAMP(6)``
 ``FLOAT``      ``DOUBLE``
 ``GEOGRAPHY``  ``VARCHAR``                     In `Well-known text (WKT) <https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry>`_ format
 ``INTEGER``    ``BIGINT``
 ``NUMERIC``    ``DECIMAL(P,S)``                Defaults to ``38`` as precision and ``9`` as scale
 ``RECORD``     ``ROW``
 ``STRING``     ``VARCHAR``
-``TIME``       ``TIME_WITH_TIME_ZONE``         Time zone is UTC
-``TIMESTAMP``  ``TIMESTAMP_WITH_TIME_ZONE``    Time zone is UTC
+``TIME``       ``TIME(6)``
+``TIMESTAMP``  ``TIMESTAMP(6) WITH TIME ZONE`` Time zone is UTC
 =============  =============================== =============================================================================================================
 
 System tables

--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -152,22 +152,22 @@ Data types
 With a few exceptions, all BigQuery types are mapped directly to their Trino
 counterparts. Here are all the mappings:
 
-=============  ============================ =============================================================================================================
-BigQuery       Trino                        Notes
-=============  ============================ =============================================================================================================
+=============  =============================== =============================================================================================================
+BigQuery       Trino                           Notes
+=============  =============================== =============================================================================================================
 ``BOOLEAN``    ``BOOLEAN``
 ``BYTES``      ``VARBINARY``
 ``DATE``       ``DATE``
 ``DATETIME``   ``TIMESTAMP``
 ``FLOAT``      ``DOUBLE``
-``GEOGRAPHY``  ``VARCHAR``                  In `Well-known text (WKT) <https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry>`_ format
+``GEOGRAPHY``  ``VARCHAR``                     In `Well-known text (WKT) <https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry>`_ format
 ``INTEGER``    ``BIGINT``
-``NUMERIC``    ``DECIMAL(P,S)``             Defaults to ``38`` as precision and ``9`` as scale
+``NUMERIC``    ``DECIMAL(P,S)``                Defaults to ``38`` as precision and ``9`` as scale
 ``RECORD``     ``ROW``
 ``STRING``     ``VARCHAR``
-``TIME``       ``TIME_WITH_TIME_ZONE``      Time zone is UTC
-``TIMESTAMP``  ``TIMESTAMP_WITH_TIME_ZONE`` Time zone is UTC
-=============  ============================ =============================================================================================================
+``TIME``       ``TIME_WITH_TIME_ZONE``         Time zone is UTC
+``TIMESTAMP``  ``TIMESTAMP_WITH_TIME_ZONE``    Time zone is UTC
+=============  =============================== =============================================================================================================
 
 System tables
 -------------

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
@@ -134,9 +134,9 @@ public class TestBigQueryIntegrationSmokeTest
                 {"double", "double"},
                 {"decimal", "decimal(38,9)"},
                 {"date", "date"},
-                {"time with time zone", "time(3) with time zone"},
-                {"timestamp", "timestamp(3)"},
-                {"timestamp with time zone", "timestamp(3) with time zone"},
+                {"time with time zone", "time(6)"},
+                {"timestamp(6)", "timestamp(6)"},
+                {"timestamp(6) with time zone", "timestamp(6) with time zone"},
                 {"char", "varchar"},
                 {"char(65535)", "varchar"},
                 {"varchar", "varchar"},
@@ -400,40 +400,6 @@ public class TestBigQueryIntegrationSmokeTest
                             "   a bigint,\n" +
                             "   b bigint\n" +
                             ")");
-        }
-    }
-
-    @Test
-    public void testTimeType()
-    {
-        String tableName = "test.test_time_type";
-
-        onBigQuery("DROP TABLE IF EXISTS " + tableName);
-        onBigQuery("CREATE TABLE " + tableName + " (a TIME)");
-        onBigQuery("INSERT INTO " + tableName + " VALUES ('01:02:03.123'), ('23:59:59.999')");
-
-        assertThat(query("SELECT a FROM " + tableName))
-                .matches("VALUES TIME '01:02:03.123+00:00', TIME '23:59:59.999+00:00'");
-        assertThat(query("SELECT a FROM " + tableName + " WHERE a = TIME '01:02:03.123+00:00'"))
-                .matches("VALUES TIME '01:02:03.123+00:00'");
-        assertThat(query("SELECT a FROM " + tableName + " WHERE rand() = 42 OR a = TIME '01:02:03.123+00:00'"))
-                .matches("VALUES TIME '01:02:03.123+00:00'");
-
-        onBigQuery("DROP TABLE " + tableName);
-    }
-
-    @Test
-    public void testDatetimeType()
-    {
-        try (TestTable table = new TestTable(
-                bigQuerySqlExecutor,
-                "test.test_datetime_type",
-                "(a DATETIME)",
-                ImmutableList.of("'2021-08-27 12:34:56.123'", "'2022-09-28 01:02:03.987'"))) {
-            assertThat(query("SELECT a FROM " + table.getName()))
-                    .matches("VALUES TIMESTAMP '2021-08-27 12:34:56.123', TIMESTAMP '2022-09-28 01:02:03.987'");
-            assertThat(query("SELECT a FROM " + table.getName() + " WHERE a = TIMESTAMP '2021-08-27 12:34:56.123'"))
-                    .matches("VALUES TIMESTAMP '2021-08-27 12:34:56.123'");
         }
     }
 

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryType.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryType.java
@@ -18,6 +18,8 @@ import org.testng.annotations.Test;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static io.trino.spi.type.Decimals.encodeScaledValue;
+import static io.trino.spi.type.LongTimestampWithTimeZone.fromEpochSecondsAndFraction;
+import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static java.math.BigDecimal.ONE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,15 +30,15 @@ public class TestBigQueryType
     {
         assertThat(BigQueryType.timeToStringConverter(
                 Long.valueOf(303497217825L)))
-                .isEqualTo("'16:00:00.148'");
+                .isEqualTo("'00:00:00.303497'");
     }
 
     @Test
     public void testTimestampToStringConverter()
     {
         assertThat(BigQueryType.timestampToStringConverter(
-                Long.valueOf(6494958783649569L)))
-                .isEqualTo("'2020-03-31 12:34:56.789'");
+                fromEpochSecondsAndFraction(1585658096, 123_456_000_000L, UTC_KEY)))
+                .isEqualTo("'2020-03-31 12:34:56.123456'");
     }
 
     @Test

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryTypeMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryTypeMapping.java
@@ -25,6 +25,9 @@ import org.testng.annotations.Test;
 
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.TimeType.createTimeType;
+import static io.trino.spi.type.TimestampType.createTimestampType;
+import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 
 public class TestBigQueryTypeMapping
         extends AbstractTestQueryFramework
@@ -89,6 +92,107 @@ public class TestBigQueryTypeMapping
                 .addRoundTrip("NUMERIC(10, 3)", "CAST(NULL AS NUMERIC)", createDecimalType(10, 3), "CAST(NULL AS DECIMAL(10, 3))")
                 .addRoundTrip("NUMERIC(38, 9)", "CAST(NULL AS NUMERIC)", createDecimalType(38, 9), "CAST(NULL AS DECIMAL(38, 9))")
                 .execute(getQueryRunner(), bigqueryCreateAndInsert("test.numeric"));
+    }
+
+    @Test
+    public void testDatetime()
+    {
+        SqlDataTypeTest.create()
+                // before epoch
+                .addRoundTrip("datetime", "datetime '1958-01-01 13:18:03.123'", createTimestampType(6), "TIMESTAMP '1958-01-01 13:18:03.123000'")
+                // after epoch
+                .addRoundTrip("datetime", "datetime '2019-03-18 10:01:17.987'", createTimestampType(6), "TIMESTAMP '2019-03-18 10:01:17.987000'")
+                .addRoundTrip("datetime", "datetime '2018-10-28 01:33:17.456'", createTimestampType(6), "TIMESTAMP '2018-10-28 01:33:17.456000'")
+                .addRoundTrip("datetime", "datetime '2018-10-28 03:33:33.333'", createTimestampType(6), "TIMESTAMP '2018-10-28 03:33:33.333000'")
+                // epoch
+                .addRoundTrip("datetime", "datetime '1970-01-01 00:00:00.000'", createTimestampType(6), "TIMESTAMP '1970-01-01 00:00:00.000000'")
+                .addRoundTrip("datetime", "datetime '1970-01-01 00:13:42.000'", createTimestampType(6), "TIMESTAMP '1970-01-01 00:13:42.000000'")
+                .addRoundTrip("datetime", "datetime '2018-04-01 02:13:55.123'", createTimestampType(6), "TIMESTAMP '2018-04-01 02:13:55.123000'")
+                .addRoundTrip("datetime", "datetime '2018-03-25 03:17:17.000'", createTimestampType(6), "TIMESTAMP '2018-03-25 03:17:17.000000'")
+                .addRoundTrip("datetime", "datetime '1986-01-01 00:13:07.000'", createTimestampType(6), "TIMESTAMP '1986-01-01 00:13:07.000000'")
+
+                // same as above but with higher precision
+                .addRoundTrip("datetime", "datetime '1958-01-01 13:18:03.123456'", createTimestampType(6), "TIMESTAMP '1958-01-01 13:18:03.123456'")
+                .addRoundTrip("datetime", "datetime '2019-03-18 10:01:17.987654'", createTimestampType(6), "TIMESTAMP '2019-03-18 10:01:17.987654'")
+                .addRoundTrip("datetime", "datetime '2018-10-28 01:33:17.123456'", createTimestampType(6), "TIMESTAMP '2018-10-28 01:33:17.123456'")
+                .addRoundTrip("datetime", "datetime '2018-10-28 03:33:33.333333'", createTimestampType(6), "TIMESTAMP '2018-10-28 03:33:33.333333'")
+                .addRoundTrip("datetime", "datetime '1970-01-01 00:00:00.000000'", createTimestampType(6), "TIMESTAMP '1970-01-01 00:00:00.000000'")
+                .addRoundTrip("datetime", "datetime '1970-01-01 00:13:42.123456'", createTimestampType(6), "TIMESTAMP '1970-01-01 00:13:42.123456'")
+                .addRoundTrip("datetime", "datetime '2018-04-01 02:13:55.123456'", createTimestampType(6), "TIMESTAMP '2018-04-01 02:13:55.123456'")
+                .addRoundTrip("datetime", "datetime '2018-03-25 03:17:17.456789'", createTimestampType(6), "TIMESTAMP '2018-03-25 03:17:17.456789'")
+                .addRoundTrip("datetime", "datetime '1986-01-01 00:13:07.456789'", createTimestampType(6), "TIMESTAMP '1986-01-01 00:13:07.456789'")
+                .addRoundTrip("datetime", "datetime '2021-09-07 23:59:59.999999'", createTimestampType(6), "TIMESTAMP '2021-09-07 23:59:59.999999'")
+
+                // test arbitrary time for all supported precisions
+                .addRoundTrip("datetime", "datetime '1970-01-01 00:00:01'", createTimestampType(6), "TIMESTAMP '1970-01-01 00:00:01.000000'")
+                .addRoundTrip("datetime", "datetime '1970-01-01 00:00:01.1'", createTimestampType(6), "TIMESTAMP '1970-01-01 00:00:01.100000'")
+                .addRoundTrip("datetime", "datetime '1970-01-01 00:00:01.12'", createTimestampType(6), "TIMESTAMP '1970-01-01 00:00:01.120000'")
+                .addRoundTrip("datetime", "datetime '1970-01-01 00:00:01.123'", createTimestampType(6), "TIMESTAMP '1970-01-01 00:00:01.123000'")
+                .addRoundTrip("datetime", "datetime '1970-01-01 00:00:01.1234'", createTimestampType(6), "TIMESTAMP '1970-01-01 00:00:01.123400'")
+                .addRoundTrip("datetime", "datetime '1970-01-01 00:00:01.12345'", createTimestampType(6), "TIMESTAMP '1970-01-01 00:00:01.123450'")
+                .addRoundTrip("datetime", "datetime '1970-01-01 00:00:01.123456'", createTimestampType(6), "TIMESTAMP '1970-01-01 00:00:01.123456'")
+
+                // negative epoch
+                .addRoundTrip("datetime", "datetime '1969-12-31 23:59:59.999995'", createTimestampType(6), "TIMESTAMP '1969-12-31 23:59:59.999995'")
+                .addRoundTrip("datetime", "datetime '1969-12-31 23:59:59.999949'", createTimestampType(6), "TIMESTAMP '1969-12-31 23:59:59.999949'")
+                .addRoundTrip("datetime", "datetime '1969-12-31 23:59:59.999994'", createTimestampType(6), "TIMESTAMP '1969-12-31 23:59:59.999994'")
+
+                .execute(getQueryRunner(), bigqueryCreateAndInsert("test.datetime"));
+    }
+
+    @Test
+    public void testTime()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("time", "'00:00:00'", createTimeType(6), "TIME '00:00:00.000000'")
+                .addRoundTrip("time", "'00:00:00.000000'", createTimeType(6), "TIME '00:00:00.000000'")
+                .addRoundTrip("time", "'00:00:00.123456'", createTimeType(6), "TIME '00:00:00.123456'")
+                .addRoundTrip("time", "'12:34:56'", createTimeType(6), "TIME '12:34:56.000000'")
+                .addRoundTrip("time", "'12:34:56.123456'", createTimeType(6), "TIME '12:34:56.123456'")
+
+                // maximal value for a precision
+                .addRoundTrip("time", "'23:59:59'", createTimeType(6), "TIME '23:59:59.000000'")
+                .addRoundTrip("time", "'23:59:59.9'", createTimeType(6), "TIME '23:59:59.900000'")
+                .addRoundTrip("time", "'23:59:59.99'", createTimeType(6), "TIME '23:59:59.990000'")
+                .addRoundTrip("time", "'23:59:59.999'", createTimeType(6), "TIME '23:59:59.999000'")
+                .addRoundTrip("time", "'23:59:59.9999'", createTimeType(6), "TIME '23:59:59.999900'")
+                .addRoundTrip("time", "'23:59:59.99999'", createTimeType(6), "TIME '23:59:59.999990'")
+                .addRoundTrip("time", "'23:59:59.999999'", createTimeType(6), "TIME '23:59:59.999999'")
+
+                .execute(getQueryRunner(), bigqueryCreateAndInsert("test.time"));
+    }
+
+    @Test
+    public void testTimestampWithTimeZone()
+    {
+        SqlDataTypeTest.create()
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '1970-01-01 00:00:00.000000 UTC'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '1970-01-01 00:00:00.000000 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '1970-01-01 00:00:00.000000 Asia/Kathmandu'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '1969-12-31 18:30:00.000000 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '1970-01-01 00:00:00.000000+02:17'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '1969-12-31 21:43:00.000000 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '1970-01-01 00:00:00.000000-07:31'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '1970-01-01 07:31:00.000000 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '1958-01-01 13:18:03.123456 UTC'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '1958-01-01 13:18:03.123456 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '1958-01-01 13:18:03.123000 Asia/Kathmandu'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '1958-01-01 07:48:03.123000 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '1958-01-01 13:18:03.123000+02:17'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '1958-01-01 11:01:03.123000 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '1958-01-01 13:18:03.123000-07:31'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '1958-01-01 20:49:03.123000 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '2019-03-18 10:01:17.987654 UTC'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '2019-03-18 10:01:17.987654 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '2019-03-18 10:01:17.987000 Asia/Kathmandu'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '2019-03-18 04:16:17.987000 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '2019-03-18 10:01:17.987000+02:17'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '2019-03-18 07:44:17.987000 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '2019-03-18 10:01:17.987000-07:31'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '2019-03-18 17:32:17.987000 UTC'")
+                .addRoundTrip("TIMESTAMP", "TIMESTAMP '2021-09-07 23:59:59.999999-00:00'",
+                        TIMESTAMP_TZ_MICROS, "TIMESTAMP '2021-09-07 23:59:59.999999 UTC'")
+                .execute(getQueryRunner(), bigqueryCreateAndInsert("test.timestamp_tz"));
     }
 
     private DataSetup bigqueryCreateAndInsert(String tableNamePrefix)

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestTypeConversions.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestTypeConversions.java
@@ -24,7 +24,7 @@ import io.trino.spi.type.DateType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.DoubleType;
 import io.trino.spi.type.RowType;
-import io.trino.spi.type.TimeWithTimeZoneType;
+import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
@@ -66,7 +66,7 @@ public class TestTypeConversions
     @Test
     public void testConvertDateTimeField()
     {
-        assertSimpleFieldTypeConversion(LegacySQLTypeName.DATETIME, TimestampType.TIMESTAMP_MILLIS);
+        assertSimpleFieldTypeConversion(LegacySQLTypeName.DATETIME, TimestampType.TIMESTAMP_MICROS);
     }
 
     @Test
@@ -102,13 +102,13 @@ public class TestTypeConversions
     @Test
     public void testConvertTimeField()
     {
-        assertSimpleFieldTypeConversion(LegacySQLTypeName.TIME, TimeWithTimeZoneType.TIME_WITH_TIME_ZONE);
+        assertSimpleFieldTypeConversion(LegacySQLTypeName.TIME, TimeType.TIME_MICROS);
     }
 
     @Test
     public void testConvertTimestampField()
     {
-        assertSimpleFieldTypeConversion(LegacySQLTypeName.TIMESTAMP, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
+        assertSimpleFieldTypeConversion(LegacySQLTypeName.TIMESTAMP, TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS);
     }
 
     @Test
@@ -178,7 +178,7 @@ public class TestTypeConversions
     @Test
     public void testConvertDateTimeColumn()
     {
-        assertSimpleColumnTypeConversion(LegacySQLTypeName.DATETIME, TimestampType.TIMESTAMP_MILLIS);
+        assertSimpleColumnTypeConversion(LegacySQLTypeName.DATETIME, TimestampType.TIMESTAMP_MICROS);
     }
 
     @Test
@@ -214,13 +214,13 @@ public class TestTypeConversions
     @Test
     public void testConvertTimeColumn()
     {
-        assertSimpleColumnTypeConversion(LegacySQLTypeName.TIME, TimeWithTimeZoneType.TIME_WITH_TIME_ZONE);
+        assertSimpleColumnTypeConversion(LegacySQLTypeName.TIME, TimeType.TIME_MICROS);
     }
 
     @Test
     public void testConvertTimestampColumn()
     {
-        assertSimpleColumnTypeConversion(LegacySQLTypeName.TIMESTAMP, TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE);
+        assertSimpleColumnTypeConversion(LegacySQLTypeName.TIMESTAMP, TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS);
     }
 
     @Test


### PR DESCRIPTION
The time precision in BigQuery is microsecond, but the value  is silently ignored likes 12:34:56.123*456* → 12:34:56.123. 

- [x] Run all BigQuery tests locally (Sep 7)