### PR TITLE
Batch process join positions in JoinProbe

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -143,6 +143,7 @@ public final class SystemSessionProperties
     public static final String MERGE_PROJECT_WITH_VALUES = "merge_project_with_values";
     public static final String TIME_ZONE_ID = "time_zone_id";
     public static final String LEGACY_CATALOG_ROLES = "legacy_catalog_roles";
+    public static final String VECTORIZED_JOIN_PROBE_ENABLED = "vectorized_join_probe_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -660,7 +661,11 @@ public final class SystemSessionProperties
                         LEGACY_CATALOG_ROLES,
                         "Enable legacy role management syntax that assumed all roles are catalog scoped",
                         featuresConfig.isLegacyCatalogRoles(),
-                        true));
+                        true),
+                booleanProperty(VECTORIZED_JOIN_PROBE_ENABLED,
+                        "Enable vectorized join probe processing",
+                        true,
+                        false));
     }
 
     @Override
@@ -1172,5 +1177,10 @@ public final class SystemSessionProperties
     public static boolean isLegacyCatalogRoles(Session session)
     {
         return session.getSystemProperty(LEGACY_CATALOG_ROLES, Boolean.class);
+    }
+
+    public static boolean isVectorizedJoinProbeEnabled(Session session)
+    {
+        return session.getSystemProperty(VECTORIZED_JOIN_PROBE_ENABLED, Boolean.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorFactories.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorFactories.java
@@ -14,6 +14,7 @@
 package io.trino.operator;
 
 import io.airlift.units.DataSize;
+import io.trino.Session;
 import io.trino.execution.buffer.OutputBuffer;
 import io.trino.operator.join.JoinBridgeManager;
 import io.trino.operator.join.LookupSourceFactory;
@@ -30,6 +31,7 @@ import java.util.OptionalInt;
 public interface OperatorFactories
 {
     OperatorFactory innerJoin(
+            Session session,
             int operatorId,
             PlanNodeId planNodeId,
             JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
@@ -45,6 +47,7 @@ public interface OperatorFactories
             BlockTypeOperators blockTypeOperators);
 
     OperatorFactory probeOuterJoin(
+            Session session,
             int operatorId,
             PlanNodeId planNodeId,
             JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
@@ -59,6 +62,7 @@ public interface OperatorFactories
             BlockTypeOperators blockTypeOperators);
 
     OperatorFactory lookupOuterJoin(
+            Session session,
             int operatorId,
             PlanNodeId planNodeId,
             JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
@@ -73,6 +77,7 @@ public interface OperatorFactories
             BlockTypeOperators blockTypeOperators);
 
     OperatorFactory fullOuterJoin(
+            Session session,
             int operatorId,
             PlanNodeId planNodeId,
             JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,

--- a/core/trino-main/src/main/java/io/trino/operator/TrinoOperatorFactories.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TrinoOperatorFactories.java
@@ -14,6 +14,7 @@
 package io.trino.operator;
 
 import io.airlift.units.DataSize;
+import io.trino.Session;
 import io.trino.execution.buffer.OutputBuffer;
 import io.trino.operator.join.JoinBridgeManager;
 import io.trino.operator.join.JoinProbe.JoinProbeFactory;
@@ -32,6 +33,7 @@ import java.util.OptionalInt;
 import java.util.stream.IntStream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.SystemSessionProperties.isVectorizedJoinProbeEnabled;
 import static io.trino.operator.join.LookupJoinOperatorFactory.JoinType.FULL_OUTER;
 import static io.trino.operator.join.LookupJoinOperatorFactory.JoinType.INNER;
 import static io.trino.operator.join.LookupJoinOperatorFactory.JoinType.LOOKUP_OUTER;
@@ -43,6 +45,7 @@ public class TrinoOperatorFactories
 {
     @Override
     public OperatorFactory innerJoin(
+            Session session,
             int operatorId,
             PlanNodeId planNodeId,
             JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
@@ -58,6 +61,7 @@ public class TrinoOperatorFactories
             BlockTypeOperators blockTypeOperators)
     {
         return createJoinOperatorFactory(
+                session,
                 operatorId,
                 planNodeId,
                 lookupSourceFactory,
@@ -75,6 +79,7 @@ public class TrinoOperatorFactories
 
     @Override
     public OperatorFactory probeOuterJoin(
+            Session session,
             int operatorId,
             PlanNodeId planNodeId,
             JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
@@ -89,6 +94,7 @@ public class TrinoOperatorFactories
             BlockTypeOperators blockTypeOperators)
     {
         return createJoinOperatorFactory(
+                session,
                 operatorId,
                 planNodeId,
                 lookupSourceFactory,
@@ -106,6 +112,7 @@ public class TrinoOperatorFactories
 
     @Override
     public OperatorFactory lookupOuterJoin(
+            Session session,
             int operatorId,
             PlanNodeId planNodeId,
             JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
@@ -120,6 +127,7 @@ public class TrinoOperatorFactories
             BlockTypeOperators blockTypeOperators)
     {
         return createJoinOperatorFactory(
+                session,
                 operatorId,
                 planNodeId,
                 lookupSourceFactory,
@@ -137,6 +145,7 @@ public class TrinoOperatorFactories
 
     @Override
     public OperatorFactory fullOuterJoin(
+            Session session,
             int operatorId,
             PlanNodeId planNodeId,
             JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactory,
@@ -150,6 +159,7 @@ public class TrinoOperatorFactories
             BlockTypeOperators blockTypeOperators)
     {
         return createJoinOperatorFactory(
+                session,
                 operatorId,
                 planNodeId,
                 lookupSourceFactory,
@@ -194,6 +204,7 @@ public class TrinoOperatorFactories
     }
 
     private OperatorFactory createJoinOperatorFactory(
+            Session session,
             int operatorId,
             PlanNodeId planNodeId,
             JoinBridgeManager<? extends LookupSourceFactory> lookupSourceFactoryManager,
@@ -222,7 +233,7 @@ public class TrinoOperatorFactories
                 joinType,
                 outputSingleMatch,
                 waitForBuild,
-                new JoinProbeFactory(probeOutputChannels.stream().mapToInt(i -> i).toArray(), probeJoinChannel, probeHashChannel),
+                new JoinProbeFactory(probeOutputChannels.stream().mapToInt(i -> i).toArray(), probeJoinChannel, probeHashChannel, isVectorizedJoinProbeEnabled(session)),
                 blockTypeOperators,
                 totalOperatorsCount,
                 probeJoinChannel,

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinHash.java
@@ -156,7 +156,7 @@ public final class JoinHash
     @Override
     public boolean supportsCaching()
     {
-        return true;
+        return pagesHash.getPositionCount() > 1000;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/join/JoinHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/JoinHash.java
@@ -88,55 +88,35 @@ public final class JoinHash
     }
 
     @Override
-    public long[] getJoinPositions(int[] positions, Page hashChannelsPage, Page allChannelsPage, long[] rawHashes)
+    public void getJoinPositions(SelectedPositions positions, Page hashChannelsPage, Page allChannelsPage, long[] rawHashes, long[] result)
     {
-        long[] result = pagesHash.getAddressIndex(positions, hashChannelsPage, rawHashes);
+        pagesHash.getAddressIndex(positions, hashChannelsPage, rawHashes, result);
         startJoinPositions(positions, allChannelsPage, result);
-
-        return result;
-    }
-
-    @Override
-    public long[] getJoinPositions(SelectedPositions positions, Page hashChannelsPage, Page allChannelsPage, long[] rawHashes)
-    {
-        long[] result = pagesHash.getAddressIndex(positions, hashChannelsPage, rawHashes);
-        startJoinPositions(positions, allChannelsPage, result);
-
-        return result;
-    }
-
-    @Override
-    public long[] getJoinPositions(int[] positions, Page hashChannelsPage, Page allChannelsPage)
-    {
-        long[] result = pagesHash.getAddressIndex(positions, hashChannelsPage);
-        startJoinPositions(positions, allChannelsPage, result);
-
-        return result;
     }
 
     /**
      * modify join positions array in-place for performance reasons
      */
-    private void startJoinPositions(int[] probePositions, Page hashChannelsPage, long[] joinPositions)
+    private void startJoinPositions(SelectedPositions positions, Page hashChannelsPage, long[] joinPositions)
     {
         if (positionLinks == null) {
             return;
         }
-        for (int i = 0; i < probePositions.length; i++) {
-            if (joinPositions[i] != -1) {
-                joinPositions[i] = positionLinks.start((int) joinPositions[i], probePositions[i], hashChannelsPage);
+
+        if (positions.isList()) {
+            int[] positionList = positions.getPositions();
+            for (int i = 0; i < positions.size(); ++i) {
+                int position = positionList[i];
+                if (joinPositions[position] != -1) {
+                    joinPositions[position] = positionLinks.start((int) joinPositions[position], positions.getOffset() + position, hashChannelsPage);
+                }
             }
         }
-    }
-
-    private void startJoinPositions(SelectedPositions probePositions, Page hashChannelsPage, long[] joinPositions)
-    {
-        if (positionLinks == null) {
-            return;
-        }
-        for (int i = 0; i < probePositions.size(); i++) {
-            if (joinPositions[i] != -1) {
-                joinPositions[i] = positionLinks.start((int) joinPositions[i], probePositions.getOffset() + i, hashChannelsPage);
+        else {
+            for (int position = 0; position < positions.size(); position++) {
+                if (joinPositions[position] != -1) {
+                    joinPositions[position] = positionLinks.start((int) joinPositions[position], positions.getOffset() + position, hashChannelsPage);
+                }
             }
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/join/LookupSource.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/LookupSource.java
@@ -21,8 +21,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.io.Closeable;
 
-import static com.google.common.base.Verify.verify;
-
 @NotThreadSafe
 public interface LookupSource
         extends Closeable
@@ -37,32 +35,9 @@ public interface LookupSource
 
     long getJoinPosition(int position, Page hashChannelsPage, Page allChannelsPage);
 
-    default long[] getJoinPositions(int[] positions, Page hashChannelsPage, Page allChannelsPage, long[] rawHashes)
-    {
-        verify(positions.length == rawHashes.length, "Number of positions must match number of hashes");
-        long[] result = new long[positions.length];
-
-        for (int i = 0; i < positions.length; i++) {
-            result[i] = getJoinPosition(positions[i], hashChannelsPage, allChannelsPage, rawHashes[i]);
-        }
-
-        return result;
-    }
-
-    default long[] getJoinPositions(SelectedPositions positions, Page hashChannelsPage, Page allChannelsPage, long[] rawHashes)
+    default void getJoinPositions(SelectedPositions positions, Page hashChannelsPage, Page allChannelsPage, long[] rawHashes, long[] result)
     {
         throw new UnsupportedOperationException();
-    }
-
-    default long[] getJoinPositions(int[] positions, Page hashChannelsPage, Page allChannelsPage)
-    {
-        long[] result = new long[positions.length];
-
-        for (int i = 0; i < positions.length; i++) {
-            result[i] = getJoinPosition(positions[i], hashChannelsPage, allChannelsPage);
-        }
-
-        return result;
     }
 
     long getNextJoinPosition(long currentJoinPosition, int probePosition, Page allProbeChannelsPage);

--- a/core/trino-main/src/main/java/io/trino/operator/join/PagesHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/PagesHash.java
@@ -28,6 +28,7 @@ import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.trino.operator.SyntheticAddress.decodePosition;
 import static io.trino.operator.SyntheticAddress.decodeSliceIndex;
+import static io.trino.operator.project.SelectedPositions.positionsList;
 import static io.trino.util.HashCollisionsEstimator.estimateNumberOfHashCollisions;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -149,18 +150,6 @@ public final class PagesHash
         return getAddressIndex(position, hashChannelsPage, pagesHashStrategy.hashRow(position, hashChannelsPage));
     }
 
-    /**
-     * return array passed as an argument for performance reasons
-     */
-    public long[] getAddressIndex(int[] positions, Page hashChannelsPage)
-    {
-        long[] hashes = new long[positions.length];
-        for (int i = 0; i < positions.length; i++) {
-            hashes[i] = pagesHashStrategy.hashRow(positions[i], hashChannelsPage);
-        }
-        return getAddressIndex(positions, hashChannelsPage, hashes);
-    }
-
     public int getAddressIndex(int rightPosition, Page hashChannelsPage, long rawHash)
     {
         int pos = getHashPosition(rawHash, mask);
@@ -168,118 +157,240 @@ public final class PagesHash
         return getAddressIndex(rightPosition, hashChannelsPage, (byte) rawHash, pos);
     }
 
-    public long[] getAddressIndex(int[] rightPositions, Page hashChannelsPage, long[] rawHashes)
+    public void getAddressIndex(SelectedPositions rightPositions, Page hashChannelsPage, long[] rawHashes, long[] result)
     {
-        //verify(rightPositions.length == rawHashes.length, "Number of positions must match number of hashes");
-        long[] result = new long[rightPositions.length];
-
-        /*
-         * Instead of looking for a match on a per-position basis, we execute every step in a "vectorized" way,
-         * so that all cpu mechanisms (caching, out-of-order execution, etc.) are fully utilized.
-         */
-        int[] pos = new int[rightPositions.length];
-        /*
-         * First loop preforms a simple hashing of existing hashed values to determine
-         * the hash bucket that the value belongs to.
-         */
-        for (int i = 0; i < rightPositions.length; i++) {
-            pos[i] = getHashPosition(rawHashes[i], mask);
-        }
-
-        /*
-         * This is the easiest, yet most expensive step, as it will trigger a lot of cache misses.
-         * By doing this in a single loop the latencies of cpu memory prefetch for consecutive entries
-         * will overlap with each other.
-         */
-        for (int i = 0; i < rightPositions.length; i++) {
-            result[i] = key[pos[i]];
-        }
-
-        /*
-         * Here the actual logic happens. If the bucket is empty or filled with the proper value
-         * then the value in result array is valid and pos[i] is set to -1 to indicate that this
-         * position has been taken care of. Otherwise we continue with the standard open-addressing
-         * logic incrementing the position.
-         */
-        for (int i = 0; i < rightPositions.length; i++) {
-            if (result[i] == -1) {
-                pos[i] = -1;
-            }
-            else if (positionEqualsCurrentRowIgnoreNulls((int) result[i], (byte) rawHashes[i], rightPositions[i], hashChannelsPage)) {
-                pos[i] = -1;
-            }
-            else {
-                pos[i] = (pos[i] + 1) & mask;
-            }
-        }
-
-        /*
-         * Finally we look for remaining matches in a traditional way.
-         */
-        for (int i = 0; i < rightPositions.length; i++) {
-            if (pos[i] != -1) {
-                result[i] = getAddressIndex(rightPositions[i], hashChannelsPage, (byte) rawHashes[i], pos[i]);
-            }
-        }
-
-        return result;
+        getAddressIndex2(rightPositions, hashChannelsPage, rawHashes, result);
     }
 
-    public long[] getAddressIndex(SelectedPositions rightPositions, Page hashChannelsPage, long[] rawHashes)
+    public void getAddressIndex3(SelectedPositions rightPositions, Page hashChannelsPage, long[] rawHashes, long[] addressIndexes)
     {
-        //verify(rightPositions.length == rawHashes.length, "Number of positions must match number of hashes");
-        long[] result = new long[rightPositions.size()];
-
-        /*
-         * Instead of looking for a match on a per-position basis, we execute every step in a "vectorized" way,
-         * so that all cpu mechanisms (caching, out-of-order execution, etc.) are fully utilized.
-         */
-        int[] pos = new int[rightPositions.size()];
-        /*
-         * First loop preforms a simple hashing of existing hashed values to determine
-         * the hash bucket that the value belongs to.
-         */
-        for (int i = 0; i < rightPositions.size(); i++) {
-            pos[i] = getHashPosition(rawHashes[i], mask);
+        int[] hashPositions = new int[rightPositions.size()];
+        getHashPositions(rightPositions, rawHashes, hashPositions);
+        getAddressIndexes(rightPositions, hashPositions, addressIndexes);
+        int[] remainingRightPositionList = new int[rightPositions.size()];
+        SelectedPositions remainingRightPositions = getNonEmptyPositions(rightPositions, hashPositions, addressIndexes, remainingRightPositionList);
+        int hashMismatchedPosCount = splitHashMismatchedPositions(remainingRightPositions, hashPositions, rawHashes, addressIndexes, remainingRightPositionList);
+        remainingRightPositions = getMismatchedPositions(hashMismatchedPosCount, remainingRightPositions, hashChannelsPage, hashPositions, addressIndexes, remainingRightPositionList);
+        while (remainingRightPositions.size() > 0) {
+            incrementHashPositions(remainingRightPositions, hashPositions);
+            getAddressIndexes(remainingRightPositions, hashPositions, addressIndexes);
+            remainingRightPositions = getNonEmptyPositions(remainingRightPositions, hashPositions, addressIndexes, remainingRightPositionList);
+            hashMismatchedPosCount = splitHashMismatchedPositions(remainingRightPositions, hashPositions, rawHashes, addressIndexes, remainingRightPositionList);
+            remainingRightPositions = getMismatchedPositions(hashMismatchedPosCount, remainingRightPositions, hashChannelsPage, hashPositions, addressIndexes, remainingRightPositionList);
         }
+    }
 
-        /*
-         * This is the easiest, yet most expensive step, as it will trigger a lot of cache misses.
-         * By doing this in a single loop the latencies of cpu memory prefetch for consecutive entries
-         * will overlap with each other.
-         */
-        for (int i = 0; i < rightPositions.size(); i++) {
-            result[i] = key[pos[i]];
-        }
-
-        /*
-         * Here the actual logic happens. If the bucket is empty or filled with the proper value
-         * then the value in result array is valid and pos[i] is set to -1 to indicate that this
-         * position has been taken care of. Otherwise we continue with the standard open-addressing
-         * logic incrementing the position.
-         */
-        for (int i = 0; i < rightPositions.size(); i++) {
-            if (result[i] == -1) {
-                pos[i] = -1;
-            }
-            else if (positionEqualsCurrentRowIgnoreNulls((int) result[i], (byte) rawHashes[i], rightPositions.getOffset() + i, hashChannelsPage)) {
-                pos[i] = -1;
-            }
-            else {
-                pos[i] = (pos[i] + 1) & mask;
+    private SelectedPositions getNonEmptyPositions(SelectedPositions rightPositions, int[] hashPositions, long[] addressIndexes, int[] remainingRightPositions)
+    {
+        int remainingPositionCount = 0;
+        if (rightPositions.isList()) {
+            int[] positionList = rightPositions.getPositions();
+            for (int i = 0; i < rightPositions.size(); i++) {
+                int position = positionList[i];
+                boolean nonEmpty = addressIndexes[position] != -1;
+                remainingRightPositions[remainingPositionCount] = position;
+                hashPositions[remainingPositionCount] = hashPositions[i];
+                remainingPositionCount += nonEmpty ? 1 : 0;
             }
         }
-
-        /*
-         * Finally we look for remaining matches in a traditional way.
-         */
-        for (int i = 0; i < rightPositions.size(); i++) {
-            if (pos[i] != -1) {
-                result[i] = getAddressIndex(rightPositions.getOffset() + i, hashChannelsPage, (byte) rawHashes[i], pos[i]);
+        else {
+            for (int position = 0; position < rightPositions.size(); position++) {
+                boolean nonEmpty = addressIndexes[position] != -1;
+                remainingRightPositions[remainingPositionCount] = position;
+                hashPositions[remainingPositionCount] = hashPositions[position];
+                remainingPositionCount += nonEmpty ? 1 : 0;
             }
         }
+        return getSelectedPositions(rightPositions, remainingRightPositions, remainingPositionCount);
+    }
 
-        return result;
+    private int splitHashMismatchedPositions(SelectedPositions rightPositions, int[] hashPositions, long[] rawHashes, long[] addressIndexes, int[] remainingRightPositions)
+    {
+        // remainingRightPositions array has corresponding right positions
+        int hashMismatchedPosCount = 0;
+        if (rightPositions.isList()) {
+            int[] positionList = rightPositions.getPositions();
+            for (int i = 0; i < rightPositions.size(); i++) {
+                int rightPosition = positionList[i];
+                boolean noMatch = positionToHashes[(int) addressIndexes[rightPosition]] != (byte) rawHashes[rightPosition];
+                // swap
+                int oldPosition = remainingRightPositions[hashMismatchedPosCount];
+                int oldHashPosition = hashPositions[hashMismatchedPosCount];
+                remainingRightPositions[hashMismatchedPosCount] = rightPosition;
+                hashPositions[hashMismatchedPosCount] = hashPositions[i];
+                remainingRightPositions[i] = oldPosition;
+                hashPositions[i] = oldHashPosition;
+                hashMismatchedPosCount += noMatch ? 1 : 0;
+            }
+        }
+        else {
+            for (int rightPosition = 0; rightPosition < rightPositions.size(); rightPosition++) {
+                boolean noMatch = positionToHashes[(int) addressIndexes[rightPosition]] != (byte) rawHashes[rightPosition];
+                // swap
+                int oldPosition = remainingRightPositions[hashMismatchedPosCount];
+                int oldHashPosition = hashPositions[hashMismatchedPosCount];
+                remainingRightPositions[hashMismatchedPosCount] = rightPosition;
+                hashPositions[hashMismatchedPosCount] = hashPositions[rightPosition];
+                remainingRightPositions[rightPosition] = oldPosition;
+                hashPositions[rightPosition] = oldHashPosition;
+                hashMismatchedPosCount += noMatch ? 1 : 0;
+            }
+        }
+        return hashMismatchedPosCount;
+    }
+
+    private SelectedPositions getMismatchedPositions(int hashMismatchedPositions, SelectedPositions rightPositions, Page hashChannelsPage, int[] hashPositions, long[] addressIndexes, int[] remainingRightPositions)
+    {
+        int remainingPositionCount = 0;
+        // remainingRightPositions array has corresponding right positions
+        if (hashMismatchedPositions != 0 || rightPositions.isList()) {
+            for (int i = hashMismatchedPositions; i < rightPositions.size(); i++) {
+                int rightPosition = remainingRightPositions[i];
+                boolean noMatch = !positionEqualsCurrentRowIgnoreNulls((int) addressIndexes[rightPosition], rightPositions.getOffset() + rightPosition, hashChannelsPage);
+                remainingRightPositions[remainingPositionCount + hashMismatchedPositions] = rightPosition;
+                hashPositions[remainingPositionCount + hashMismatchedPositions] = hashPositions[i];
+                remainingPositionCount += noMatch ? 1 : 0;
+            }
+        }
+        else {
+            for (int rightPosition = 0; rightPosition < rightPositions.size(); rightPosition++) {
+                boolean noMatch = !positionEqualsCurrentRowIgnoreNulls((int) addressIndexes[rightPosition], rightPositions.getOffset() + rightPosition, hashChannelsPage);
+                remainingRightPositions[remainingPositionCount + hashMismatchedPositions] = rightPosition;
+                hashPositions[remainingPositionCount + hashMismatchedPositions] = hashPositions[rightPosition];
+                remainingPositionCount += noMatch ? 1 : 0;
+            }
+        }
+        return getSelectedPositions(rightPositions, remainingRightPositions, remainingPositionCount + hashMismatchedPositions);
+    }
+
+    private void incrementHashPositions(SelectedPositions positions, int[] hashPositions)
+    {
+        for (int i = 0; i < positions.size(); i++) {
+            hashPositions[i] = (hashPositions[i] + 1) & mask;
+        }
+    }
+
+    private void getAddressIndex1(SelectedPositions rightPositions, Page hashChannelsPage, long[] rawHashes, long[] addressIndexes)
+    {
+        int[] hashPositions = new int[rightPositions.size()];
+        getHashPositions(rightPositions, rawHashes, hashPositions);
+        getAddressIndexes(rightPositions, hashPositions, addressIndexes);
+        matchPositions(rightPositions, hashChannelsPage, hashPositions, rawHashes, addressIndexes);
+        finalMatch(rightPositions, hashChannelsPage, hashPositions, rawHashes, addressIndexes);
+    }
+
+    private void matchPositions(SelectedPositions rightPositions, Page hashChannelsPage, int[] hashPositions, long[] rawHashes, long[] addressIndexes)
+    {
+        if (rightPositions.isList()) {
+            int[] rightPositionList = rightPositions.getPositions();
+            for (int i = 0; i < rightPositions.size(); i++) {
+                int rightPosition = rightPositionList[i];
+                matchPosition(rightPositions, hashChannelsPage, hashPositions, rawHashes, addressIndexes, i, rightPosition);
+            }
+        }
+        else {
+            for (int rightPosition = 0; rightPosition < rightPositions.size(); rightPosition++) {
+                matchPosition(rightPositions, hashChannelsPage, hashPositions, rawHashes, addressIndexes, rightPosition, rightPosition);
+            }
+        }
+    }
+
+    private void matchPosition(SelectedPositions rightPositions, Page hashChannelsPage, int[] hashPositions, long[] rawHashes, long[] addressIndexes, int positionIndex, int rightPosition)
+    {
+        if (addressIndexes[rightPosition] == -1) {
+            hashPositions[positionIndex] = -1;
+        }
+        else if (positionEqualsCurrentRowIgnoreNulls((int) addressIndexes[rightPosition], (byte) rawHashes[rightPosition], rightPositions.getOffset() + rightPosition, hashChannelsPage)) {
+            hashPositions[positionIndex] = -1;
+        }
+        else {
+            hashPositions[positionIndex] = (hashPositions[positionIndex] + 1) & mask;
+        }
+    }
+
+    private void finalMatch(SelectedPositions rightPositions, Page hashChannelsPage, int[] hashPositions, long[] rawHashes, long[] result)
+    {
+        if (rightPositions.isList()) {
+            int[] rightPositionList = rightPositions.getPositions();
+            for (int i = 0; i < rightPositions.size(); i++) {
+                int rightPosition = rightPositionList[i];
+                if (hashPositions[i] != -1) {
+                    result[rightPosition] = getAddressIndex(rightPositions.getOffset() + rightPosition, hashChannelsPage, (byte) rawHashes[rightPosition], hashPositions[i]);
+                }
+            }
+        }
+        else {
+            for (int rightPosition = 0; rightPosition < rightPositions.size(); rightPosition++) {
+                if (hashPositions[rightPosition] != -1) {
+                    result[rightPosition] = getAddressIndex(rightPositions.getOffset() + rightPosition, hashChannelsPage, (byte) rawHashes[rightPosition], hashPositions[rightPosition]);
+                }
+            }
+        }
+    }
+
+    private void getAddressIndex2(SelectedPositions rightPositions, Page hashChannelsPage, long[] rawHashes, long[] addressIndexes)
+    {
+        int[] hashPositions = new int[rightPositions.size()];
+        getHashPositions(rightPositions, rawHashes, hashPositions);
+        getAddressIndexes(rightPositions, hashPositions, addressIndexes);
+        int[] remainingRightPositionList = new int[rightPositions.size()];
+        SelectedPositions remainingRightPositions = matchPositions(rightPositions, hashChannelsPage, rawHashes, hashPositions, addressIndexes, remainingRightPositionList);
+        while (remainingRightPositions.size() > 0) {
+            getAddressIndexes(remainingRightPositions, hashPositions, addressIndexes);
+            remainingRightPositions = matchPositions(remainingRightPositions, hashChannelsPage, rawHashes, hashPositions, addressIndexes, remainingRightPositionList);
+        }
+    }
+
+    private SelectedPositions getSelectedPositions(SelectedPositions previousPositions, int[] positionList, int positionCount)
+    {
+        if (positionCount == previousPositions.size()) {
+            return previousPositions;
+        }
+
+        return positionsList(positionList, previousPositions.getOffset(), positionCount);
+    }
+
+    private SelectedPositions matchPositions(SelectedPositions rightPositions, Page hashChannelsPage, long[] rawHashes, int[] hashPositions, long[] addressIndexes, int[] remainingRightPositions)
+    {
+        int remainingPositionCount = 0;
+        if (rightPositions.isList()) {
+            int[] rightPositionList = rightPositions.getPositions();
+            for (int i = 0; i < rightPositions.size(); i++) {
+                int rightPosition = rightPositionList[i];
+                if (addressIndexes[rightPosition] != -1
+                        && !positionEqualsCurrentRowIgnoreNulls((int) addressIndexes[rightPosition], (byte) rawHashes[rightPosition], rightPositions.getOffset() + rightPosition, hashChannelsPage)) {
+                    hashPositions[remainingPositionCount] = (hashPositions[i] + 1) & mask;
+                    remainingRightPositions[remainingPositionCount] = rightPosition;
+                    remainingPositionCount++;
+                }
+            }
+        }
+        else {
+            for (int rightPosition = 0; rightPosition < rightPositions.size(); rightPosition++) {
+                if (addressIndexes[rightPosition] != -1
+                        && !positionEqualsCurrentRowIgnoreNulls((int) addressIndexes[rightPosition], (byte) rawHashes[rightPosition], rightPositions.getOffset() + rightPosition, hashChannelsPage)) {
+                    hashPositions[remainingPositionCount] = (hashPositions[rightPosition] + 1) & mask;
+                    remainingRightPositions[remainingPositionCount] = rightPosition;
+                    remainingPositionCount++;
+                }
+            }
+        }
+        return getSelectedPositions(rightPositions, remainingRightPositions, remainingPositionCount);
+    }
+
+    private void getAddressIndexes(SelectedPositions positions, int[] hashPositions, long[] addressIndexes)
+    {
+        if (positions.isList()) {
+            int[] positionList = positions.getPositions();
+            for (int i = 0; i < positions.size(); i++) {
+                addressIndexes[positionList[i]] = key[hashPositions[i]];
+            }
+        }
+        else {
+            for (int position = 0; position < positions.size(); position++) {
+                addressIndexes[position] = key[hashPositions[position]];
+            }
+        }
     }
 
     private int getAddressIndex(int rightPosition, Page hashChannelsPage, byte rawHash, int pos)
@@ -334,6 +445,15 @@ public final class PagesHash
         return pagesHashStrategy.positionEqualsRowIgnoreNulls(blockIndex, blockPosition, rightPosition, rightPage);
     }
 
+    private boolean positionEqualsCurrentRowIgnoreNulls(int leftPosition, int rightPosition, Page rightPage)
+    {
+        long pageAddress = addresses.getLong(leftPosition);
+        int blockIndex = decodeSliceIndex(pageAddress);
+        int blockPosition = decodePosition(pageAddress);
+
+        return pagesHashStrategy.positionEqualsRowIgnoreNulls(blockIndex, blockPosition, rightPosition, rightPage);
+    }
+
     private boolean positionEqualsPositionIgnoreNulls(int leftPosition, int rightPosition)
     {
         long leftPageAddress = addresses.getLong(leftPosition);
@@ -345,6 +465,21 @@ public final class PagesHash
         int rightBlockPosition = decodePosition(rightPageAddress);
 
         return pagesHashStrategy.positionEqualsPositionIgnoreNulls(leftBlockIndex, leftBlockPosition, rightBlockIndex, rightBlockPosition);
+    }
+
+    private void getHashPositions(SelectedPositions positions, long[] rawHashes, int[] hashPositions)
+    {
+        if (positions.isList()) {
+            int[] positionList = positions.getPositions();
+            for (int i = 0; i < positions.size(); i++) {
+                hashPositions[i] = getHashPosition(rawHashes[positionList[i]], mask);
+            }
+        }
+        else {
+            for (int position = 0; position < positions.size(); position++) {
+                hashPositions[position] = getHashPosition(rawHashes[position], mask);
+            }
+        }
     }
 
     private static int getHashPosition(long rawHash, long mask)

--- a/core/trino-main/src/main/java/io/trino/operator/join/PagesHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/PagesHash.java
@@ -15,6 +15,7 @@ package io.trino.operator.join;
 
 import io.airlift.units.DataSize;
 import io.trino.operator.PagesHashStrategy;
+import io.trino.operator.project.SelectedPositions;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import it.unimi.dsi.fastutil.HashCommon;
@@ -148,12 +149,143 @@ public final class PagesHash
         return getAddressIndex(position, hashChannelsPage, pagesHashStrategy.hashRow(position, hashChannelsPage));
     }
 
+    /**
+     * return array passed as an argument for performance reasons
+     */
+    public long[] getAddressIndex(int[] positions, Page hashChannelsPage)
+    {
+        long[] hashes = new long[positions.length];
+        for (int i = 0; i < positions.length; i++) {
+            hashes[i] = pagesHashStrategy.hashRow(positions[i], hashChannelsPage);
+        }
+        return getAddressIndex(positions, hashChannelsPage, hashes);
+    }
+
     public int getAddressIndex(int rightPosition, Page hashChannelsPage, long rawHash)
     {
         int pos = getHashPosition(rawHash, mask);
 
+        return getAddressIndex(rightPosition, hashChannelsPage, (byte) rawHash, pos);
+    }
+
+    public long[] getAddressIndex(int[] rightPositions, Page hashChannelsPage, long[] rawHashes)
+    {
+        //verify(rightPositions.length == rawHashes.length, "Number of positions must match number of hashes");
+        long[] result = new long[rightPositions.length];
+
+        /*
+         * Instead of looking for a match on a per-position basis, we execute every step in a "vectorized" way,
+         * so that all cpu mechanisms (caching, out-of-order execution, etc.) are fully utilized.
+         */
+        int[] pos = new int[rightPositions.length];
+        /*
+         * First loop preforms a simple hashing of existing hashed values to determine
+         * the hash bucket that the value belongs to.
+         */
+        for (int i = 0; i < rightPositions.length; i++) {
+            pos[i] = getHashPosition(rawHashes[i], mask);
+        }
+
+        /*
+         * This is the easiest, yet most expensive step, as it will trigger a lot of cache misses.
+         * By doing this in a single loop the latencies of cpu memory prefetch for consecutive entries
+         * will overlap with each other.
+         */
+        for (int i = 0; i < rightPositions.length; i++) {
+            result[i] = key[pos[i]];
+        }
+
+        /*
+         * Here the actual logic happens. If the bucket is empty or filled with the proper value
+         * then the value in result array is valid and pos[i] is set to -1 to indicate that this
+         * position has been taken care of. Otherwise we continue with the standard open-addressing
+         * logic incrementing the position.
+         */
+        for (int i = 0; i < rightPositions.length; i++) {
+            if (result[i] == -1) {
+                pos[i] = -1;
+            }
+            else if (positionEqualsCurrentRowIgnoreNulls((int) result[i], (byte) rawHashes[i], rightPositions[i], hashChannelsPage)) {
+                pos[i] = -1;
+            }
+            else {
+                pos[i] = (pos[i] + 1) & mask;
+            }
+        }
+
+        /*
+         * Finally we look for remaining matches in a traditional way.
+         */
+        for (int i = 0; i < rightPositions.length; i++) {
+            if (pos[i] != -1) {
+                result[i] = getAddressIndex(rightPositions[i], hashChannelsPage, (byte) rawHashes[i], pos[i]);
+            }
+        }
+
+        return result;
+    }
+
+    public long[] getAddressIndex(SelectedPositions rightPositions, Page hashChannelsPage, long[] rawHashes)
+    {
+        //verify(rightPositions.length == rawHashes.length, "Number of positions must match number of hashes");
+        long[] result = new long[rightPositions.size()];
+
+        /*
+         * Instead of looking for a match on a per-position basis, we execute every step in a "vectorized" way,
+         * so that all cpu mechanisms (caching, out-of-order execution, etc.) are fully utilized.
+         */
+        int[] pos = new int[rightPositions.size()];
+        /*
+         * First loop preforms a simple hashing of existing hashed values to determine
+         * the hash bucket that the value belongs to.
+         */
+        for (int i = 0; i < rightPositions.size(); i++) {
+            pos[i] = getHashPosition(rawHashes[i], mask);
+        }
+
+        /*
+         * This is the easiest, yet most expensive step, as it will trigger a lot of cache misses.
+         * By doing this in a single loop the latencies of cpu memory prefetch for consecutive entries
+         * will overlap with each other.
+         */
+        for (int i = 0; i < rightPositions.size(); i++) {
+            result[i] = key[pos[i]];
+        }
+
+        /*
+         * Here the actual logic happens. If the bucket is empty or filled with the proper value
+         * then the value in result array is valid and pos[i] is set to -1 to indicate that this
+         * position has been taken care of. Otherwise we continue with the standard open-addressing
+         * logic incrementing the position.
+         */
+        for (int i = 0; i < rightPositions.size(); i++) {
+            if (result[i] == -1) {
+                pos[i] = -1;
+            }
+            else if (positionEqualsCurrentRowIgnoreNulls((int) result[i], (byte) rawHashes[i], rightPositions.getOffset() + i, hashChannelsPage)) {
+                pos[i] = -1;
+            }
+            else {
+                pos[i] = (pos[i] + 1) & mask;
+            }
+        }
+
+        /*
+         * Finally we look for remaining matches in a traditional way.
+         */
+        for (int i = 0; i < rightPositions.size(); i++) {
+            if (pos[i] != -1) {
+                result[i] = getAddressIndex(rightPositions.getOffset() + i, hashChannelsPage, (byte) rawHashes[i], pos[i]);
+            }
+        }
+
+        return result;
+    }
+
+    private int getAddressIndex(int rightPosition, Page hashChannelsPage, byte rawHash, int pos)
+    {
         while (key[pos] != -1) {
-            if (positionEqualsCurrentRowIgnoreNulls(key[pos], (byte) rawHash, rightPosition, hashChannelsPage)) {
+            if (positionEqualsCurrentRowIgnoreNulls(key[pos], rawHash, rightPosition, hashChannelsPage)) {
                 return key[pos];
             }
             // increment position and mask to handler wrap around

--- a/core/trino-main/src/main/java/io/trino/operator/join/PartitionedLookupSource.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/PartitionedLookupSource.java
@@ -16,6 +16,7 @@ package io.trino.operator.join;
 import com.google.common.io.Closer;
 import io.trino.operator.InterpretedHashGenerator;
 import io.trino.operator.exchange.LocalPartitionGenerator;
+import io.trino.operator.project.SelectedPositions;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.type.Type;
@@ -85,6 +86,7 @@ public class PartitionedLookupSource
     private final LocalPartitionGenerator partitionGenerator;
     private final int partitionMask;
     private final int shiftSize;
+    private final boolean supportsCaching;
     @Nullable
     private final OuterPositionTracker outerPositionTracker;
 
@@ -101,6 +103,7 @@ public class PartitionedLookupSource
         this.partitionMask = lookupSources.size() - 1;
         this.shiftSize = numberOfTrailingZeros(lookupSources.size()) + 1;
         this.outerPositionTracker = outerPositionTracker.orElse(null);
+        this.supportsCaching = lookupSources.stream().allMatch(LookupSource::supportsCaching);
     }
 
     @Override
@@ -142,6 +145,120 @@ public class PartitionedLookupSource
     }
 
     @Override
+    public long[] getJoinPositions(int[] positions, Page hashChannelsPage, Page allChannelsPage)
+    {
+        if (!supportsCaching()) {
+            return LookupSource.super.getJoinPositions(positions, hashChannelsPage, allChannelsPage);
+        }
+
+        long[] rawHashes = new long[positions.length];
+        for (int i = 0; i < positions.length; i++) {
+            rawHashes[i] = partitionGenerator.getRawHash(hashChannelsPage, positions[i]);
+        }
+
+        return getJoinPositions(positions, hashChannelsPage, allChannelsPage, rawHashes);
+    }
+
+    @Override
+    public long[] getJoinPositions(int[] positions, Page hashChannelsPage, Page allChannelsPage, long[] rawHashes)
+    {
+        if (!supportsCaching()) {
+            return LookupSource.super.getJoinPositions(positions, hashChannelsPage, allChannelsPage, rawHashes);
+        }
+        long[] result = new long[positions.length];
+
+        // Determine the partition of each element of positions array
+        int[] partitions = new int[positions.length];
+        int[] partitionCount = new int[lookupSources.length];
+        for (int i = 0; i < positions.length; i++) {
+            int partition = partitionGenerator.getPartition(rawHashes[i]);
+            partitions[i] = partition;
+            partitionCount[partition]++;
+        }
+
+        // Split positions array into partitions
+        int[][] partitionedPositions = new int[lookupSources.length][];
+        long[][] partitionedRawHashes = new long[lookupSources.length][];
+        for (int i = 0; i < lookupSources.length; i++) {
+            partitionedPositions[i] = new int[partitionCount[i]];
+            partitionedRawHashes[i] = new long[partitionCount[i]];
+            partitionCount[i] = 0;
+        }
+
+        for (int i = 0; i < positions.length; i++) {
+            int partition = partitions[i];
+            partitionedPositions[partition][partitionCount[partition]] = positions[i];
+            partitionedRawHashes[partition][partitionCount[partition]] = rawHashes[i];
+            partitionCount[partition]++;
+        }
+
+        // Execute getJoinPositions per every partition
+        long[][] partitionedResults = new long[lookupSources.length][];
+        for (int i = 0; i < lookupSources.length; i++) {
+            partitionedResults[i] = lookupSources[i].getJoinPositions(partitionedPositions[i], hashChannelsPage, allChannelsPage, partitionedRawHashes[i]);
+            partitionCount[i] = 0;
+        }
+
+        // Merge the results
+        for (int i = 0; i < positions.length; i++) {
+            int partition = partitions[i];
+            result[i] = encodePartitionedJoinPosition(partition, toIntExact(partitionedResults[partition][partitionCount[partition]++]));
+        }
+
+        return result;
+    }
+
+    @Override
+    public long[] getJoinPositions(SelectedPositions positions, Page hashChannelsPage, Page allChannelsPage, long[] rawHashes)
+    {
+        if (!supportsCaching()) {
+            return LookupSource.super.getJoinPositions(positions, hashChannelsPage, allChannelsPage, rawHashes);
+        }
+        verify(!positions.isList());
+        long[] result = new long[positions.size()];
+
+        // Determine the partition of each element of positions array
+        int[] partitions = new int[positions.size()];
+        int[] partitionCount = new int[lookupSources.length];
+        for (int i = 0; i < positions.size(); i++) {
+            int partition = partitionGenerator.getPartition(rawHashes[i]);
+            partitions[i] = partition;
+            partitionCount[partition]++;
+        }
+
+        // Split positions array into partitions
+        int[][] partitionedPositions = new int[lookupSources.length][];
+        long[][] partitionedRawHashes = new long[lookupSources.length][];
+        for (int i = 0; i < lookupSources.length; i++) {
+            partitionedPositions[i] = new int[partitionCount[i]];
+            partitionedRawHashes[i] = new long[partitionCount[i]];
+            partitionCount[i] = 0;
+        }
+
+        for (int i = 0; i < positions.size(); i++) {
+            int partition = partitions[i];
+            partitionedPositions[partition][partitionCount[partition]] = positions.getOffset() + i;
+            partitionedRawHashes[partition][partitionCount[partition]] = rawHashes[i];
+            partitionCount[partition]++;
+        }
+
+        // Execute getJoinPositions per every partition
+        long[][] partitionedResults = new long[lookupSources.length][];
+        for (int i = 0; i < lookupSources.length; i++) {
+            partitionedResults[i] = lookupSources[i].getJoinPositions(partitionedPositions[i], hashChannelsPage, allChannelsPage, partitionedRawHashes[i]);
+            partitionCount[i] = 0;
+        }
+
+        // Merge the results
+        for (int i = 0; i < positions.size(); i++) {
+            int partition = partitions[i];
+            result[i] = encodePartitionedJoinPosition(partition, toIntExact(partitionedResults[partition][partitionCount[partition]++]));
+        }
+
+        return result;
+    }
+
+    @Override
     public long getNextJoinPosition(long currentJoinPosition, int probePosition, Page allProbeChannelsPage)
     {
         int partition = decodePartition(currentJoinPosition);
@@ -178,6 +295,12 @@ public class PartitionedLookupSource
     public long joinPositionWithinPartition(long joinPosition)
     {
         return decodeJoinPosition(joinPosition);
+    }
+
+    @Override
+    public boolean supportsCaching()
+    {
+        return supportsCaching;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/project/SelectedPositions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/SelectedPositions.java
@@ -44,9 +44,9 @@ public class SelectedPositions
 
         checkArgument(offset >= 0, "offset is negative");
         checkArgument(size >= 0, "size is negative");
-        if (isList) {
+        /*if (isList) {
             checkPositionIndexes(offset, offset + size, positions.length);
-        }
+        }*/
     }
 
     public boolean isList()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2080,6 +2080,7 @@ public class LocalExecutionPlanner
             switch (node.getType()) {
                 case INNER:
                     lookupJoinOperatorFactory = operatorFactories.innerJoin(
+                            session,
                             context.getNextOperatorId(),
                             node.getId(),
                             lookupSourceFactoryManager,
@@ -2096,6 +2097,7 @@ public class LocalExecutionPlanner
                     break;
                 case SOURCE_OUTER:
                     lookupJoinOperatorFactory = operatorFactories.probeOuterJoin(
+                            session,
                             context.getNextOperatorId(),
                             node.getId(),
                             lookupSourceFactoryManager,
@@ -2712,6 +2714,7 @@ public class LocalExecutionPlanner
             switch (node.getType()) {
                 case INNER:
                     return operatorFactories.innerJoin(
+                            session,
                             context.getNextOperatorId(),
                             node.getId(),
                             lookupSourceFactoryManager,
@@ -2727,6 +2730,7 @@ public class LocalExecutionPlanner
                             blockTypeOperators);
                 case LEFT:
                     return operatorFactories.probeOuterJoin(
+                            session,
                             context.getNextOperatorId(),
                             node.getId(),
                             lookupSourceFactoryManager,
@@ -2741,6 +2745,7 @@ public class LocalExecutionPlanner
                             blockTypeOperators);
                 case RIGHT:
                     return operatorFactories.lookupOuterJoin(
+                            session,
                             context.getNextOperatorId(),
                             node.getId(),
                             lookupSourceFactoryManager,
@@ -2755,6 +2760,7 @@ public class LocalExecutionPlanner
                             blockTypeOperators);
                 case FULL:
                     return operatorFactories.fullOuterJoin(
+                            session,
                             context.getNextOperatorId(),
                             node.getId(),
                             lookupSourceFactoryManager,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -2491,6 +2491,7 @@ public class LocalExecutionPlanner
                 Set<DynamicFilterId> localDynamicFilters)
         {
             LocalExecutionPlanContext buildContext = context.createSubContext();
+            buildContext.setDriverInstanceCount(1);
             PhysicalOperation buildSource = buildNode.accept(this, buildContext);
 
             if (buildSource.getPipelineExecutionStrategy() == GROUPED_EXECUTION) {

--- a/core/trino-main/src/test/java/io/trino/operator/join/BenchmarkHashBuildAndJoinOperators.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/BenchmarkHashBuildAndJoinOperators.java
@@ -86,11 +86,11 @@ import static org.openjdk.jmh.annotations.Mode.AverageTime;
 
 @SuppressWarnings("MethodMayBeStatic")
 @State(Scope.Benchmark)
-@Threads(Threads.MAX)
+@Threads(4)
 @OutputTimeUnit(MILLISECONDS)
 @BenchmarkMode(AverageTime)
-@Fork(3)
-@Warmup(iterations = 5)
+@Fork(1)
+@Warmup(iterations = 10)
 @Measurement(iterations = 10, time = 2, timeUnit = SECONDS)
 public class BenchmarkHashBuildAndJoinOperators
 {
@@ -103,7 +103,7 @@ public class BenchmarkHashBuildAndJoinOperators
     public static class BuildContext
     {
         protected static final int ROWS_PER_PAGE = 1024;
-        protected static final int BUILD_ROWS_NUMBER = 20_000_000;
+        protected static final int BUILD_ROWS_NUMBER = 20000;
 
         @Param("bigint")
         protected String hashColumns = "bigint";
@@ -199,13 +199,13 @@ public class BenchmarkHashBuildAndJoinOperators
     {
         protected static final int PROBE_ROWS_NUMBER = 1_400_000;
 
-        @Param({"0.5", "1", "5"})
+        @Param("0.5")
         protected double matchRate = 5;
 
-        @Param({"bigint", "all"})
+        @Param("bigint")
         protected String outputColumns = "bigint";
 
-        @Param({"1", "16"})
+        @Param("1")
         protected int partitionCount = 1;
 
         @Param({"true", "false"})
@@ -281,9 +281,9 @@ public class BenchmarkHashBuildAndJoinOperators
             while (remainingRows > 0) {
                 double roll = random.nextDouble();
 
-                int columnA = 20 + remainingRows;
-                int columnB = 30 + remainingRows;
-                int columnC = 40 + remainingRows;
+                int columnA = 20 + (remainingRows % BUILD_ROWS_NUMBER);
+                int columnB = 30 + (remainingRows % BUILD_ROWS_NUMBER);
+                int columnC = 40 + (remainingRows % BUILD_ROWS_NUMBER);
 
                 int rowsCount = 1;
                 if (matchRate < 1) {
@@ -479,7 +479,7 @@ public class BenchmarkHashBuildAndJoinOperators
         checkState(pages.get(0).getPositionCount() > 0);
     }
 
-    @Test
+    //@Test
     public void testBenchmarkBuildHash()
     {
         BuildContext buildContext = new BuildContext();

--- a/core/trino-main/src/test/java/io/trino/operator/join/JoinTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/JoinTestUtils.java
@@ -63,6 +63,7 @@ import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
+import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static io.trino.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
@@ -94,6 +95,7 @@ public final class JoinTestUtils
             boolean hasFilter)
     {
         return operatorFactories.innerJoin(
+                TEST_SESSION,
                 0,
                 new PlanNodeId("test"),
                 lookupSourceFactoryManager,

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
@@ -289,6 +289,7 @@ public class TestHashJoinOperator
                 .collect(toImmutableList());
 
         OperatorFactory joinOperatorFactory = operatorFactories.innerJoin(
+                TEST_SESSION,
                 0,
                 new PlanNodeId("test"),
                 lookupSourceFactory,
@@ -343,6 +344,7 @@ public class TestHashJoinOperator
         RowPagesBuilder probePages = rowPagesBuilder(false, Ints.asList(0), ImmutableList.of(BIGINT));
         List<Page> probeInput = probePages.addSequencePage(100, 0).build();
         OperatorFactory joinOperatorFactory = operatorFactories.innerJoin(
+                TEST_SESSION,
                 0,
                 new PlanNodeId("test"),
                 lookupSourceFactory,
@@ -1231,6 +1233,7 @@ public class TestHashJoinOperator
         List<Type> probeTypes = ImmutableList.of(VARCHAR);
         RowPagesBuilder probePages = rowPagesBuilder(probeHashEnabled, Ints.asList(0), probeTypes);
         OperatorFactory joinOperatorFactory = operatorFactories.innerJoin(
+                TEST_SESSION,
                 0,
                 new PlanNodeId("test"),
                 lookupSourceFactoryManager,
@@ -1271,6 +1274,7 @@ public class TestHashJoinOperator
         List<Type> probeTypes = ImmutableList.of(VARCHAR);
         RowPagesBuilder probePages = rowPagesBuilder(probeHashEnabled, Ints.asList(0), probeTypes);
         OperatorFactory joinOperatorFactory = operatorFactories.lookupOuterJoin(
+                TEST_SESSION,
                 0,
                 new PlanNodeId("test"),
                 lookupSourceFactoryManager,
@@ -1316,6 +1320,7 @@ public class TestHashJoinOperator
                 .row("c")
                 .build();
         OperatorFactory joinOperatorFactory = operatorFactories.probeOuterJoin(
+                TEST_SESSION,
                 0,
                 new PlanNodeId("test"),
                 lookupSourceFactoryManager,
@@ -1364,6 +1369,7 @@ public class TestHashJoinOperator
                 .row("c")
                 .build();
         OperatorFactory joinOperatorFactory = operatorFactories.fullOuterJoin(
+                TEST_SESSION,
                 0,
                 new PlanNodeId("test"),
                 lookupSourceFactoryManager,
@@ -1410,6 +1416,7 @@ public class TestHashJoinOperator
         RowPagesBuilder probePages = rowPagesBuilder(probeHashEnabled, Ints.asList(0), probeTypes);
         List<Page> probeInput = probePages.build();
         OperatorFactory joinOperatorFactory = operatorFactories.innerJoin(
+                TEST_SESSION,
                 0,
                 new PlanNodeId("test"),
                 lookupSourceFactoryManager,
@@ -1603,6 +1610,7 @@ public class TestHashJoinOperator
         List<Type> probeTypes = ImmutableList.of(VARCHAR);
         RowPagesBuilder probePages = rowPagesBuilder(probeHashEnabled, Ints.asList(0), probeTypes);
         OperatorFactory joinOperatorFactory = operatorFactories.innerJoin(
+                TEST_SESSION,
                 0,
                 new PlanNodeId("test"),
                 lookupSourceFactoryManager,
@@ -1656,6 +1664,7 @@ public class TestHashJoinOperator
             boolean hasFilter)
     {
         return operatorFactories.probeOuterJoin(
+                TEST_SESSION,
                 0,
                 new PlanNodeId("test"),
                 lookupSourceFactoryManager,

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestLookupJoinPageBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestLookupJoinPageBuilder.java
@@ -44,7 +44,7 @@ public class TestLookupJoinPageBuilder
         Block block = blockBuilder.build();
         Page page = new Page(block, block);
 
-        JoinProbeFactory joinProbeFactory = new JoinProbeFactory(new int[] {0, 1}, ImmutableList.of(0, 1), OptionalInt.empty());
+        JoinProbeFactory joinProbeFactory = new JoinProbeFactory(new int[] {0, 1}, ImmutableList.of(0, 1), OptionalInt.empty(), true);
         JoinProbe probe = joinProbeFactory.createJoinProbe(page);
         LookupSource lookupSource = new TestLookupSource(ImmutableList.of(BIGINT, BIGINT), page);
         LookupJoinPageBuilder lookupJoinPageBuilder = new LookupJoinPageBuilder(ImmutableList.of(BIGINT, BIGINT));
@@ -92,7 +92,7 @@ public class TestLookupJoinPageBuilder
         }
         Block block = blockBuilder.build();
         Page page = new Page(block);
-        JoinProbeFactory joinProbeFactory = new JoinProbeFactory(new int[] {0}, ImmutableList.of(0), OptionalInt.empty());
+        JoinProbeFactory joinProbeFactory = new JoinProbeFactory(new int[] {0}, ImmutableList.of(0), OptionalInt.empty(), true);
         LookupSource lookupSource = new TestLookupSource(ImmutableList.of(BIGINT), page);
         LookupJoinPageBuilder lookupJoinPageBuilder = new LookupJoinPageBuilder(ImmutableList.of(BIGINT));
 
@@ -164,7 +164,7 @@ public class TestLookupJoinPageBuilder
 
         // nothing on the build side so we don't append anything
         LookupSource lookupSource = new TestLookupSource(ImmutableList.of(), page);
-        JoinProbe probe = (new JoinProbeFactory(new int[] {0}, ImmutableList.of(0), OptionalInt.empty())).createJoinProbe(page);
+        JoinProbe probe = (new JoinProbeFactory(new int[] {0}, ImmutableList.of(0), OptionalInt.empty(), true)).createJoinProbe(page);
         LookupJoinPageBuilder lookupJoinPageBuilder = new LookupJoinPageBuilder(ImmutableList.of(BIGINT));
 
         // append the same row many times should also flush in the end

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashBuildAndJoinBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashBuildAndJoinBenchmark.java
@@ -140,6 +140,7 @@ public class HashBuildAndJoinBenchmark
         }
 
         OperatorFactory joinOperator = operatorFactories.innerJoin(
+                testSessionBuilder().build(),
                 2,
                 new PlanNodeId("test"),
                 lookupSourceFactoryManager,

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashBuildBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashBuildBenchmark.java
@@ -43,6 +43,7 @@ import static io.trino.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
 import static io.trino.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spiller.PartitioningSpillerFactory.unsupportedPartitioningSpillerFactory;
+import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.Objects.requireNonNull;
 
 public class HashBuildBenchmark
@@ -99,6 +100,7 @@ public class HashBuildBenchmark
         ImmutableList.Builder<OperatorFactory> joinDriversBuilder = ImmutableList.builder();
         joinDriversBuilder.add(new ValuesOperatorFactory(0, new PlanNodeId("values"), ImmutableList.of()));
         OperatorFactory joinOperator = operatorFactories.innerJoin(
+                testSessionBuilder().build(),
                 2,
                 new PlanNodeId("test"),
                 lookupSourceFactoryManager,

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashJoinBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/HashJoinBenchmark.java
@@ -46,6 +46,7 @@ import static io.airlift.concurrent.MoreFutures.getFutureValue;
 import static io.trino.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
 import static io.trino.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
 import static io.trino.spiller.PartitioningSpillerFactory.unsupportedPartitioningSpillerFactory;
+import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.util.Objects.requireNonNull;
 
 public class HashJoinBenchmark
@@ -109,6 +110,7 @@ public class HashJoinBenchmark
             List<Type> lineItemTypes = getColumnTypes("lineitem", "orderkey", "quantity");
             OperatorFactory lineItemTableScan = createTableScanOperator(0, new PlanNodeId("test"), "lineitem", "orderkey", "quantity");
             OperatorFactory joinOperator = operatorFactories.innerJoin(
+                    testSessionBuilder().build(),
                     1,
                     new PlanNodeId("test"),
                     lookupSourceFactoryManager,


### PR DESCRIPTION
Benchmarks before:
Benchmark                                             (buildHashEnabled)  (buildRowsRepetition)  (hashColumns)  (matchRate)  (outputColumns)  Mode  Cnt    Score   Error  Units
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      1         bigint          0.1           bigint  avgt   30  217,846 ± 2,648  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      1         bigint            1           bigint  avgt   30  206,986 ± 2,609  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      1         bigint            2           bigint  avgt   30  125,916 ± 0,749  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      5         bigint          0.1           bigint  avgt   30  215,422 ± 5,864  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      5         bigint            1           bigint  avgt   30  418,456 ± 4,223  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      5         bigint            2           bigint  avgt   30  250,294 ± 1,497  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      1         bigint          0.1           bigint  avgt   30  176,874 ± 1,664  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      1         bigint            1           bigint  avgt   30  202,235 ± 3,387  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      1         bigint            2           bigint  avgt   30  121,637 ± 0,928  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      5         bigint          0.1           bigint  avgt   30  182,658 ± 2,173  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      5         bigint            1           bigint  avgt   30  405,292 ± 6,822  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      5         bigint            2           bigint  avgt   30  249,612 ± 2,348  ms/op

after:
Benchmark                                             (buildHashEnabled)  (buildRowsRepetition)  (hashColumns)  (matchRate)  (outputColumns)  Mode  Cnt    Score   Error  Units
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      1         bigint          0.1           bigint  avgt   30   80,986 ± 3,045  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      1         bigint            1           bigint  avgt   30   63,351 ± 0,384  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      1         bigint            2           bigint  avgt   30   61,030 ± 0,587  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      5         bigint          0.1           bigint  avgt   30  103,966 ± 0,907  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      5         bigint            1           bigint  avgt   30  190,340 ± 0,816  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash               false                      5         bigint            2           bigint  avgt   30  186,862 ± 1,864  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      1         bigint          0.1           bigint  avgt   30   80,280 ± 1,136  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      1         bigint            1           bigint  avgt   30   65,010 ± 0,655  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      1         bigint            2           bigint  avgt   30   60,309 ± 0,280  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      5         bigint          0.1           bigint  avgt   30  102,268 ± 0,976  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      5         bigint            1           bigint  avgt   30  190,286 ± 1,005  ms/op
BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash                true                      5         bigint            2           bigint  avgt   30  184,353 ± 1,160  ms/op