### PR TITLE
Enable discovery server by default for coordinator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorDiscoveryModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorDiscoveryModule.java
@@ -23,7 +23,7 @@ public class CoordinatorDiscoveryModule
     @Override
     protected void setup(Binder binder)
     {
-        if (buildConfigObject(ServerConfig.class).isCoordinator() &&
+        if (buildConfigObject(ServerConfig.class).isCoordinator() ||
                 buildConfigObject(EmbeddedDiscoveryConfig.class).isEnabled()) {
             install(new EmbeddedDiscoveryModule());
         }


### PR DESCRIPTION
According to commit message https://github.com/trinodb/trino/pull/7983 introduced a unintentional default config change where discovery server is not started on coordinator