### PR TITLE
Move ClickHouse tests to separate CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,7 @@ jobs:
             !:trino-raptor-legacy,
             !:trino-accumulo,
             !:trino-cassandra,
+            !:trino-clickhouse,
             !:trino-hive,!:trino-orc,!:trino-parquet,
             !:trino-mongodb,!:trino-kafka,!:trino-elasticsearch,
             !:trino-redis,
@@ -264,6 +265,7 @@ jobs:
           - ":trino-raptor-legacy"
           - ":trino-accumulo"
           - ":trino-cassandra"
+          - ":trino-clickhouse"
           - ":trino-hive,:trino-orc"
           - ":trino-hive,:trino-parquet -P test-parquet"
           - ":trino-mongodb,:trino-kafka,:trino-elasticsearch"


### PR DESCRIPTION
The tests are pretty flaky right now, and it makes sense to isolate them
to make CI feedback more useful.

Relates to https://github.com/trinodb/trino/issues/9300, https://github.com/trinodb/trino/issues/8073