### PR TITLE
Reset all PrimitiveColumnWriter fields when writer is reset

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/PrimitiveColumnWriter.java
@@ -315,6 +315,9 @@ public class PrimitiveColumnWriter
     @Override
     public void reset()
     {
+        definitionLevelEncoder.reset();
+        repetitionLevelEncoder.reset();
+        primitiveValueWriter.reset();
         pageBuffer.clear();
         closed = false;
 


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/5518