### PR TITLE
Run maven checks on JDK 17 instead of 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         java-version:
           - 11
-          - 16
+          - 17
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
JDK 17 is an LTS which makes it a candidate for next minimum required Java version.