### PR TITLE
Support Parquet nanosecond timestamp stored as INT64

### DIFF
--- a/lib/trino-parquet/pom.xml
+++ b/lib/trino-parquet/pom.xml
@@ -39,6 +39,11 @@
 
         <dependency>
             <groupId>io.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
         </dependency>
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/Int64TimestampNanosColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/Int64TimestampNanosColumnReader.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.reader;
+
+import io.trino.parquet.RichColumnDescriptor;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.Timestamps;
+import io.trino.spi.type.Type;
+
+import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.lang.String.format;
+
+public class Int64TimestampNanosColumnReader
+        extends PrimitiveColumnReader
+{
+    public Int64TimestampNanosColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            long epochNanos = valuesReader.readLong();
+            // TODO: specialize the class at creation time
+            if (type == TIMESTAMP_MILLIS) {
+                type.writeLong(blockBuilder, Timestamps.round(epochNanos, 6) / NANOSECONDS_PER_MICROSECOND);
+            }
+            else if (type == TIMESTAMP_MICROS) {
+                type.writeLong(blockBuilder, Timestamps.round(epochNanos, 3) / NANOSECONDS_PER_MICROSECOND);
+            }
+            else if (type == TIMESTAMP_NANOS) {
+                type.writeObject(blockBuilder, new LongTimestamp(
+                        floorDiv(epochNanos, NANOSECONDS_PER_MICROSECOND),
+                        floorMod(epochNanos, NANOSECONDS_PER_MICROSECOND) * PICOSECONDS_PER_NANOSECOND));
+            }
+            else {
+                throw new TrinoException(NOT_SUPPORTED, format("Unsupported Trino column type (%s) for Parquet column (%s)", type, columnDescriptor));
+            }
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readLong();
+        }
+    }
+}

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/MetadataReader.java
@@ -13,6 +13,7 @@
  */
 package io.trino.parquet.reader;
 
+import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.trino.parquet.ParquetDataSource;
@@ -65,6 +66,8 @@ import static org.apache.parquet.format.converter.ParquetMetadataConverterUtil.g
 
 public final class MetadataReader
 {
+    private static final Logger log = Logger.get(MetadataReader.class);
+
     private static final Slice MAGIC = Slices.utf8Slice("PAR1");
     private static final int POST_SCRIPT_SIZE = Integer.BYTES + MAGIC.length();
     private static final int EXPECTED_FOOTER_SIZE = 16 * 1024;
@@ -176,6 +179,7 @@ public final class MetadataReader
 
     private static void readTypeSchema(Types.GroupBuilder<?> builder, Iterator<SchemaElement> schemaIterator, int typeCount)
     {
+        ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
         for (int i = 0; i < typeCount; i++) {
             SchemaElement element = schemaIterator.next();
             Types.Builder<?, ?> typeBuilder;
@@ -197,9 +201,38 @@ public final class MetadataReader
                 typeBuilder = primitiveBuilder;
             }
 
-            if (element.isSetConverted_type()) {
-                typeBuilder.as(getLogicalTypeAnnotation(new ParquetMetadataConverter(), element.converted_type, element));
+            // Reading of element.logicalType and element.converted_type corresponds to parquet-mr's code at
+            // https://github.com/apache/parquet-mr/blob/apache-parquet-1.12.0/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java#L1568-L1582
+            LogicalTypeAnnotation annotationFromLogicalType = null;
+            if (element.isSetLogicalType()) {
+                annotationFromLogicalType = getLogicalTypeAnnotation(parquetMetadataConverter, element.logicalType);
+                typeBuilder.as(annotationFromLogicalType);
             }
+            if (element.isSetConverted_type()) {
+                LogicalTypeAnnotation annotationFromConvertedType = getLogicalTypeAnnotation(parquetMetadataConverter, element.converted_type, element);
+                if (annotationFromLogicalType != null) {
+                    // Both element.logicalType and element.converted_type set
+                    if (annotationFromLogicalType.toOriginalType() == annotationFromConvertedType.toOriginalType()) {
+                        // element.converted_type matches element.logicalType, even though annotationFromLogicalType may differ from annotationFromConvertedType
+                        // Following parquet-mr behavior, we favor LogicalTypeAnnotation derived from element.logicalType, as potentially containing more information.
+                    }
+                    else {
+                        // Following parquet-mr behavior, issue warning and let converted_type take precedence.
+                        log.warn("Converted type and logical type metadata map to different OriginalType (convertedType: %s, logical type: %s). Using value in converted type.",
+                                element.converted_type, element.logicalType);
+                        // parquet-mr reads only OriginalType from converted_type. We retain full LogicalTypeAnnotation
+                        // 1. for compatibility, as previous Trino reader code would read LogicalTypeAnnotation from element.converted_type and some additional fields.
+                        // 2. so that we override LogicalTypeAnnotation annotation read from element.logicalType in case of mismatch detected.
+                        typeBuilder.as(annotationFromConvertedType);
+                    }
+                }
+                else {
+                    // parquet-mr reads only OriginalType from converted_type. We retain full LogicalTypeAnnotation for compatibility, as previous
+                    // Trino reader code would read LogicalTypeAnnotation from element.converted_type and some additional fields.
+                    typeBuilder.as(annotationFromConvertedType);
+                }
+            }
+
             if (element.isSetField_id()) {
                 typeBuilder.id(element.field_id);
             }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/PrimitiveColumnReader.java
@@ -36,6 +36,8 @@ import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridDecoder;
 import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.OriginalType;
 import org.joda.time.DateTimeZone;
 
@@ -101,6 +103,10 @@ public abstract class PrimitiveColumnReader
                 }
                 if (descriptor.getPrimitiveType().getOriginalType() == OriginalType.TIMESTAMP_MILLIS) {
                     return new Int64TimestampMillisColumnReader(descriptor);
+                }
+                if (descriptor.getPrimitiveType().getLogicalTypeAnnotation() instanceof TimestampLogicalTypeAnnotation &&
+                        ((TimestampLogicalTypeAnnotation) descriptor.getPrimitiveType().getLogicalTypeAnnotation()).getUnit() == LogicalTypeAnnotation.TimeUnit.NANOS) {
+                    return new Int64TimestampNanosColumnReader(descriptor);
                 }
                 return createDecimalColumnReader(descriptor).orElse(new LongColumnReader(descriptor));
             case INT96:

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/MessageTypeConverter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/MessageTypeConverter.java
@@ -17,6 +17,7 @@ import org.apache.parquet.format.ConvertedType;
 import org.apache.parquet.format.FieldRepetitionType;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.format.Type;
+import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.OriginalType;
@@ -25,6 +26,8 @@ import org.apache.parquet.schema.TypeVisitor;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.apache.parquet.format.converter.ParquetMetadataConverterUtil.convertToLogicalType;
 
 class MessageTypeConverter
 {
@@ -49,6 +52,9 @@ class MessageTypeConverter
                 element.setType(getType(primitiveType.getPrimitiveTypeName()));
                 if (primitiveType.getOriginalType() != null) {
                     element.setConverted_type(getConvertedType(primitiveType.getOriginalType()));
+                }
+                if (primitiveType.getLogicalTypeAnnotation() != null) {
+                    element.setLogicalType(convertToLogicalType(new ParquetMetadataConverter(), primitiveType.getLogicalTypeAnnotation()));
                 }
                 if (primitiveType.getDecimalMetadata() != null) {
                     element.setPrecision(primitiveType.getDecimalMetadata().getPrecision());
@@ -80,6 +86,9 @@ class MessageTypeConverter
                 element.setRepetition_type(toParquetRepetition(groupType.getRepetition()));
                 if (groupType.getOriginalType() != null) {
                     element.setConverted_type(getConvertedType(groupType.getOriginalType()));
+                }
+                if (groupType.getLogicalTypeAnnotation() != null) {
+                    element.setLogicalType(convertToLogicalType(new ParquetMetadataConverter(), groupType.getLogicalTypeAnnotation()));
                 }
                 if (groupType.getId() != null) {
                     element.setField_id(groupType.getId().intValue());

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java
@@ -25,6 +25,7 @@ import io.trino.parquet.writer.valuewriter.PrimitiveValueWriter;
 import io.trino.parquet.writer.valuewriter.RealValueWriter;
 import io.trino.parquet.writer.valuewriter.TimeMicrosValueWriter;
 import io.trino.parquet.writer.valuewriter.TimestampMillisValueWriter;
+import io.trino.parquet.writer.valuewriter.TimestampNanosValueWriter;
 import io.trino.parquet.writer.valuewriter.TimestampTzMicrosValueWriter;
 import io.trino.parquet.writer.valuewriter.TimestampTzMillisValueWriter;
 import io.trino.spi.TrinoException;
@@ -38,6 +39,8 @@ import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
@@ -45,6 +48,7 @@ import org.apache.parquet.schema.PrimitiveType;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -58,6 +62,7 @@ import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TimeType.TIME_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MICROS;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
 import static io.trino.spi.type.TinyintType.TINYINT;
@@ -183,11 +188,20 @@ final class ParquetWriters
         }
         if (TIMESTAMP_MILLIS.equals(type)) {
             verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MILLIS);
+            // TODO when writing with Hive connector, isAdjustedToUTC is being set to true, which might be incorrect
+            //   verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MILLIS));
             return new TimestampMillisValueWriter(valuesWriter, type, parquetType);
         }
         if (TIMESTAMP_MICROS.equals(type)) {
             verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MICROS);
+            // TODO when writing with Hive connector, isAdjustedToUTC is being set to true, which might be incorrect
+            //   verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.MICROS));
             return new BigintValueWriter(valuesWriter, type, parquetType);
+        }
+        if (TIMESTAMP_NANOS.equals(type)) {
+            verifyParquetType(type, parquetType, (OriginalType) null); // no OriginalType for timestamp NANOS
+            verifyParquetType(type, parquetType, TimestampLogicalTypeAnnotation.class, isTimestamp(LogicalTypeAnnotation.TimeUnit.NANOS));
+            return new TimestampNanosValueWriter(valuesWriter, type, parquetType);
         }
         if (TIMESTAMP_TZ_MILLIS.equals(type)) {
             verifyParquetType(type, parquetType, OriginalType.TIMESTAMP_MILLIS);
@@ -213,5 +227,21 @@ final class ParquetWriters
     private static void verifyParquetType(Type type, PrimitiveType parquetType, OriginalType originalType)
     {
         checkArgument(parquetType.getOriginalType() == originalType, "Wrong Parquet type '%s' for Trino type '%s'", parquetType, type);
+    }
+
+    private static <T> void verifyParquetType(Type type, PrimitiveType parquetType, Class<T> annotationType, Predicate<T> predicate)
+    {
+        checkArgument(
+                annotationType.isInstance(parquetType.getLogicalTypeAnnotation()) &&
+                        predicate.test(annotationType.cast(parquetType.getLogicalTypeAnnotation())),
+                "Wrong Parquet type '%s' for Trino type '%s'", parquetType, type);
+    }
+
+    private static Predicate<TimestampLogicalTypeAnnotation> isTimestamp(LogicalTypeAnnotation.TimeUnit precision)
+    {
+        requireNonNull(precision, "precision is null");
+        return annotation -> annotation.getUnit() == precision &&
+                // isAdjustedToUTC=false indicates Local semantics (timestamps not normalized to UTC)
+                !annotation.isAdjustedToUTC();
     }
 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampNanosValueWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/valuewriter/TimestampNanosValueWriter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.parquet.writer.valuewriter;
+
+import com.google.common.math.LongMath;
+import io.trino.spi.block.Block;
+import io.trino.spi.type.LongTimestamp;
+import io.trino.spi.type.Type;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.schema.PrimitiveType;
+
+import static io.trino.spi.type.Timestamps.NANOSECONDS_PER_MICROSECOND;
+import static io.trino.spi.type.Timestamps.PICOSECONDS_PER_NANOSECOND;
+import static java.lang.Math.multiplyExact;
+import static java.math.RoundingMode.UNNECESSARY;
+import static java.util.Objects.requireNonNull;
+
+public class TimestampNanosValueWriter
+        extends PrimitiveValueWriter
+{
+    private final Type type;
+
+    public TimestampNanosValueWriter(ValuesWriter valuesWriter, Type type, PrimitiveType parquetType)
+    {
+        super(parquetType, valuesWriter);
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @Override
+    public void write(Block block)
+    {
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (!block.isNull(i)) {
+                LongTimestamp value = (LongTimestamp) type.getObject(block, i);
+                long epochNanos = multiplyExact(value.getEpochMicros(), NANOSECONDS_PER_MICROSECOND) +
+                        LongMath.divide(value.getPicosOfMicro(), PICOSECONDS_PER_NANOSECOND, UNNECESSARY);
+                getValueWriter().writeLong(epochNanos);
+                getStatistics().updateStats(epochNanos);
+            }
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
@@ -7577,16 +7577,7 @@ public class TestHiveConnectorTest
     @Test
     public void testTimestampPrecisionInsert()
     {
-        testWithAllStorageFormats((session, storageFormat) -> {
-            if (isNativeParquetWriter(session, storageFormat)) {
-                // TODO (https://github.com/trinodb/trino/issues/5357) Implement variable precision timestamp handling for optimized Parquet writer
-                assertThatThrownBy(() -> testTimestampPrecisionInsert(session, storageFormat))
-                        .hasMessage("Unsupported primitive type: timestamp(9)")
-                        .hasStackTraceContaining("at io.trino.parquet.writer.ParquetSchemaConverter.getPrimitiveType");
-                return;
-            }
-            testTimestampPrecisionInsert(session, storageFormat);
-        });
+        testWithAllStorageFormats(this::testTimestampPrecisionInsert);
     }
 
     private void testTimestampPrecisionInsert(Session session, HiveStorageFormat storageFormat)
@@ -7613,16 +7604,7 @@ public class TestHiveConnectorTest
     @Test
     public void testTimestampPrecisionCtas()
     {
-        testWithAllStorageFormats((session, storageFormat) -> {
-            if (isNativeParquetWriter(session, storageFormat)) {
-                // TODO (https://github.com/trinodb/trino/issues/5357) Implement variable precision timestamp handling for optimized Parquet writer
-                assertThatThrownBy(() -> testTimestampPrecisionCtas(session, storageFormat))
-                        .hasMessage("Unsupported primitive type: timestamp(9)")
-                        .hasStackTraceContaining("at io.trino.parquet.writer.ParquetSchemaConverter.getPrimitiveType");
-                return;
-            }
-            testTimestampPrecisionCtas(session, storageFormat);
-        });
+        testWithAllStorageFormats((session, storageFormat) -> testTimestampPrecisionCtas(session, storageFormat));
     }
 
     private void testTimestampPrecisionCtas(Session session, HiveStorageFormat storageFormat)

--- a/pom.xml
+++ b/pom.xml
@@ -547,7 +547,7 @@
             <dependency>
                 <groupId>io.trino.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>3.1.2-14</version>
+                <version>3.1.2-15</version>
             </dependency>
 
             <dependency>

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -241,8 +241,6 @@ public class TestHiveStorageFormats
         return Stream.of(storageFormats())
                 // nanoseconds are not supported with Avro
                 .filter(format -> !"AVRO".equals(format.getName()))
-                // TODO (https://github.com/trinodb/trino/issues/5357) Implement variable precision timestamp handling for optimized Parquet writer
-                .filter(format -> !("PARQUET".equals(format.getName()) && "true".equals(format.getSessionProperties().get("hive.experimental_parquet_optimized_writer_enabled"))))
                 .iterator();
     }
 


### PR DESCRIPTION
This affects:

- Trino Parquet reader
  - MetadataReader now correctly reads LogicalTypeAnnotation
  - the reader can now read INT64 with logical type annotation
    indicating timestamp in nanoseconds
- Trino native Parquet writer
  - add support for `timestamp(9)`, which per Parquet spec gets stored
    as INT64 with logical type annotation indicating timestamp in
    nanoseconds.

Fixes https://github.com/trinodb/trino/issues/5357
For https://github.com/trinodb/trino/issues/6382
