### PR TITLE
Fix infinite loop in optimizer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -897,7 +897,7 @@ public class PlanOptimizers
                 costCalculator,
                 ImmutableSet.<Rule<?>>builder()
                         .addAll(simplifyOptimizerRules) // Should be always run after PredicatePushDown
-                        .add(new RemoveRedundantTableScanPredicate(metadata, typeOperators))
+                        .add(new RemoveRedundantTableScanPredicate(metadata, typeOperators, typeAnalyzer))
                         .build()));
         builder.add(pushProjectionIntoTableScanOptimizer);
         // Projection pushdown rules may push reducing projections (e.g. dereferences) below filters for potential

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyExpressions.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SimplifyExpressions.java
@@ -13,7 +13,6 @@
  */
 package io.trino.sql.planner.iterative.rule;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.metadata.Metadata;
@@ -38,8 +37,7 @@ import static java.util.Objects.requireNonNull;
 public class SimplifyExpressions
         extends ExpressionRewriteRuleSet
 {
-    @VisibleForTesting
-    static Expression rewrite(Expression expression, Session session, SymbolAllocator symbolAllocator, Metadata metadata, LiteralEncoder literalEncoder, TypeAnalyzer typeAnalyzer)
+    public static Expression rewrite(Expression expression, Session session, SymbolAllocator symbolAllocator, Metadata metadata, LiteralEncoder literalEncoder, TypeAnalyzer typeAnalyzer)
     {
         requireNonNull(metadata, "metadata is null");
         requireNonNull(typeAnalyzer, "typeAnalyzer is null");

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddExchanges.java
@@ -565,7 +565,7 @@ public class AddExchanges
                         (TableScanNode) node.getSource(),
                         true,
                         session,
-                        types,
+                        symbolAllocator,
                         metadata,
                         typeOperators,
                         typeAnalyzer,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTableScanPredicate.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTableScanPredicate.java
@@ -60,7 +60,7 @@ public class TestRemoveRedundantTableScanPredicate
     @BeforeClass
     public void setUpBeforeClass()
     {
-        removeRedundantTableScanPredicate = new RemoveRedundantTableScanPredicate(tester().getMetadata(), new TypeOperators());
+        removeRedundantTableScanPredicate = new RemoveRedundantTableScanPredicate(tester().getMetadata(), new TypeOperators(), tester().getTypeAnalyzer());
         CatalogName catalogName = tester().getCurrentConnectorId();
         TpchTableHandle nation = new TpchTableHandle("nation", 1.0);
         nationTableHandle = new TableHandle(

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestNestedLogicalBinaryExpression.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestNestedLogicalBinaryExpression.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.tpch.TpchConnectorFactory;
+import io.trino.testing.LocalQueryRunner;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for https://github.com/trinodb/trino/issues/9250
+ */
+public class TestNestedLogicalBinaryExpression
+{
+    private static final String CATALOG = "local";
+
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(CATALOG)
+                .setSchema(TINY_SCHEMA_NAME)
+                .build();
+
+        LocalQueryRunner runner = LocalQueryRunner.builder(session)
+                .build();
+
+        runner.createCatalog(CATALOG, new TpchConnectorFactory(1), ImmutableMap.of());
+
+        assertions = new QueryAssertions(runner);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void test()
+    {
+        assertThat(assertions.query("SELECT orderkey FROM orders WHERE custkey IS NULL OR custkey = 370 AND orderkey = 1"))
+                .matches("VALUES BIGINT '1'");
+    }
+}


### PR DESCRIPTION
Commit 39ebb43839c554469ee7dcde82199fa1db9352f6 surfaced an incompatibility between optimizer rules that causes ping-ponging and an infinite loop when the rules are placed in the same IterativeOptimizer.

For this query:

```sql
SELECT orderkey FROM orders WHERE custkey IS NULL OR custkey = 370 AND orderkey = 1
```

The SimplifyExpressions optimizer and RemoveRedundantTableScanPredicate ping pong between:

```
((("custkey" = BIGINT '370') OR ("custkey" IS NULL)) AND (("custkey" IS NULL) OR ("orderkey" = BIGINT '1')))
```

and

```
((("custkey" IS NULL) OR ("custkey" = BIGINT '370')) AND (("custkey" IS NULL) OR ("orderkey" = BIGINT '1')))
```

This is because PushPredicateIntoTableScan.createResultingPredicate() and ExtractCommonPredicatesExpressionRewriter.extractCommonPredicates() produce different canonicalizations of the expression. A simple, although not ideal, fix is to process the result of createResultingPredicate() through the same rewriter used by SimplifyExpressions to use the same canonical form.

Fixes https://github.com/trinodb/trino/issues/9250