### PR TITLE
Rename Presto references in OAuth2 success.html

### DIFF
--- a/core/trino-main/src/main/resources/oauth2/success.html
+++ b/core/trino-main/src/main/resources/oauth2/success.html
@@ -17,8 +17,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
-    <meta name="description" content="Web Interface - Presto">
-    <title>Cluster Overview - Presto</title>
+    <meta name="description" content="Web Interface - Trino">
+    <title>Cluster Overview - Trino</title>
 
     <link rel="icon" href="/ui/assets/favicon.ico">
 

--- a/core/trino-main/src/main/resources/oauth2/success.html
+++ b/core/trino-main/src/main/resources/oauth2/success.html
@@ -44,7 +44,7 @@
     <link href="/ui/vendor/css-loaders/loader.css" rel="stylesheet">
 
     <!-- Custom CSS -->
-    <link href="/ui/assets/presto.css" rel="stylesheet">
+    <link href="/ui/assets/trino.css" rel="stylesheet">
 </head>
 
 <body>


### PR DESCRIPTION
I have noticed Presto references for OAuth2 authentication succeeded window.
![image](https://user-images.githubusercontent.com/67517453/135282638-d1203dc9-7d8e-4011-9ed9-3676962a49fd.png)

