### PR TITLE
Prevent aggregation pushdown for textual types for MemSQL

### DIFF
--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
@@ -27,6 +27,8 @@ import io.trino.plugin.jdbc.PreparedQuery;
 import io.trino.plugin.jdbc.WriteMapping;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.AggregateFunction;
+import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -100,6 +102,13 @@ public class MemSqlClient
         super(config, "`", connectionFactory, identifierMapping);
         requireNonNull(typeManager, "typeManager is null");
         this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
+    }
+
+    @Override
+    public boolean supportsAggregationPushdown(ConnectorSession session, JdbcTableHandle table, List<AggregateFunction> aggregates, Map<String, ColumnHandle> assignments, List<List<ColumnHandle>> groupingSets)
+    {
+        // Remote database can be case insensitive.
+        return preventTextualTypeAggregationPushdown(groupingSets);
     }
 
     @Override


### PR DESCRIPTION
After d55bb1c5a8ef2850816498e93efb4ae562081b45 the DISTINCT part of
count(DISTINCT) is pushed down to connectors as GROUP BY even if the
connector itself doesn't implement aggregation pushdown.

MemSQL is case-insensitive by default. For such databases pushdown of
aggregation functions when the grouping set includes a textual type can
lead to incorrect results. So we prevent aggregation pushdown for such
cases.

Fixes https://github.com/trinodb/trino/issues/9166