### PR TITLE
Fix failure when querying optimizer_rule_stats system table

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/CoordinatorModule.java
@@ -87,6 +87,7 @@ import io.trino.sql.planner.OptimizerStatsMBeanExporter;
 import io.trino.sql.planner.PlanFragmenter;
 import io.trino.sql.planner.PlanOptimizers;
 import io.trino.sql.planner.PlanOptimizersFactory;
+import io.trino.sql.planner.RuleStatsRecorder;
 import io.trino.transaction.ForTransactionManager;
 import io.trino.transaction.InMemoryTransactionManager;
 import io.trino.transaction.TransactionManager;
@@ -215,6 +216,7 @@ public class CoordinatorModule
                 .setDefault().to(PlanOptimizers.class).in(Scopes.SINGLETON);
 
         // Optimizer/Rule Stats exporter
+        binder.bind(RuleStatsRecorder.class).in(Scopes.SINGLETON);
         binder.bind(OptimizerStatsMBeanExporter.class).in(Scopes.SINGLETON);
 
         // query explainer

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -252,12 +252,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.trino.SystemSessionProperties.isIterativeRuleBasedColumnPruning;
+import static java.util.Objects.requireNonNull;
 
 public class PlanOptimizers
         implements PlanOptimizersFactory
 {
     private final List<PlanOptimizer> optimizers;
-    private final RuleStatsRecorder ruleStats = new RuleStatsRecorder();
+    private final RuleStatsRecorder ruleStats;
     private final OptimizerStatsRecorder optimizerStats = new OptimizerStatsRecorder();
 
     @Inject
@@ -274,7 +275,8 @@ public class PlanOptimizers
             @EstimatedExchanges CostCalculator estimatedExchangesCostCalculator,
             CostComparator costComparator,
             TaskCountEstimator taskCountEstimator,
-            NodePartitioningManager nodePartitioningManager)
+            NodePartitioningManager nodePartitioningManager,
+            RuleStatsRecorder ruleStats)
     {
         this(metadata,
                 typeOperators,
@@ -289,7 +291,8 @@ public class PlanOptimizers
                 estimatedExchangesCostCalculator,
                 costComparator,
                 taskCountEstimator,
-                nodePartitioningManager);
+                nodePartitioningManager,
+                ruleStats);
     }
 
     public PlanOptimizers(
@@ -306,8 +309,10 @@ public class PlanOptimizers
             CostCalculator estimatedExchangesCostCalculator,
             CostComparator costComparator,
             TaskCountEstimator taskCountEstimator,
-            NodePartitioningManager nodePartitioningManager)
+            NodePartitioningManager nodePartitioningManager,
+            RuleStatsRecorder ruleStats)
     {
+        this.ruleStats = requireNonNull(ruleStats, "ruleStats is null");
         ImmutableList.Builder<PlanOptimizer> builder = ImmutableList.builder();
 
         Set<Rule<?>> columnPruningRules = ImmutableSet.of(

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -157,6 +157,7 @@ import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.PlanFragmenter;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.PlanOptimizers;
+import io.trino.sql.planner.RuleStatsRecorder;
 import io.trino.sql.planner.SubPlan;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.optimizations.PlanOptimizer;
@@ -1041,7 +1042,8 @@ public class LocalQueryRunner
                         estimatedExchangesCostCalculator,
                         new CostComparator(featuresConfig),
                         taskCountEstimator,
-                        nodePartitioningManager).get();
+                        nodePartitioningManager,
+                        new RuleStatsRecorder()).get();
         private OperatorFactories operatorFactories = new TrinoOperatorFactories();
 
         private Builder(Session defaultSession)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSystemConnector.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSystemConnector.java
@@ -38,6 +38,14 @@ public class TestSystemConnector
     }
 
     @Test(groups = {SYSTEM_CONNECTOR, JDBC})
+    public void testRuleStats()
+    {
+        assertThat(query("SELECT rule_name, invocations, matches, failures FROM system.runtime.optimizer_rule_stats"))
+                .hasColumns(VARCHAR, BIGINT, BIGINT, BIGINT)
+                .hasAnyRows();
+    }
+
+    @Test(groups = {SYSTEM_CONNECTOR, JDBC})
     public void selectRuntimeQueries()
     {
         String sql = "SELECT" +

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -40,6 +40,7 @@ import io.trino.sql.parser.SqlParser;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.PlanFragmenter;
 import io.trino.sql.planner.PlanOptimizers;
+import io.trino.sql.planner.RuleStatsRecorder;
 import io.trino.sql.planner.TypeAnalyzer;
 import io.trino.sql.planner.optimizations.PlanNodeSearcher;
 import io.trino.sql.planner.optimizations.PlanOptimizer;
@@ -438,7 +439,8 @@ public abstract class AbstractTestQueryFramework
                 new CostCalculatorWithEstimatedExchanges(costCalculator, taskCountEstimator),
                 new CostComparator(featuresConfig),
                 taskCountEstimator,
-                queryRunner.getNodePartitioningManager()).get();
+                queryRunner.getNodePartitioningManager(),
+                new RuleStatsRecorder()).get();
         return new QueryExplainer(
                 optimizers,
                 new PlanFragmenter(metadata, queryRunner.getNodePartitioningManager(), new QueryManagerConfig()),


### PR DESCRIPTION
RuleStatsRecorder was being constructed directly inside PlanOptimizers
instead of being injected and made available also to RuleStatsSystemTable.

Fixes https://github.com/trinodb/trino/issues/8700