### PR TITLE
Improve logic for reading page column indexes in parquet

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/reader/TrinoColumnIndexStore.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/reader/TrinoColumnIndexStore.java
@@ -13,7 +13,13 @@
  */
 package io.trino.parquet.reader;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
 import io.airlift.slice.Slice;
+import io.trino.parquet.ChunkReader;
+import io.trino.parquet.DiskRange;
 import io.trino.parquet.ParquetDataSource;
 import org.apache.parquet.format.Util;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
@@ -24,167 +30,158 @@ import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexStore;
 import org.apache.parquet.internal.hadoop.metadata.IndexReference;
+import org.apache.parquet.schema.PrimitiveType;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 
-import static java.util.Collections.emptySet;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Internal implementation of {@link ColumnIndexStore}.
- * Copy of org.apache.parquet.hadoop.ColumnIndexStoreImpl which is not accessible
+ * Similar to org.apache.parquet.hadoop.ColumnIndexStoreImpl which is not accessible
  */
 public class TrinoColumnIndexStore
         implements ColumnIndexStore
 {
-    private interface IndexStore
-    {
-        ColumnIndex getColumnIndex();
-
-        OffsetIndex getOffsetIndex();
-    }
-
-    private class TrinoIndexStore
-            implements IndexStore
-    {
-        private final ColumnChunkMetaData meta;
-        private ColumnIndex columnIndex;
-        private boolean columnIndexRead;
-        private final OffsetIndex offsetIndex;
-
-        TrinoIndexStore(ColumnChunkMetaData meta)
-        {
-            this.meta = meta;
-            OffsetIndex offsetIndex;
-            try {
-                offsetIndex = readOffsetIndex(meta);
-            }
-            catch (IOException e) {
-                // If the I/O issue still stands it will fail the reading later;
-                // otherwise we fail the filtering only with a missing offset index.
-                offsetIndex = null;
-            }
-            if (offsetIndex == null) {
-                throw new MissingOffsetIndexException(meta.getPath());
-            }
-            this.offsetIndex = offsetIndex;
-        }
-
-        @Override
-        public ColumnIndex getColumnIndex()
-        {
-            if (!columnIndexRead) {
-                try {
-                    columnIndex = readColumnIndex(meta);
-                }
-                catch (IOException e) {
-                    // If the I/O issue still stands it will fail the reading later;
-                    // otherwise we fail the filtering only with a missing column index.
-                }
-                columnIndexRead = true;
-            }
-            return columnIndex;
-        }
-
-        @Override
-        public OffsetIndex getOffsetIndex()
-        {
-            return offsetIndex;
-        }
-
-        private OffsetIndex readOffsetIndex(ColumnChunkMetaData column) throws IOException
-        {
-            IndexReference index = column.getOffsetIndexReference();
-            if (index == null) {
-                return null;
-            }
-            Slice slice = dataSource.readFully(index.getOffset(), index.getLength());
-            return ParquetMetadataConverter.fromParquetOffsetIndex(Util.readOffsetIndex(slice.getInput()));
-        }
-
-        private ColumnIndex readColumnIndex(ColumnChunkMetaData meta) throws IOException
-        {
-            IndexReference index = meta.getColumnIndexReference();
-            if (index == null) {
-                return null;
-            }
-            Slice slice = dataSource.readFully(index.getOffset(), index.getLength());
-            return ParquetMetadataConverter.fromParquetColumnIndex(meta.getPrimitiveType(), Util.readColumnIndex(slice.getInput()));
-        }
-    }
-
-    // Used for columns are not in this parquet file
-    private static final TrinoColumnIndexStore.IndexStore MISSING_INDEX_STORE = new IndexStore()
-    {
-        @Override
-        public ColumnIndex getColumnIndex()
-        {
-            return null;
-        }
-
-        @Override
-        public OffsetIndex getOffsetIndex()
-        {
-            return null;
-        }
-    };
-
-    private static final TrinoColumnIndexStore EMPTY = new TrinoColumnIndexStore(null, new BlockMetaData(), emptySet())
-    {
-        @Override
-        public ColumnIndex getColumnIndex(ColumnPath column)
-        {
-            return null;
-        }
-
-        @Override
-        public OffsetIndex getOffsetIndex(ColumnPath column)
-        {
-            throw new MissingOffsetIndexException(column);
-        }
-    };
-
     private final ParquetDataSource dataSource;
-    private final Map<ColumnPath, TrinoColumnIndexStore.IndexStore> store;
+    private final List<ColumnIndexMetadata> columnIndexReferences;
+    private final List<ColumnIndexMetadata> offsetIndexReferences;
 
-    /*
-     * Creates a column index store which lazily reads column/offset indexes for the columns in paths. (paths are the set
-     * of columns used for the projection)
+    @Nullable
+    private Map<ColumnPath, ColumnIndex> columnIndexStore;
+    @Nullable
+    private Map<ColumnPath, OffsetIndex> offsetIndexStore;
+
+    /**
+     * Creates a column index store which lazily reads column/offset indexes for the columns in paths.
+     *
+     * @param columnsRead is the set of columns used for projection
+     * @param columnsFiltered is the set of columns used for filtering
      */
-    public static ColumnIndexStore create(ParquetDataSource dataSource, BlockMetaData block, Set<ColumnPath> paths)
+    public TrinoColumnIndexStore(
+            ParquetDataSource dataSource,
+            BlockMetaData block,
+            Set<ColumnPath> columnsRead,
+            Set<ColumnPath> columnsFiltered)
     {
-        try {
-            return new TrinoColumnIndexStore(dataSource, block, paths);
-        }
-        catch (MissingOffsetIndexException e) {
-            return EMPTY;
-        }
-    }
+        this.dataSource = requireNonNull(dataSource, "dataSource is null");
+        requireNonNull(block, "block is null");
+        requireNonNull(columnsRead, "columnsRead is null");
+        requireNonNull(columnsFiltered, "columnsFiltered is null");
 
-    private TrinoColumnIndexStore(ParquetDataSource dataSource, BlockMetaData block, Set<ColumnPath> paths)
-    {
-        this.dataSource = dataSource;
-        Map<ColumnPath, TrinoColumnIndexStore.IndexStore> store = new HashMap<>();
+        ImmutableList.Builder<ColumnIndexMetadata> columnIndexBuilder = ImmutableList.builderWithExpectedSize(columnsFiltered.size());
+        ImmutableList.Builder<ColumnIndexMetadata> offsetIndexBuilder = ImmutableList.builderWithExpectedSize(columnsRead.size());
         for (ColumnChunkMetaData column : block.getColumns()) {
             ColumnPath path = column.getPath();
-            if (paths.contains(path)) {
-                store.put(path, new TrinoIndexStore(column));
+            if (column.getColumnIndexReference() != null && columnsFiltered.contains(path)) {
+                columnIndexBuilder.add(new ColumnIndexMetadata(
+                        column.getColumnIndexReference(),
+                        path,
+                        column.getPrimitiveType()));
+            }
+            if (column.getOffsetIndexReference() != null && columnsRead.contains(path)) {
+                offsetIndexBuilder.add(new ColumnIndexMetadata(
+                        column.getOffsetIndexReference(),
+                        path,
+                        column.getPrimitiveType()));
             }
         }
-        this.store = store;
+        this.columnIndexReferences = columnIndexBuilder.build();
+        this.offsetIndexReferences = offsetIndexBuilder.build();
     }
 
     @Override
     public ColumnIndex getColumnIndex(ColumnPath column)
     {
-        return store.getOrDefault(column, MISSING_INDEX_STORE).getColumnIndex();
+        if (columnIndexStore == null) {
+            columnIndexStore = loadIndexes(dataSource, columnIndexReferences, (buffer, columnMetadata) -> {
+                try {
+                    return ParquetMetadataConverter.fromParquetColumnIndex(columnMetadata.getPrimitiveType(), Util.readColumnIndex(buffer.getInput()));
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        return columnIndexStore.get(column);
     }
 
     @Override
     public OffsetIndex getOffsetIndex(ColumnPath column)
     {
-        return store.getOrDefault(column, MISSING_INDEX_STORE).getOffsetIndex();
+        if (offsetIndexStore == null) {
+            offsetIndexStore = loadIndexes(dataSource, offsetIndexReferences, (buffer, columnMetadata) -> {
+                try {
+                    return ParquetMetadataConverter.fromParquetOffsetIndex(Util.readOffsetIndex(buffer.getInput()));
+                }
+                catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+
+        return offsetIndexStore.get(column);
+    }
+
+    private static <T> Map<ColumnPath, T> loadIndexes(
+            ParquetDataSource dataSource,
+            List<ColumnIndexMetadata> indexMetadata,
+            BiFunction<Slice, ColumnIndexMetadata, T> deserializer)
+    {
+        // Merge multiple small reads of the file for indexes stored close to each other
+        ListMultimap<ColumnPath, DiskRange> ranges = ArrayListMultimap.create(indexMetadata.size(), 1);
+        for (ColumnIndexMetadata column : indexMetadata) {
+            ranges.put(column.getPath(), column.getDiskRange());
+        }
+
+        Multimap<ColumnPath, ChunkReader> chunkReaders = dataSource.planRead(ranges);
+        try {
+            return indexMetadata.stream()
+                    .collect(toImmutableMap(
+                            ColumnIndexMetadata::getPath,
+                            column -> deserializer.apply(getOnlyElement(chunkReaders.get(column.getPath())).read(), column)));
+        }
+        finally {
+            chunkReaders.values().forEach(ChunkReader::free);
+        }
+    }
+
+    private static class ColumnIndexMetadata
+    {
+        private final DiskRange diskRange;
+        private final ColumnPath path;
+        private final PrimitiveType primitiveType;
+
+        private ColumnIndexMetadata(IndexReference indexReference, ColumnPath path, PrimitiveType primitiveType)
+        {
+            requireNonNull(indexReference, "indexReference is null");
+            this.diskRange = new DiskRange(indexReference.getOffset(), indexReference.getLength());
+            this.path = requireNonNull(path, "path is null");
+            this.primitiveType = requireNonNull(primitiveType, "primitiveType is null");
+        }
+
+        private DiskRange getDiskRange()
+        {
+            return diskRange;
+        }
+
+        private ColumnPath getPath()
+        {
+            return path;
+        }
+
+        private PrimitiveType getPrimitiveType()
+        {
+            return primitiveType;
+        }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetPageSourceFactory.java
@@ -241,7 +241,7 @@ public class ParquetPageSourceFactory
             ImmutableList.Builder<Optional<ColumnIndexStore>> columnIndexes = ImmutableList.builder();
             for (BlockMetaData block : parquetMetadata.getBlocks()) {
                 long firstDataPage = block.getColumns().get(0).getFirstDataPageOffset();
-                Optional<ColumnIndexStore> columnIndex = getColumnIndexStore(dataSource, block, descriptorsByPath, options);
+                Optional<ColumnIndexStore> columnIndex = getColumnIndexStore(dataSource, block, descriptorsByPath, parquetTupleDomain, options);
                 if (start <= firstDataPage && firstDataPage < start + length
                         && predicateMatches(parquetPredicate, block, dataSource, descriptorsByPath, parquetTupleDomain, columnIndex)) {
                     blocks.add(block);
@@ -368,9 +368,10 @@ public class ParquetPageSourceFactory
             ParquetDataSource dataSource,
             BlockMetaData blockMetadata,
             Map<List<String>, RichColumnDescriptor> descriptorsByPath,
+            TupleDomain<ColumnDescriptor> parquetTupleDomain,
             ParquetReaderOptions options)
     {
-        if (!options.isUseColumnIndex()) {
+        if (!options.isUseColumnIndex() || parquetTupleDomain.isAll() || parquetTupleDomain.isNone()) {
             return Optional.empty();
         }
 


### PR DESCRIPTION
Prefetch the required portions of file for column/offset index
instead of making multiple small requests.
Lazily read offset index only when they're required.