### PR TITLE
Fix too eager thread pruning in row pattern matching

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -607,7 +607,8 @@ public class WindowOperator
                         windowFunctions,
                         frames,
                         pagesIndexWithHashStrategies.peerGroupHashStrategy,
-                        pagesIndexWithHashStrategies.frameBoundComparators);
+                        pagesIndexWithHashStrategies.frameBoundComparators,
+                        operatorContext.aggregateUserMemoryContext());
 
                 windowInfo.addPartition(partition);
                 partitionStart = partitionEnd;

--- a/core/trino-main/src/main/java/io/trino/operator/window/Partitioner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/Partitioner.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.window;
 
+import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.operator.PagesHashStrategy;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndexComparator;
@@ -32,5 +33,6 @@ public interface Partitioner
             List<WindowFunction> windowFunctions,
             List<FrameInfo> frames,
             PagesHashStrategy peerGroupHashStrategy,
-            Map<FrameBoundKey, PagesIndexComparator> frameBoundComparators);
+            Map<FrameBoundKey, PagesIndexComparator> frameBoundComparators,
+            AggregatedMemoryContext memoryContext);
 }

--- a/core/trino-main/src/main/java/io/trino/operator/window/PatternRecognitionPartitioner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/PatternRecognitionPartitioner.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator.window;
 
+import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.operator.PagesHashStrategy;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndexComparator;
@@ -80,7 +81,8 @@ public class PatternRecognitionPartitioner
             List<WindowFunction> windowFunctions,
             List<FrameInfo> frames,
             PagesHashStrategy peerGroupHashStrategy,
-            Map<FrameBoundKey, PagesIndexComparator> frameBoundComparators)
+            Map<FrameBoundKey, PagesIndexComparator> frameBoundComparators,
+            AggregatedMemoryContext memoryContext)
     {
         return new PatternRecognitionPartition(
                 pagesIndex,
@@ -89,6 +91,7 @@ public class PatternRecognitionPartitioner
                 outputChannels,
                 windowFunctions,
                 peerGroupHashStrategy,
+                memoryContext,
                 measures,
                 commonBaseFrame,
                 rowsPerMatch,

--- a/core/trino-main/src/main/java/io/trino/operator/window/RegularWindowPartitioner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/RegularWindowPartitioner.java
@@ -14,6 +14,7 @@
 package io.trino.operator.window;
 
 import com.google.common.collect.Streams;
+import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.operator.PagesHashStrategy;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndexComparator;
@@ -37,7 +38,8 @@ public class RegularWindowPartitioner
             List<WindowFunction> windowFunctions,
             List<FrameInfo> frames,
             PagesHashStrategy peerGroupHashStrategy,
-            Map<FrameBoundKey, PagesIndexComparator> frameBoundComparators)
+            Map<FrameBoundKey, PagesIndexComparator> frameBoundComparators,
+            AggregatedMemoryContext memoryContext)
     {
         List<FramedWindowFunction> functions = Streams.zip(windowFunctions.stream(), frames.stream(), FramedWindowFunction::new)
                 .collect(toImmutableList());

--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/IntMultimap.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/IntMultimap.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.window.matcher;
+
+import io.airlift.slice.SizeOf;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+class IntMultimap
+{
+    private static final long INSTANCE_SIZE = ClassLayout.parseClass(IntMultimap.class).instanceSize();
+
+    private IntList[] values;
+    private final int capacity;
+    private final int listCapacity;
+    private long valuesSize;
+
+    public IntMultimap(int capacity, int listCapacity)
+    {
+        this.values = new IntList[capacity];
+        this.capacity = capacity;
+        this.listCapacity = listCapacity;
+        this.valuesSize = 0L;
+    }
+
+    public void add(int key, int value)
+    {
+        boolean expanded = ensureCapacity(key);
+        long listSizeBefore;
+        if (expanded || values[key] == null) {
+            listSizeBefore = 0L;
+            values[key] = new IntList(listCapacity);
+        }
+        else {
+            listSizeBefore = values[key].getSizeInBytes();
+        }
+        values[key].add(value);
+        valuesSize += values[key].getSizeInBytes() - listSizeBefore;
+    }
+
+    public void release(int key)
+    {
+        if (values[key] != null) {
+            valuesSize -= values[key].getSizeInBytes();
+            values[key] = null;
+        }
+    }
+
+    public void copy(int parent, int child)
+    {
+        boolean expanded = ensureCapacity(child);
+        if (expanded || values[child] == null) {
+            if (values[parent] != null) {
+                values[child] = values[parent].copy();
+                valuesSize += values[child].getSizeInBytes();
+            }
+        }
+        else if (values[parent] != null) {
+            long listSizeBefore = values[child].getSizeInBytes();
+            values[child] = values[parent].copy();
+            valuesSize += values[child].getSizeInBytes() - listSizeBefore;
+        }
+        else {
+            valuesSize -= values[child].getSizeInBytes();
+            values[child] = null;
+        }
+    }
+
+    public ArrayView getArrayView(int key)
+    {
+        if (values[key] == null) {
+            return ArrayView.EMPTY;
+        }
+        return values[key].toArrayView();
+    }
+
+    public void clear()
+    {
+        values = new IntList[capacity];
+        valuesSize = 0L;
+    }
+
+    // returns true if the array was expanded; otherwise returns false
+    private boolean ensureCapacity(int key)
+    {
+        if (key >= values.length) {
+            values = Arrays.copyOf(values, Math.max(values.length * 2, key + 1));
+            return true;
+        }
+
+        return false;
+    }
+
+    public long getSizeInBytes()
+    {
+        return INSTANCE_SIZE + SizeOf.sizeOf(values) + valuesSize;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/IntStack.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/IntStack.java
@@ -13,9 +13,16 @@
  */
 package io.trino.operator.window.matcher;
 
+import io.airlift.slice.SizeOf;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
 class IntStack
 {
-    private final int[] values;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(IntStack.class).instanceSize();
+
+    private int[] values;
     private int next;
 
     public IntStack(int capacity)
@@ -25,6 +32,7 @@ class IntStack
 
     public void push(int value)
     {
+        ensureCapacity();
         values[next] = value;
         next++;
     }
@@ -38,5 +46,17 @@ class IntStack
     public int size()
     {
         return next;
+    }
+
+    private void ensureCapacity()
+    {
+        if (next == values.length) {
+            values = Arrays.copyOf(values, next * 2 + 1);
+        }
+    }
+
+    public long getSizeInBytes()
+    {
+        return INSTANCE_SIZE + SizeOf.sizeOf(values);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/window/matcher/ThreadEquivalence.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/matcher/ThreadEquivalence.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.window.matcher;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.operator.window.pattern.LogicalIndexNavigation;
+import io.trino.operator.window.pattern.PhysicalValuePointer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.operator.window.pattern.PhysicalValuePointer.CLASSIFIER;
+import static io.trino.operator.window.pattern.PhysicalValuePointer.MATCH_NUMBER;
+
+/**
+ * The purpose of this class is to determine whether two pattern matching threads
+ * are equivalent. Based on the thread equivalence, threads which are duplicates
+ * of some other thread can be pruned.
+ * <p>
+ * It is assumed that the two compared threads:
+ * - have already matched the same portion of input. This also means that
+ * their corresponding arrays of matched labels are of equal lengths.
+ * - have reached the same instruction in the program.
+ * <p>
+ * It takes the following steps to determine if two threads are equivalent:
+ * <p>
+ * 1. get the set of labels reachable by the program from the current
+ * instruction until the end of the program (`reachableLabels`)
+ * <p>
+ * 2. for all those labels, get all navigating operations for accessing
+ * input values which need to be performed during label evaluation
+ * (`positionsToCompare`). For all those navigating operations, check if they
+ * return the same result (i.e. navigate to the same input row) for both threads.
+ * NOTE: the computations can be simplified by stripping the physical offsets
+ * and skipping navigations which refer to the universal pattern variable.
+ * <p>
+ * 3. for all those labels, get all navigating operations for `CLASSIFIER` calls
+ * which need to be performed during label evaluation (`labelsToCompare`).
+ * For all those navigating operations, check if they navigate to rows tagged
+ * with the same label (but not necessarily the same position in input) for both threads.
+ * <p>
+ * NOTE: the navigating operations for `MATCH_NUMBER` calls can be skipped
+ * altogether, since the match number is constant in this context.
+ */
+public class ThreadEquivalence
+{
+    // for every pointer (instruction) in the program, the set of labels reachable by the program
+    // starting from this instruction until the program ends, through any path.
+    private final List<Set<Integer>> reachableLabels;
+
+    // for every label, the set of navigations for accessing input values based on the defining condition
+    private final List<Set<LogicalIndexNavigation>> positionsToCompare;
+
+    // for every label, the set of navigations for accessing the matched labels based on the defining condition
+    private final List<Set<LogicalIndexNavigation>> labelsToCompare;
+
+    public ThreadEquivalence(Program program, List<List<PhysicalValuePointer>> valuePointers)
+    {
+        this.reachableLabels = computeReachableLabels(program);
+
+        this.positionsToCompare = getInputValuePointers(valuePointers).stream()
+                .map(pointersList -> pointersList.stream()
+                        .map(PhysicalValuePointer::getLogicalIndexNavigation)
+                        .filter(navigation -> !navigation.getLabels().isEmpty())
+                        .map(LogicalIndexNavigation::withoutPhysicalOffset)
+                        .map(ThreadEquivalence::allPositionsToCompare)
+                        .flatMap(Collection::stream)
+                        .collect(toImmutableSet()))
+                .collect(toImmutableList());
+
+        this.labelsToCompare = getClassifierValuePointers(valuePointers).stream()
+                .map(pointersList -> pointersList.stream()
+                        .map(PhysicalValuePointer::getLogicalIndexNavigation)
+                        .map(ThreadEquivalence::allPositionsToCompare)
+                        .flatMap(Collection::stream)
+                        .collect(toImmutableSet()))
+                .collect(toImmutableList());
+    }
+
+    public boolean equivalent(int firstThread, ArrayView firstLabels, int secondThread, ArrayView secondLabels, int pointer)
+    {
+        checkArgument(firstLabels.length() == secondLabels.length(), "matched labels for compared threads differ in length");
+        checkArgument(pointer >= 0 && pointer < reachableLabels.size(), "instruction pointer out of program bounds");
+
+        if (firstThread == secondThread || firstLabels.length() == 0) {
+            return true;
+        }
+
+        // compare resulting positions for input navigations
+        Set<LogicalIndexNavigation> distinctPositionsToCompare = new HashSet<>();
+        for (int label : reachableLabels.get(pointer)) {
+            distinctPositionsToCompare.addAll(positionsToCompare.get(label));
+        }
+        for (LogicalIndexNavigation navigation : distinctPositionsToCompare) {
+            if (resolvePosition(navigation, firstLabels) != resolvePosition(navigation, secondLabels)) {
+                return false;
+            }
+        }
+
+        // compare resulting labels for `CLASSIFIER` navigations
+        Set<LogicalIndexNavigation> distinctLabelPositionsToCompare = new HashSet<>();
+        for (int label : reachableLabels.get(pointer)) {
+            distinctLabelPositionsToCompare.addAll(labelsToCompare.get(label));
+        }
+        for (LogicalIndexNavigation navigation : distinctLabelPositionsToCompare) {
+            int firstPosition = resolvePosition(navigation, firstLabels);
+            int secondPosition = resolvePosition(navigation, secondLabels);
+            if ((firstPosition == -1) != (secondPosition == -1)) {
+                return false;
+            }
+            if (firstPosition != -1 && firstLabels.get(firstPosition) != secondLabels.get(secondPosition)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int resolvePosition(LogicalIndexNavigation navigation, ArrayView labels)
+    {
+        return navigation.resolvePosition(labels.length() - 1, labels, 0, labels.length(), 0);
+    }
+
+    private static List<Set<Integer>> computeReachableLabels(Program program)
+    {
+        List<Set<Integer>> reachableLabels = new ArrayList<>(program.size());
+
+        // because the program might have cycles, the computation is done for every instruction
+        // TODO optimize the computations to reuse the results whenever possible
+        for (int instructionIndex = 0; instructionIndex < program.size(); instructionIndex++) {
+            reachableLabels.add(reachableLabels(program, instructionIndex, new boolean[program.size()]));
+        }
+
+        return reachableLabels;
+    }
+
+    private static Set<Integer> reachableLabels(Program program, int instructionIndex, boolean[] visited)
+    {
+        if (visited[instructionIndex]) {
+            return new HashSet<>();
+        }
+
+        visited[instructionIndex] = true;
+
+        Set<Integer> reachableLabels = new HashSet<>();
+        Instruction instruction = program.at(instructionIndex);
+        switch (instruction.type()) {
+            case MATCH_LABEL:
+                reachableLabels.addAll(reachableLabels(program, instructionIndex + 1, visited));
+                reachableLabels.add(((MatchLabel) instruction).getLabel());
+                break;
+            case JUMP:
+                reachableLabels.addAll(reachableLabels(program, ((Jump) instruction).getTarget(), visited));
+                break;
+            case SPLIT:
+                reachableLabels.addAll(reachableLabels(program, ((Split) instruction).getFirst(), visited));
+                reachableLabels.addAll(reachableLabels(program, ((Split) instruction).getSecond(), visited));
+                break;
+            case MATCH_START:
+            case MATCH_END:
+            case SAVE:
+                reachableLabels.addAll(reachableLabels(program, instructionIndex + 1, visited));
+                break;
+            case DONE:
+                // no reachable labels
+        }
+
+        return reachableLabels;
+    }
+
+    private static List<List<PhysicalValuePointer>> getInputValuePointers(List<List<PhysicalValuePointer>> valuePointers)
+    {
+        return valuePointers.stream()
+                .map(pointerList -> pointerList.stream()
+                        .filter(pointer -> pointer.getSourceChannel() != CLASSIFIER && pointer.getSourceChannel() != MATCH_NUMBER)
+                        .collect(toImmutableList()))
+                .collect(toImmutableList());
+    }
+
+    private static List<List<PhysicalValuePointer>> getClassifierValuePointers(List<List<PhysicalValuePointer>> valuePointers)
+    {
+        return valuePointers.stream()
+                .map(pointerList -> pointerList.stream()
+                        .filter(pointer -> pointer.getSourceChannel() == CLASSIFIER)
+                        .collect(toImmutableList()))
+                .collect(toImmutableList());
+    }
+
+    /**
+     * For a LogicalIndexNavigation, returns a set of all navigations which must return
+     * equal results for the two compared threads if the threads are equivalent.
+     * <p>
+     * FIRST(A.value) -> compare the position "FIRST(A)"
+     * FIRST(A.value, 2) -> compare the position "FIRST(A, 2)"
+     * LAST(A.value) -> compare the position "LAST(A)"
+     * LAST(A.value, 2) -> compare the positions "LAST(A, 2)", "LAST(A, 1)", "LAST(A)".
+     * They must all be equal for both threads in case there are more labels "A" assigned in the future.
+     * <p>
+     * PREV(LAST(CLASSIFIER(A), 2), 5) -> compare the positions "PREV(LAST(A, 2), 5)", "PREV(LAST(A, 1), 5)", "PREV(LAST(A), 5)",
+     * and the 5 trailing labels. They must all be equal for both threads in case there are more labels "A" assigned in the future.
+     */
+    private static List<LogicalIndexNavigation> allPositionsToCompare(LogicalIndexNavigation navigation)
+    {
+        if (navigation.isLast()) {
+            List<LogicalIndexNavigation> result = new ArrayList<>();
+            for (int offset = 0; offset <= navigation.getLogicalOffset(); offset++) {
+                result.add(navigation.withLogicalOffset(offset));
+            }
+
+            // physical offset can be present only in `CLASSIFIER` navigations. For input navigations it was pruned.
+            // In case when the physical offset is negative, we need to compare all labels in the offset-length suffix
+            // of the match between both compared threads.
+            for (int tail = navigation.getPhysicalOffset() + 1; tail < 0; tail++) {
+                result.add(navigation.withoutLogicalOffset().withPhysicalOffset(tail));
+            }
+            return result;
+        }
+
+        return ImmutableList.of(navigation);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/window/pattern/LabelEvaluator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/pattern/LabelEvaluator.java
@@ -107,6 +107,11 @@ public class LabelEvaluator
             this.session = requireNonNull(session, "session is null");
         }
 
+        public List<PhysicalValuePointer> getExpectedLayout()
+        {
+            return expectedLayout;
+        }
+
         // TODO This method allocates an intermediate block and passes it as the input to the pre-compiled expression.
         //  Instead, the expression should be compiled directly against the row navigations.
         //  The same applies to MeasureComputation.compute()

--- a/core/trino-main/src/main/java/io/trino/operator/window/pattern/LogicalIndexNavigation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/window/pattern/LogicalIndexNavigation.java
@@ -15,6 +15,7 @@ package io.trino.operator.window.pattern;
 
 import io.trino.operator.window.matcher.ArrayView;
 
+import java.util.Objects;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -40,6 +41,26 @@ public class LogicalIndexNavigation
         checkArgument(logicalOffset >= 0, "logical offset must be >= 0, actual: ", logicalOffset);
         this.logicalOffset = logicalOffset;
         this.physicalOffset = physicalOffset;
+    }
+
+    public Set<Integer> getLabels()
+    {
+        return labels;
+    }
+
+    public boolean isLast()
+    {
+        return last;
+    }
+
+    public int getLogicalOffset()
+    {
+        return logicalOffset;
+    }
+
+    public int getPhysicalOffset()
+    {
+        return physicalOffset;
     }
 
     /**
@@ -180,5 +201,49 @@ public class LogicalIndexNavigation
             return position;
         }
         return -1;
+    }
+
+    // for thread equivalence
+    public LogicalIndexNavigation withoutLogicalOffset()
+    {
+        return withLogicalOffset(0);
+    }
+
+    public LogicalIndexNavigation withLogicalOffset(int logicalOffset)
+    {
+        return new LogicalIndexNavigation(labels, last, running, logicalOffset, physicalOffset);
+    }
+
+    public LogicalIndexNavigation withoutPhysicalOffset()
+    {
+        return withPhysicalOffset(0);
+    }
+
+    public LogicalIndexNavigation withPhysicalOffset(int physicalOffset)
+    {
+        return new LogicalIndexNavigation(labels, last, running, logicalOffset, physicalOffset);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LogicalIndexNavigation that = (LogicalIndexNavigation) o;
+        return last == that.last &&
+                running == that.running &&
+                logicalOffset == that.logicalOffset &&
+                physicalOffset == that.physicalOffset &&
+                Objects.equals(labels, that.labels);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(labels, last, running, logicalOffset, physicalOffset);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1250,6 +1250,7 @@ public class LocalExecutionPlanner
 
             ConnectorSession connectorSession = session.toConnectorSession();
             // 4. prepare label evaluations (LabelEvaluator is to be instantiated once per Partition)
+            ImmutableList.Builder<List<PhysicalValuePointer>> evaluationsValuePointers = ImmutableList.builder();
             List<EvaluationSupplier> labelEvaluations = node.getVariableDefinitions().values().stream()
                     .map(expressionAndValuePointers -> {
                         // compile the rewritten expression
@@ -1257,6 +1258,7 @@ public class LocalExecutionPlanner
 
                         // prepare physical value accessors to provide input for the expression
                         List<PhysicalValuePointer> physicalValuePointers = preparePhysicalValuePointers(expressionAndValuePointers, mapping, source.getLayout(), context);
+                        evaluationsValuePointers.add(physicalValuePointers);
 
                         // build label evaluation
                         return new EvaluationSupplier(pageProjectionSupplier, physicalValuePointers, labelNames, connectorSession);
@@ -1297,7 +1299,7 @@ public class LocalExecutionPlanner
                     skipToNavigation,
                     node.getSkipToPosition(),
                     node.isInitial(),
-                    new Matcher(program),
+                    new Matcher(program, evaluationsValuePointers.build()),
                     labelEvaluations);
 
             OperatorFactory operatorFactory = new WindowOperatorFactory(

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatching.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestRowPatternMatching.java
@@ -474,6 +474,76 @@ public class TestRowPatternMatching
     }
 
     @Test
+    public void testBackReference()
+    {
+        // defining condition of `X` refers to input values at matched label `A`
+        assertThat(assertions.query("SELECT value, classy " +
+                "       FROM (VALUES 1, 1) t(value) " +
+                "       MATCH_RECOGNIZE ( " +
+                "       MEASURES CLASSIFIER() AS classy " +
+                "       ALL ROWS PER MATCH " +
+                "       PATTERN ((A | B)* X) " +
+                "       DEFINE X AS value = A.value " +
+                "     )"))
+                .matches("VALUES " +
+                        "(1, VARCHAR 'A'), " +
+                        "(1, 'X') ");
+
+        // defining condition of `X` refers to input values at matched label `B`
+        assertThat(assertions.query("SELECT value, classy " +
+                "       FROM (VALUES 1, 1) t(value) " +
+                "       MATCH_RECOGNIZE ( " +
+                "       MEASURES CLASSIFIER() AS classy " +
+                "       ALL ROWS PER MATCH " +
+                "       PATTERN ((A | B)* X) " +
+                "       DEFINE X AS value = B.value " +
+                "     )"))
+                .matches("VALUES " +
+                        "(1, VARCHAR 'B'), " +
+                        "(1, 'X') ");
+
+        // defining condition of `X` refers to input values at matched labels `A` and `B`
+        assertThat(assertions.query("SELECT value, classy, defining_condition " +
+                "       FROM (VALUES 1, 2, 3, 4, 5, 6) t(value) " +
+                "       MATCH_RECOGNIZE ( " +
+                "       ORDER BY value " +
+                "       MEASURES " +
+                "               CLASSIFIER() AS classy, " +
+                "               PREV(LAST(A.value), 3) + FIRST(A.value) + PREV(LAST(B.value), 2) AS defining_condition" +
+                "       ALL ROWS PER MATCH " +
+                "       PATTERN ((A | B)* X) " +
+                "       DEFINE X AS value = PREV(LAST(A.value), 3) + FIRST(A.value) + PREV(LAST(B.value), 2) " +
+                "     )"))
+                .matches("VALUES " +
+                        "(1, VARCHAR 'B',   null), " +
+                        "(2,         'A',   null), " +
+                        "(3,         'A',   null), " +
+                        "(4,         'A',   null), " +
+                        "(5,         'B',      6), " +
+                        "(6,         'X',      6) ");
+
+        // defining condition of `X` refers to matched labels `A` and `B`
+        assertThat(assertions.query("SELECT value, classy, defining_condition " +
+                "       FROM (VALUES 1, 2, 3, 4, 5) t(value) " +
+                "       MATCH_RECOGNIZE ( " +
+                "       ORDER BY value " +
+                "       MEASURES " +
+                "               CLASSIFIER() AS classy, " +
+                "               PREV(CLASSIFIER(U), 1) = 'A' AND LAST(CLASSIFIER(), 3) = 'B' AND FIRST(CLASSIFIER(U)) = 'B' AS defining_condition" +
+                "       ALL ROWS PER MATCH " +
+                "       PATTERN ((A | B)* X $) " +
+                "       SUBSET U = (A, B) " +
+                "       DEFINE X AS PREV(CLASSIFIER(U), 1) = 'A' AND LAST(CLASSIFIER(), 3) = 'B' AND FIRST(CLASSIFIER(U)) = 'B' " +
+                "     )"))
+                .matches("VALUES " +
+                        "(1, VARCHAR 'B',   null), " +
+                        "(2,         'B',   false), " +
+                        "(3,         'A',   false), " +
+                        "(4,         'A',   true), " +
+                        "(5,         'X',   true) ");
+    }
+
+    @Test
     public void testEmptyCycle()
     {
         String query = "SELECT m.id AS row_id, m.match, m.val, m.label " +
@@ -1416,5 +1486,46 @@ public class TestRowPatternMatching
                         "     (true), " +
                         "     (true), " +
                         "     (true) ");
+    }
+
+    @Test
+    public void testPotentiallyExponentialMatch()
+    {
+        // the following example can produce exponential number of different match attempts.
+        // because equivalent threads in Matcher are detected and pruned, it is solved in linear time.
+        assertThat(assertions.query("SELECT m.classy " +
+                "          FROM (VALUES (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1)) t(value) " +
+                "                 MATCH_RECOGNIZE ( " +
+                "                   MEASURES CLASSIFIER() AS classy " +
+                "                   PATTERN ((A+)+ B) " +
+                "                   DEFINE " +
+                "                           A AS value = 1, " +
+                "                           B AS value = 2 " +
+                "                ) AS m"))
+                .returnsEmptyResult();
+    }
+
+    @Test
+    public void testExponentialMatch()
+    {
+        // the match `B B B B B B B B LAST` is the last one checked out of over 2^9 possible matches
+        assertThat(assertions.query("SELECT m.classy " +
+                "          FROM (VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9)) t(value) " +
+                "                 MATCH_RECOGNIZE ( " +
+                "                   ORDER BY value " +
+                "                   MEASURES CLASSIFIER() AS classy " +
+                "                   ALL ROWS PER MATCH " +
+                "                   PATTERN ((A | B)+ LAST) " +
+                "                   DEFINE LAST AS FIRST(CLASSIFIER()) = 'B' AND " +
+                "                                  FIRST(CLASSIFIER(), 1) = 'B' AND " +
+                "                                  FIRST(CLASSIFIER(), 2) = 'B' AND " +
+                "                                  FIRST(CLASSIFIER(), 3) = 'B' AND " +
+                "                                  FIRST(CLASSIFIER(), 4) = 'B' AND " +
+                "                                  FIRST(CLASSIFIER(), 5) = 'B' AND " +
+                "                                  FIRST(CLASSIFIER(), 6) = 'B' AND " +
+                "                                  FIRST(CLASSIFIER(), 7) = 'B' " +
+
+                "                ) AS m"))
+                .matches("VALUES (VARCHAR 'B'), ('B'), ('B'), ('B'), ('B'), ('B'), ('B'), ('B'), ('LAST') ");
     }
 }


### PR DESCRIPTION
This change applies to row pattern recognition
matching algorithm.

Before this change, the threads in Matcher were killed
too eagerly. This change introduces a more complex
comparison method.

This change also introduces memory usage reporting,
since the new thread pruning strategy allows
exponential explosion.