### PR TITLE
Fix planning failure of INSERT when source table has hidden columns

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -392,6 +392,14 @@ public class LogicalPlanner
 
         RelationPlan plan = createRelationPlan(analysis, query);
 
+        ImmutableList.Builder<Symbol> builder = ImmutableList.builder();
+        for (int i = 0; i < plan.getFieldMappings().size(); i++) {
+            if (!plan.getDescriptor().getFieldByIndex(i).isHidden()) {
+                builder.add(plan.getFieldMappings().get(i));
+            }
+        }
+        List<Symbol> visibleFieldMappings = builder.build();
+
         Map<String, ColumnHandle> columns = metadata.getColumnHandles(session, tableHandle);
         Assignments.Builder assignments = Assignments.builder();
         boolean supportsMissingColumnsOnInsert = metadata.supportsMissingColumnsOnInsert(session, tableHandle);
@@ -412,7 +420,7 @@ public class LogicalPlanner
                 insertedColumnsBuilder.add(column);
             }
             else {
-                Symbol input = plan.getSymbol(index);
+                Symbol input = visibleFieldMappings.get(index);
                 Type tableType = column.getType();
                 Type queryType = symbolAllocator.getTypes().get(input);
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedEngineOnlyQueries.java
@@ -277,6 +277,34 @@ public class TestDistributedEngineOnlyQueries
     }
 
     @Test
+    public void testInsertTableIntoTable()
+    {
+        // Ensure INSERT works when the source table exposes hidden fields
+        // First, verify that the table 'nation' contains the expected hidden column 'row_number'
+        assertThat(query("SELECT count(*) FROM information_schema.columns " +
+                "WHERE table_catalog = 'tpch' and table_schema = 'tiny' and table_name = 'nation' and column_name = 'row_number'"))
+                .matches("VALUES BIGINT '0'");
+        assertThat(query("SELECT min(row_number) FROM tpch.tiny.nation"))
+                .matches("VALUES BIGINT '0'");
+
+        // Create empty target table for INSERT
+        assertUpdate(getSession(), "CREATE TABLE n AS TABLE tpch.tiny.nation WITH NO DATA", 0);
+        assertThat(query("SELECT * FROM n"))
+                .matches("SELECT * FROM tpch.tiny.nation LIMIT 0");
+
+        // Verify that the hidden column is not present in the created table
+        assertThatThrownBy(() -> query("SELECT row_number FROM n"))
+                .hasMessage("line 1:8: Column 'row_number' cannot be resolved");
+
+        // Insert values from the original table into the created table
+        assertUpdate(getSession(), "INSERT INTO n TABLE tpch.tiny.nation", 25);
+        assertThat(query("SELECT * FROM n"))
+                .matches("SELECT * FROM tpch.tiny.nation");
+
+        assertUpdate(getSession(), "DROP TABLE n");
+    }
+
+    @Test
     public void testImplicitCastToRowWithFieldsRequiringDelimitation()
     {
         // source table uses char(4) as ROW fields


### PR DESCRIPTION
Before this change, a statement of the shape:
INSERT INTO target_table TABLE source_table
potentially failed if the `source_table` had hidden columns.
After this change, the hidden columns are skipped.

This change also affects planning of `REFRESH MATERIALIZED VIEW`
statements, and the benefit is the same as for `INSERT` statements.
That is, for a materialized view created by:
`CREATE MATERIALIZED VIEW name ... AS TABLE source_table`,
if the `source_table` has hidden columns, this change prevents
failure during planning.

Fixes https://github.com/trinodb/trino/issues/9150