### PR TITLE
Add a rule to derive IsNotNull predicates from INNER joins

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -143,6 +143,7 @@ public final class SystemSessionProperties
     public static final String MAX_UNACKNOWLEDGED_SPLITS_PER_TASK = "max_unacknowledged_splits_per_task";
     public static final String MERGE_PROJECT_WITH_VALUES = "merge_project_with_values";
     public static final String TIME_ZONE_ID = "time_zone_id";
+    public static final String DERIVE_ISNOTNULL_PREDICATES = "derive_isnotnull_predicates";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -660,7 +661,12 @@ public final class SystemSessionProperties
                                 getTimeZoneKey(value);
                             }
                         },
-                        true));
+                        true),
+                booleanProperty(
+                        DERIVE_ISNOTNULL_PREDICATES,
+                        "Derive IS_NOT_NULL predicates from INNER joins when possible",
+                        featuresConfig.isDeriveIsNotNullPredicates(),
+                        false));
     }
 
     @Override
@@ -1172,5 +1178,10 @@ public final class SystemSessionProperties
     public static Optional<String> getTimeZoneId(Session session)
     {
         return Optional.ofNullable(session.getSystemProperty(TIME_ZONE_ID, String.class));
+    }
+
+    public static boolean deriveIsNotNullPredicates(Session session)
+    {
+        return session.getSystemProperty(DERIVE_ISNOTNULL_PREDICATES, Boolean.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/FeaturesConfig.java
@@ -135,6 +135,7 @@ public class FeaturesConfig
     private boolean useTableScanNodePartitioning = true;
     private double tableScanNodePartitioningMinBucketToTaskRatio = 0.5;
     private boolean mergeProjectWithValues = true;
+    private boolean deriveIsNotNullPredicates;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
     private DataSize filterAndProjectMinOutputPageSize = DataSize.of(500, KILOBYTE);
@@ -1101,6 +1102,18 @@ public class FeaturesConfig
     public FeaturesConfig setLegacyCatalogRoles(boolean legacyCatalogRoles)
     {
         this.legacyCatalogRoles = legacyCatalogRoles;
+        return this;
+    }
+
+    public boolean isDeriveIsNotNullPredicates()
+    {
+        return deriveIsNotNullPredicates;
+    }
+
+    @Config("optimizer.derive-isnotnull-predicates")
+    public FeaturesConfig setDeriveIsNotNullPredicates(boolean deriveIsNotNullPredicates)
+    {
+        this.deriveIsNotNullPredicates = deriveIsNotNullPredicates;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -38,6 +38,7 @@ import io.trino.sql.planner.iterative.rule.CreatePartialTopN;
 import io.trino.sql.planner.iterative.rule.DecorrelateInnerUnnestWithGlobalAggregation;
 import io.trino.sql.planner.iterative.rule.DecorrelateLeftUnnestWithGlobalAggregation;
 import io.trino.sql.planner.iterative.rule.DecorrelateUnnest;
+import io.trino.sql.planner.iterative.rule.DeriveNotNull;
 import io.trino.sql.planner.iterative.rule.DesugarArrayConstructor;
 import io.trino.sql.planner.iterative.rule.DesugarAtTimeZone;
 import io.trino.sql.planner.iterative.rule.DesugarCurrentCatalog;
@@ -692,6 +693,12 @@ public class PlanOptimizers
                                 .addAll(simplifyOptimizerRules) // Should be always run after PredicatePushDown
                                 .add(new PushPredicateIntoTableScan(metadata, typeOperators, typeAnalyzer))
                                 .build()),
+                new IterativeOptimizer(
+                        metadata,
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.of(new DeriveNotNull())),
                 new UnaliasSymbolReferences(metadata), // Run again because predicate pushdown and projection pushdown might add more projections
                 columnPruningOptimizer, // Make sure to run this before index join. Filtered projections may not have all the columns.
                 new IndexJoinOptimizer(metadata, typeOperators), // Run this after projections and filters have been fully simplified and pushed down

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DeriveNotNull.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/DeriveNotNull.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.Session;
+import io.trino.matching.Captures;
+import io.trino.matching.Pattern;
+import io.trino.sql.ExpressionUtils;
+import io.trino.sql.planner.iterative.Rule;
+import io.trino.sql.planner.plan.JoinNode;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.IsNotNullPredicate;
+
+import java.util.Optional;
+
+import static io.trino.SystemSessionProperties.deriveIsNotNullPredicates;
+import static io.trino.sql.planner.plan.Patterns.join;
+import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
+
+public class DeriveNotNull
+        implements Rule<JoinNode>
+{
+    // The purpose of this rule is to derive a conjunction of IS_NOT_NULL predicates from the join clauses for INNER joins.
+    // Although this may not directly benefit the current join node itself, the main goal is to provide the null-rejected condition for potential OUTER joins from upstream,
+    // and hopefully help with the transformation from outer joins to inner joins. Another benefit is possible cardinality reduction in upstream thanks to the derived predicates.
+
+    // Only apply this rule to inner join nodes, as IS_NOT_NULL predicates derived from inner join clauses won't change the semantic. That is not the case for outer joins.
+    private static final Pattern<JoinNode> PATTERN = join().matching(joinNode -> joinNode.getType() == JoinNode.Type.INNER && !joinNode.getCriteria().isEmpty());
+
+    @Override
+    public Pattern<JoinNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        return deriveIsNotNullPredicates(session);
+    }
+
+    @Override
+    public Result apply(JoinNode node, Captures captures, Context context)
+    {
+        Expression filter = node.getFilter().isPresent() ? node.getFilter().get() : TRUE_LITERAL;
+        ImmutableSet<Expression> filterConjuncts = ImmutableSet.copyOf(ExpressionUtils.extractConjuncts(filter));
+
+        // In theory, we could derive "IS NOT NULL" information from both join conditions and filter conditions.
+        // For simplicity, we will only use join conditions for now.
+        // The rule can be extended later to support derivation from filter conditions.
+        for (JoinNode.EquiJoinClause joinClause : node.getCriteria()) {
+            Expression leftIsNotNullPredicate = new IsNotNullPredicate(joinClause.getLeft().toSymbolReference());
+            Expression rightIsNotNullPredicate = new IsNotNullPredicate(joinClause.getRight().toSymbolReference());
+
+            if (filterConjuncts.contains(leftIsNotNullPredicate)
+                    && filterConjuncts.contains(rightIsNotNullPredicate)) {
+                // this indicates we've matched and visited this node before
+                return Result.empty();
+            }
+
+            filter = ExpressionUtils.and(filter, leftIsNotNullPredicate);
+            filter = ExpressionUtils.and(filter, rightIsNotNullPredicate);
+        }
+
+        return Result.ofPlanNode(new JoinNode(node.getId(),
+                node.getType(),
+                node.getLeft(),
+                node.getRight(),
+                node.getCriteria(),
+                node.getLeftOutputSymbols(),
+                node.getRightOutputSymbols(),
+                node.isMaySkipOutputDuplicates(),
+                Optional.of(filter),    // the consolidated filter containing derived IS_NOT_NULL predicates
+                node.getLeftHashSymbol(),
+                node.getRightHashSymbol(),
+                node.getDistributionType(),
+                node.isSpillable(),
+                node.getDynamicFilters(),
+                node.getReorderJoinStatsAndCost()));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
@@ -114,7 +114,8 @@ public class TestFeaturesConfig
                 .setUseTableScanNodePartitioning(true)
                 .setTableScanNodePartitioningMinBucketToTaskRatio(0.5)
                 .setMergeProjectWithValues(true)
-                .setLegacyCatalogRoles(false));
+                .setLegacyCatalogRoles(false)
+                .setDeriveIsNotNullPredicates(false));
     }
 
     @Test
@@ -194,6 +195,7 @@ public class TestFeaturesConfig
                 .put("optimizer.table-scan-node-partitioning-min-bucket-to-task-ratio", "0.0")
                 .put("optimizer.merge-project-with-values", "false")
                 .put("deprecated.legacy-catalog-roles", "true")
+                .put("optimizer.derive-isnotnull-predicates", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -269,7 +271,8 @@ public class TestFeaturesConfig
                 .setUseTableScanNodePartitioning(false)
                 .setTableScanNodePartitioningMinBucketToTaskRatio(0.0)
                 .setMergeProjectWithValues(false)
-                .setLegacyCatalogRoles(true);
+                .setLegacyCatalogRoles(true)
+                .setDeriveIsNotNullPredicates(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDeriveNotNull.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestDeriveNotNull.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.iterative.rule;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.SystemSessionProperties.DERIVE_ISNOTNULL_PREDICATES;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.plan.JoinNode.EquiJoinClause;
+import static io.trino.sql.planner.plan.JoinNode.Type.FULL;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.sql.planner.plan.JoinNode.Type.LEFT;
+import static io.trino.sql.planner.plan.JoinNode.Type.RIGHT;
+
+public class TestDeriveNotNull
+        extends BaseRuleTest
+{
+    @Test
+    public void testDeriveNotNull()
+    {
+        tester().assertThat(new DeriveNotNull())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(p.symbol("a")),
+                                p.values(p.symbol("b")),
+                                ImmutableList.of(new EquiJoinClause(p.symbol("a"), p.symbol("b"))),
+                                ImmutableList.of(p.symbol("a")),
+                                ImmutableList.of(p.symbol("b")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                .setSystemProperty(DERIVE_ISNOTNULL_PREDICATES, "true")
+                .matches(join(
+                        INNER,
+                        ImmutableList.of(equiJoinClause("a", "b")),
+                        Optional.of("((true AND (\"a\" IS NOT NULL)) AND (\"b\" IS NOT NULL))"),
+                        values(ImmutableMap.of("a", 0)),
+                        values(ImmutableMap.of("b", 0))));
+    }
+
+    @Test
+    public void testCrossJoinDoesNotFire()
+    {
+        tester().assertThat(new DeriveNotNull())
+                .on(p ->
+                        p.join(
+                                INNER,
+                                p.values(p.symbol("a")),
+                                p.values(p.symbol("b")),
+                                ImmutableList.of(),
+                                ImmutableList.of(p.symbol("a")),
+                                ImmutableList.of(p.symbol("b")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testOuterJoinDoesNotFire()
+    {
+        tester().assertThat(new DeriveNotNull())
+                .on(p ->
+                        p.join(
+                                LEFT,
+                                p.values(p.symbol("a")),
+                                p.values(p.symbol("b")),
+                                ImmutableList.of(new EquiJoinClause(p.symbol("a"), p.symbol("b"))),
+                                ImmutableList.of(p.symbol("a")),
+                                ImmutableList.of(p.symbol("b")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                .doesNotFire();
+
+        tester().assertThat(new DeriveNotNull())
+                .on(p ->
+                        p.join(
+                                RIGHT,
+                                p.values(p.symbol("a")),
+                                p.values(p.symbol("b")),
+                                ImmutableList.of(new EquiJoinClause(p.symbol("a"), p.symbol("b"))),
+                                ImmutableList.of(p.symbol("a")),
+                                ImmutableList.of(p.symbol("b")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                .doesNotFire();
+
+        tester().assertThat(new DeriveNotNull())
+                .on(p ->
+                        p.join(
+                                FULL,
+                                p.values(p.symbol("a")),
+                                p.values(p.symbol("b")),
+                                ImmutableList.of(new EquiJoinClause(p.symbol("a"), p.symbol("b"))),
+                                ImmutableList.of(p.symbol("a")),
+                                ImmutableList.of(p.symbol("b")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                .doesNotFire();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestDeriveNotNull.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestDeriveNotNull.java
@@ -1,0 +1,471 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.optimizations;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.sql.planner.assertions.BasePlanTest;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.SystemSessionProperties.DERIVE_ISNOTNULL_PREDICATES;
+import static io.trino.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
+import static io.trino.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.exchange;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
+import static io.trino.sql.planner.plan.JoinNode.Type.FULL;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.sql.planner.plan.JoinNode.Type.LEFT;
+import static io.trino.sql.planner.plan.JoinNode.Type.RIGHT;
+
+public class TestDeriveNotNull
+        extends BasePlanTest
+{
+    TestDeriveNotNull()
+    {
+        // Dynamic filtering creates a $internal$dynamic_filter_function which acts as a null-rejected condition by accident.
+        // Need to disable it to rule out its side effect impacting outer to inner transformation in subquery, and only let the IS_NOT_NULL predicate do its job.
+        // Also, set JOIN_REORDERING_STRATEGY to NONE to make sure the join orders in testSubqueryOuterToInner() follows the literal sequence.
+        super(ImmutableMap.of(ENABLE_DYNAMIC_FILTERING, "false",
+                JOIN_REORDERING_STRATEGY, "none",
+                DERIVE_ISNOTNULL_PREDICATES, "true"));
+    }
+
+    @Test
+    public void testInnerJoin()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o INNER JOIN lineitem l ON o.orderkey = l.orderkey",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
+                                Optional.empty(),
+                                project(
+                                        filter("NOT (ORDERS_OK IS NULL)",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))),
+                                exchange(
+                                        project(
+                                                filter("NOT (LINEITEM_OK IS NULL)",
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
+
+        // Implicit
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey = l.orderkey",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
+                                Optional.empty(),
+                                project(
+                                        filter("NOT (ORDERS_OK IS NULL)",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))),
+                                exchange(
+                                        project(
+                                                filter("NOT (LINEITEM_OK IS NULL)",
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
+    }
+
+    @Test
+    public void testInnerJoinWithSimpleExpression()
+    {
+        // A simple addition expression on the join clause
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey + 1 = l.orderkey",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERKEY_PLUS_ONE", "LINEITEM_OK")),
+                                Optional.empty(),
+                                project(
+                                        project(ImmutableMap.of("ORDERKEY_PLUS_ONE", expression("ORDERS_OK + BIGINT '1'")),
+                                                filter("NOT (ORDERS_OK + BIGINT '1') IS NULL",
+                                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))),
+                                exchange(
+                                        project(
+                                                filter("NOT (LINEITEM_OK IS NULL)",
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
+    }
+
+    @Test
+    public void testInnerJoinWithCast()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE cast(l.orderkey as int) = cast(o.orderkey as int)",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_CAST", "LINEITEM_CAST")),
+                                project(
+                                        project(ImmutableMap.of("ORDERS_CAST", expression("CAST(ORDERS_OK AS INT)")),
+                                                filter(PlanBuilder.expression("NOT (CAST(ORDERS_OK AS INT)) IS NULL"),
+                                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))),
+                                exchange(
+                                        project(
+                                                project(ImmutableMap.of("LINEITEM_CAST", expression("CAST(LINEITEM_OK AS INT)")),
+                                                        filter(PlanBuilder.expression("NOT (CAST(LINEITEM_OK AS INT)) IS NULL"),
+                                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))))));
+    }
+
+    @Test
+    public void testInnerJoinWithTrivialFilter()
+    {
+        // existing filter stays as is
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey = l.orderkey AND o.custkey = 1",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
+                                Optional.empty(),
+                                project(
+                                        filter("(ORDERS_CK = BIGINT '1') AND (NOT (ORDERS_OK IS NULL))",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey", "ORDERS_CK", "custkey")))),
+                                exchange(
+                                        project(
+                                                filter("NOT (LINEITEM_OK IS NULL)",
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
+
+        // partitioning filter is not treated as a regular filter
+        // Is orderstatus a partitioning column?
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey = l.orderkey AND o.orderstatus = 'O'",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
+                                Optional.empty(),
+                                project(
+                                        filter("NOT (ORDERS_OK IS NULL)",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))),
+                                exchange(
+                                        project(
+                                                filter("NOT (LINEITEM_OK IS NULL)",
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
+    }
+
+    @Test
+    public void testInnerJoinWithInequalityFilter()
+    {
+        assertPlan("SELECT 1 FROM orders o JOIN lineitem l ON o.shippriority = l.linenumber AND o.orderkey < l.orderkey",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_SP", "LINEITEM_LN")),
+                                Optional.of("ORDERS_OK < LINEITEM_OK"),
+                                project(
+                                        filter("NOT (ORDERS_SP IS NULL)",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_SP", "shippriority", "ORDERS_OK", "orderkey")))),
+                                exchange(
+                                        project(
+                                                filter("NOT (LINEITEM_LN IS NULL)",
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_LN", "linenumber", "LINEITEM_OK", "orderkey"))))))));
+    }
+
+    @Test
+    public void testInnerJoinWithDuplicateFilter()
+    {
+        // It's OK we derive a new IS NOT NULL predicate, as the de-dup is handled by PredicatePushDown -> combineConjuncts -> removeDuplicates
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey = l.orderkey AND o.orderkey IS NOT NULL",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
+                                Optional.empty(),
+                                project(
+                                        filter("NOT (ORDERS_OK IS NULL)",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))),
+                                exchange(
+                                        project(
+                                                filter("NOT (LINEITEM_OK IS NULL)",
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))))));
+    }
+
+    @Test
+    public void testInnerJoinWithConflictingFilter()
+    {
+        // the derived IS NOT NULL predicate and the existing IS NULL predicate conflict, and results in a FALSE join condition
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey = l.orderkey AND o.orderkey IS NULL",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("orderkey", "orderkey_0")),
+                                Optional.empty(),
+                                project(values("orderkey")),
+                                project(values("orderkey_0")))));
+    }
+
+    @Test
+    public void testInnerJoinWithConditionalJoinClause()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey = CASE WHEN l.orderkey = 1 THEN 2 END",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_CASE")),
+                                Optional.empty(),
+                                project(
+                                        filter("NOT (ORDERS_OK IS NULL)",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))),
+                                exchange(
+                                        project(
+                                                project(ImmutableMap.of("LINEITEM_CASE", expression("CAST((CASE WHEN (LINEITEM_OK = BIGINT '1') THEN 2 END) AS bigint)")),
+                                                        filter("(NOT (CAST((CASE WHEN (LINEITEM_OK = BIGINT '1') THEN 2 END) AS bigint) IS NULL))",
+                                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))))));
+
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey = COALESCE(l.orderkey, 1)",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_COALESCE")),
+                                Optional.empty(),
+                                project(
+                                        filter("NOT (ORDERS_OK IS NULL)",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))),
+                                exchange(
+                                        project(
+                                                project(ImmutableMap.of("LINEITEM_COALESCE", expression("COALESCE(LINEITEM_OK, BIGINT '1')")),
+                                                        filter("NOT (COALESCE(LINEITEM_OK, BIGINT '1')) IS NULL",
+                                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))))));
+    }
+
+    @Test
+    public void testInnerJoinWithNonDeterministic()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o INNER JOIN lineitem l ON o.orderkey = l.orderkey + random(100)",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_RAND")),
+                                Optional.empty(),
+                                project(
+                                        filter("NOT (ORDERS_OK IS NULL)",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")))),
+                                exchange(
+                                        project(
+                                                filter("NOT LINEITEM_RAND IS NULL",
+                                                        project(ImmutableMap.of("LINEITEM_RAND", expression("LINEITEM_OK + CAST(random(100) AS bigint)")),
+                                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))))));
+    }
+
+    @Test
+    public void testConjunctiveEquiJoinClauses()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey AND l.partkey = o.custkey",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK"),
+                                        equiJoinClause("ORDERS_CK", "LINEITEM_PK")),
+                                Optional.empty(),
+                                project(
+                                        filter("(NOT (ORDERS_OK IS NULL)) AND (NOT (ORDERS_CK IS NULL))",
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey", "ORDERS_CK", "custkey")))),
+                                exchange(
+                                        project(
+                                                filter("(NOT (LINEITEM_OK IS NULL)) AND (NOT (LINEITEM_PK IS NULL))",
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey", "LINEITEM_PK", "partkey"))))))));
+    }
+
+    @Test
+    public void testMultiColumnEquiJoinClause()
+    {
+        // columns from the same table on one side
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey + o.custkey = l.orderkey + l.partkey",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDER_SUM", "LINEITEM_SUM")),
+                                Optional.empty(),
+                                project(
+                                        project(ImmutableMap.of("ORDER_SUM", expression("ORDERS_OK + ORDERS_CK")),
+                                                filter("NOT (ORDERS_OK + ORDERS_CK) IS NULL",
+                                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey", "ORDERS_CK", "custkey"))))),
+                                exchange(
+                                        project(
+                                                project(ImmutableMap.of("LINEITEM_SUM", expression("LINEITEM_OK + LINEITEM_PK")),
+                                                        filter("NOT (LINEITEM_OK + LINEITEM_PK) IS NULL",
+                                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey", "LINEITEM_PK", "partkey")))))))));
+
+        // columns from the different tables on one side
+        // This results in CROSS JOIN, so no derived predicates
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey + l.orderkey = 10",
+                anyTree(
+                        filter("ORDERS_OK + LINEITEM_OK = BIGINT '10'",
+                                join(INNER,
+                                        ImmutableList.of(),
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")),
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+    }
+
+    @Test
+    public void testSubqueryOuterToInner()
+    {
+        // In the subquery the outer join is transformed to inner join thanks to the IS_NOT_NULL filter generated from outer query
+
+        // LEFT OUTER => INNER
+        assertPlan("SELECT totalprice " +
+                        "FROM (SELECT orders.totalprice, orders.custkey " +
+                        "      FROM lineitem LEFT JOIN orders " +
+                        "      ON lineitem.orderkey = orders.orderkey) t, customer " +
+                        "WHERE customer.custkey = t.custkey " +
+                        "AND customer.name = 'Joe'",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_CK", "CUSTOMER_CK")),
+                                Optional.empty(),
+                                project(
+                                        join(INNER,
+                                                ImmutableList.of(equiJoinClause("LINEITEM_OK", "ORDERS_OK")),
+                                                Optional.empty(),
+                                                project(
+                                                        tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))),
+                                                exchange(
+                                                        project(
+                                                                filter("NOT (ORDERS_CK IS NULL)",
+                                                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey", "ORDERS_CK", "custkey", "ORDERS_TP", "totalprice"))))))),
+                                exchange(
+                                        project(
+                                                filter("(CUSTOMER_NM = CAST('Joe' AS varchar(25))) AND (NOT (CUSTOMER_CK IS NULL))",
+                                                        tableScan("customer", ImmutableMap.of("CUSTOMER_CK", "custkey", "CUSTOMER_NM", "name"))))))));
+
+        // RIGHT OUTER => INNER
+        // This is just a symmetry to the above query
+        assertPlan("SELECT totalprice " +
+                        "FROM (SELECT orders.totalprice, orders.custkey " +
+                        "      FROM orders RIGHT JOIN lineitem" +
+                        "      ON lineitem.orderkey = orders.orderkey) t, customer " +
+                        "WHERE customer.custkey = t.custkey " +
+                        "AND customer.name = 'Joe'",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(equiJoinClause("ORDERS_CK", "CUSTOMER_CK")),
+                                Optional.empty(),
+                                project(
+                                        join(INNER,
+                                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
+                                                Optional.empty(),
+                                                project(
+                                                        filter("NOT (ORDERS_CK IS NULL)",
+                                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey", "ORDERS_CK", "custkey", "ORDERS_TP", "totalprice")))),
+                                                exchange(
+                                                        project(
+                                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))),
+                                exchange(
+                                        project(
+                                                filter("(CUSTOMER_NM = CAST('Joe' AS varchar(25))) AND (NOT (CUSTOMER_CK IS NULL))",
+                                                        tableScan("customer", ImmutableMap.of("CUSTOMER_CK", "custkey", "CUSTOMER_NM", "name"))))))));
+    }
+
+    // -- Below are negative tests, where no IS_NOT_NULL filters are derived --
+
+    @Test
+    public void testLeftOuterJoin()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o LEFT JOIN lineitem l ON l.orderkey = o.orderkey",
+                anyTree(
+                        join(LEFT,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
+                                project(
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
+                                exchange(
+                                        project(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+    }
+
+    @Test
+    public void testRightOuterJoin()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o RIGHT JOIN lineitem l ON l.orderkey = o.orderkey",
+                anyTree(
+                        join(RIGHT,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
+                                project(
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
+                                exchange(
+                                        project(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+    }
+
+    @Test
+    public void testFullOuterJoin()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o FULL JOIN lineitem l ON l.orderkey = o.orderkey",
+                anyTree(
+                        join(FULL,
+                                ImmutableList.of(equiJoinClause("ORDERS_OK", "LINEITEM_OK")),
+                                project(
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
+                                exchange(
+                                        project(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+    }
+
+    @Test
+    public void testCrossJoin()
+    {
+        assertPlan("SELECT o.orderkey FROM orders o CROSS JOIN lineitem l",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(),
+                                tableScan("orders"),
+                                exchange(
+                                        tableScan("lineitem")))));
+
+        // Implicit
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey = 1",
+                anyTree(
+                        join(INNER,
+                                ImmutableList.of(),
+                                filter("ORDERS_OK = BIGINT '1'",
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))),
+                                exchange(
+                                        tableScan("lineitem")))));
+
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey <> l.orderkey",
+                anyTree(
+                        filter("ORDERS_OK <> LINEITEM_OK",
+                                join(INNER,
+                                        ImmutableList.of(),
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")),
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+    }
+
+    @Test
+    public void testNonEquiJoinClause()
+    {   // this is converted to CROSS JOIN.
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE o.orderkey > l.orderkey",
+                anyTree(
+                        filter("ORDERS_OK > LINEITEM_OK",
+                                join(INNER,
+                                        ImmutableList.of(),
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey")),
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey")))))));
+    }
+
+    @Test
+    public void testDisjunctiveEquiJoinClauses()
+    {   // this is converted to CROSS JOIN.
+        assertPlan("SELECT o.orderkey FROM orders o INNER JOIN lineitem l ON l.orderkey = o.orderkey OR l.partkey = o.custkey",
+                anyTree(
+                        filter("LINEITEM_OK = ORDERS_OK OR LINEITEM_PK = ORDERS_CK",
+                                join(INNER,
+                                        ImmutableList.of(),
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey", "ORDERS_CK", "custkey")),
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey", "LINEITEM_PK", "partkey")))))));
+
+        // Implicit
+        assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE l.orderkey = o.orderkey OR l.partkey = o.custkey",
+                anyTree(
+                        filter("LINEITEM_OK = ORDERS_OK OR LINEITEM_PK = ORDERS_CK",
+                                join(INNER,
+                                        ImmutableList.of(),
+                                        tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey", "ORDERS_CK", "custkey")),
+                                        exchange(
+                                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey", "LINEITEM_PK", "partkey")))))));
+    }
+}


### PR DESCRIPTION
We need a way to push “null-rejected” conditions from a downstream INNER join to an upstream OUTER join, so that the OUTER join may take advantage of that information and be transformed to an INNER join if possible.

Besides being important for the OUTER to INNER join transformation, “IS NOT NULL” conditions are in general useful as they can be pushed down to joins and table scans, and can help with better estimation and reducing the cardinality of intermediate dataset.

Fixes #2392

