### PR TITLE
Fix flakiness in TestMemoryConnectorTest

### DIFF
--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -117,17 +117,6 @@ public class TestMemoryConnectorTest
         throw new SkipException("Cassandra connector does not support column default values");
     }
 
-    @Test
-    public void testCreateAndDropTable()
-    {
-        int tablesBeforeCreate = listMemoryTables().size();
-        assertUpdate("CREATE TABLE test AS SELECT * FROM tpch.tiny.nation", "SELECT count(*) FROM nation");
-        assertEquals(listMemoryTables().size(), tablesBeforeCreate + 1);
-
-        assertUpdate("DROP TABLE test");
-        assertEquals(listMemoryTables().size(), tablesBeforeCreate);
-    }
-
     // it has to be RuntimeException as FailureInfo$FailureException is private
     @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "line 1:1: Destination table 'memory.default.nation' already exists")
     public void testCreateTableWhenTableIsAlreadyCreated()

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import io.trino.Session;
 import io.trino.execution.QueryStats;
-import io.trino.metadata.QualifiedObjectName;
 import io.trino.operator.OperatorStats;
 import io.trino.plugin.base.metrics.LongCount;
 import io.trino.spi.QueryId;
@@ -48,6 +47,7 @@ import static io.trino.sql.analyzer.FeaturesConfig.JoinDistributionType.BROADCAS
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 public class TestMemoryConnectorTest
@@ -516,14 +516,12 @@ public class TestMemoryConnectorTest
     @Test
     public void testCreateTableAndViewInNotExistSchema()
     {
-        int tablesBeforeCreate = listMemoryTables().size();
-
         assertQueryFails("CREATE TABLE schema3.test_table3 (x date)", "Schema schema3 not found");
+        assertFalse(getQueryRunner().tableExists(getSession(), "schema3.test_table3"));
         assertQueryFails("CREATE VIEW schema4.test_view4 AS SELECT 123 x", "Schema schema4 not found");
+        assertFalse(getQueryRunner().tableExists(getSession(), "schema4.test_view4"));
         assertQueryFails("CREATE OR REPLACE VIEW schema5.test_view5 AS SELECT 123 x", "Schema schema5 not found");
-
-        int tablesAfterCreate = listMemoryTables().size();
-        assertEquals(tablesBeforeCreate, tablesAfterCreate);
+        assertFalse(getQueryRunner().tableExists(getSession(), "schema5.test_view5"));
     }
 
     @Test
@@ -561,11 +559,6 @@ public class TestMemoryConnectorTest
 
         assertUpdate("DROP VIEW test_different_schema.test_view_renamed");
         assertUpdate("DROP SCHEMA test_different_schema");
-    }
-
-    private List<QualifiedObjectName> listMemoryTables()
-    {
-        return getQueryRunner().listTables(getSession(), "memory", "default");
     }
 
     private void assertQueryResult(@Language("SQL") String sql, Object... expected)

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -114,7 +114,7 @@ public class TestMemoryConnectorTest
     @Override
     protected TestTable createTableWithDefaultColumns()
     {
-        throw new SkipException("Cassandra connector does not support column default values");
+        throw new SkipException("Memory connector does not support column default values");
     }
 
     // it has to be RuntimeException as FailureInfo$FailureException is private


### PR DESCRIPTION
AbstractTestDistributedQueries already runs testCreateTable which
creates a table, drops it and then asserts that the table is indeed
dropped.

See https://github.com/trinodb/trino/blob/6f1297f3fc60671873b2f59e742b03e9c0c2195b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestDistributedQueries.java#L145-L150 for the existing coverage.

Fixes https://github.com/trinodb/trino/issues/9051