### PR TITLE
Improve SortedPositionLinks performance

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/join/ArrayPositionLinks.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/ArrayPositionLinks.java
@@ -69,9 +69,9 @@ public final class ArrayPositionLinks
         }
 
         @Override
-        public int size()
+        public boolean isEmpty()
         {
-            return size;
+            return size == 0;
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/join/PositionLinks.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/PositionLinks.java
@@ -48,15 +48,7 @@ public interface PositionLinks
 
         Factory build();
 
-        /**
-         * @return number of linked elements
-         */
-        int size();
-
-        default boolean isEmpty()
-        {
-            return size() == 0;
-        }
+        boolean isEmpty();
     }
 
     interface Factory

--- a/core/trino-main/src/main/java/io/trino/operator/join/SortedPositionLinks.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/SortedPositionLinks.java
@@ -135,9 +135,9 @@ public final class SortedPositionLinks
         }
 
         @Override
-        public int size()
+        public boolean isEmpty()
         {
-            return positionLinks.size();
+            return positionLinks.isEmpty();
         }
 
         // Separate static method to avoid embedding references to "this"

--- a/core/trino-main/src/main/java/io/trino/operator/join/SortedPositionLinks.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/SortedPositionLinks.java
@@ -19,10 +19,12 @@ import io.trino.spi.Page;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrays;
 import it.unimi.dsi.fastutil.ints.IntComparator;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -45,9 +47,9 @@ public final class SortedPositionLinks
     public static class FactoryBuilder
             implements PositionLinks.FactoryBuilder
     {
-        private final Int2ObjectMap<IntArrayList> positionLinks;
+        private final Int2ObjectOpenHashMap<IntArrayList> positionLinks;
         private final int size;
-        private final IntComparator comparator;
+        private final PositionComparator comparator;
         private final PagesHashStrategy pagesHashStrategy;
         private final LongArrayList addresses;
 
@@ -79,8 +81,7 @@ public final class SortedPositionLinks
             // make sure that from value is the smaller one
             if (comparator.compare(from, to) > 0) {
                 // _from_ is larger so, just add to current chain _to_
-                List<Integer> links = positionLinks.computeIfAbsent(to, key -> new IntArrayList());
-                links.add(from);
+                positionLinks.computeIfAbsent(to, key -> new IntArrayList()).add(from);
                 return to;
             }
             else {
@@ -90,7 +91,7 @@ public final class SortedPositionLinks
                     links = new IntArrayList();
                 }
                 links.add(to);
-                checkState(positionLinks.putIfAbsent(from, links) == null, "sorted links is corrupted");
+                checkState(positionLinks.put(from, links) == null, "sorted links is corrupted");
                 return from;
             }
         }
@@ -109,26 +110,24 @@ public final class SortedPositionLinks
             ArrayPositionLinks.FactoryBuilder arrayPositionLinksFactoryBuilder = ArrayPositionLinks.builder(size);
             int[][] sortedPositionLinks = new int[size][];
 
-            for (Int2ObjectMap.Entry<IntArrayList> entry : positionLinks.int2ObjectEntrySet()) {
+            Iterator<Int2ObjectMap.Entry<IntArrayList>> iterator = positionLinks.int2ObjectEntrySet().fastIterator();
+            while (iterator.hasNext()) {
+                Int2ObjectOpenHashMap.Entry<IntArrayList> entry = iterator.next();
                 int key = entry.getIntKey();
-                IntArrayList positions = entry.getValue();
-                positions.sort(comparator);
+                IntArrayList positionsList = entry.getValue();
 
-                sortedPositionLinks[key] = new int[positions.size()];
-                for (int i = 0; i < positions.size(); i++) {
-                    sortedPositionLinks[key][i] = positions.getInt(i);
-                }
-
-                // ArrayPositionsLinks.Builder::link builds position links from
-                // tail to head, so we must add them in descending order to have
-                // smallest element as a head
-                for (int i = positions.size() - 2; i >= 0; i--) {
-                    arrayPositionLinksFactoryBuilder.link(positions.getInt(i), positions.getInt(i + 1));
-                }
-
-                // add link from starting position to position links chain
-                if (!positions.isEmpty()) {
-                    arrayPositionLinksFactoryBuilder.link(key, positions.getInt(0));
+                int[] positions = positionsList.toIntArray();
+                sortedPositionLinks[key] = positions;
+                if (positions.length > 0) {
+                    // Use the positionsList array for the merge sort temporary work buffer to avoid an extra redundant
+                    // copy. This works because we know that initially it has the same values as the array being sorted
+                    IntArrays.mergeSort(positions, 0, positions.length, comparator, positionsList.elements());
+                    // add link from starting position to position links chain
+                    arrayPositionLinksFactoryBuilder.link(key, positions[0]);
+                    // add links for the sorted internal elements
+                    for (int i = 0; i < positions.length - 1; i++) {
+                        arrayPositionLinksFactoryBuilder.link(positions[i], positions[i + 1]);
+                    }
                 }
             }
 
@@ -179,7 +178,7 @@ public final class SortedPositionLinks
         this.sizeInBytes = INSTANCE_SIZE + positionLinks.getSizeInBytes() + sizeOfPositionLinks(sortedPositionLinks);
         requireNonNull(searchFunctions, "searchFunctions is null");
         checkState(!searchFunctions.isEmpty(), "Using sortedPositionLinks with no search functions");
-        this.searchFunctions = searchFunctions.stream().toArray(JoinFilterFunction[]::new);
+        this.searchFunctions = searchFunctions.toArray(JoinFilterFunction[]::new);
     }
 
     private static long sizeOfPositionLinks(int[][] sortedPositionLinks)

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -425,7 +425,7 @@ public class LocalQueryRunner
         connectorManager.createCatalog(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());
 
         // rewrite session to use managed SessionPropertyMetadata
-        Optional<TransactionId> transactionId = withInitialTransaction ? Optional.of(transactionManager.beginTransaction(false)) : defaultSession.getTransactionId();
+        Optional<TransactionId> transactionId = withInitialTransaction ? Optional.of(transactionManager.beginTransaction(true)) : defaultSession.getTransactionId();
         this.defaultSession = new Session(
                 defaultSession.getQueryId(),
                 transactionId,

--- a/testing/trino-benchmark/src/test/java/io/trino/benchmark/BenchmarkInequalityJoin.java
+++ b/testing/trino-benchmark/src/test/java/io/trino/benchmark/BenchmarkInequalityJoin.java
@@ -25,6 +25,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.RunnerException;
+import org.testng.annotations.Test;
 
 import java.util.List;
 
@@ -133,6 +134,22 @@ public class BenchmarkInequalityJoin
     {
         return context.getQueryRunner()
                 .execute("SELECT count(*) FROM t1 JOIN t2 on (t1.bucket = t2.bucket) AND t2.val2 BETWEEN t1.val1 + 1 AND t1.val1 + 5");
+    }
+
+    @Test
+    public void verifyJoinBenchmark()
+    {
+        Context context = new Context();
+        try {
+            // Contrive a cheap benchmark setup for use in testing
+            context.buckets = 10;
+            context.filterOutCoefficient = 10;
+            context.setUp();
+            benchmarkJoin(context);
+        }
+        finally {
+            context.tearDown();
+        }
     }
 
     public static void main(String[] args)


### PR DESCRIPTION
Extracted from https://github.com/prestodb/presto/pull/16758

Improves the performance of inequality joins (specifically, building `SortedPositionLinks.Factory` instances by:
- Avoiding boxing the values to and from `Integer` while loading and extracting positions from `IntArrayList`
- Using `Int2ObjectOpenHashMap.fastIterator()` to avoid extra allocations inside of the entry set traversal
- Reusing the `IntArrayList` elements array as a temporary buffer for `IntArrays.mergeSort` (which was the implementation being called by `IntArrayList.sort`, but would make an extra copy of the array being sorted internally on each invocation)
- Making methods that used no instance state static