### PR TITLE
Support reading parquet int64 timestamp as bigint

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/Int64TimestampMillisColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/Int64TimestampMillisColumnReader.java
@@ -22,6 +22,7 @@ import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.Timestamps.MICROSECONDS_PER_MILLISECOND;
@@ -51,6 +52,9 @@ public class Int64TimestampMillisColumnReader
                 else {
                     type.writeObject(blockBuilder, new LongTimestamp(epochMicros, 0));
                 }
+            }
+            else if (type == BIGINT) {
+                type.writeLong(blockBuilder, epochMillis);
             }
             else {
                 throw new TrinoException(NOT_SUPPORTED, format("Unsupported Trino column type (%s) for Parquet column (%s)", type, columnDescriptor));

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/Int64TimestampMillisColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/Int64TimestampMillisColumnReader.java
@@ -39,12 +39,12 @@ public class Int64TimestampMillisColumnReader
     protected void readValue(BlockBuilder blockBuilder, Type type)
     {
         if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
-            long utcMillis = valuesReader.readLong();
+            long epochMillis = valuesReader.readLong();
             if (type instanceof TimestampWithTimeZoneType) {
-                type.writeLong(blockBuilder, packDateTimeWithZone(utcMillis, UTC_KEY));
+                type.writeLong(blockBuilder, packDateTimeWithZone(epochMillis, UTC_KEY));
             }
             else if (type instanceof TimestampType) {
-                long epochMicros = utcMillis * MICROSECONDS_PER_MILLISECOND;
+                long epochMicros = epochMillis * MICROSECONDS_PER_MILLISECOND;
                 if (((TimestampType) type).isShort()) {
                     type.writeLong(blockBuilder, epochMicros);
                 }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/Int64TimestampNanosColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/Int64TimestampNanosColumnReader.java
@@ -21,6 +21,7 @@ import io.trino.spi.type.Timestamps;
 import io.trino.spi.type.Type;
 
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_NANOS;
@@ -54,6 +55,9 @@ public class Int64TimestampNanosColumnReader
                 type.writeObject(blockBuilder, new LongTimestamp(
                         floorDiv(epochNanos, NANOSECONDS_PER_MICROSECOND),
                         floorMod(epochNanos, NANOSECONDS_PER_MICROSECOND) * PICOSECONDS_PER_NANOSECOND));
+            }
+            else if (type == BIGINT) {
+                type.writeLong(blockBuilder, epochNanos);
             }
             else {
                 throw new TrinoException(NOT_SUPPORTED, format("Unsupported Trino column type (%s) for Parquet column (%s)", type, columnDescriptor));

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/TimestampMicrosColumnReader.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/TimestampMicrosColumnReader.java
@@ -22,6 +22,7 @@ import io.trino.spi.type.Timestamps;
 import io.trino.spi.type.Type;
 
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MICROS;
@@ -67,6 +68,9 @@ public class TimestampMicrosColumnReader
                 long epochMillis = floorDiv(epochMicros, MICROSECONDS_PER_MILLISECOND);
                 int picosOfMillis = toIntExact(epochMicros % MICROSECONDS_PER_MILLISECOND) * PICOSECONDS_PER_MICROSECOND;
                 type.writeObject(blockBuilder, LongTimestampWithTimeZone.fromEpochMillisAndFraction(epochMillis, picosOfMillis, UTC_KEY));
+            }
+            else if (type == BIGINT) {
+                type.writeLong(blockBuilder, epochMicros);
             }
             else {
                 throw new TrinoException(NOT_SUPPORTED, format("Unsupported Trino column type (%s) for Parquet column (%s)", type, columnDescriptor));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
@@ -24,12 +24,14 @@ import io.trino.spi.block.Block;
 import io.trino.spi.connector.ConnectorPageSource;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.type.SqlTimestamp;
+import io.trino.spi.type.Type;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.MessageType;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -55,9 +57,9 @@ public class TestTimestamp
     {
         MessageType parquetSchema = parseMessageType("message hive_timestamp { optional int64 test (TIMESTAMP_MILLIS); }");
         ContiguousSet<Long> epochMillisValues = ContiguousSet.create(Range.closedOpen((long) -1_000, (long) 1_000), DiscreteDomain.longs());
-        ImmutableList.Builder<SqlTimestamp> timestamps = new ImmutableList.Builder<>();
+        ImmutableList.Builder<SqlTimestamp> timestampsMillis = new ImmutableList.Builder<>();
         for (long value : epochMillisValues) {
-            timestamps.add(SqlTimestamp.fromMillis(3, value));
+            timestampsMillis.add(SqlTimestamp.fromMillis(3, value));
         }
 
         List<ObjectInspector> objectInspectors = singletonList(javaLongObjectInspector);
@@ -79,38 +81,42 @@ public class TestTimestamp
                     Optional.of(parquetSchema),
                     false);
 
-            Iterator<SqlTimestamp> expectedValues = timestamps.build().iterator();
-            try (ConnectorPageSource pageSource = StandardFileFormats.TRINO_PARQUET.createFileFormatReader(session, HDFS_ENVIRONMENT, tempFile.getFile(), columnNames, ImmutableList.of(TIMESTAMP_MILLIS))) {
-                // skip a page to exercise the decoder's skip() logic
-                Page firstPage = pageSource.getNextPage();
+            testReadingAs(TIMESTAMP_MILLIS, session, tempFile, columnNames, timestampsMillis.build());
+        }
+    }
 
-                assertTrue(firstPage.getPositionCount() > 0, "Expected first page to have at least 1 row");
+    private void testReadingAs(Type type, ConnectorSession session, ParquetTester.TempFile tempFile, List<String> columnNames, List<?> expectedValues)
+             throws IOException
+    {
+        Iterator<?> expected = expectedValues.iterator();
+        try (ConnectorPageSource pageSource = StandardFileFormats.TRINO_PARQUET.createFileFormatReader(session, HDFS_ENVIRONMENT, tempFile.getFile(), columnNames, ImmutableList.of(type))) {
+            // skip a page to exercise the decoder's skip() logic
+            Page firstPage = pageSource.getNextPage();
+            assertTrue(firstPage.getPositionCount() > 0, "Expected first page to have at least 1 row");
 
-                for (int i = 0; i < firstPage.getPositionCount(); i++) {
-                    expectedValues.next();
-                }
-
-                int pageCount = 1;
-                while (!pageSource.isFinished()) {
-                    Page page = pageSource.getNextPage();
-                    if (page == null) {
-                        continue;
-                    }
-                    pageCount++;
-                    Block block = page.getBlock(0);
-
-                    for (int i = 0; i < block.getPositionCount(); i++) {
-                        assertThat(TIMESTAMP_MILLIS.getObjectValue(session, block, i))
-                                .isEqualTo(expectedValues.next());
-                    }
-                }
-
-                assertThat(pageCount)
-                        .withFailMessage("Expected more than one page but processed %s", pageCount)
-                        .isGreaterThan(1);
+            for (int i = 0; i < firstPage.getPositionCount(); i++) {
+                expected.next();
             }
 
-            assertFalse(expectedValues.hasNext(), "Read fewer values than expected");
+            int pageCount = 1;
+            while (!pageSource.isFinished()) {
+                Page page = pageSource.getNextPage();
+                if (page == null) {
+                    continue;
+                }
+                pageCount++;
+                Block block = page.getBlock(0);
+
+                for (int i = 0; i < block.getPositionCount(); i++) {
+                    assertThat(type.getObjectValue(session, block, i)).isEqualTo(expected.next());
+                }
+            }
+
+            assertThat(pageCount)
+                    .withFailMessage("Expected more than one page but processed %s", pageCount)
+                    .isGreaterThan(1);
+
+            assertFalse(expected.hasNext(), "Read fewer values than expected");
         }
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestTimestamp.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static io.trino.plugin.hive.HiveTestUtils.getHiveSession;
+import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
@@ -58,8 +59,10 @@ public class TestTimestamp
         MessageType parquetSchema = parseMessageType("message hive_timestamp { optional int64 test (TIMESTAMP_MILLIS); }");
         ContiguousSet<Long> epochMillisValues = ContiguousSet.create(Range.closedOpen((long) -1_000, (long) 1_000), DiscreteDomain.longs());
         ImmutableList.Builder<SqlTimestamp> timestampsMillis = new ImmutableList.Builder<>();
+        ImmutableList.Builder<Long> bigints = new ImmutableList.Builder<>();
         for (long value : epochMillisValues) {
             timestampsMillis.add(SqlTimestamp.fromMillis(3, value));
+            bigints.add(value);
         }
 
         List<ObjectInspector> objectInspectors = singletonList(javaLongObjectInspector);
@@ -82,6 +85,7 @@ public class TestTimestamp
                     false);
 
             testReadingAs(TIMESTAMP_MILLIS, session, tempFile, columnNames, timestampsMillis.build());
+            testReadingAs(BIGINT, session, tempFile, columnNames, bigints.build());
         }
     }
 


### PR DESCRIPTION
# Problem
We have many Hive-Tables stored as parquet in HDFS which we can query fine with Hive and Spark. If we try to query the same tables with Trino we get
```
Query failed: Unsupported Trino column type (bigint) for Parquet column ([_meta_archived_ts] optional int64 _meta_archived_ts (TIMESTAMP(MICROS,true)))
```
As the exception states the Hive Metastore column is of type `_meta_archived_ts bigint` and the parquet column of `optional int64 _meta_archived_ts (TIMESTAMP(MICROS,true))`

Hive and Spark both are able to read the column as bigints so i would suggest that Trino should be also able to, so that we can use Trino as a drop-in replacement for Hive.

# Solution
This patch adds this functionality by allowing to read parquet's int64 timestamp fields as bigint.
