### PR TITLE
Add ability to customize fallback case of session creation

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/NoOpSessionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/server/NoOpSessionSupplier.java
@@ -27,4 +27,10 @@ public class NoOpSessionSupplier
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public Session createFailedSession(QueryId queryId, SessionContext context)
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/server/QuerySessionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/server/QuerySessionSupplier.java
@@ -156,4 +156,14 @@ public class QuerySessionSupplier
 
         return session;
     }
+
+    @Override
+    public Session createFailedSession(QueryId queryId, SessionContext context)
+    {
+        return Session.builder(sessionPropertyManager)
+                .setQueryId(queryId)
+                .setIdentity(context.getIdentity())
+                .setSource(context.getSource().orElse(null))
+                .build();
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/server/SessionSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/server/SessionSupplier.java
@@ -19,4 +19,10 @@ import io.trino.spi.QueryId;
 public interface SessionSupplier
 {
     Session createSession(QueryId queryId, SessionContext context);
+
+    /**
+     * Rescue a session creation failure.
+     * Must create a session without any errors when this method is called.
+     */
+    Session createFailedSession(QueryId queryId, SessionContext context);
 }

--- a/core/trino-main/src/test/java/io/trino/server/TestQuerySessionSupplier.java
+++ b/core/trino-main/src/test/java/io/trino/server/TestQuerySessionSupplier.java
@@ -235,6 +235,20 @@ public class TestQuerySessionSupplier
         assertThat(session.getSchema()).isEmpty();
     }
 
+    @Test
+    public void testCreateFailedSession()
+    {
+        MultivaluedMap<String, String> headers = new GuavaMultivaluedMap<>(ImmutableListMultimap.<String, String>builder()
+                .put(TRINO_HEADERS.requestUser(), "testUser")
+                .put(TRINO_HEADERS.requestSource(), "testSource")
+                .build());
+        SessionContext context = SESSION_CONTEXT_FACTORY.createSessionContext(headers, Optional.empty(), Optional.of("remoteAddress"), Optional.empty());
+        QuerySessionSupplier sessionSupplier = createSessionSupplier(new SqlEnvironmentConfig());
+        Session session = sessionSupplier.createFailedSession(new QueryId("test_query_id"), context);
+        assertEquals(session.getIdentity().getUser(), "testUser");
+        assertEquals(session.getSource(), Optional.of("testSource"));
+    }
+
     private static Session createSession(ListMultimap<String, String> headers, SqlEnvironmentConfig config)
     {
         MultivaluedMap<String, String> headerMap = new GuavaMultivaluedMap<>(headers);


### PR DESCRIPTION
When `DispatchManager` failed to create a session, it registers the query as a failed query created here:
https://github.com/trinodb/trino/blob/ca8e71eaee50709670c6a903602c69032ed18a1b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java#L222-L230

We can customize the session creation by extending `SessionSupplier` but no way to customize this fallback case. It would be nice if `SessionSupplier` has that ability. Of course, customizing the fallback case needs to be done carefully, though.