### PR TITLE
Bump snappy-java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1526,7 +1526,7 @@
             <dependency>
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
-                <version>1.1.7.3</version>
+                <version>1.1.8.4</version>
             </dependency>
 
             <!-- Transitive dependency. Avoid different versions being used -->


### PR DESCRIPTION
This makes the recently added tests for Snappy (#9131) pass on ARM64. Without this, I was getting this error:
```
java.lang.UnsatisfiedLinkError: /tmp/snappy-1.1.7-a12a7888-0c8c-4e7f-8722-83436104a644-libsnappyjava.so: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /tmp/snappy-1.1.7-a12a7888-0c8c-4e7f-8722-83436104a644-libsnappyjava.so)
```
It was fixed in 1.1.8, see the last point at https://github.com/xerial/snappy-java/releases/tag/1.1.8

I ran the product test using ARM64 containers and qemu by rebuilding the base images (`ghcr.io/trinodb/testing/centos7-oj8:41` and `ghcr.io/trinodb/testing/centos7-oj11:41`) with:
* `arm64v8/centos:7` as base
* adding `/usr/bin/qemu-aarch64-static` from the `multiarch/qemu-user-static:x86_64-aarch64` image
* using Zulu 11 from a tarball, not the rpm, because only the tarball is available for ARM64

Full Dockerfile: https://github.com/trinodb/docker-images/compare/master...nineinchnick:arm64

Emulation is much slower (duh) so I don't think we could run all PTs like this.