### PR TITLE
Add more Kerberos debugging JVM flags in docs

### DIFF
--- a/docs/src/main/sphinx/security/cli.rst
+++ b/docs/src/main/sphinx/security/cli.rst
@@ -90,10 +90,11 @@ Additional Kerberos debugging information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can enable additional Kerberos debugging information for the Trino CLI
-process by passing ``-Dsun.security.krb5.debug=true`` as a JVM argument, when
-starting the CLI process. Doing so requires invoking the CLI JAR via ``java``
-instead of running the self-executable JAR directly. The self-executable jar
-file cannot pass the option to the JVM.
+process by passing ``-Dsun.security.krb5.debug=true``,
+``-Dtrino.client.debugKerberos=true``, and
+``-Djava.security.debug=gssloginconfig,configfile,configparser,logincontext``
+as a JVM argument, when starting the CLI process. Doing so requires invoking
+the CLI JAR via ``java`` instead of running the self-executable JAR directly.
 
 .. code-block:: text
 
@@ -101,6 +102,8 @@ file cannot pass the option to the JVM.
 
     java \
       -Dsun.security.krb5.debug=true \
+      -Djava.security.debug=gssloginconfig,configfile,configparser,logincontext \
+      -Dtrino.client.debugKerberos=true \
       -jar trino-cli-*-executable.jar \
       --server https://trino-coordinator.example.com:7778 \
       --krb5-config-path /etc/krb5.conf \
@@ -115,3 +118,10 @@ file cannot pass the option to the JVM.
 The :ref:`additional resources <server_additional_resources>` listed in the
 documentation for setting up Kerberos authentication for the Trino coordinator
 may be of help when interpreting the Kerberos debugging messages.
+
+See `Troubleshooting Security
+<https://docs.oracle.com/en/java/javase/11/security/troubleshooting-security.html>`_
+in the Java documentation for more details about
+the ``-Djava.security.debug`` flag, and `Troubleshooting
+<https://docs.oracle.com/en/java/javase/11/security/troubleshooting.html>`_
+for more details about the Java GSS-API and Kerberos issues.


### PR DESCRIPTION
To further help with debugging Kerberos issues, suggest adding two more JVM settings:
* `-Dtrino.client.debugKerberos=true` that sets `debug=true` for the [Krb5LoginModule](https://docs.oracle.com/javase/8/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/Krb5LoginModule.html)
* `-Djava.security.debug=gssloginconfig,configfile,configparser,logincontext` to make GSS-API log more details, especially result of LoginContext, see [Troubleshooting Security](https://docs.oracle.com/javase/8/docs/technotes/guides/security/troubleshooting-security.html)
