### PR TITLE
Add non-full pages to benchmark data in Hive

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkFileFormatsUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/benchmark/BenchmarkFileFormatsUtils.java
@@ -108,6 +108,9 @@ public final class BenchmarkFileFormatsUtils
                 }
             }
         }
+        if (!pageBuilder.isEmpty()) {
+            pages.add(pageBuilder.build());
+        }
         return new TestData(columnNames, columnTypes, pages.build());
     }
 


### PR DESCRIPTION
Pages from TPCH were added only when full, leading to empty page list
when there was not enough data to fill the page