### PR TITLE
Refactor BigQuery tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
           fi
       - name: Cloud BigQuery Case Insensitive Mapping Tests
         env:
-          BIGQUERY_CREDENTIALS_KEY: ${{ secrets.BIGQUERY_CREDENTIALS_KEY }}
+          BIGQUERY_CREDENTIALS_KEY: ${{ secrets.BIGQUERY_CASE_INSENSITIVE_CREDENTIALS_KEY }}
         run: |
           if [ "${BIGQUERY_CREDENTIALS_KEY}" != "" ]; then
             $MAVEN test ${MAVEN_TEST} -pl :trino-bigquery -Pcloud-tests-case-insensitive-mapping -Dbigquery.credentials-key="${BIGQUERY_CREDENTIALS_KEY}"

--- a/plugin/trino-bigquery/pom.xml
+++ b/plugin/trino-bigquery/pom.xml
@@ -287,6 +287,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino.tpch</groupId>
+            <artifactId>tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>
@@ -328,6 +334,7 @@
                                 <!-- If you are adding entry here also add an entry to cloud-tests or cloud-tests-case-insensitive-mapping profile below -->
                                 <exclude>**/TestBigQueryIntegrationSmokeTest.java</exclude>
                                 <exclude>**/TestBigQueryTypeMapping.java</exclude>
+                                <exclude>**/TestBigQueryInstanceCleaner.java</exclude>
                                 <exclude>**/TestBigQueryCaseInsensitiveMapping.java</exclude>
                             </excludes>
                         </configuration>
@@ -350,6 +357,7 @@
                             <includes>
                                 <include>**/TestBigQueryIntegrationSmokeTest.java</include>
                                 <include>**/TestBigQueryTypeMapping.java</include>
+                                <include>**/TestBigQueryInstanceCleaner.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -47,11 +47,13 @@ import static com.google.cloud.bigquery.BigQuery.DatasetListOption.labelFilter;
 import static io.airlift.testing.Closeables.closeAllSuppress;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public final class BigQueryQueryRunner
 {
     private static final Logger log = Logger.get(BigQueryQueryRunner.class);
 
+    private static final String BIGQUERY_CREDENTIALS_KEY = requireNonNull(System.getProperty("bigquery.credentials-key"), "bigquery.credentials-key is not set");
     private static final String TPCH_SCHEMA = "tpch";
 
     private BigQueryQueryRunner() {}
@@ -154,7 +156,7 @@ public final class BigQueryQueryRunner
         private static BigQuery createBigQueryClient()
         {
             try {
-                InputStream jsonKey = new ByteArrayInputStream(Base64.getDecoder().decode(System.getProperty("bigquery.credentials-key")));
+                InputStream jsonKey = new ByteArrayInputStream(Base64.getDecoder().decode(BIGQUERY_CREDENTIALS_KEY));
                 return BigQueryOptions.newBuilder()
                         .setCredentials(ServiceAccountCredentials.fromStream(jsonKey))
                         .build()

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/BigQueryQueryRunner.java
@@ -22,6 +22,7 @@ import com.google.cloud.bigquery.DatasetId;
 import com.google.cloud.bigquery.DatasetInfo;
 import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableResult;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -54,7 +55,8 @@ public final class BigQueryQueryRunner
     private static final Logger log = Logger.get(BigQueryQueryRunner.class);
 
     private static final String BIGQUERY_CREDENTIALS_KEY = requireNonNull(System.getProperty("bigquery.credentials-key"), "bigquery.credentials-key is not set");
-    private static final String TPCH_SCHEMA = "tpch";
+    public static final String TPCH_SCHEMA = "tpch";
+    public static final String TEST_SCHEMA = "test";
 
     private BigQueryQueryRunner() {}
 
@@ -110,8 +112,13 @@ public final class BigQueryQueryRunner
         @Override
         public void execute(String sql)
         {
+            executeQuery(sql);
+        }
+
+        public TableResult executeQuery(String sql)
+        {
             try {
-                bigQuery.query(QueryJobConfiguration.of(sql));
+                return bigQuery.query(QueryJobConfiguration.of(sql));
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
@@ -45,7 +45,6 @@ public class TestBigQueryCaseInsensitiveMapping
     public void initBigQueryExecutor()
     {
         this.bigQuerySqlExecutor = new BigQuerySqlExecutor();
-        bigQuerySqlExecutor.deleteSelfCreatedDatasets();
     }
 
     @Override

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryCaseInsensitiveMapping.java
@@ -218,8 +218,8 @@ public class TestBigQueryCaseInsensitiveMapping
     public void testDropSchema()
             throws Exception
     {
-        String schemaName = "Test_Drop_Case_Sensitive";
-        try (AutoCloseable schema = withSchema(schemaName);) {
+        String schemaName = "Test_Drop_Case_Sensitive_" + randomTableSuffix();
+        try (AutoCloseable schema = withSchema(schemaName)) {
             assertUpdate("DROP SCHEMA " + schemaName.toLowerCase(ENGLISH));
         }
     }
@@ -228,7 +228,7 @@ public class TestBigQueryCaseInsensitiveMapping
     public void testDropSchemaNameClash()
             throws Exception
     {
-        String schemaName = "Test_Drop_Case_Sensitive_Clash";
+        String schemaName = "Test_Drop_Case_Sensitive_Clash_" + randomTableSuffix();
         try (AutoCloseable schema = withSchema(schemaName);
                 AutoCloseable secondSchema = withSchema(schemaName.toLowerCase(ENGLISH))) {
             assertQueryFails("DROP SCHEMA " + schemaName.toLowerCase(ENGLISH), "Found ambiguous names in BigQuery.*");

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryInstanceCleaner.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryInstanceCleaner.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.cloud.bigquery.TableResult;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import io.airlift.log.Logger;
+import io.trino.plugin.bigquery.BigQueryQueryRunner.BigQuerySqlExecutor;
+import io.trino.tpch.TpchTable;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map.Entry;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.bigquery.BigQueryQueryRunner.TEST_SCHEMA;
+import static io.trino.plugin.bigquery.BigQueryQueryRunner.TPCH_SCHEMA;
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
+public class TestBigQueryInstanceCleaner
+{
+    public static final Logger LOG = Logger.get(TestBigQueryInstanceCleaner.class);
+
+    /**
+     * List of table names that will not be dropped.
+     */
+    private static final Collection<String> tablesToKeep = TpchTable.getTables().stream()
+            .map(TpchTable::getTableName)
+            .map(s -> s.toLowerCase(Locale.ENGLISH))
+            .collect(toUnmodifiableSet());
+
+    // see https://cloud.google.com/bigquery/docs/information-schema-tables#tables_view for possible values
+    public static final Collection<String> tableTypesToDrop = ImmutableList.of("BASE TABLE", "VIEW", "MATERIALIZED VIEW");
+
+    private BigQuerySqlExecutor bigQuerySqlExecutor;
+
+    @BeforeClass
+    public void setUp()
+    {
+        this.bigQuerySqlExecutor = new BigQuerySqlExecutor();
+    }
+
+    @Test(dataProvider = "cleanUpSchemasDataProvider")
+    public void cleanUpTables(String schemaName)
+    {
+        logObjectsCount(schemaName);
+        if (!tablesToKeep.isEmpty()) {
+            LOG.info("Will not drop these tables: %s", join(", ", tablesToKeep));
+        }
+
+        LOG.info("Identifying tables to drop...");
+        // Drop all tables created more than 24 hours ago
+        TableResult result = bigQuerySqlExecutor.executeQuery(format("" +
+                        "SELECT table_name, table_type " +
+                        "FROM %s.INFORMATION_SCHEMA.TABLES " +
+                        "WHERE datetime_diff(current_datetime(), datetime(creation_time), HOUR) > 24 " +
+                        "AND table_name NOT IN (%s)" +
+                        "AND table_type IN (%s)",
+                quoted(schemaName),
+                tablesToKeep.stream().collect(joining("','", "'", "'")),
+                tableTypesToDrop.stream().collect(joining("','", "'", "'"))));
+        List<Entry<String, String>> objectsToDrop = Streams.stream(result.getValues())
+                .map(fieldValues -> new SimpleImmutableEntry<>(fieldValues.get("table_name").getStringValue(), fieldValues.get("table_type").getStringValue()))
+                .collect(toImmutableList());
+
+        if (objectsToDrop.isEmpty()) {
+            LOG.info("Did not find any objects to drop.");
+            return;
+        }
+
+        LOG.info("Dropping %s objects.", objectsToDrop.size());
+        LOG.info("Dropping: %s", objectsToDrop.stream().map(Entry::getKey).collect(joining(", ")));
+        objectsToDrop.forEach(entry -> {
+            String dropStatement = getDropStatement(schemaName, entry.getKey(), entry.getValue());
+            LOG.info("Executing: %s", dropStatement);
+            bigQuerySqlExecutor.execute(dropStatement);
+        });
+
+        logObjectsCount(schemaName);
+    }
+
+    @DataProvider
+    public static Object[][] cleanUpSchemasDataProvider()
+    {
+        // Other schemas created by tests are taken care of by cleanUpDatasets
+        return new Object[][] {
+                {TPCH_SCHEMA},
+                {TEST_SCHEMA},
+        };
+    }
+
+    private void logObjectsCount(String schemaName)
+    {
+        TableResult result = bigQuerySqlExecutor.executeQuery(format("" +
+                        "SELECT table_type, count(*) AS c " +
+                        "FROM %s.INFORMATION_SCHEMA.TABLES " +
+                        "GROUP BY table_type",
+                quoted(schemaName)));
+        result.getValues().forEach(fieldValues -> LOG.info("Schema '%s' contains '%s' objects of type '%s'",
+                schemaName,
+                fieldValues.get("c").getLongValue(),
+                fieldValues.get("table_type").getStringValue()));
+    }
+
+    private static String getDropStatement(String schemaName, String objectName, String objectType)
+    {
+        switch (objectType) {
+            case "BASE TABLE":
+                return format("DROP TABLE IF EXISTS %s.%s", quoted(schemaName), quoted(objectName));
+            case "VIEW":
+                return format("DROP VIEW IF EXISTS %s.%s", quoted(schemaName), quoted(objectName));
+            case "MATERIALIZED VIEW":
+                return format("DROP MATERIALIZED VIEW IF EXISTS %s.%s", quoted(schemaName), quoted(objectName));
+            default:
+                throw new IllegalArgumentException("Unexpected object type " + objectType);
+        }
+    }
+
+    private static String quoted(String identifier)
+    {
+        return "`" + identifier.replace("\\", "\\\\").replace("`", "\\`") + "`";
+    }
+}

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
@@ -43,7 +43,6 @@ public class TestBigQueryIntegrationSmokeTest
     public void initBigQueryExecutor()
     {
         this.bigQuerySqlExecutor = new BigQuerySqlExecutor();
-        bigQuerySqlExecutor.deleteSelfCreatedDatasets();
     }
 
     @Override

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryIntegrationSmokeTest.java
@@ -13,15 +13,17 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.testing.AbstractTestIntegrationSmokeTest;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.QueryRunner;
 import io.trino.testing.sql.TestTable;
+import io.trino.testing.sql.TestView;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.util.List;
 
 import static io.trino.plugin.bigquery.BigQueryQueryRunner.BigQuerySqlExecutor;
 import static io.trino.spi.type.VarcharType.VARCHAR;
@@ -57,7 +59,7 @@ public class TestBigQueryIntegrationSmokeTest
     @Test
     public void testCreateSchema()
     {
-        String schemaName = "test_create_schema";
+        String schemaName = "test_create_schema_" + randomTableSuffix();
 
         assertUpdate("DROP SCHEMA IF EXISTS " + schemaName);
 
@@ -74,7 +76,7 @@ public class TestBigQueryIntegrationSmokeTest
     @Test
     public void testDropSchema()
     {
-        String schemaName = "test_drop_schema";
+        String schemaName = "test_drop_schema_" + randomTableSuffix();
 
         assertUpdate("DROP SCHEMA IF EXISTS " + schemaName);
         assertUpdate("CREATE SCHEMA " + schemaName);
@@ -108,17 +110,11 @@ public class TestBigQueryIntegrationSmokeTest
     @Test(dataProvider = "createTableSupportedTypes")
     public void testCreateTableSupportedType(String createType, String expectedType)
     {
-        String tableName = "test_create_table_supported_type_" + createType.replaceAll("[^a-zA-Z0-9]", "");
-
-        assertUpdate("DROP TABLE IF EXISTS " + tableName);
-
-        assertUpdate(format("CREATE TABLE %s (col1 %s)", tableName, createType));
-
-        assertEquals(
-                computeScalar("SELECT data_type FROM information_schema.columns WHERE table_name = '" + tableName + "' AND column_name = 'col1'"),
-                expectedType);
-
-        assertUpdate("DROP TABLE " + tableName);
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_table_supported_type_" + createType.replaceAll("[^a-zA-Z0-9]", ""), format("(col1 %s)", createType))) {
+            assertEquals(
+                    computeScalar("SELECT data_type FROM information_schema.columns WHERE table_name = '" + table.getName() + "' AND column_name = 'col1'"),
+                    expectedType);
+        }
     }
 
     @DataProvider
@@ -150,14 +146,8 @@ public class TestBigQueryIntegrationSmokeTest
     @Test(dataProvider = "createTableUnsupportedTypes")
     public void testCreateTableUnsupportedType(String createType)
     {
-        String tableName = "test_create_table_unsupported_type_" + createType.replaceAll("[^a-zA-Z0-9]", "");
-
-        assertUpdate("DROP TABLE IF EXISTS " + tableName);
-
-        assertQueryFails(
-                format("CREATE TABLE %s (col1 %s)", tableName, createType),
-                "Unsupported column type: " + createType);
-
+        String tableName = format("test_create_table_unsupported_type_%s_%s", createType.replaceAll("[^a-zA-Z0-9]", ""), randomTableSuffix());
+        assertQueryFails(format("CREATE TABLE %s (col1 %s)", tableName, createType), "Unsupported column type: " + createType);
         assertUpdate("DROP TABLE IF EXISTS " + tableName);
     }
 
@@ -174,52 +164,34 @@ public class TestBigQueryIntegrationSmokeTest
     @Test
     public void testCreateTableWithRowTypeWithoutField()
     {
-        String tableName = "test_row_type_table";
-
-        assertUpdate("DROP TABLE IF EXISTS " + tableName);
-
+        String tableName = "test_row_type_table_" + randomTableSuffix();
         assertQueryFails(
                 "CREATE TABLE " + tableName + "(col1 row(int))",
                 "\\QROW type does not have field names declared: row(integer)\\E");
-
-        assertUpdate("DROP TABLE IF EXISTS " + tableName);
     }
 
     @Test
     public void testCreateTableAlreadyExists()
     {
-        String tableName = "test_create_table_already_exists";
-
-        assertUpdate("DROP TABLE IF EXISTS " + tableName);
-
-        assertUpdate("CREATE TABLE " + tableName + "(col1 int)");
-        assertQueryFails(
-                "CREATE TABLE " + tableName + "(col1 int)",
-                "\\Qline 1:1: Table 'bigquery.tpch.test_create_table_already_exists' already exists\\E");
-
-        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_table_already_exists", "(col1 int)")) {
+            assertQueryFails(
+                    "CREATE TABLE " + table.getName() + "(col1 int)",
+                    "\\Qline 1:1: Table 'bigquery.tpch." + table.getName() + "' already exists\\E");
+        }
     }
 
     @Test
     public void testCreateTableIfNotExists()
     {
-        String tableName = "test_create_table_if_not_exists";
-
-        assertUpdate("DROP TABLE IF EXISTS " + tableName);
-
-        assertUpdate("CREATE TABLE " + tableName + "(col1 int)");
-        assertUpdate("CREATE TABLE IF NOT EXISTS " + tableName + "(col1 int)");
-
-        assertUpdate("DROP TABLE IF EXISTS " + tableName);
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test_create_table_if_not_exists", "(col1 int)")) {
+            assertUpdate("CREATE TABLE IF NOT EXISTS " + table.getName() + "(col1 int)");
+        }
     }
 
     @Test
     public void testDropTable()
     {
-        String tableName = "test_drop_table";
-
-        assertUpdate("DROP TABLE IF EXISTS " + tableName);
-
+        String tableName = "test_drop_table_" + randomTableSuffix();
         assertUpdate("CREATE TABLE " + tableName + "(col bigint)");
         assertTrue(getQueryRunner().tableExists(getSession(), tableName));
 
@@ -230,81 +202,68 @@ public class TestBigQueryIntegrationSmokeTest
     @Test(enabled = false)
     public void testSelectFromHourlyPartitionedTable()
     {
-        onBigQuery("DROP TABLE IF EXISTS test.hourly_partitioned");
-        onBigQuery("CREATE TABLE test.hourly_partitioned (value INT64, ts TIMESTAMP) PARTITION BY TIMESTAMP_TRUNC(ts, HOUR)");
-        onBigQuery("INSERT INTO test.hourly_partitioned (value, ts) VALUES (1000, '2018-01-01 10:00:00')");
-
-        MaterializedResult actualValues = computeActual("SELECT COUNT(1) FROM test.hourly_partitioned");
-
-        assertEquals((long) actualValues.getOnlyValue(), 1L);
+        try (TestTable table = new TestTable(
+                bigQuerySqlExecutor,
+                "test.hourly_partitioned",
+                "(value INT64, ts TIMESTAMP) PARTITION BY TIMESTAMP_TRUNC(ts, HOUR)",
+                List.of("1000, '2018-01-01 10:00:00'"))) {
+            assertQuery("SELECT COUNT(1) FROM " + table.getName(), "VALUES 1");
+        }
     }
 
     @Test(enabled = false)
     public void testSelectFromYearlyPartitionedTable()
     {
-        onBigQuery("DROP TABLE IF EXISTS test.yearly_partitioned");
-        onBigQuery("CREATE TABLE test.yearly_partitioned (value INT64, ts TIMESTAMP) PARTITION BY TIMESTAMP_TRUNC(ts, YEAR)");
-        onBigQuery("INSERT INTO test.yearly_partitioned (value, ts) VALUES (1000, '2018-01-01 10:00:00')");
-
-        MaterializedResult actualValues = computeActual("SELECT COUNT(1) FROM test.yearly_partitioned");
-
-        assertEquals((long) actualValues.getOnlyValue(), 1L);
+        try (TestTable table = new TestTable(
+                bigQuerySqlExecutor,
+                "test.yearly_partitioned",
+                "(value INT64, ts TIMESTAMP) PARTITION BY TIMESTAMP_TRUNC(ts, YEAR)",
+                List.of("1000, '2018-01-01 10:00:00'"))) {
+            assertQuery("SELECT COUNT(1) FROM " + table.getName(), "VALUES 1");
+        }
     }
 
     @Test(description = "regression test for https://github.com/trinodb/trino/issues/7784")
     public void testSelectWithSingleQuoteInWhereClause()
     {
-        String tableName = "test.select_with_single_quote";
-
-        onBigQuery("DROP TABLE IF EXISTS " + tableName);
-        onBigQuery("CREATE TABLE " + tableName + "(col INT64, val STRING)");
-        onBigQuery("INSERT INTO " + tableName + " VALUES (1,'escape\\'single quote')");
-
-        MaterializedResult actualValues = computeActual("SELECT val FROM " + tableName + " WHERE val = 'escape''single quote'");
-
-        assertEquals(actualValues.getRowCount(), 1);
-        assertEquals(actualValues.getOnlyValue(), "escape'single quote");
+        try (TestTable table = new TestTable(
+                bigQuerySqlExecutor,
+                "test.select_with_single_quote",
+                "(col INT64, val STRING)",
+                List.of("1, 'escape\\'single quote'"))) {
+            assertQuery("SELECT val FROM " + table.getName() + " WHERE val = 'escape''single quote'", "VALUES 'escape''single quote'");
+        }
     }
 
     @Test(description = "regression test for https://github.com/trinodb/trino/issues/5618")
     public void testPredicatePushdownPrunnedColumns()
     {
-        String tableName = "test.predicate_pushdown_prunned_columns";
-
-        onBigQuery("DROP TABLE IF EXISTS " + tableName);
-        onBigQuery("CREATE TABLE " + tableName + " (a INT64, b INT64, c INT64)");
-        onBigQuery("INSERT INTO " + tableName + " VALUES (1,2,3)");
-
-        assertQuery(
-                "SELECT 1 FROM " + tableName + " WHERE " +
-                        "    ((NULL IS NULL) OR a = 100) AND " +
-                        "    b = 2",
-                "VALUES (1)");
+        try (TestTable table = new TestTable(
+                bigQuerySqlExecutor,
+                "test.predicate_pushdown_prunned_columns",
+                "(a INT64, b INT64, c INT64)",
+                List.of("1, 2, 3"))) {
+            assertQuery(
+                    "SELECT 1 FROM " + table.getName() + " WHERE " +
+                            "    ((NULL IS NULL) OR a = 100) AND " +
+                            "    b = 2",
+                    "VALUES (1)");
+        }
     }
 
     @Test(description = "regression test for https://github.com/trinodb/trino/issues/5635")
     public void testCountAggregationView()
     {
-        String tableName = "test.count_aggregation_table";
-        String viewName = "test.count_aggregation_view";
-
-        onBigQuery("DROP TABLE IF EXISTS " + tableName);
-        onBigQuery("DROP VIEW IF EXISTS " + viewName);
-        onBigQuery("CREATE TABLE " + tableName + " (a INT64, b INT64, c INT64)");
-        onBigQuery("INSERT INTO " + tableName + " VALUES (1, 2, 3), (4, 5, 6)");
-        onBigQuery("CREATE VIEW " + viewName + " AS SELECT * FROM " + tableName);
-
-        assertQuery(
-                "SELECT count(*) FROM " + viewName,
-                "VALUES (2)");
-
-        assertQuery(
-                "SELECT count(*) FROM " + viewName + " WHERE a = 1",
-                "VALUES (1)");
-
-        assertQuery(
-                "SELECT count(a) FROM " + viewName + " WHERE b = 2",
-                "VALUES (1)");
+        try (TestTable table = new TestTable(
+                bigQuerySqlExecutor,
+                "test.count_aggregation_table",
+                "(a INT64, b INT64, c INT64)",
+                List.of("1, 2, 3", "4, 5, 6"));
+                TestView view = new TestView(bigQuerySqlExecutor, "test.count_aggregation_view", "SELECT * FROM " + table.getName())) {
+            assertQuery("SELECT count(*) FROM " + view.getName(), "VALUES (2)");
+            assertQuery("SELECT count(*) FROM " + view.getName() + " WHERE a = 1", "VALUES (1)");
+            assertQuery("SELECT count(a) FROM " + view.getName() + " WHERE b = 2", "VALUES (1)");
+        }
     }
 
     /**
@@ -313,15 +272,10 @@ public class TestBigQueryIntegrationSmokeTest
     @Test
     public void testRepeatCountAggregationView()
     {
-        String viewName = "test.repeat_count_aggregation_view_" + randomTableSuffix();
-
-        onBigQuery("DROP VIEW IF EXISTS " + viewName);
-        onBigQuery("CREATE VIEW " + viewName + " AS SELECT 1 AS col1");
-
-        assertQuery("SELECT count(*) FROM " + viewName, "VALUES (1)");
-        assertQuery("SELECT count(*) FROM " + viewName, "VALUES (1)");
-
-        onBigQuery("DROP VIEW " + viewName);
+        try (TestView view = new TestView(bigQuerySqlExecutor, "test.repeat_count_aggregation_view", "SELECT 1 AS col1")) {
+            assertQuery("SELECT count(*) FROM " + view.getName(), "VALUES (1)");
+            assertQuery("SELECT count(*) FROM " + view.getName(), "VALUES (1)");
+        }
     }
 
     /**
@@ -330,18 +284,11 @@ public class TestBigQueryIntegrationSmokeTest
     @Test
     public void testColumnPositionMismatch()
     {
-        String tableName = "test.test_column_position_mismatch";
-
-        assertUpdate("DROP TABLE IF EXISTS " + tableName);
-        assertUpdate(format("CREATE TABLE %s (c_varchar VARCHAR, c_int INT, c_date DATE)", tableName));
-        onBigQuery(format("INSERT INTO %s VALUES ('a', 1, '2021-01-01')", tableName));
-
-        // Adding a CAST makes BigQuery return columns in a different order
-        assertQuery(
-                "SELECT c_varchar, CAST(c_int AS SMALLINT), c_date FROM " + tableName,
-                "VALUES ('a', 1, '2021-01-01')");
-
-        assertUpdate("DROP TABLE " + tableName);
+        try (TestTable table = new TestTable(getQueryRunner()::execute, "test.test_column_position_mismatch", "(c_varchar VARCHAR, c_int INT, c_date DATE)")) {
+            onBigQuery("INSERT INTO " + table.getName() + " VALUES ('a', 1, '2021-01-01')");
+            // Adding a CAST makes BigQuery return columns in a different order
+            assertQuery("SELECT c_varchar, CAST(c_int AS SMALLINT), c_date FROM " + table.getName(), "VALUES ('a', 1, '2021-01-01')");
+        }
     }
 
     @Test
@@ -351,8 +298,6 @@ public class TestBigQueryIntegrationSmokeTest
         String tableName = "views_system_table_base_" + randomTableSuffix();
         String viewName = "views_system_table_view_" + randomTableSuffix();
 
-        onBigQuery(format("DROP TABLE IF EXISTS %s.%s", schemaName, tableName));
-        onBigQuery(format("DROP VIEW IF EXISTS %s.%s", schemaName, viewName));
         onBigQuery(format("CREATE TABLE %s.%s (a INT64, b INT64, c INT64)", schemaName, tableName));
         onBigQuery(format("CREATE VIEW %s.%s AS SELECT * FROM %s.%s", schemaName, viewName, schemaName, tableName));
 
@@ -392,7 +337,7 @@ public class TestBigQueryIntegrationSmokeTest
                 bigQuerySqlExecutor,
                 "test.test_skip_unsupported_type",
                 "(a INT64, unsupported BIGNUMERIC, b INT64)",
-                ImmutableList.of("1, 999, 2"))) {
+                List.of("1, 999, 2"))) {
             assertQuery("SELECT * FROM " + table.getName(), "VALUES (1, 2)");
             assertThat((String) computeActual("SHOW CREATE TABLE " + table.getName()).getOnlyValue())
                     .isEqualTo("CREATE TABLE bigquery." + table.getName() + " (\n" +

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryTypeMapping.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryTypeMapping.java
@@ -38,7 +38,6 @@ public class TestBigQueryTypeMapping
     public void initBigQueryExecutor()
     {
         bigQuerySqlExecutor = new BigQueryQueryRunner.BigQuerySqlExecutor();
-        bigQuerySqlExecutor.deleteSelfCreatedDatasets();
     }
 
     @Override


### PR DESCRIPTION
The changes in this PR are meant to allow running BigQuery tests concurrently by:

* Dropping old tables in test schema
* Dropping old datasets created by BigQuerySqlExecutor
* Using random table and schema names
* Modifying CI config to use different projects for case-insensitive and other tests

- [x] Make sure tests pass locally