### PR TITLE
Reduce hash calculations and streams collecting overhead for query planning

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EffectivePredicateExtractor.java
@@ -535,14 +535,14 @@ public class EffectivePredicateExtractor
 
             ImmutableList.Builder<Expression> effectiveConjuncts = ImmutableList.builder();
             Set<Symbol> scope = ImmutableSet.copyOf(symbols);
-            for (Expression conjunct : EqualityInference.nonInferrableConjuncts(metadata, expression)) {
+            EqualityInference.nonInferrableConjuncts(metadata, expression).forEach(conjunct -> {
                 if (DeterminismEvaluator.isDeterministic(conjunct, metadata)) {
                     Expression rewritten = equalityInference.rewrite(conjunct, scope);
                     if (rewritten != null) {
                         effectiveConjuncts.add(rewritten);
                     }
                 }
-            }
+            });
 
             effectiveConjuncts.addAll(equalityInference.generateEqualitiesPartitionedBy(scope).getScopeEqualities());
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
@@ -55,12 +55,12 @@ public class EqualityInference
         // Current cost heuristic:
         // 1) Prefer fewer input symbols
         // 2) Prefer smaller expression trees
-        // 3) Sort the expressions alphabetically - creates a stable consistent ordering (extremely useful for unit testing)
+        // 3) Sort the expressions by hash - creates a stable consistent ordering (extremely useful for unit testing)
         // TODO: be more precise in determining the cost of an expression
         return ComparisonChain.start()
                 .compare(SymbolsExtractor.extractAll(expression1).size(), SymbolsExtractor.extractAll(expression2).size())
                 .compare(SubExpressionExtractor.extract(expression1).size(), SubExpressionExtractor.extract(expression2).size())
-                .compare(expression1.toString(), expression2.toString())
+                .compare(expression1.hashCode(), expression2.hashCode())
                 .result();
     });
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
@@ -142,14 +142,14 @@ public class EqualityInference
                 }
             });
             // Compile the equality expressions on each side of the scope
-            Expression matchingCanonical = getCanonical(scopeExpressions);
+            Expression matchingCanonical = getCanonical(scopeExpressions.stream());
             if (scopeExpressions.size() >= 2) {
                 scopeExpressions.stream()
                         .filter(expression -> !expression.equals(matchingCanonical))
                         .map(expression -> new ComparisonExpression(ComparisonExpression.Operator.EQUAL, matchingCanonical, expression))
                         .forEach(scopeEqualities::add);
             }
-            Expression complementCanonical = getCanonical(scopeComplementExpressions);
+            Expression complementCanonical = getCanonical(scopeComplementExpressions.stream());
             if (scopeComplementExpressions.size() >= 2) {
                 scopeComplementExpressions.stream()
                         .filter(expression -> !expression.equals(complementCanonical))
@@ -165,7 +165,7 @@ public class EqualityInference
             connectingExpressions = connectingExpressions.stream()
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
-            Expression connectingCanonical = getCanonical(connectingExpressions);
+            Expression connectingCanonical = getCanonical(connectingExpressions.stream());
             if (connectingCanonical != null) {
                 connectingExpressions.stream()
                         .filter(expression -> !expression.equals(connectingCanonical))
@@ -298,12 +298,9 @@ public class EqualityInference
     /**
      * Returns the most preferrable expression to be used as the canonical expression
      */
-    private static Expression getCanonical(Collection<Expression> expressions)
+    private static Expression getCanonical(Stream<Expression> expressions)
     {
-        if (expressions.isEmpty()) {
-            return null;
-        }
-        return CANONICAL_ORDERING.min(expressions);
+        return expressions.min(CANONICAL_ORDERING).orElse(null);
     }
 
     /**
@@ -330,9 +327,8 @@ public class EqualityInference
             }
         }
 
-        Set<Expression> candidates = equivalences.stream()
-                .filter(e -> isScoped(e, symbolScope))
-                .collect(Collectors.toSet());
+        Stream<Expression> candidates = equivalences.stream()
+                .filter(e -> isScoped(e, symbolScope));
 
         return getCanonical(candidates);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static io.trino.sql.ExpressionUtils.extractConjuncts;
 import static io.trino.sql.planner.DeterminismEvaluator.isDeterministic;
@@ -59,7 +60,7 @@ public class EqualityInference
         // TODO: be more precise in determining the cost of an expression
         return ComparisonChain.start()
                 .compare(SymbolsExtractor.extractAll(expression1).size(), SymbolsExtractor.extractAll(expression2).size())
-                .compare(SubExpressionExtractor.extract(expression1).size(), SubExpressionExtractor.extract(expression2).size())
+                .compare(SubExpressionExtractor.extract(expression1).count(), SubExpressionExtractor.extract(expression2).count())
                 .compare(expression1.hashCode(), expression2.hashCode())
                 .result();
     });
@@ -231,8 +232,9 @@ public class EqualityInference
                 continue;
             }
 
-            List<Expression> subExpressions = SubExpressionExtractor.extract(expression).stream()
+            List<Expression> subExpressions = SubExpressionExtractor.extract(expression)
                     .filter(e -> !e.equals(expression))
+                    .distinct()
                     .collect(Collectors.toList());
 
             for (Expression subExpression : subExpressions) {
@@ -272,20 +274,19 @@ public class EqualityInference
 
     private Expression rewrite(Expression expression, Predicate<Symbol> symbolScope, boolean allowFullReplacement)
     {
-        Set<Expression> subExpressions = SubExpressionExtractor.extract(expression);
+        Stream<Expression> subExpressions = SubExpressionExtractor.extract(expression);
         if (!allowFullReplacement) {
-            subExpressions = subExpressions.stream()
-                    .filter(e -> !e.equals(expression))
-                    .collect(Collectors.toSet());
+            subExpressions = subExpressions
+                    .filter(e -> !e.equals(expression));
         }
 
         ImmutableMap.Builder<Expression, Expression> expressionRemap = ImmutableMap.builder();
-        for (Expression subExpression : subExpressions) {
+        subExpressions.distinct().forEach(subExpression -> {
             Expression canonical = getScopedCanonical(subExpression, symbolScope);
             if (canonical != null) {
                 expressionRemap.put(subExpression, canonical);
             }
-        }
+        });
 
         // Perform a naive single-pass traversal to try to rewrite non-compliant portions of the tree. Prefers to replace
         // larger subtrees over smaller subtrees

--- a/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
@@ -259,13 +259,13 @@ public class EqualityInference
     }
 
     /**
-     * Provides a convenience Iterable of Expression conjuncts which have not been added to the inference
+     * Provides a convenience Stream of Expression conjuncts which have not been added to the inference
+     * @return
      */
-    public static List<Expression> nonInferrableConjuncts(Metadata metadata, Expression expression)
+    public static Stream<Expression> nonInferrableConjuncts(Metadata metadata, Expression expression)
     {
         return extractConjuncts(expression).stream()
-                .filter(e -> !isInferenceCandidate(metadata, e))
-                .collect(Collectors.toList());
+                .filter(e -> !isInferenceCandidate(metadata, e));
     }
 
     private Expression rewrite(Expression expression, Predicate<Symbol> symbolScope, boolean allowFullReplacement)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/EqualityInference.java
@@ -14,13 +14,11 @@
 package io.trino.sql.planner;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Ordering;
 import io.trino.metadata.Metadata;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.Expression;
@@ -30,6 +28,7 @@ import io.trino.util.DisjointSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -37,6 +36,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -52,18 +52,15 @@ import static java.util.Objects.requireNonNull;
 public class EqualityInference
 {
     // Ordering used to determine Expression preference when determining canonicals
-    private static final Ordering<Expression> CANONICAL_ORDERING = Ordering.from((expression1, expression2) -> {
-        // Current cost heuristic:
-        // 1) Prefer fewer input symbols
-        // 2) Prefer smaller expression trees
-        // 3) Sort the expressions by hash - creates a stable consistent ordering (extremely useful for unit testing)
-        // TODO: be more precise in determining the cost of an expression
-        return ComparisonChain.start()
-                .compare(SymbolsExtractor.extractAll(expression1).size(), SymbolsExtractor.extractAll(expression2).size())
-                .compare(SubExpressionExtractor.extract(expression1).count(), SubExpressionExtractor.extract(expression2).count())
-                .compare(expression1.hashCode(), expression2.hashCode())
-                .result();
-    });
+    private static final Comparator<Expression> CANONICAL_ORDERING = Comparator
+            // Current cost heuristic:
+            // 1) Prefer fewer input symbols
+            // 2) Prefer smaller expression trees
+            // 3) Sort the expressions by hash - creates a stable consistent ordering (extremely useful for unit testing)
+            // TODO: be more precise in determining the cost of an expression
+            .comparingInt((ToIntFunction<Expression>) (expression -> SymbolsExtractor.extractAll(expression).size()))
+            .thenComparingLong(expression -> SubExpressionExtractor.extract(expression).count())
+            .thenComparingInt(Expression::hashCode);
 
     private final Multimap<Expression, Expression> equalitySets; // Indexed by canonical expression
     private final Map<Expression, Expression> canonicalMap; // Map each known expression to canonical expression
@@ -343,7 +340,7 @@ public class EqualityInference
         ImmutableSetMultimap.Builder<Expression, Expression> builder = ImmutableSetMultimap.builder();
         for (Set<Expression> equalityGroup : equalities.getEquivalentClasses()) {
             if (!equalityGroup.isEmpty()) {
-                builder.putAll(CANONICAL_ORDERING.min(equalityGroup), equalityGroup);
+                builder.putAll(equalityGroup.stream().min(CANONICAL_ORDERING).get(), equalityGroup);
             }
         }
         return builder.build();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/SubExpressionExtractor.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/SubExpressionExtractor.java
@@ -16,9 +16,7 @@ package io.trino.sql.planner;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.util.AstUtils;
 
-import java.util.Set;
-
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import java.util.stream.Stream;
 
 /**
  * Extracts and returns the set of all expression subtrees within an Expression, including Expression itself
@@ -27,11 +25,10 @@ public final class SubExpressionExtractor
 {
     private SubExpressionExtractor() {}
 
-    public static Set<Expression> extract(Expression expression)
+    public static Stream<Expression> extract(Expression expression)
     {
         return AstUtils.preOrder(expression)
                 .filter(Expression.class::isInstance)
-                .map(Expression.class::cast)
-                .collect(toImmutableSet());
+                .map(Expression.class::cast);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReorderJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ReorderJoins.java
@@ -352,7 +352,7 @@ public class ReorderJoins
             // This takes all conjuncts that were part of allFilters that
             // could not be used for equality inference.
             // If they use both the left and right symbols, we add them to the list of joinPredicates
-            nonInferrableConjuncts(metadata, allFilter).stream()
+            nonInferrableConjuncts(metadata, allFilter)
                     .map(conjunct -> allFilterInference.rewrite(conjunct, Sets.union(leftSymbols, rightSymbols)))
                     .filter(Objects::nonNull)
                     // filter expressions that contain only left or right symbols
@@ -376,7 +376,7 @@ public class ReorderJoins
                 Set<Symbol> scope = ImmutableSet.copyOf(outputSymbols);
                 ImmutableList.Builder<Expression> predicates = ImmutableList.builder();
                 predicates.addAll(allFilterInference.generateEqualitiesPartitionedBy(scope).getScopeEqualities());
-                nonInferrableConjuncts(metadata, allFilter).stream()
+                nonInferrableConjuncts(metadata, allFilter)
                         .map(conjunct -> allFilterInference.rewrite(conjunct, scope))
                         .filter(Objects::nonNull)
                         .forEach(predicates::add);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/DynamicFiltersChecker.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/DynamicFiltersChecker.java
@@ -161,7 +161,8 @@ public class DynamicFiltersChecker
 
     private static List<DynamicFilters.Descriptor> extractDynamicPredicates(Expression expression)
     {
-        return SubExpressionExtractor.extract(expression).stream()
+        return SubExpressionExtractor.extract(expression)
+                .distinct()
                 .map(DynamicFilters::getDescriptor)
                 .filter(Optional::isPresent)
                 .map(Optional::get)

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestTypeSignatureTranslator.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestTypeSignatureTranslator.java
@@ -33,6 +33,7 @@ public class TestTypeSignatureTranslator
     {
         assertThat(type(expression))
                 .ignoringLocation()
+                .ignoringHash()
                 .withComparatorForType(Comparator.comparing(identifier -> identifier.getValue().toLowerCase(Locale.ENGLISH)), Identifier.class)
                 .isEqualTo(toDataType(toTypeSignature(SQL_PARSER.createType(expression))));
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
@@ -86,12 +86,12 @@ import org.testng.annotations.Test;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -1230,12 +1230,10 @@ public class TestEffectivePredicateExtractor
         EqualityInference inference = EqualityInference.newInstance(metadata, predicate);
 
         Set<Symbol> scope = SymbolsExtractor.extractUnique(predicate);
-        Set<Expression> rewrittenSet = new HashSet<>();
-        for (Expression expression : EqualityInference.nonInferrableConjuncts(metadata, predicate)) {
-            Expression rewritten = inference.rewrite(expression, scope);
-            checkState(rewritten != null, "Rewrite with full symbol scope should always be possible");
-            rewrittenSet.add(rewritten);
-        }
+        Set<Expression> rewrittenSet = EqualityInference.nonInferrableConjuncts(metadata, predicate)
+                .map(expression -> inference.rewrite(expression, scope))
+                .peek(rewritten -> checkState(rewritten != null, "Rewrite with full symbol scope should always be possible"))
+                .collect(Collectors.toSet());
         rewrittenSet.addAll(inference.generateEqualitiesPartitionedBy(scope).getScopeEqualities());
 
         return rewrittenSet;

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEffectivePredicateExtractor.java
@@ -1265,7 +1265,7 @@ public class TestEffectivePredicateExtractor
             Expression identityNormalizedExpression = expressionCache.get(expression);
             if (identityNormalizedExpression == null) {
                 // Make sure all sub-expressions are normalized first
-                SubExpressionExtractor.extract(expression).stream()
+                SubExpressionExtractor.extract(expression)
                         .filter(e -> !e.equals(expression))
                         .forEach(this::normalize);
 

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ArithmeticBinaryExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ArithmeticBinaryExpression.java
@@ -45,6 +45,7 @@ public class ArithmeticBinaryExpression
     private final Operator operator;
     private final Expression left;
     private final Expression right;
+    private int hash;
 
     public ArithmeticBinaryExpression(Operator operator, Expression left, Expression right)
     {
@@ -110,7 +111,10 @@ public class ArithmeticBinaryExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(operator, left, right);
+        if (hash == 0) {
+            hash = Objects.hash(operator, left, right);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ArithmeticUnaryExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ArithmeticUnaryExpression.java
@@ -32,6 +32,7 @@ public class ArithmeticUnaryExpression
 
     private final Expression value;
     private final Sign sign;
+    private int hash;
 
     public ArithmeticUnaryExpression(Sign sign, Expression value)
     {
@@ -113,7 +114,10 @@ public class ArithmeticUnaryExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(value, sign);
+        if (hash == 0) {
+            hash = Objects.hash(value, sign);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ArrayConstructor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ArrayConstructor.java
@@ -26,6 +26,7 @@ public class ArrayConstructor
 {
     public static final String ARRAY_CONSTRUCTOR = "ARRAY_CONSTRUCTOR";
     private final List<Expression> values;
+    private int hash;
 
     public ArrayConstructor(List<Expression> values)
     {
@@ -78,7 +79,10 @@ public class ArrayConstructor
     @Override
     public int hashCode()
     {
-        return values.hashCode();
+        if (hash == 0) {
+            hash = values.hashCode();
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AtTimeZone.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AtTimeZone.java
@@ -27,6 +27,7 @@ public class AtTimeZone
 {
     private final Expression value;
     private final Expression timeZone;
+    private int hash;
 
     public AtTimeZone(Expression value, Expression timeZone)
     {
@@ -71,7 +72,10 @@ public class AtTimeZone
     @Override
     public int hashCode()
     {
-        return Objects.hash(value, timeZone);
+        if (hash == 0) {
+            hash = Objects.hash(value, timeZone);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/BetweenPredicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/BetweenPredicate.java
@@ -27,6 +27,7 @@ public class BetweenPredicate
     private final Expression value;
     private final Expression min;
     private final Expression max;
+    private int hash;
 
     public BetweenPredicate(Expression value, Expression min, Expression max)
     {
@@ -96,7 +97,10 @@ public class BetweenPredicate
     @Override
     public int hashCode()
     {
-        return Objects.hash(value, min, max);
+        if (hash == 0) {
+            hash = Objects.hash(value, min, max);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/BindExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/BindExpression.java
@@ -51,6 +51,7 @@ public class BindExpression
     // Function expression must be of function type.
     // It is not necessarily a lambda. For example, it can be another bind expression.
     private final Expression function;
+    private int hash;
 
     public BindExpression(List<Expression> values, Expression function)
     {
@@ -111,7 +112,10 @@ public class BindExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(values, function);
+        if (hash == 0) {
+            hash = Objects.hash(values, function);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Cast.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Cast.java
@@ -28,6 +28,7 @@ public final class Cast
     private final DataType type;
     private final boolean safe;
     private final boolean typeOnly;
+    private int hash;
 
     public Cast(Expression expression, DataType type)
     {
@@ -116,7 +117,10 @@ public final class Cast
     @Override
     public int hashCode()
     {
-        return Objects.hash(expression, type, safe, typeOnly);
+        if (hash == 0) {
+            hash = Objects.hash(expression, type, safe, typeOnly);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CoalesceExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CoalesceExpression.java
@@ -26,6 +26,7 @@ public class CoalesceExpression
         extends Expression
 {
     private final List<Expression> operands;
+    int hash;
 
     public CoalesceExpression(Expression first, Expression second, Expression... additional)
     {
@@ -88,7 +89,10 @@ public class CoalesceExpression
     @Override
     public int hashCode()
     {
-        return operands.hashCode();
+        if (hash == 0) {
+            hash = operands.hashCode();
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/ComparisonExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/ComparisonExpression.java
@@ -27,6 +27,7 @@ public class ComparisonExpression
     private final Operator operator;
     private final Expression left;
     private final Expression right;
+    int hash;
 
     public ComparisonExpression(Operator operator, Expression left, Expression right)
     {
@@ -96,7 +97,10 @@ public class ComparisonExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(operator, left, right);
+        if (hash == 0) {
+            hash = Objects.hash(operator, left, right);
+        }
+        return hash;
     }
 
     public enum Operator

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentCatalog.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentCatalog.java
@@ -16,7 +16,6 @@ package io.trino.sql.tree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public class CurrentCatalog
@@ -47,7 +46,7 @@ public class CurrentCatalog
     @Override
     public int hashCode()
     {
-        return Objects.hash();
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentPath.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentPath.java
@@ -16,7 +16,6 @@ package io.trino.sql.tree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public class CurrentPath
@@ -47,7 +46,7 @@ public class CurrentPath
     @Override
     public int hashCode()
     {
-        return Objects.hash();
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentSchema.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentSchema.java
@@ -16,7 +16,6 @@ package io.trino.sql.tree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public class CurrentSchema
@@ -47,7 +46,7 @@ public class CurrentSchema
     @Override
     public int hashCode()
     {
-        return Objects.hash();
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentUser.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentUser.java
@@ -16,7 +16,6 @@ package io.trino.sql.tree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public class CurrentUser
@@ -52,7 +51,7 @@ public class CurrentUser
     @Override
     public int hashCode()
     {
-        return Objects.hash();
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/DereferenceExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/DereferenceExpression.java
@@ -26,6 +26,7 @@ public class DereferenceExpression
 {
     private final Expression base;
     private final Identifier field;
+    int hash;
 
     public DereferenceExpression(Expression base, Identifier field)
     {
@@ -124,7 +125,10 @@ public class DereferenceExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(base, field);
+        if (hash == 0) {
+            hash = Objects.hash(base, field);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Extract.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Extract.java
@@ -29,6 +29,7 @@ public class Extract
 {
     private final Expression expression;
     private final Field field;
+    private int hash;
 
     public enum Field
     {
@@ -111,7 +112,10 @@ public class Extract
     @Override
     public int hashCode()
     {
-        return Objects.hash(expression, field);
+        if (hash == 0) {
+            hash = Objects.hash(expression, field);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Format.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Format.java
@@ -26,6 +26,7 @@ public class Format
         extends Expression
 {
     private final List<Expression> arguments;
+    int hash;
 
     public Format(List<Expression> arguments)
     {
@@ -79,7 +80,10 @@ public class Format
     @Override
     public int hashCode()
     {
-        return Objects.hash(arguments);
+        if (hash == 0) {
+            hash = Objects.hash(arguments);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/FunctionCall.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/FunctionCall.java
@@ -33,6 +33,7 @@ public class FunctionCall
     private final Optional<NullTreatment> nullTreatment;
     private final Optional<ProcessingMode> processingMode;
     private final List<Expression> arguments;
+    private int hash;
 
     public FunctionCall(QualifiedName name, List<Expression> arguments)
     {
@@ -155,7 +156,10 @@ public class FunctionCall
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, distinct, nullTreatment, processingMode, window, filter, orderBy, arguments);
+        if (hash == 0) {
+            hash = Objects.hash(name, distinct, nullTreatment, processingMode, window, filter, orderBy, arguments);
+        }
+        return hash;
     }
 
     // TODO: make this a proper Tree node so that we can report error

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/GenericDataType.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/GenericDataType.java
@@ -26,6 +26,7 @@ public class GenericDataType
 {
     private final Identifier name;
     private final List<DataTypeParameter> arguments;
+    private int hash;
 
     public GenericDataType(NodeLocation location, Identifier name, List<DataTypeParameter> arguments)
     {
@@ -83,7 +84,10 @@ public class GenericDataType
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, arguments);
+        if (hash == 0) {
+            hash = Objects.hash(name, arguments);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/GroupingOperation.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/GroupingOperation.java
@@ -25,6 +25,7 @@ public class GroupingOperation
         extends Expression
 {
     private final List<Expression> groupingColumns;
+    private int hash;
 
     public GroupingOperation(Optional<NodeLocation> location, List<QualifiedName> groupingColumns)
     {
@@ -69,7 +70,10 @@ public class GroupingOperation
     @Override
     public int hashCode()
     {
-        return Objects.hash(groupingColumns);
+        if (hash == 0) {
+            hash = groupingColumns.hashCode();
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/IfExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/IfExpression.java
@@ -30,6 +30,7 @@ public class IfExpression
     private final Expression condition;
     private final Expression trueValue;
     private final Optional<Expression> falseValue;
+    private int hash;
 
     public IfExpression(Expression condition, Expression trueValue, Expression falseValue)
     {
@@ -98,7 +99,10 @@ public class IfExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(condition, trueValue, falseValue);
+        if (hash == 0) {
+            hash = Objects.hash(condition, trueValue, falseValue);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/InListExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/InListExpression.java
@@ -26,6 +26,7 @@ public class InListExpression
         extends Expression
 {
     private final List<Expression> values;
+    private int hash;
 
     public InListExpression(List<Expression> values)
     {
@@ -79,7 +80,10 @@ public class InListExpression
     @Override
     public int hashCode()
     {
-        return values.hashCode();
+        if (hash == 0) {
+            hash = values.hashCode();
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/InPredicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/InPredicate.java
@@ -24,6 +24,7 @@ public class InPredicate
 {
     private final Expression value;
     private final Expression valueList;
+    private int hash;
 
     public InPredicate(Expression value, Expression valueList)
     {
@@ -82,7 +83,10 @@ public class InPredicate
     @Override
     public int hashCode()
     {
-        return Objects.hash(value, valueList);
+        if (hash == 0) {
+            hash = Objects.hash(value, valueList);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/IsNotNullPredicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/IsNotNullPredicate.java
@@ -25,6 +25,7 @@ public class IsNotNullPredicate
         extends Expression
 {
     private final Expression value;
+    private int hash;
 
     public IsNotNullPredicate(Expression value)
     {
@@ -77,7 +78,10 @@ public class IsNotNullPredicate
     @Override
     public int hashCode()
     {
-        return value.hashCode();
+        if (hash == 0) {
+            hash = value.hashCode();
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/IsNullPredicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/IsNullPredicate.java
@@ -25,6 +25,7 @@ public class IsNullPredicate
         extends Expression
 {
     private final Expression value;
+    private int hash;
 
     public IsNullPredicate(Expression value)
     {
@@ -77,7 +78,10 @@ public class IsNullPredicate
     @Override
     public int hashCode()
     {
-        return value.hashCode();
+        if (hash == 0) {
+            hash = value.hashCode();
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/LambdaExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/LambdaExpression.java
@@ -26,6 +26,7 @@ public class LambdaExpression
 {
     private final List<LambdaArgumentDeclaration> arguments;
     private final Expression body;
+    int hash;
 
     public LambdaExpression(List<LambdaArgumentDeclaration> arguments, Expression body)
     {
@@ -86,7 +87,10 @@ public class LambdaExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(arguments, body);
+        if (hash == 0) {
+            hash = Objects.hash(arguments, body);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/LikePredicate.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/LikePredicate.java
@@ -27,6 +27,7 @@ public class LikePredicate
     private final Expression value;
     private final Expression pattern;
     private final Optional<Expression> escape;
+    private int hash;
 
     public LikePredicate(Expression value, Expression pattern, Expression escape)
     {
@@ -107,7 +108,10 @@ public class LikePredicate
     @Override
     public int hashCode()
     {
-        return Objects.hash(value, pattern, escape);
+        if (hash == 0) {
+            hash = Objects.hash(value, pattern, escape);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/LogicalBinaryExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/LogicalBinaryExpression.java
@@ -43,6 +43,7 @@ public class LogicalBinaryExpression
     private final Operator operator;
     private final Expression left;
     private final Expression right;
+    private int hash;
 
     public LogicalBinaryExpression(Operator operator, Expression left, Expression right)
     {
@@ -122,7 +123,10 @@ public class LogicalBinaryExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(operator, left, right);
+        if (hash == 0) {
+            hash = Objects.hash(operator, left, right);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/NullIfExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/NullIfExpression.java
@@ -27,6 +27,7 @@ public class NullIfExpression
 {
     private final Expression first;
     private final Expression second;
+    private int hash;
 
     public NullIfExpression(Expression first, Expression second)
     {
@@ -85,7 +86,10 @@ public class NullIfExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(first, second);
+        if (hash == 0) {
+            hash = Objects.hash(first, second);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/QuantifiedComparisonExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/QuantifiedComparisonExpression.java
@@ -35,6 +35,7 @@ public class QuantifiedComparisonExpression
     private final Quantifier quantifier;
     private final Expression value;
     private final Expression subquery;
+    private int hash;
 
     public QuantifiedComparisonExpression(ComparisonExpression.Operator operator, Quantifier quantifier, Expression value, Expression subquery)
     {
@@ -107,7 +108,10 @@ public class QuantifiedComparisonExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(operator, quantifier, value, subquery);
+        if (hash == 0) {
+            hash = Objects.hash(operator, quantifier, value, subquery);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Query.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Query.java
@@ -31,6 +31,7 @@ public class Query
     private final Optional<OrderBy> orderBy;
     private final Optional<Offset> offset;
     private final Optional<Node> limit;
+    private int hash;
 
     public Query(
             Optional<With> with,
@@ -152,7 +153,10 @@ public class Query
     @Override
     public int hashCode()
     {
-        return Objects.hash(with, queryBody, orderBy, offset, limit);
+        if (hash == 0) {
+            hash = Objects.hash(with, queryBody, orderBy, offset, limit);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Row.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Row.java
@@ -25,6 +25,7 @@ public final class Row
         extends Expression
 {
     private final List<Expression> items;
+    private int hash;
 
     public Row(List<Expression> items)
     {
@@ -63,7 +64,10 @@ public final class Row
     @Override
     public int hashCode()
     {
-        return Objects.hash(items);
+        if (hash == 0) {
+            hash = items.hashCode();
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/RowDataType.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/RowDataType.java
@@ -25,6 +25,7 @@ public class RowDataType
         extends DataType
 {
     private final List<Field> fields;
+    private int hash;
 
     public RowDataType(NodeLocation location, List<Field> fields)
     {
@@ -71,7 +72,10 @@ public class RowDataType
     @Override
     public int hashCode()
     {
-        return Objects.hash(fields);
+        if (hash == 0) {
+            hash = fields.hashCode();
+        }
+        return hash;
     }
 
     public static class Field

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/SearchedCaseExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/SearchedCaseExpression.java
@@ -26,6 +26,7 @@ public class SearchedCaseExpression
 {
     private final List<WhenClause> whenClauses;
     private final Optional<Expression> defaultValue;
+    private int hash;
 
     public SearchedCaseExpression(List<WhenClause> whenClauses, Optional<Expression> defaultValue)
     {
@@ -89,7 +90,10 @@ public class SearchedCaseExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(whenClauses, defaultValue);
+        if (hash == 0) {
+            hash = Objects.hash(whenClauses, defaultValue);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/SimpleCaseExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/SimpleCaseExpression.java
@@ -27,6 +27,7 @@ public class SimpleCaseExpression
     private final Expression operand;
     private final List<WhenClause> whenClauses;
     private final Optional<Expression> defaultValue;
+    private int hash;
 
     public SimpleCaseExpression(Expression operand, List<WhenClause> whenClauses, Optional<Expression> defaultValue)
     {
@@ -99,7 +100,10 @@ public class SimpleCaseExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(operand, whenClauses, defaultValue);
+        if (hash == 0) {
+            hash = Objects.hash(operand, whenClauses, defaultValue);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/SubscriptExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/SubscriptExpression.java
@@ -26,6 +26,7 @@ public class SubscriptExpression
 {
     private final Expression base;
     private final Expression index;
+    private int hash;
 
     public SubscriptExpression(Expression base, Expression index)
     {
@@ -84,7 +85,10 @@ public class SubscriptExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(base, index);
+        if (hash == 0) {
+            hash = Objects.hash(base, index);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/TryExpression.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/TryExpression.java
@@ -25,6 +25,7 @@ public class TryExpression
         extends Expression
 {
     private final Expression innerExpression;
+    private int hash;
 
     public TryExpression(Expression innerExpression)
     {
@@ -75,7 +76,10 @@ public class TryExpression
     @Override
     public int hashCode()
     {
-        return Objects.hash(innerExpression);
+        if (hash == 0) {
+            hash = innerExpression.hashCode();
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/WhenClause.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/WhenClause.java
@@ -24,6 +24,7 @@ public class WhenClause
 {
     private final Expression operand;
     private final Expression result;
+    int hash;
 
     public WhenClause(Expression operand, Expression result)
     {
@@ -82,7 +83,10 @@ public class WhenClause
     @Override
     public int hashCode()
     {
-        return Objects.hash(operand, result);
+        if (hash == 0) {
+            hash = Objects.hash(operand, result);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/WindowOperation.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/WindowOperation.java
@@ -39,6 +39,7 @@ public class WindowOperation
 {
     private final Identifier name;
     private final Window window;
+    int hash;
 
     public WindowOperation(Identifier name, Window window)
     {
@@ -100,7 +101,10 @@ public class WindowOperation
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, window);
+        if (hash == 0) {
+            hash = Objects.hash(name, window);
+        }
+        return hash;
     }
 
     @Override

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/ParserAssert.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/ParserAssert.java
@@ -99,6 +99,11 @@ public class ParserAssert
         return ignoringFieldsMatchingRegexes("(.*\\.)?location");
     }
 
+    public ParserAssert ignoringHash()
+    {
+        return ignoringFieldsMatchingRegexes("(.*\\.)?hash");
+    }
+
     private static <T extends Node> AssertProvider<ParserAssert> createAssertion(Function<String, T> parser, String sql)
     {
         return () -> new ParserAssert(parser.apply(sql), newRecursiveComparisonConfig())


### PR DESCRIPTION
This PR tries to improve query planning performance issues identified by analysing profiling information.

For smaller data sets planning phase may take a significant portion of query total execution time. For example, for tpcds benchmark run with size factor 10, planning takes:

- For tpcds q08 - 2.9s vs 6.7s (43%)
- For tpcds q14 - 1.3 s vs 14.5s (9%)
- For tpcds q17 - 0.9 vs 15.6s (6%)
- For tpcds q64 - 7.7s vs 11.3s (68%)
- For tpcds q72 - 3.3s vs 39.0s (8%)
- For tpcds q85 - 2.9s vs 8.9s (32%)

When looking at profiling information (gathered by running JFR on query planned using TpcdsConnectorFactory), top methods include e.g. for q85:
```
Top Method	Count	Percentage
int java.util.Arrays.hashCode(Object[])	264	9.738104020656584 %
int io.trino.sql.tree.Cast.hashCode()	172	6.344522316488381 %
int com.google.common.collect.ImmutableList.hashCode()	102	3.7624492807082257 %
```
There's also a large impact of code related to collecting expressions streams to Set/ImmutableSet structures in EqualityInference class - it includes rehashing maps as more expressions are added.

Changes in this PR try to improve planning performance by:

- Caching expressions hash codes. Class EqualityInference analysis subexpressions of expressions found in SQL query, using expressions as keys in maps. It causes constant traversing of the expression tree and re-calculating hash codes of nodes in the tree. Caching causes hash for every node in the expression tree to be calculated only once. 
- Avoiding collecting streams of expressions to sets/list whenever possible. Replacing collecting to set requires using distinct() on stream, however this is still faster than creating a set, especially with larger amount of elements, when rehashing is required.

When comparing code before and after applying this PR:
- Benchto concurrency benchmark (32 concurrent round-robin threads on tpc-ds sf10 parquet files, 4 worker nodes with total of 128 ARM CPU cores) shows improvements of about 2% to 3% in queries per hour (so for total execution time, not only planning time), e.g. from 5477 to 5567 queries per second.
- Standard benchto benchmark on sf_1 ORC files show improvement in planning time for both tpch and tpcds, e.g. 6.7% improvement for sum of average planning times for each tpcds query.

Potential improvements should be even larger on more complex queries, for example the ones generated by BI tools.

Result of standard benchmark is attached: [Benchmarks comparison-Pawel-hashcode.pdf](https://github.com/trinodb/trino/files/7251005/Benchmarks.comparison-Pawel-hashcode.pdf)

