### PR TITLE
Add outer ROW to VALUES in SqlDataTypeTest.verifySelect

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/datatype/SqlDataTypeTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/datatype/SqlDataTypeTest.java
@@ -90,7 +90,7 @@ public final class SqlDataTypeTest
         QueryAssert assertion = assertThat(queryAssertions.query(session, "SELECT * FROM " + testTable.getName()));
         MaterializedResult expected = queryRunner.execute(session, testCases.stream()
                 .map(TestCase::getExpectedLiteral)
-                .collect(joining(",", "VALUES (", ")")));
+                .collect(joining(",", "VALUES ROW(", ")")));
 
         // Verify types if specified
         for (int column = 0; column < testCases.size(); column++) {


### PR DESCRIPTION
SELECT is more convinient because VALUES with a ROW type
unpacks the field into individual columns.