### PR TITLE
Allow using 1 as cassandra.speculative-execution.limit

### DIFF
--- a/docs/src/main/sphinx/connector/cassandra.rst
+++ b/docs/src/main/sphinx/connector/cassandra.rst
@@ -147,7 +147,7 @@ Property Name                                                 Description
 
 ``cassandra.no-host-available-retry-timeout``                 Retry timeout for ``NoHostAvailableException``, defaults to ``1m``.
 
-``cassandra.speculative-execution.limit``                     The number of speculative executions, defaults to ``1``.
+``cassandra.speculative-execution.limit``                     The number of speculative executions. This is disabled by default.
 
 ``cassandra.speculative-execution.delay``                     The delay between each speculative execution, defaults to ``500ms``.
 

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClientConfig.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClientConfig.java
@@ -70,7 +70,7 @@ public class CassandraClientConfig
     private boolean tokenAwareShuffleReplicas;
     private List<String> allowedAddresses = ImmutableList.of();
     private Duration noHostAvailableRetryTimeout = new Duration(1, MINUTES);
-    private int speculativeExecutionLimit = 1;
+    private Optional<Integer> speculativeExecutionLimit = Optional.empty();
     private Duration speculativeExecutionDelay = new Duration(500, MILLISECONDS);
     private ProtocolVersion protocolVersion;
     private boolean tlsEnabled;
@@ -379,16 +379,15 @@ public class CassandraClientConfig
         return this;
     }
 
-    @Min(1)
-    public int getSpeculativeExecutionLimit()
+    public Optional<@Min(1) Integer> getSpeculativeExecutionLimit()
     {
         return speculativeExecutionLimit;
     }
 
     @Config("cassandra.speculative-execution.limit")
-    public CassandraClientConfig setSpeculativeExecutionLimit(int speculativeExecutionLimit)
+    public CassandraClientConfig setSpeculativeExecutionLimit(Integer speculativeExecutionLimit)
     {
-        this.speculativeExecutionLimit = speculativeExecutionLimit;
+        this.speculativeExecutionLimit = Optional.ofNullable(speculativeExecutionLimit);
         return this;
     }
 

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClientModule.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraClientModule.java
@@ -154,10 +154,10 @@ public class CassandraClientModule
         options.setConsistencyLevel(config.getConsistencyLevel());
         clusterBuilder.withQueryOptions(options);
 
-        if (config.getSpeculativeExecutionLimit() > 1) {
+        if (config.getSpeculativeExecutionLimit().isPresent()) {
             clusterBuilder.withSpeculativeExecutionPolicy(new ConstantSpeculativeExecutionPolicy(
                     config.getSpeculativeExecutionDelay().toMillis(), // delay before a new execution is launched
-                    config.getSpeculativeExecutionLimit())); // maximum number of executions
+                    config.getSpeculativeExecutionLimit().get())); // maximum number of executions
         }
 
         return new CassandraSession(

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraClientConfig.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraClientConfig.java
@@ -61,7 +61,7 @@ public class TestCassandraClientConfig
                 .setTokenAwareShuffleReplicas(false)
                 .setAllowedAddresses("")
                 .setNoHostAvailableRetryTimeout(new Duration(1, MINUTES))
-                .setSpeculativeExecutionLimit(1)
+                .setSpeculativeExecutionLimit(null)
                 .setSpeculativeExecutionDelay(new Duration(500, MILLISECONDS))
                 .setProtocolVersion(null)
                 .setTlsEnabled(false)


### PR DESCRIPTION
We should allow 1 for ConstantSpeculativeExecutionPolicy. While our documentation said it's 1 by default, it was unused unless users set value > 1. I would change to `Optional<Integer>` instead of changing the condition `> to >=` to keep the default behavior. 

```java
    public ConstantSpeculativeExecutionPolicy(long constantDelayMillis, int maxSpeculativeExecutions) {
        Preconditions.checkArgument(constantDelayMillis > 0L, "delay must be strictly positive (was %d)", new Object[]{constantDelayMillis});
        Preconditions.checkArgument(maxSpeculativeExecutions > 0, "number of speculative executions must be strictly positive (was %d)", new Object[]{maxSpeculativeExecutions});
        this.constantDelayMillis = constantDelayMillis;
        this.maxSpeculativeExecutions = maxSpeculativeExecutions;
    }
```

cc: @abicky