### PR TITLE
Fix lack of idempotency in client protocol results

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/protocol/TestQueryResultRows.java
+++ b/core/trino-main/src/test/java/io/trino/server/protocol/TestQueryResultRows.java
@@ -90,7 +90,6 @@ public class TestQueryResultRows
         assertThat((Iterable<? extends List<Object>>) rows).as("rows").isNotEmpty();
         assertThat(getAllValues(rows)).hasSize(1).containsOnly(ImmutableList.of(true));
         assertThat(rows.getColumns().orElseThrow()).containsOnly(column);
-        assertThat(rows.iterator().hasNext()).isFalse();
     }
 
     @Test
@@ -110,7 +109,6 @@ public class TestQueryResultRows
 
         assertThat(getAllValues(rows)).containsExactly(ImmutableList.of(value));
         assertThat(rows.getColumns().orElseThrow()).containsOnly(column);
-        assertThat(rows.iterator()).isExhausted();
     }
 
     @Test


### PR DESCRIPTION
QueryResultRows incorrectly implemented both Iterator and Iterable interfaces.
The expectation for Iterable is that every time iterator() gets called, a new
from-scratch iterator is returned. In the previous implementation, this method
was returning "this", which meant that subsequent iterators might be tainted.