### PR TITLE
Update benchto-driver dependency version to 0.15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
             <dependency>
                 <groupId>io.trino.benchto</groupId>
                 <artifactId>benchto-driver</artifactId>
-                <version>0.14</version>
+                <version>0.15</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -533,6 +533,12 @@
 
             <!-- Trino external -->
             <dependency>
+                <groupId>io.trino.benchto</groupId>
+                <artifactId>benchto-driver</artifactId>
+                <version>0.14</version>
+            </dependency>
+
+            <dependency>
                 <groupId>io.trino.cassandra</groupId>
                 <artifactId>cassandra-driver</artifactId>
                 <version>3.1.4-3</version>

--- a/testing/trino-benchto-benchmarks/pom.xml
+++ b/testing/trino-benchto-benchmarks/pom.xml
@@ -21,7 +21,6 @@
         <dependency>
             <groupId>io.trino.benchto</groupId>
             <artifactId>benchto-driver</artifactId>
-            <version>0.14</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Updated benchto-driver version brings round-robin throughput test mode.