### PR TITLE
Ignore join build side exchange type in tests

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExchangeMatcher.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/ExchangeMatcher.java
@@ -37,15 +37,15 @@ final class ExchangeMatcher
         implements Matcher
 {
     private final ExchangeNode.Scope scope;
-    private final ExchangeNode.Type type;
+    private final Optional<ExchangeNode.Type> type;
     private final List<Ordering> orderBy;
     private final Set<String> partitionedBy;
     private final Optional<List<List<String>>> inputs;
 
-    public ExchangeMatcher(ExchangeNode.Scope scope, ExchangeNode.Type type, List<Ordering> orderBy, Set<String> partitionedBy, Optional<List<List<String>>> inputs)
+    public ExchangeMatcher(ExchangeNode.Scope scope, Optional<ExchangeNode.Type> type, List<Ordering> orderBy, Set<String> partitionedBy, Optional<List<List<String>>> inputs)
     {
-        this.scope = scope;
-        this.type = type;
+        this.scope = requireNonNull(scope, "scope is null");
+        this.type = requireNonNull(type, "type is null");
         this.orderBy = requireNonNull(orderBy, "orderBy is null");
         this.partitionedBy = requireNonNull(partitionedBy, "partitionedBy is null");
         this.inputs = requireNonNull(inputs, "inputs is null");
@@ -59,7 +59,7 @@ final class ExchangeMatcher
         }
 
         ExchangeNode exchangeNode = (ExchangeNode) node;
-        return exchangeNode.getScope() == scope && exchangeNode.getType() == type;
+        return exchangeNode.getScope() == scope && type.map(requiredType -> requiredType == exchangeNode.getType()).orElse(true);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -632,6 +632,11 @@ public final class PlanMatchPattern
         return node(ExchangeNode.class, sources);
     }
 
+    public static PlanMatchPattern exchange(ExchangeNode.Scope scope, PlanMatchPattern... sources)
+    {
+        return exchange(scope, Optional.empty(), ImmutableList.of(), ImmutableSet.of(), Optional.empty(), sources);
+    }
+
     public static PlanMatchPattern exchange(ExchangeNode.Scope scope, ExchangeNode.Type type, PlanMatchPattern... sources)
     {
         return exchange(scope, type, ImmutableList.of(), sources);
@@ -650,6 +655,17 @@ public final class PlanMatchPattern
     public static PlanMatchPattern exchange(
             ExchangeNode.Scope scope,
             ExchangeNode.Type type,
+            List<Ordering> orderBy,
+            Set<String> partitionedBy,
+            Optional<List<List<String>>> inputs,
+            PlanMatchPattern... sources)
+    {
+        return exchange(scope, Optional.of(type), orderBy, partitionedBy, inputs, sources);
+    }
+
+    public static PlanMatchPattern exchange(
+            ExchangeNode.Scope scope,
+            Optional<ExchangeNode.Type> type,
             List<Ordering> orderBy,
             Set<String> partitionedBy,
             Optional<List<List<String>>> inputs,

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1077,10 +1077,10 @@ public abstract class BaseJdbcConnectorTest
 
         String notDistinctOperator = "IS NOT DISTINCT FROM";
         List<String> nonEqualities = Stream.concat(
-                Stream.of(JoinCondition.Operator.values())
-                        .filter(operator -> operator != JoinCondition.Operator.EQUAL)
-                        .map(JoinCondition.Operator::getValue),
-                Stream.of(notDistinctOperator))
+                        Stream.of(JoinCondition.Operator.values())
+                                .filter(operator -> operator != JoinCondition.Operator.EQUAL)
+                                .map(JoinCondition.Operator::getValue),
+                        Stream.of(notDistinctOperator))
                 .collect(toImmutableList());
 
         try (TestTable nationLowercaseTable = new TestTable(

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1021,7 +1021,7 @@ public abstract class BaseJdbcConnectorTest
         PlanMatchPattern partitionedJoinOverTableScans = node(JoinNode.class,
                 exchange(ExchangeNode.Scope.REMOTE, ExchangeNode.Type.REPARTITION,
                         node(TableScanNode.class)),
-                exchange(ExchangeNode.Scope.LOCAL, ExchangeNode.Type.REPARTITION,
+                exchange(ExchangeNode.Scope.LOCAL,
                         exchange(ExchangeNode.Scope.REMOTE, ExchangeNode.Type.REPARTITION,
                                 node(TableScanNode.class))));
 
@@ -1058,7 +1058,7 @@ public abstract class BaseJdbcConnectorTest
         PlanMatchPattern broadcastJoinOverTableScans =
                 node(JoinNode.class,
                         node(TableScanNode.class),
-                        exchange(ExchangeNode.Scope.LOCAL, ExchangeNode.Type.GATHER,
+                        exchange(ExchangeNode.Scope.LOCAL,
                                 exchange(ExchangeNode.Scope.REMOTE, ExchangeNode.Type.REPLICATE,
                                         node(TableScanNode.class))));
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
@@ -165,7 +165,7 @@ public class TestHivePlans
                                                 project(
                                                         filter("\"like\"(L_STR_PART, \"$like_pattern\"('t%'))",
                                                                 tableScan("table_str_partitioned", Map.of("L_INT_COL", "int_col", "L_STR_PART", "str_part"))))),
-                                        exchange(LOCAL, REPARTITION,
+                                        exchange(LOCAL,
                                                 exchange(REMOTE, REPARTITION,
                                                         project(
                                                                 filter("R_STR_COL IN ('three', CAST('two' AS varchar(5))) AND \"like\"(R_STR_COL, \"$like_pattern\"('t%'))",
@@ -188,7 +188,7 @@ public class TestHivePlans
                                                 project(
                                                         filter("true", // dynamic filter
                                                                 tableScan("table_int_partitioned", Map.of("L_INT_PART", "int_part", "L_STR_COL", "str_col"))))),
-                                        exchange(LOCAL, REPARTITION,
+                                        exchange(LOCAL,
                                                 exchange(REMOTE, REPARTITION,
                                                         project(
                                                                 filter("R_INT_COL IN (2, 3, 4)",
@@ -212,7 +212,7 @@ public class TestHivePlans
                                                 project(
                                                         filter("L_STR_COL != 'three' AND L_INT_PART IN (2, 3, 4)", // TODO the L_INT_PART filter is redundant
                                                                 tableScan("table_int_partitioned", Map.of("L_INT_PART", "int_part", "L_STR_COL", "str_col"))))),
-                                        exchange(LOCAL, REPARTITION,
+                                        exchange(LOCAL,
                                                 exchange(REMOTE, REPARTITION,
                                                         project(
                                                                 filter("R_INT_COL IN (2, 3, 4)",
@@ -236,7 +236,7 @@ public class TestHivePlans
                                                 project(
                                                         filter("substring(L_STR_COL, BIGINT '2') != CAST('hree' AS varchar(5))",
                                                                 tableScan("table_int_partitioned", Map.of("L_INT_PART", "int_part", "L_STR_COL", "str_col"))))),
-                                        exchange(LOCAL, REPARTITION,
+                                        exchange(LOCAL,
                                                 exchange(REMOTE, REPARTITION,
                                                         project(
                                                                 filter("R_INT_COL IN (2, 3, 4)",
@@ -260,7 +260,7 @@ public class TestHivePlans
                                                 project(
                                                         filter("L_INT_PART % 2 = 0",
                                                                 tableScan("table_int_partitioned", Map.of("L_INT_PART", "int_part", "L_STR_COL", "str_col"))))),
-                                        exchange(LOCAL, REPARTITION,
+                                        exchange(LOCAL,
                                                 exchange(REMOTE, REPARTITION,
                                                         project(
                                                                 filter("R_INT_COL IN (2, 4) AND R_INT_COL % 2 = 0",


### PR DESCRIPTION
This change aims at reducing test over-specification for tests that assert join plans with specific build side exchange type.