### PR TITLE
Refactor PartitioningExchanger

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/exchange/BroadcastExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/BroadcastExchanger.java
@@ -40,9 +40,8 @@ class BroadcastExchanger
     @Override
     public void accept(Page page)
     {
-        memoryManager.updateMemoryUsage(page.getRetainedSizeInBytes());
-
         PageReference pageReference = new PageReference(page, buffers.size(), onPageReleased);
+        memoryManager.updateMemoryUsage(pageReference.getRetainedSizeInBytes());
 
         for (Consumer<PageReference> buffer : buffers) {
             buffer.accept(pageReference);

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSource.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSource.java
@@ -132,7 +132,7 @@ public class LocalExchangeSource
 
         // dereference the page outside of lock, since may trigger a callback
         Page page = pageReference.removePage();
-        bufferedBytes.addAndGet(-page.getRetainedSizeInBytes());
+        bufferedBytes.addAndGet(-pageReference.getRetainedSizeInBytes());
 
         checkFinished();
 

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PartitioningExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PartitioningExchanger.java
@@ -20,6 +20,9 @@ import io.trino.operator.exchange.PageReference.PageReleasedListener;
 import io.trino.spi.Page;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -33,6 +36,7 @@ class PartitioningExchanger
     private final LocalExchangeMemoryManager memoryManager;
     private final Function<Page, Page> partitionedPagePreparer;
     private final PartitionFunction partitionFunction;
+    @GuardedBy("this")
     private final IntArrayList[] partitionAssignments;
     private final PageReleasedListener onPageReleased;
 
@@ -57,10 +61,17 @@ class PartitioningExchanger
     @Override
     public void accept(Page page)
     {
-        partitionPage(page, partitionedPagePreparer.apply(page));
+        Consumer<PageReference> wholePagePartition = partitionPageOrFindWholePagePartition(page, partitionedPagePreparer.apply(page));
+        if (wholePagePartition != null) {
+            // whole input page will go to this partition, compact the input page avoid over-retaining memory and to
+            // match the behavior of sub-partitioned pages that copy positions out
+            page.compact();
+            sendPageToPartition(wholePagePartition, page);
+        }
     }
 
-    private synchronized void partitionPage(Page page, Page partitionPage)
+    @Nullable
+    private synchronized Consumer<PageReference> partitionPageOrFindWholePagePartition(Page page, Page partitionPage)
     {
         // assign each row to a partition. The assignments lists are all expected to cleared by the previous iterations
         for (int position = 0; position < partitionPage.getPositionCount(); position++) {
@@ -81,19 +92,22 @@ class PartitioningExchanger
             int[] positions = positionsList.elements();
             positionsList.clear();
 
-            Page pageSplit;
             if (partitionSize == page.getPositionCount()) {
-                // entire page will be sent to this partition, just compact the page to avoid over-retaining
-                // memory and match the behavior of the sub-partitioned case
-                page.compact();
-                pageSplit = page;
+                // entire page will be sent to this partition, compact and send the page after releasing the lock
+                return buffers.get(partition);
             }
-            else {
-                pageSplit = page.copyPositions(positions, 0, partitionSize);
-            }
-            memoryManager.updateMemoryUsage(pageSplit.getRetainedSizeInBytes());
-            buffers.get(partition).accept(new PageReference(pageSplit, 1, onPageReleased));
+            Page pageSplit = page.copyPositions(positions, 0, partitionSize);
+            sendPageToPartition(buffers.get(partition), pageSplit);
         }
+        // No single partition receives the entire input page
+        return null;
+    }
+
+    // This is safe to call without synchronizing because the partition buffers are themselves threadsafe
+    private void sendPageToPartition(Consumer<PageReference> buffer, Page pageSplit)
+    {
+        memoryManager.updateMemoryUsage(pageSplit.getRetainedSizeInBytes());
+        buffer.accept(new PageReference(pageSplit, 1, onPageReleased));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PartitioningExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PartitioningExchanger.java
@@ -106,8 +106,9 @@ class PartitioningExchanger
     // This is safe to call without synchronizing because the partition buffers are themselves threadsafe
     private void sendPageToPartition(Consumer<PageReference> buffer, Page pageSplit)
     {
-        memoryManager.updateMemoryUsage(pageSplit.getRetainedSizeInBytes());
-        buffer.accept(new PageReference(pageSplit, 1, onPageReleased));
+        PageReference pageReference = new PageReference(pageSplit, 1, onPageReleased);
+        memoryManager.updateMemoryUsage(pageReference.getRetainedSizeInBytes());
+        buffer.accept(pageReference);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/PassthroughExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/PassthroughExchanger.java
@@ -43,11 +43,12 @@ public class PassthroughExchanger
     @Override
     public void accept(Page page)
     {
-        long retainedSizeInBytes = page.getRetainedSizeInBytes();
+        PageReference pageReference = new PageReference(page, 1, onPageReleased);
+        long retainedSizeInBytes = pageReference.getRetainedSizeInBytes();
         bufferMemoryManager.updateMemoryUsage(retainedSizeInBytes);
         memoryTracker.accept(retainedSizeInBytes);
 
-        localExchangeSource.addPage(new PageReference(page, 1, onPageReleased));
+        localExchangeSource.addPage(pageReference);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/RandomExchanger.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/RandomExchanger.java
@@ -41,9 +41,10 @@ class RandomExchanger
     @Override
     public void accept(Page page)
     {
-        memoryManager.updateMemoryUsage(page.getRetainedSizeInBytes());
+        PageReference pageReference = new PageReference(page, 1, onPageReleased);
+        memoryManager.updateMemoryUsage(pageReference.getRetainedSizeInBytes());
         int randomIndex = ThreadLocalRandom.current().nextInt(buffers.size());
-        buffers.get(randomIndex).accept(new PageReference(page, 1, onPageReleased));
+        buffers.get(randomIndex).accept(pageReference);
     }
 
     @Override


### PR DESCRIPTION
Refactors to `PartitioningExchanger` to compact pages being sent to a single partition outside of the synchronized section to allow other threads to proceed while Page compaction completes. This is a follow up after a discussion as part of https://github.com/trinodb/trino/pull/9327.

This PR also refactors `PageReference` to store retainedSizeInBytes in a local field, and updates usage sites in local exchanges get the retained size from that field instead of from the Page itself. In the common case, this reduces the number of volatile reads on the `Page` retained size field from 4 to 1.