### PR TITLE
Update to aircompressor 0.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -634,7 +634,7 @@
             <dependency>
                 <groupId>io.airlift</groupId>
                 <artifactId>aircompressor</artifactId>
-                <version>0.19</version>
+                <version>0.21</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fixes an "overflow detected" issue when compressing incompressible
data with zstd.

Fixes https://github.com/trinodb/trino/issues/8602