### PR TITLE
Recommend disabling "method always inverted" inspection

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -149,7 +149,8 @@ Enable the following inspections:
 Disable the following inspections:
 
 - ``Java | Performance | Call to 'Arrays.asList()' with too few arguments``,
-- ``Java | Abstraction issues | 'Optional' used as field or parameter type``.
+- ``Java | Abstraction issues | 'Optional' used as field or parameter type``,
+- ``Java | Data flow | Boolean method is always inverted``.
 
 Enable errorprone ([Error Prone Installation#IDEA](https://errorprone.info/docs/installation#intellij-idea)):
 - Install ``Error Prone Compiler`` plugin from marketplace,


### PR DESCRIPTION
While it generally makes sense, it's not always convenient to refactor such a method into something that's not contrived and/or containing multiple negations. For example, if we have a method `hasAccess`, it's natural that all users will react to its negation:

```java
if (!hasAccess()) {
   ...
}
```

But rephrasing it as `doesNotHaveAccess` might be much less readable.