### PR TITLE
Test Iceberg schema top-level evolution

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/common/Standard.java
@@ -52,9 +52,11 @@ import static org.testcontainers.containers.wait.strategy.Wait.forHealthcheck;
 import static org.testcontainers.containers.wait.strategy.Wait.forLogMessage;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
-// Use io.trino.tests.product.launcher.env.common.StandardMultinode instead
-// Product tests should mimic production like use case.
-// Single node environment does not do it well enough and some issues are only exposed with multi node installations.
+/**
+ * @deprecated Product tests should mimic production like use case.
+ * Single node environment does not do it well enough and some issues are
+ * only exposed with multi node installations. Use {@link StandardMultinode} instead.
+ */
 @Deprecated
 public final class Standard
         implements EnvironmentExtender

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SinglenodeSparkIceberg.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SinglenodeSparkIceberg.java
@@ -30,7 +30,6 @@ import javax.inject.Inject;
 import static io.trino.tests.product.launcher.docker.ContainerUtil.forSelectedPorts;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.HADOOP;
-import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_HADOOP_INIT_D;
 import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -57,12 +56,7 @@ public class SinglenodeSparkIceberg
     @Override
     public void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer(HADOOP, dockerContainer -> {
-            dockerContainer.setDockerImageName("ghcr.io/trinodb/testing/hdp3.1-hive:" + hadoopImagesVersion);
-            dockerContainer.withCopyFileToContainer(
-                    forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-hdp3/apply-hdp3-config.sh")),
-                    CONTAINER_HADOOP_INIT_D + "apply-hdp3-config.sh");
-        });
+        builder.configureContainer(HADOOP, container -> container.setDockerImageName("ghcr.io/trinodb/testing/hdp3.1-hive:" + hadoopImagesVersion));
 
         builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SinglenodeSparkIceberg.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/environment/SinglenodeSparkIceberg.java
@@ -30,6 +30,7 @@ import javax.inject.Inject;
 import static io.trino.tests.product.launcher.docker.ContainerUtil.forSelectedPorts;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.COORDINATOR;
 import static io.trino.tests.product.launcher.env.EnvironmentContainers.HADOOP;
+import static io.trino.tests.product.launcher.env.common.Hadoop.CONTAINER_HADOOP_INIT_D;
 import static io.trino.tests.product.launcher.env.common.Standard.CONTAINER_PRESTO_ETC;
 import static java.util.Objects.requireNonNull;
 import static org.testcontainers.utility.MountableFile.forHostPath;
@@ -56,7 +57,12 @@ public class SinglenodeSparkIceberg
     @Override
     public void extendEnvironment(Environment.Builder builder)
     {
-        builder.configureContainer(HADOOP, container -> container.setDockerImageName("ghcr.io/trinodb/testing/hdp3.1-hive:" + hadoopImagesVersion));
+        builder.configureContainer(HADOOP, container -> {
+            container.setDockerImageName("ghcr.io/trinodb/testing/hdp3.1-hive:" + hadoopImagesVersion);
+            container.withCopyFileToContainer(
+                    forHostPath(dockerFiles.getDockerFilesHostPath("conf/environment/singlenode-spark-iceberg/apply-hive-config-for-iceberg.sh")),
+                    CONTAINER_HADOOP_INIT_D + "/apply-hive-config-for-iceberg.sh");
+        });
 
         builder.configureContainer(COORDINATOR, container -> container
                 .withCopyFileToContainer(

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/apply-hive-config-for-iceberg.sh
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/apply-hive-config-for-iceberg.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+fail() {
+  echo "$(basename "$0"): $*" >&2
+  exit 1
+}
+
+echo "Applying hive-site configuration overrides for Spark"
+
+apply-site-xml-override /etc/hive/conf/hive-site.xml "/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/hive-site-overrides.xml" || fail "Could not apply hive-site-overrides.xml"

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/hive-site-overrides.xml
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-iceberg/hive-site-overrides.xml
@@ -1,0 +1,9 @@
+<configuration>
+
+    <property>
+        <!-- Required to enable full schema evolution. See https://github.com/apache/iceberg/issues/1092#issuecomment-638432848 -->
+        <name>hive.metastore.disallow.incompatible.col.type.changes</name>
+        <value>false</value>
+    </property>
+
+</configuration>

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -230,7 +230,7 @@ public class TestIcebergSparkCompatibility
                 "2021-08-03 06:32:21.123456 UTC", // Iceberg's timestamptz stores point in time, without zone
                 "1950-06-28"
                 // "01:23:45.123456"
-        /**/);
+                /**/);
         assertThat(onTrino().executeQuery(
                 "SELECT " +
                         "  _string" +


### PR DESCRIPTION
Extend
    `io.trino.tests.product.iceberg.TestIcebergSparkCompatibility#testIdBasedFieldMapping`
    to cover not only struct field evolution, but also table top-level
    schema evolution.