### PR TITLE
Fix partial projection with duplicate expression instances

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -46,7 +46,6 @@ import io.trino.spi.type.RowType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeOperators;
 import io.trino.sql.planner.Symbol;
-import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.iterative.rule.PruneTableScanColumns;
 import io.trino.sql.planner.iterative.rule.PushPredicateIntoTableScan;
 import io.trino.sql.planner.iterative.rule.PushProjectionIntoTableScan;
@@ -280,7 +279,7 @@ public class TestConnectorPushdownRulesWithHive
                 })
                 .matches(
                         strictProject(
-                                ImmutableMap.of("expr", PlanMatchPattern.expression("COLA")),
+                                ImmutableMap.of("expr", expression("COLA")),
                                 tableScan(
                                         hiveTable.withProjectedColumns(ImmutableSet.of(columnA))::equals,
                                         TupleDomain.all(),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -53,6 +53,9 @@ import io.trino.sql.planner.iterative.rule.PushProjectionIntoTableScan;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
 import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.tree.ArithmeticBinaryExpression;
+import io.trino.sql.tree.ArithmeticUnaryExpression;
+import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.LongLiteral;
 import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.SymbolReference;
@@ -78,6 +81,8 @@ import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.strictProject;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.sql.tree.ArithmeticBinaryExpression.Operator.ADD;
+import static io.trino.sql.tree.ArithmeticUnaryExpression.Sign.MINUS;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
@@ -280,6 +285,87 @@ public class TestConnectorPushdownRulesWithHive
                                         hiveTable.withProjectedColumns(ImmutableSet.of(columnA))::equals,
                                         TupleDomain.all(),
                                         ImmutableMap.of("COLA", columnA::equals))));
+
+        metastore.dropTable(new HiveIdentity(SESSION), SCHEMA_NAME, tableName, true);
+    }
+
+    @Test
+    public void testPushdownWithDuplicateExpressions()
+    {
+        String tableName = "duplicate_expressions";
+        tester().getQueryRunner().execute(format(
+                "CREATE TABLE  %s (struct_of_bigint, just_bigint) AS SELECT cast(row(5, 6) AS row(a bigint, b bigint)) AS struct_of_int, 5 AS just_bigint WHERE false",
+                tableName));
+
+        PushProjectionIntoTableScan pushProjectionIntoTableScan = new PushProjectionIntoTableScan(
+                tester().getMetadata(),
+                tester().getTypeAnalyzer(),
+                new ScalarStatsCalculator(tester().getMetadata(), tester().getTypeAnalyzer()));
+
+        HiveTableHandle hiveTable = new HiveTableHandle(SCHEMA_NAME, tableName, ImmutableMap.of(), ImmutableList.of(), ImmutableList.of(), Optional.empty());
+        TableHandle table = new TableHandle(new CatalogName(HIVE_CATALOG_NAME), hiveTable, new HiveTransactionHandle(), Optional.empty());
+
+        HiveColumnHandle bigintColumn = createBaseColumn("just_bigint", 1, toHiveType(BIGINT), BIGINT, REGULAR, Optional.empty());
+        HiveColumnHandle partialColumn = new HiveColumnHandle(
+                "struct_of_bigint",
+                0,
+                toHiveType(ROW_TYPE),
+                ROW_TYPE,
+                Optional.of(new HiveColumnProjectionInfo(
+                        ImmutableList.of(0),
+                        ImmutableList.of("a"),
+                        toHiveType(BIGINT),
+                        BIGINT)),
+                REGULAR,
+                Optional.empty());
+
+        // Test projection pushdown with duplicate column references
+        tester().assertThat(pushProjectionIntoTableScan)
+                .on(p -> {
+                    SymbolReference column = p.symbol("just_bigint", BIGINT).toSymbolReference();
+                    Expression negation = new ArithmeticUnaryExpression(MINUS, column);
+                    return p.project(
+                            Assignments.of(
+                                    // The column reference is part of both the assignments
+                                    p.symbol("column_ref", BIGINT), column,
+                                    p.symbol("negated_column_ref", BIGINT), negation),
+                            p.tableScan(
+                                    table,
+                                    ImmutableList.of(p.symbol("just_bigint", BIGINT)),
+                                    ImmutableMap.of(p.symbol("just_bigint", BIGINT), bigintColumn)));
+                })
+                .matches(project(
+                        ImmutableMap.of(
+                                "column_ref", expression("just_bigint_0"),
+                                "negated_column_ref", expression("- just_bigint_0")),
+                        tableScan(
+                                hiveTable.withProjectedColumns(ImmutableSet.of(bigintColumn))::equals,
+                                TupleDomain.all(),
+                                ImmutableMap.of("just_bigint_0", bigintColumn::equals))));
+
+        // Test Dereference pushdown
+        tester().assertThat(pushProjectionIntoTableScan)
+                .on(p -> {
+                    SubscriptExpression subscript = new SubscriptExpression(p.symbol("struct_of_bigint", ROW_TYPE).toSymbolReference(), new LongLiteral("1"));
+                    Expression sum = new ArithmeticBinaryExpression(ADD, subscript, new LongLiteral("2"));
+                    return p.project(
+                            Assignments.of(
+                                    // The subscript expression instance is part of both the assignments
+                                    p.symbol("expr_deref", BIGINT), subscript,
+                                    p.symbol("expr_deref_2", BIGINT), sum),
+                            p.tableScan(
+                                    table,
+                                    ImmutableList.of(p.symbol("struct_of_bigint", ROW_TYPE)),
+                                    ImmutableMap.of(p.symbol("struct_of_bigint", ROW_TYPE), partialColumn.getBaseColumn())));
+                })
+                .matches(project(
+                        ImmutableMap.of(
+                                "expr_deref", expression(new SymbolReference("struct_of_bigint#a")),
+                                "expr_deref_2", expression(new ArithmeticBinaryExpression(ADD, new SymbolReference("struct_of_bigint#a"), new LongLiteral("2")))),
+                        tableScan(
+                                hiveTable.withProjectedColumns(ImmutableSet.of(partialColumn))::equals,
+                                TupleDomain.all(),
+                                ImmutableMap.of("struct_of_bigint#a", partialColumn::equals))));
 
         metastore.dropTable(new HiveIdentity(SESSION), SCHEMA_NAME, tableName, true);
     }


### PR DESCRIPTION
#9185 

The map `nodesToNewPartialProjections` is keyed on `NodeRef<Expression>`. Duplicate keys are encountered if there're duplicate expression instances within different assignments of the projectnode. This PR avoids sending such duplicates to the connector in the first place. 

Fixes #6200.