### PR TITLE
Defer loading Hive partitions when only NOT NULL filter provided

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2461,12 +2461,13 @@ public class HiveMetadata
         HiveTableHandle hiveTable = (HiveTableHandle) table;
 
         List<ColumnHandle> partitionColumns = ImmutableList.copyOf(hiveTable.getPartitionColumns());
-        List<HivePartition> partitions = partitionManager.getOrLoadPartitions(metastore, new HiveIdentity(session), hiveTable);
 
-        TupleDomain<ColumnHandle> predicate = createPredicate(partitionColumns, partitions);
-
+        TupleDomain<ColumnHandle> predicate = TupleDomain.all();
         Optional<DiscretePredicates> discretePredicates = Optional.empty();
-        if (!partitionColumns.isEmpty()) {
+        if (!partitionColumns.isEmpty() && hiveTable.getPartitions().isPresent()) {
+            List<HivePartition> partitions = hiveTable.getPartitions().get();
+            predicate = createPredicate(partitionColumns, partitions);
+
             // Do not create tuple domains for every partition at the same time!
             // There can be a huge number of partitions so use an iterable so
             // all domains do not need to be in memory at the same time.

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -4828,7 +4828,7 @@ public abstract class AbstractTestHive
     {
         return metadata.applyFilter(newSession(), tableHandle, constraint)
                 .map(ConstraintApplicationResult::getHandle)
-                .orElseThrow(AssertionError::new);
+                .orElse(tableHandle);
     }
 
     protected MaterializedResult readTable(

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
@@ -3102,6 +3102,9 @@ public class TestHiveConnectorTest
         assertQuery(
                 "SELECT * FROM " + tableName + " WHERE part % 400 = 3", // may be translated to Domain.all
                 "VALUES ('bar', 3), ('bar', 403), ('bar', 803)");
+        assertQuery(
+                "SELECT * FROM " + tableName + " WHERE part % 400 = 3 AND part IS NOT NULL",  // may be translated to Domain.all except nulls
+                "VALUES ('bar', 3), ('bar', 403), ('bar', 803)");
 
         // verify cannot query all partitions
         assertQueryFails(
@@ -3150,6 +3153,10 @@ public class TestHiveConnectorTest
                 .matches("VALUES (VARCHAR 'bar', BIGINT '3', BIGINT '3')");
         assertThat(query("SELECT * FROM " + tableName + " WHERE part1 % 400 = 3 AND part1 IS NOT NULL"))  // may be translated to Domain.all except nulls
                 .matches("VALUES (VARCHAR 'bar', BIGINT '3', BIGINT '3')");
+
+        // verify we can query with a predicate that is just NOT NULL
+        assertThat(query("SELECT count(*) FROM " + tableName + " WHERE part1 IS NOT NULL"))
+                .matches("VALUES BIGINT '10'");
 
         // we are not constrained by hive.max-partitions-per-scan (=1000) when listing partitions
         assertThat(query("SELECT * FROM " + partitionsTable))


### PR DESCRIPTION
In particular, this helps avoid hitting partition limit
    (`hive.max-partitions-per-scan`), when partitions are constrained in a
    way that is not representable with a `TupleDomain`.