### PR TITLE
Improve HashGenerator.getPartition performance

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/HashGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashGenerator.java
@@ -15,8 +15,6 @@ package io.trino.operator;
 
 import io.trino.spi.Page;
 
-import static com.google.common.base.Preconditions.checkState;
-
 public interface HashGenerator
 {
     long hashPosition(int position, Page page);
@@ -24,13 +22,8 @@ public interface HashGenerator
     default int getPartition(int partitionCount, int position, Page page)
     {
         long rawHash = hashPosition(position, page);
-
-        // clear the sign bit
-        rawHash &= 0x7fff_ffff_ffff_ffffL;
-
-        int partition = (int) (rawHash % partitionCount);
-
-        checkState(partition >= 0 && partition < partitionCount);
-        return partition;
+        // This function reduces the 64 bit rawHash to [0, partitionCount) uniformly. It first reduces the rawHash to 32 bit
+        // integer x then normalize it to x / 2^32 * partitionCount to reduce the range of x from [0, 2^32) to [0, partitionCount)
+        return (int) ((Integer.toUnsignedLong(Long.hashCode(rawHash)) * partitionCount) >>> 32);
     }
 }


### PR DESCRIPTION
Port of https://github.com/prestodb/presto/pull/13611.
Change the mod operation to bit shifting in HashGenerator.getPartition.
BenchmarkPartitionedOutputOperator shows ~10% gain.

Before
```
(channelCount)  (nullRate)  (partitionCount)  (positionCount)  (type)  Mode  Cnt     Score    Error  Units
             1           0               256             8192  BIGINT  avgt   10  2300.677 ± 49.181  ms/op
             1         0.2               256             8192  BIGINT  avgt   10  2292.622 ± 60.765  ms/op
             2           0               256             8192  BIGINT  avgt   10  3411.225 ± 47.299  ms/op
             2         0.2               256             8192  BIGINT  avgt   10  3601.043 ± 49.378  ms/op
```

After
```
(channelCount)  (nullRate)  (partitionCount)  (positionCount)  (type)  Mode  Cnt     Score     Error  Units
             1           0               256             8192  BIGINT  avgt   10  1962.333 ±  36.066  ms/op
             1         0.2               256             8192  BIGINT  avgt   10  2067.068 ± 137.070  ms/op
             2           0               256             8192  BIGINT  avgt   10  3070.689 ±  41.821  ms/op
             2         0.2               256             8192  BIGINT  avgt   10  3329.175 ± 122.881  ms/op
```