### PR TITLE
Cache CanonicalizationAware hashcode

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/CanonicalizationAware.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/CanonicalizationAware.java
@@ -26,6 +26,11 @@ public class CanonicalizationAware<T extends Node>
 {
     private final T node;
 
+    // Updates to this field are thread-safe despite benign data race due to:
+    // 1. idempotent hash computation
+    // 2. atomic updates to int fields per JMM
+    private int hashCode;
+
     private CanonicalizationAware(T node)
     {
         this.node = requireNonNull(node, "node is null");
@@ -44,7 +49,17 @@ public class CanonicalizationAware<T extends Node>
     @Override
     public int hashCode()
     {
-        return treeHash(node, CanonicalizationAware::canonicalizationAwareHash);
+        int hash = hashCode;
+        if (hash == 0) {
+            hash = treeHash(node, CanonicalizationAware::canonicalizationAwareHash);
+            if (hash == 0) {
+                hash = 1;
+            }
+
+            hashCode = hash;
+        }
+
+        return hash;
     }
 
     @Override


### PR DESCRIPTION
This is to reduce computation on deep expression trees when used in a Set or a Map.