### PR TITLE
Sanitize artifact names when uploading results in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,11 +287,19 @@ jobs:
           $RETRY $MAVEN install ${MAVEN_FAST_INSTALL} -am -pl $(echo '${{ matrix.modules }}' | cut -d' ' -f1)
       - name: Maven Tests
         run: $MAVEN test ${MAVEN_TEST} -pl ${{ matrix.modules }}
+      - name: Sanitize artifact name
+        if: always()
+        run: |
+          # Generate a valid artifact name and make it available to next steps as
+          # an environment variable ARTIFACT_NAME
+          # ", :, <, >, |, *, ?, \, / are not allowed in artifact names but we only use : so we remove it
+          name=$(echo -n "${{ matrix.modules }}" | sed -e 's/[:]//g')
+          echo "ARTIFACT_NAME=$name" >> $GITHUB_ENV
       - name: Upload test results
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: result ${{ matrix.modules }}
+          name: result ${{ env.ARTIFACT_NAME }}
           path: |
             **/target/surefire-reports
             **/target/checkstyle-*


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/trinodb/trino/pull/9205#issuecomment-918305958

Workaround for https://github.com/actions/upload-artifact/issues/22

