### PR TITLE
Test Iceberg non-partition predicate pushdown

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -57,7 +57,6 @@ public class ParquetWriter
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ParquetWriter.class).instanceSize();
 
     private static final int CHUNK_MAX_BYTES = toIntExact(DataSize.of(128, MEGABYTE).toBytes());
-    private static final int DEFAULT_ROW_GROUP_MAX_ROW_COUNT = 10_000;
 
     private final List<ColumnWriter> columnWriters;
     private final OutputStreamSliceOutput outputStream;
@@ -127,7 +126,7 @@ public class ParquetWriter
         checkArgument(page.getChannelCount() == columnWriters.size());
 
         while (page != null) {
-            int chunkRows = min(page.getPositionCount(), DEFAULT_ROW_GROUP_MAX_ROW_COUNT);
+            int chunkRows = min(page.getPositionCount(), writerOption.getBatchSize());
             Page chunk = page.getRegion(0, chunkRows);
 
             // avoid chunk with huge logical size

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
@@ -23,6 +23,7 @@ public class ParquetWriterOptions
 {
     private static final DataSize DEFAULT_MAX_ROW_GROUP_SIZE = DataSize.ofBytes(ParquetWriter.DEFAULT_BLOCK_SIZE);
     private static final DataSize DEFAULT_MAX_PAGE_SIZE = DataSize.ofBytes(ParquetWriter.DEFAULT_PAGE_SIZE);
+    public static final int DEFAULT_BATCH_SIZE = 10_000;
 
     public static ParquetWriterOptions.Builder builder()
     {
@@ -31,11 +32,13 @@ public class ParquetWriterOptions
 
     private final int maxRowGroupSize;
     private final int maxPageSize;
+    private final int batchSize;
 
-    private ParquetWriterOptions(DataSize maxBlockSize, DataSize maxPageSize)
+    private ParquetWriterOptions(DataSize maxBlockSize, DataSize maxPageSize, int batchSize)
     {
         this.maxRowGroupSize = toIntExact(requireNonNull(maxBlockSize, "maxBlockSize is null").toBytes());
         this.maxPageSize = toIntExact(requireNonNull(maxPageSize, "maxPageSize is null").toBytes());
+        this.batchSize = batchSize;
     }
 
     public long getMaxRowGroupSize()
@@ -48,10 +51,16 @@ public class ParquetWriterOptions
         return maxPageSize;
     }
 
+    public int getBatchSize()
+    {
+        return batchSize;
+    }
+
     public static class Builder
     {
         private DataSize maxBlockSize = DEFAULT_MAX_ROW_GROUP_SIZE;
         private DataSize maxPageSize = DEFAULT_MAX_PAGE_SIZE;
+        private int batchSize = DEFAULT_BATCH_SIZE;
 
         public Builder setMaxBlockSize(DataSize maxBlockSize)
         {
@@ -65,9 +74,15 @@ public class ParquetWriterOptions
             return this;
         }
 
+        public Builder setBatchSize(int batchSize)
+        {
+            this.batchSize = batchSize;
+            return this;
+        }
+
         public ParquetWriterOptions build()
         {
-            return new ParquetWriterOptions(maxBlockSize, maxPageSize);
+            return new ParquetWriterOptions(maxBlockSize, maxPageSize, batchSize);
         }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -86,6 +86,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
+    private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
     private static final String MAX_SPLIT_SIZE = "max_split_size";
     private static final String MAX_INITIAL_SPLIT_SIZE = "max_initial_split_size";
     private static final String RCFILE_OPTIMIZED_WRITER_VALIDATE = "rcfile_optimized_writer_validate";
@@ -324,6 +325,11 @@ public final class HiveSessionProperties
                         PARQUET_WRITER_PAGE_SIZE,
                         "Parquet: Writer page size",
                         parquetWriterConfig.getPageSize(),
+                        false),
+                integerProperty(
+                        PARQUET_WRITER_BATCH_SIZE,
+                        "Parquet: Maximum number of rows passed to the writer in each batch",
+                        parquetWriterConfig.getBatchSize(),
                         false),
                 dataSizeProperty(
                         MAX_SPLIT_SIZE,
@@ -631,6 +637,11 @@ public final class HiveSessionProperties
     public static DataSize getParquetWriterPageSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_PAGE_SIZE, DataSize.class);
+    }
+
+    public static int getParquetBatchSize(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_BATCH_SIZE, Integer.class);
     }
 
     public static DataSize getMaxSplitSize(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -88,6 +88,7 @@ public class ParquetFileWriterFactory
         ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                 .setMaxPageSize(HiveSessionProperties.getParquetWriterPageSize(session))
                 .setMaxBlockSize(HiveSessionProperties.getParquetWriterBlockSize(session))
+                .setBatchSize(HiveSessionProperties.getParquetBatchSize(session))
                 .build();
 
         CompressionCodecName compressionCodecName = getCompression(conf);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetWriterConfig.java
@@ -26,6 +26,7 @@ public class ParquetWriterConfig
 
     private DataSize blockSize = DataSize.ofBytes(ParquetWriter.DEFAULT_BLOCK_SIZE);
     private DataSize pageSize = DataSize.ofBytes(ParquetWriter.DEFAULT_PAGE_SIZE);
+    private int batchSize = ParquetWriterOptions.DEFAULT_BATCH_SIZE;
 
     public DataSize getBlockSize()
     {
@@ -72,6 +73,20 @@ public class ParquetWriterConfig
         return ParquetWriterOptions.builder()
                 .setMaxBlockSize(getBlockSize())
                 .setMaxPageSize(getPageSize())
+                .setBatchSize(getBatchSize())
                 .build();
+    }
+
+    @Config("parquet.writer.batch-size")
+    @ConfigDescription("Maximum number of rows passed to the writer in each batch")
+    public ParquetWriterConfig setBatchSize(int batchSize)
+    {
+        this.batchSize = batchSize;
+        return this;
+    }
+
+    public int getBatchSize()
+    {
+        return batchSize;
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetWriterConfig.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetWriterConfig.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.hive.parquet;
 
 import io.airlift.units.DataSize;
+import io.trino.parquet.writer.ParquetWriterOptions;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.testng.annotations.Test;
 
@@ -33,7 +34,8 @@ public class TestParquetWriterConfig
         assertRecordedDefaults(recordDefaults(ParquetWriterConfig.class)
                 .setParquetOptimizedWriterEnabled(false)
                 .setBlockSize(DataSize.ofBytes(ParquetWriter.DEFAULT_BLOCK_SIZE))
-                .setPageSize(DataSize.ofBytes(ParquetWriter.DEFAULT_PAGE_SIZE)));
+                .setPageSize(DataSize.ofBytes(ParquetWriter.DEFAULT_PAGE_SIZE))
+                .setBatchSize(ParquetWriterOptions.DEFAULT_BATCH_SIZE));
     }
 
     @Test
@@ -57,12 +59,14 @@ public class TestParquetWriterConfig
         Map<String, String> properties = Map.of(
                 "parquet.experimental-optimized-writer.enabled", "true",
                 "parquet.writer.block-size", "234MB",
-                "parquet.writer.page-size", "11MB");
+                "parquet.writer.page-size", "11MB",
+                "parquet.writer.batch-size", "100");
 
         ParquetWriterConfig expected = new ParquetWriterConfig()
                 .setParquetOptimizedWriterEnabled(true)
                 .setBlockSize(DataSize.of(234, MEGABYTE))
-                .setPageSize(DataSize.of(11, MEGABYTE));
+                .setPageSize(DataSize.of(11, MEGABYTE))
+                .setBatchSize(100);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -145,7 +145,7 @@ public class IcebergFileWriterFactory
 
             ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                     .setMaxPageSize(getParquetWriterPageSize(session))
-                    .setMaxPageSize(getParquetWriterBlockSize(session))
+                    .setMaxBlockSize(getParquetWriterBlockSize(session))
                     .build();
 
             return new IcebergParquetFileWriter(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -62,6 +62,7 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterMaxSt
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterMaxStripeSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterMinStripeSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterValidateMode;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterBatchSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcWriterValidate;
@@ -146,6 +147,7 @@ public class IcebergFileWriterFactory
             ParquetWriterOptions parquetWriterOptions = ParquetWriterOptions.builder()
                     .setMaxPageSize(getParquetWriterPageSize(session))
                     .setMaxBlockSize(getParquetWriterBlockSize(session))
+                    .setBatchSize(getParquetWriterBatchSize(session))
                     .build();
 
             return new IcebergParquetFileWriter(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -297,6 +297,6 @@ public final class IcebergSessionProperties
 
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)
     {
-        return session.getProperty(PARQUET_WRITER_PAGE_SIZE, DataSize.class);
+        return session.getProperty(PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -63,6 +63,7 @@ public final class IcebergSessionProperties
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
+    private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -184,6 +185,11 @@ public final class IcebergSessionProperties
                         "Parquet: Writer page size",
                         parquetWriterConfig.getPageSize(),
                         false))
+                .add(integerProperty(
+                        PARQUET_WRITER_BATCH_SIZE,
+                        "Parquet: Maximum number of rows passed to the writer in each batch",
+                        parquetWriterConfig.getBatchSize(),
+                        false))
                 .build();
     }
 
@@ -298,5 +304,10 @@ public final class IcebergSessionProperties
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_BLOCK_SIZE, DataSize.class);
+    }
+
+    public static int getParquetWriterBatchSize(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_BATCH_SIZE, Integer.class);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergOrcConnectorTest.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.iceberg;
 
+import io.trino.Session;
+
 import static org.apache.iceberg.FileFormat.ORC;
 
 public class TestIcebergOrcConnectorTest
@@ -21,5 +23,27 @@ public class TestIcebergOrcConnectorTest
     public TestIcebergOrcConnectorTest()
     {
         super(ORC);
+    }
+
+    @Override
+    protected boolean supportsIcebergFileStatistics(String typeName)
+    {
+        return !(typeName.equalsIgnoreCase("boolean") ||
+                typeName.equalsIgnoreCase("varbinary") ||
+                typeName.contains("timestamp"));
+    }
+
+    @Override
+    protected boolean supportsRowGroupStatistics(String typeName)
+    {
+        return !typeName.equalsIgnoreCase("varbinary");
+    }
+
+    @Override
+    protected Session withSmallRowGroups(Session session)
+    {
+        return Session.builder(session)
+                .setCatalogSessionProperty("iceberg", "orc_writer_max_stripe_rows", "10")
+                .build();
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergParquetConnectorTest.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.iceberg;
 
+import io.trino.Session;
+
 import static org.apache.iceberg.FileFormat.PARQUET;
 
 public class TestIcebergParquetConnectorTest
@@ -21,5 +23,28 @@ public class TestIcebergParquetConnectorTest
     public TestIcebergParquetConnectorTest()
     {
         super(PARQUET);
+    }
+
+    @Override
+    protected boolean supportsIcebergFileStatistics(String typeName)
+    {
+        return true;
+    }
+
+    @Override
+    protected boolean supportsRowGroupStatistics(String typeName)
+    {
+        return !(typeName.equalsIgnoreCase("varbinary") ||
+                typeName.contains("time"));
+    }
+
+    @Override
+    protected Session withSmallRowGroups(Session session)
+    {
+        return Session.builder(session)
+                .setCatalogSessionProperty("iceberg", "parquet_writer_page_size", "100B")
+                .setCatalogSessionProperty("iceberg", "parquet_writer_block_size", "100B")
+                .setCatalogSessionProperty("iceberg", "parquet_writer_batch_size", "10")
+                .build();
     }
 }


### PR DESCRIPTION
Adds tests on ORC and Parquet Iceberg tables to ensure both Iceberg's file
level statistics and data format specific stats are used to prune splits.

As well as some changes/bug fixes for the Iceberg session properties.

Similar to @losipiuk 's tests here: https://github.com/trinodb/trino/pull/9304