### PR TITLE
Add support for compacting small files for Hive tables

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -48,6 +48,7 @@ import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorRecordSetProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.SystemTable;
+import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.procedure.Procedure;
 import io.trino.spi.session.PropertyMetadata;
@@ -299,6 +300,7 @@ public class ConnectorManager
                 .ifPresent(partitioningProvider -> nodePartitioningManager.addPartitioningProvider(catalogName, partitioningProvider));
 
         metadataManager.getProcedureRegistry().addProcedures(catalogName, connector.getProcedures());
+        metadataManager.getTableProcedureRegistry().addTableProcedures(catalogName, connector.getTableProcedures());
 
         connector.getAccessControl()
                 .ifPresent(accessControl -> accessControlManager.addCatalogAccessControl(catalogName, accessControl));
@@ -401,6 +403,7 @@ public class ConnectorManager
         private final Connector connector;
         private final Set<SystemTable> systemTables;
         private final Set<Procedure> procedures;
+        private final Set<TableProcedureMetadata> tableProcedures;
         private final Optional<ConnectorSplitManager> splitManager;
         private final Optional<ConnectorPageSourceProvider> pageSourceProvider;
         private final Optional<ConnectorPageSinkProvider> pageSinkProvider;
@@ -427,6 +430,10 @@ public class ConnectorManager
             Set<Procedure> procedures = connector.getProcedures();
             requireNonNull(procedures, format("Connector '%s' returned a null procedures set", catalogName));
             this.procedures = ImmutableSet.copyOf(procedures);
+
+            Set<TableProcedureMetadata> tableProcedures = connector.getTableProcedures();
+            requireNonNull(procedures, format("Connector '%s' returned a null table procedures set", catalogName));
+            this.tableProcedures = ImmutableSet.copyOf(tableProcedures);
 
             ConnectorSplitManager splitManager = null;
             try {
@@ -536,6 +543,11 @@ public class ConnectorManager
         public Set<Procedure> getProcedures()
         {
             return procedures;
+        }
+
+        public Set<TableProcedureMetadata> getTableProcedures()
+        {
+            return tableProcedures;
         }
 
         public Optional<ConnectorSplitManager> getSplitManager()

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -300,7 +300,8 @@ public class ConnectorManager
                 .ifPresent(partitioningProvider -> nodePartitioningManager.addPartitioningProvider(catalogName, partitioningProvider));
 
         metadataManager.getProcedureRegistry().addProcedures(catalogName, connector.getProcedures());
-        metadataManager.getTableProcedureRegistry().addTableProcedures(catalogName, connector.getTableProcedures());
+        Set<TableProcedureMetadata> tableProcedures = connector.getTableProcedures();
+        metadataManager.getTableProcedureRegistry().addTableProcedures(catalogName, tableProcedures);
 
         connector.getAccessControl()
                 .ifPresent(accessControl -> accessControlManager.addCatalogAccessControl(catalogName, accessControl));
@@ -310,6 +311,9 @@ public class ConnectorManager
         metadataManager.getColumnPropertyManager().addProperties(catalogName, connector.getColumnProperties());
         metadataManager.getSchemaPropertyManager().addProperties(catalogName, connector.getSchemaProperties());
         metadataManager.getAnalyzePropertyManager().addProperties(catalogName, connector.getAnalyzeProperties());
+        for (TableProcedureMetadata tableProcedure : tableProcedures) {
+            metadataManager.getTableProceduresPropertyManager().addProperties(catalogName, tableProcedure.getName(), tableProcedure.getProperties());
+        }
         metadataManager.getSessionPropertyManager().addConnectorSessionProperties(catalogName, connector.getSessionProperties());
     }
 
@@ -340,6 +344,7 @@ public class ConnectorManager
         metadataManager.getColumnPropertyManager().removeProperties(catalogName);
         metadataManager.getSchemaPropertyManager().removeProperties(catalogName);
         metadataManager.getAnalyzePropertyManager().removeProperties(catalogName);
+        metadataManager.getTableProceduresPropertyManager().removeProperties(catalogName);
         metadataManager.getSessionPropertyManager().removeConnectorSessionProperties(catalogName);
 
         MaterializedConnector materializedConnector = connectors.remove(catalogName);

--- a/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlQueryExecution.java
@@ -132,6 +132,7 @@ public class SqlQueryExecution
     private final StatsCalculator statsCalculator;
     private final CostCalculator costCalculator;
     private final DynamicFilterService dynamicFilterService;
+    private final TableExecuteContextManager tableExecuteContextManager;
 
     private SqlQueryExecution(
             PreparedQuery preparedQuery,
@@ -159,7 +160,8 @@ public class SqlQueryExecution
             StatsCalculator statsCalculator,
             CostCalculator costCalculator,
             DynamicFilterService dynamicFilterService,
-            WarningCollector warningCollector)
+            WarningCollector warningCollector,
+            TableExecuteContextManager tableExecuteContextManager)
     {
         try (SetThreadName ignored = new SetThreadName("Query-%s", stateMachine.getQueryId())) {
             this.slug = requireNonNull(slug, "slug is null");
@@ -180,6 +182,7 @@ public class SqlQueryExecution
             this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
             this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
             this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
+            this.tableExecuteContextManager = requireNonNull(tableExecuteContextManager, "tableExecuteContextManager is null");
 
             checkArgument(scheduleSplitBatchSize > 0, "scheduleSplitBatchSize must be greater than 0");
             this.scheduleSplitBatchSize = scheduleSplitBatchSize;
@@ -544,7 +547,8 @@ public class SqlQueryExecution
                 nodeTaskMap,
                 executionPolicy,
                 schedulerStats,
-                dynamicFilterService);
+                dynamicFilterService,
+                tableExecuteContextManager);
 
         queryScheduler.set(scheduler);
 
@@ -741,6 +745,7 @@ public class SqlQueryExecution
         private final StatsCalculator statsCalculator;
         private final CostCalculator costCalculator;
         private final DynamicFilterService dynamicFilterService;
+        private final TableExecuteContextManager tableExecuteContextManager;
 
         @Inject
         SqlQueryExecutionFactory(
@@ -765,7 +770,8 @@ public class SqlQueryExecution
                 SplitSchedulerStats schedulerStats,
                 StatsCalculator statsCalculator,
                 CostCalculator costCalculator,
-                DynamicFilterService dynamicFilterService)
+                DynamicFilterService dynamicFilterService,
+                TableExecuteContextManager tableExecuteContextManager)
         {
             requireNonNull(config, "config is null");
             this.schedulerStats = requireNonNull(schedulerStats, "schedulerStats is null");
@@ -790,6 +796,7 @@ public class SqlQueryExecution
             this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
             this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
             this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
+            this.tableExecuteContextManager = requireNonNull(tableExecuteContextManager, "tableExecuteContextManager is null");
         }
 
         @Override
@@ -829,7 +836,8 @@ public class SqlQueryExecution
                     statsCalculator,
                     costCalculator,
                     dynamicFilterService,
-                    warningCollector);
+                    warningCollector,
+                    tableExecuteContextManager);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -133,7 +133,8 @@ public class SqlTaskManager
             NodeMemoryConfig nodeMemoryConfig,
             LocalSpillManager localSpillManager,
             NodeSpillConfig nodeSpillConfig,
-            GcMonitor gcMonitor)
+            GcMonitor gcMonitor,
+            TableExecuteContextManager tableExecuteQueryContextManager)
     {
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(config, "config is null");

--- a/core/trino-main/src/main/java/io/trino/execution/TableExecuteContext.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TableExecuteContext.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class TableExecuteContext
+{
+    private final AtomicReference<List<Object>> splitsInfo = new AtomicReference<>();
+
+    public void setSplitsInfo(List<Object> splitsInfo)
+    {
+        boolean success = this.splitsInfo.compareAndSet(null, splitsInfo);
+        if (!success) {
+            throw new IllegalStateException("splitsInfo already set to " + this.splitsInfo.get());
+        }
+    }
+
+    public List<Object> getSplitsInfo()
+    {
+        List<Object> splitsInfo = this.splitsInfo.get();
+        if (splitsInfo == null) {
+            throw new IllegalStateException("splits info not set yet");
+        }
+        return splitsInfo;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/TableExecuteContextManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TableExecuteContextManager.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.execution;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import io.trino.spi.QueryId;
+
+public class TableExecuteContextManager
+{
+    private final LoadingCache<QueryId, TableExecuteContext> contexts;
+
+    public TableExecuteContextManager()
+    {
+        contexts = CacheBuilder.newBuilder().weakValues().build(CacheLoader.from(
+                queryId -> new TableExecuteContext()));
+    }
+
+    public TableExecuteContext getTableExecuteContextForQuery(QueryId queryId)
+    {
+        return contexts.getUnchecked(queryId);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -21,6 +21,7 @@ import io.airlift.log.Logger;
 import io.trino.execution.Lifespan;
 import io.trino.execution.RemoteTask;
 import io.trino.execution.SqlStageExecution;
+import io.trino.execution.TableExecuteContextManager;
 import io.trino.execution.scheduler.ScheduleResult.BlockedReason;
 import io.trino.execution.scheduler.group.DynamicLifespanScheduler;
 import io.trino.execution.scheduler.group.FixedLifespanScheduler;
@@ -75,13 +76,15 @@ public class FixedSourcePartitionedScheduler
             OptionalInt concurrentLifespansPerTask,
             NodeSelector nodeSelector,
             List<ConnectorPartitionHandle> partitionHandles,
-            DynamicFilterService dynamicFilterService)
+            DynamicFilterService dynamicFilterService,
+            TableExecuteContextManager tableExecuteContextManager)
     {
         requireNonNull(stage, "stage is null");
         requireNonNull(splitSources, "splitSources is null");
         requireNonNull(bucketNodeMap, "bucketNodeMap is null");
         checkArgument(!requireNonNull(nodes, "nodes is null").isEmpty(), "nodes is empty");
         requireNonNull(partitionHandles, "partitionHandles is null");
+        requireNonNull(tableExecuteContextManager, "tableExecuteContextManager is null");
 
         this.stage = stage;
         this.nodes = ImmutableList.copyOf(nodes);
@@ -119,6 +122,7 @@ public class FixedSourcePartitionedScheduler
                     Math.max(splitBatchSize / concurrentLifespans, 1),
                     groupedExecutionForScanNode,
                     dynamicFilterService,
+                    tableExecuteContextManager,
                     () -> true);
 
             if (stageExecutionDescriptor.isStageGroupedExecution() && !groupedExecutionForScanNode) {

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SourcePartitionedScheduler.java
@@ -23,6 +23,8 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.trino.execution.Lifespan;
 import io.trino.execution.RemoteTask;
 import io.trino.execution.SqlStageExecution;
+import io.trino.execution.TableExecuteContext;
+import io.trino.execution.TableExecuteContextManager;
 import io.trino.execution.scheduler.FixedSourcePartitionedScheduler.BucketedSplitPlacementPolicy;
 import io.trino.metadata.InternalNode;
 import io.trino.metadata.Split;
@@ -40,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BooleanSupplier;
@@ -96,6 +99,7 @@ public class SourcePartitionedScheduler
     private final PlanNodeId partitionedNode;
     private final boolean groupedExecution;
     private final DynamicFilterService dynamicFilterService;
+    private final TableExecuteContextManager tableExecuteContextManager;
     private final BooleanSupplier anySourceTaskBlocked;
 
     private final Map<Lifespan, ScheduleGroup> scheduleGroups = new HashMap<>();
@@ -112,6 +116,7 @@ public class SourcePartitionedScheduler
             int splitBatchSize,
             boolean groupedExecution,
             DynamicFilterService dynamicFilterService,
+            TableExecuteContextManager tableExecuteContextManager,
             BooleanSupplier anySourceTaskBlocked)
     {
         this.stage = requireNonNull(stage, "stage is null");
@@ -119,6 +124,7 @@ public class SourcePartitionedScheduler
         this.splitSource = requireNonNull(splitSource, "splitSource is null");
         this.splitPlacementPolicy = requireNonNull(splitPlacementPolicy, "splitPlacementPolicy is null");
         this.dynamicFilterService = requireNonNull(dynamicFilterService, "dynamicFilterService is null");
+        this.tableExecuteContextManager = requireNonNull(tableExecuteContextManager, "tableExecuteContextManager is null");
         this.anySourceTaskBlocked = requireNonNull(anySourceTaskBlocked, "anySourceTaskBlocked is null");
 
         checkArgument(splitBatchSize > 0, "splitBatchSize must be at least one");
@@ -146,6 +152,7 @@ public class SourcePartitionedScheduler
             SplitPlacementPolicy splitPlacementPolicy,
             int splitBatchSize,
             DynamicFilterService dynamicFilterService,
+            TableExecuteContextManager tableExecuteContextManager,
             BooleanSupplier anySourceTaskBlocked)
     {
         SourcePartitionedScheduler sourcePartitionedScheduler = new SourcePartitionedScheduler(
@@ -156,6 +163,7 @@ public class SourcePartitionedScheduler
                 splitBatchSize,
                 false,
                 dynamicFilterService,
+                tableExecuteContextManager,
                 anySourceTaskBlocked);
         sourcePartitionedScheduler.startLifespan(Lifespan.taskWide(), NOT_PARTITIONED);
         sourcePartitionedScheduler.noMoreLifespans();
@@ -197,6 +205,7 @@ public class SourcePartitionedScheduler
             int splitBatchSize,
             boolean groupedExecution,
             DynamicFilterService dynamicFilterService,
+            TableExecuteContextManager tableExecuteContextManager,
             BooleanSupplier anySourceTaskBlocked)
     {
         return new SourcePartitionedScheduler(
@@ -207,6 +216,7 @@ public class SourcePartitionedScheduler
                 splitBatchSize,
                 groupedExecution,
                 dynamicFilterService,
+                tableExecuteContextManager,
                 anySourceTaskBlocked);
     }
 
@@ -357,6 +367,12 @@ public class SourcePartitionedScheduler
                     throw new IllegalStateException("At least 1 split should have been scheduled for this plan node");
                 case SPLITS_ADDED:
                     state = State.NO_MORE_SPLITS;
+
+                    // todo: would be great to call getTableExecuteSplitsInfo if we are executing plan which requires that.
+                    TableExecuteContext tableExecuteContext = tableExecuteContextManager.getTableExecuteContextForQuery(stage.getStageId().getQueryId());
+                    Optional<List<Object>> tableExecuteSplitsInfo = splitSource.getTableExecuteSplitsInfo();
+                    tableExecuteSplitsInfo.ifPresent(tableExecuteContext::setSplitsInfo);
+
                     splitSource.close();
                     // fall through
                 case NO_MORE_SPLITS:

--- a/core/trino-main/src/main/java/io/trino/metadata/HandleJsonModule.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/HandleJsonModule.java
@@ -23,6 +23,7 @@ import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPartitioningHandle;
 import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableLayoutHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
@@ -70,6 +71,12 @@ public class HandleJsonModule
     public static com.fasterxml.jackson.databind.Module insertTableHandleModule(HandleResolver resolver)
     {
         return new AbstractTypedJacksonModule<>(ConnectorInsertTableHandle.class, resolver::getId, resolver::getInsertTableHandleClass) {};
+    }
+
+    @ProvidesIntoSet
+    public static com.fasterxml.jackson.databind.Module tableExecuteHandleModule(HandleResolver resolver)
+    {
+        return new AbstractTypedJacksonModule<>(ConnectorTableExecuteHandle.class, resolver::getId, resolver::getTableExecuteHandleClass) {};
     }
 
     @ProvidesIntoSet

--- a/core/trino-main/src/main/java/io/trino/metadata/HandleResolver.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/HandleResolver.java
@@ -22,6 +22,7 @@ import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPartitioningHandle;
 import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableLayoutHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
@@ -103,6 +104,11 @@ public final class HandleResolver
         return getId(insertHandle, MaterializedHandleResolver::getInsertTableHandleClass);
     }
 
+    public String getId(ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        return getId(tableExecuteHandle, MaterializedHandleResolver::getTableExecuteHandleClass);
+    }
+
     public String getId(ConnectorPartitioningHandle partitioningHandle)
     {
         return getId(partitioningHandle, MaterializedHandleResolver::getPartitioningHandleClass);
@@ -148,6 +154,11 @@ public final class HandleResolver
         return resolverFor(id).getInsertTableHandleClass().orElseThrow(() -> new IllegalArgumentException("No resolver for " + id));
     }
 
+    public Class<? extends ConnectorTableExecuteHandle> getTableExecuteHandleClass(String id)
+    {
+        return resolverFor(id).getTableExecuteHandleClass().orElseThrow(() -> new IllegalArgumentException("No resolver for " + id));
+    }
+
     public Class<? extends ConnectorPartitioningHandle> getPartitioningHandleClass(String id)
     {
         return resolverFor(id).getPartitioningHandleClass().orElseThrow(() -> new IllegalArgumentException("No resolver for " + id));
@@ -188,6 +199,7 @@ public final class HandleResolver
         private final Optional<Class<? extends ConnectorIndexHandle>> indexHandle;
         private final Optional<Class<? extends ConnectorOutputTableHandle>> outputTableHandle;
         private final Optional<Class<? extends ConnectorInsertTableHandle>> insertTableHandle;
+        private final Optional<Class<? extends ConnectorTableExecuteHandle>> tableExecuteHandle;
         private final Optional<Class<? extends ConnectorPartitioningHandle>> partitioningHandle;
         private final Optional<Class<? extends ConnectorTransactionHandle>> transactionHandle;
 
@@ -200,6 +212,7 @@ public final class HandleResolver
             indexHandle = getHandleClass(resolver::getIndexHandleClass);
             outputTableHandle = getHandleClass(resolver::getOutputTableHandleClass);
             insertTableHandle = getHandleClass(resolver::getInsertTableHandleClass);
+            tableExecuteHandle = getHandleClass(resolver::getTableExecuteHandleClass);
             partitioningHandle = getHandleClass(resolver::getPartitioningHandleClass);
             transactionHandle = getHandleClass(resolver::getTransactionHandleClass);
         }
@@ -249,6 +262,11 @@ public final class HandleResolver
             return insertTableHandle;
         }
 
+        public Optional<Class<? extends ConnectorTableExecuteHandle>> getTableExecuteHandleClass()
+        {
+            return tableExecuteHandle;
+        }
+
         public Optional<Class<? extends ConnectorPartitioningHandle>> getPartitioningHandleClass()
         {
             return partitioningHandle;
@@ -276,6 +294,7 @@ public final class HandleResolver
                     Objects.equals(indexHandle, that.indexHandle) &&
                     Objects.equals(outputTableHandle, that.outputTableHandle) &&
                     Objects.equals(insertTableHandle, that.insertTableHandle) &&
+                    Objects.equals(tableExecuteHandle, that.tableExecuteHandle) &&
                     Objects.equals(partitioningHandle, that.partitioningHandle) &&
                     Objects.equals(transactionHandle, that.transactionHandle);
         }
@@ -283,7 +302,7 @@ public final class HandleResolver
         @Override
         public int hashCode()
         {
-            return Objects.hash(tableHandle, layoutHandle, columnHandle, split, indexHandle, outputTableHandle, insertTableHandle, partitioningHandle, transactionHandle);
+            return Objects.hash(tableHandle, layoutHandle, columnHandle, split, indexHandle, outputTableHandle, insertTableHandle, tableExecuteHandle, partitioningHandle, transactionHandle);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -662,6 +662,8 @@ public interface Metadata
 
     AnalyzePropertyManager getAnalyzePropertyManager();
 
+    TableProceduresPropertyManager getTableProceduresPropertyManager();
+
     /**
      * Creates the specified materialized view with the specified view definition.
      */

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -29,7 +29,10 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorCapabilities;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
+import io.trino.spi.connector.ConnectorNewTableLayout;
 import io.trino.spi.connector.ConnectorOutputMetadata;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.Constraint;
@@ -96,6 +99,19 @@ public interface Metadata
     Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName);
 
     Optional<TableHandle> getTableHandleForStatisticsCollection(Session session, QualifiedObjectName tableName, Map<String, Object> analyzeProperties);
+
+    Optional<TableExecuteHandle> getTableHandleForExecute(
+            Session session,
+            TableHandle tableHandle,
+            String procedureName,
+            Map<String, Object> executeProperties,
+            Constraint constraint);
+
+    Optional<NewTableLayout> getLayoutForTableExecute(Session session, TableExecuteHandle tableExecuteHandle);
+
+    TableExecuteHandle beginTableExecute(Session session, TableExecuteHandle handle);
+
+    void finishTableExecute(Session session, TableExecuteHandle handle, Collection<Slice> fragments);
 
     @Deprecated
     Optional<TableLayoutResult> getLayout(Session session, TableHandle tableHandle, Constraint constraint, Optional<Set<ColumnHandle>> desiredColumns);

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -29,10 +29,7 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorCapabilities;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
-import io.trino.spi.connector.ConnectorNewTableLayout;
 import io.trino.spi.connector.ConnectorOutputMetadata;
-import io.trino.spi.connector.ConnectorSession;
-import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.Constraint;
@@ -111,7 +108,7 @@ public interface Metadata
 
     TableExecuteHandle beginTableExecute(Session session, TableExecuteHandle handle);
 
-    void finishTableExecute(Session session, TableExecuteHandle handle, Collection<Slice> fragments);
+    void finishTableExecute(Session session, TableExecuteHandle handle, Collection<Slice> fragments, List<Object> tableExecuteState);
 
     @Deprecated
     Optional<TableLayoutResult> getLayout(Session session, TableHandle tableHandle, Constraint constraint, Optional<Set<ColumnHandle>> desiredColumns);

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -638,6 +638,8 @@ public interface Metadata
 
     ProcedureRegistry getProcedureRegistry();
 
+    TableProceduresRegistry getTableProcedureRegistry();
+
     //
     // Blocks
     //

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -71,6 +71,7 @@ import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPartitioningHandle;
 import io.trino.spi.connector.ConnectorResolvedIndex;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableLayout;
 import io.trino.spi.connector.ConnectorTableLayoutHandle;
@@ -432,6 +433,61 @@ public final class MetadataManager
             }
         }
         return Optional.empty();
+    }
+
+    @Override
+    public Optional<TableExecuteHandle> getTableHandleForExecute(Session session, TableHandle tableHandle, String procedure, Map<String, Object> executeProperties, Constraint constraint)
+    {
+        requireNonNull(session, "session is null");
+        requireNonNull(tableHandle, "tableHandle is null");
+        requireNonNull(procedure, "procedure is null");
+        requireNonNull(executeProperties, "executeProperties is null");
+        requireNonNull(constraint, "constraint is null");
+
+        CatalogName catalogName = tableHandle.getCatalogName();
+        CatalogMetadata catalogMetadata = getCatalogMetadata(session, catalogName);
+        ConnectorMetadata metadata = catalogMetadata.getMetadataFor(catalogName);
+
+        ConnectorTableExecuteHandle executeHandle = metadata.getTableHandleForExecute(
+                session.toConnectorSession(catalogName),
+                tableHandle.getConnectorHandle(),
+                procedure,
+                executeProperties,
+                constraint);
+
+        return Optional.ofNullable(executeHandle).map(handle -> new TableExecuteHandle(
+                catalogName,
+                tableHandle.getTransaction(),
+                handle));
+    }
+
+    @Override
+    public Optional<NewTableLayout> getLayoutForTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
+    {
+        CatalogName catalogName = tableExecuteHandle.getCatalogName();
+        CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, catalogName);
+        ConnectorMetadata metadata = catalogMetadata.getMetadata();
+
+        return metadata.getLayoutForTableExecute(session.toConnectorSession(catalogName), tableExecuteHandle.getConnectorHandle())
+                .map(layout -> new NewTableLayout(catalogName, catalogMetadata.getTransactionHandleFor(catalogName), layout));
+    }
+
+    @Override
+    public TableExecuteHandle beginTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
+    {
+        CatalogName catalogName = tableExecuteHandle.getCatalogName();
+        CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, catalogName);
+        ConnectorMetadata metadata = catalogMetadata.getMetadata();
+        ConnectorTableExecuteHandle newConnectorHandle = metadata.beginTableExecute(session.toConnectorSession(), tableExecuteHandle.getConnectorHandle());
+        return tableExecuteHandle.withConnectorHandle(newConnectorHandle);
+    }
+
+    @Override
+    public void finishTableExecute(Session session, TableExecuteHandle tableExecuteHandle, Collection<Slice> fragments)
+    {
+        CatalogName catalogName = tableExecuteHandle.getCatalogName();
+        ConnectorMetadata metadata = getMetadata(session, catalogName);
+        metadata.finishTableExecute(session.toConnectorSession(catalogName), tableExecuteHandle.getConnectorHandle(), fragments);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -209,6 +209,7 @@ public final class MetadataManager
     private final TypeOperators typeOperators;
     private final FunctionResolver functionResolver;
     private final ProcedureRegistry procedures;
+    private final TableProceduresRegistry tableProcedures;
     private final SessionPropertyManager sessionPropertyManager;
     private final SchemaPropertyManager schemaPropertyManager;
     private final TablePropertyManager tablePropertyManager;
@@ -248,6 +249,7 @@ public final class MetadataManager
         functionResolver = new FunctionResolver(this);
 
         this.procedures = new ProcedureRegistry();
+        this.tableProcedures = new TableProceduresRegistry();
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.schemaPropertyManager = requireNonNull(schemaPropertyManager, "schemaPropertyManager is null");
         this.tablePropertyManager = requireNonNull(tablePropertyManager, "tablePropertyManager is null");
@@ -2504,6 +2506,12 @@ public final class MetadataManager
     public ProcedureRegistry getProcedureRegistry()
     {
         return procedures;
+    }
+
+    @Override
+    public TableProceduresRegistry getTableProcedureRegistry()
+    {
+        return tableProcedures;
     }
 
     //

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -483,11 +483,11 @@ public final class MetadataManager
     }
 
     @Override
-    public void finishTableExecute(Session session, TableExecuteHandle tableExecuteHandle, Collection<Slice> fragments)
+    public void finishTableExecute(Session session, TableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
     {
         CatalogName catalogName = tableExecuteHandle.getCatalogName();
         ConnectorMetadata metadata = getMetadata(session, catalogName);
-        metadata.finishTableExecute(session.toConnectorSession(catalogName), tableExecuteHandle.getConnectorHandle(), fragments);
+        metadata.finishTableExecute(session.toConnectorSession(catalogName), tableExecuteHandle.getConnectorHandle(), fragments, tableExecuteState);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -216,6 +216,7 @@ public final class MetadataManager
     private final MaterializedViewPropertyManager materializedViewPropertyManager;
     private final ColumnPropertyManager columnPropertyManager;
     private final AnalyzePropertyManager analyzePropertyManager;
+    private final TableProceduresPropertyManager tableProceduresPropertyManager;
     private final SystemSecurityMetadata systemSecurityMetadata;
     private final TransactionManager transactionManager;
     private final TypeRegistry typeRegistry;
@@ -237,6 +238,7 @@ public final class MetadataManager
             MaterializedViewPropertyManager materializedViewPropertyManager,
             ColumnPropertyManager columnPropertyManager,
             AnalyzePropertyManager analyzePropertyManager,
+            TableProceduresPropertyManager tableProceduresPropertyManager,
             SystemSecurityMetadata systemSecurityMetadata,
             TransactionManager transactionManager,
             TypeOperators typeOperators,
@@ -256,6 +258,7 @@ public final class MetadataManager
         this.materializedViewPropertyManager = requireNonNull(materializedViewPropertyManager, "materializedViewPropertyManager is null");
         this.columnPropertyManager = requireNonNull(columnPropertyManager, "columnPropertyManager is null");
         this.analyzePropertyManager = requireNonNull(analyzePropertyManager, "analyzePropertyManager is null");
+        this.tableProceduresPropertyManager = requireNonNull(tableProceduresPropertyManager, "tableProceduresPropertyManager is null");
         this.systemSecurityMetadata = requireNonNull(systemSecurityMetadata, "systemSecurityMetadata is null");
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
@@ -330,6 +333,7 @@ public final class MetadataManager
                 new MaterializedViewPropertyManager(),
                 new ColumnPropertyManager(),
                 new AnalyzePropertyManager(),
+                new TableProceduresPropertyManager(),
                 new DisabledSystemSecurityMetadata(),
                 transactionManager,
                 typeOperators,
@@ -2576,6 +2580,12 @@ public final class MetadataManager
     public AnalyzePropertyManager getAnalyzePropertyManager()
     {
         return analyzePropertyManager;
+    }
+
+    @Override
+    public TableProceduresPropertyManager getTableProceduresPropertyManager()
+    {
+        return tableProceduresPropertyManager;
     }
 
     //

--- a/core/trino-main/src/main/java/io/trino/metadata/TableExecuteHandle.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableExecuteHandle.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.connector.CatalogName;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public final class TableExecuteHandle
+{
+    private final CatalogName catalogName;
+    private final ConnectorTransactionHandle transactionHandle;
+    private final ConnectorTableExecuteHandle connectorHandle;
+    private final TableHandle sourceTableHandle;
+
+    @JsonCreator
+    public TableExecuteHandle(
+            @JsonProperty("catalogName") CatalogName catalogName,
+            @JsonProperty("transactionHandle") ConnectorTransactionHandle transactionHandle,
+            @JsonProperty("connectorHandle") ConnectorTableExecuteHandle connectorHandle)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.transactionHandle = requireNonNull(transactionHandle, "transactionHandle is null");
+        this.connectorHandle = requireNonNull(connectorHandle, "connectorHandle is null");
+        this.sourceTableHandle = new TableHandle(catalogName, connectorHandle.getSourceTableHandle(), transactionHandle, Optional.empty());
+    }
+
+    @JsonProperty
+    public CatalogName getCatalogName()
+    {
+        return catalogName;
+    }
+
+    @JsonProperty
+    public ConnectorTransactionHandle getTransactionHandle()
+    {
+        return transactionHandle;
+    }
+
+    @JsonProperty
+    public ConnectorTableExecuteHandle getConnectorHandle()
+    {
+        return connectorHandle;
+    }
+
+    @JsonIgnore
+    public TableHandle getSourceTableHandle()
+    {
+        return sourceTableHandle;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(catalogName, transactionHandle, connectorHandle, sourceTableHandle);
+    }
+
+    public TableExecuteHandle withConnectorHandle(ConnectorTableExecuteHandle connectorHandle)
+    {
+        return new TableExecuteHandle(catalogName, transactionHandle, connectorHandle);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        TableExecuteHandle o = (TableExecuteHandle) obj;
+        return Objects.equals(this.catalogName, o.catalogName) &&
+                Objects.equals(this.transactionHandle, o.transactionHandle) &&
+                Objects.equals(this.connectorHandle, o.connectorHandle) &&
+                Objects.equals(this.sourceTableHandle, o.sourceTableHandle);
+    }
+
+    @Override
+    public String toString()
+    {
+        return catalogName + ":" + connectorHandle;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/TableProceduresPropertyManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableProceduresPropertyManager.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import io.trino.Session;
+import io.trino.connector.CatalogName;
+import io.trino.security.AccessControl;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.session.PropertyMetadata;
+import io.trino.spi.type.Type;
+import io.trino.sql.planner.ParameterRewriter;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.ExpressionTreeRewriter;
+import io.trino.sql.tree.NodeRef;
+import io.trino.sql.tree.Parameter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
+import static io.trino.spi.StandardErrorCode.NOT_FOUND;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
+import static io.trino.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+// TODO maybe refactor AbstractPropertyManager and use as a base so there is less code copied
+public class TableProceduresPropertyManager
+{
+    private final ConcurrentMap<Key, Map<String, PropertyMetadata<?>>> connectorProperties = new ConcurrentHashMap<>();
+
+    public final void addProperties(CatalogName catalogName, String procedureName, List<PropertyMetadata<?>> properties)
+    {
+        requireNonNull(catalogName, "catalogName is null");
+        requireNonNull(procedureName, "procedureName is null");
+        requireNonNull(properties, "properties is null");
+
+        Map<String, PropertyMetadata<?>> propertiesByName = Maps.uniqueIndex(properties, PropertyMetadata::getName);
+
+        checkState(connectorProperties.putIfAbsent(new Key(catalogName, procedureName), propertiesByName) == null, "Properties for procedure '%s.%s' are already registered", catalogName, procedureName);
+    }
+
+    public final void removeProperties(CatalogName catalogName)
+    {
+        Set<Key> keysToRemove = connectorProperties.keySet().stream()
+                .filter(key -> catalogName.equals(key.getCatalogName()))
+                .collect(toImmutableSet());
+        for (Key key : keysToRemove) {
+            connectorProperties.remove(key);
+        }
+    }
+
+    public final Map<String, Object> getProperties(
+            CatalogName catalogName,
+            String procedureName,
+            String catalog, // only use this for error messages
+            Map<String, Expression> sqlPropertyValues,
+            Session session,
+            Metadata metadata,
+            AccessControl accessControl,
+            Map<NodeRef<Parameter>, Expression> parameters)
+    {
+        Map<String, PropertyMetadata<?>> supportedProperties = connectorProperties.get(new Key(catalogName, procedureName));
+        if (supportedProperties == null) {
+            throw new TrinoException(NOT_FOUND, format("Procedure %s.%s not found", catalog, procedureName));
+        }
+
+        ImmutableMap.Builder<String, Object> properties = ImmutableMap.builder();
+
+        // Fill in user-specified properties
+        for (Map.Entry<String, Expression> sqlProperty : sqlPropertyValues.entrySet()) {
+            String propertyName = sqlProperty.getKey().toLowerCase(ENGLISH);
+            PropertyMetadata<?> property = supportedProperties.get(propertyName);
+            if (property == null) {
+                throw new TrinoException(
+                        INVALID_PROCEDURE_ARGUMENT,
+                        format("Procedure '%s.%s' does not support property '%s'",
+                                catalog,
+                                procedureName,
+                                propertyName));
+            }
+
+            Object sqlObjectValue;
+            try {
+                sqlObjectValue = evaluatePropertyValue(sqlProperty.getValue(), property.getSqlType(), session, metadata, accessControl, parameters);
+            }
+            catch (TrinoException e) {
+                throw new TrinoException(
+                        INVALID_PROCEDURE_ARGUMENT,
+                        format("Invalid value for procedure property '%s': Cannot convert [%s] to %s",
+                                property.getName(),
+                                sqlProperty.getValue(),
+                                property.getSqlType()),
+                        e);
+            }
+
+            Object value;
+            try {
+                value = property.decode(sqlObjectValue);
+            }
+            catch (Exception e) {
+                throw new TrinoException(
+                        INVALID_PROCEDURE_ARGUMENT,
+                        format(
+                                "Unable to set procedure property '%s' to [%s]: %s",
+                                property.getName(),
+                                sqlProperty.getValue(),
+                                e.getMessage()),
+                        e);
+            }
+
+            properties.put(property.getName(), value);
+        }
+        Map<String, Object> userSpecifiedProperties = properties.build();
+
+        // Fill in the remaining properties with non-null defaults
+        for (PropertyMetadata<?> propertyMetadata : supportedProperties.values()) {
+            if (!userSpecifiedProperties.containsKey(propertyMetadata.getName())) {
+                Object value = propertyMetadata.getDefaultValue();
+                if (value != null) {
+                    properties.put(propertyMetadata.getName(), value);
+                }
+            }
+        }
+        return properties.build();
+    }
+
+//    public Map<CatalogName, Map<String, PropertyMetadata<?>>> getAllProperties()
+//    {
+//        return ImmutableMap.copyOf(connectorProperties);
+//    }
+
+    private Object evaluatePropertyValue(
+            Expression expression,
+            Type expectedType,
+            Session session,
+            Metadata metadata,
+            AccessControl accessControl,
+            Map<NodeRef<Parameter>, Expression> parameters)
+    {
+        Expression rewritten = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(parameters), expression);
+        Object value = evaluateConstantExpression(rewritten, expectedType, metadata, session, accessControl, parameters);
+
+        // convert to object value type of SQL type
+        BlockBuilder blockBuilder = expectedType.createBlockBuilder(null, 1);
+        writeNativeValue(expectedType, blockBuilder, value);
+        Object objectValue = expectedType.getObjectValue(session.toConnectorSession(), blockBuilder, 0);
+
+        if (objectValue == null) {
+            throw new TrinoException(INVALID_PROCEDURE_ARGUMENT, format("Invalid null value for procedure property"));
+        }
+        return objectValue;
+    }
+
+    private class Key
+    {
+        private final CatalogName catalogName;
+        private final String procedureName;
+
+        public Key(CatalogName catalogName, String procedureName)
+        {
+            this.catalogName = requireNonNull(catalogName, "catalogName is null");
+            this.procedureName = requireNonNull(procedureName, "procedureName is null");
+        }
+
+        public CatalogName getCatalogName()
+        {
+            return catalogName;
+        }
+
+        public String getProcedureName()
+        {
+            return procedureName;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Key key = (Key) o;
+            return Objects.equals(catalogName, key.catalogName)
+                    && Objects.equals(procedureName, key.procedureName);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(catalogName, procedureName);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/TableProceduresRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TableProceduresRegistry.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.Maps;
+import io.trino.connector.CatalogName;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.TableProcedureMetadata;
+
+import java.util.Collection;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.spi.StandardErrorCode.PROCEDURE_NOT_FOUND;
+import static java.util.Objects.requireNonNull;
+
+public class TableProceduresRegistry
+{
+    private final Map<CatalogName, Map<String, TableProcedureMetadata>> tableProcedures = new ConcurrentHashMap<>();
+
+    public TableProceduresRegistry()
+    {
+    }
+
+    public void addTableProcedures(CatalogName catalogName, Collection<TableProcedureMetadata> procedures)
+    {
+        requireNonNull(catalogName, "catalogName is null");
+        requireNonNull(procedures, "procedures is null");
+
+        Map<String, TableProcedureMetadata> proceduresByName = Maps.uniqueIndex(
+                procedures,
+                tableProcedureMetadata -> tableProcedureMetadata.getName().toLowerCase(Locale.ENGLISH));
+
+        checkState(tableProcedures.putIfAbsent(catalogName, proceduresByName) == null, "Table procedures already registered for connector: %s", catalogName);
+    }
+
+    public void removeProcedures(CatalogName catalogName)
+    {
+        tableProcedures.remove(catalogName);
+    }
+
+    public TableProcedureMetadata resolve(CatalogName catalogName, String name)
+    {
+        Map<String, TableProcedureMetadata> procedures = tableProcedures.get(catalogName);
+        if (procedures != null) {
+            TableProcedureMetadata procedure = procedures.get(name.toLowerCase(Locale.ENGLISH));
+            if (procedure != null) {
+                return procedure;
+            }
+        }
+        throw new TrinoException(PROCEDURE_NOT_FOUND, "Procedure not registered: " + name);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableWriterOperator.java
@@ -98,8 +98,12 @@ public class TableWriterOperator
             this.columnChannels = requireNonNull(columnChannels, "columnChannels is null");
             this.notNullChannelColumnNames = requireNonNull(notNullChannelColumnNames, "notNullChannelColumnNames is null");
             this.pageSinkManager = requireNonNull(pageSinkManager, "pageSinkManager is null");
-            checkArgument(writerTarget instanceof CreateTarget || writerTarget instanceof InsertTarget || writerTarget instanceof TableWriterNode.RefreshMaterializedViewTarget,
-                    "writerTarget must be CreateTarget, InsertTarget or RefreshMaterializedViewTarget");
+            checkArgument(
+                    writerTarget instanceof CreateTarget
+                            || writerTarget instanceof InsertTarget
+                            || writerTarget instanceof TableWriterNode.RefreshMaterializedViewTarget
+                            || writerTarget instanceof TableWriterNode.TableExecuteTarget,
+                    "writerTarget must be CreateTarget, InsertTarget, RefreshMaterializedViewTarget or TableExecuteTarget");
             this.target = requireNonNull(writerTarget, "writerTarget is null");
             this.session = session;
             this.statisticsAggregationOperatorFactory = requireNonNull(statisticsAggregationOperatorFactory, "statisticsAggregationOperatorFactory is null");
@@ -126,6 +130,9 @@ public class TableWriterOperator
             }
             if (target instanceof TableWriterNode.RefreshMaterializedViewTarget) {
                 return pageSinkManager.createPageSink(session, ((TableWriterNode.RefreshMaterializedViewTarget) target).getInsertHandle());
+            }
+            if (target instanceof TableWriterNode.TableExecuteTarget) {
+                return pageSinkManager.createPageSink(session, ((TableWriterNode.TableExecuteTarget) target).getHandle());
             }
             throw new UnsupportedOperationException("Unhandled target type: " + target.getClass().getName());
         }

--- a/core/trino-main/src/main/java/io/trino/server/QueryExecutionFactoryModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/QueryExecutionFactoryModule.java
@@ -94,6 +94,7 @@ import io.trino.sql.tree.SetTimeZone;
 import io.trino.sql.tree.SetViewAuthorization;
 import io.trino.sql.tree.StartTransaction;
 import io.trino.sql.tree.Statement;
+import io.trino.sql.tree.TableExecute;
 import io.trino.sql.tree.Use;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -113,6 +114,9 @@ public class QueryExecutionFactoryModule
         for (Class<? extends Statement> statement : getNonDataDefinitionStatements()) {
             executionBinder.addBinding(statement).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
         }
+
+        // we want to execute TableExecute in distributed manner so we are binding it to SqlQueryExecutionFactory.
+        executionBinder.addBinding(TableExecute.class).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON);
 
         binder.bind(DataDefinitionExecutionFactory.class).in(Scopes.SINGLETON);
         bindDataDefinitionTask(binder, executionBinder, AddColumn.class, AddColumnTask.class);

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -44,6 +44,7 @@ import io.trino.execution.MemoryRevokingScheduler;
 import io.trino.execution.NodeTaskMap;
 import io.trino.execution.QueryManagerConfig;
 import io.trino.execution.SqlTaskManager;
+import io.trino.execution.TableExecuteContextManager;
 import io.trino.execution.TaskManagementExecutor;
 import io.trino.execution.TaskManager;
 import io.trino.execution.TaskManagerConfig;
@@ -273,6 +274,7 @@ public class ServerMainModule
         binder.bind(TaskManagementExecutor.class).in(Scopes.SINGLETON);
         binder.bind(SqlTaskManager.class).in(Scopes.SINGLETON);
         binder.bind(TaskManager.class).to(Key.get(SqlTaskManager.class));
+        binder.bind(TableExecuteContextManager.class).in(Scopes.SINGLETON);
 
         // memory revoking scheduler
         binder.bind(MemoryRevokingScheduler.class).in(Scopes.SINGLETON);

--- a/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
+++ b/core/trino-main/src/main/java/io/trino/server/ServerMainModule.java
@@ -77,6 +77,7 @@ import io.trino.metadata.SessionPropertyManager;
 import io.trino.metadata.StaticCatalogStore;
 import io.trino.metadata.StaticCatalogStoreConfig;
 import io.trino.metadata.SystemSecurityMetadata;
+import io.trino.metadata.TableProceduresPropertyManager;
 import io.trino.metadata.TablePropertyManager;
 import io.trino.operator.ExchangeClientConfig;
 import io.trino.operator.ExchangeClientFactory;
@@ -230,6 +231,9 @@ public class ServerMainModule
 
         // analyze properties
         binder.bind(AnalyzePropertyManager.class).in(Scopes.SINGLETON);
+
+        // table procedures properties
+        binder.bind(TableProceduresPropertyManager.class).in(Scopes.SINGLETON);
 
         // node manager
         discoveryBinder(binder).bindSelector("trino");

--- a/core/trino-main/src/main/java/io/trino/split/BufferingSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/BufferingSplitSource.java
@@ -22,6 +22,7 @@ import io.trino.spi.connector.ConnectorPartitionHandle;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
@@ -63,6 +64,12 @@ public class BufferingSplitSource
     public boolean isFinished()
     {
         return source.isFinished();
+    }
+
+    @Override
+    public Optional<List<Object>> getTableExecuteSplitsInfo()
+    {
+        return source.getTableExecuteSplitsInfo();
     }
 
     private static class GetNextBatch

--- a/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/ConnectorAwareSplitSource.java
@@ -24,6 +24,9 @@ import io.trino.spi.connector.ConnectorSplit;
 import io.trino.spi.connector.ConnectorSplitSource;
 import io.trino.spi.connector.ConnectorSplitSource.ConnectorSplitBatch;
 
+import java.util.List;
+import java.util.Optional;
+
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.toListenableFuture;
 import static java.util.Objects.requireNonNull;
@@ -69,6 +72,12 @@ public class ConnectorAwareSplitSource
     public boolean isFinished()
     {
         return source.isFinished();
+    }
+
+    @Override
+    public Optional<List<Object>> getTableExecuteSplitsInfo()
+    {
+        return source.getTableExecuteSplitsInfo();
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/split/PageSinkManager.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSinkManager.java
@@ -17,6 +17,7 @@ import io.trino.Session;
 import io.trino.connector.CatalogName;
 import io.trino.metadata.InsertTableHandle;
 import io.trino.metadata.OutputTableHandle;
+import io.trino.metadata.TableExecuteHandle;
 import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
@@ -55,6 +56,14 @@ public class PageSinkManager
 
     @Override
     public ConnectorPageSink createPageSink(Session session, InsertTableHandle tableHandle)
+    {
+        // assumes connectorId and catalog are the same
+        ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getCatalogName());
+        return providerFor(tableHandle.getCatalogName()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle());
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(Session session, TableExecuteHandle tableHandle)
     {
         // assumes connectorId and catalog are the same
         ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getCatalogName());

--- a/core/trino-main/src/main/java/io/trino/split/PageSinkProvider.java
+++ b/core/trino-main/src/main/java/io/trino/split/PageSinkProvider.java
@@ -16,6 +16,7 @@ package io.trino.split;
 import io.trino.Session;
 import io.trino.metadata.InsertTableHandle;
 import io.trino.metadata.OutputTableHandle;
+import io.trino.metadata.TableExecuteHandle;
 import io.trino.spi.connector.ConnectorPageSink;
 
 public interface PageSinkProvider
@@ -23,4 +24,6 @@ public interface PageSinkProvider
     ConnectorPageSink createPageSink(Session session, OutputTableHandle tableHandle);
 
     ConnectorPageSink createPageSink(Session session, InsertTableHandle tableHandle);
+
+    ConnectorPageSink createPageSink(Session session, TableExecuteHandle tableHandle);
 }

--- a/core/trino-main/src/main/java/io/trino/split/SampledSplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/SampledSplitSource.java
@@ -21,6 +21,8 @@ import io.trino.spi.connector.ConnectorPartitionHandle;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -67,5 +69,15 @@ public class SampledSplitSource
     public boolean isFinished()
     {
         return splitSource.isFinished();
+    }
+
+    @Override
+    public Optional<List<Object>> getTableExecuteSplitsInfo()
+    {
+        Optional<List<Object>> tableExecuteSplitsInfo = splitSource.getTableExecuteSplitsInfo();
+        if (tableExecuteSplitsInfo.isPresent()) {
+            throw new IllegalStateException("Cannot use SampledSplitSource with SplitSource which returns non-empty TableExecuteSplitsInfo");
+        }
+        return Optional.empty();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/split/SplitSource.java
+++ b/core/trino-main/src/main/java/io/trino/split/SplitSource.java
@@ -21,6 +21,7 @@ import io.trino.spi.connector.ConnectorPartitionHandle;
 
 import java.io.Closeable;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -35,6 +36,8 @@ public interface SplitSource
     void close();
 
     boolean isFinished();
+
+    Optional<List<Object>> getTableExecuteSplitsInfo();
 
     class SplitBatch
     {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analysis.java
@@ -213,6 +213,8 @@ public class Analysis
     private final Multimap<Field, SourceColumn> originColumnDetails = ArrayListMultimap.create();
     private final Multimap<NodeRef<Expression>, Field> fieldLineage = ArrayListMultimap.create();
 
+    private Map<String, Object> tableExecuteProperties;
+
     public Analysis(@Nullable Statement root, Map<NodeRef<Parameter>, Expression> parameters, boolean isDescribe)
     {
         this.root = root;
@@ -1103,6 +1105,18 @@ public class Analysis
     public PredicateCoercions getPredicateCoercions(Expression expression)
     {
         return predicateCoercions.get(NodeRef.of(expression));
+    }
+
+    public void setTableExecuteProperties(Map<String, Object> tableExecuteProperties)
+    {
+        requireNonNull(tableExecuteProperties, "tableExecuteProperties is null");
+        checkState(this.tableExecuteProperties == null, "tableExecuteProperties alredy set");
+        this.tableExecuteProperties = ImmutableMap.copyOf(tableExecuteProperties);
+    }
+
+    public Map<String, Object> getTableExecuteProperties()
+    {
+        return tableExecuteProperties;
     }
 
     @Immutable

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -51,6 +51,7 @@ import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.function.OperatorType;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.GroupProvider;
@@ -169,6 +170,7 @@ import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.Table;
+import io.trino.sql.tree.TableExecute;
 import io.trino.sql.tree.TableSubquery;
 import io.trino.sql.tree.Union;
 import io.trino.sql.tree.Unnest;
@@ -970,6 +972,68 @@ class StatementAnalyzer
         protected Scope visitSetTableAuthorization(SetTableAuthorization node, Optional<Scope> scope)
         {
             return createAndAssignScope(node, scope);
+        }
+
+        @Override
+        protected Scope visitTableExecute(TableExecute node, Optional<Scope> scope)
+        {
+            Table table = node.getTable();
+            QualifiedObjectName originalName = createQualifiedObjectName(session, table, table.getName());
+            if (metadata.getView(session, originalName).isPresent()) {
+                throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for views");
+            }
+
+            RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, originalName);
+            QualifiedObjectName tableName = redirection.getRedirectedTableName().orElse(originalName);
+            TableHandle tableHandle = redirection.getTableHandle()
+                    .orElseThrow(() -> semanticException(TABLE_NOT_FOUND, table, "Table '%s' does not exist", tableName));
+
+            // TODO add access check
+            // accessControl.check...(session.toSecurityContext(), tableName);
+
+            // TODO Maybe make check optional; does it sometimes makes sense to execute table procedure on table with row filter or column masks?
+            if (!accessControl.getRowFilters(session.toSecurityContext(), tableName).isEmpty()) {
+                throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for table with ROW filter");
+            }
+
+            TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle);
+            for (ColumnMetadata tableColumn : tableMetadata.getColumns()) {
+                if (!accessControl.getColumnMasks(session.toSecurityContext(), tableName, tableColumn.getName(), tableColumn.getType()).isEmpty()) {
+                    throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for table with column masks");
+                }
+            }
+
+            Scope tableScope = analyze(table, scope);
+
+            CatalogName catalogName = getRequiredCatalogHandle(metadata, session, node, tableName.getCatalogName());
+            String procedureName = node.getProcedureName().getValue();
+            TableProcedureMetadata procedureMetadata = metadata.getTableProcedureRegistry().resolve(catalogName, procedureName);
+
+            // analyze WHERE
+            if (!procedureMetadata.getExecutionMode().isFilter() && node.getWhere().isPresent()) {
+                throw semanticException(NOT_SUPPORTED, node, "WHERE not supported for procedure " + procedureName);
+            }
+            node.getWhere().ifPresent(where -> analyzeWhere(node, tableScope, where));
+
+            // analyze ORDER BY
+            if (node.getOrderBy().isPresent()) {
+                throw semanticException(NOT_SUPPORTED, node, "ORDER BY not supported yet"); // TODO
+            }
+
+            // analyze WITH
+            validateProperties(node.getProperties(), scope);
+            Map<String, Object> tableProperties = metadata.getTableProceduresPropertyManager().getProperties(
+                    catalogName,
+                    procedureName,
+                    catalogName.getCatalogName(),
+                    mapFromProperties(node.getProperties()),
+                    session,
+                    metadata,
+                    accessControl,
+                    analysis.getParameters());
+            analysis.setTableExecuteProperties(tableProperties);
+
+            return createAndAssignScope(node, scope, Field.newUnqualified("rows", BIGINT));
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -198,6 +198,7 @@ import io.trino.sql.planner.plan.TableFinishNode;
 import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.planner.plan.TableWriterNode;
 import io.trino.sql.planner.plan.TableWriterNode.DeleteTarget;
+import io.trino.sql.planner.plan.TableWriterNode.TableExecuteTarget;
 import io.trino.sql.planner.plan.TableWriterNode.UpdateTarget;
 import io.trino.sql.planner.plan.TopNNode;
 import io.trino.sql.planner.plan.TopNRankingNode;
@@ -3603,6 +3604,10 @@ public class LocalExecutionPlanner
             }
             else if (target instanceof UpdateTarget) {
                 metadata.finishUpdate(session, ((UpdateTarget) target).getHandleOrElseThrow(), fragments);
+                return Optional.empty();
+            }
+            else if (target instanceof TableExecuteTarget) {
+                metadata.finishTableExecute(session, ((TableExecuteTarget) target).getHandle(), fragments);
                 return Optional.empty();
             }
             else {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -34,6 +34,7 @@ import io.trino.SystemSessionProperties;
 import io.trino.execution.DynamicFilterConfig;
 import io.trino.execution.ExplainAnalyzeContext;
 import io.trino.execution.StageId;
+import io.trino.execution.TableExecuteContextManager;
 import io.trino.execution.TaskId;
 import io.trino.execution.TaskManagerConfig;
 import io.trino.execution.buffer.OutputBuffer;
@@ -363,6 +364,7 @@ public class LocalExecutionPlanner
     private final DynamicFilterConfig dynamicFilterConfig;
     private final TypeOperators typeOperators;
     private final BlockTypeOperators blockTypeOperators;
+    private final TableExecuteContextManager tableExecuteContextManager;
 
     @Inject
     public LocalExecutionPlanner(
@@ -388,7 +390,8 @@ public class LocalExecutionPlanner
             OrderingCompiler orderingCompiler,
             DynamicFilterConfig dynamicFilterConfig,
             TypeOperators typeOperators,
-            BlockTypeOperators blockTypeOperators)
+            BlockTypeOperators blockTypeOperators,
+            TableExecuteContextManager tableExecuteContextManager)
     {
         this.explainAnalyzeContext = requireNonNull(explainAnalyzeContext, "explainAnalyzeContext is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
@@ -416,6 +419,7 @@ public class LocalExecutionPlanner
         this.dynamicFilterConfig = requireNonNull(dynamicFilterConfig, "dynamicFilterConfig is null");
         this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
         this.blockTypeOperators = requireNonNull(blockTypeOperators, "blockTypeOperators is null");
+        this.tableExecuteContextManager = requireNonNull(tableExecuteContextManager, "tableExecuteContextManager is null");
     }
 
     public LocalExecutionPlan plan(
@@ -3004,12 +3008,18 @@ public class LocalExecutionPlanner
                     .map(desc -> desc.map(aggregationOutput::get))
                     .orElse(StatisticAggregationsDescriptor.empty());
 
+            Optional<TableExecuteContextManager> optionalTableExecuteContextManager = Optional.empty();
+            if (node.getTarget() instanceof TableExecuteTarget) {
+                optionalTableExecuteContextManager = Optional.of(tableExecuteContextManager);
+            }
+
             OperatorFactory operatorFactory = new TableFinishOperatorFactory(
                     context.getNextOperatorId(),
                     node.getId(),
                     createTableFinisher(session, node, metadata),
                     statisticsAggregation,
                     descriptor,
+                    optionalTableExecuteContextManager,
                     session);
             Map<Symbol, Integer> layout = ImmutableMap.of(node.getOutputSymbols().get(0), 0);
 
@@ -3581,7 +3591,7 @@ public class LocalExecutionPlanner
     private static TableFinisher createTableFinisher(Session session, TableFinishNode node, Metadata metadata)
     {
         WriterTarget target = node.getTarget();
-        return (fragments, statistics) -> {
+        return (fragments, statistics, tableExecuteState) -> {
             if (target instanceof CreateTarget) {
                 return metadata.finishCreateTable(session, ((CreateTarget) target).getHandle(), fragments, statistics);
             }
@@ -3607,7 +3617,7 @@ public class LocalExecutionPlanner
                 return Optional.empty();
             }
             else if (target instanceof TableExecuteTarget) {
-                metadata.finishTableExecute(session, ((TableExecuteTarget) target).getHandle(), fragments);
+                metadata.finishTableExecute(session, ((TableExecuteTarget) target).getHandle(), fragments, tableExecuteState);
                 return Optional.empty();
             }
             else {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LogicalPlanner.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.log.Logger;
 import io.trino.Session;
+import io.trino.connector.CatalogName;
 import io.trino.cost.CachingCostProvider;
 import io.trino.cost.CachingStatsProvider;
 import io.trino.cost.CostCalculator;
@@ -29,12 +30,14 @@ import io.trino.metadata.Metadata;
 import io.trino.metadata.NewTableLayout;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.ResolvedFunction;
+import io.trino.metadata.TableExecuteHandle;
 import io.trino.metadata.TableHandle;
 import io.trino.metadata.TableMetadata;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.Constraint;
 import io.trino.spi.statistics.TableStatisticsMetadata;
 import io.trino.spi.type.CharType;
 import io.trino.spi.type.Type;
@@ -87,6 +90,8 @@ import io.trino.sql.tree.RefreshMaterializedView;
 import io.trino.sql.tree.Row;
 import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.StringLiteral;
+import io.trino.sql.tree.Table;
+import io.trino.sql.tree.TableExecute;
 import io.trino.sql.tree.Update;
 import io.trino.type.TypeCoercion;
 import io.trino.type.UnknownType;
@@ -109,11 +114,16 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Streams.zip;
 import static io.trino.SystemSessionProperties.isCollectPlanStatisticsForAllQueries;
+import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
+import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.spi.connector.Constraint.alwaysTrue;
 import static io.trino.spi.statistics.TableStatisticType.ROW_COUNT;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.sql.ExpressionUtils.filterNonDeterministicConjuncts;
+import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.toSqlType;
 import static io.trino.sql.planner.LogicalPlanner.Stage.OPTIMIZED;
@@ -125,6 +135,7 @@ import static io.trino.sql.planner.plan.TableWriterNode.CreateReference;
 import static io.trino.sql.planner.plan.TableWriterNode.InsertReference;
 import static io.trino.sql.planner.plan.TableWriterNode.WriterTarget;
 import static io.trino.sql.planner.sanity.PlanSanityChecker.DISTRIBUTED_PLAN_SANITY_CHECKER;
+import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
 import static io.trino.sql.tree.ComparisonExpression.Operator.GREATER_THAN_OR_EQUAL;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -280,6 +291,9 @@ public class LogicalPlanner
         }
         if (statement instanceof ExplainAnalyze) {
             return createExplainAnalyzePlan(analysis, (ExplainAnalyze) statement);
+        }
+        if (statement instanceof TableExecute) {
+            return createTableExecutePlan(analysis, (TableExecute) statement);
         }
         throw new TrinoException(NOT_SUPPORTED, "Unsupported statement type " + statement.getClass().getSimpleName());
     }
@@ -749,6 +763,133 @@ public class LogicalPlanner
         }
 
         return result;
+    }
+
+    private RelationPlan createTableExecutePlan(Analysis analysis, TableExecute statement)
+    {
+        Table table = statement.getTable();
+        TableHandle tableHandle = analysis.getTableHandle(table);
+        CatalogName catalogName = tableHandle.getCatalogName();
+        QualifiedObjectName tableName = createQualifiedObjectName(session, statement, table.getName());
+        String procedureName = statement.getProcedureName().getValue();
+
+        Optional<Constraint> constraint = getConstraintForTableExecute(analysis, statement);
+
+        TableExecuteHandle executeHandle =
+                metadata.getTableHandleForExecute(
+                        session,
+                        tableHandle,
+                        procedureName,
+                        analysis.getTableExecuteProperties(),
+                        constraint.orElse(alwaysTrue()))
+                        .orElseThrow(() -> semanticException(NOT_FOUND, statement, "Table '%s' does not exist", tableName));
+
+        Scope scope = analysis.getScope(table);
+        ImmutableList.Builder<Symbol> outputSymbolsBuilder = ImmutableList.builder();
+        ImmutableMap.Builder<Symbol, ColumnHandle> assignments = ImmutableMap.builder();
+        for (Field field : scope.getRelationType().getAllFields()) {
+            Symbol symbol = symbolAllocator.newSymbol(field);
+
+            outputSymbolsBuilder.add(symbol);
+            assignments.put(symbol, analysis.getColumn(field));
+        }
+
+        List<Symbol> outputSymbols = outputSymbolsBuilder.build();
+        PlanNode tableScanNode = TableScanNode.newInstance(
+                idAllocator.getNextId(),
+                executeHandle.getSourceTableHandle(),
+                outputSymbols,
+                assignments.build(),
+                false,
+                Optional.empty());
+        RelationPlan tableScanPlan = new RelationPlan(
+                tableScanNode,
+                scope,
+                outputSymbols,
+                Optional.empty());
+
+        TableMetadata tableMetadata = metadata.getTableMetadata(session, tableHandle);
+        List<String> columnNames = tableMetadata.getColumns().stream()
+                .filter(column -> !column.isHidden()) // todo this filter is redundant
+                .map(ColumnMetadata::getName)
+                .collect(toImmutableList());
+
+        Optional<NewTableLayout> layout = metadata.getLayoutForTableExecute(session, executeHandle);
+
+        RelationPlan tableWriterPlan = createTableWriterPlan(
+                analysis,
+                tableScanPlan.getRoot(),
+                visibleFields(tableScanPlan),
+                new TableWriterNode.TableExecuteTarget(executeHandle, tableName.asSchemaTableName()),
+                columnNames,
+                tableMetadata.getColumns(),
+                layout,
+                TableStatisticsMetadata.empty());
+
+        // todo do we need that?
+//        List<Type> types = analysis.getRelationCoercion(node);
+//        if (types != null) {
+//            // apply required coercion and prune invisible fields from child outputs
+//            NodeAndMappings coerced = coerce(plan, types, symbolAllocator, idAllocator);
+//            plan = new RelationPlan(coerced.getNode(), scope, coerced.getFields(), outerContext);
+//        }
+
+//        plan = addRowFilters(node, plan);
+//        plan = addColumnMasks(node, plan);
+
+        return tableWriterPlan;
+    }
+
+    private Optional<Constraint> getConstraintForTableExecute(Analysis analysis, TableExecute statement)
+    {
+        Table table = statement.getTable();
+        TableHandle tableHandle = analysis.getTableHandle(table);
+        Scope scope = analysis.getScope(table);
+
+        // prepare a temporary plan with just table scan for sake of rewriting filter expression to use Symbols
+        // TODO: find a simpler way
+        Map<Symbol, ColumnHandle> assignments = new HashMap<>();
+        List<Symbol> outputs = new ArrayList<>();
+        for (Field field : scope.getRelationType().getAllFields()) {
+            Symbol symbol = symbolAllocator.newSymbol(field);
+            assignments.put(symbol, analysis.getColumn(field));
+            outputs.add(symbol);
+        }
+        RelationPlan temporaryPlan = new RelationPlan(
+                TableScanNode.newInstance(
+                        idAllocator.getNextId(),
+                        tableHandle,
+                        outputs,
+                        assignments,
+                        false,
+                        Optional.empty()),
+                scope,
+                outputs,
+                Optional.empty());
+        PlanBuilder planBuilder = PlanBuilder.newPlanBuilder(temporaryPlan, analysis, ImmutableMap.of(), ImmutableMap.of());
+
+        return statement.getWhere().map(predicate -> {
+            // don't include non-deterministic predicates
+            if (!TRUE_LITERAL.equals(filterNonDeterministicConjuncts(metadata, predicate))) {
+                throw new TrinoException(NOT_SUPPORTED, "cannot use non-deterministic predicate with ALTER TABLE ... EXECUTE");
+            }
+
+            Expression rewrittenPredicate = planBuilder.rewrite(predicate);
+
+            DomainTranslator.ExtractionResult decomposedPredicate = DomainTranslator.fromPredicate(
+                    metadata,
+                    typeOperators,
+                    session,
+                    rewrittenPredicate,
+                    symbolAllocator.getTypes());
+
+            if (!TRUE_LITERAL.equals(decomposedPredicate.getRemainingExpression())) {
+                // TODO support broader range.
+                throw new TrinoException(NOT_SUPPORTED, "only predicates expressible as TupleDomain can be used with ALTER TABLE ... EXECUTE");
+            }
+
+            return new Constraint(decomposedPredicate.getTupleDomain().transformKeys(assignments::get));
+        });
     }
 
     private static class Key

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/BeginTableWrite.java
@@ -18,6 +18,7 @@ import io.trino.Session;
 import io.trino.cost.StatsAndCosts;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
+import io.trino.metadata.TableExecuteHandle;
 import io.trino.metadata.TableHandle;
 import io.trino.sql.planner.PlanNodeIdAllocator;
 import io.trino.sql.planner.SymbolAllocator;
@@ -40,6 +41,7 @@ import io.trino.sql.planner.plan.TableWriterNode.CreateTarget;
 import io.trino.sql.planner.plan.TableWriterNode.DeleteTarget;
 import io.trino.sql.planner.plan.TableWriterNode.InsertReference;
 import io.trino.sql.planner.plan.TableWriterNode.InsertTarget;
+import io.trino.sql.planner.plan.TableWriterNode.TableExecuteTarget;
 import io.trino.sql.planner.plan.TableWriterNode.UpdateTarget;
 import io.trino.sql.planner.plan.TableWriterNode.WriterTarget;
 import io.trino.sql.planner.plan.UnionNode;
@@ -247,6 +249,11 @@ public class BeginTableWrite
                         metadata.beginRefreshMaterializedView(session, refreshMV.getStorageTableHandle(), refreshMV.getSourceTableHandles()),
                         metadata.getTableMetadata(session, refreshMV.getStorageTableHandle()).getTable(),
                         refreshMV.getSourceTableHandles());
+            }
+            if (target instanceof TableExecuteTarget) {
+                TableExecuteTarget tableExecute = (TableExecuteTarget) target;
+                TableExecuteHandle newHandle = metadata.beginTableExecute(session, tableExecute.getHandle());
+                return new TableExecuteTarget(newHandle, tableExecute.getSchemaTableName());
             }
             throw new IllegalArgumentException("Unhandled target type: " + target.getClass().getSimpleName());
         }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TableWriterNode.java
@@ -25,6 +25,7 @@ import io.trino.metadata.InsertTableHandle;
 import io.trino.metadata.NewTableLayout;
 import io.trino.metadata.OutputTableHandle;
 import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.TableExecuteHandle;
 import io.trino.metadata.TableHandle;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -199,7 +200,9 @@ public class TableWriterNode
             @JsonSubTypes.Type(value = InsertTarget.class, name = "InsertTarget"),
             @JsonSubTypes.Type(value = DeleteTarget.class, name = "DeleteTarget"),
             @JsonSubTypes.Type(value = UpdateTarget.class, name = "UpdateTarget"),
-            @JsonSubTypes.Type(value = RefreshMaterializedViewTarget.class, name = "RefreshMaterializedViewTarget")})
+            @JsonSubTypes.Type(value = RefreshMaterializedViewTarget.class, name = "RefreshMaterializedViewTarget"),
+            @JsonSubTypes.Type(value = TableExecuteTarget.class, name = "TableExecuteTarget")
+    })
     @SuppressWarnings({"EmptyClass", "ClassMayBeInterface"})
     public abstract static class WriterTarget
     {
@@ -526,6 +529,40 @@ public class TableWriterNode
         public String toString()
         {
             return handle.map(Object::toString).orElse("[]");
+        }
+    }
+
+    public static class TableExecuteTarget
+            extends WriterTarget
+    {
+        private final TableExecuteHandle handle;
+        private final SchemaTableName schemaTableName;
+
+        @JsonCreator
+        public TableExecuteTarget(
+                @JsonProperty("handle") TableExecuteHandle handle,
+                @JsonProperty("schemaTableName") SchemaTableName schemaTableName)
+        {
+            this.handle = requireNonNull(handle, "handle is null");
+            this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+        }
+
+        @JsonProperty
+        public TableExecuteHandle getHandle()
+        {
+            return handle;
+        }
+
+        @JsonProperty
+        public SchemaTableName getSchemaTableName()
+        {
+            return schemaTableName;
+        }
+
+        @Override
+        public String toString()
+        {
+            return handle.toString();
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -103,6 +103,7 @@ import io.trino.metadata.SessionPropertyManager;
 import io.trino.metadata.Split;
 import io.trino.metadata.SqlFunction;
 import io.trino.metadata.TableHandle;
+import io.trino.metadata.TableProceduresPropertyManager;
 import io.trino.metadata.TablePropertyManager;
 import io.trino.operator.Driver;
 import io.trino.operator.DriverContext;
@@ -343,6 +344,7 @@ public class LocalQueryRunner
                 new MaterializedViewPropertyManager(),
                 new ColumnPropertyManager(),
                 new AnalyzePropertyManager(),
+                new TableProceduresPropertyManager(),
                 new DisabledSystemSecurityMetadata(),
                 transactionManager,
                 typeOperators,

--- a/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/LocalQueryRunner.java
@@ -76,6 +76,7 @@ import io.trino.execution.SetPathTask;
 import io.trino.execution.SetSessionTask;
 import io.trino.execution.SetTimeZoneTask;
 import io.trino.execution.StartTransactionTask;
+import io.trino.execution.TableExecuteContextManager;
 import io.trino.execution.TaskManagerConfig;
 import io.trino.execution.TaskSource;
 import io.trino.execution.resourcegroups.NoOpResourceGroupManager;
@@ -819,7 +820,8 @@ public class LocalQueryRunner
                 new OrderingCompiler(typeOperators),
                 new DynamicFilterConfig(),
                 typeOperators,
-                blockTypeOperators);
+                blockTypeOperators,
+                new TableExecuteContextManager());
 
         // plan query
         StageExecutionDescriptor stageExecutionDescriptor = subplan.getFragment().getStageExecutionDescriptor();

--- a/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
@@ -72,6 +72,7 @@ import io.trino.sql.tree.ShowStats;
 import io.trino.sql.tree.ShowTables;
 import io.trino.sql.tree.StartTransaction;
 import io.trino.sql.tree.Statement;
+import io.trino.sql.tree.TableExecute;
 import io.trino.sql.tree.Update;
 import io.trino.sql.tree.Use;
 
@@ -156,6 +157,7 @@ public final class StatementUtils
             .put(SetTimeZone.class, DATA_DEFINITION)
             .put(SetViewAuthorization.class, DATA_DEFINITION)
             .put(StartTransaction.class, DATA_DEFINITION)
+            .put(TableExecute.class, DATA_DEFINITION) // TODO: should we define it as DATA_DEFINITION if explictily use SqlQueryExecutionFactory for it?
             .put(Use.class, DATA_DEFINITION)
             .build();
 

--- a/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TaskTestUtils.java
@@ -150,7 +150,8 @@ public final class TaskTestUtils
                 new OrderingCompiler(typeOperators),
                 new DynamicFilterConfig(),
                 typeOperators,
-                blockTypeOperators);
+                blockTypeOperators,
+                new TableExecuteContextManager());
     }
 
     public static TaskInfo updateTask(SqlTask sqlTask, List<TaskSource> taskSources, OutputBuffers outputBuffers)

--- a/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSqlTaskManager.java
@@ -309,7 +309,8 @@ public class TestSqlTaskManager
                 nodeMemoryConfig,
                 localSpillManager,
                 new NodeSpillConfig(),
-                new TestingGcMonitor());
+                new TestingGcMonitor(),
+                new TableExecuteContextManager());
     }
 
     private TaskInfo createTask(SqlTaskManager sqlTaskManager, TaskId taskId, ImmutableSet<ScheduledSplit> splits, OutputBuffers outputBuffers)

--- a/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -29,6 +29,7 @@ import io.trino.execution.NodeTaskMap;
 import io.trino.execution.RemoteTask;
 import io.trino.execution.SqlStageExecution;
 import io.trino.execution.StageId;
+import io.trino.execution.TableExecuteContextManager;
 import io.trino.execution.TableInfo;
 import io.trino.execution.buffer.OutputBuffers.OutputBufferId;
 import io.trino.failuredetector.NoOpFailureDetector;
@@ -340,6 +341,7 @@ public class TestSourcePartitionedScheduler
                     new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session, Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                     2,
                     new DynamicFilterService(metadata, typeOperators, new DynamicFilterConfig()),
+                    new TableExecuteContextManager(),
                     () -> false);
             scheduler.schedule();
         }).hasErrorCode(NO_NODES_AVAILABLE);
@@ -414,6 +416,7 @@ public class TestSourcePartitionedScheduler
                 new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session, Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                 500,
                 new DynamicFilterService(metadata, typeOperators, new DynamicFilterConfig()),
+                new TableExecuteContextManager(),
                 () -> false);
 
         // the queues of 3 running nodes should be full
@@ -453,6 +456,7 @@ public class TestSourcePartitionedScheduler
                 new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session, Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                 400,
                 new DynamicFilterService(metadata, typeOperators, new DynamicFilterConfig()),
+                new TableExecuteContextManager(),
                 () -> true);
 
         // the queues of 3 running nodes should be full
@@ -490,6 +494,7 @@ public class TestSourcePartitionedScheduler
                 new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(session, Optional.of(CONNECTOR_ID)), stage::getAllTasks),
                 2,
                 dynamicFilterService,
+                new TableExecuteContextManager(),
                 () -> true);
 
         SymbolAllocator symbolAllocator = new SymbolAllocator();
@@ -555,6 +560,7 @@ public class TestSourcePartitionedScheduler
                 placementPolicy,
                 splitBatchSize,
                 new DynamicFilterService(metadata, typeOperators, new DynamicFilterConfig()),
+                new TableExecuteContextManager(),
                 () -> false);
     }
 

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -810,6 +810,12 @@ public abstract class AbstractMockMetadata
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public TableProceduresRegistry getTableProcedureRegistry()
+    {
+        throw new UnsupportedOperationException();
+    }
+
     //
     // Blocks
     //

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -151,7 +151,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void finishTableExecute(Session session, TableExecuteHandle handle, Collection<Slice> fragments)
+    public void finishTableExecute(Session session, TableExecuteHandle handle, Collection<Slice> fragments, List<Object> tableExecuteState)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -133,6 +133,30 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public Optional<TableExecuteHandle> getTableHandleForExecute(Session session, TableHandle tableHandle, String procedureName, Map<String, Object> executeProperties, Constraint constraint)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<NewTableLayout> getLayoutForTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TableExecuteHandle beginTableExecute(Session session, TableExecuteHandle tableExecuteHandle)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void finishTableExecute(Session session, TableExecuteHandle handle, Collection<Slice> fragments)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Optional<SystemTable> getSystemTable(Session session, QualifiedObjectName tableName)
     {
         throw new UnsupportedOperationException();

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -867,6 +867,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public TableProceduresPropertyManager getTableProceduresPropertyManager()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Optional<ProjectionApplicationResult<TableHandle>> applyProjection(Session session, TableHandle table, List<ConnectorExpression> projections, Map<String, ColumnHandle> assignments)
     {
         return Optional.empty();

--- a/core/trino-main/src/test/java/io/trino/operator/TestTableFinishOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTableFinishOperator.java
@@ -106,6 +106,7 @@ public class TestTableFinishOperator
                         ImmutableList.of(LONG_MAX.bind(ImmutableList.of(2), Optional.empty())),
                         true),
                 descriptor,
+                Optional.empty(),
                 session);
         DriverContext driverContext = createTaskContext(scheduledExecutor, scheduledExecutor, session)
                 .addPipelineContext(0, true, true, false)
@@ -159,14 +160,16 @@ public class TestTableFinishOperator
         private boolean finished;
         private Collection<Slice> fragments;
         private Collection<ComputedStatistics> computedStatistics;
+        private List<Object> tableExecuteSplitsInfo;
 
         @Override
-        public Optional<ConnectorOutputMetadata> finishTable(Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+        public Optional<ConnectorOutputMetadata> finishTable(Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics, List<Object> tableExecuteSplitsInfo)
         {
             checkState(!finished, "already finished");
             finished = true;
             this.fragments = fragments;
             this.computedStatistics = computedStatistics;
+            this.tableExecuteSplitsInfo = ImmutableList.copyOf(tableExecuteSplitsInfo);
             return Optional.empty();
         }
 
@@ -178,6 +181,11 @@ public class TestTableFinishOperator
         public Collection<ComputedStatistics> getComputedStatistics()
         {
             return computedStatistics;
+        }
+
+        public List<Object> getTableExecuteSplitsInfo()
+        {
+            return tableExecuteSplitsInfo;
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/split/MockSplitSource.java
+++ b/core/trino-main/src/test/java/io/trino/split/MockSplitSource.java
@@ -28,6 +28,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -139,6 +140,12 @@ public class MockSplitSource
     public boolean isFinished()
     {
         return splitsProduced == totalSplits && atSplitDepletion == FINISH;
+    }
+
+    @Override
+    public Optional<List<Object>> getTableExecuteSplitsInfo()
+    {
+        return Optional.empty();
     }
 
     public int getNextBatchInvocationCount()

--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -70,6 +70,11 @@ statement
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
         DROP COLUMN (IF EXISTS)? column=qualifiedName                  #dropColumn
     | ALTER TABLE tableName=qualifiedName SET AUTHORIZATION principal  #setTableAuthorization
+    | ALTER TABLE tableName=qualifiedName
+        EXECUTE procedureName=identifier
+        (WITH properties)?
+        (WHERE where=booleanExpression)?
+        (ORDER BY sortItem (',' sortItem)*)?                           #tableExecute
     | ANALYZE qualifiedName (WITH properties)?                         #analyze
     | CREATE (OR REPLACE)? MATERIALIZED VIEW
         (IF NOT EXISTS)? qualifiedName

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -116,6 +116,7 @@ import io.trino.sql.tree.ShowTables;
 import io.trino.sql.tree.SingleColumn;
 import io.trino.sql.tree.StartTransaction;
 import io.trino.sql.tree.Table;
+import io.trino.sql.tree.TableExecute;
 import io.trino.sql.tree.TableSubquery;
 import io.trino.sql.tree.TransactionAccessMode;
 import io.trino.sql.tree.TransactionMode;
@@ -1363,6 +1364,26 @@ public final class SqlFormatter
             }
             builder.append(formatExpression(node.getColumn()));
 
+            return null;
+        }
+
+        @Override
+        protected Void visitTableExecute(TableExecute node, Integer indent)
+        {
+            builder.append("ALTER TABLE ");
+            builder.append(formatName(node.getTable().getName()));
+            builder.append(" EXECUTE ");
+            builder.append(node.getProcedureName());
+            builder.append(formatPropertiesMultiLine(node.getProperties()));
+            node.getWhere().ifPresent(where ->
+                    builder.append("\n")
+                            .append(indentString(indent))
+                            .append("WHERE ").append(formatExpression(where)));
+
+            node.getOrderBy().ifPresent(orderBy ->
+                    builder.append("\n")
+                            .append(indentString(indent))
+                            .append(formatOrderBy(orderBy)));
             return null;
         }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -205,6 +205,7 @@ import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.SubsetDefinition;
 import io.trino.sql.tree.Table;
 import io.trino.sql.tree.TableElement;
+import io.trino.sql.tree.TableExecute;
 import io.trino.sql.tree.TableSubquery;
 import io.trino.sql.tree.TimeLiteral;
 import io.trino.sql.tree.TimestampLiteral;
@@ -636,6 +637,22 @@ class AstBuilder
                 (Identifier) visit(context.column),
                 context.EXISTS().stream().anyMatch(node -> node.getSymbol().getTokenIndex() < context.COLUMN().getSymbol().getTokenIndex()),
                 context.EXISTS().stream().anyMatch(node -> node.getSymbol().getTokenIndex() > context.COLUMN().getSymbol().getTokenIndex()));
+    }
+
+    @Override
+    public Node visitTableExecute(SqlBaseParser.TableExecuteContext context)
+    {
+        List<Property> properties = ImmutableList.of();
+        if (context.properties() != null) {
+            properties = visit(context.properties().property(), Property.class);
+        }
+
+        return new TableExecute(
+                new Table(getLocation(context), getQualifiedName(context.tableName)),
+                (Identifier) visit(context.procedureName),
+                properties,
+                visitIfPresent(context.booleanExpression(), Expression.class),
+                Optional.ofNullable(context.ORDER()).map(order -> new OrderBy(getLocation(order), visit(context.sortItem(), SortItem.class))));
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AstVisitor.java
@@ -657,6 +657,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitTableExecute(TableExecute node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitAnalyze(Analyze node, C context)
     {
         return visitStatement(node, context);

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/TableExecute.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/TableExecute.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class TableExecute
+        extends Statement
+{
+    private final Table table;
+    private final Identifier procedureName;
+    private final List<Property> properties;
+    private final Optional<Expression> where;
+    private final Optional<OrderBy> orderBy;
+
+    public TableExecute(
+            Table table,
+            Identifier procedureName,
+            List<Property> properties,
+            Optional<Expression> where,
+            Optional<OrderBy> orderBy)
+    {
+        this(Optional.empty(), table, procedureName, properties, where, orderBy);
+    }
+
+    public TableExecute(
+            NodeLocation location,
+            Table table,
+            Identifier procedureName,
+            List<Property> properties,
+            Optional<Expression> where,
+            Optional<OrderBy> orderBy)
+    {
+        this(Optional.of(location), table, procedureName, properties, where, orderBy);
+    }
+
+    private TableExecute(
+            Optional<NodeLocation> location,
+            Table table,
+            Identifier procedureName,
+            List<Property> properties,
+            Optional<Expression> where,
+            Optional<OrderBy> orderBy)
+    {
+        super(location);
+        this.table = requireNonNull(table, "table is null");
+        this.procedureName = requireNonNull(procedureName, "procedureName is null");
+        this.properties = requireNonNull(properties, "properties is null");
+        this.where = requireNonNull(where, "where is null");
+        this.orderBy = requireNonNull(orderBy, "orderBy is null");
+    }
+
+    public Table getTable()
+    {
+        return table;
+    }
+
+    public Identifier getProcedureName()
+    {
+        return procedureName;
+    }
+
+    public List<Property> getProperties()
+    {
+        return properties;
+    }
+
+    public Optional<Expression> getWhere()
+    {
+        return where;
+    }
+
+    public Optional<OrderBy> getOrderBy()
+    {
+        return orderBy;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitTableExecute(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        ImmutableList.Builder<Node> nodes = ImmutableList.builder();
+        nodes.addAll(properties);
+        where.ifPresent(nodes::add);
+        orderBy.ifPresent(nodes::add);
+        return nodes.build();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(table, procedureName, properties, where, orderBy);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TableExecute that = (TableExecute) o;
+        return Objects.equals(table, that.table) &&
+                Objects.equals(procedureName, that.procedureName) &&
+                Objects.equals(properties, that.properties) &&
+                Objects.equals(where, that.where) &&
+                Objects.equals(orderBy, that.orderBy);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("table", table)
+                .add("procedureNaem", procedureName)
+                .add("properties", properties)
+                .add("where", where)
+                .add("orderBy", orderBy)
+                .toString();
+    }
+}

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -170,6 +170,7 @@ import io.trino.sql.tree.SubqueryExpression;
 import io.trino.sql.tree.SubscriptExpression;
 import io.trino.sql.tree.SubsetDefinition;
 import io.trino.sql.tree.Table;
+import io.trino.sql.tree.TableExecute;
 import io.trino.sql.tree.TableSubquery;
 import io.trino.sql.tree.TimeLiteral;
 import io.trino.sql.tree.TimestampLiteral;
@@ -1803,6 +1804,29 @@ public class TestSqlParser
         assertStatement(
                 "ALTER VIEW foo.bar.baz SET AUTHORIZATION ROLE qux",
                 new SetViewAuthorization(QualifiedName.of("foo", "bar", "baz"), new PrincipalSpecification(PrincipalSpecification.Type.ROLE, new Identifier("qux"))));
+    }
+
+    @Test
+    public void testTableExecute()
+    {
+        Table table = new Table(QualifiedName.of("foo"));
+        Identifier procedure = new Identifier("bar");
+
+        assertStatement("ALTER TABLE foo EXECUTE bar", new TableExecute(table, procedure, ImmutableList.of(), Optional.empty(), Optional.empty()));
+        assertStatement(
+                "ALTER TABLE foo EXECUTE bar WITH(bah=1, wuh='clap') WHERE age > 17 ORDER BY height",
+                new TableExecute(
+                        table,
+                        procedure,
+                        ImmutableList.of(
+                                new Property(new Identifier("bah"), new LongLiteral("1")),
+                                new Property(new Identifier("wuh"), new StringLiteral("clap"))),
+                        Optional.of(
+                                new ComparisonExpression(ComparisonExpression.Operator.GREATER_THAN,
+                                        new Identifier("age"),
+                                        new LongLiteral("17"))),
+                        Optional.of(new OrderBy(ImmutableList.of(
+                                new SortItem(new Identifier(location(1, 42), "height", false), ASCENDING, UNDEFINED))))));
     }
 
     @Test

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
@@ -108,6 +108,11 @@ public interface Connector
         return emptySet();
     }
 
+    default Set<TableProcedureMetadata> getTableProcedures()
+    {
+        return emptySet();
+    }
+
     /**
      * @return the system properties for this connector
      */

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorHandleResolver.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorHandleResolver.java
@@ -50,6 +50,11 @@ public interface ConnectorHandleResolver
         throw new UnsupportedOperationException();
     }
 
+    default Class<? extends ConnectorTableExecuteHandle> getTableExecuteHandleClass()
+    {
+        throw new UnsupportedOperationException();
+    }
+
     default Class<? extends ConnectorPartitioningHandle> getPartitioningHandleClass()
     {
         throw new UnsupportedOperationException();

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -92,6 +92,44 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Create initial handle for execution of table procedure. The handle will be used through planning process. It will be converted to final
+     * handle used for execution via @{link {@link ConnectorMetadata#}beginTableExecute}
+     */
+    @Nullable
+    default ConnectorTableExecuteHandle getTableHandleForExecute(
+            ConnectorSession session,
+            ConnectorTableHandle tableHandle,
+            String procedureName,
+            Map<String, Object> executeProperties,
+            Constraint constraint)
+    {
+        return null;
+    }
+
+    default Optional<ConnectorNewTableLayout> getLayoutForTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        return Optional.empty();
+    }
+
+    /**
+     * Begin execution of table procedure
+     */
+    default ConnectorTableExecuteHandle beginTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not table procedures");
+    }
+
+    /**
+     * Finish table execute
+     *
+     * @param fragments all fragments returned by {@link io.trino.spi.connector.UpdatablePageSource#finish()}
+     */
+    default void finishTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments)
+    {
+        throw new TrinoException(NOT_SUPPORTED, "This connector does not table procedures");
+    }
+
+    /**
      * Returns the system table for the specified table name, if one exists.
      * The system tables handled via {@link #getSystemTable} differ form those returned by {@link Connector#getSystemTables()}.
      * The former mechanism allows dynamic resolution of system tables, while the latter is

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -122,9 +122,10 @@ public interface ConnectorMetadata
     /**
      * Finish table execute
      *
-     * @param fragments all fragments returned by {@link io.trino.spi.connector.UpdatablePageSource#finish()}
+     * @param fragments all fragments returned by {@link UpdatablePageSource#finish()}
+     * @param tableExecuteState
      */
-    default void finishTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments)
+    default void finishTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
     {
         throw new TrinoException(NOT_SUPPORTED, "This connector does not table procedures");
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSinkProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorPageSinkProvider.java
@@ -18,4 +18,9 @@ public interface ConnectorPageSinkProvider
     ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle);
 
     ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle);
+
+    default ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        throw new IllegalArgumentException("createPageSink not supported for tableExecuteHandle");
+    }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorSplitSource.java
@@ -15,6 +15,7 @@ package io.trino.spi.connector;
 
 import java.io.Closeable;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Objects.requireNonNull;
@@ -36,6 +37,11 @@ public interface ConnectorSplitSource
      * will be inherently racy.
      */
     boolean isFinished();
+
+    default Optional<List<Object>> getTableExecuteSplitsInfo()
+    {
+        return Optional.empty();
+    }
 
     class ConnectorSplitBatch
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableExecuteHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorTableExecuteHandle.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+public interface ConnectorTableExecuteHandle
+{
+    ConnectorTableHandle getSourceTableHandle();
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/FixedSplitSource.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/FixedSplitSource.java
@@ -14,7 +14,9 @@
 package io.trino.spi.connector;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static io.trino.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static java.util.Objects.requireNonNull;
@@ -26,12 +28,25 @@ public class FixedSplitSource
         implements ConnectorSplitSource
 {
     private final List<ConnectorSplit> splits;
+    private final Optional<List<Object>> tableExecuteSplitsInfo;
     private int offset;
 
     public FixedSplitSource(Iterable<? extends ConnectorSplit> splits)
     {
+        this(splits, Optional.empty());
+    }
+
+    public FixedSplitSource(Iterable<? extends ConnectorSplit> splits, List<Object> tableExecuteSplitsInfo)
+    {
+        this(splits, Optional.of(tableExecuteSplitsInfo));
+    }
+
+    private FixedSplitSource(Iterable<? extends ConnectorSplit> splits, Optional<List<Object>> tableExecuteSplitsInfo)
+    {
         requireNonNull(splits, "splits is null");
+        requireNonNull(tableExecuteSplitsInfo, "tableExecuteSplitsInfo is null");
         this.splits = stream(splits.spliterator(), false).collect(toUnmodifiableList());
+        this.tableExecuteSplitsInfo = tableExecuteSplitsInfo.map(infos -> infos.stream().collect(Collectors.toUnmodifiableList()));
     }
 
     @SuppressWarnings("ObjectEquality")
@@ -54,6 +69,12 @@ public class FixedSplitSource
     public boolean isFinished()
     {
         return offset >= splits.size();
+    }
+
+    @Override
+    public Optional<List<Object>> getTableExecuteSplitsInfo()
+    {
+        return tableExecuteSplitsInfo;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/TableProcedureExecutionMode.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/TableProcedureExecutionMode.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+public class TableProcedureExecutionMode
+{
+    private final boolean processData;
+    private final boolean filter;
+    private final boolean repartition;
+    private final boolean sort;
+
+    public TableProcedureExecutionMode(boolean processData, boolean repartition, boolean filter, boolean sort)
+    {
+        this.processData = processData;
+        if (!processData) {
+            if (repartition) {
+                throw new IllegalArgumentException("repartitioning not supported if table data is not processed");
+            }
+            if (filter) {
+                throw new IllegalArgumentException("filtering not supported if table data is not processed");
+            }
+            if (sort) {
+                throw new IllegalArgumentException("sorting not supported if table data is not processed");
+            }
+        }
+
+        this.repartition = repartition;
+        this.filter = filter;
+        this.sort = sort;
+    }
+
+    public boolean isProcessData()
+    {
+        return processData;
+    }
+
+    public boolean isFilter()
+    {
+        return filter;
+    }
+
+    public boolean isRepartition()
+    {
+        return repartition;
+    }
+
+    public boolean isSort()
+    {
+        return sort;
+    }
+
+    public static TableProcedureExecutionMode coordinatorOnly()
+    {
+        return new TableProcedureExecutionMode(false, false, false, false);
+    }
+
+    public static TableProcedureExecutionMode distributedWithFilteringAndRepartitioning()
+    {
+        return new TableProcedureExecutionMode(true, true, true, false);
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/TableProcedureMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/TableProcedureMetadata.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.trino.spi.connector.SchemaUtil.checkNotEmpty;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+
+public class TableProcedureMetadata
+{
+    private final String name;
+    private final TableProcedureExecutionMode executionMode;
+    private final List<PropertyMetadata<?>> properties;
+
+    public TableProcedureMetadata(String name, TableProcedureExecutionMode executionMode, List<PropertyMetadata<?>> properties)
+    {
+        this.name = checkNotEmpty(name, "name");
+        this.executionMode = requireNonNull(executionMode, "executionMode is null");
+        requireNonNull(properties, "properties is null");
+        this.properties = properties.isEmpty() ? emptyList() : unmodifiableList(new ArrayList<>(properties));
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public TableProcedureExecutionMode getExecutionMode()
+    {
+        return executionMode;
+    }
+
+    public List<PropertyMetadata<?>> getProperties()
+    {
+        return properties;
+    }
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -30,6 +30,7 @@ import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPartitioningHandle;
 import io.trino.spi.connector.ConnectorResolvedIndex;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableLayout;
 import io.trino.spi.connector.ConnectorTableLayoutHandle;
@@ -66,6 +67,7 @@ import io.trino.spi.statistics.ComputedStatistics;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.spi.statistics.TableStatisticsMetadata;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 import java.util.Collection;
@@ -213,6 +215,39 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getTableHandleForStatisticsCollection(session, tableName, analyzeProperties);
+        }
+    }
+
+    @Nullable
+    @Override
+    public ConnectorTableExecuteHandle getTableHandleForExecute(ConnectorSession session, ConnectorTableHandle tableHandle, String procedureName, Map<String, Object> executeProperties, Constraint constraint)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableHandleForExecute(session, tableHandle, procedureName, executeProperties, constraint);
+        }
+    }
+
+    @Override
+    public Optional<ConnectorNewTableLayout> getLayoutForTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getLayoutForTableExecute(session, tableExecuteHandle);
+        }
+    }
+
+    @Override
+    public ConnectorTableExecuteHandle beginTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.beginTableExecute(session, tableExecuteHandle);
+        }
+    }
+
+    @Override
+    public void finishTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.finishTableExecute(session, tableExecuteHandle, fragments, tableExecuteState);
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
@@ -19,6 +19,7 @@ import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 
 import javax.inject.Inject;
@@ -51,6 +52,14 @@ public final class ClassLoaderSafeConnectorPageSinkProvider
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, insertTableHandle), classLoader);
+        }
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, tableExecuteHandle), classLoader);
         }
     }
 }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorSplitSource.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorSplitSource.java
@@ -19,6 +19,8 @@ import io.trino.spi.connector.ConnectorSplitSource;
 
 import javax.inject.Inject;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static java.util.Objects.requireNonNull;
@@ -41,6 +43,14 @@ public class ClassLoaderSafeConnectorSplitSource
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getNextBatch(partitionHandle, maxSize);
+        }
+    }
+
+    @Override
+    public Optional<List<Object>> getTableExecuteSplitsInfo()
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getTableExecuteSplitsInfo();
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -164,6 +164,7 @@ public class BackgroundHiveSplitLoader
     private final ConcurrentLazyQueue<HivePartitionMetadata> partitions;
     private final Deque<Iterator<InternalHiveSplit>> fileIterators = new ConcurrentLinkedDeque<>();
     private final Optional<ValidWriteIdList> validWriteIds;
+    private final Optional<Long> maxSplitFileSize;
 
     // Purpose of this lock:
     // * Write lock: when you need a consistent view across partitions, fileIterators, and hiveSplitSource.
@@ -204,7 +205,8 @@ public class BackgroundHiveSplitLoader
             boolean recursiveDirWalkerEnabled,
             boolean ignoreAbsentPartitions,
             boolean optimizeSymlinkListing,
-            Optional<ValidWriteIdList> validWriteIds)
+            Optional<ValidWriteIdList> validWriteIds,
+            Optional<Long> maxSplitFileSize)
     {
         this.table = table;
         this.transaction = requireNonNull(transaction, "transaction is null");
@@ -226,6 +228,7 @@ public class BackgroundHiveSplitLoader
         this.partitions = new ConcurrentLazyQueue<>(partitions);
         this.hdfsContext = new HdfsContext(session);
         this.validWriteIds = requireNonNull(validWriteIds, "validWriteIds is null");
+        this.maxSplitFileSize = requireNonNull(maxSplitFileSize, "maxSplitFileSize is null");
     }
 
     @Override
@@ -465,7 +468,8 @@ public class BackgroundHiveSplitLoader
                 getMaxInitialSplitSize(session),
                 isForceLocalScheduling(session),
                 s3SelectPushdownEnabled,
-                transaction);
+                transaction,
+                maxSplitFileSize);
 
         // To support custom input formats, we want to call getSplits()
         // on the input format to obtain file splits.
@@ -653,7 +657,7 @@ public class BackgroundHiveSplitLoader
                     getMaxInitialSplitSize(session),
                     isForceLocalScheduling(session),
                     s3SelectPushdownEnabled,
-                    transaction);
+                    transaction, maxSplitFileSize);
             lastResult = addSplitsToSource(targetSplits, splitFactory);
             if (stopped) {
                 return COMPLETED_FUTURE;
@@ -709,7 +713,7 @@ public class BackgroundHiveSplitLoader
                 getMaxInitialSplitSize(session),
                 isForceLocalScheduling(session),
                 s3SelectPushdownEnabled,
-                transaction);
+                transaction, maxSplitFileSize);
         return Optional.of(locatedFileStatuses.stream()
                 .map(locatedFileStatus -> splitFactory.createInternalHiveSplit(locatedFileStatus, OptionalInt.empty(), splittable, Optional.empty()))
                 .filter(Optional::isPresent)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveHandleResolver.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveHandleResolver.java
@@ -19,6 +19,7 @@ import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPartitioningHandle;
 import io.trino.spi.connector.ConnectorSplit;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 
@@ -53,6 +54,12 @@ public class HiveHandleResolver
     public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
     {
         return HiveInsertTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTableExecuteHandle> getTableExecuteHandleClass()
+    {
+        return HiveTableExecuteHandle.class;
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -64,6 +64,7 @@ import io.trino.spi.connector.ConnectorOutputMetadata;
 import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPartitioningHandle;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTableHandle;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTablePartitioning;
@@ -184,6 +185,7 @@ import static io.trino.plugin.hive.HiveSessionProperties.isQueryPartitionFilterR
 import static io.trino.plugin.hive.HiveSessionProperties.isRespectTableFormat;
 import static io.trino.plugin.hive.HiveSessionProperties.isSortedWritingEnabled;
 import static io.trino.plugin.hive.HiveSessionProperties.isStatisticsEnabled;
+import static io.trino.plugin.hive.HiveTableProcedures.COMPACT_SMALL_FILES;
 import static io.trino.plugin.hive.HiveTableProperties.ANALYZE_COLUMNS_PROPERTY;
 import static io.trino.plugin.hive.HiveTableProperties.AVRO_SCHEMA_URL;
 import static io.trino.plugin.hive.HiveTableProperties.BUCKETED_BY_PROPERTY;
@@ -1855,6 +1857,179 @@ public class HiveMetadata
     }
 
     @Override
+    public ConnectorTableExecuteHandle getTableHandleForExecute(ConnectorSession session, ConnectorTableHandle tableHandle, String procedureName, Map<String, Object> executeProperties, Constraint constraint)
+    {
+        if (procedureName.equals(COMPACT_SMALL_FILES)) {
+            return getTableHandleForCompactSmallFiles(session, tableHandle, executeProperties, constraint);
+        }
+        throw new IllegalArgumentException("unknown procedure '" + procedureName + "'");
+    }
+
+    private ConnectorTableExecuteHandle getTableHandleForCompactSmallFiles(ConnectorSession session, ConnectorTableHandle tableHandle, Map<String, Object> executeProperties, Constraint constraint)
+    {
+        // TODO lots of that is copied from beginInsert; rafactoring opportunity
+        HiveIdentity identity = new HiveIdentity(session);
+        HiveTableHandle hiveTableHandle = (HiveTableHandle) tableHandle;
+        SchemaTableName tableName = hiveTableHandle.getSchemaTableName();
+
+        if (constraint.predicate().isPresent() || !constraint.getSummary().isAll()) {
+            // TODO: relax check to to allow constraints which filter out whole partitions
+            throw new TrinoException(NOT_SUPPORTED, format("Compacting small files for Hive table %s with non empty predicate is not supported", tableName));
+        }
+
+        Table table = metastore.getTable(identity, tableName.getSchemaName(), tableName.getTableName())
+                .orElseThrow(() -> new TableNotFoundException(tableName));
+
+        checkTableIsWritable(table, writesToNonManagedTablesEnabled);
+
+        for (Column column : table.getDataColumns()) {
+            if (!isWritableType(column.getType())) {
+                throw new TrinoException(NOT_SUPPORTED, format("Compacting small files for Hive table %s with column type %s not supported", tableName, column.getType()));
+            }
+        }
+
+        if (isTransactionalTable(table.getParameters())) {
+            throw new TrinoException(NOT_SUPPORTED, format("Compacting small files for transactional Hive table %s is not supported", tableName));
+        }
+
+        if (table.getStorage().getBucketProperty().isPresent()) {
+            throw new TrinoException(NOT_SUPPORTED, format("Compacting small files for bucketed Hive table %s is not supported", tableName));
+        }
+
+        List<HiveColumnHandle> handles = hiveColumnHandles(table, typeManager, getTimestampPrecision(session)).stream()
+                .filter(columnHandle -> !columnHandle.isHidden())
+                .collect(toList());
+
+        HiveStorageFormat tableStorageFormat = extractHiveStorageFormat(table);
+        Optional.ofNullable(table.getParameters().get(SKIP_HEADER_COUNT_KEY)).map(Integer::parseInt).ifPresent(headerSkipCount -> {
+            if (headerSkipCount > 1) {
+                throw new TrinoException(NOT_SUPPORTED, format("Compacting small files for Hive table %s with value of %s property greater than 1 is not supported", tableName, SKIP_HEADER_COUNT_KEY));
+            }
+        });
+
+        if (table.getParameters().containsKey(SKIP_FOOTER_COUNT_KEY)) {
+            throw new TrinoException(NOT_SUPPORTED, format("Compacting small files for Hive table %s with %s property not supported", tableName, SKIP_FOOTER_COUNT_KEY));
+        }
+        LocationHandle locationHandle = locationService.forExistingTable(metastore, session, table);
+
+        long fileSizeThreshold = (long) executeProperties.get("file_size_threshold");
+        HiveTableHandle newTableHandle = hiveTableHandle
+                .withRecordScannedFiles(true)
+                .withMaxScannedFileSize(Optional.of(fileSizeThreshold));
+
+        HiveTableExecuteHandle result = new HiveTableExecuteHandle(
+                COMPACT_SMALL_FILES,
+                newTableHandle,
+                tableName.getSchemaName(),
+                tableName.getTableName(),
+                handles,
+                metastore.generatePageSinkMetadata(identity, tableName),
+                locationHandle,
+                table.getStorage().getBucketProperty(),
+                tableStorageFormat,
+                isRespectTableFormat(session) ? tableStorageFormat : getHiveStorageFormat(session),
+                NO_ACID_TRANSACTION);
+        return result;
+    }
+
+    @Override
+    public ConnectorTableExecuteHandle beginTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        String procedureName = ((HiveTableExecuteHandle) tableExecuteHandle).getProcedureName();
+
+        if (procedureName.equals(COMPACT_SMALL_FILES)) {
+            return beginCompactSmallFiles(session, tableExecuteHandle);
+        }
+        throw new IllegalArgumentException("unknown procedure '" + procedureName + "'");
+    }
+
+    private ConnectorTableExecuteHandle beginCompactSmallFiles(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        HiveTableExecuteHandle hiveExecuteHandle = (HiveTableExecuteHandle) tableExecuteHandle;
+        WriteInfo writeInfo = locationService.getQueryWriteInfo(hiveExecuteHandle.getLocationHandle());
+        metastore.declareIntentionToWrite(session, writeInfo.getWriteMode(), writeInfo.getWritePath(), hiveExecuteHandle.getSchemaTableName());
+        return tableExecuteHandle;
+    }
+
+    @Override
+    public void finishTableExecute(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
+    {
+        String procedureName = ((HiveTableExecuteHandle) tableExecuteHandle).getProcedureName();
+
+        if (procedureName.equals(COMPACT_SMALL_FILES)) {
+            finishCompactSmallFiles(session, tableExecuteHandle, fragments, tableExecuteState);
+            return;
+        }
+        throw new IllegalArgumentException("unknown procedure '" + procedureName + "'");
+    }
+
+    private void finishCompactSmallFiles(ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle, Collection<Slice> fragments, List<Object> tableExecuteState)
+    {
+        // TODO lots of that is copied from finishInsert; rafactoring opportunity
+        HiveTableExecuteHandle handle = (HiveTableExecuteHandle) tableExecuteHandle;
+
+        List<PartitionUpdate> partitionUpdates = fragments.stream()
+                .map(Slice::getBytes)
+                .map(partitionUpdateCodec::fromJson)
+                .collect(toList());
+
+        HiveStorageFormat tableStorageFormat = handle.getTableStorageFormat();
+        partitionUpdates = PartitionUpdate.mergePartitionUpdates(partitionUpdates);
+
+        Table table = metastore.getTable(new HiveIdentity(session), handle.getSchemaName(), handle.getTableName())
+                .orElseThrow(() -> new TableNotFoundException(handle.getSchemaTableName()));
+        if (!table.getStorage().getStorageFormat().getInputFormat().equals(tableStorageFormat.getInputFormat()) && isRespectTableFormat(session)) {
+            throw new TrinoException(HIVE_CONCURRENT_MODIFICATION_DETECTED, "Table format changed during insert");
+        }
+
+        verify(handle.getBucketProperty().isEmpty());
+
+        for (PartitionUpdate partitionUpdate : partitionUpdates) {
+            verify(partitionUpdate.getUpdateMode() == APPEND);
+
+            if (partitionUpdate.getName().isEmpty()) {
+                // operating on an unpartitioned table
+                if (!table.getStorage().getStorageFormat().getInputFormat().equals(handle.getPartitionStorageFormat().getInputFormat()) && isRespectTableFormat(session)) {
+                    throw new TrinoException(HIVE_CONCURRENT_MODIFICATION_DETECTED, "Table format changed during insert");
+                }
+
+                // insert into unpartitioned table
+                metastore.finishInsertIntoExistingTable(
+                        session,
+                        handle.getSchemaName(),
+                        handle.getTableName(),
+                        partitionUpdate.getWritePath(),
+                        partitionUpdate.getFileNames(),
+                        PartitionStatistics.empty());
+            }
+            else {
+                // insert into existing partition
+                List<String> partitionValues = toPartitionValues(partitionUpdate.getName());
+                metastore.finishInsertIntoExistingPartition(
+                        session,
+                        handle.getSchemaName(),
+                        handle.getTableName(),
+                        partitionValues,
+                        partitionUpdate.getWritePath(),
+                        partitionUpdate.getFileNames(),
+                        PartitionStatistics.empty());
+            }
+        }
+
+        try {
+            // TODO; this is not safe; we can delete old files. And then if there is error new files will be deleted too.
+            FileSystem fs = hdfsEnvironment.getFileSystem(new HdfsContext(session), new Path(table.getStorage().getLocation()));
+            for (Object scannedPathObject : tableExecuteState) {
+                Path scannedPath = new Path((String) scannedPathObject);
+                fs.delete(scannedPath, false);
+            }
+        }
+        catch (IOException e) {
+            throw new TrinoException(HIVE_FILESYSTEM_ERROR, "Error while deleting ", e);
+        }
+    }
+
+    @Override
     public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
     {
         HiveIdentity identity = new HiveIdentity(session);
@@ -2458,7 +2633,9 @@ public class HiveMetadata
                 hiveTable.getAnalyzeColumnNames(),
                 Optional.empty(),
                 Optional.empty(), // Projected columns is used only during optimization phase of planning
-                hiveTable.getTransaction());
+                hiveTable.getTransaction(),
+                hiveTable.isRecordScannedFiles(),
+                hiveTable.getMaxScannedFileSize());
     }
 
     @VisibleForTesting

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSinkProvider.java
@@ -32,6 +32,7 @@ import io.trino.spi.connector.ConnectorOutputTableHandle;
 import io.trino.spi.connector.ConnectorPageSink;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.type.TypeManager;
 import org.joda.time.DateTimeZone;
@@ -119,6 +120,13 @@ public class HivePageSinkProvider
     {
         HiveWritableTableHandle handle = (HiveInsertTableHandle) tableHandle;
         return createPageSink(handle, false, session, ImmutableMap.of() /* for insert properties are taken from metastore */);
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorTableExecuteHandle tableExecuteHandle)
+    {
+        HiveTableExecuteHandle handle = (HiveTableExecuteHandle) tableExecuteHandle;
+        return createPageSink(handle, false, session, ImmutableMap.of());
     }
 
     private ConnectorPageSink createPageSink(HiveWritableTableHandle handle, boolean isCreateTable, ConnectorSession session, Map<String, String> additionalTableParameters)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionManager.java
@@ -193,7 +193,9 @@ public class HivePartitionManager
                 handle.getAnalyzeColumnNames(),
                 Optionals.combine(handle.getConstraintColumns(), columns, Sets::union),
                 handle.getProjectedColumns(),
-                handle.getTransaction());
+                handle.getTransaction(),
+                handle.isRecordScannedFiles(),
+                handle.getMaxScannedFileSize());
     }
 
     public List<HivePartition> getOrLoadPartitions(SemiTransactionalHiveMetastore metastore, HiveIdentity identity, HiveTableHandle table)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSplitManager.java
@@ -245,7 +245,8 @@ public class HiveSplitManager
                 !hiveTable.getPartitionColumns().isEmpty() && isIgnoreAbsentPartitions(session),
                 isOptimizeSymlinkListing(session),
                 metastore.getValidWriteIds(session, hiveTable)
-                        .map(validTxnWriteIdList -> validTxnWriteIdList.getTableValidWriteIdList(table.getDatabaseName() + "." + table.getTableName())));
+                        .map(validTxnWriteIdList -> validTxnWriteIdList.getTableValidWriteIdList(table.getDatabaseName() + "." + table.getTableName())),
+                hiveTable.getMaxScannedFileSize());
 
         HiveSplitSource splitSource;
         switch (splitSchedulingStrategy) {
@@ -260,7 +261,8 @@ public class HiveSplitManager
                         maxSplitsPerSecond,
                         hiveSplitLoader,
                         executor,
-                        highMemorySplitSourceCounter);
+                        highMemorySplitSourceCounter,
+                        hiveTable.isRecordScannedFiles());
                 break;
             case GROUPED_SCHEDULING:
                 splitSource = HiveSplitSource.bucketed(
@@ -273,7 +275,8 @@ public class HiveSplitManager
                         maxSplitsPerSecond,
                         hiveSplitLoader,
                         executor,
-                        highMemorySplitSourceCounter);
+                        highMemorySplitSourceCounter,
+                        hiveTable.isRecordScannedFiles());
                 break;
             default:
                 throw new IllegalArgumentException("Unknown splitSchedulingStrategy: " + splitSchedulingStrategy);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableExecuteHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableExecuteHandle.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.plugin.hive.acid.AcidTransaction;
+import io.trino.plugin.hive.metastore.HivePageSinkMetadata;
+import io.trino.spi.connector.ConnectorTableExecuteHandle;
+import io.trino.spi.connector.ConnectorTableHandle;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class HiveTableExecuteHandle
+        extends HiveWritableTableHandle
+        implements ConnectorTableExecuteHandle
+{
+    private final String procedureName;
+    private final HiveTableHandle sourceTableHandle;
+
+    @JsonCreator
+    public HiveTableExecuteHandle(
+            @JsonProperty("procedureName") String procedureName,
+            @JsonProperty("sourceTableHandle") HiveTableHandle sourceTableHandle,
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("inputColumns") List<HiveColumnHandle> inputColumns,
+            @JsonProperty("pageSinkMetadata") HivePageSinkMetadata pageSinkMetadata,
+            @JsonProperty("locationHandle") LocationHandle locationHandle,
+            @JsonProperty("bucketProperty") Optional<HiveBucketProperty> bucketProperty,
+            @JsonProperty("tableStorageFormat") HiveStorageFormat tableStorageFormat,
+            @JsonProperty("partitionStorageFormat") HiveStorageFormat partitionStorageFormat,
+            @JsonProperty("transaction") AcidTransaction transaction)
+    {
+        super(
+                schemaName,
+                tableName,
+                inputColumns,
+                pageSinkMetadata,
+                locationHandle,
+                bucketProperty,
+                tableStorageFormat,
+                partitionStorageFormat,
+                transaction);
+
+        this.procedureName = requireNonNull(procedureName, "procedureName is null");
+        this.sourceTableHandle = requireNonNull(sourceTableHandle, "sourceTableHandle is null");
+    }
+
+    @JsonProperty
+    public String getProcedureName()
+    {
+        return procedureName;
+    }
+
+    @Override
+    @JsonProperty
+    public ConnectorTableHandle getSourceTableHandle()
+    {
+        return sourceTableHandle;
+    }
+
+    @Override
+    public String toString()
+    {
+        return procedureName + "(" + getSchemaName() + "." + getTableName() + ")";
+    }
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableHandle.java
@@ -56,6 +56,8 @@ public class HiveTableHandle
     private final Optional<Set<ColumnHandle>> constraintColumns;
     private final Optional<Set<ColumnHandle>> projectedColumns;
     private final AcidTransaction transaction;
+    private final boolean recordScannedFiles;
+    private final Optional<Long> maxScannedFileSize;
 
     @JsonCreator
     public HiveTableHandle(
@@ -86,7 +88,9 @@ public class HiveTableHandle
                 analyzeColumnNames,
                 Optional.empty(),
                 Optional.empty(),
-                transaction);
+                transaction,
+                false,
+                Optional.empty());
     }
 
     public HiveTableHandle(
@@ -112,7 +116,9 @@ public class HiveTableHandle
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
-                NO_ACID_TRANSACTION);
+                NO_ACID_TRANSACTION,
+                false,
+                Optional.empty());
     }
 
     public HiveTableHandle(
@@ -130,7 +136,9 @@ public class HiveTableHandle
             Optional<Set<String>> analyzeColumnNames,
             Optional<Set<ColumnHandle>> constraintColumns,
             Optional<Set<ColumnHandle>> projectedColumns,
-            AcidTransaction transaction)
+            AcidTransaction transaction,
+            boolean recordScannedFiles,
+            Optional<Long> maxSplitFileSize)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -147,6 +155,8 @@ public class HiveTableHandle
         this.constraintColumns = requireNonNull(constraintColumns, "constraintColumns is null");
         this.projectedColumns = requireNonNull(projectedColumns, "projectedColumns is null");
         this.transaction = requireNonNull(transaction, "transaction is null");
+        this.recordScannedFiles = recordScannedFiles;
+        this.maxScannedFileSize = requireNonNull(maxSplitFileSize, "maxSplitFileSize is null");
     }
 
     public HiveTableHandle withAnalyzePartitionValues(List<List<String>> analyzePartitionValues)
@@ -166,7 +176,9 @@ public class HiveTableHandle
                 analyzeColumnNames,
                 constraintColumns,
                 projectedColumns,
-                transaction);
+                transaction,
+                recordScannedFiles,
+                maxScannedFileSize);
     }
 
     public HiveTableHandle withAnalyzeColumnNames(Set<String> analyzeColumnNames)
@@ -186,7 +198,9 @@ public class HiveTableHandle
                 Optional.of(analyzeColumnNames),
                 constraintColumns,
                 projectedColumns,
-                transaction);
+                transaction,
+                recordScannedFiles,
+                maxScannedFileSize);
     }
 
     public HiveTableHandle withTransaction(AcidTransaction transaction)
@@ -206,7 +220,9 @@ public class HiveTableHandle
                 analyzeColumnNames,
                 constraintColumns,
                 projectedColumns,
-                transaction);
+                transaction,
+                recordScannedFiles,
+                maxScannedFileSize);
     }
 
     public HiveTableHandle withUpdateProcessor(AcidTransaction transaction, HiveUpdateProcessor updateProcessor)
@@ -227,7 +243,9 @@ public class HiveTableHandle
                 analyzeColumnNames,
                 constraintColumns,
                 projectedColumns,
-                transaction);
+                transaction,
+                recordScannedFiles,
+                maxScannedFileSize);
     }
 
     public HiveTableHandle withProjectedColumns(Set<ColumnHandle> projectedColumns)
@@ -247,7 +265,53 @@ public class HiveTableHandle
                 analyzeColumnNames,
                 constraintColumns,
                 Optional.of(projectedColumns),
-                transaction);
+                transaction,
+                recordScannedFiles,
+                maxScannedFileSize);
+    }
+
+    public HiveTableHandle withRecordScannedFiles(boolean recordScannedFiles)
+    {
+        return new HiveTableHandle(
+                schemaName,
+                tableName,
+                tableParameters,
+                partitionColumns,
+                dataColumns,
+                partitions,
+                compactEffectivePredicate,
+                enforcedConstraint,
+                bucketHandle,
+                bucketFilter,
+                analyzePartitionValues,
+                analyzeColumnNames,
+                constraintColumns,
+                projectedColumns,
+                transaction,
+                recordScannedFiles,
+                maxScannedFileSize);
+    }
+
+    public HiveTableHandle withMaxScannedFileSize(Optional<Long> maxScannedFileSize)
+    {
+        return new HiveTableHandle(
+                schemaName,
+                tableName,
+                tableParameters,
+                partitionColumns,
+                dataColumns,
+                partitions,
+                compactEffectivePredicate,
+                enforcedConstraint,
+                bucketHandle,
+                bucketFilter,
+                analyzePartitionValues,
+                analyzeColumnNames,
+                constraintColumns,
+                projectedColumns,
+                transaction,
+                recordScannedFiles,
+                maxScannedFileSize);
     }
 
     @JsonProperty
@@ -385,6 +449,18 @@ public class HiveTableHandle
     {
         checkState(transaction.isAcidTransactionRunning(), "The AcidTransaction is not running");
         return transaction.getWriteId();
+    }
+
+    @JsonIgnore
+    public boolean isRecordScannedFiles()
+    {
+        return recordScannedFiles;
+    }
+
+    @JsonIgnore
+    public Optional<Long> getMaxScannedFileSize()
+    {
+        return maxScannedFileSize;
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProcedures.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveTableProcedures.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+public class HiveTableProcedures
+{
+    private HiveTableProcedures() {}
+
+    public static final String COMPACT_SMALL_FILES = "compact_small_files";
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/InternalHiveSplitFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/InternalHiveSplitFactory.java
@@ -69,6 +69,7 @@ public class InternalHiveSplitFactory
     private final Optional<BucketConversion> bucketConversion;
     private final Optional<HiveSplit.BucketValidation> bucketValidation;
     private final long minimumTargetSplitSizeInBytes;
+    private final Optional<Long> maxSplitFileSize;
     private final boolean forceLocalScheduling;
     private final boolean s3SelectPushdownEnabled;
     private final AcidTransaction transaction;
@@ -88,7 +89,8 @@ public class InternalHiveSplitFactory
             DataSize minimumTargetSplitSize,
             boolean forceLocalScheduling,
             boolean s3SelectPushdownEnabled,
-            AcidTransaction transaction)
+            AcidTransaction transaction,
+            Optional<Long> maxSplitFileSize)
     {
         this.fileSystem = requireNonNull(fileSystem, "fileSystem is null");
         this.partitionName = requireNonNull(partitionName, "partitionName is null");
@@ -104,6 +106,7 @@ public class InternalHiveSplitFactory
         this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
         this.transaction = requireNonNull(transaction, "transaction is null");
         this.minimumTargetSplitSizeInBytes = requireNonNull(minimumTargetSplitSize, "minimumTargetSplitSize is null").toBytes();
+        this.maxSplitFileSize = requireNonNull(maxSplitFileSize, "maxSplitFileSize is null");
         checkArgument(minimumTargetSplitSizeInBytes > 0, "minimumTargetSplitSize must be > 0, found: %s", minimumTargetSplitSize);
     }
 
@@ -164,6 +167,10 @@ public class InternalHiveSplitFactory
         // Dynamic filter may not have been ready when partition was loaded in BackgroundHiveSplitLoader,
         // but it might be ready when splits are enumerated lazily.
         if (!partitionMatchSupplier.getAsBoolean()) {
+            return Optional.empty();
+        }
+
+        if (maxSplitFileSize.isPresent() && estimatedFileSize > maxSplitFileSize.get()) {
             return Optional.empty();
         }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -543,6 +543,7 @@ public class TestBackgroundHiveSplitLoader
                 false,
                 false,
                 true,
+                Optional.empty(),
                 Optional.empty());
 
         HiveSplitSource hiveSplitSource = hiveSplitSource(backgroundHiveSplitLoader);
@@ -1068,7 +1069,8 @@ public class TestBackgroundHiveSplitLoader
                 false,
                 false,
                 true,
-                validWriteIds);
+                validWriteIds,
+                Optional.empty());
     }
 
     private BackgroundHiveSplitLoader backgroundHiveSplitLoader(List<LocatedFileStatus> files, DirectoryLister directoryLister)
@@ -1100,6 +1102,7 @@ public class TestBackgroundHiveSplitLoader
                 false,
                 false,
                 true,
+                Optional.empty(),
                 Optional.empty());
     }
 
@@ -1126,6 +1129,7 @@ public class TestBackgroundHiveSplitLoader
                 false,
                 false,
                 true,
+                Optional.empty(),
                 Optional.empty());
     }
 
@@ -1169,7 +1173,8 @@ public class TestBackgroundHiveSplitLoader
                 Integer.MAX_VALUE,
                 hiveSplitLoader,
                 executor,
-                new CounterStat());
+                new CounterStat(),
+                false);
     }
 
     private static Table table(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
@@ -57,7 +57,8 @@ public class TestHiveSplitSource
                 Integer.MAX_VALUE,
                 new TestingHiveSplitLoader(),
                 Executors.newFixedThreadPool(5),
-                new CounterStat());
+                new CounterStat(),
+                false);
 
         // add 10 splits
         for (int i = 0; i < 10; i++) {
@@ -91,7 +92,8 @@ public class TestHiveSplitSource
                 Integer.MAX_VALUE,
                 new TestingHiveSplitLoader(),
                 Executors.newFixedThreadPool(5),
-                new CounterStat());
+                new CounterStat(),
+                false);
 
         // add 10 splits
         for (int i = 0; i < 10; i++) {
@@ -119,7 +121,8 @@ public class TestHiveSplitSource
                 Integer.MAX_VALUE,
                 new TestingHiveSplitLoader(),
                 Executors.newSingleThreadExecutor(),
-                new CounterStat());
+                new CounterStat(),
+                false);
 
         // One byte larger than the initial split max size
         DataSize fileSize = DataSize.ofBytes(initialSplitSize.toBytes() + 1);
@@ -146,7 +149,8 @@ public class TestHiveSplitSource
                 Integer.MAX_VALUE,
                 new TestingHiveSplitLoader(),
                 Executors.newFixedThreadPool(5),
-                new CounterStat());
+                new CounterStat(),
+                false);
 
         // add some splits
         for (int i = 0; i < 5; i++) {
@@ -196,7 +200,8 @@ public class TestHiveSplitSource
                 Integer.MAX_VALUE,
                 new TestingHiveSplitLoader(),
                 Executors.newFixedThreadPool(5),
-                new CounterStat());
+                new CounterStat(),
+                false);
 
         SettableFuture<ConnectorSplit> splits = SettableFuture.create();
 
@@ -250,7 +255,8 @@ public class TestHiveSplitSource
                 Integer.MAX_VALUE,
                 new TestingHiveSplitLoader(),
                 Executors.newFixedThreadPool(5),
-                new CounterStat());
+                new CounterStat(),
+                false);
         int testSplitSizeInBytes = new TestSplit(0).getEstimatedSizeInBytes();
 
         int maxSplitCount = toIntExact(maxOutstandingSplitsSize.toBytes()) / testSplitSizeInBytes;
@@ -283,7 +289,8 @@ public class TestHiveSplitSource
                 Integer.MAX_VALUE,
                 new TestingHiveSplitLoader(),
                 Executors.newFixedThreadPool(5),
-                new CounterStat());
+                new CounterStat(),
+                false);
         hiveSplitSource.addToQueue(new TestSplit(0, OptionalInt.of(2)));
         hiveSplitSource.noMoreSplits();
         assertEquals(getSplits(hiveSplitSource, OptionalInt.of(0), 10).size(), 0);


### PR DESCRIPTION
### POC PR: High level review comments. No nit-picking at this phase please.

The PR adds support for ALTER TABLE execute syntax.

On top of that, it adds support for compacting small files for non-transactional, non-bucketed Hive tables.

```
ALTER TABLE xxxxx EXECUTE compact_small_files WITH(file_size_threshold = ...)
```

