### PR TITLE
Fix in clause handling of varchars in filter pushdown

### DIFF
--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotQueryBuilder.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/query/PinotQueryBuilder.java
@@ -24,6 +24,7 @@ import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.RealType;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -136,13 +137,13 @@ public final class PinotQueryBuilder
                 checkState(!rangeConjuncts.isEmpty());
                 disjuncts.add("(" + Joiner.on(" AND ").join(rangeConjuncts) + ")");
             }
-            // Add back all of the possible single values either as an equality or an IN predicate
-            if (singleValues.size() == 1) {
-                disjuncts.add(toConjunct(columnName, "=", getOnlyElement(singleValues)));
-            }
-            else if (singleValues.size() > 1) {
-                disjuncts.add(inClauseValues(columnName, singleValues));
-            }
+        }
+        // Add back all of the possible single values either as an equality or an IN predicate
+        if (singleValues.size() == 1) {
+            disjuncts.add(toConjunct(columnName, "=", getOnlyElement(singleValues)));
+        }
+        else if (singleValues.size() > 1) {
+            disjuncts.add(inClauseValues(columnName, singleValues));
         }
         return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
     }
@@ -151,6 +152,9 @@ public final class PinotQueryBuilder
     {
         if (type instanceof RealType) {
             return intBitsToFloat(toIntExact((Long) value));
+        }
+        else if (type instanceof VarcharType) {
+            return ((Slice) value).toStringUtf8();
         }
         return value;
     }

--- a/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotIntegrationSmokeTest.java
+++ b/plugin/trino-pinot/src/test/java/io/trino/plugin/pinot/TestPinotIntegrationSmokeTest.java
@@ -1203,4 +1203,32 @@ public class TestPinotIntegrationSmokeTest
                 .withRootCauseInstanceOf(RuntimeException.class)
                 .withMessage("Operation not supported for DISTINCT aggregation function");
     }
+
+    @Test
+    public void testInClause()
+    {
+        assertThat(query("SELECT string_col, sum(long_col)" +
+                "  FROM " + ALL_TYPES_TABLE +
+                "  WHERE string_col IN ('string_1200','string_2400','string_3600')" +
+                "  GROUP BY string_col"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT string_col, sum(long_col)" +
+                "  FROM " + ALL_TYPES_TABLE +
+                "  WHERE string_col NOT IN ('string_1200','string_2400','string_3600')" +
+                "  GROUP BY string_col"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT int_col, sum(long_col)" +
+                "  FROM " + ALL_TYPES_TABLE +
+                "  WHERE int_col IN (54, 56)" +
+                "  GROUP BY int_col"))
+                .isFullyPushedDown();
+
+        assertThat(query("SELECT int_col, sum(long_col)" +
+                "  FROM " + ALL_TYPES_TABLE +
+                "  WHERE int_col NOT IN (54, 56)" +
+                "  GROUP BY int_col"))
+                .isFullyPushedDown();
+    }
 }


### PR DESCRIPTION
In and not in clauses did not handle varchar correctly.

Fixes https://github.com/trinodb/trino/issues/9133