### PR TITLE
Improve Block#getLoadedBlock() and Page#getLoadedPage()

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/Page.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Page.java
@@ -274,22 +274,20 @@ public final class Page
      */
     public Page getLoadedPage()
     {
-        Block[] loadedBlocks = null;
         for (int i = 0; i < blocks.length; i++) {
             Block loaded = blocks[i].getLoadedBlock();
             if (loaded != blocks[i]) {
-                if (loadedBlocks == null) {
-                    loadedBlocks = blocks.clone();
+                // Transition to new block creation mode after the first newly loaded block is encountered
+                Block[] loadedBlocks = blocks.clone();
+                loadedBlocks[i++] = loaded;
+                for (; i < blocks.length; i++) {
+                    loadedBlocks[i] = blocks[i].getLoadedBlock();
                 }
-                loadedBlocks[i] = loaded;
+                return wrapBlocksWithoutCopy(positionCount, loadedBlocks);
             }
         }
-
-        if (loadedBlocks == null) {
-            return this;
-        }
-
-        return wrapBlocksWithoutCopy(positionCount, loadedBlocks);
+        // No newly loaded blocks
+        return this;
     }
 
     public Page getLoadedPage(int column)

--- a/core/trino-spi/src/main/java/io/trino/spi/block/BlockUtil.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/BlockUtil.java
@@ -209,4 +209,25 @@ final class BlockUtil
         }
         return true;
     }
+
+    /**
+     * Returns the input blocks array if all blocks are already loaded, otherwise returns a new blocks array with all blocks loaded
+     */
+    static Block[] ensureBlocksAreLoaded(Block[] blocks)
+    {
+        for (int i = 0; i < blocks.length; i++) {
+            Block loaded = blocks[i].getLoadedBlock();
+            if (loaded != blocks[i]) {
+                // Transition to new block creation mode after the first newly loaded block is encountered
+                Block[] loadedBlocks = blocks.clone();
+                loadedBlocks[i++] = loaded;
+                for (; i < blocks.length; i++) {
+                    loadedBlocks[i] = blocks[i].getLoadedBlock();
+                }
+                return loadedBlocks;
+            }
+        }
+        // No newly loaded blocks
+        return blocks;
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/RowBlock.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
+import static io.trino.spi.block.BlockUtil.ensureBlocksAreLoaded;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -213,17 +214,9 @@ public class RowBlock
     @Override
     public Block getLoadedBlock()
     {
-        boolean allLoaded = true;
-        Block[] loadedFieldBlocks = new Block[fieldBlocks.length];
-
-        for (int i = 0; i < fieldBlocks.length; i++) {
-            loadedFieldBlocks[i] = fieldBlocks[i].getLoadedBlock();
-            if (loadedFieldBlocks[i] != fieldBlocks[i]) {
-                allLoaded = false;
-            }
-        }
-
-        if (allLoaded) {
+        Block[] loadedFieldBlocks = ensureBlocksAreLoaded(fieldBlocks);
+        if (loadedFieldBlocks == fieldBlocks) {
+            // All blocks are already loaded
             return this;
         }
         return createRowBlockInternal(

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlock.java
@@ -18,6 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.function.BiConsumer;
 
+import static io.trino.spi.block.BlockUtil.ensureBlocksAreLoaded;
 import static java.lang.String.format;
 
 public class SingleRowBlock
@@ -116,17 +117,9 @@ public class SingleRowBlock
     @Override
     public Block getLoadedBlock()
     {
-        boolean allLoaded = true;
-        Block[] loadedFieldBlocks = new Block[fieldBlocks.length];
-
-        for (int i = 0; i < fieldBlocks.length; i++) {
-            loadedFieldBlocks[i] = fieldBlocks[i].getLoadedBlock();
-            if (loadedFieldBlocks[i] != fieldBlocks[i]) {
-                allLoaded = false;
-            }
-        }
-
-        if (allLoaded) {
+        Block[] loadedFieldBlocks = ensureBlocksAreLoaded(fieldBlocks);
+        if (loadedFieldBlocks == fieldBlocks) {
+            // All blocks are already loaded
             return this;
         }
         return new SingleRowBlock(rowIndex, loadedFieldBlocks);


### PR DESCRIPTION
Extracted changes from https://github.com/prestodb/presto/pull/16683

Improves the implementations for `Block#getLoadedBlock()` in `RowBlock` and `SingleRowBlock` to avoid unnecessary allocations when all blocks are already loaded. Also refactors the implementation of `Page#getLoadedPage()` to match.

This follows up on changes made in https://github.com/trinodb/trino/pull/8891 that will call `Page#getLoadedPage` more frequently and could regress performance when a large number of `RowBlock` columns were present.