### PR TITLE
Iceberg: support dynamic filter for page source and get splits

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -15,11 +15,14 @@ package io.trino.plugin.iceberg;
 
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveCompressionCodec;
 import org.apache.iceberg.FileFormat;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
 
 import static io.trino.plugin.hive.HiveCompressionCodec.GZIP;
 import static io.trino.plugin.iceberg.CatalogType.HIVE;
@@ -33,6 +36,10 @@ public class IcebergConfig
     private int maxPartitionsPerWriter = 100;
     private boolean uniqueTableLocation;
     private CatalogType catalogType = HIVE;
+
+    private boolean enableLocalDynamicFiltering;
+    private boolean enableCoordinatorDynamicFiltering;
+    private Duration dynamicFilteringProbeBlockingTimeout = new Duration(0, TimeUnit.MINUTES);
 
     public CatalogType getCatalogType()
     {
@@ -117,6 +124,44 @@ public class IcebergConfig
     public IcebergConfig setUniqueTableLocation(boolean uniqueTableLocation)
     {
         this.uniqueTableLocation = uniqueTableLocation;
+        return this;
+    }
+
+    public boolean isEnableLocalDynamicFiltering()
+    {
+        return enableLocalDynamicFiltering;
+    }
+
+    @Config("iceberg.enable-local-dynamic-filtering")
+    public IcebergConfig setEnableLocalDynamicFiltering(boolean enableLocalDynamicFiltering)
+    {
+        this.enableLocalDynamicFiltering = enableLocalDynamicFiltering;
+        return this;
+    }
+
+    public boolean isEnableCoordinatorDynamicFiltering()
+    {
+        return enableCoordinatorDynamicFiltering;
+    }
+
+    @Config("iceberg.enable-coordinator-dynamic-filtering")
+    public IcebergConfig setEnableCoordinatorDynamicFiltering(boolean enableCoordinatorDynamicFiltering)
+    {
+        this.enableCoordinatorDynamicFiltering = enableCoordinatorDynamicFiltering;
+        return this;
+    }
+
+    @NotNull
+    public Duration getDynamicFilteringProbeBlockingTimeout()
+    {
+        return dynamicFilteringProbeBlockingTimeout;
+    }
+
+    @Config("iceberg.dynamic-filtering-probe-blocking-timeout")
+    @ConfigDescription("Duration to wait for completion of dynamic filters during split generation for probe side table")
+    public IcebergConfig setDynamicFilteringProbeBlockingTimeout(Duration dynamicFilteringProbeBlockingTimeout)
+    {
+        this.dynamicFilteringProbeBlockingTimeout = dynamicFilteringProbeBlockingTimeout;
         return this;
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergDynamicFilterUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergDynamicFilterUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.base.Stopwatch;
+import io.airlift.log.Logger;
+import io.trino.spi.connector.DynamicFilter;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+final class IcebergDynamicFilterUtil
+{
+    private static final Logger log = Logger.get(IcebergDynamicFilterUtil.class);
+
+    private IcebergDynamicFilterUtil() {}
+
+    public static void waitDynamicFilterUntilTimeout(long timeout, DynamicFilter dynamicFilter)
+    {
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        long timeLeft = timeout - stopwatch.elapsed(MILLISECONDS);
+        try {
+            while (timeLeft > 0 && dynamicFilter.isAwaitable()) {
+                dynamicFilter.isBlocked().get(timeLeft, MILLISECONDS);
+                // since DF may be narrowed down multiple times during query runtime,
+                // we should loop until time out here
+                timeLeft = timeout - stopwatch.elapsed(MILLISECONDS);
+            }
+        }
+        catch (Exception e) {
+            log.warn("Wait for dynamic filter exited with failure!", e);
+        }
+
+        log.debug("Dynamic Filter current predicate %s"
+                + dynamicFilter.getCurrentPredicate().toString());
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -15,6 +15,7 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import io.trino.orc.OrcWriteValidation.OrcWriteValidationMode;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.hive.HiveCompressionCodec;
@@ -33,6 +34,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.trino.plugin.base.session.PropertyMetadataUtil.dataSizeProperty;
+import static io.trino.plugin.base.session.PropertyMetadataUtil.durationProperty;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.spi.session.PropertyMetadata.booleanProperty;
 import static io.trino.spi.session.PropertyMetadata.doubleProperty;
@@ -63,6 +65,9 @@ public final class IcebergSessionProperties
     private static final String PARQUET_MAX_READ_BLOCK_SIZE = "parquet_max_read_block_size";
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
+    private static final String LOCAL_DYNAMIC_FILTER_ENABLED = "local_dynamic_filter_enabled";
+    private static final String COORDINATOR_DYNAMIC_FILTER_ENABLED = "coordinator_dynamic_filter_enabled";
+    private static final String DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT = "dynamic_filtering_probe_blocking_timeout";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -184,6 +189,21 @@ public final class IcebergSessionProperties
                         "Parquet: Writer page size",
                         parquetWriterConfig.getPageSize(),
                         false))
+                .add(booleanProperty(
+                        LOCAL_DYNAMIC_FILTER_ENABLED,
+                        "DynamicFilter: Lazy local dynamic filter",
+                        icebergConfig.isEnableLocalDynamicFiltering(),
+                        false))
+                .add(booleanProperty(
+                        COORDINATOR_DYNAMIC_FILTER_ENABLED,
+                        "DynamicFilter: Lazy local dynamic filter",
+                        icebergConfig.isEnableCoordinatorDynamicFiltering(),
+                        false))
+                .add(durationProperty(
+                        DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT,
+                        "Duration to wait for completion of dynamic filters during split generation for probe side table",
+                        icebergConfig.getDynamicFilteringProbeBlockingTimeout(),
+                        false))
                 .build();
     }
 
@@ -298,5 +318,20 @@ public final class IcebergSessionProperties
     public static DataSize getParquetWriterBlockSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_PAGE_SIZE, DataSize.class);
+    }
+
+    public static boolean isLocalDynamicFilterEnabled(ConnectorSession session)
+    {
+        return session.getProperty(LOCAL_DYNAMIC_FILTER_ENABLED, Boolean.class);
+    }
+
+    public static boolean isCoordinatorDynamicFilterEnabled(ConnectorSession session)
+    {
+        return session.getProperty(COORDINATOR_DYNAMIC_FILTER_ENABLED, Boolean.class);
+    }
+
+    public static Duration getDynamicFilteringProbeBlockingTimeout(ConnectorSession session)
+    {
+        return session.getProperty(DYNAMIC_FILTERING_PROBE_BLOCKING_TIMEOUT, Duration.class);
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -14,10 +14,12 @@
 package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveCompressionCodec;
 import org.testng.annotations.Test;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
@@ -39,7 +41,10 @@ public class TestIcebergConfig
                 .setUseFileSizeFromMetadata(true)
                 .setMaxPartitionsPerWriter(100)
                 .setUniqueTableLocation(false)
-                .setCatalogType(HIVE));
+                .setCatalogType(HIVE)
+                .setDynamicFilteringProbeBlockingTimeout(new Duration(0, TimeUnit.MINUTES))
+                .setEnableCoordinatorDynamicFiltering(false)
+                .setEnableLocalDynamicFiltering(false));
     }
 
     @Test
@@ -52,6 +57,9 @@ public class TestIcebergConfig
                 .put("iceberg.max-partitions-per-writer", "222")
                 .put("iceberg.unique-table-location", "true")
                 .put("iceberg.catalog.type", "UNKNOWN")
+                .put("iceberg.dynamic-filtering-probe-blocking-timeout", "10s")
+                .put("iceberg.enable-coordinator-dynamic-filtering", "true")
+                .put("iceberg.enable-local-dynamic-filtering", "true")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -60,7 +68,10 @@ public class TestIcebergConfig
                 .setUseFileSizeFromMetadata(false)
                 .setMaxPartitionsPerWriter(222)
                 .setUniqueTableLocation(true)
-                .setCatalogType(UNKNOWN);
+                .setCatalogType(UNKNOWN)
+                .setDynamicFilteringProbeBlockingTimeout(new Duration(10, TimeUnit.SECONDS))
+                .setEnableCoordinatorDynamicFiltering(true)
+                .setEnableLocalDynamicFiltering(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Support dynamic filtering in Iceberg connector. Releated with https://github.com/trinodb/trino/issues/4115