### PR TITLE
Skip Long.reverse in LocalPartitionGenerator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalPartitionGenerator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalPartitionGenerator.java
@@ -61,6 +61,6 @@ public class LocalPartitionGenerator
     private static int processRawHash(long rawHash)
     {
         // mix the bits so we don't use the same hash used to distribute between stages
-        return (int) XxHash64.hash(Long.reverse(rawHash));
+        return (int) XxHash64.hash(rawHash);
     }
 }


### PR DESCRIPTION
Reversing the long bits in LocalPartitionGenerator is not necessary in addition to using XxHash in local partitioning, especially not since remote exchanges were changed to use a different bucketing algorithm that is not fundamentally based on a modulo operation