### PR TITLE
Document join-pushdown.enabled for JDBC connectors

### DIFF
--- a/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
@@ -33,3 +33,8 @@ connector:
       Do not change this setting from the default. Non-default values may
       negatively impact performance.
     - 1000
+  * - ``join-pushdown.enabled``
+    - Enable :ref:`join pushdown <join-pushdown>`. Equivalent :doc:`catalog
+      session property </sql/set-session>` is ``join_pushdown_enabled``.  Enabling
+      this may negatively impact performance for some queries.
+    - False

--- a/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
+++ b/docs/src/main/sphinx/connector/jdbc-common-configurations.fragment
@@ -12,7 +12,7 @@ connector:
     - Description
     - Default value
   * - ``case-insensitive-name-matching``
-    - Support case insensitive database and collection names
+    - Match schema and table names case insensitively
     - False
   * - ``case-insensitive-name-matching.cache-ttl``
     -


### PR DESCRIPTION
I did not document the session property `join_pushdown_enabled` since I couldn't find examples of session properties being documented for JDBC connectors.

If needed I can add that too provided someone can point me to an existing example for the convention.