### PR TITLE
Implement Adaptive Partial Aggregation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/StreamingReductionRatio.java
+++ b/core/trino-main/src/main/java/io/trino/operator/StreamingReductionRatio.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import static java.lang.String.format;
+
+/**
+ * Not thread safe, needs to be held in AtomicReference
+ */
+public class StreamingReductionRatio
+{
+    // TODO: Make this a system session property
+    private static final long STATS_SAMPLING_MIN_ROW_COUNT = 3000;
+    private static final double DATA_REDUCTION_THRESHOLD = 0.85;
+
+    private long sampledRowCountSoFar;
+    private double reductionRatioAvg;
+
+    public StreamingReductionRatio()
+    {
+        this.sampledRowCountSoFar = 0;
+        this.reductionRatioAvg = 0;
+    }
+
+    public void update(double reductionRatioSample)
+    {
+        if (sampledRowCountSoFar >= STATS_SAMPLING_MIN_ROW_COUNT) {
+            return;
+        }
+
+        ++sampledRowCountSoFar;
+        double difference = (reductionRatioSample - reductionRatioAvg) / sampledRowCountSoFar;
+        reductionRatioAvg += difference;
+    }
+
+    public boolean isSampleSizeTooSmall()
+    {
+        return sampledRowCountSoFar < STATS_SAMPLING_MIN_ROW_COUNT;
+    }
+
+    public boolean isInsufficient()
+    {
+        // resulting group count is larger than threshold to apply PA dynamically.
+        return reductionRatioAvg > DATA_REDUCTION_THRESHOLD;
+    }
+
+    public double getAverage()
+    {
+        return reductionRatioAvg;
+    }
+
+    public String toString()
+    {
+        return format(
+                "[row count sample: %d, reduction ratio (avg): %f]",
+                sampledRowCountSoFar,
+                reductionRatioAvg);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/GenericAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/GenericAccumulatorFactory.java
@@ -445,6 +445,79 @@ public class GenericAccumulatorFactory
         }
     }
 
+    private static class RawAsIntermediateGroupedAccumulator
+            implements GroupedAccumulator
+    {
+        private final GroupedAccumulator accumulator;
+        private final Optional<Integer> maskChannel;
+
+        public RawAsIntermediateGroupedAccumulator(
+                GroupedAccumulator accumulator,
+                List<Type> inputTypes,
+                List<Integer> inputChannels,
+                Optional<Integer> maskChannel,
+                Session session,
+                JoinCompiler joinCompiler,
+                BlockTypeOperators blockTypeOperators)
+        {
+            this.accumulator = requireNonNull(accumulator, "accumulator is null");
+            this.maskChannel = requireNonNull(maskChannel, "maskChannel is null");
+
+            int[] inputs = new int[inputChannels.size() + 1];
+            inputs[0] = 0; // we'll use the first channel for group id column
+            for (int i = 0; i < inputChannels.size(); i++) {
+                inputs[i + 1] = inputChannels.get(i) + 1;
+            }
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return accumulator.getEstimatedSize();
+        }
+
+        @Override
+        public Type getFinalType()
+        {
+            return accumulator.getFinalType();
+        }
+
+        @Override
+        public Type getIntermediateType()
+        {
+            return null;
+        }
+
+        @Override
+        public void addInput(GroupByIdBlock groupIdsBlock, Page page)
+        {
+            // add input as intermediate
+        }
+
+        @Override
+        public void addIntermediate(GroupByIdBlock groupIdsBlock, Block block)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void evaluateIntermediate(int groupId, BlockBuilder output)
+        {
+        }
+
+        @Override
+        public void evaluateFinal(int groupId, BlockBuilder output)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void prepareFinal()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
     private static class OrderingAccumulator
             implements Accumulator
     {

--- a/core/trino-main/src/test/java/io/trino/operator/TestStreamingReductionRatio.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestStreamingReductionRatio.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.com.google.common.base.Preconditions.checkArgument;
+
+public class TestStreamingReductionRatio
+{
+    private static StreamingReductionRatio getAvgOfNumericSeries(int start, int end)
+    {
+        checkArgument(start <= end);
+        StreamingReductionRatio streamingReductionRatio = new StreamingReductionRatio();
+
+        for (int i = start; i < end; ++i) {
+            streamingReductionRatio.update(i);
+        }
+
+        return streamingReductionRatio;
+    }
+
+    @Test
+    public void testUpdate()
+    {
+        // test avg of numeric series
+        assertThat(getAvgOfNumericSeries(1, 20).getAverage())
+                .isEqualTo(10);
+
+        assertThat(getAvgOfNumericSeries(1, 4000).getAverage())
+                .isEqualTo(1500.5);
+
+        // test no avg accounted for taken after 4000 rows (sample size)
+        assertThat(getAvgOfNumericSeries(1, 10000).getAverage())
+                .isEqualTo(1500.5);
+    }
+}


### PR DESCRIPTION
**Description**

- Implement calculation and monitoring of reduction ratio for first 4K input positions in streamed in pages.
- Extend Grouped Accumulator (requires further implementation)
- Added documentation about `GroupByIdBlock`'s behaviour and group count scope (per query vs per page)

cc @sopel39