### PR TITLE
Iceberg support partitioning on a nested field

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ColumnIdentity.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/ColumnIdentity.java
@@ -149,8 +149,12 @@ public class ColumnIdentity
 
     public static ColumnIdentity createColumnIdentity(Types.NestedField column)
     {
+        return createColumnIdentity(column.name(), column);
+    }
+
+    public static ColumnIdentity createColumnIdentity(String name, Types.NestedField column)
+    {
         int id = column.fieldId();
-        String name = column.name();
         org.apache.iceberg.types.Type fieldType = column.type();
 
         if (!fieldType.isNestedType()) {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergColumnHandle.java
@@ -20,11 +20,15 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.type.Type;
+import io.trino.spi.type.TypeManager;
+import org.apache.iceberg.types.Types;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+import static io.trino.plugin.iceberg.ColumnIdentity.createColumnIdentity;
+import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergColumnHandle
@@ -165,5 +169,25 @@ public class IcebergColumnHandle
     public String toString()
     {
         return getId() + ":" + getName() + ":" + type.getDisplayName();
+    }
+
+    public static IcebergColumnHandle create(Types.NestedField column, TypeManager typeManager)
+    {
+        return new IcebergColumnHandle(
+                createColumnIdentity(column),
+                toTrinoType(column.type(), typeManager),
+                ImmutableList.of(),
+                toTrinoType(column.type(), typeManager),
+                Optional.ofNullable(column.doc()));
+    }
+
+    public static IcebergColumnHandle create(String name, Types.NestedField column, TypeManager typeManager)
+    {
+        return new IcebergColumnHandle(
+                createColumnIdentity(name, column),
+                toTrinoType(column.type(), typeManager),
+                ImmutableList.of(),
+                toTrinoType(column.type(), typeManager),
+                Optional.ofNullable(column.doc()));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -109,7 +109,7 @@ import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERT
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
-import static io.trino.plugin.iceberg.IcebergUtil.getColumns;
+import static io.trino.plugin.iceberg.IcebergUtil.getAllColumns;
 import static io.trino.plugin.iceberg.IcebergUtil.getFileFormat;
 import static io.trino.plugin.iceberg.IcebergUtil.getPartitionKeys;
 import static io.trino.plugin.iceberg.IcebergUtil.getTableComment;
@@ -263,7 +263,7 @@ public class IcebergMetadata
         DiscretePredicates discretePredicates = null;
         if (!partitionSourceIds.isEmpty()) {
             // Extract identity partition columns
-            Map<Integer, IcebergColumnHandle> columns = getColumns(icebergTable.schema(), typeManager).stream()
+            Map<Integer, IcebergColumnHandle> columns = getAllColumns(icebergTable.schema(), typeManager).stream()
                     .filter(column -> partitionSourceIds.contains(column.getId()))
                     .collect(toImmutableMap(IcebergColumnHandle::getId, Function.identity()));
 
@@ -340,7 +340,7 @@ public class IcebergMetadata
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
         Table icebergTable = catalog.loadTable(session, table.getSchemaTableName());
-        return getColumns(icebergTable.schema(), typeManager).stream()
+        return getAllColumns(icebergTable.schema(), typeManager).stream()
                 .collect(toImmutableMap(IcebergColumnHandle::getName, identity()));
     }
 
@@ -432,7 +432,7 @@ public class IcebergMetadata
                 tableMetadata.getTable().getTableName(),
                 SchemaParser.toJson(transaction.table().schema()),
                 PartitionSpecParser.toJson(transaction.table().spec()),
-                getColumns(transaction.table().schema(), typeManager),
+                getAllColumns(transaction.table().schema(), typeManager),
                 transaction.table().location(),
                 getFileFormat(transaction.table()),
                 transaction.table().properties());
@@ -458,7 +458,7 @@ public class IcebergMetadata
             return Optional.empty();
         }
 
-        Map<Integer, IcebergColumnHandle> columnById = getColumns(tableSchema, typeManager).stream()
+        Map<Integer, IcebergColumnHandle> columnById = getAllColumns(tableSchema, typeManager).stream()
                 .collect(toImmutableMap(IcebergColumnHandle::getId, identity()));
 
         List<IcebergColumnHandle> partitioningColumns = partitionSpec.fields().stream()
@@ -492,7 +492,7 @@ public class IcebergMetadata
                 table.getTableName(),
                 SchemaParser.toJson(icebergTable.schema()),
                 PartitionSpecParser.toJson(icebergTable.spec()),
-                getColumns(icebergTable.schema(), typeManager),
+                getAllColumns(icebergTable.schema(), typeManager),
                 icebergTable.location(),
                 getFileFormat(icebergTable),
                 icebergTable.properties());
@@ -914,7 +914,7 @@ public class IcebergMetadata
                 table.getTableName(),
                 SchemaParser.toJson(icebergTable.schema()),
                 PartitionSpecParser.toJson(icebergTable.spec()),
-                getColumns(icebergTable.schema(), typeManager),
+                getAllColumns(icebergTable.schema(), typeManager),
                 icebergTable.location(),
                 getFileFormat(icebergTable),
                 icebergTable.properties());

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionFields.java
@@ -29,7 +29,8 @@ import static java.lang.String.format;
 
 public final class PartitionFields
 {
-    private static final String NAME = "[a-z_][a-z0-9_]*";
+    private static final String IDENTIFIER = "[a-z_][a-z0-9_]*";
+    private static final String NAME = IDENTIFIER + "(\\." + IDENTIFIER + ")*";
     private static final String FUNCTION_ARGUMENT_NAME = "\\((" + NAME + ")\\)";
     private static final String FUNCTION_ARGUMENT_NAME_AND_INT = "\\((" + NAME + "), *(\\d+)\\)";
 
@@ -65,8 +66,8 @@ public final class PartitionFields
                 tryMatch(field, MONTH_PATTERN, match -> builder.month(match.group(1))) ||
                 tryMatch(field, DAY_PATTERN, match -> builder.day(match.group(1))) ||
                 tryMatch(field, HOUR_PATTERN, match -> builder.hour(match.group(1))) ||
-                tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(match.group(1), parseInt(match.group(2)))) ||
-                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(match.group(1), parseInt(match.group(2)))) ||
+                tryMatch(field, BUCKET_PATTERN, match -> builder.bucket(match.group(1), parseInt(match.group(match.groupCount())))) ||
+                tryMatch(field, TRUNCATE_PATTERN, match -> builder.truncate(match.group(1), parseInt(match.group(match.groupCount())))) ||
                 tryMatch(field, VOID_PATTERN, match -> builder.alwaysNull(match.group(1))) ||
                 false;
         if (!matched) {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestPartitionFields.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.DoubleType;
 import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.LongType;
@@ -38,6 +39,7 @@ public class TestPartitionFields
     public void testParse()
     {
         assertParse("order_key", partitionSpec(builder -> builder.identity("order_key")));
+        assertParse("nested.value", partitionSpec(builder -> builder.identity("nested.value")));
         assertParse("comment", partitionSpec(builder -> builder.identity("comment")));
         assertParse("year(ts)", partitionSpec(builder -> builder.year("ts")));
         assertParse("month(ts)", partitionSpec(builder -> builder.month("ts")));
@@ -49,6 +51,7 @@ public class TestPartitionFields
         assertParse("void(order_key)", partitionSpec(builder -> builder.alwaysNull("order_key")));
 
         assertInvalid("bucket()", "Invalid partition field declaration: bucket()");
+        assertInvalid(".nested", "Invalid partition field declaration: .nested");
         assertInvalid("abc", "Cannot find source column: abc");
         assertInvalid("notes", "Cannot partition by non-primitive source field: list<string>");
         assertInvalid("bucket(price, 42)", "Cannot bucket by type: double");
@@ -86,7 +89,8 @@ public class TestPartitionFields
                 NestedField.required(2, "ts", TimestampType.withoutZone()),
                 NestedField.required(3, "price", DoubleType.get()),
                 NestedField.optional(4, "comment", StringType.get()),
-                NestedField.optional(5, "notes", ListType.ofRequired(6, StringType.get())));
+                NestedField.optional(5, "notes", ListType.ofRequired(6, StringType.get())),
+                NestedField.required(7, "nested", Types.StructType.of(NestedField.required(8, "value", StringType.get()))));
 
         PartitionSpec.Builder builder = PartitionSpec.builderFor(schema);
         consumer.accept(builder);


### PR DESCRIPTION
## Problem
When querying an iceberg table which is partitioned, you can get the following error.
`java.lang.IllegalArgumentException: columns is empty.`

```
java.lang.IllegalArgumentException: columns is empty
	at io.trino.spi.connector.DiscretePredicates.<init>(DiscretePredicates.java:31)
	at io.trino.plugin.iceberg.IcebergMetadata.getTableProperties(IcebergMetadata.java:368)
	at io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata.getTableProperties(ClassLoaderSafeConnectorMetadata.java:764)
	at io.trino.metadata.MetadataManager.getTableProperties(MetadataManager.java:489)
	at io.trino.sql.planner.iterative.rule.DetermineTableScanNodePartitioning.apply(DetermineTableScanNodePartitioning.java:59)
	at io.trino.sql.planner.iterative.rule.DetermineTableScanNodePartitioning.apply(DetermineTableScanNodePartitioning.java:33)

...
```

## Deep Dive into the problem
This `columns` value is returning an empty list

```java
  // Extract identity partition columns
  Map<Integer, IcebergColumnHandle> columns = getColumns(icebergTable.schema(), typeManager).stream()
          .filter(column -> partitionSourceIds.contains(column.getId()))
          .collect(toImmutableMap(IcebergColumnHandle::getId, Function.identity()));
```


If we take a look at the `getColumns` we can see that this is a simple iteration over the return value of the `schema.columns()` from the iceberg api. The problem is that some of these fields can be nested. This method is not unpacking those columns.

```java
public static List<IcebergColumnHandle> getColumns(Schema schema, TypeManager typeManager)
{
    return schema.columns().stream()
            .map(column -> IcebergColumnHandle.create(column, typeManager))
            .collect(toImmutableList());
}
```


Now go back to to see how that original `columns` variable is being generated we see a filter being applied, to the top level column that we got from `getColumns`. 
```java
  // Extract identity partition columns
  Map<Integer, IcebergColumnHandle> columns = getColumns(icebergTable.schema(), typeManager).stream()
          .filter(column -> partitionSourceIds.contains(column.getId()))
          .collect(toImmutableMap(IcebergColumnHandle::getId, Function.identity()));
```

It means that all columns get filtered out because none of those columns are the partition field, hence getting the `columns is empty` when building 
```java
discretePredicates = new DiscretePredicates(
        columns.values().stream()
                .map(ColumnHandle.class::cast)
                .collect(toImmutableList()),
        discreteTupleDomain);
```

and then error thrown here
```java
  public DiscretePredicates(List<ColumnHandle> columns, Iterable<TupleDomain<ColumnHandle>> predicates)
  {
      requireNonNull(columns, "columns is null");
      if (columns.isEmpty()) {
          throw new IllegalArgumentException("columns is empty");
```


## Solution
This pr does three things main things.

* When getting table column handles from IcebergMetadata we get all column, including the ones that are nested.
* When looking for Iceberg column partitions we dig out the partition column and store the index positions to get that column from the schema (sourceIds).
* The Iceberg page partitioner also digs out the partition column block from a page with the stored sourceIds.

Closes: https://github.com/trinodb/trino/issues/5458