### PR TITLE
Fix file path generation in configureTempto() method

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentContainers.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/EnvironmentContainers.java
@@ -15,10 +15,20 @@ package io.trino.tests.product.launcher.env;
 
 import io.trino.tests.product.launcher.docker.DockerFiles.ResourceProvider;
 
+import java.nio.file.Path;
+import java.security.SecureRandom;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Character.MAX_RADIX;
+import static java.lang.Math.abs;
+import static java.lang.Math.min;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
 public final class EnvironmentContainers
 {
+    private static final SecureRandom random = new SecureRandom();
+    private static final int RANDOM_SUFFIX_LENGTH = 5;
+
     public static final String PRESTO = "presto";
     public static final String COORDINATOR = PRESTO + "-master";
     public static final String WORKER = PRESTO + "-worker";
@@ -45,16 +55,27 @@ public final class EnvironmentContainers
     public static void configureTempto(Environment.Builder builder, ResourceProvider configDir)
     {
         builder.configureContainer(TESTS, dockerContainer -> {
-            String environmentName = configDir.getPath("..").toFile().getName();
-            String temptoConfig = "/docker/presto-product-tests/conf/tempto/tempto-configuration-for-" + environmentName + ".yaml";
+            Path path = configDir.getPath("tempto-configuration.yaml");
+            String suffix = getParentDirectoryName(path) + "-" + randomSuffix();
+            String temptoConfig = "/docker/presto-product-tests/conf/tempto/tempto-configuration-for-" + suffix + ".yaml";
             dockerContainer
-                    .withCopyFileToContainer(
-                            forHostPath(configDir.getPath("tempto-configuration.yaml")),
-                            temptoConfig)
+                    .withCopyFileToContainer(forHostPath(path), temptoConfig)
                     .withEnv("TEMPTO_CONFIG_FILES", temptoConfigFiles ->
                             temptoConfigFiles
                                     .map(files -> files + "," + temptoConfig)
                                     .orElse(temptoConfig));
         });
+    }
+
+    private static String getParentDirectoryName(Path path)
+    {
+        checkArgument(path.getNameCount() >= 2, "Cannot determine parent directory of: %s", path);
+        return path.getName(path.getNameCount() - 2).toString();
+    }
+
+    private static String randomSuffix()
+    {
+        String randomSuffix = Long.toString(abs(random.nextLong()), MAX_RADIX);
+        return randomSuffix.substring(0, min(RANDOM_SUFFIX_LENGTH, randomSuffix.length()));
     }
 }


### PR DESCRIPTION
Fix file path generation in configureTempto() method

Previously it was generating always constant name:
tempto-configuration-for-...yaml

Now it should generate something like:
tempto-configuration-for-kafka-abs34.yaml
