### PR TITLE
Always deny authorization grants in FileBasedAccessControl

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -106,13 +106,11 @@ public class FileBasedAccessControl
         ImmutableSet.Builder<AnySchemaPermissionsRule> anySchemaPermissionsRules = ImmutableSet.builder();
         schemaRules.stream()
                 .map(SchemaAccessControlRule::toAnySchemaPermissionsRule)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(Optional::stream)
                 .forEach(anySchemaPermissionsRules::add);
         tableRules.stream()
                 .map(TableAccessControlRule::toAnySchemaPermissionsRule)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(Optional::stream)
                 .forEach(anySchemaPermissionsRules::add);
         this.anySchemaPermissionsRules = anySchemaPermissionsRules.build();
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedAccessControl.java
@@ -296,9 +296,12 @@ public class FileBasedAccessControl
     @Override
     public void checkCanSetTableAuthorization(ConnectorSecurityContext context, SchemaTableName tableName, TrinoPrincipal principal)
     {
-        if (!checkTablePermission(context, tableName, OWNERSHIP)) {
-            denySetTableAuthorization(tableName.toString(), principal);
-        }
+        /*
+         * The rule is to grant access only when the principal is a role which
+         * can create views, and we're a member of that role, but we don't
+         * support role rules, so can't do it here.
+         */
+        denySetTableAuthorization(tableName.toString(), principal);
     }
 
     @Override
@@ -364,9 +367,12 @@ public class FileBasedAccessControl
     @Override
     public void checkCanSetViewAuthorization(ConnectorSecurityContext context, SchemaTableName viewName, TrinoPrincipal principal)
     {
-        if (!checkTablePermission(context, viewName, OWNERSHIP)) {
-            denySetViewAuthorization(viewName.toString(), principal);
-        }
+        /*
+         * The rule is to grant access only when the principal is a role which
+         * can create views, and we're a member of that role, but we don't
+         * support role rules, so can't do it here.
+         */
+        denySetViewAuthorization(viewName.toString(), principal);
     }
 
     @Override


### PR DESCRIPTION
The rule for setting authorization on view and table should follow what PostgreSQL does:

> To alter the owner, you must also be a direct or indirect member of the new owning role, and that role must have CREATE privilege on the view's schema. (These restrictions enforce that altering the owner doesn't do anything you couldn't do by dropping and recreating the view. However, a superuser can alter ownership of any view anyway.)

But in `FileBasedAccessControl` we don't support rules based on roles, so it's impossible to check the second part of the above condition. So given this security model, we'll prohibit all authorization grants.