### PR TITLE
Document the way to show VM options in IntelliJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ development. Use the following options to create a run configuration:
 The working directory should be the `trino-server-dev` subdirectory. In
 IntelliJ, using `$MODULE_DIR$` accomplishes this automatically.
 
+If `VM options` doesn't exist in the dialog, you need to select `Modify options`
+and enable `Add VM options`.
+
 ### Running the CLI
 
 Start the CLI to connect to the server and run SQL queries:


### PR DESCRIPTION
I found some people set VM options to `Program arguments` by mistake because recent IntelliJ doesn't show `VM options` input form by default. 

<img width="388" alt="Screen Shot 2021-09-16 at 21 35 19" src="https://user-images.githubusercontent.com/6237050/133613097-4857835f-ae9e-41e6-a89f-e65fc0468929.png">
