### PR TITLE
Rename parse_presto_data_size function to parse_data_size

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DataSizeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DataSizeFunctions.java
@@ -34,7 +34,7 @@ public final class DataSizeFunctions
     private DataSizeFunctions() {}
 
     @Description("Converts data size string to bytes")
-    @ScalarFunction("parse_presto_data_size")
+    @ScalarFunction(value = "parse_data_size", alias = "parse_presto_data_size")
     @LiteralParameters("x")
     @SqlType("decimal(38,0)")
     public static Slice parsePrestoDataSize(@SqlType("varchar(x)") Slice input)

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestDataSizeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestDataSizeFunctions.java
@@ -28,31 +28,31 @@ public class TestDataSizeFunctions
     @Test
     public void testParseDataSize()
     {
-        assertFunction("parse_presto_data_size('0B')", DECIMAL, decimal("0"));
-        assertFunction("parse_presto_data_size('1B')", DECIMAL, decimal("1"));
-        assertFunction("parse_presto_data_size('1.2B')", DECIMAL, decimal("1"));
-        assertFunction("parse_presto_data_size('1.9B')", DECIMAL, decimal("1"));
-        assertFunction("parse_presto_data_size('2.2kB')", DECIMAL, decimal("2252"));
-        assertFunction("parse_presto_data_size('2.23kB')", DECIMAL, decimal("2283"));
-        assertFunction("parse_presto_data_size('2.23kB')", DECIMAL, decimal("2283"));
-        assertFunction("parse_presto_data_size('2.234kB')", DECIMAL, decimal("2287"));
-        assertFunction("parse_presto_data_size('3MB')", DECIMAL, decimal("3145728"));
-        assertFunction("parse_presto_data_size('4GB')", DECIMAL, decimal("4294967296"));
-        assertFunction("parse_presto_data_size('4TB')", DECIMAL, decimal("4398046511104"));
-        assertFunction("parse_presto_data_size('5PB')", DECIMAL, decimal("5629499534213120"));
-        assertFunction("parse_presto_data_size('6EB')", DECIMAL, decimal("6917529027641081856"));
-        assertFunction("parse_presto_data_size('7ZB')", DECIMAL, decimal("8264141345021879123968"));
-        assertFunction("parse_presto_data_size('8YB')", DECIMAL, decimal("9671406556917033397649408"));
-        assertFunction("parse_presto_data_size('6917529027641081856EB')", DECIMAL, decimal("7975367974709495237422842361682067456"));
-        assertFunction("parse_presto_data_size('69175290276410818560EB')", DECIMAL, decimal("79753679747094952374228423616820674560"));
+        assertFunction("parse_data_size('0B')", DECIMAL, decimal("0"));
+        assertFunction("parse_data_size('1B')", DECIMAL, decimal("1"));
+        assertFunction("parse_data_size('1.2B')", DECIMAL, decimal("1"));
+        assertFunction("parse_data_size('1.9B')", DECIMAL, decimal("1"));
+        assertFunction("parse_data_size('2.2kB')", DECIMAL, decimal("2252"));
+        assertFunction("parse_data_size('2.23kB')", DECIMAL, decimal("2283"));
+        assertFunction("parse_data_size('2.23kB')", DECIMAL, decimal("2283"));
+        assertFunction("parse_data_size('2.234kB')", DECIMAL, decimal("2287"));
+        assertFunction("parse_data_size('3MB')", DECIMAL, decimal("3145728"));
+        assertFunction("parse_data_size('4GB')", DECIMAL, decimal("4294967296"));
+        assertFunction("parse_data_size('4TB')", DECIMAL, decimal("4398046511104"));
+        assertFunction("parse_data_size('5PB')", DECIMAL, decimal("5629499534213120"));
+        assertFunction("parse_data_size('6EB')", DECIMAL, decimal("6917529027641081856"));
+        assertFunction("parse_data_size('7ZB')", DECIMAL, decimal("8264141345021879123968"));
+        assertFunction("parse_data_size('8YB')", DECIMAL, decimal("9671406556917033397649408"));
+        assertFunction("parse_data_size('6917529027641081856EB')", DECIMAL, decimal("7975367974709495237422842361682067456"));
+        assertFunction("parse_data_size('69175290276410818560EB')", DECIMAL, decimal("79753679747094952374228423616820674560"));
 
-        assertInvalidFunction("parse_presto_data_size('')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: ''");
-        assertInvalidFunction("parse_presto_data_size('0')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: '0'");
-        assertInvalidFunction("parse_presto_data_size('10KB')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: '10KB'");
-        assertInvalidFunction("parse_presto_data_size('KB')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: 'KB'");
-        assertInvalidFunction("parse_presto_data_size('-1B')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: '-1B'");
-        assertInvalidFunction("parse_presto_data_size('12345K')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: '12345K'");
-        assertInvalidFunction("parse_presto_data_size('A12345B')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: 'A12345B'");
-        assertInvalidFunction("parse_presto_data_size('99999999999999YB')", NUMERIC_VALUE_OUT_OF_RANGE, "Value out of range: '99999999999999YB' ('120892581961461708544797985370825293824B')");
+        assertInvalidFunction("parse_data_size('')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: ''");
+        assertInvalidFunction("parse_data_size('0')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: '0'");
+        assertInvalidFunction("parse_data_size('10KB')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: '10KB'");
+        assertInvalidFunction("parse_data_size('KB')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: 'KB'");
+        assertInvalidFunction("parse_data_size('-1B')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: '-1B'");
+        assertInvalidFunction("parse_data_size('12345K')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: '12345K'");
+        assertInvalidFunction("parse_data_size('A12345B')", INVALID_FUNCTION_ARGUMENT, "Invalid data size: 'A12345B'");
+        assertInvalidFunction("parse_data_size('99999999999999YB')", NUMERIC_VALUE_OUT_OF_RANGE, "Value out of range: '99999999999999YB' ('120892581961461708544797985370825293824B')");
     }
 }

--- a/docs/src/main/sphinx/functions/conversion.rst
+++ b/docs/src/main/sphinx/functions/conversion.rst
@@ -62,7 +62,7 @@ Formatting
 Data size
 ---------
 
-The ``parse_presto_data_size`` function supports the following units:
+The ``parse_data_size`` function supports the following units:
 
 ======= ============= ==============
 Unit    Description   Value
@@ -78,15 +78,15 @@ Unit    Description   Value
 ``YB``  Yottabytes    1024\ :sup:`8`
 ======= ============= ==============
 
-.. function:: parse_presto_data_size(string) -> decimal(38)
+.. function:: parse_data_size(string) -> decimal(38)
 
     Parses ``string`` of format ``value unit`` into a number, where
     ``value`` is the fractional number of ``unit`` values::
 
-        SELECT parse_presto_data_size('1B'); -- 1
-        SELECT parse_presto_data_size('1kB'); -- 1024
-        SELECT parse_presto_data_size('1MB'); -- 1048576
-        SELECT parse_presto_data_size('2.3MB'); -- 2411724
+        SELECT parse_data_size('1B'); -- 1
+        SELECT parse_data_size('1kB'); -- 1024
+        SELECT parse_data_size('1MB'); -- 1048576
+        SELECT parse_data_size('2.3MB'); -- 2411724
 
 Miscellaneous
 -------------

--- a/docs/src/main/sphinx/functions/list.rst
+++ b/docs/src/main/sphinx/functions/list.rst
@@ -324,7 +324,7 @@ P
 
 - :func:`parse_datetime`
 - :func:`parse_duration`
-- :func:`parse_presto_data_size`
+- :func:`parse_data_size`
 - :func:`percent_rank`
 - :func:`pi`
 - :func:`position`


### PR DESCRIPTION
The old name is retained as an alias for compatibility.