### PR TITLE
Hive insert overwrite when using S3 storage

### DIFF
--- a/client/trino-jdbc/pom.xml
+++ b/client/trino-jdbc/pom.xml
@@ -79,6 +79,12 @@
             <groupId>io.trino</groupId>
             <artifactId>trino-hive-hadoop2</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -379,6 +379,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveWriterFactory.java
@@ -70,7 +70,6 @@ import java.util.UUID;
 import java.util.function.Consumer;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
@@ -426,7 +425,6 @@ public class HiveWriterFactory
                     schema = getHiveSchema(table);
 
                     writeInfo = locationService.getPartitionWriteInfo(locationHandle, Optional.empty(), partitionName.get());
-                    checkState(writeInfo.getWriteMode() != DIRECT_TO_TARGET_EXISTING_DIRECTORY, "Overwriting existing partition doesn't support DIRECT_TO_TARGET_EXISTING_DIRECTORY write mode");
                     break;
                 case ERROR:
                     throw new TrinoException(HIVE_PARTITION_READ_ONLY, "Cannot insert into an existing partition of Hive table: " + partitionName.get());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -100,6 +100,7 @@ import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilege
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.NUM_ROWS;
 import static io.trino.plugin.hive.util.HiveUtil.toPartitionValues;
 import static io.trino.plugin.hive.util.HiveWriteUtils.createDirectory;
+import static io.trino.plugin.hive.util.HiveWriteUtils.isFileCreatedByQuery;
 import static io.trino.plugin.hive.util.HiveWriteUtils.pathExists;
 import static io.trino.plugin.hive.util.Statistics.ReduceOperator.SUBTRACT;
 import static io.trino.plugin.hive.util.Statistics.merge;
@@ -2452,7 +2453,7 @@ public class SemiTransactionalHiveMetastore
                 boolean eligible = false;
                 // don't delete hidden Trino directories use by FileHiveMetastore
                 if (!fileName.startsWith(".trino")) {
-                    eligible = queryIds.stream().anyMatch(id -> fileName.startsWith(id) || fileName.endsWith(id));
+                    eligible = queryIds.stream().anyMatch(id -> isFileCreatedByQuery(fileName, id));
                 }
                 if (eligible) {
                     if (!deleteIfExists(fileSystem, filePath, false)) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -528,6 +528,11 @@ public final class HiveWriteUtils
         }
     }
 
+    public static boolean isFileCreatedByQuery(String fileName, String queryId)
+    {
+        return fileName.startsWith(queryId) || fileName.endsWith(queryId);
+    }
+
     public static Path createTemporaryPath(ConnectorSession session, HdfsContext context, HdfsEnvironment hdfsEnvironment, Path targetPath)
     {
         // use a per-user temporary directory to avoid permission problems

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveInsertOverwrite.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/BaseTestHiveInsertOverwrite.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.plugin.hive.containers.HiveMinioDataLake;
+import io.trino.plugin.hive.s3.S3HiveQueryRunner;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static io.trino.testing.MaterializedResult.resultBuilder;
+import static io.trino.testing.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+public abstract class BaseTestHiveInsertOverwrite
+        extends AbstractTestQueryFramework
+{
+    private static final String HIVE_TEST_SCHEMA = "hive_insert_overwrite";
+
+    private String bucketName;
+    private HiveMinioDataLake dockerizedS3DataLake;
+
+    private final String hiveHadoopImage;
+
+    public BaseTestHiveInsertOverwrite(String hiveHadoopImage)
+    {
+        this.hiveHadoopImage = requireNonNull(hiveHadoopImage, "hiveHadoopImage is null");
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.bucketName = "test-hive-insert-overwrite-" + randomTableSuffix();
+        this.dockerizedS3DataLake = closeAfterClass(
+                new HiveMinioDataLake(bucketName, ImmutableMap.of(), hiveHadoopImage));
+        this.dockerizedS3DataLake.start();
+        return S3HiveQueryRunner.create(
+                this.dockerizedS3DataLake.getHiveHadoop().getHiveMetastoreEndpoint(),
+                this.dockerizedS3DataLake.getMinio().getMinioApiEndpoint(),
+                HiveMinioDataLake.ACCESS_KEY,
+                HiveMinioDataLake.SECRET_KEY,
+                ImmutableMap.<String, String>builder()
+                        // This is required when using MinIO which requires path style access
+                        .put("hive.s3.path-style-access", "true")
+                        .put("hive.insert-existing-partitions-behavior", "OVERWRITE")
+                        .put("hive.non-managed-table-writes-enabled", "true")
+                        .build());
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        computeActual(format(
+                "CREATE SCHEMA hive.%1$s WITH (location='s3a://%2$s/%1$s')",
+                HIVE_TEST_SCHEMA,
+                bucketName));
+    }
+
+    @Test
+    public void testInsertOverwriteNonPartitionedTable()
+    {
+        String testTable = getTestTableName();
+        computeActual(getCreateTableStatement(testTable));
+        assertInsertFailure(
+                testTable,
+                "Overwriting unpartitioned table not supported when writing directly to target directory");
+        computeActual(format("DROP TABLE %s", testTable));
+    }
+
+    @Test
+    public void testInsertOverwriteNonPartitionedBucketedTable()
+    {
+        String testTable = getTestTableName();
+        computeActual(getCreateTableStatement(
+                testTable,
+                "bucketed_by = ARRAY['nationkey']",
+                "bucket_count = 3"));
+        assertInsertFailure(
+                testTable,
+                "Overwriting unpartitioned table not supported when writing directly to target directory");
+        computeActual(format("DROP TABLE %s", testTable));
+    }
+
+    @Test
+    public void testInsertOverwritePartitionedTable()
+    {
+        String testTable = getTestTableName();
+        computeActual(getCreateTableStatement(
+                testTable,
+                "partitioned_by=ARRAY['regionkey']"));
+        copyTpchNationToTable(testTable);
+        assertOverwritePartition(testTable);
+    }
+
+    @Test
+    public void testInsertOverwritePartitionedAndBucketedTable()
+    {
+        String testTable = getTestTableName();
+        computeActual(getCreateTableStatement(
+                testTable,
+                "partitioned_by=ARRAY['regionkey']",
+                "bucketed_by = ARRAY['nationkey']",
+                "bucket_count = 3"));
+        copyTpchNationToTable(testTable);
+        assertOverwritePartition(testTable);
+    }
+
+    @Test
+    public void testInsertOverwritePartitionedAndBucketedExternalTable()
+    {
+        String testTable = getTestTableName();
+        // Store table data in data lake bucket
+        computeActual(getCreateTableStatement(
+                testTable,
+                "partitioned_by=ARRAY['regionkey']",
+                "bucketed_by = ARRAY['nationkey']",
+                "bucket_count = 3"));
+        copyTpchNationToTable(testTable);
+
+        // Map this table as external table
+        String externalTableName = testTable + "_ext";
+        computeActual(getCreateTableStatement(
+                externalTableName,
+                "partitioned_by=ARRAY['regionkey']",
+                "bucketed_by = ARRAY['nationkey']",
+                "bucket_count = 3",
+                format("external_location = 's3a://%s/%s/%s/'", this.bucketName, HIVE_TEST_SCHEMA, testTable)));
+        copyTpchNationToTable(testTable);
+        assertOverwritePartition(externalTableName);
+    }
+
+    protected void assertInsertFailure(String testTable, String expectedMessageRegExp)
+    {
+        assertQueryFails(
+                format("INSERT INTO %s " +
+                                "SELECT name, comment, nationkey, regionkey " +
+                                "FROM tpch.tiny.nation",
+                        testTable),
+                expectedMessageRegExp);
+    }
+
+    protected void assertOverwritePartition(String testTable)
+    {
+        computeActual(format(
+                "INSERT INTO %s VALUES " +
+                        "('POLAND', 'Test Data', 25, 5), " +
+                        "('CZECH', 'Test Data', 26, 5)",
+                testTable));
+        query(format("SELECT count(*) FROM %s WHERE regionkey = 5", testTable))
+                .assertThat()
+                .skippingTypesCheck()
+                .containsAll(resultBuilder(getSession())
+                        .row(2L)
+                        .build());
+
+        query(format("INSERT INTO %s values('POLAND', 'Overwrite', 25, 5)", testTable))
+                .assertThat()
+                .skippingTypesCheck()
+                .containsAll(resultBuilder(getSession())
+                        .row(1L)
+                        .build());
+        computeActual(format("DROP TABLE %s", testTable));
+    }
+
+    protected String getTestTableName()
+    {
+        return format("hive.%s.%s", HIVE_TEST_SCHEMA, "nation_" + randomTableSuffix());
+    }
+
+    protected String getCreateTableStatement(String tableName, String... propertiesEntries)
+    {
+        return getCreateTableStatement(tableName, Arrays.asList(propertiesEntries));
+    }
+
+    protected String getCreateTableStatement(String tableName, List<String> propertiesEntries)
+    {
+        return format(
+                "CREATE TABLE %s (" +
+                        "    name varchar(25), " +
+                        "    comment varchar(152),  " +
+                        "    nationkey bigint, " +
+                        "    regionkey bigint) " +
+                        (propertiesEntries.size() < 1 ? "" : propertiesEntries
+                                .stream()
+                                .collect(joining(",", "WITH (", ")"))),
+                tableName);
+    }
+
+    protected void copyTpchNationToTable(String testTable)
+    {
+        computeActual(format("INSERT INTO " + testTable + " SELECT name, comment, nationkey, regionkey FROM tpch.tiny.nation"));
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive2InsertOverwrite.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive2InsertOverwrite.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.plugin.hive.containers.HiveHadoop;
+
+public class TestHive2InsertOverwrite
+        extends BaseTestHiveInsertOverwrite
+{
+    public TestHive2InsertOverwrite()
+    {
+        super(HiveHadoop.DEFAULT_IMAGE);
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3InsertOverwrite.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHive3InsertOverwrite.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.plugin.hive.containers.HiveHadoop;
+import org.testng.annotations.Test;
+
+public class TestHive3InsertOverwrite
+        extends BaseTestHiveInsertOverwrite
+{
+    public TestHive3InsertOverwrite()
+    {
+        super(HiveHadoop.HIVE3_IMAGE);
+    }
+
+    @Test
+    public void testInsertOverwritePartitionedAndBucketedAcidTable()
+    {
+        String testTable = getTestTableName();
+        computeActual(getCreateTableStatement(
+                testTable,
+                "partitioned_by=ARRAY['regionkey']",
+                "bucketed_by = ARRAY['nationkey']",
+                "bucket_count = 3",
+                "format = 'ORC'",
+                "transactional = true"));
+        assertInsertFailure(
+                testTable,
+                "Overwriting existing partition in transactional tables doesn't support DIRECT_TO_TARGET_EXISTING_DIRECTORY write mode");
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveHadoop.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveHadoop.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.containers;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HostAndPort;
+import io.trino.testing.containers.BaseTestContainer;
+import org.testcontainers.containers.Network;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class HiveHadoop
+        extends BaseTestContainer
+{
+    private static final String IMAGE_VERSION = "43";
+    public static final String DEFAULT_IMAGE = "ghcr.io/trinodb/testing/hdp2.6-hive:" + IMAGE_VERSION;
+    public static final String HIVE3_IMAGE = "ghcr.io/trinodb/testing/hdp3.1-hive:" + IMAGE_VERSION;
+
+    public static final String HOST_NAME = "hadoop-master";
+
+    public static final int PROXY_PORT = 1180;
+    public static final int HIVE_SERVER_PORT = 10000;
+    public static final int HIVE_METASTORE_PORT = 9083;
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    private HiveHadoop(
+            String image,
+            String hostName,
+            Set<Integer> ports,
+            Map<String, String> filesToMount,
+            Map<String, String> envVars,
+            Optional<Network> network,
+            int startupRetryLimit)
+    {
+        super(
+                image,
+                hostName,
+                ports,
+                filesToMount,
+                envVars,
+                network,
+                startupRetryLimit);
+    }
+
+    @Override
+    protected void setupContainer()
+    {
+        super.setupContainer();
+        String runCmd = "/usr/local/hadoop-run.sh";
+        copyFileToContainer("containers/hive_hadoop/hadoop-run.sh", runCmd);
+        withRunCommand(
+                ImmutableList.of(
+                        "/bin/bash",
+                        runCmd));
+    }
+
+    public HostAndPort getMappedHdfsSocksProxy()
+    {
+        return getMappedHostAndPortForExposedPort(PROXY_PORT);
+    }
+
+    public HostAndPort getHiveServerEndpoint()
+    {
+        return getMappedHostAndPortForExposedPort(HIVE_SERVER_PORT);
+    }
+
+    public HostAndPort getHiveMetastoreEndpoint()
+    {
+        return getMappedHostAndPortForExposedPort(HIVE_METASTORE_PORT);
+    }
+
+    public static class Builder
+            extends BaseTestContainer.Builder<HiveHadoop.Builder, HiveHadoop>
+    {
+        private Builder()
+        {
+            this.image = DEFAULT_IMAGE;
+            this.hostName = HOST_NAME;
+            this.exposePorts =
+                    ImmutableSet.of(
+                            HIVE_METASTORE_PORT,
+                            PROXY_PORT);
+        }
+
+        @Override
+        public HiveHadoop build()
+        {
+            return new HiveHadoop(image, hostName, exposePorts, filesToMount, envVars, network, startupRetryLimit);
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveMinioDataLake.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/HiveMinioDataLake.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.containers;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.google.common.collect.ImmutableMap;
+import io.trino.util.AutoCloseableCloser;
+import org.testcontainers.containers.Network;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+import static org.testcontainers.containers.Network.newNetwork;
+
+public class HiveMinioDataLake
+        implements AutoCloseable
+{
+    public static final String ACCESS_KEY = "accesskey";
+    public static final String SECRET_KEY = "secretkey";
+
+    private final String bucketName;
+    private final Minio minio;
+    private final HiveHadoop hiveHadoop;
+
+    private final AtomicBoolean isStarted = new AtomicBoolean(false);
+    private final AutoCloseableCloser closer = AutoCloseableCloser.create();
+
+    public HiveMinioDataLake(String bucketName, Map<String, String> hiveHadoopFilesToMount)
+    {
+        this(bucketName, hiveHadoopFilesToMount, HiveHadoop.DEFAULT_IMAGE);
+    }
+
+    public HiveMinioDataLake(String bucketName, Map<String, String> hiveHadoopFilesToMount, String hiveHadoopImage)
+    {
+        this.bucketName = requireNonNull(bucketName, "bucketName is null");
+        Network network = closer.register(newNetwork());
+        this.minio = closer.register(
+                Minio.builder()
+                        .withNetwork(network)
+                        .withEnvVars(ImmutableMap.<String, String>builder()
+                                .put("MINIO_ACCESS_KEY", ACCESS_KEY)
+                                .put("MINIO_SECRET_KEY", SECRET_KEY)
+                                .build())
+                        .build());
+        this.hiveHadoop = closer.register(
+                HiveHadoop.builder()
+                        .withFilesToMount(ImmutableMap.<String, String>builder()
+                                .put("hive_s3_insert_overwrite/hive-core-site.xml", "/etc/hadoop/conf/core-site.xml")
+                                .putAll(hiveHadoopFilesToMount)
+                                .build())
+                        .withImage(hiveHadoopImage)
+                        .withNetwork(network)
+                        .build());
+    }
+
+    public void start()
+    {
+        if (isStarted()) {
+            return;
+        }
+        try {
+            this.minio.start();
+            this.hiveHadoop.start();
+            AmazonS3 s3Client = AmazonS3ClientBuilder
+                    .standard()
+                    .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
+                            "http://localhost:" + minio.getMinioApiEndpoint().getPort(),
+                            "us-east-1"))
+                    .withPathStyleAccessEnabled(true)
+                    .withCredentials(new AWSStaticCredentialsProvider(
+                            new BasicAWSCredentials(ACCESS_KEY, SECRET_KEY)))
+                    .build();
+            s3Client.createBucket(this.bucketName);
+        }
+        finally {
+            isStarted.set(true);
+        }
+    }
+
+    public boolean isStarted()
+    {
+        return isStarted.get();
+    }
+
+    public void stop()
+    {
+        if (!isStarted()) {
+            return;
+        }
+        try {
+            closer.close();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to stop HiveMinioDataLake", e);
+        }
+        finally {
+            isStarted.set(false);
+        }
+    }
+
+    public Minio getMinio()
+    {
+        return minio;
+    }
+
+    public HiveHadoop getHiveHadoop()
+    {
+        return hiveHadoop;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        stop();
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/Minio.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/containers/Minio.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.containers;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HostAndPort;
+import io.airlift.log.Logger;
+import io.trino.testing.containers.BaseTestContainer;
+import org.testcontainers.containers.Network;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.lang.String.format;
+
+public class Minio
+        extends BaseTestContainer
+{
+    private static final Logger log = Logger.get(Minio.class);
+
+    public static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2021-07-15T22-27-34Z";
+    public static final String DEFAULT_HOST_NAME = "minio";
+
+    public static final int MINIO_API_PORT = 4566;
+    public static final int MINIO_CONSOLE_PORT = 4567;
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    private Minio(
+            String image,
+            String hostName,
+            Set<Integer> exposePorts,
+            Map<String, String> filesToMount,
+            Map<String, String> envVars,
+            Optional<Network> network,
+            int retryLimit)
+    {
+        super(
+                image,
+                hostName,
+                exposePorts,
+                filesToMount,
+                envVars,
+                network,
+                retryLimit);
+    }
+
+    @Override
+    protected void setupContainer()
+    {
+        super.setupContainer();
+        withRunCommand(
+                ImmutableList.of(
+                        "server",
+                        "--address", "0.0.0.0:" + MINIO_API_PORT,
+                        "--console-address", "0.0.0.0:" + MINIO_CONSOLE_PORT,
+                        "/data"));
+    }
+
+    @Override
+    protected void startContainer()
+    {
+        super.startContainer();
+        log.info(format(
+                "MinIO container started with address for api: http://%s and console: http://%s",
+                getMinioApiEndpoint().toString(),
+                getMinioConsoleEndpoint().toString()));
+    }
+
+    public HostAndPort getMinioApiEndpoint()
+    {
+        return getMappedHostAndPortForExposedPort(MINIO_API_PORT);
+    }
+
+    public HostAndPort getMinioConsoleEndpoint()
+    {
+        return getMappedHostAndPortForExposedPort(MINIO_CONSOLE_PORT);
+    }
+
+    public static class Builder
+            extends BaseTestContainer.Builder<Minio.Builder, Minio>
+    {
+        private Builder()
+        {
+            this.image = DEFAULT_IMAGE;
+            this.hostName = DEFAULT_HOST_NAME;
+            this.exposePorts =
+                    ImmutableSet.of(
+                            MINIO_API_PORT,
+                            MINIO_CONSOLE_PORT);
+        }
+
+        @Override
+        public Minio build()
+        {
+            return new Minio(image, hostName, exposePorts, filesToMount, envVars, network, startupRetryLimit);
+        }
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/S3HiveQueryRunner.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive.s3;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HostAndPort;
+import io.trino.plugin.hive.HdfsConfig;
+import io.trino.plugin.hive.HdfsConfigurationInitializer;
+import io.trino.plugin.hive.HdfsEnvironment;
+import io.trino.plugin.hive.HiveConfig;
+import io.trino.plugin.hive.HiveHdfsConfiguration;
+import io.trino.plugin.hive.HiveQueryRunner;
+import io.trino.plugin.hive.authentication.NoHdfsAuthentication;
+import io.trino.plugin.hive.metastore.MetastoreConfig;
+import io.trino.plugin.hive.metastore.thrift.BridgingHiveMetastore;
+import io.trino.plugin.hive.metastore.thrift.TestingMetastoreLocator;
+import io.trino.plugin.hive.metastore.thrift.ThriftHiveMetastore;
+import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreConfig;
+import io.trino.testing.DistributedQueryRunner;
+
+import java.util.Map;
+import java.util.Optional;
+
+public final class S3HiveQueryRunner
+{
+    private S3HiveQueryRunner() {}
+
+    public static DistributedQueryRunner create(
+            HostAndPort hiveEndpoint,
+            HostAndPort s3Endpoint,
+            String s3AccessKey,
+            String s3SecretKey,
+            Map<String, String> additionalHiveProperties)
+            throws Exception
+    {
+        return HiveQueryRunner.builder()
+                .setMetastore(distributedQueryRunner -> new BridgingHiveMetastore(
+                        new ThriftHiveMetastore(
+                                new TestingMetastoreLocator(
+                                        Optional.empty(),
+                                        hiveEndpoint),
+                                new HiveConfig(),
+                                new MetastoreConfig(),
+                                new ThriftMetastoreConfig(),
+                                new HdfsEnvironment(new HiveHdfsConfiguration(
+                                        new HdfsConfigurationInitializer(
+                                                new HdfsConfig(),
+                                                ImmutableSet.of()),
+                                        ImmutableSet.of()),
+                                        new HdfsConfig(),
+                                        new NoHdfsAuthentication()),
+                                false)))
+                .setHiveProperties(ImmutableMap.<String, String>builder()
+                        .put("hive.s3.endpoint", "http://" + s3Endpoint)
+                        .put("hive.s3.aws-access-key", s3AccessKey)
+                        .put("hive.s3.aws-secret-key", s3SecretKey)
+                        .putAll(additionalHiveProperties)
+                        .build())
+                .setInitialTables(ImmutableList.of())
+                .build();
+    }
+}

--- a/plugin/trino-hive/src/test/resources/containers/hive_hadoop/hadoop-run.sh
+++ b/plugin/trino-hive/src/test/resources/containers/hive_hadoop/hadoop-run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if test $# -gt 0; then
+    echo "$0 does not accept arguments" >&2
+    exit 32
+fi
+
+set -x
+
+trap exit INT
+
+echo "Running services with supervisord"
+
+supervisord -c /etc/supervisord.conf

--- a/plugin/trino-hive/src/test/resources/hive_s3_insert_overwrite/hive-core-site.xml
+++ b/plugin/trino-hive/src/test/resources/hive_s3_insert_overwrite/hive-core-site.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<configuration>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://hadoop-master:9000</value>
+    </property>
+    <property>
+        <name>fs.s3a.endpoint</name>
+        <value>http://minio:4566</value>
+    </property>
+    <property>
+        <name>fs.s3a.access.key</name>
+        <value>accesskey</value>
+    </property>
+    <property>
+        <name>fs.s3a.secret.key</name>
+        <value>secretkey</value>
+    </property>
+    <property>
+        <name>fs.s3a.path.style.access</name>
+        <value>true</value>
+    </property>
+</configuration>

--- a/testing/trino-testing/pom.xml
+++ b/testing/trino-testing/pom.xml
@@ -101,6 +101,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <version>${dep.docker-java.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
         </dependency>
@@ -123,6 +129,11 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
         </dependency>
 
         <dependency>

--- a/testing/trino-testing/src/main/java/io/trino/testing/containers/BaseTestContainer.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/containers/BaseTestContainer.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing.containers;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HostAndPort;
+import io.airlift.log.Logger;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.net.HostAndPort.fromParts;
+import static java.util.Objects.requireNonNull;
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
+import static org.testcontainers.utility.MountableFile.forHostPath;
+
+public abstract class BaseTestContainer
+        implements AutoCloseable
+{
+    private final Logger log;
+
+    private final String hostName;
+    private final Set<Integer> ports;
+    private final Map<String, String> filesToMount;
+    private final Map<String, String> envVars;
+    private final Optional<Network> network;
+    private final int startupRetryLimit;
+
+    private GenericContainer<?> container;
+
+    protected BaseTestContainer(
+            String image,
+            String hostName,
+            Set<Integer> ports,
+            Map<String, String> filesToMount,
+            Map<String, String> envVars,
+            Optional<Network> network,
+            int startupRetryLimit)
+    {
+        checkArgument(startupRetryLimit > 0, "startupRetryLimit needs to be greater or equal to 0");
+        this.log = Logger.get(this.getClass());
+        this.container = new GenericContainer<>(requireNonNull(image, "image is null"));
+        this.ports = requireNonNull(ports, "ports is null");
+        this.hostName = requireNonNull(hostName, "hostName is null");
+        this.filesToMount = requireNonNull(filesToMount, "filesToMount is null");
+        this.envVars = requireNonNull(envVars, "envVars is null");
+        this.network = requireNonNull(network, "network is null");
+        this.startupRetryLimit = startupRetryLimit;
+        setupContainer();
+    }
+
+    protected void setupContainer()
+    {
+        for (int port : this.ports) {
+            container.addExposedPort(port);
+        }
+        filesToMount.forEach(this::copyFileToContainer);
+        container.withEnv(envVars);
+        container.withCreateContainerCmdModifier(c -> c.withHostName(hostName))
+                .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                .waitingFor(Wait.forListeningPort())
+                .withStartupTimeout(Duration.ofMinutes(5));
+        network.ifPresent(container::withNetwork);
+    }
+
+    protected void withRunCommand(List<String> runCommand)
+    {
+        container.withCommand(runCommand.toArray(new String[runCommand.size()]));
+    }
+
+    protected void copyFileToContainer(String resourcePath, String dockerPath)
+    {
+        container.withCopyFileToContainer(
+                forHostPath(
+                        forClasspathResource(resourcePath)
+                                // Container fails to mount jar:file:/<host_path>!<resource_path> resources
+                                // This assures that JAR resources are being copied out to tmp locations
+                                // and mounted from there.
+                                .getResolvedPath()),
+                dockerPath);
+    }
+
+    protected void startContainer()
+    {
+        Failsafe.with(new RetryPolicy<>()
+                        .withMaxRetries(startupRetryLimit)
+                        .onRetry(event -> log.warn(
+                                "%s initialization failed (attempt %s), will retry. Exception: %s",
+                                this.getClass().getSimpleName(),
+                                event.getAttemptCount(),
+                                event.getLastFailure().getMessage())))
+                .get(() -> TestContainers.startOrReuse(this.container));
+    }
+
+    protected HostAndPort getMappedHostAndPortForExposedPort(int exposedPort)
+    {
+        return fromParts(container.getHost(), container.getMappedPort(exposedPort));
+    }
+
+    public void start()
+    {
+        setupContainer();
+        startContainer();
+    }
+
+    public void stop()
+    {
+        container.stop();
+    }
+
+    @Override
+    public void close()
+    {
+        stop();
+    }
+
+    protected abstract static class Builder<SELF extends BaseTestContainer.Builder, BUILD extends BaseTestContainer>
+    {
+        protected String image;
+        protected String hostName;
+        protected Set<Integer> exposePorts = ImmutableSet.of();
+        protected Map<String, String> filesToMount = ImmutableMap.of();
+        protected Map<String, String> envVars = ImmutableMap.of();
+        protected Optional<Network> network = Optional.empty();
+        protected int startupRetryLimit = 1;
+
+        protected SELF self;
+
+        @SuppressWarnings("unchecked")
+        public Builder()
+        {
+            this.self = (SELF) this;
+        }
+
+        public SELF withImage(String image)
+        {
+            this.image = image;
+            return self;
+        }
+
+        public SELF withHostName(String hostName)
+        {
+            this.hostName = hostName;
+            return self;
+        }
+
+        public SELF withExposePorts(Set<Integer> exposePorts)
+        {
+            this.exposePorts = exposePorts;
+            return self;
+        }
+
+        public SELF withFilesToMount(Map<String, String> filesToMount)
+        {
+            this.filesToMount = filesToMount;
+            return self;
+        }
+
+        public SELF withEnvVars(Map<String, String> envVars)
+        {
+            this.envVars = envVars;
+            return self;
+        }
+
+        public SELF withNetwork(Network network)
+        {
+            this.network = Optional.of(network);
+            return self;
+        }
+
+        public SELF withStartupRetryLimit(int startupRetryLimit)
+        {
+            this.startupRetryLimit = startupRetryLimit;
+            return self;
+        }
+
+        public abstract BUILD build();
+    }
+}


### PR DESCRIPTION
This PR  :
- fixes insert overwrite operation on S3 backing storage when below property is set
```
hive.insert-existing-partitions-behavior=OVERWRITE
```
Applied fix writes to partition target directory directly. After successfully writing new files coordinator deletes all files within partition whose name prefix or suffix didn't match current query ID

add's test utils:
- test containers for HMS and MinIO allowing to test and debug S3 related issue easily from IDE
- based on above Local dockerized S3 data lake