### PR TITLE
Improve environment variable checks in Hive test scripts

### DIFF
--- a/plugin/trino-hive-hadoop2/bin/common.sh
+++ b/plugin/trino-hive-hadoop2/bin/common.sh
@@ -21,7 +21,7 @@ function retry() {
     return ${EXIT_CODE}
 }
 
-function hadoop_master_container(){
+function hadoop_master_container() {
     docker-compose -f "${DOCKER_COMPOSE_LOCATION}" ps -q hadoop-master | grep .
 }
 
@@ -76,10 +76,28 @@ function cleanup_hadoop_docker_containers() {
     cleanup_docker_containers "${DOCKER_COMPOSE_LOCATION}"
 }
 
-function termination_handler(){
+function termination_handler() {
     set +e
     cleanup_docker_containers "$@"
     exit 130
+}
+
+# Check that all arguments are the names of non-empty variables.
+function check_vars() {
+    ( # Subshell to preserve xtrace
+        set +x # Disable xtrace to make the messages printed clear
+        local failing=0
+        for arg; do
+            if [[ ! -v "${arg}" ]]; then
+                echo "error: Variable not set: ${arg}" >&2
+                failing=1
+            elif [[ -z "${!arg}" ]]; then
+                echo "error: Variable is empty: ${arg}" >&2
+                failing=1
+            fi
+        done
+        return "$failing"
+    )
 }
 
 SCRIPT_DIR="${BASH_SOURCE%/*}"

--- a/plugin/trino-hive-hadoop2/bin/run_hive_abfs_access_key_tests.sh
+++ b/plugin/trino-hive-hadoop2/bin/run_hive_abfs_access_key_tests.sh
@@ -4,9 +4,7 @@ set -euo pipefail -x
 
 . "${BASH_SOURCE%/*}/common.sh"
 
-test -v ABFS_CONTAINER
-test -v ABFS_ACCOUNT
-test -v ABFS_ACCESS_KEY
+check_vars ABFS_CONTAINER ABFS_ACCOUNT ABFS_ACCESS_KEY
 
 cleanup_hadoop_docker_containers
 start_hadoop_docker_containers

--- a/plugin/trino-hive-hadoop2/bin/run_hive_abfs_oauth_tests.sh
+++ b/plugin/trino-hive-hadoop2/bin/run_hive_abfs_oauth_tests.sh
@@ -3,11 +3,8 @@ set -euxo pipefail
 
 . "${BASH_SOURCE%/*}/common.sh"
 
-test -v ABFS_ACCOUNT
-test -v ABFS_CONTAINER
-test -v ABFS_OAUTH_ENDPOINT
-test -v ABFS_OAUTH_CLIENTID
-test -v ABFS_OAUTH_SECRET
+check_vars ABFS_ACCOUNT ABFS_CONTAINER \
+    ABFS_OAUTH_ENDPOINT ABFS_OAUTH_CLIENTID ABFS_OAUTH_SECRET
 
 test_directory="$(date '+%Y%m%d-%H%M%S')-$(uuidgen | sha1sum | cut -b 1-6)"
 

--- a/plugin/trino-hive-hadoop2/bin/run_hive_adl_tests.sh
+++ b/plugin/trino-hive-hadoop2/bin/run_hive_adl_tests.sh
@@ -4,10 +4,7 @@ set -euo pipefail -x
 
 . "${BASH_SOURCE%/*}/common.sh"
 
-test -v ADL_NAME
-test -v ADL_CLIENT_ID
-test -v ADL_CREDENTIAL
-test -v ADL_REFRESH_URL
+check_vars ADL_NAME ADL_CLIENT_ID ADL_CREDENTIAL ADL_REFRESH_URL
 
 cleanup_hadoop_docker_containers
 start_hadoop_docker_containers

--- a/plugin/trino-hive-hadoop2/bin/run_hive_s3_tests.sh
+++ b/plugin/trino-hive-hadoop2/bin/run_hive_s3_tests.sh
@@ -4,6 +4,9 @@ set -euo pipefail -x
 
 . "${BASH_SOURCE%/*}/common.sh"
 
+check_vars S3_BUCKET S3_BUCKET_ENDPOINT \
+    AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+
 cleanup_hadoop_docker_containers
 start_hadoop_docker_containers
 

--- a/plugin/trino-hive-hadoop2/bin/run_hive_wasb_tests.sh
+++ b/plugin/trino-hive-hadoop2/bin/run_hive_wasb_tests.sh
@@ -4,9 +4,7 @@ set -euo pipefail -x
 
 . "${BASH_SOURCE%/*}/common.sh"
 
-test -v WASB_CONTAINER
-test -v WASB_ACCOUNT
-test -v WASB_ACCESS_KEY
+check_vars WASB_CONTAINER WASB_ACCOUNT WASB_ACCESS_KEY
 
 cleanup_hadoop_docker_containers
 start_hadoop_docker_containers


### PR DESCRIPTION
Previously, the scripts checked that each required environment variable in turn was defined. With this change, they check that all of those variables are defined and non-empty, and fails if they are not.

This helps avoid a handful of opaque errors when running the tests by hand.