### PR TITLE
Add workflow to automatically label pull requests

### DIFF
--- a/.github/config/labeler-config.yml
+++ b/.github/config/labeler-config.yml
@@ -1,0 +1,3 @@
+# Pull Request Labeler Github Action Configuration: https://github.com/marketplace/actions/labeler
+docs:
+  - docs/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: "Pull Request Labeler"
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: true
+          configuration-path: .github/config/labeler-config.yml


### PR DESCRIPTION
For starting with this will add the `docs` label to any changes under the `docs` tree.

We can eventually add more rules.
The end-goal is to use these labels to selectively run tests or run additional tests.

e.g. for docs the product tests don't make sense to run. Also for example if there are changes in Hive related code the `tests:hive` label could be added automatically to ensure all the Hive product test configs run.

In this PR no actions are being taken based on the label so nothing changes except triaging might be a little easier now.