### PR TITLE
Fix bug when using ROUND(0.x, 0)

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/MathFunctions.java
@@ -914,7 +914,7 @@ public final class MathFunctions
                 @SqlType("decimal(p, s)") long num,
                 @SqlType(StandardTypes.INTEGER) long decimals)
         {
-            if (num == 0 || numPrecision - numScale + decimals <= 0) {
+            if (num == 0 || numPrecision - numScale + decimals < 0) {
                 return 0;
             }
             if (decimals >= numScale) {

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestMathFunctions.java
@@ -952,6 +952,18 @@ public class TestMathFunctions
         assertFunction("round(DECIMAL '9.99', 1)", createDecimalType(4, 2), SqlDecimal.of("10.00"));
         assertFunction("round(DECIMAL '-9.99', 1)", createDecimalType(4, 2), SqlDecimal.of("-10.00"));
 
+        assertFunction("round(DECIMAL '0.3', 0)", createDecimalType(2, 1), SqlDecimal.of("0.0"));
+        assertFunction("round(DECIMAL '0.7', 0)", createDecimalType(2, 1), SqlDecimal.of("1.0"));
+        assertFunction("round(DECIMAL '1.7', 0)", createDecimalType(3, 1), SqlDecimal.of("2.0"));
+        assertFunction("round(DECIMAL '-0.3', 0)", createDecimalType(2, 1), SqlDecimal.of("0.0"));
+        assertFunction("round(DECIMAL '-0.7', 0)", createDecimalType(2, 1), SqlDecimal.of("-1.0"));
+        assertFunction("round(DECIMAL '-1.7', 0)", createDecimalType(3, 1), SqlDecimal.of("-2.0"));
+        assertFunction("round(DECIMAL '0.7', -1)", createDecimalType(2, 1), SqlDecimal.of("0.0"));
+        assertFunction("round(DECIMAL '1.7', -1)", createDecimalType(3, 1), SqlDecimal.of("0.0"));
+        assertFunction("round(DECIMAL '7.1', -1)", createDecimalType(3, 1), SqlDecimal.of("10.0"));
+        assertFunction("round(DECIMAL '0.3', -1)", createDecimalType(2, 1), SqlDecimal.of("0.0"));
+        assertFunction("round(DECIMAL '33.3', -2)", createDecimalType(4, 1), SqlDecimal.of("0.0"));
+        assertFunction("round(CAST(DECIMAL '0.7' AS decimal(20, 1)), -19)", createDecimalType(21, 1), SqlDecimal.of("0.0"));
         assertFunction("round(DECIMAL '0.00', 1)", createDecimalType(3, 2), SqlDecimal.of("0.00"));
         assertFunction("round(DECIMAL '1234', 7)", createDecimalType(5, 0), SqlDecimal.of("1234"));
         assertFunction("round(DECIMAL '-1234', 7)", createDecimalType(5, 0), SqlDecimal.of("-1234"));


### PR DESCRIPTION
Before this commit, ROUND act like:

```
presto> select round(0.7, 0);
 _col0
-------
   0.0

presto> select round(0.7);
 _col0
-------
     1

presto> select round(1.7, 0);
 _col0
-------
   2.0
```

round(0.7, 0) got wrong result 0.0, should be 1.0. After this commit, round(0.7, 0) returns 1.0
