### PR TITLE
Add created_by field to native Parquet writer metadata

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -13,6 +13,7 @@
  */
 package io.trino.parquet.writer;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.OutputStreamSliceOutput;
@@ -63,7 +64,7 @@ public class ParquetWriter
     private final OutputStreamSliceOutput outputStream;
     private final ParquetWriterOptions writerOption;
     private final MessageType messageType;
-
+    private final String createdBy;
     private final int chunkMaxLogicalBytes;
 
     private final ImmutableList.Builder<RowGroup> rowGroupBuilder = ImmutableList.builder();
@@ -80,7 +81,8 @@ public class ParquetWriter
             MessageType messageType,
             Map<List<String>, Type> primitiveTypes,
             ParquetWriterOptions writerOption,
-            CompressionCodecName compressionCodecName)
+            CompressionCodecName compressionCodecName,
+            String trinoVersion)
     {
         this.outputStream = new OutputStreamSliceOutput(requireNonNull(outputStream, "outputstream is null"));
         this.messageType = requireNonNull(messageType, "messageType is null");
@@ -96,6 +98,7 @@ public class ParquetWriter
         this.columnWriters = ParquetWriters.getColumnWriters(messageType, primitiveTypes, parquetProperties, compressionCodecName);
 
         this.chunkMaxLogicalBytes = max(1, CHUNK_MAX_BYTES / 2);
+        this.createdBy = formatCreatedBy(requireNonNull(trinoVersion, "trinoVersion is null"));
     }
 
     public long getWrittenBytes()
@@ -235,11 +238,12 @@ public class ParquetWriter
         createDataOutput(MAGIC).writeData(outputStream);
     }
 
-    static Slice getFooter(List<RowGroup> rowGroups, MessageType messageType)
+    Slice getFooter(List<RowGroup> rowGroups, MessageType messageType)
             throws IOException
     {
         FileMetaData fileMetaData = new FileMetaData();
         fileMetaData.setVersion(1);
+        fileMetaData.setCreated_by(createdBy);
         fileMetaData.setSchema(MessageTypeConverter.toParquetSchema(messageType));
         long totalRows = rowGroups.stream().mapToLong(RowGroup::getNum_rows).sum();
         fileMetaData.setNum_rows(totalRows);
@@ -277,5 +281,12 @@ public class ParquetWriter
             currentOffset += column.getTotal_compressed_size();
         }
         return builder.build();
+    }
+
+    @VisibleForTesting
+    static String formatCreatedBy(String trinoVersion)
+    {
+        // Add "(build n/a)" suffix to satisfy Parquet's VersionParser expectations
+        return "Trino version " + trinoVersion + " (build n/a)";
     }
 }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer;
+
+import org.apache.parquet.VersionParser;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestParquetWriter
+{
+    @Test
+    public void testCreatedByIsParsable()
+            throws VersionParser.VersionParseException, IOException
+    {
+        String createdBy = ParquetWriter.formatCreatedBy("test-version");
+        VersionParser.ParsedVersion version = VersionParser.parse(createdBy);
+        assertThat(version).isNotNull();
+        assertThat(version.application).isEqualTo("Trino");
+        assertThat(version.version).isEqualTo("test-version");
+        assertThat(version.appBuildHash).isEqualTo("n/a");
+
+        // Ensure that createdBy field is parsable in CDH 5 to avoid the exception "parquet.io.ParquetDecodingException: Cannot read data due to PARQUET-246: to read safely, set parquet.split.files to false";
+        // the pattern is taken from https://github.com/cloudera/parquet-mr/blob/cdh5-1.5.0_5.15.1/parquet-common/src/main/java/parquet/VersionParser.java#L34
+        Pattern pattern = Pattern.compile("(.+) version ((.*) )?\\(build ?(.*)\\)");
+        Matcher matcher = pattern.matcher(createdBy);
+        assertThat(matcher.matches()).isTrue();
+        assertThat(matcher.group(1)).isEqualTo("Trino");
+        assertThat(matcher.group(3)).isEqualTo("test-version");
+        assertThat(matcher.group(4)).isEqualTo("n/a");
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriter.java
@@ -57,16 +57,19 @@ public class ParquetFileWriter
             Map<List<String>, Type> primitiveTypes,
             ParquetWriterOptions parquetWriterOptions,
             int[] fileInputColumnIndexes,
-            CompressionCodecName compressionCodecName)
+            CompressionCodecName compressionCodecName,
+            String trinoVersion)
     {
         requireNonNull(outputStream, "outputStream is null");
+        requireNonNull(trinoVersion, "trinoVersion is null");
 
         this.parquetWriter = new ParquetWriter(
                 outputStream,
                 messageType,
                 primitiveTypes,
                 parquetWriterOptions,
-                compressionCodecName);
+                compressionCodecName,
+                trinoVersion);
 
         this.rollbackAction = requireNonNull(rollbackAction, "rollbackAction is null");
         this.fileInputColumnIndexes = requireNonNull(fileInputColumnIndexes, "fileInputColumnIndexes is null");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -19,6 +19,7 @@ import io.trino.plugin.hive.FileWriter;
 import io.trino.plugin.hive.HdfsEnvironment;
 import io.trino.plugin.hive.HiveFileWriterFactory;
 import io.trino.plugin.hive.HiveSessionProperties;
+import io.trino.plugin.hive.NodeVersion;
 import io.trino.plugin.hive.WriterKind;
 import io.trino.plugin.hive.acid.AcidTransaction;
 import io.trino.plugin.hive.metastore.StorageFormat;
@@ -53,14 +54,17 @@ public class ParquetFileWriterFactory
         implements HiveFileWriterFactory
 {
     private final HdfsEnvironment hdfsEnvironment;
+    private final NodeVersion nodeVersion;
     private final TypeManager typeManager;
 
     @Inject
     public ParquetFileWriterFactory(
             HdfsEnvironment hdfsEnvironment,
+            NodeVersion nodeVersion,
             TypeManager typeManager)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.nodeVersion = requireNonNull(nodeVersion, "nodeVersion is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
     }
 
@@ -119,7 +123,8 @@ public class ParquetFileWriterFactory
                     schemaConverter.getPrimitiveTypes(),
                     parquetWriterOptions,
                     fileInputColumnIndexes,
-                    compressionCodecName));
+                    compressionCodecName,
+                    nodeVersion.toString()));
         }
         catch (IOException e) {
             throw new TrinoException(HIVE_WRITER_OPEN_ERROR, "Error creating Parquet file", e);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveFileFormats.java
@@ -444,7 +444,7 @@ public class TestHiveFileFormats
                 .withSession(session)
                 .withColumns(testColumns)
                 .withRowsCount(rowCount)
-                .withFileWriterFactory(new ParquetFileWriterFactory(HDFS_ENVIRONMENT, TYPE_MANAGER))
+                .withFileWriterFactory(new ParquetFileWriterFactory(HDFS_ENVIRONMENT, new NodeVersion("test-version"), TYPE_MANAGER))
                 .isReadableByPageSource(new ParquetPageSourceFactory(HDFS_ENVIRONMENT, STATS, new ParquetReaderConfig(), new HiveConfig()));
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/StandardFileFormats.java
@@ -305,7 +305,8 @@ public final class StandardFileFormats
                     schemaConverter.getMessageType(),
                     schemaConverter.getPrimitiveTypes(),
                     ParquetWriterOptions.builder().build(),
-                    compressionCodec.getParquetCompressionCodec());
+                    compressionCodec.getParquetCompressionCodec(),
+                    "test-version");
         }
 
         @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -729,7 +729,8 @@ public class ParquetTester
                         .setMaxPageSize(DataSize.ofBytes(100))
                         .setMaxBlockSize(DataSize.ofBytes(100000))
                         .build(),
-                compressionCodecName);
+                compressionCodecName,
+                "test-version");
 
         PageBuilder pageBuilder = new PageBuilder(types);
         for (int i = 0; i < types.size(); ++i) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -157,6 +157,7 @@ public class IcebergFileWriterFactory
                     parquetWriterOptions,
                     IntStream.range(0, fileColumnNames.size()).toArray(),
                     getCompressionCodec(session).getParquetCompressionCodec(),
+                    nodeVersion.toString(),
                     outputPath,
                     hdfsEnvironment,
                     hdfsContext);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergParquetFileWriter.java
@@ -49,6 +49,7 @@ public class IcebergParquetFileWriter
             ParquetWriterOptions parquetWriterOptions,
             int[] fileInputColumnIndexes,
             CompressionCodecName compressionCodecName,
+            String trinoVersion,
             Path outputPath,
             HdfsEnvironment hdfsEnvironment,
             HdfsContext hdfsContext)
@@ -60,7 +61,8 @@ public class IcebergParquetFileWriter
                 primitiveTypes,
                 parquetWriterOptions,
                 fileInputColumnIndexes,
-                compressionCodecName);
+                compressionCodecName,
+                trinoVersion);
         this.outputPath = requireNonNull(outputPath, "outputPath is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.hdfsContext = requireNonNull(hdfsContext, "hdfsContext is null");

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-hive/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-spark-hive/hive.properties
@@ -1,6 +1,7 @@
 connector.name=hive
 hive.metastore.uri=thrift://hadoop-master:9083
 hive.config.resources=/docker/presto-product-tests/conf/presto/etc/hive-default-fs-site.xml
+hive.allow-drop-table=true
 
 # Note: it's currently unclear why this one is needed, while also hive.orc.time-zone=UTC is not needed.
 hive.parquet.time-zone=UTC

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompression.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompression.java
@@ -92,12 +92,15 @@ public class TestHiveCompression
     @Test(groups = HIVE_COMPRESSION)
     public void testSnappyCompressedParquetTableCreatedInTrinoWithNativeWriter()
     {
-        // TODO (https://github.com/trinodb/trino/issues/6377) Parquet files written by native Parquet writer cannot be read by Hive
+        // TODO (https://github.com/trinodb/trino/issues/6377) Native Parquet writer creates files that cannot be read by Hive
         assertThatThrownBy(() -> testSnappyCompressedParquetTableCreatedInTrino(true))
                 .hasStackTraceContaining("at org.apache.hive.jdbc.HiveQueryResultSet.next") // comes via Hive JDBC
                 .extracting(Throwable::toString, InstanceOfAssertFactories.STRING)
-                // CDH5's Parquet uses parquet.* packages, while e.g. HDP 3.1's uses org.apache.parquet.* packages.
-                .matches("\\Qio.trino.tempto.query.QueryExecutionException: java.sql.SQLException: java.io.IOException:\\E (org.apache.)?\\Qparquet.io.ParquetDecodingException: Cannot read data due to PARQUET-246: to read safely, set parquet.split.files to false");
+                // There are a few cases here each of which are downstream:
+                // - HDP 2 and CDH 5 cannot read Parquet V2 files and throw "org.apache.parquet.io.ParquetDecodingException: Can not read value at 0 in block -1 in file"
+                // - CDH 5 Parquet uses parquet.* packages, while HDP 2 uses org.apache.parquet.* packages
+                // - HDP 3 throws java.lang.ClassCastException: org.apache.hadoop.io.BytesWritable cannot be cast to org.apache.hadoop.hive.serde2.io.HiveVarcharWritable
+                .matches("\\Qio.trino.tempto.query.QueryExecutionException: java.sql.SQLException: java.io.IOException:\\E ((org.apache.)?parquet.io.ParquetDecodingException: Can not read value at 0 in block -1 in file .*|org.apache.hadoop.hive.ql.metadata.HiveException: java.lang.ClassCastException: org.apache.hadoop.io.BytesWritable cannot be cast to org.apache.hadoop.hive.serde2.io.HiveVarcharWritable)");
     }
 
     private void testSnappyCompressedParquetTableCreatedInTrino(boolean optimizedParquetWriter)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSparkCompatibility.java
@@ -14,6 +14,7 @@
 package io.trino.tests.product.hive;
 
 import io.trino.tempto.ProductTest;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -35,6 +36,7 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHiveSparkCompatibility
         extends ProductTest
@@ -195,6 +197,144 @@ public class TestHiveSparkCompatibility
                 {"USING PARQUET", "PARQUET"},
                 // TODO add Avro
         };
+    }
+
+    @Test(groups = {HIVE_SPARK, PROFILE_SPECIFIC_TESTS})
+    public void testReadTrinoCreatedOrcTable()
+    {
+        testReadTrinoCreatedTable("using_orc", "ORC");
+    }
+
+    @Test(groups = {HIVE_SPARK, PROFILE_SPECIFIC_TESTS})
+    public void testReadTrinoCreatedParquetTable()
+    {
+        testReadTrinoCreatedTable("using_parquet", "PARQUET");
+    }
+
+    @Test(groups = {HIVE_SPARK, PROFILE_SPECIFIC_TESTS})
+    public void testReadTrinoCreatedParquetTableWithNativeWriter()
+    {
+        onTrino().executeQuery("SET SESSION " + TRINO_CATALOG + ".experimental_parquet_optimized_writer_enabled = true");
+        // TODO (https://github.com/trinodb/trino/issues/6377) Native Parquet Writer writes Parquet V2 files that are not compatible with Spark's vectorized reader, see https://github.com/trinodb/trino/issues/7953 for more details
+        assertThatThrownBy(() -> testReadTrinoCreatedTable("using_native_parquet", "PARQUET"))
+                .hasStackTraceContaining("at org.apache.hive.jdbc.HiveStatement.execute")
+                .extracting(Throwable::toString, InstanceOfAssertFactories.STRING)
+                .matches("\\Qio.trino.tempto.query.QueryExecutionException: java.sql.SQLException: Error running query: java.lang.UnsupportedOperationException: Unsupported encoding: RLE\\E");
+    }
+
+    private void testReadTrinoCreatedTable(String tableName, String tableFormat)
+    {
+        String sparkTableName = "trino_created_table_" + tableName + "_" + randomTableSuffix();
+        String trinoTableName = format("%s.default.%s", TRINO_CATALOG, sparkTableName);
+
+        // Spark timestamps are in microsecond precision
+        onTrino().executeQuery("SET SESSION hive.timestamp_precision = 'MICROSECONDS'");
+        onTrino().executeQuery(format(
+                "CREATE TABLE %s ( " +
+                        "   a_boolean boolean, " +
+                        "   a_tinyint tinyint, " +
+                        "   a_smallint smallint, " +
+                        "   an_integer integer, " +
+                        "   a_bigint bigint, " +
+                        "   a_real real, " +
+                        "   a_double double, " +
+                        "   a_short_decimal decimal(11, 4), " +
+                        "   a_long_decimal decimal(26, 7), " +
+                        "   a_string varchar, " +
+                        // TODO binary
+                        "   a_date date, " +
+                        "   a_timestamp_seconds timestamp(6), " +
+                        "   a_timestamp_millis timestamp(6), " +
+                        "   a_timestamp_micros timestamp(6), " +
+                        // TODO interval
+                        // TODO array
+                        // TODO struct
+                        // TODO map
+                        "   a_dummy varchar " +
+                        ") " +
+                        "WITH ( " +
+                        "   format = '%s' " +
+                        ")",
+                trinoTableName,
+                tableFormat));
+
+        // nulls
+        onTrino().executeQuery("INSERT INTO " + trinoTableName + " VALUES (" + join(",", nCopies(15, "NULL")) + ")");
+        // positive values
+        onTrino().executeQuery(
+                "INSERT INTO " + trinoTableName + " VALUES (" +
+                        "true, " + // a_boolean
+                        "127, " + // a_tinyint
+                        "32767, " + // a_smallint
+                        "1000000000, " + // an_integer
+                        "1000000000000000, " + // a_bigint
+                        "10000000.123, " + // a_real
+                        "100000000000.123, " + // a_double
+                        "CAST('1234567.8901' AS decimal(11, 4)), " + // a_short_decimal
+                        "CAST('1234567890123456789.0123456' AS decimal(26, 7)), " + // a_short_decimal
+                        "'some string', " + // a_string
+                        "DATE '2005-09-10', " +  // a_date
+                        "TIMESTAMP '2005-09-10 13:00:00', " + // a_timestamp_seconds
+                        "TIMESTAMP '2005-09-10 13:00:00.123', " + // a_timestamp_millis
+                        "TIMESTAMP '2005-09-10 13:00:00.123456', " + // a_timestamp_micros
+                        "'dummy')");
+        // negative values
+        onTrino().executeQuery(
+                "INSERT INTO " + trinoTableName + " VALUES (" +
+                        "false, " + // a_boolean
+                        "-128, " + // a_tinyint
+                        "-32768, " + // a_smallint
+                        "-1000000012, " + // an_integer
+                        "-1000000000000012, " + // a_bigint
+                        "-10000000.123, " + // a_real
+                        "-100000000000.123, " + // a_double
+                        "CAST('-1234567.8901' AS decimal(11, 4)), " + // a_short_decimal
+                        "CAST('-1234567890123456789.0123456' AS decimal(26, 7)), " + // a_short_decimal
+                        "'', " + // a_string
+                        "DATE '1965-09-10', " + // a_date
+                        "TIMESTAMP '1965-09-10 13:00:00', " + // a_timestamp_seconds
+                        "TIMESTAMP '1965-09-10 13:00:00.123', " + // a_timestamp_millis
+                        "TIMESTAMP '1965-09-10 13:00:00.123456', " + // a_timestamp_micros
+                        "'dummy')");
+
+        List<Row> expected = List.of(
+                row(nCopies(15, null).toArray()),
+                row(
+                        true, // a_boolean
+                        (byte) 127, // a_tinyint
+                        (short) 32767, // a_smallint
+                        1000000000, // an_integer
+                        1000000000000000L, // a_bigint
+                        10000000.123F, // a_real
+                        100000000000.123, // a_double
+                        new BigDecimal("1234567.8901"), // a_short_decimal
+                        new BigDecimal("1234567890123456789.0123456"), // a_long_decimal
+                        "some string", // a_string
+                        java.sql.Date.valueOf(LocalDate.of(2005, 9, 10)), // a_date
+                        java.sql.Timestamp.valueOf(LocalDateTime.of(2005, 9, 10, 13, 0, 0)), // a_timestamp_seconds
+                        java.sql.Timestamp.valueOf(LocalDateTime.of(2005, 9, 10, 13, 0, 0, 123_000_000)), // a_timestamp_millis
+                        java.sql.Timestamp.valueOf(LocalDateTime.of(2005, 9, 10, 13, 0, 0, 123_456_000)), // a_timestamp_micros
+                        "dummy"),
+                row(
+                        false, // a_bigint
+                        (byte) -128, // a_tinyint
+                        (short) -32768, // a_smallint
+                        -1000000012, // an_integer
+                        -1000000000000012L, // a_bigint
+                        -10000000.123F, // a_real
+                        -100000000000.123, // a_double
+                        new BigDecimal("-1234567.8901"), // a_short_decimal
+                        new BigDecimal("-1234567890123456789.0123456"), // a_long_decimal
+                        "", // a_string
+                        java.sql.Date.valueOf(LocalDate.of(1965, 9, 10)), // a_date
+                        java.sql.Timestamp.valueOf(LocalDateTime.of(1965, 9, 10, 13, 0, 0)), // a_timestamp_seconds
+                        java.sql.Timestamp.valueOf(LocalDateTime.of(1965, 9, 10, 13, 0, 0, 123_000_000)), // a_timestamp_millis
+                        java.sql.Timestamp.valueOf(LocalDateTime.of(1965, 9, 10, 13, 0, 0, 123_456_000)), // a_timestamp_micros
+                        "dummy"));
+        assertThat(onSpark().executeQuery("SELECT * FROM " + sparkTableName)).containsOnly(expected);
+        assertThat(onTrino().executeQuery("SELECT * FROM " + trinoTableName)).containsOnly(expected);
+
+        onTrino().executeQuery("DROP TABLE " + trinoTableName);
     }
 
     @Test(groups = {HIVE_SPARK, PROFILE_SPECIFIC_TESTS})


### PR DESCRIPTION
This PR adds the `created_by` attribute to the metadata written by the native Parquet writer. The `created_by` attribute should always be set to `org.apache.parquet.Version.FULL_VERSION` which represents the version of parquet-mr used to write the data. 

~Tests are added to verify that https://github.com/trinodb/trino/issues/6377 is resolved with this change.~