### PR TITLE
Add write batch size to common properties fragment

### DIFF
--- a/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
@@ -25,3 +25,8 @@ connector:
     - Cache the fact that metadata, including table and column statistics, is
       not available
     - False
+  * - ``write.batch-size``
+    - Maximum number of statements in a batched execution.
+      Do not change this setting from the default. Non-default values may
+      negatively impact performance.
+    - 1000


### PR DESCRIPTION
Follow-up from https://github.com/trinodb/trino/pull/8712

Document the ``write.batch-size`` configuration property, with warning about performance impact, in the JDBC common configuration properties fragment.