### PR TITLE
Make IdentityCacheMapping accept ConnectorSession

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -479,7 +479,7 @@ public class CachingJdbcClient
 
     private IdentityCacheKey getIdentityKey(ConnectorSession session)
     {
-        return identityMapping.getRemoteUserCacheKey(session.getIdentity());
+        return identityMapping.getRemoteUserCacheKey(session);
     }
 
     private Map<String, Object> getSessionProperties(ConnectorSession session)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ExtraCredentialsBasedIdentityCacheMapping.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ExtraCredentialsBasedIdentityCacheMapping.java
@@ -14,7 +14,7 @@
 package io.trino.plugin.jdbc;
 
 import io.trino.plugin.jdbc.credential.ExtraCredentialConfig;
-import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.connector.ConnectorSession;
 
 import javax.inject.Inject;
 
@@ -49,9 +49,9 @@ public final class ExtraCredentialsBasedIdentityCacheMapping
     }
 
     @Override
-    public IdentityCacheKey getRemoteUserCacheKey(ConnectorIdentity identity)
+    public IdentityCacheKey getRemoteUserCacheKey(ConnectorSession session)
     {
-        Map<String, String> extraCredentials = identity.getExtraCredentials();
+        Map<String, String> extraCredentials = session.getIdentity().getExtraCredentials();
         return new ExtraCredentialsBasedIdentityCacheKey(
                 userCredentialName.map(extraCredentials::get)
                         .map(this::hash),

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/IdentityCacheMapping.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/IdentityCacheMapping.java
@@ -13,16 +13,16 @@
  */
 package io.trino.plugin.jdbc;
 
-import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.connector.ConnectorSession;
 
 public interface IdentityCacheMapping
 {
-    IdentityCacheKey getRemoteUserCacheKey(ConnectorIdentity identity);
+    IdentityCacheKey getRemoteUserCacheKey(ConnectorSession session);
 
     /**
-     * This will be used as cache key for metadata. If {@link ConnectorIdentity} content can influence the
+     * This will be used as cache key for metadata. If {@link ConnectorSession} content can influence the
      * metadata then we should have {@link IdentityCacheKey} instance so
-     * we could cache proper metadata for given {@link ConnectorIdentity}.
+     * we could cache proper metadata for given {@link ConnectorSession}.
      */
     abstract class IdentityCacheKey
     {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/SingletonIdentityCacheMapping.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/SingletonIdentityCacheMapping.java
@@ -13,13 +13,13 @@
  */
 package io.trino.plugin.jdbc;
 
-import io.trino.spi.security.ConnectorIdentity;
+import io.trino.spi.connector.ConnectorSession;
 
 public final class SingletonIdentityCacheMapping
         implements IdentityCacheMapping
 {
     @Override
-    public IdentityCacheKey getRemoteUserCacheKey(ConnectorIdentity identity)
+    public IdentityCacheKey getRemoteUserCacheKey(ConnectorSession session)
     {
         return SingletonIdentityCacheKey.INSTANCE;
     }


### PR DESCRIPTION
It is conceivable that some mapping will require something more than just the `ConnectorIdentity`; in particular, the current session properties might be influencing the caching behaviour as well.