### PR TITLE
Fix TestSpatialPartitioningInternalAggregation

### DIFF
--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
@@ -78,7 +78,7 @@ public class TestSpatialPartitioningInternalAggregation
         Rectangle expectedExtent = new Rectangle(-10, -10, Math.nextUp(10.0), Math.nextUp(10.0));
         String expectedValue = getSpatialPartitioning(expectedExtent, geometries, partitionCount);
 
-        AccumulatorFactory accumulatorFactory = function.bind(Ints.asList(0, 1, 2), Optional.empty());
+        AccumulatorFactory accumulatorFactory = function.bind(Ints.asList(0, 1), Optional.empty());
         Page page = new Page(geometryBlock, partitionCountBlock);
 
         Accumulator accumulator = accumulatorFactory.createAccumulator();


### PR DESCRIPTION
Extracted from https://github.com/prestodb/presto/pull/16726

The test accidentally passed an additional unused input channel element to aggregation function. Currently `AccumulatorCompiler` generated classes accept inputChannels lists that are longer than the number of input paramters, so the test worked anyway- but changes in https://github.com/trinodb/trino/pull/9194 that validate the list length caused this test to start failing.