### PR TITLE
Do not set stats that are not propagated for nested operators

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -58,7 +58,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 /**
  * Contains information about {@link Operator} execution.
  * <p>
- * Not thread-safe. Only {@link #getOperatorStats()}, {@link #getNestedOperatorStats()}
+ * Not thread-safe. Only {@link #getNestedOperatorStats()}
  * and revocable-memory-related operations are thread-safe.
  */
 public class OperatorContext
@@ -508,7 +508,7 @@ public class OperatorContext
         return format("%s-%s", operatorType, planNodeId);
     }
 
-    public OperatorStats getOperatorStats()
+    private OperatorStats getOperatorStats()
     {
         Supplier<? extends OperatorInfo> infoSupplier = this.infoSupplier.get();
         OperatorInfo info = Optional.ofNullable(infoSupplier).map(Supplier::get).orElse(null);

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -508,6 +508,19 @@ public class OperatorContext
         return format("%s-%s", operatorType, planNodeId);
     }
 
+    public List<OperatorStats> getNestedOperatorStats()
+    {
+        Supplier<List<OperatorStats>> nestedOperatorStatsSupplier = this.nestedOperatorStatsSupplier.get();
+        return Optional.ofNullable(nestedOperatorStatsSupplier)
+                .map(Supplier::get)
+                .orElseGet(() -> ImmutableList.of(getOperatorStats()));
+    }
+
+    public <C, R> R accept(QueryContextVisitor<C, R> visitor, C context)
+    {
+        return visitor.visitOperatorContext(this, context);
+    }
+
     private OperatorStats getOperatorStats()
     {
         Supplier<? extends OperatorInfo> infoSupplier = this.infoSupplier.get();
@@ -566,19 +579,6 @@ public class OperatorContext
 
                 memoryFuture.get().isDone() ? Optional.empty() : Optional.of(WAITING_FOR_MEMORY),
                 info);
-    }
-
-    public List<OperatorStats> getNestedOperatorStats()
-    {
-        Supplier<List<OperatorStats>> nestedOperatorStatsSupplier = this.nestedOperatorStatsSupplier.get();
-        return Optional.ofNullable(nestedOperatorStatsSupplier)
-                .map(Supplier::get)
-                .orElseGet(() -> ImmutableList.of(getOperatorStats()));
-    }
-
-    public <C, R> R accept(QueryContextVisitor<C, R> visitor, C context)
-    {
-        return visitor.visitOperatorContext(this, context);
     }
 
     private static long nanosBetween(long start, long end)

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -233,15 +233,13 @@ public class WorkProcessorPipelineSourceOperator
 
             long deltaReadTimeNanos = deltaAndSet(context.readTimeNanos, sourceOperator.getReadTime().roundTo(NANOSECONDS));
 
-            long deltaDynamicFilterSplitsProcessed = deltaAndSet(context.dynamicFilterSplitsProcessed, sourceOperator.getDynamicFilterSplitsProcessed());
+            context.dynamicFilterSplitsProcessed.set(sourceOperator.getDynamicFilterSplitsProcessed());
             Metrics metrics = sourceOperator.getConnectorMetrics();
             context.connectorMetrics.set(metrics);
 
             operatorContext.recordPhysicalInputWithTiming(deltaPhysicalInputDataSize, deltaPhysicalInputPositions, deltaReadTimeNanos);
             operatorContext.recordNetworkInput(deltaInternalNetworkInputDataSize, deltaInternalNetworkInputPositions);
             operatorContext.recordProcessedInput(deltaInputDataSize, deltaInputPositions);
-            operatorContext.recordDynamicFilterSplitProcessed(deltaDynamicFilterSplitsProcessed);
-            operatorContext.setLatestMetrics(metrics);
         }
 
         if (state.getType() == FINISHED) {

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -734,7 +734,9 @@ public class LocalQueryRunner
                 for (Driver driver : drivers) {
                     if (alwaysRevokeMemory) {
                         driver.getDriverContext().getOperatorContexts().stream()
-                                .filter(operatorContext -> operatorContext.getOperatorStats().getRevocableMemoryReservation().toBytes() > 0)
+                                .filter(operatorContext -> operatorContext.getNestedOperatorStats().stream()
+                                        .mapToLong(stats -> stats.getRevocableMemoryReservation().toBytes())
+                                        .sum() > 0)
                                 .forEach(OperatorContext::requestMemoryRevoking);
                     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestExchangeOperator.java
@@ -44,6 +44,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.trino.SessionTestUtils.TEST_SESSION;
@@ -257,7 +258,7 @@ public class TestExchangeOperator
                 .addDriverContext();
 
         SourceOperator operator = operatorFactory.createOperator(driverContext);
-        assertEquals(operator.getOperatorContext().getOperatorStats().getSystemMemoryReservation().toBytes(), 0);
+        assertEquals(getOnlyElement(operator.getOperatorContext().getNestedOperatorStats()).getSystemMemoryReservation().toBytes(), 0);
         return operator;
     }
 
@@ -312,7 +313,7 @@ public class TestExchangeOperator
             assertPageEquals(TYPES, page, PAGE);
         }
 
-        assertEquals(operator.getOperatorContext().getOperatorStats().getSystemMemoryReservation().toBytes(), 0);
+        assertEquals(getOnlyElement(operator.getOperatorContext().getNestedOperatorStats()).getSystemMemoryReservation().toBytes(), 0);
 
         return outputPages;
     }
@@ -335,6 +336,6 @@ public class TestExchangeOperator
         assertEquals(operator.isFinished(), true);
         assertEquals(operator.needsInput(), false);
         assertNull(operator.getOutput());
-        assertEquals(operator.getOperatorContext().getOperatorStats().getSystemMemoryReservation().toBytes(), 0);
+        assertEquals(getOnlyElement(operator.getOperatorContext().getNestedOperatorStats()).getSystemMemoryReservation().toBytes(), 0);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashAggregationOperator.java
@@ -312,7 +312,7 @@ public class TestHashAggregationOperator
 
         Operator operator = operatorFactory.createOperator(driverContext);
         toPages(operator, input.iterator(), revokeMemoryWhenAddingPages);
-        assertEquals(operator.getOperatorContext().getOperatorStats().getUserMemoryReservation().toBytes(), 0);
+        assertEquals(getOnlyElement(operator.getOperatorContext().getNestedOperatorStats()).getUserMemoryReservation().toBytes(), 0);
     }
 
     @Test(dataProvider = "hashEnabled", expectedExceptions = ExceededMemoryLimitException.class, expectedExceptionsMessageRegExp = "Query exceeded per-node user memory limit of 10B.*")

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -85,17 +85,17 @@ public class TestWorkProcessorPipelineSourceOperator
 
         SettableFuture<Void> firstBlockedFuture = SettableFuture.create();
         Transformation<Page, Page> firstOperatorPages = transformationFrom(ImmutableList.of(
-                Transform.of(Optional.of(page1), TransformationState.blocked(firstBlockedFuture)),
-                Transform.of(Optional.of(page1), TransformationState.ofResult(page3, true)),
-                Transform.of(Optional.of(page2), TransformationState.ofResult(page4, false)),
-                Transform.of(Optional.of(page2), TransformationState.finished())),
+                        Transform.of(Optional.of(page1), TransformationState.blocked(firstBlockedFuture)),
+                        Transform.of(Optional.of(page1), TransformationState.ofResult(page3, true)),
+                        Transform.of(Optional.of(page2), TransformationState.ofResult(page4, false)),
+                        Transform.of(Optional.of(page2), TransformationState.finished())),
                 (left, right) -> left.getPositionCount() == right.getPositionCount());
 
         SettableFuture<Void> secondBlockedFuture = SettableFuture.create();
         Transformation<Page, Page> secondOperatorPages = transformationFrom(ImmutableList.of(
-                Transform.of(Optional.of(page3), TransformationState.ofResult(page5, true)),
-                Transform.of(Optional.of(page4), TransformationState.needsMoreData()),
-                Transform.of(Optional.empty(), TransformationState.blocked(secondBlockedFuture))),
+                        Transform.of(Optional.of(page3), TransformationState.ofResult(page5, true)),
+                        Transform.of(Optional.of(page4), TransformationState.needsMoreData()),
+                        Transform.of(Optional.empty(), TransformationState.blocked(secondBlockedFuture))),
                 (left, right) -> left.getPositionCount() == right.getPositionCount());
 
         TestWorkProcessorSourceOperatorFactory sourceOperatorFactory = new TestWorkProcessorSourceOperatorFactory(


### PR DESCRIPTION
    Do not set stats that are not propagated for nested operators

    WorkProcessorPipelineSourceOperator consist of a nested
    operators pipeline. Nested operators stats are reported via
    nestedOperatorStatsSupplier. Hence, stats that are
    set directly with OperatorContext#recordDynamicFilterSplitProcessed or
    OperatorContext#setLatestMetrics are not propagated.