### PR TITLE
 Mark hive bucketed testBucketingWithUnsupportedDataTypes test as @Flaky 

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBucketedTables.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBucketedTables.java
@@ -310,6 +310,7 @@ public class TestHiveBucketedTables
     }
 
     @Test(dataProvider = "testBucketingWithUnsupportedDataTypesDataProvider")
+    @Flaky(issue = ERROR_COMMITTING_WRITE_TO_HIVE_ISSUE, match = ERROR_COMMITTING_WRITE_TO_HIVE_MATCH)
     public void testBucketingWithUnsupportedDataTypes(BucketingType bucketingType, String columnToBeBucketed)
     {
         try (TemporaryHiveTable table = temporaryHiveTable("table_with_unsupported_bucketing_types_" + randomTableSuffix())) {


### PR DESCRIPTION
It was stress checked [here](https://github.com/trinodb/trino/actions/runs/1244655670), failures were due to other flakiness - which will be fixed in subsequent PRs. 