### PR TITLE
Fix unspill scheduling in join spill

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/HashBuilderOperator.java
@@ -596,6 +596,7 @@ public class HashBuilderOperator
         localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes());
 
         close();
+        spilledLookupSourceHandle.setDisposeCompleted();
     }
 
     private LookupSourceSupplier buildLookupSource()

--- a/core/trino-main/src/main/java/io/trino/operator/join/LookupSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/LookupSourceFactory.java
@@ -43,7 +43,10 @@ public interface LookupSourceFactory
                 i -> {
                     throw new UnsupportedOperationException();
                 },
-                i -> {}));
+                i -> {},
+                i -> {
+                    throw new UnsupportedOperationException();
+                }));
     }
 
     /**

--- a/core/trino-main/src/main/java/io/trino/operator/join/PartitionedConsumption.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/PartitionedConsumption.java
@@ -46,9 +46,14 @@ public final class PartitionedConsumption<T>
     @Nullable
     private List<Partition<T>> partitions;
 
-    PartitionedConsumption(int consumersCount, Iterable<Integer> partitionNumbers, IntFunction<ListenableFuture<T>> loader, IntConsumer disposer)
+    PartitionedConsumption(
+            int consumersCount,
+            Iterable<Integer> partitionNumbers,
+            IntFunction<ListenableFuture<T>> loader,
+            IntConsumer disposer,
+            IntFunction<ListenableFuture<Void>> disposed)
     {
-        this(consumersCount, immediateVoidFuture(), partitionNumbers, loader, disposer);
+        this(consumersCount, immediateVoidFuture(), partitionNumbers, loader, disposer, disposed);
     }
 
     private PartitionedConsumption(
@@ -56,18 +61,20 @@ public final class PartitionedConsumption<T>
             ListenableFuture<Void> activator,
             Iterable<Integer> partitionNumbers,
             IntFunction<ListenableFuture<T>> loader,
-            IntConsumer disposer)
+            IntConsumer disposer,
+            IntFunction<ListenableFuture<Void>> disposed)
     {
         checkArgument(consumersCount > 0, "consumersCount must be positive");
         this.consumersCount = consumersCount;
-        this.partitions = createPartitions(activator, partitionNumbers, loader, disposer);
+        this.partitions = createPartitions(activator, partitionNumbers, loader, disposer, disposed);
     }
 
     private List<Partition<T>> createPartitions(
             ListenableFuture<Void> activator,
             Iterable<Integer> partitionNumbers,
             IntFunction<ListenableFuture<T>> loader,
-            IntConsumer disposer)
+            IntConsumer disposer,
+            IntFunction<ListenableFuture<Void>> disposed)
     {
         requireNonNull(partitionNumbers, "partitionNumbers is null");
         requireNonNull(loader, "loader is null");
@@ -78,7 +85,7 @@ public final class PartitionedConsumption<T>
         for (Integer partitionNumber : partitionNumbers) {
             Partition<T> partition = new Partition<>(consumersCount, partitionNumber, loader, partitionActivator, disposer);
             partitions.add(partition);
-            partitionActivator = partition.released;
+            partitionActivator = disposed.apply(partitionNumber);
         }
         return partitions.build();
     }
@@ -111,7 +118,7 @@ public final class PartitionedConsumption<T>
         private final int partitionNumber;
         private final SettableFuture<Void> requested;
         private final ListenableFuture<T> loaded;
-        private final SettableFuture<Void> released;
+        private final IntConsumer disposer;
 
         @GuardedBy("this")
         private int pendingReleases;
@@ -129,8 +136,7 @@ public final class PartitionedConsumption<T>
                     allAsList(requested, previousReleased),
                     ignored -> loader.apply(partitionNumber),
                     directExecutor());
-            this.released = SettableFuture.create();
-            released.addListener(() -> disposer.accept(partitionNumber), directExecutor());
+            this.disposer = disposer;
             this.pendingReleases = consumersCount;
         }
 
@@ -151,7 +157,7 @@ public final class PartitionedConsumption<T>
             pendingReleases--;
             checkState(pendingReleases >= 0);
             if (pendingReleases == 0) {
-                released.set(null);
+                disposer.accept(partitionNumber);
             }
         }
     }

--- a/core/trino-main/src/main/java/io/trino/operator/join/PartitionedLookupSourceFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/PartitionedLookupSourceFactory.java
@@ -317,7 +317,10 @@ public final class PartitionedLookupSourceFactory
                         i -> {
                             throw new UnsupportedOperationException();
                         },
-                        i -> {}));
+                        i -> {},
+                        i -> {
+                            throw new UnsupportedOperationException();
+                        }));
             }
 
             int operatorsCount = lookupJoinsCount
@@ -338,7 +341,8 @@ public final class PartitionedLookupSourceFactory
                         partitionedConsumptionParticipants.getAsInt(),
                         spilledPartitions.keySet(),
                         this::loadSpilledLookupSource,
-                        this::disposeSpilledLookupSource));
+                        this::disposeSpilledLookupSource,
+                        this::spilledLookupSourceDisposed));
             }
 
             return partitionedConsumption;
@@ -356,6 +360,11 @@ public final class PartitionedLookupSourceFactory
     private void disposeSpilledLookupSource(int partitionNumber)
     {
         getSpilledLookupSourceHandle(partitionNumber).dispose();
+    }
+
+    private ListenableFuture<Void> spilledLookupSourceDisposed(int partitionNumber)
+    {
+        return getSpilledLookupSourceHandle(partitionNumber).getDisposeCompleted();
     }
 
     private SpilledLookupSourceHandle getSpilledLookupSourceHandle(int partitionNumber)


### PR DESCRIPTION
Comparable changes extracted from [prestodb/presto#16339](https://github.com/prestodb/presto/pull/16339)

Before the fix, unspill of next partition is
triggered when previous partition is released.
However, it just sends release request without
waiting for release to complete. As a result,
multiple partitions exist simultaneously and
result in memory limit error.