### PR TITLE
 Mark hive table statistics testMixedHiveAndPrestoStatistics as @Flaky 

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTableStatistics.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTableStatistics.java
@@ -23,6 +23,7 @@ import io.trino.tempto.configuration.Configuration;
 import io.trino.tempto.fulfillment.table.MutableTableRequirement;
 import io.trino.tempto.fulfillment.table.hive.HiveTableDefinition;
 import io.trino.tempto.fulfillment.table.hive.InlineDataSource;
+import io.trino.testng.services.Flaky;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -1467,6 +1468,7 @@ public class TestHiveTableStatistics
     }
 
     @Test
+    @Flaky(issue = ERROR_COMMITTING_WRITE_TO_HIVE_ISSUE, match = ERROR_COMMITTING_WRITE_TO_HIVE_MATCH)
     public void testMixedHiveAndPrestoStatistics()
     {
         String tableName = "test_mixed_hive_and_presto_statistics";


### PR DESCRIPTION
It was stress checked [here](https://github.com/trinodb/trino/actions/runs/1244654592), It has other flakiness will be fixed in subsequent PRs. 