### PR TITLE
Recommend disabling warnings about Guava's @Beta

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -152,6 +152,10 @@ Disable the following inspections:
 - ``Java | Abstraction issues | 'Optional' used as field or parameter type``,
 - ``Java | Data flow | Boolean method is always inverted``.
 
+Update the following inspections:
+
+- Remove ``com.google.common.annotations.Beta`` from ``JVM languages | Unstable API usage``.
+
 Enable errorprone ([Error Prone Installation#IDEA](https://errorprone.info/docs/installation#intellij-idea)):
 - Install ``Error Prone Compiler`` plugin from marketplace,
 - In ``Java Compiler`` tab, select ``Javac with error-prone`` as the compiler,

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
@@ -1178,7 +1178,6 @@ public class TestFileBasedSystemAccessControl
     {
         File configFile = newTemporaryFile();
         configFile.deleteOnExit();
-        //noinspection UnstableApiUsage
         copy(new File(getResourcePath("catalog.json")), configFile);
 
         SystemAccessControl accessControl = newFileBasedSystemAccessControl(ImmutableMap.of(
@@ -1190,7 +1189,6 @@ public class TestFileBasedSystemAccessControl
         accessControl.checkCanCreateView(alice, aliceView);
         accessControl.checkCanCreateView(alice, aliceView);
 
-        //noinspection UnstableApiUsage
         copy(new File(getResourcePath("security-config-file-with-unknown-rules.json")), configFile);
         sleep(2);
 
@@ -1203,7 +1201,6 @@ public class TestFileBasedSystemAccessControl
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageStartingWith("Invalid JSON file");
 
-        //noinspection UnstableApiUsage
         copy(new File(getResourcePath("catalog.json")), configFile);
         sleep(2);
 

--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/metastore/cache/TestCachingHiveMetastoreWithQueryRunner.java
@@ -38,7 +38,6 @@ import static io.trino.spi.security.SelectedRole.Type.ROLE;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SuppressWarnings("UnstableApiUsage")
 @Test(singleThreaded = true)
 public class TestCachingHiveMetastoreWithQueryRunner
 {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkHiveFileFormat.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkHiveFileFormat.java
@@ -69,7 +69,7 @@ import static io.trino.tpch.TpchTable.ORDERS;
 @Measurement(iterations = 50)
 @Warmup(iterations = 20)
 @Fork(3)
-@SuppressWarnings({"UseOfSystemOutOrSystemErr", "UnstableApiUsage", "ResultOfMethodCallIgnored"})
+@SuppressWarnings({"UseOfSystemOutOrSystemErr", "ResultOfMethodCallIgnored"})
 public class BenchmarkHiveFileFormat
 {
     static {


### PR DESCRIPTION
We use a lot of beta APIs from Guava, so these warnings generate lots of noise. Instead of disabling the inspection entirely, it's recommended to remove just the @Beta annotation from it.