### PR TITLE
Support reading variable time precision in MySQL

### DIFF
--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -135,7 +135,7 @@ import static java.util.stream.Collectors.joining;
 public class MySqlClient
         extends BaseJdbcClient
 {
-    private static final int MAX_SUPPORTED_TIMESTAMP_PRECISION = 6;
+    private static final int MAX_SUPPORTED_DATE_TIME_PRECISION = 6;
     // MySQL driver returns width of timestamp types instead of precision.
     // 19 characters are used for zero-precision timestamps while others
     // require 19 + precision + 1 characters with the additional character
@@ -344,7 +344,7 @@ public class MySqlClient
             return 0;
         }
         int timestampPrecision = timestampColumnSize - ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE - 1;
-        verify(1 <= timestampPrecision && timestampPrecision <= MAX_SUPPORTED_TIMESTAMP_PRECISION, "Unexpected timestamp precision %s calculated from timestamp column size %s", timestampPrecision, timestampColumnSize);
+        verify(1 <= timestampPrecision && timestampPrecision <= MAX_SUPPORTED_DATE_TIME_PRECISION, "Unexpected timestamp precision %s calculated from timestamp column size %s", timestampPrecision, timestampColumnSize);
         return timestampPrecision;
     }
 
@@ -389,11 +389,11 @@ public class MySqlClient
 
         if (type instanceof TimestampType) {
             TimestampType timestampType = (TimestampType) type;
-            if (timestampType.getPrecision() <= MAX_SUPPORTED_TIMESTAMP_PRECISION) {
+            if (timestampType.getPrecision() <= MAX_SUPPORTED_DATE_TIME_PRECISION) {
                 verify(timestampType.getPrecision() <= TimestampType.MAX_SHORT_PRECISION);
                 return WriteMapping.longMapping(format("datetime(%s)", timestampType.getPrecision()), timestampWriteFunction(timestampType));
             }
-            return WriteMapping.objectMapping(format("datetime(%s)", MAX_SUPPORTED_TIMESTAMP_PRECISION), longTimestampWriteFunction(timestampType, MAX_SUPPORTED_TIMESTAMP_PRECISION));
+            return WriteMapping.objectMapping(format("datetime(%s)", MAX_SUPPORTED_DATE_TIME_PRECISION), longTimestampWriteFunction(timestampType, MAX_SUPPORTED_DATE_TIME_PRECISION));
         }
 
         if (VARBINARY.equals(type)) {

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -53,6 +53,7 @@ import io.trino.spi.type.CharType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.Decimals;
 import io.trino.spi.type.StandardTypes;
+import io.trino.spi.type.TimeType;
 import io.trino.spi.type.TimestampType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeManager;
@@ -106,6 +107,8 @@ import static io.trino.plugin.jdbc.StandardColumnMappings.realWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.shortDecimalWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.smallintWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.timeColumnMapping;
+import static io.trino.plugin.jdbc.StandardColumnMappings.timeWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.timestampColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.timestampWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.tinyintColumnMapping;
@@ -122,6 +125,7 @@ import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
+import static io.trino.spi.type.TimeType.createTimeType;
 import static io.trino.spi.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.TimestampWithTimeZoneType.TIMESTAMP_TZ_MILLIS;
@@ -141,6 +145,8 @@ public class MySqlClient
     // require 19 + precision + 1 characters with the additional character
     // required for the decimal separator.
     private static final int ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE = 19;
+    // MySQL driver returns width of time types instead of precision, same as the above timestamp type.
+    private static final int ZERO_PRECISION_TIME_COLUMN_SIZE = 8;
 
     private final Type jsonType;
     private final AggregateFunctionRewriter<JdbcExpression> aggregateFunctionRewriter;
@@ -329,6 +335,10 @@ public class MySqlClient
             case Types.DATE:
                 return Optional.of(dateColumnMapping());
 
+            case Types.TIME:
+                TimeType timeType = createTimeType(getTimePrecision(typeHandle.getRequiredColumnSize()));
+                return Optional.of(timeColumnMapping(timeType));
+
             case Types.TIMESTAMP:
                 TimestampType timestampType = createTimestampType(getTimestampPrecision(typeHandle.getRequiredColumnSize()));
                 return Optional.of(timestampColumnMapping(timestampType));
@@ -346,6 +356,16 @@ public class MySqlClient
         int timestampPrecision = timestampColumnSize - ZERO_PRECISION_TIMESTAMP_COLUMN_SIZE - 1;
         verify(1 <= timestampPrecision && timestampPrecision <= MAX_SUPPORTED_DATE_TIME_PRECISION, "Unexpected timestamp precision %s calculated from timestamp column size %s", timestampPrecision, timestampColumnSize);
         return timestampPrecision;
+    }
+
+    private static int getTimePrecision(int timeColumnSize)
+    {
+        if (timeColumnSize == ZERO_PRECISION_TIME_COLUMN_SIZE) {
+            return 0;
+        }
+        int timePrecision = timeColumnSize - ZERO_PRECISION_TIME_COLUMN_SIZE - 1;
+        verify(1 <= timePrecision && timePrecision <= MAX_SUPPORTED_DATE_TIME_PRECISION, "Unexpected time precision %s calculated from time column size %s", timePrecision, timeColumnSize);
+        return timePrecision;
     }
 
     @Override
@@ -381,6 +401,14 @@ public class MySqlClient
 
         if (type == DATE) {
             return WriteMapping.longMapping("date", dateWriteFunction());
+        }
+
+        if (type instanceof TimeType) {
+            TimeType timeType = (TimeType) type;
+            if (timeType.getPrecision() <= MAX_SUPPORTED_DATE_TIME_PRECISION) {
+                return WriteMapping.longMapping(format("time(%s)", timeType.getPrecision()), timeWriteFunction(timeType.getPrecision()));
+            }
+            return WriteMapping.longMapping(format("time(%s)", MAX_SUPPORTED_DATE_TIME_PRECISION), timeWriteFunction(MAX_SUPPORTED_DATE_TIME_PRECISION));
         }
 
         if (TIME_WITH_TIME_ZONE.equals(type) || TIMESTAMP_TZ_MILLIS.equals(type)) {

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/BaseMySqlConnectorTest.java
@@ -125,8 +125,7 @@ public abstract class BaseMySqlConnectorTest
     protected Optional<DataMappingTestSetup> filterDataMappingSmokeTestData(DataMappingTestSetup dataMappingTestSetup)
     {
         String typeName = dataMappingTestSetup.getTrinoTypeName();
-        if (typeName.equals("time")
-                || typeName.equals("timestamp(3) with time zone")) {
+        if (typeName.equals("timestamp(3) with time zone")) {
             return Optional.of(dataMappingTestSetup.asUnsupported());
         }
 

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlTypeMapping.java
@@ -58,6 +58,7 @@ import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.UNSUPPORTED
 import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
 import static io.trino.plugin.mysql.MySqlQueryRunner.createMySqlQueryRunner;
 import static io.trino.spi.type.DecimalType.createDecimalType;
+import static io.trino.spi.type.TimeType.createTimeType;
 import static io.trino.spi.type.TimeZoneKey.UTC_KEY;
 import static io.trino.spi.type.TimestampType.createTimestampType;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
@@ -479,6 +480,111 @@ public class TestMySqlTypeMapping
             testCases.execute(getQueryRunner(), session, trinoCreateAsSelect(getSession(), "test_date"));
             testCases.execute(getQueryRunner(), session, trinoCreateAndInsert(session, "test_date"));
         }
+    }
+
+    @Test(dataProvider = "sessionZonesDataProvider")
+    public void testTimeFromMySql(ZoneId sessionZone)
+    {
+        Session session = Session.builder(getSession())
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(sessionZone.getId()))
+                .build();
+
+        SqlDataTypeTest.create()
+                // default precision in MySQL is 0
+                .addRoundTrip("TIME", "TIME '00:00:00'", createTimeType(0), "TIME '00:00:00'")
+                .addRoundTrip("TIME", "TIME '12:34:56'", createTimeType(0), "TIME '12:34:56'")
+                .addRoundTrip("TIME", "TIME '23:59:59'", createTimeType(0), "TIME '23:59:59'")
+
+                // maximal value for a precision
+                .addRoundTrip("TIME(1)", "TIME '23:59:59.9'", createTimeType(1), "TIME '23:59:59.9'")
+                .addRoundTrip("TIME(2)", "TIME '23:59:59.99'", createTimeType(2), "TIME '23:59:59.99'")
+                .addRoundTrip("TIME(3)", "TIME '23:59:59.999'", createTimeType(3), "TIME '23:59:59.999'")
+                .addRoundTrip("TIME(4)", "TIME '23:59:59.9999'", createTimeType(4), "TIME '23:59:59.9999'")
+                .addRoundTrip("TIME(5)", "TIME '23:59:59.99999'", createTimeType(5), "TIME '23:59:59.99999'")
+                .addRoundTrip("TIME(6)", "TIME '23:59:59.999999'", createTimeType(6), "TIME '23:59:59.999999'")
+                .execute(getQueryRunner(), session, mysqlCreateAndInsert("tpch.test_time"));
+    }
+
+    @Test(dataProvider = "sessionZonesDataProvider")
+    public void testTimeFromTrino(ZoneId sessionZone)
+    {
+        Session session = Session.builder(getSession())
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey(sessionZone.getId()))
+                .build();
+
+        SqlDataTypeTest.create()
+                // default precision in Trino is 3
+                .addRoundTrip("TIME", "TIME '00:00:00'", createTimeType(3), "TIME '00:00:00.000'")
+                .addRoundTrip("TIME", "TIME '12:34:56.123'", createTimeType(3), "TIME '12:34:56.123'")
+                .addRoundTrip("TIME", "TIME '23:59:59.999'", createTimeType(3), "TIME '23:59:59.999'")
+
+                // maximal value for a precision
+                .addRoundTrip("TIME", "TIME '23:59:59'", createTimeType(3), "TIME '23:59:59.000'")
+                .addRoundTrip("TIME(1)", "TIME '23:59:59.9'", createTimeType(1), "TIME '23:59:59.9'")
+                .addRoundTrip("TIME(2)", "TIME '23:59:59.99'", createTimeType(2), "TIME '23:59:59.99'")
+                .addRoundTrip("TIME(3)", "TIME '23:59:59.999'", createTimeType(3), "TIME '23:59:59.999'")
+                .addRoundTrip("TIME(4)", "TIME '23:59:59.9999'", createTimeType(4), "TIME '23:59:59.9999'")
+                .addRoundTrip("TIME(5)", "TIME '23:59:59.99999'", createTimeType(5), "TIME '23:59:59.99999'")
+                .addRoundTrip("TIME(6)", "TIME '23:59:59.999999'", createTimeType(6), "TIME '23:59:59.999999'")
+
+                // supported precisions
+                .addRoundTrip("TIME '23:59:59.9'", "TIME '23:59:59.9'")
+                .addRoundTrip("TIME '23:59:59.99'", "TIME '23:59:59.99'")
+                .addRoundTrip("TIME '23:59:59.999'", "TIME '23:59:59.999'")
+                .addRoundTrip("TIME '23:59:59.9999'", "TIME '23:59:59.9999'")
+                .addRoundTrip("TIME '23:59:59.99999'", "TIME '23:59:59.99999'")
+                .addRoundTrip("TIME '23:59:59.999999'", "TIME '23:59:59.999999'")
+
+                // round down
+                .addRoundTrip("TIME '00:00:00.0000001'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.000000000001'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '12:34:56.1234561'", "TIME '12:34:56.123456'")
+                .addRoundTrip("TIME '23:59:59.9999994'", "TIME '23:59:59.999999'")
+                .addRoundTrip("TIME '23:59:59.999999499999'", "TIME '23:59:59.999999'")
+
+                // round down, maximal value
+                .addRoundTrip("TIME '00:00:00.0000004'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.00000049'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.000000449'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.0000004449'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.00000044449'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '00:00:00.000000444449'", "TIME '00:00:00.000000'")
+
+                // round up, minimal value
+                .addRoundTrip("TIME '00:00:00.0000005'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.00000050'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.000000500'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.0000005000'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.00000050000'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.000000500000'", "TIME '00:00:00.000001'")
+
+                // round up, maximal value
+                .addRoundTrip("TIME '00:00:00.0000009'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.00000099'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.000000999'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.0000009999'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.00000099999'", "TIME '00:00:00.000001'")
+                .addRoundTrip("TIME '00:00:00.000000999999'", "TIME '00:00:00.000001'")
+
+                // round up to next day, minimal value
+                .addRoundTrip("TIME '23:59:59.9999995'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.99999950'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.999999500'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.9999995000'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.99999950000'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.999999500000'", "TIME '00:00:00.000000'")
+
+                // round up to next day, maximal value
+                .addRoundTrip("TIME '23:59:59.9999999'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.99999999'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.999999999'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.9999999999'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.99999999999'", "TIME '00:00:00.000000'")
+                .addRoundTrip("TIME '23:59:59.999999999999'", "TIME '00:00:00.000000'")
+
+                .execute(getQueryRunner(), session, trinoCreateAsSelect("tpch.test_time"))
+                .execute(getQueryRunner(), session, trinoCreateAndInsert(session, "tpch.test_time"))
+                .execute(getQueryRunner(), session, trinoCreateAndInsert(getSession(), "tpch.test_time"));
     }
 
     /**


### PR DESCRIPTION
There are two changes for MySQL connector in this PR:
1. Support reading `time` type with variable precision
2. Support `CREATE TABLE` and `CREATE TABLE AS` for `time` type

Fixes #9334