### PR TITLE
Do not use CTAS in TestHiveTransactionalTable and relax test assertions in testCommentColumn

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -1390,7 +1390,8 @@ public class TestHiveTransactionalTable
             verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "row updated"), row(2, "y"));
 
             withTemporaryTable("second_table", true, false, NONE, secondTable -> {
-                onTrino().executeQuery(format("CREATE TABLE %s WITH (transactional = true) AS TABLE tpch.tiny.region", secondTable));
+                onTrino().executeQuery(format("CREATE TABLE %s (regionkey bigint, name varchar(25), comment varchar(152)) WITH (transactional = true)", secondTable));
+                onTrino().executeQuery(format("INSERT INTO %s SELECT * FROM tpch.tiny.region", secondTable));
 
                 // UPDATE while reading from another transactional table. Multiple transactional could interfere with ConnectorMetadata.beginQuery
                 onTrino().executeQuery(format("UPDATE %s SET column2 = 'another row updated' WHERE column1 = (SELECT min(regionkey) + 2 FROM %s)", tableName, secondTable));
@@ -1418,7 +1419,8 @@ public class TestHiveTransactionalTable
             verifySelectForTrinoAndHive("SELECT * FROM " + tableName, "true", row(1, "MIDDLE EAST"), row(2, "MIDDLE EAST"));
 
             withTemporaryTable("second_table", true, false, NONE, secondTable -> {
-                onTrino().executeQuery(format("CREATE TABLE %s WITH (transactional = true) AS TABLE tpch.tiny.region", secondTable));
+                onTrino().executeQuery(format("CREATE TABLE %s (regionkey bigint, name varchar(25), comment varchar(152)) WITH (transactional = true)", secondTable));
+                onTrino().executeQuery(format("INSERT INTO %s SELECT * FROM tpch.tiny.region", secondTable));
 
                 // UPDATE while reading from another transactional table. Multiple transactional could interfere with ConnectorMetadata.beginQuery
                 onTrino().executeQuery(format("UPDATE %s SET column2 = (SELECT min(name) FROM %s)", tableName, secondTable));
@@ -1626,12 +1628,15 @@ public class TestHiveTransactionalTable
             // being split into pages, this test won't detect issues arising
             // from row numbering across pages, which is its original purpose.
             onTrino().executeQuery(format(
-                    "CREATE TABLE %s\n"
-                            + "WITH (transactional = true)\n"
-                            + "AS SELECT *\n"
-                            + "FROM tpch.tiny.supplier\n"
-                            + "WITH NO DATA",
-                    tableName));
+                    "CREATE TABLE %s (" +
+                            "  suppkey bigint," +
+                            "  name varchar(25)," +
+                            "  address varchar(40)," +
+                            "  nationkey bigint," +
+                            "  phone varchar(15)," +
+                            "  acctbal double," +
+                            "  comment varchar(101))" +
+                            "WITH (transactional = true)", tableName));
             onTrino().executeQuery(format("INSERT INTO %s select * from tpch.tiny.supplier", tableName));
 
             int supplierRows = 100;


### PR DESCRIPTION
Use CREATE+INSERT instead CTAS in test setup in
TestHiveTransactionalTable as CTAS for transactional tables  is not supported with all Hive
districutions.