### PR TITLE
Enable usage of Avro schema url with partitions

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -866,7 +866,7 @@ Limitations
 The following operations are not supported when ``avro_schema_url`` is set:
 
 * ``CREATE TABLE AS`` is not supported.
-* Using partitioning(``partitioned_by``) or bucketing(``bucketed_by``) columns are not supported in ``CREATE TABLE``.
+* Bucketing(``bucketed_by``) columns are not supported in ``CREATE TABLE``.
 * ``ALTER TABLE`` commands modifying columns are not supported.
 
 .. _hive-procedures:

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -799,8 +799,8 @@ public class HiveMetadata
         List<String> partitionedBy = getPartitionedBy(tableMetadata.getProperties());
         Optional<HiveBucketProperty> bucketProperty = getBucketProperty(tableMetadata.getProperties());
 
-        if ((bucketProperty.isPresent() || !partitionedBy.isEmpty()) && getAvroSchemaUrl(tableMetadata.getProperties()) != null) {
-            throw new TrinoException(NOT_SUPPORTED, "Bucketing/Partitioning columns not supported when Avro schema url is set");
+        if (bucketProperty.isPresent() && getAvroSchemaUrl(tableMetadata.getProperties()) != null) {
+            throw new TrinoException(NOT_SUPPORTED, "Bucketing columns not supported when Avro schema url is set");
         }
 
         validateTimestampColumns(tableMetadata.getColumns(), getTimestampPrecision(session));

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
@@ -7389,17 +7389,7 @@ public class TestHiveConnectorTest
                 "WITH (avro_schema_url = 'dummy_schema',\n" +
                 "      bucket_count = 2, bucketed_by=ARRAY['dummy'])";
 
-        assertQueryFails(createSql, "Bucketing/Partitioning columns not supported when Avro schema url is set");
-    }
-
-    @Test
-    public void testPartitionedTablesFailWithAvroSchemaUrl()
-    {
-        @Language("SQL") String createSql = "CREATE TABLE create_avro (dummy VARCHAR)\n" +
-                "WITH (avro_schema_url = 'dummy_schema',\n" +
-                "      partitioned_by=ARRAY['dummy'])";
-
-        assertQueryFails(createSql, "Bucketing/Partitioning columns not supported when Avro schema url is set");
+        assertQueryFails(createSql, "Bucketing columns not supported when Avro schema url is set");
     }
 
     @Test

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestAvroSchemaEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestAvroSchemaEvolution.java
@@ -13,10 +13,19 @@
  */
 package io.trino.tests.product.hive;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import io.trino.tempto.AfterTestWithContext;
 import io.trino.tempto.BeforeTestWithContext;
 import io.trino.tempto.ProductTest;
+import io.trino.tempto.assertions.QueryAssert.Row;
 import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
@@ -29,150 +38,213 @@ import static java.lang.String.format;
 public abstract class BaseTestAvroSchemaEvolution
         extends ProductTest
 {
-    private static final String TABLE_NAME = "product_tests_avro_table";
     // TODO move Avro schema files to classpath and use tempto SshClient to upload them
     private static final String ORIGINAL_SCHEMA = "file:///docker/presto-product-tests/avro/original_schema.avsc";
-    private static final String CREATE_TABLE = format("" +
-                    "CREATE TABLE %s (dummy_col VARCHAR)" +
-                    "WITH (" +
-                    "format='AVRO', " +
-                    "avro_schema_url='%s'" +
-                    ")",
-            TABLE_NAME,
-            ORIGINAL_SCHEMA);
     private static final String RENAMED_COLUMN_SCHEMA = "file:///docker/presto-product-tests/avro/rename_column_schema.avsc";
     private static final String REMOVED_COLUMN_SCHEMA = "file:///docker/presto-product-tests/avro/remove_column_schema.avsc";
     private static final String ADDED_COLUMN_SCHEMA = "file:///docker/presto-product-tests/avro/add_column_schema.avsc";
     private static final String CHANGE_COLUMN_TYPE_SCHEMA = "file:///docker/presto-product-tests/avro/change_column_type_schema.avsc";
     private static final String INCOMPATIBLE_TYPE_SCHEMA = "file:///docker/presto-product-tests/avro/incompatible_type_schema.avsc";
-    private static final String SELECT_STAR = "SELECT * FROM " + TABLE_NAME;
-    private static final String COLUMNS_IN_TABLE = "SHOW COLUMNS IN " + TABLE_NAME;
+
+    private final String tableName;
+    private final String columnsInTableStatement;
+    private final String selectStarStatement;
+    private final List<String> varcharPartitionColumns;
+
+    protected BaseTestAvroSchemaEvolution(String tableName, String... varcharPartitionColumns)
+    {
+        this.tableName = tableName;
+        this.columnsInTableStatement = "SHOW COLUMNS IN " + tableName;
+        this.selectStarStatement = "SELECT * FROM " + tableName;
+        this.varcharPartitionColumns = ImmutableList.copyOf(varcharPartitionColumns);
+    }
 
     @BeforeTestWithContext
     public void createAndLoadTable()
     {
-        onTrino().executeQuery(CREATE_TABLE);
-        onTrino().executeQuery(format("INSERT INTO %s VALUES ('string0', 0)", TABLE_NAME));
+        onTrino().executeQuery(format(
+                "CREATE TABLE %s (" +
+                        "  dummy_col VARCHAR" +
+                        (varcharPartitionColumns.isEmpty() ? "" : ", " + getPartitionsAsListString(partitionColumns -> partitionColumns + " varchar")) +
+                        ")" +
+                        "WITH (" +
+                        "  format='AVRO', " +
+                        "  avro_schema_url='%s'" +
+                        (varcharPartitionColumns.isEmpty() ? "" : ", partitioned_by=ARRAY[" + getPartitionsAsListString(partitionColumns -> "'" + partitionColumns + "'") + "]") +
+                        ")",
+                tableName,
+                ORIGINAL_SCHEMA));
+        insertData(tableName, 0, "'stringA0'", "0");
     }
 
     @AfterTestWithContext
     public void dropTestTable()
     {
-        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
     }
 
     @Test(groups = AVRO)
     public void testSelectTable()
     {
-        assertThat(onTrino().executeQuery(format("SELECT string_col FROM %s", TABLE_NAME)))
-                .containsExactlyInOrder(row("string0"));
+        assertThat(onTrino().executeQuery(format("SELECT string_col FROM %s", tableName)))
+                .containsExactlyInOrder(row("stringA0"));
     }
 
     @Test(groups = AVRO)
     public void testInsertAfterSchemaEvolution()
     {
-        assertThat(onTrino().executeQuery(SELECT_STAR))
-                .containsExactlyInOrder(row("string0", 0));
+        assertThat(onTrino().executeQuery(selectStarStatement))
+                .containsOnly(
+                        createRow(0, "stringA0", 0));
 
         alterTableSchemaTo(ADDED_COLUMN_SCHEMA);
-        onTrino().executeQuery(format("INSERT INTO %s VALUES ('string1', 1, 101)", TABLE_NAME));
-        assertThat(onTrino().executeQuery(SELECT_STAR))
+        insertData(tableName, 1, "'stringA1'", "1", "101");
+        assertThat(onTrino().executeQuery(selectStarStatement))
                 .containsOnly(
-                        row("string0", 0, 100),
-                        row("string1", 1, 101));
+                        createRow(0, "stringA0", 0, 100),
+                        createRow(1, "stringA1", 1, 101));
     }
 
     @Test(groups = AVRO)
     public void testSchemaEvolutionWithIncompatibleType()
     {
-        assertThat(onTrino().executeQuery(COLUMNS_IN_TABLE))
+        assertThat(onTrino().executeQuery(columnsInTableStatement))
                 .containsExactlyInOrder(
-                        row("string_col", "varchar", "", ""),
-                        row("int_col", "integer", "", ""));
-        assertThat(onTrino().executeQuery(SELECT_STAR))
-                .containsExactlyInOrder(row("string0", 0));
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "integer", "", "")));
+        assertThat(onTrino().executeQuery(selectStarStatement))
+                .containsExactlyInOrder(
+                        createRow(0, "stringA0", 0));
 
         alterTableSchemaTo(INCOMPATIBLE_TYPE_SCHEMA);
-        assertQueryFailure(() -> onTrino().executeQuery(SELECT_STAR))
+        assertQueryFailure(() -> onTrino().executeQuery(selectStarStatement))
                 .hasMessageContaining("Found int, expecting string");
     }
 
     @Test(groups = AVRO)
     public void testSchemaEvolution()
     {
-        assertThat(onTrino().executeQuery(COLUMNS_IN_TABLE))
+        assertThat(onTrino().executeQuery(columnsInTableStatement))
                 .containsExactlyInOrder(
-                        row("string_col", "varchar", "", ""),
-                        row("int_col", "integer", "", ""));
-        assertThat(onTrino().executeQuery(SELECT_STAR))
-                .containsExactlyInOrder(row("string0", 0));
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "integer", "", "")));
+
+        assertThat(onTrino().executeQuery(selectStarStatement))
+                .containsExactlyInOrder(
+                        createRow(0, "stringA0", 0));
 
         alterTableSchemaTo(CHANGE_COLUMN_TYPE_SCHEMA);
-        assertThat(onTrino().executeQuery(COLUMNS_IN_TABLE))
+        assertThat(onTrino().executeQuery(columnsInTableStatement))
                 .containsExactlyInOrder(
-                        row("string_col", "varchar", "", ""),
-                        row("int_col", "bigint", "", ""));
-        assertThat(onTrino().executeQuery(SELECT_STAR))
-                .containsExactlyInOrder(row("string0", 0));
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "bigint", "", "")));
+        assertThat(onTrino().executeQuery(selectStarStatement))
+                .containsExactlyInOrder(
+                        createRow(0, "stringA0", 0));
 
         alterTableSchemaTo(ADDED_COLUMN_SCHEMA);
-        assertThat(onTrino().executeQuery(COLUMNS_IN_TABLE))
+        assertThat(onTrino().executeQuery(columnsInTableStatement))
                 .containsExactlyInOrder(
-                        row("string_col", "varchar", "", ""),
-                        row("int_col", "integer", "", ""),
-                        row("int_col_added", "integer", "", ""));
-        assertThat(onTrino().executeQuery(SELECT_STAR))
-                .containsExactlyInOrder(row("string0", 0, 100));
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "integer", "", ""),
+                                row("int_col_added", "integer", "", "")));
+        assertThat(onTrino().executeQuery(selectStarStatement))
+                .containsExactlyInOrder(
+                        createRow(0, "stringA0", 0, 100));
 
         alterTableSchemaTo(REMOVED_COLUMN_SCHEMA);
-        assertThat(onTrino().executeQuery(COLUMNS_IN_TABLE))
-                .containsExactlyInOrder(row("int_col", "integer", "", ""));
-        assertThat(onTrino().executeQuery(SELECT_STAR))
-                .containsExactlyInOrder(row(0));
+        assertThat(onTrino().executeQuery(columnsInTableStatement))
+                .containsExactlyInOrder(
+                        prepareShowColumnsResultRows(
+                                row("int_col", "integer", "", "")));
+        assertThat(onTrino().executeQuery(selectStarStatement))
+                .containsExactlyInOrder(
+                        createRow(0, 0));
 
         alterTableSchemaTo(RENAMED_COLUMN_SCHEMA);
-        assertThat(onTrino().executeQuery(COLUMNS_IN_TABLE))
+        assertThat(onTrino().executeQuery(columnsInTableStatement))
                 .containsExactlyInOrder(
-                        row("string_col", "varchar", "", ""),
-                        row("int_col_renamed", "integer", "", ""));
-        assertThat(onTrino().executeQuery(SELECT_STAR))
-                .containsExactlyInOrder(row("string0", null));
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col_renamed", "integer", "", "")));
+
+        assertThat(onTrino().executeQuery(selectStarStatement))
+                .containsExactlyInOrder(
+                        createRow(0, "stringA0", null));
     }
 
     @Test(groups = AVRO)
     public void testSchemaWhenUrlIsUnset()
     {
-        assertThat(onTrino().executeQuery(COLUMNS_IN_TABLE))
+        assertThat(onTrino().executeQuery(columnsInTableStatement))
                 .containsExactlyInOrder(
-                        row("string_col", "varchar", "", ""),
-                        row("int_col", "integer", "", ""));
-        assertThat(onTrino().executeQuery(SELECT_STAR))
-                .containsExactlyInOrder(row("string0", 0));
+                        prepareShowColumnsResultRows(
+                                row("string_col", "varchar", "", ""),
+                                row("int_col", "integer", "", "")));
+        assertThat(onTrino().executeQuery(selectStarStatement))
+                .containsExactlyInOrder(
+                        createRow(0, "stringA0", 0));
 
-        onHive().executeQuery(format("ALTER TABLE %s UNSET TBLPROPERTIES('avro.schema.url')", TABLE_NAME));
-        assertThat(onTrino().executeQuery(COLUMNS_IN_TABLE))
+        onHive().executeQuery(format("ALTER TABLE %s UNSET TBLPROPERTIES('avro.schema.url')", tableName));
+        assertThat(onTrino().executeQuery(columnsInTableStatement))
                 .containsExactlyInOrder(
-                        row("dummy_col", "varchar", "", ""));
+                        prepareShowColumnsResultRows(
+                                row("dummy_col", "varchar", "", "")));
     }
 
     @Test(groups = AVRO)
     public void testCreateTableLike()
     {
-        String createTableLikeName = "test_avro_like";
+        String createTableLikeName = tableName + "_avro_like";
         onTrino().executeQuery(format(
                 "CREATE TABLE %s (LIKE %s INCLUDING PROPERTIES)",
                 createTableLikeName,
-                TABLE_NAME));
+                tableName));
 
-        onTrino().executeQuery(format("INSERT INTO %s VALUES ('string0', 0)", createTableLikeName));
+        insertData(createTableLikeName, 0, "'stringA0'", "0");
 
         assertThat(onTrino().executeQuery(format("SELECT string_col FROM %s", createTableLikeName)))
-                .containsExactlyInOrder(row("string0"));
+                .containsExactlyInOrder(row("stringA0"));
         onTrino().executeQuery("DROP TABLE IF EXISTS " + createTableLikeName);
     }
 
     private void alterTableSchemaTo(String schema)
     {
-        onHive().executeQuery(format("ALTER TABLE %s SET TBLPROPERTIES('avro.schema.url'='%s')", TABLE_NAME, schema));
+        onHive().executeQuery(format("ALTER TABLE %s SET TBLPROPERTIES('avro.schema.url'='%s')", tableName, schema));
+    }
+
+    private void insertData(String tableName, int rowNumber, String... sqlValues)
+    {
+        String columnValues = Joiner.on(", ").join(sqlValues) +
+                (varcharPartitionColumns.isEmpty() ? "" : ", " + getPartitionsAsListString(partitionColumn -> "'" + partitionColumn + "_" + rowNumber + "'"));
+        onTrino().executeQuery(format("INSERT INTO %s VALUES (%s)", tableName, columnValues));
+    }
+
+    private Row createRow(int rowNumber, Object... data)
+    {
+        List<Object> rowData = new ArrayList<>(Arrays.asList(data));
+        varcharPartitionColumns.forEach(partition -> rowData.add(partition + "_" + rowNumber));
+        return new Row(rowData);
+    }
+
+    private List<Row> prepareShowColumnsResultRows(Row... rows)
+    {
+        ImmutableList.Builder<Row> rowsWithPartitionsBuilder = new ImmutableList.Builder<>();
+        rowsWithPartitionsBuilder.add(rows);
+        varcharPartitionColumns.stream()
+                .map(partition -> row(partition, "varchar", "partition key", ""))
+                .forEach(rowsWithPartitionsBuilder::add);
+        return rowsWithPartitionsBuilder.build();
+    }
+
+    private String getPartitionsAsListString(Function<String, String> partitionMapper)
+    {
+        return varcharPartitionColumns.stream()
+                .map(partitionMapper)
+                .collect(Collectors.joining(", "));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestAvroSchemaEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/BaseTestAvroSchemaEvolution.java
@@ -26,7 +26,7 @@ import static io.trino.tests.product.TestGroups.AVRO;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static java.lang.String.format;
 
-public class TestAvroSchemaEvolution
+public abstract class BaseTestAvroSchemaEvolution
         extends ProductTest
 {
     private static final String TABLE_NAME = "product_tests_avro_table";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaEvolutionOnSimpleTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaEvolutionOnSimpleTable.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests.product.hive;
+
+public class TestAvroSchemaEvolutionOnSimpleTable
+        extends BaseTestAvroSchemaEvolution
+{
+    public TestAvroSchemaEvolutionOnSimpleTable()
+    {
+        super();
+    }
+}

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaEvolutionOnTableWithPartitioning.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaEvolutionOnTableWithPartitioning.java
@@ -13,11 +13,11 @@
  */
 package io.trino.tests.product.hive;
 
-public class TestAvroSchemaEvolutionOnSimpleTable
+public class TestAvroSchemaEvolutionOnTableWithPartitioning
         extends BaseTestAvroSchemaEvolution
 {
-    public TestAvroSchemaEvolutionOnSimpleTable()
+    public TestAvroSchemaEvolutionOnTableWithPartitioning()
     {
-        super("product_tests_avro_table");
+        super("product_tests_avro_table_with_partitioning", "partition_col");
     }
 }


### PR DESCRIPTION
This PR:
- enables creating table with AVRO format using ```avro_schema_url``` property like below:
```
CREATE TABLE some_table (
  dummy_col VARCHAR, 
  partition_col VARCHAR 
) WITH (
  format='AVRO', 
  partitioned_by=ARRAY['partition_col'], 
  avro_schema_url='some_uri'
)
```
IMPORTANT:
Partition columns can't overlap with Avro schema. They are additional set of columns which are not subject to schema evolution. Original schema of table is stored in HMS and is being overwrite by Hive in runtime basing on ```avro_schema_url``` provided. This is replicated in Trino when we fetch table metadata. In case ```avro_schema_url``` is set we rewrite metadata basing on Avro Schema.
