### PR TITLE
Mark TestMemoryConnectorTest.testCustomMetricsScanOnly as flaky

### DIFF
--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -151,6 +151,7 @@ public class TestMemoryConnectorTest
     }
 
     @Test
+    @Flaky(issue = "https://github.com/trinodb/trino/issues/8691", match = "ComparisonFailure: expected:<LongCount\\{total=\\[\\d+]}> but was:<LongCount\\{total=\\[\\d+]}>")
     public void testCustomMetricsScanOnly()
     {
         Metrics metrics = collectCustomMetrics("SELECT partkey FROM part");


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/8691