### PR TITLE
Fix wrong result of BigQuery parameterized NUMERIC type

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -162,7 +162,7 @@ BigQuery       Trino                        Notes
 ``FLOAT``      ``DOUBLE``
 ``GEOGRAPHY``  ``VARCHAR``                  In `Well-known text (WKT) <https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry>`_ format
 ``INTEGER``    ``BIGINT``
-``NUMERIC``    ``DECIMAL(38,9)``
+``NUMERIC``    ``DECIMAL(P,S)``             Defaults to ``38`` as precision and ``9`` as scale
 ``RECORD``     ``ROW``
 ``STRING``     ``VARCHAR``
 ``TIME``       ``TIME_WITH_TIME_ZONE``      Time zone is UTC

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -23,7 +23,7 @@
                 <groupId>com.google.cloud</groupId>
                 <artifactId>libraries-bom</artifactId>
                 <type>pom</type>
-                <version>16.3.0</version>
+                <version>22.0.0</version>
                 <scope>import</scope>
             </dependency>
 
@@ -48,7 +48,7 @@
             <dependency>
                 <groupId>org.threeten</groupId>
                 <artifactId>threetenbp</artifactId>
-                <version>1.5.0</version>
+                <version>1.5.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -327,6 +327,7 @@
                             <excludes>
                                 <!-- If you are adding entry here also add an entry to cloud-tests profile below -->
                                 <exclude>**/TestBigQueryIntegrationSmokeTest.java</exclude>
+                                <exclude>**/TestBigQueryTypeMapping.java</exclude>
                                 <exclude>**/TestBigQueryCaseInsensitiveMapping.java</exclude>
                             </excludes>
                         </configuration>
@@ -348,6 +349,7 @@
                         <configuration>
                             <includes>
                                 <include>**/TestBigQueryIntegrationSmokeTest.java</include>
+                                <include>**/TestBigQueryTypeMapping.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryColumnHandle.java
@@ -37,6 +37,8 @@ public class BigQueryColumnHandle
     private final String name;
     private final BigQueryType bigQueryType;
     private final Field.Mode mode;
+    private final Long precision;
+    private final Long scale;
     private final List<BigQueryColumnHandle> subColumns;
     private final String description;
     private final boolean hidden;
@@ -46,6 +48,8 @@ public class BigQueryColumnHandle
             @JsonProperty("name") String name,
             @JsonProperty("bigQueryType") BigQueryType bigQueryType,
             @JsonProperty("mode") Field.Mode mode,
+            @JsonProperty("precision") Long precision,
+            @JsonProperty("scale") Long scale,
             @JsonProperty("subColumns") List<BigQueryColumnHandle> subColumns,
             @JsonProperty("description") String description,
             @JsonProperty("hidden") boolean hidden)
@@ -53,6 +57,8 @@ public class BigQueryColumnHandle
         this.name = requireNonNull(name, "column name cannot be null");
         this.bigQueryType = requireNonNull(bigQueryType, () -> format("column type cannot be null for column [%s]", name));
         this.mode = requireNonNull(mode, "Field mode cannot be null");
+        this.precision = precision;
+        this.scale = scale;
         this.subColumns = ImmutableList.copyOf(requireNonNull(subColumns, "subColumns is null"));
         this.description = description;
         this.hidden = hidden;
@@ -63,10 +69,12 @@ public class BigQueryColumnHandle
             String name,
             BigQueryType bigQueryType,
             Field.Mode mode,
+            Long precision,
+            Long scale,
             List<BigQueryColumnHandle> subColumns,
             String description)
     {
-        this(name, bigQueryType, mode, subColumns, description, false);
+        this(name, bigQueryType, mode, precision, scale, subColumns, description, false);
     }
 
     @JsonProperty
@@ -93,6 +101,20 @@ public class BigQueryColumnHandle
     public Field.Mode getMode()
     {
         return mode;
+    }
+
+    @Override
+    @JsonProperty
+    public Long getPrecision()
+    {
+        return precision;
+    }
+
+    @Override
+    @JsonProperty
+    public Long getScale()
+    {
+        return scale;
     }
 
     @JsonProperty
@@ -137,6 +159,8 @@ public class BigQueryColumnHandle
         return Objects.equals(name, that.name) &&
                 Objects.equals(bigQueryType, that.bigQueryType) &&
                 Objects.equals(mode, that.mode) &&
+                Objects.equals(precision, that.precision) &&
+                Objects.equals(scale, that.scale) &&
                 Objects.equals(subColumns, that.subColumns) &&
                 Objects.equals(description, that.description);
     }
@@ -144,7 +168,7 @@ public class BigQueryColumnHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, bigQueryType, mode, subColumns, description);
+        return Objects.hash(name, bigQueryType, mode, precision, scale, subColumns, description);
     }
 
     @Override
@@ -154,6 +178,8 @@ public class BigQueryColumnHandle
                 .add("name", name)
                 .add("type", bigQueryType)
                 .add("mode", mode)
+                .add("precision", precision)
+                .add("scale", scale)
                 .add("subColumns", subColumns)
                 .add("description", description)
                 .toString();

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryFilterQueryBuilder.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryFilterQueryBuilder.java
@@ -115,7 +115,7 @@ class BigQueryFilterQueryBuilder
         }
         else if (singleValues.size() > 1) {
             String values = singleValues.stream()
-                    .map(column.getBigQueryType()::convertToString)
+                    .map(value -> column.getBigQueryType().convertToString(column.getTrinoType(), value))
                     .collect(joining(","));
             disjuncts.add(quote(columnName) + " IN (" + values + ")");
         }
@@ -131,7 +131,7 @@ class BigQueryFilterQueryBuilder
 
     private String toPredicate(String columnName, String operator, Object value, BigQueryColumnHandle column)
     {
-        String valueAsString = column.getBigQueryType().convertToString(value);
+        String valueAsString = column.getBigQueryType().convertToString(column.getTrinoType(), value);
         return quote(columnName) + " " + operator + " " + valueAsString;
     }
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -80,8 +80,8 @@ public class BigQueryMetadata
 {
     private static final Logger log = Logger.get(BigQueryMetadata.class);
 
-    static final int NUMERIC_DATA_TYPE_PRECISION = 38;
-    static final int NUMERIC_DATA_TYPE_SCALE = 9;
+    static final int DEFAULT_NUMERIC_TYPE_PRECISION = 38;
+    static final int DEFAULT_NUMERIC_TYPE_SCALE = 9;
     static final String INFORMATION_SCHEMA = "information_schema";
     private static final String VIEW_DEFINITION_SYSTEM_TABLE_SUFFIX = "$view_definition";
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryType.java
@@ -53,15 +53,18 @@ import java.util.Map;
 import static com.google.cloud.bigquery.Field.Mode.REPEATED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.math.LongMath.divide;
-import static io.trino.plugin.bigquery.BigQueryMetadata.NUMERIC_DATA_TYPE_PRECISION;
-import static io.trino.plugin.bigquery.BigQueryMetadata.NUMERIC_DATA_TYPE_SCALE;
+import static io.trino.plugin.bigquery.BigQueryMetadata.DEFAULT_NUMERIC_TYPE_PRECISION;
+import static io.trino.plugin.bigquery.BigQueryMetadata.DEFAULT_NUMERIC_TYPE_SCALE;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.Decimals.isShortDecimal;
 import static io.trino.spi.type.TimeWithTimeZoneType.DEFAULT_PRECISION;
 import static io.trino.spi.type.TimeWithTimeZoneType.createTimeWithTimeZoneType;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MILLISECOND;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static java.lang.Integer.parseInt;
+import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.time.ZoneOffset.UTC;
 import static java.util.stream.Collectors.toList;
@@ -75,7 +78,7 @@ public enum BigQueryType
     FLOAT(DoubleType.DOUBLE, BigQueryType::simpleToStringConverter),
     GEOGRAPHY(VarcharType.VARCHAR, BigQueryType::stringToStringConverter),
     INTEGER(BigintType.BIGINT, BigQueryType::simpleToStringConverter),
-    NUMERIC(DecimalType.createDecimalType(NUMERIC_DATA_TYPE_PRECISION, NUMERIC_DATA_TYPE_SCALE), BigQueryType::numericToStringConverter),
+    NUMERIC(null, BigQueryType::numericToStringConverter),
     RECORD(null, BigQueryType::simpleToStringConverter),
     STRING(createUnboundedVarcharType(), BigQueryType::stringToStringConverter),
     TIME(TimeWithTimeZoneType.TIME_WITH_TIME_ZONE, BigQueryType::timeToStringConverter),
@@ -187,7 +190,7 @@ public enum BigQueryType
     static String numericToStringConverter(Object value)
     {
         Slice slice = (Slice) value;
-        return Decimals.toString(slice, NUMERIC_DATA_TYPE_SCALE);
+        return Decimals.toString(slice, DEFAULT_NUMERIC_TYPE_SCALE);
     }
 
     static String bytesToStringConverter(Object value)
@@ -277,14 +280,30 @@ public enum BigQueryType
         return "'" + value + "'";
     }
 
-    String convertToString(Object value)
+    String convertToString(Type type, Object value)
     {
+        if (type instanceof DecimalType) {
+            if (isShortDecimal(type)) {
+                return "NUMERIC " + quote(Decimals.toString((long) value, ((DecimalType) type).getScale()));
+            }
+            return "NUMERIC " + quote(Decimals.toString((Slice) value, ((DecimalType) type).getScale()));
+        }
         return toStringConverter.convertToString(value);
     }
 
     public Type getNativeType(BigQueryType.Adaptor typeAdaptor)
     {
         switch (this) {
+            case NUMERIC:
+                Long precision = typeAdaptor.getPrecision();
+                Long scale = typeAdaptor.getScale();
+                if (precision != null && scale != null) {
+                    return createDecimalType(toIntExact(precision), toIntExact(scale));
+                }
+                if (precision != null) {
+                    return createDecimalType(toIntExact(precision));
+                }
+                return createDecimalType(DEFAULT_NUMERIC_TYPE_PRECISION, DEFAULT_NUMERIC_TYPE_SCALE);
             case RECORD:
                 // create the row
                 Map<String, BigQueryType.Adaptor> subTypes = typeAdaptor.getBigQuerySubTypes();
@@ -299,6 +318,10 @@ public enum BigQueryType
     interface Adaptor
     {
         BigQueryType getBigQueryType();
+
+        Long getPrecision();
+
+        Long getScale();
 
         Map<String, BigQueryType.Adaptor> getBigQuerySubTypes();
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/Conversions.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/Conversions.java
@@ -42,6 +42,8 @@ final class Conversions
                 field.getName(),
                 BigQueryType.valueOf(field.getType().name()),
                 getMode(field),
+                field.getPrecision(),
+                field.getScale(),
                 subColumns,
                 field.getDescription(),
                 false);
@@ -65,6 +67,18 @@ final class Conversions
             public BigQueryType getBigQueryType()
             {
                 return BigQueryType.valueOf(field.getType().name());
+            }
+
+            @Override
+            public Long getPrecision()
+            {
+                return field.getPrecision();
+            }
+
+            @Override
+            public Long getScale()
+            {
+                return field.getScale();
             }
 
             @Override

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryTypeMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryTypeMapping.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import io.trino.testing.datatype.CreateAndInsertDataSetup;
+import io.trino.testing.datatype.DataSetup;
+import io.trino.testing.datatype.SqlDataTypeTest;
+import io.trino.testing.sql.SqlExecutor;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static io.trino.spi.type.DecimalType.createDecimalType;
+
+public class TestBigQueryTypeMapping
+        extends AbstractTestQueryFramework
+{
+    private BigQueryQueryRunner.BigQuerySqlExecutor bigQuerySqlExecutor;
+
+    @BeforeClass(alwaysRun = true)
+    public void initBigQueryExecutor()
+    {
+        bigQuerySqlExecutor = new BigQueryQueryRunner.BigQuerySqlExecutor();
+        bigQuerySqlExecutor.deleteSelfCreatedDatasets();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return BigQueryQueryRunner.createQueryRunner(
+                ImmutableMap.of(),
+                ImmutableMap.of());
+    }
+
+    @Test
+    public void testNumericMapping()
+    {
+        // Max precision is 29 when the scale is 0 in BigQuery
+        // Valid scale range is between 0 and 9 in BigQuery
+
+        // Use "NUMERIC 'value'" style because BigQuery doesn't accept parameterized cast "CAST (... AS NUMERIC(p, s))"
+        SqlDataTypeTest.create()
+                .addRoundTrip("NUMERIC(3, 0)", "NUMERIC '193'", createDecimalType(3, 0), "CAST(193 AS DECIMAL(3, 0))")
+                .addRoundTrip("NUMERIC(3, 0)", "NUMERIC '19'", createDecimalType(3, 0), "CAST(19 AS DECIMAL(3, 0))")
+                .addRoundTrip("NUMERIC(3, 0)", "NUMERIC '-193'", createDecimalType(3, 0), "CAST(-193 AS DECIMAL(3, 0))")
+                .addRoundTrip("NUMERIC(3, 1)", "NUMERIC '10.0'", createDecimalType(3, 1), "CAST(10.0 AS DECIMAL(3, 1))")
+                .addRoundTrip("NUMERIC(3, 1)", "NUMERIC '10.1'", createDecimalType(3, 1), "CAST(10.1 AS DECIMAL(3, 1))")
+                .addRoundTrip("NUMERIC(3, 1)", "NUMERIC '-10.1'", createDecimalType(3, 1), "CAST(-10.1 AS DECIMAL(3, 1))")
+                .addRoundTrip("NUMERIC(4, 2)", "NUMERIC '2'", createDecimalType(4, 2), "CAST(2 AS DECIMAL(4, 2))")
+                .addRoundTrip("NUMERIC(4, 2)", "NUMERIC '2.3'", createDecimalType(4, 2), "CAST(2.3 AS DECIMAL(4, 2))")
+                .addRoundTrip("NUMERIC(24, 2)", "NUMERIC '2'", createDecimalType(24, 2), "CAST(2 AS DECIMAL(24, 2))")
+                .addRoundTrip("NUMERIC(24, 2)", "NUMERIC '2.3'", createDecimalType(24, 2), "CAST(2.3 AS DECIMAL(24, 2))")
+                .addRoundTrip("NUMERIC(24, 2)", "NUMERIC '123456789.3'", createDecimalType(24, 2), "CAST(123456789.3 AS DECIMAL(24, 2))")
+                .addRoundTrip("NUMERIC(24, 4)", "NUMERIC '12345678901234567890.31'", createDecimalType(24, 4), "CAST(12345678901234567890.31 AS DECIMAL(24, 4))")
+                .addRoundTrip("NUMERIC(29, 0)", "NUMERIC '27182818284590452353602874713'", createDecimalType(29, 0), "CAST('27182818284590452353602874713' AS DECIMAL(29, 0))")
+                .addRoundTrip("NUMERIC(29, 0)", "NUMERIC '-27182818284590452353602874713'", createDecimalType(29, 0), "CAST('-27182818284590452353602874713' AS DECIMAL(29, 0))")
+                .addRoundTrip("NUMERIC(30, 5)", "NUMERIC '3141592653589793238462643.38327'", createDecimalType(30, 5), "CAST(3141592653589793238462643.38327 AS DECIMAL(30, 5))")
+                .addRoundTrip("NUMERIC(30, 5)", "NUMERIC '-3141592653589793238462643.38327'", createDecimalType(30, 5), "CAST(-3141592653589793238462643.38327 AS DECIMAL(30, 5))")
+                .addRoundTrip("NUMERIC(38, 9)", "NUMERIC '100000000020000000001234567.123456789'", createDecimalType(38, 9), "CAST(100000000020000000001234567.123456789 AS DECIMAL(38, 9))")
+                .addRoundTrip("NUMERIC(38, 9)", "NUMERIC '-100000000020000000001234567.123456789'", createDecimalType(38, 9), "CAST(-100000000020000000001234567.123456789 AS DECIMAL(38, 9))")
+                .addRoundTrip("NUMERIC(10, 3)", "CAST(NULL AS NUMERIC)", createDecimalType(10, 3), "CAST(NULL AS DECIMAL(10, 3))")
+                .addRoundTrip("NUMERIC(38, 9)", "CAST(NULL AS NUMERIC)", createDecimalType(38, 9), "CAST(NULL AS DECIMAL(38, 9))")
+                .execute(getQueryRunner(), bigqueryCreateAndInsert("test.numeric"));
+    }
+
+    private DataSetup bigqueryCreateAndInsert(String tableNamePrefix)
+    {
+        return new CreateAndInsertDataSetup(getBigQuerySqlExecutor(), tableNamePrefix);
+    }
+
+    private SqlExecutor getBigQuerySqlExecutor()
+    {
+        return sql -> bigQuerySqlExecutor.execute(sql);
+    }
+}

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestTypeConversions.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestTypeConversions.java
@@ -226,9 +226,9 @@ public class TestTypeConversions
     @Test
     public void testConvertOneLevelRecordColumn()
     {
-        BigQueryColumnHandle column = new BigQueryColumnHandle("rec", BigQueryType.RECORD, Field.Mode.NULLABLE, ImmutableList.of(
-                new BigQueryColumnHandle("sub_s", BigQueryType.STRING, Field.Mode.NULLABLE, ImmutableList.of(), null),
-                new BigQueryColumnHandle("sub_i", BigQueryType.INTEGER, Field.Mode.NULLABLE, ImmutableList.of(), null)
+        BigQueryColumnHandle column = new BigQueryColumnHandle("rec", BigQueryType.RECORD, Field.Mode.NULLABLE, null, null, ImmutableList.of(
+                new BigQueryColumnHandle("sub_s", BigQueryType.STRING, Field.Mode.NULLABLE, null, null, ImmutableList.of(), null),
+                new BigQueryColumnHandle("sub_i", BigQueryType.INTEGER, Field.Mode.NULLABLE, null, null, ImmutableList.of(), null)
         ), null);
         ColumnMetadata metadata = column.getColumnMetadata();
         RowType targetType = RowType.rowType(
@@ -240,13 +240,13 @@ public class TestTypeConversions
     @Test
     public void testConvertTwoLevelsRecordColumn()
     {
-        BigQueryColumnHandle column = new BigQueryColumnHandle("rec", BigQueryType.RECORD, Field.Mode.NULLABLE, ImmutableList.of(
-                new BigQueryColumnHandle("sub_rec", BigQueryType.RECORD, Field.Mode.NULLABLE, ImmutableList.of(
-                        new BigQueryColumnHandle("sub_sub_s", BigQueryType.STRING, Field.Mode.NULLABLE, ImmutableList.of(), null),
-                        new BigQueryColumnHandle("sub_sub_i", BigQueryType.INTEGER, Field.Mode.NULLABLE, ImmutableList.of(), null)
+        BigQueryColumnHandle column = new BigQueryColumnHandle("rec", BigQueryType.RECORD, Field.Mode.NULLABLE, null, null, ImmutableList.of(
+                new BigQueryColumnHandle("sub_rec", BigQueryType.RECORD, Field.Mode.NULLABLE, null, null, ImmutableList.of(
+                        new BigQueryColumnHandle("sub_sub_s", BigQueryType.STRING, Field.Mode.NULLABLE, null, null, ImmutableList.of(), null),
+                        new BigQueryColumnHandle("sub_sub_i", BigQueryType.INTEGER, Field.Mode.NULLABLE, null, null, ImmutableList.of(), null)
                 ), null),
-                new BigQueryColumnHandle("sub_s", BigQueryType.STRING, Field.Mode.NULLABLE, ImmutableList.of(), null),
-                new BigQueryColumnHandle("sub_i", BigQueryType.INTEGER, Field.Mode.NULLABLE, ImmutableList.of(), null)
+                new BigQueryColumnHandle("sub_s", BigQueryType.STRING, Field.Mode.NULLABLE, null, null, ImmutableList.of(), null),
+                new BigQueryColumnHandle("sub_i", BigQueryType.INTEGER, Field.Mode.NULLABLE, null, null, ImmutableList.of(), null)
         ), null);
         ColumnMetadata metadata = column.getColumnMetadata();
         RowType targetType = RowType.rowType(
@@ -261,7 +261,7 @@ public class TestTypeConversions
     @Test
     public void testConvertStringArrayColumn()
     {
-        BigQueryColumnHandle column = new BigQueryColumnHandle("test", BigQueryType.STRING, Field.Mode.REPEATED, ImmutableList.of(), null);
+        BigQueryColumnHandle column = new BigQueryColumnHandle("test", BigQueryType.STRING, Field.Mode.REPEATED, null, null, ImmutableList.of(), null);
         ColumnMetadata metadata = column.getColumnMetadata();
         assertThat(metadata.getType()).isEqualTo(new ArrayType(VarcharType.VARCHAR));
     }
@@ -296,6 +296,6 @@ public class TestTypeConversions
 
     private static BigQueryColumnHandle createColumn(LegacySQLTypeName type)
     {
-        return new BigQueryColumnHandle("test", BigQueryType.valueOf(type.name()), Field.Mode.NULLABLE, ImmutableList.of(), null);
+        return new BigQueryColumnHandle("test", BigQueryType.valueOf(type.name()), Field.Mode.NULLABLE, null, null, ImmutableList.of(), null);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dep.selenium.version>3.141.59</dep.selenium.version>
         <dep.tempto.version>185</dep.tempto.version>
         <dep.gcs.version>2.0.0</dep.gcs.version>
-        <dep.errorprone.version>2.8.1</dep.errorprone.version>
+        <dep.errorprone.version>2.9.0</dep.errorprone.version>
         <dep.testcontainers.version>1.16.0</dep.testcontainers.version>
         <dep.docker-java.version>3.2.11</dep.docker-java.version>
         <dep.coral.version>1.0.89</dep.coral.version>


### PR DESCRIPTION
BigQuery added parameterized NUMERIC type in [Jun 7 release](https://cloud.google.com/bigquery/docs/release-notes#June_07_2021) and it leads to incorrect result because the current mapping is static precision and scale (38, 9). 

The type support is still Pre-GA phase, but I suppose we can move forward this even before GA. 
https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#parameterized_decimal_type

- [x] Run BigQuery tests locally