### PR TITLE
Change RPM architecture to noarch on trino-server-rpm.

### DIFF
--- a/core/trino-server-rpm/README.md
+++ b/core/trino-server-rpm/README.md
@@ -8,7 +8,7 @@ The RPM builds by default in Maven, and can be found under the directory `core/t
 
 To install Trino using an RPM, run:
 
-    rpm -i trino-server-rpm-<version>-x86_64.rpm
+    rpm -i trino-server-rpm-<version>-noarch.rpm
 
 This will install Trino in single node mode, where both coordinator and workers are co-located on localhost.
 This will deploy the necessary default configurations along with a service script to control the Trino server process.

--- a/core/trino-server-rpm/pom.xml
+++ b/core/trino-server-rpm/pom.xml
@@ -146,13 +146,13 @@
                     <packages>
                         <package>
                             <name>trino-server-rpm</name>
-                            <nameOverride>trino-server-rpm-${project.version}.x86_64.rpm</nameOverride>
+                            <nameOverride>trino-server-rpm-${project.version}.noarch.rpm</nameOverride>
                             <version>${project.version}</version>
                             <release>1</release>
 
                             <group>Applications/Databases</group>
                             <description>Trino Server RPM Package.</description>
-                            <architecture>x86_64</architecture>
+                            <architecture>noarch</architecture>
                             <preInstallScriptFile>src/main/rpm/preinstall</preInstallScriptFile>
                             <postInstallScriptFile>src/main/rpm/postinstall</postInstallScriptFile>
                             <preUninstallScriptFile>src/main/rpm/preremove</preUninstallScriptFile>
@@ -290,7 +290,7 @@
                                     <!-- Maven Central has a 1GB limit -->
                                     <maxsize>1106000000</maxsize>
                                     <files>
-                                        <file>${project.build.directory}/${project.build.finalName}.x86_64.rpm</file>
+                                        <file>${project.build.directory}/${project.build.finalName}.noarch.rpm</file>
                                     </files>
                                 </requireFilesSize>
                             </rules>
@@ -313,7 +313,7 @@
                         <version>2.22.2</version>
                         <configuration>
                             <systemPropertyVariables>
-                                <rpm>${project.build.directory}/${project.build.finalName}.x86_64.rpm</rpm>
+                                <rpm>${project.build.directory}/${project.build.finalName}.noarch.rpm</rpm>
                             </systemPropertyVariables>
                         </configuration>
                         <executions>


### PR DESCRIPTION
Trino RPM is actually installable and runs on many other architectures, changing architecture to noarch to avoid being to restrictive