### PR TITLE
fix explain analyze statement do not show estimates

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -71,7 +71,6 @@ import io.trino.sql.tree.CoalesceExpression;
 import io.trino.sql.tree.ComparisonExpression;
 import io.trino.sql.tree.CreateTableAsSelect;
 import io.trino.sql.tree.Delete;
-import io.trino.sql.tree.Explain;
 import io.trino.sql.tree.ExplainAnalyze;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.FunctionCall;
@@ -200,7 +199,7 @@ public class LogicalPlanner
 
     public Plan plan(Analysis analysis, Stage stage)
     {
-        return plan(analysis, stage, analysis.getStatement() instanceof Explain || isCollectPlanStatisticsForAllQueries(session));
+        return plan(analysis, stage, analysis.getStatement() instanceof ExplainAnalyze || isCollectPlanStatisticsForAllQueries(session));
     }
 
     public Plan plan(Analysis analysis, Stage stage, boolean collectPlanStatistics)

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedEngineOnlyQueries.java
@@ -216,6 +216,10 @@ public class TestDistributedEngineOnlyQueries
         assertExplainAnalyze(
                 "EXPLAIN ANALYZE SELECT nationkey FROM nation GROUP BY nationkey",
                 "Collisions avg\\.: .* \\(.* est\\.\\), Collisions std\\.dev\\.: .*");
+
+        assertExplainAnalyze(
+                "EXPLAIN ANALYZE SELECT * FROM nation a, nation b WHERE a.nationkey = b.nationkey",
+                "Estimates: \\{rows: .* \\(.*\\), cpu: .*, memory: .*, network: .*}");
     }
 
     @Test


### PR DESCRIPTION
fix EXPLAIN ANALYZE and EXPLAIN ANALYZE VERBOSE statement do not show estimates after trino 360 which were previously displayed in Trino version 358. issue in #9356 