### PR TITLE
Improve AccumulatorCompiler generated code

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregationUtils.java
@@ -14,6 +14,7 @@
 package io.trino.operator.aggregation;
 
 import com.google.common.base.CaseFormat;
+import io.trino.annotation.UsedByGeneratedCode;
 import io.trino.operator.aggregation.state.CentralMomentsState;
 import io.trino.operator.aggregation.state.CorrelationState;
 import io.trino.operator.aggregation.state.CovarianceState;
@@ -21,10 +22,13 @@ import io.trino.operator.aggregation.state.RegressionState;
 import io.trino.operator.aggregation.state.VarianceState;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
+import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.type.TypeSignature;
+import io.trino.sql.gen.CompilerOperations;
+
+import javax.annotation.Nullable;
 
 import java.util.List;
-import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Locale.ENGLISH;
@@ -241,9 +245,27 @@ public final class AggregationUtils
     }
 
     // used by aggregation compiler
+    @UsedByGeneratedCode
     @SuppressWarnings("UnusedDeclaration")
-    public static Function<Integer, Block> pageBlockGetter(final Page page)
+    public static Block extractMaskBlock(int maskChannel, Page page)
     {
-        return page::getBlock;
+        if (maskChannel < 0) {
+            return null;
+        }
+        Block maskBlock = page.getBlock(maskChannel);
+        if (page.getPositionCount() > 0 && maskBlock instanceof RunLengthEncodedBlock && CompilerOperations.testMask(maskBlock, 0)) {
+            return null; // filter out RLE true blocks to bypass unnecessary mask checks
+        }
+        return maskBlock;
+    }
+
+    @UsedByGeneratedCode
+    @SuppressWarnings("UnusedDeclaration")
+    public static boolean maskGuaranteedToFilterAllRows(int positions, @Nullable Block maskBlock)
+    {
+        if (maskBlock == null || positions == 0) {
+            return false;
+        }
+        return (maskBlock instanceof RunLengthEncodedBlock && !CompilerOperations.testMask(maskBlock, 0));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/GenericAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/GenericAccumulatorFactory.java
@@ -25,6 +25,7 @@ import io.trino.operator.aggregation.AggregationMetadata.AccumulatorStateDescrip
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.RunLengthEncodedBlock;
 import io.trino.spi.connector.SortOrder;
 import io.trino.spi.function.WindowIndex;
 import io.trino.spi.type.Type;
@@ -242,7 +243,7 @@ public class GenericAccumulatorFactory
     {
         private final Accumulator accumulator;
         private final MarkDistinctHash hash;
-        private final Optional<Integer> maskChannel;
+        private final int maskChannel;
 
         private DistinctingAccumulator(
                 Accumulator accumulator,
@@ -254,7 +255,7 @@ public class GenericAccumulatorFactory
                 BlockTypeOperators blockTypeOperators)
         {
             this.accumulator = requireNonNull(accumulator, "accumulator is null");
-            this.maskChannel = requireNonNull(maskChannel, "maskChannel is null");
+            this.maskChannel = requireNonNull(maskChannel, "maskChannel is null").orElse(-1);
 
             hash = new MarkDistinctHash(session, inputTypes, Ints.toArray(inputs), Optional.empty(), joinCompiler, blockTypeOperators, UpdateMemory.NOOP);
         }
@@ -281,9 +282,13 @@ public class GenericAccumulatorFactory
         public void addInput(Page page)
         {
             // 1. filter out positions based on mask, if present
-            Page filtered = maskChannel
-                    .map(channel -> filter(page, page.getBlock(channel)))
-                    .orElse(page);
+            Page filtered;
+            if (maskChannel >= 0) {
+                filtered = filter(page, page.getBlock(maskChannel));
+            }
+            else {
+                filtered = page;
+            }
 
             if (filtered.getPositionCount() == 0) {
                 return;
@@ -331,9 +336,19 @@ public class GenericAccumulatorFactory
 
     private static Page filter(Page page, Block mask)
     {
-        int[] ids = new int[mask.getPositionCount()];
+        int positions = mask.getPositionCount();
+        if (positions > 0 && mask instanceof RunLengthEncodedBlock) {
+            // must have at least 1 position to be able to check the value at position 0
+            if (BOOLEAN.getBoolean(mask, 0)) {
+                return page;
+            }
+            else {
+                return page.getPositions(new int[0], 0, 0);
+            }
+        }
+        int[] ids = new int[positions];
         int next = 0;
-        for (int i = 0; i < page.getPositionCount(); ++i) {
+        for (int i = 0; i < ids.length; ++i) {
             if (BOOLEAN.getBoolean(mask, i)) {
                 ids[next++] = i;
             }
@@ -347,7 +362,7 @@ public class GenericAccumulatorFactory
     {
         private final GroupedAccumulator accumulator;
         private final MarkDistinctHash hash;
-        private final Optional<Integer> maskChannel;
+        private final int maskChannel;
 
         private DistinctingGroupedAccumulator(
                 GroupedAccumulator accumulator,
@@ -359,7 +374,7 @@ public class GenericAccumulatorFactory
                 BlockTypeOperators blockTypeOperators)
         {
             this.accumulator = requireNonNull(accumulator, "accumulator is null");
-            this.maskChannel = requireNonNull(maskChannel, "maskChannel is null");
+            this.maskChannel = requireNonNull(maskChannel, "maskChannel is null").orElse(-1);
 
             List<Type> types = ImmutableList.<Type>builder()
                     .add(BIGINT) // group id column
@@ -399,9 +414,13 @@ public class GenericAccumulatorFactory
             Page withGroup = page.prependColumn(groupIdsBlock);
 
             // 1. filter out positions based on mask, if present
-            Page filtered = maskChannel
-                    .map(channel -> filter(withGroup, withGroup.getBlock(channel + 1))) // offset by one because of group id in column 0
-                    .orElse(withGroup);
+            Page filtered;
+            if (maskChannel >= 0) {
+                filtered = filter(withGroup, withGroup.getBlock(maskChannel + 1)); // offset by one because of group id in column 0
+            }
+            else {
+                filtered = withGroup;
+            }
 
             // 2. compute a mask for the distinct rows (including the group id)
             Work<Block> work = hash.markDistinctRows(filtered);

--- a/core/trino-main/src/main/java/io/trino/sql/gen/CompilerOperations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/gen/CompilerOperations.java
@@ -17,8 +17,11 @@ import io.trino.spi.block.Block;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 
 // This methods are statically bound by the compiler
@@ -71,5 +74,17 @@ public final class CompilerOperations
             return BOOLEAN.getBoolean(masks, index);
         }
         return true;
+    }
+
+    public static int optionalChannelToIntOrNegative(Optional<Integer> channel)
+    {
+        return channel.orElse(-1);
+    }
+
+    public static void validateChannelsListLength(List<Integer> channels, int requiredSize)
+    {
+        int channelsSize = channels.size();
+        // empty channels is allowed for intermediate aggregations
+        checkArgument(channelsSize == 0 || requiredSize == 0 || channelsSize == requiredSize, "Invalid channels length, expected %s but found: %s", requiredSize, channelsSize);
     }
 }


### PR DESCRIPTION
Extracted from https://github.com/prestodb/presto/pull/16722

Improves the AccumulatorCompilerGeneratedCode by
- Using `int` field for `maskChannel` and `inputChannel` fields, instead of retaining a boxed `Optional` or `List` of Integer
- Filtering RLE mask blocks of true into null before entering the input loop to bypass unnecessary mask checks
- Checking for RLE false mask blocks before entering the addInput main loop

Benchmark Results (none of these exercise distinct RLE block behaviors):
- [BenchmarkDecimalAggregations](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/faf716c3ad866d3d557d63bbbf1dbbea/raw/98a0f0cd700f0a4497c54cbb73488faf0c1e16af/baseline_trino_aggs_decimal_v8.json,https://gist.githubusercontent.com/pettyjamesm/faf716c3ad866d3d557d63bbbf1dbbea/raw/98a0f0cd700f0a4497c54cbb73488faf0c1e16af/improved_trino_aggs_decimal_v8.json)
- [BenchmarkHashAndStreamingAggregationOperators](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/faf716c3ad866d3d557d63bbbf1dbbea/raw/98a0f0cd700f0a4497c54cbb73488faf0c1e16af/baseline_trino_aggregations_v8.json,https://gist.githubusercontent.com/pettyjamesm/faf716c3ad866d3d557d63bbbf1dbbea/raw/98a0f0cd700f0a4497c54cbb73488faf0c1e16af/improved_trino_aggregations_v8.json)