### PR TITLE
Fix predicate pushdown for Parquet decimal columns

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
@@ -89,7 +89,8 @@ public final class PredicateUtils
                 // Smallest long decimal type with 0 scale has broader range than representable in long, as used in ParquetLongStatistics
                 return false;
             }
-            return BigDecimal.valueOf(min).compareTo(minimalValue(decimalType)) < 0 || BigDecimal.valueOf(max).compareTo(maximalValue(decimalType)) > 0;
+            return BigDecimal.valueOf(min, decimalType.getScale()).compareTo(minimalValue(decimalType)) < 0 ||
+                    BigDecimal.valueOf(max, decimalType.getScale()).compareTo(maximalValue(decimalType)) > 0;
         }
 
         throw new IllegalArgumentException("Unsupported type: " + type);


### PR DESCRIPTION
~First four commits are from https://github.com/trinodb/trino/pull/9326~

The overflow detection constructs a BigDecimal which was missing the decimal scale argument. This resulted in the statistics incorrectly detecting an overflow in many cases. 

Example:
Decimal(5, 3) has a maximum value of 99.999. Before the fix, any value over 0.099 would result in an overflow. 0.099 would be represented as 99, which is still lower than the max value, but 0.100 is represented as 100, triggering the overflow logic.