### PR TITLE
Execute ./mvnw -v before getting version in milestone job

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get milestone from pom.xml
         run: |
+          ./mvnw -v
           echo "MILESTONE_NUMBER=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' -N exec:exec | cut -d- -f1)" >> $GITHUB_ENV
       - name: Set milestone to PR
         uses: actions/github-script@v3


### PR DESCRIPTION
Test result in my personal repository
<img width="1763" alt="Screen Shot 2021-09-14 at 13 01 15" src="https://user-images.githubusercontent.com/6237050/133193040-30aa63ea-bb5e-49ff-8432-dc9267d55ab8.png">

Reference https://github.com/trinodb/trino/pull/9231#issuecomment-918757679