### PR TITLE
Document datetimeoffset type support in SQL Server

### DIFF
--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -107,6 +107,7 @@ SQL Server Type                     Trino Type
 ``varchar(n)``                      ``varchar(n)``
 ``date``                            ``date``
 ``datetime2(n)``                    ``timestamp(n)``
+``datetimeoffset(n)``               ``timestamp(n) with time zone``
 ==================================  ===============================
 
 Complete list of `SQL Server data types


### PR DESCRIPTION
Sorry, I was missing the doc in #9329