### PR TITLE
Improve JDBC connector configuration documentation

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -23,8 +23,8 @@ The connector can query a ClickHouse server. Create a catalog properties file
 that specifies the ClickHouse connector by setting the ``connector.name`` to
 ``clickhouse``.
 
-For example, to access a server as ``myclickhouse``, create the file
-``etc/catalog/myclickhouse.properties``. Replace the connection properties as
+For example, to access a server as ``clickhouse``, create the file
+``etc/catalog/clickhouse.properties``. Replace the connection properties as
 appropriate for your setup:
 
 .. code-block:: none
@@ -33,10 +33,6 @@ appropriate for your setup:
     connection-url=jdbc:clickhouse://host1:8123/
     connection-user=exampleuser
     connection-password=examplepassword
-
-.. include:: jdbc-common-configurations.fragment
-
-.. include:: non-transactional-insert.fragment
 
 Multiple ClickHouse servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,6 +45,10 @@ catalog for each server. To add another catalog:
 
 For example, if you name the property file ``sales.properties``, Trino uses the
 configured connector to create a catalog named ``sales``.
+
+.. include:: jdbc-common-configurations.fragment
+
+.. include:: non-transactional-insert.fragment
 
 Querying ClickHouse
 -------------------

--- a/docs/src/main/sphinx/connector/druid.rst
+++ b/docs/src/main/sphinx/connector/druid.rst
@@ -21,8 +21,8 @@ Create a catalog properties file that specifies the Druid connector by setting
 the ``connector.name`` to ``druid`` and configuring the ``connection-url`` with
 the JDBC string to connect to Druid.
 
-For example, to access a database as ``druiddb``, create the file
-``etc/catalog/druiddb.properties``. Replace ``BROKER:8082`` with the correct
+For example, to access a database as ``druid``, create the file
+``etc/catalog/druid.properties``. Replace ``BROKER:8082`` with the correct
 host and port of your Druid broker.
 
 .. code-block:: properties

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -20,8 +20,8 @@ Configuration
 -------------
 
 To configure the SingleStore connector, create a catalog properties file
-in ``etc/catalog`` named, for example, ``memsql.properties``, to
-mount the SingleStore connector as the ``memsql`` catalog.
+in ``etc/catalog`` named, for example, ``singlestore.properties``, to
+mount the SingleStore connector as the ``singlestore`` catalog.
 Create the file with the following contents, replacing the
 connection properties as appropriate for your setup:
 
@@ -32,10 +32,6 @@ connection properties as appropriate for your setup:
     connection-user=root
     connection-password=secret
 
-.. include:: jdbc-common-configurations.fragment
-
-.. include:: non-transactional-insert.fragment
-
 Multiple SingleStore servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -44,6 +40,10 @@ SingleStore servers, simply add another properties file to ``etc/catalog``
 with a different name (making sure it ends in ``.properties``). For
 example, if you name the property file ``sales.properties``, Trino
 will create a catalog named ``sales`` using the configured connector.
+
+.. include:: jdbc-common-configurations.fragment
+
+.. include:: non-transactional-insert.fragment
 
 Querying SingleStore
 --------------------

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -50,10 +50,6 @@ determine the user credentials for the connection, often a service user. You can
 use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
 properties files.
 
-.. include:: jdbc-common-configurations.fragment
-
-.. include:: non-transactional-insert.fragment
-
 Multiple MySQL servers
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -62,6 +58,10 @@ MySQL servers, simply add another properties file to ``etc/catalog``
 with a different name, making sure it ends in ``.properties``. For
 example, if you name the property file ``sales.properties``, Trino
 creates a catalog named ``sales`` using the configured connector.
+
+.. include:: jdbc-common-configurations.fragment
+
+.. include:: non-transactional-insert.fragment
 
 .. _mysql-type-mapping:
 

--- a/docs/src/main/sphinx/connector/oracle.rst
+++ b/docs/src/main/sphinx/connector/oracle.rst
@@ -65,10 +65,6 @@ To disable connection pooling, update properties to include the following:
 
     oracle.connection-pool.enabled=false
 
-.. include:: jdbc-common-configurations.fragment
-
-.. include:: non-transactional-insert.fragment
-
 Multiple Oracle servers
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -77,7 +73,11 @@ the Oracle connector as a separate catalog.
 
 To add another Oracle catalog, create a new properties file. For example, if
 you name the property file ``sales.properties``, Trino creates a catalog named
-sales.
+``sales``.
+
+.. include:: jdbc-common-configurations.fragment
+
+.. include:: non-transactional-insert.fragment
 
 Querying Oracle
 ---------------

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -23,8 +23,8 @@ The connector can query a database on a PostgreSQL server. Create a catalog
 properties file that specifies the PostgreSQL connector by setting the
 ``connector.name`` to ``postgresql``.
 
-For example, to access a database as the ``postgresqlsdb`` catalog, create the
-file ``etc/catalog/postgresqlsdb.properties``. Replace the connection properties
+For example, to access a database as the ``postgresql`` catalog, create the
+file ``etc/catalog/postgresql.properties``. Replace the connection properties
 as appropriate for your setup:
 
 .. code-block:: text
@@ -46,10 +46,6 @@ determine the user credentials for the connection, often a service user. You can
 use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
 properties files.
 
-.. include:: jdbc-common-configurations.fragment
-
-.. include:: non-transactional-insert.fragment
-
 Multiple PostgreSQL databases or servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -62,6 +58,10 @@ To add another catalog, simply add another properties file to ``etc/catalog``
 with a different name, making sure it ends in ``.properties``. For example,
 if you name the property file ``sales.properties``, Trino creates a
 catalog named ``sales`` using the configured connector.
+
+.. include:: jdbc-common-configurations.fragment
+
+.. include:: non-transactional-insert.fragment
 
 .. _postgresql-type-mapping:
 

--- a/docs/src/main/sphinx/connector/redshift.rst
+++ b/docs/src/main/sphinx/connector/redshift.rst
@@ -31,10 +31,6 @@ connection properties as appropriate for your setup:
     connection-user=root
     connection-password=secret
 
-.. include:: jdbc-common-configurations.fragment
-
-.. include:: non-transactional-insert.fragment
-
 Multiple Redshift databases or clusters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -47,6 +43,10 @@ To add another catalog, simply add another properties file to ``etc/catalog``
 with a different name, making sure it ends in ``.properties``. For example,
 if you name the property file ``sales.properties``, Trino creates a
 catalog named ``sales`` using the configured connector.
+
+.. include:: jdbc-common-configurations.fragment
+
+.. include:: non-transactional-insert.fragment
 
 Querying Redshift
 -----------------

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -23,8 +23,8 @@ The connector can query a single database on an SQL server instance. Create a
 catalog properties file that specifies the SQL server connector by setting the
 ``connector.name`` to ``sqlserver``.
 
-For example, to access a database as ``sqlserverdb``, create the file
-``etc/catalog/sqlserverdb.properties``. Replace the connection properties as
+For example, to access a database as ``sqlserver``, create the file
+``etc/catalog/sqlserver.properties``. Replace the connection properties as
 appropriate for your setup:
 
 .. code-block:: properties
@@ -44,26 +44,22 @@ determine the user credentials for the connection, often a service user. You can
 use :doc:`secrets </security/secrets>` to avoid actual values in the catalog
 properties files.
 
-.. include:: jdbc-common-configurations.fragment
-
-.. include:: non-transactional-insert.fragment
-
 Multiple SQL Server databases or servers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The SQL Server connector can't access more than one database using a single
-catalog.
+The SQL Server connector can only access a single SQL Server database
+within a single catalog. Thus, if you have multiple SQL Server databases,
+or want to connect to multiple SQL Server instances, you must configure
+multiple instances of the SQL Server connector.
 
-If you have multiple databases, or want to access multiple instances
-of SQL Server, you need to configure one catalog for each instance.
+To add another catalog, simply add another properties file to ``etc/catalog``
+with a different name, making sure it ends in ``.properties``. For example,
+if you name the property file ``sales.properties``, Trino creates a
+catalog named ``sales`` using the configured connector.
 
-To add another catalog:
+.. include:: jdbc-common-configurations.fragment
 
-- Add another properties file to ``etc/catalog``
-- Save it with a different name that ends in ``.properties``
-
-For example, if you name the property file ``sales.properties``, Trino uses the
-configured connector to create a catalog named ``sales``.
+.. include:: non-transactional-insert.fragment
 
 Querying SQL Server
 -------------------


### PR DESCRIPTION
Simplify catalog names and move section about multiple catalogs to be directly below the main configuration section.