### PR TITLE
Produce better hash for short decimal type

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/ShortDecimalType.java
@@ -127,7 +127,7 @@ final class ShortDecimalType
     @ScalarOperator(HASH_CODE)
     private static long hashCodeOperator(long value)
     {
-        return value;
+        return AbstractLongType.hash(value);
     }
 
     @ScalarOperator(XX_HASH_64)


### PR DESCRIPTION
The previous implementation produces bad hashes,
which can cause downstream skew when the hashes
are not combined in a way that scrambles the bits properly
(e.g., combine hash).