### PR TITLE
Run milestone job in master branch push event

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Get milestone from pom.xml
         run: |
-          ./mvnw -v
+          .github/bin/retry ./mvnw -v
           echo "MILESTONE_NUMBER=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' -N exec:exec | cut -d- -f1)" >> $GITHUB_ENV
       - name: Set milestone to PR
         uses: actions/github-script@v3

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,9 +1,8 @@
 name: milestone
 
 on:
-  pull_request:
+  push:
     branches: [master]
-    types: [closed]
 
 jobs:
   set-milestone:
@@ -17,10 +16,23 @@ jobs:
           .github/bin/retry ./mvnw -v
           echo "MILESTONE_NUMBER=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' -N exec:exec | cut -d- -f1)" >> $GITHUB_ENV
       - name: Set milestone to PR
-        uses: actions/github-script@v3
+        uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
+            // Get pull request number from commit sha
+            // 'listPullRequestsAssociatedWithCommit()' lists the merged pull request
+            // https://docs.github.com/en/rest/reference/repos#list-pull-requests-associated-with-a-commit
+            const pr_response = await github.repos.listPullRequestsAssociatedWithCommit({ owner: context.repo.owner, repo:context.repo.repo, commit_sha: context.sha })
+            if (pr_response.data.length === 0) {
+              console.log('Pull request not found')
+              return
+            }
+            if (pr_response.data.length > 1) {
+              console.log(pr_response.data)
+              throw 'Expect 1 pull request but found: ' + pr_response.data.length
+            }
+
             // Get milestone
             const { MILESTONE_NUMBER } = process.env
 
@@ -35,4 +47,4 @@ jobs:
             }
 
             // Set milestone to PR
-            await github.issues.update({ owner: context.repo.owner, repo: context.repo.repo, milestone: milestone.number, issue_number: context.issue.number })
+            await github.issues.update({ owner: context.repo.owner, repo: context.repo.repo, milestone: milestone.number, issue_number: pr_response.data[0].number })


### PR DESCRIPTION
Tested in this repository: https://github.com/snowlift/github-actions-playground
In the past PR, I tested with my personal repository, but I should have tested with forked repository & PR considering GitHub token's permission diff.

https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
> Pull requests from public forks are still considered a special case and will receive a read token regardless of these settings.

https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions
> You can use the permissions key to add and remove read permissions for forked repositories, but typically you can't grant write access. The exception to this behavior is where an admin user has selected the Send write tokens to workflows from pull requests option in the GitHub Actions settings. For more information, see "Managing GitHub Actions settings for a repository."
