### PR TITLE
Fix bug when DELETE ACID block is a DictionaryBlock

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/Block.java
@@ -311,7 +311,9 @@ public interface Block
     }
 
     /**
-     * Gets the direct child blocks of this block.
+     * Gets the direct child blocks of this block. This method is an internal subroutine
+     * of the {@link Block} API, and should never be called directly.  To take apart
+     * {@link Block} components, see {@link ColumnarRow}
      */
     default List<Block> getChildren()
     {


### PR DESCRIPTION
This PR consists of two commits:

Before the first commit, `Block.getChildren()` was used to take apart the
DELETE ACID rowId block.  That is always the wrong thing to do.
Fixed by using `ColumnarRow` to access the elements of the ACID rowId block.

This first commit also adds a comment warning developers not to use
`Block.getChildren()` so others don't make the same mistake of
calling the method.

The second commit replaces use of Block.getChildren in
HiveUpdateProcessor with ColumnarRow methods.