### PR TITLE
Fix TestParquetPageSkipping when run concurrently

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
@@ -49,23 +49,23 @@ public class TestParquetPageSkipping
     {
         String createTableTemplate =
                 "CREATE TABLE %s.%s.%s (\n" +
-                "   orderkey bigint,\n" +
-                "   custkey bigint,\n" +
-                "   orderstatus varchar(1),\n" +
-                "   totalprice double,\n" +
-                "   orderdate date,\n" +
-                "   orderpriority varchar(15),\n" +
-                "   clerk varchar(15),\n" +
-                "   shippriority integer,\n" +
-                "   comment varchar(79),\n" +
-                "   rvalues double array\n" +
-                ")\n" +
-                "WITH (\n" +
-                "   format = 'PARQUET',\n" +
-                "   bucketed_by = array['orderstatus'],\n" +
-                "   bucket_count = 1,\n" +
-                "   sorted_by = array['%s']\n" +
-                ")";
+                        "   orderkey bigint,\n" +
+                        "   custkey bigint,\n" +
+                        "   orderstatus varchar(1),\n" +
+                        "   totalprice double,\n" +
+                        "   orderdate date,\n" +
+                        "   orderpriority varchar(15),\n" +
+                        "   clerk varchar(15),\n" +
+                        "   shippriority integer,\n" +
+                        "   comment varchar(79),\n" +
+                        "   rvalues double array\n" +
+                        ")\n" +
+                        "WITH (\n" +
+                        "   format = 'PARQUET',\n" +
+                        "   bucketed_by = array['orderstatus'],\n" +
+                        "   bucket_count = 1,\n" +
+                        "   sorted_by = array['%s']\n" +
+                        ")";
         createTableTemplate = createTableTemplate.replaceFirst(sortByColumnName + "[ ]+([^,]*)", sortByColumnName + " " + sortByColumnType);
         String createTableSql = format(
                 createTableTemplate,
@@ -141,24 +141,24 @@ public class TestParquetPageSkipping
     public Object[][] dataType()
     {
         return new Object[][] {
-                {"orderkey", "bigint", new Object[][]{{2, 7520, 7523, 14950}}},
-                {"totalprice", "double", new Object[][]{{974.04, 131094.34, 131279.97, 406938.36}}},
-                {"totalprice", "real", new Object[][]{{974.04, 131094.34, 131279.97, 406938.36}}},
-                {"totalprice", "decimal(12,2)", new Object[][]{
+                {"orderkey", "bigint", new Object[][] {{2, 7520, 7523, 14950}}},
+                {"totalprice", "double", new Object[][] {{974.04, 131094.34, 131279.97, 406938.36}}},
+                {"totalprice", "real", new Object[][] {{974.04, 131094.34, 131279.97, 406938.36}}},
+                {"totalprice", "decimal(12,2)", new Object[][] {
                         {974.04, 131094.34, 131279.97, 406938.36},
                         {973, 131095, 131280, 406950},
                         {974.04123, 131094.34123, 131279.97012, 406938.36555}}},
-                {"totalprice", "decimal(12,0)", new Object[][]{
+                {"totalprice", "decimal(12,0)", new Object[][] {
                         {973, 131095, 131280, 406950}}},
-                {"totalprice", "decimal(35,2)", new Object[][]{
+                {"totalprice", "decimal(35,2)", new Object[][] {
                         {974.04, 131094.34, 131279.97, 406938.36},
                         {973, 131095, 131280, 406950},
                         {974.04123, 131094.34123, 131279.97012, 406938.36555}}},
-                {"orderdate", "date", new Object[][]{{"DATE '1992-01-05'", "DATE '1995-10-13'", "DATE '1995-10-13'", "DATE '1998-07-29'"}}},
-                {"orderdate", "timestamp", new Object[][]{{"TIMESTAMP '1992-01-05'", "TIMESTAMP '1995-10-13'", "TIMESTAMP '1995-10-14'", "TIMESTAMP '1998-07-29'"}}},
-                {"clerk", "varchar(15)", new Object[][]{{"'Clerk#000000006'", "'Clerk#000000508'", "'Clerk#000000513'", "'Clerk#000000996'"}}},
-                {"custkey", "integer", new Object[][]{{4, 634, 640, 1493}}},
-                {"custkey", "smallint", new Object[][]{{4, 634, 640, 1493}}}
+                {"orderdate", "date", new Object[][] {{"DATE '1992-01-05'", "DATE '1995-10-13'", "DATE '1995-10-13'", "DATE '1998-07-29'"}}},
+                {"orderdate", "timestamp", new Object[][] {{"TIMESTAMP '1992-01-05'", "TIMESTAMP '1995-10-13'", "TIMESTAMP '1995-10-14'", "TIMESTAMP '1998-07-29'"}}},
+                {"clerk", "varchar(15)", new Object[][] {{"'Clerk#000000006'", "'Clerk#000000508'", "'Clerk#000000513'", "'Clerk#000000996'"}}},
+                {"custkey", "integer", new Object[][] {{4, 634, 640, 1493}}},
+                {"custkey", "smallint", new Object[][] {{4, 634, 640, 1493}}}
         };
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestParquetPageSkipping.java
@@ -26,7 +26,7 @@ import static io.trino.testing.assertions.Assert.assertEquals;
 import static io.trino.testing.sql.TestTable.randomTableSuffix;
 import static io.trino.tpch.TpchTable.ORDERS;
 import static java.lang.String.format;
-import static org.testng.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestParquetPageSkipping
         extends AbstractTestQueryFramework
@@ -88,7 +88,7 @@ public class TestParquetPageSkipping
         String tableName = "test_and_predicate_" + randomTableSuffix();
         buildSortedTables(tableName, "totalprice", "double");
         int rowCount = assertSameResults("SELECT * FROM " + tableName + " WHERE totalprice BETWEEN 100000 AND 131280 AND clerk = 'Clerk#000000624'");
-        assertTrue(rowCount > 0);
+        assertThat(rowCount).isGreaterThan(0);
         assertUpdate("DROP TABLE " + tableName);
     }
 
@@ -103,14 +103,14 @@ public class TestParquetPageSkipping
             Object middleHighValue = values[2];
             Object highValue = values[3];
             assertSameResults(format("SELECT %s FROM %s WHERE %s = %s", sortByColumn, tableName, sortByColumn, middleLowValue));
-            assertTrue(assertSameResults(format("SELECT %s FROM %s WHERE %s < %s ORDER BY %s", sortByColumn, tableName, sortByColumn, lowValue, sortByColumn)) > 0);
-            assertTrue(assertSameResults(format("SELECT %s FROM %s WHERE %s > %s ORDER BY %s", sortByColumn, tableName, sortByColumn, highValue, sortByColumn)) > 0);
-            assertTrue(assertSameResults(format("SELECT %s FROM %s WHERE %s BETWEEN %s AND %s ORDER BY %s", sortByColumn, tableName, sortByColumn, middleLowValue, middleHighValue, sortByColumn)) > 0);
+            assertThat(assertSameResults(format("SELECT %s FROM %s WHERE %s < %s ORDER BY %s", sortByColumn, tableName, sortByColumn, lowValue, sortByColumn))).isGreaterThan(0);
+            assertThat(assertSameResults(format("SELECT %s FROM %s WHERE %s > %s ORDER BY %s", sortByColumn, tableName, sortByColumn, highValue, sortByColumn))).isGreaterThan(0);
+            assertThat(assertSameResults(format("SELECT %s FROM %s WHERE %s BETWEEN %s AND %s ORDER BY %s", sortByColumn, tableName, sortByColumn, middleLowValue, middleHighValue, sortByColumn))).isGreaterThan(0);
             // Tests synchronization of reading values across columns
             assertSameResults(format("SELECT * FROM %s WHERE %s = %s ORDER BY orderkey", tableName, sortByColumn, middleLowValue));
-            assertTrue(assertSameResults(format("SELECT * FROM %s WHERE %s < %s ORDER BY orderkey", tableName, sortByColumn, lowValue)) > 0);
-            assertTrue(assertSameResults(format("SELECT * FROM %s WHERE %s > %s ORDER BY orderkey", tableName, sortByColumn, highValue)) > 0);
-            assertTrue(assertSameResults(format("SELECT * FROM %s WHERE %s BETWEEN %s AND %s ORDER BY orderkey", tableName, sortByColumn, middleLowValue, middleHighValue)) > 0);
+            assertThat(assertSameResults(format("SELECT * FROM %s WHERE %s < %s ORDER BY orderkey", tableName, sortByColumn, lowValue))).isGreaterThan(0);
+            assertThat(assertSameResults(format("SELECT * FROM %s WHERE %s > %s ORDER BY orderkey", tableName, sortByColumn, highValue))).isGreaterThan(0);
+            assertThat(assertSameResults(format("SELECT * FROM %s WHERE %s BETWEEN %s AND %s ORDER BY orderkey", tableName, sortByColumn, middleLowValue, middleHighValue))).isGreaterThan(0);
         }
         assertUpdate("DROP TABLE " + tableName);
     }


### PR DESCRIPTION
The test class reused table name between methods, so could be failing
when run in parallel (e.g. on CI).