### PR TITLE
Fix Hive DELETE bug due to colliding split files

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/InternalHiveSplitFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/InternalHiveSplitFactory.java
@@ -71,7 +71,6 @@ public class InternalHiveSplitFactory
     private final long minimumTargetSplitSizeInBytes;
     private final boolean forceLocalScheduling;
     private final boolean s3SelectPushdownEnabled;
-    private final AcidTransaction transaction;
     private final Map<Integer, AtomicInteger> bucketStatementCounters = new ConcurrentHashMap<>();
 
     public InternalHiveSplitFactory(
@@ -102,7 +101,6 @@ public class InternalHiveSplitFactory
         this.bucketValidation = requireNonNull(bucketValidation, "bucketValidation is null");
         this.forceLocalScheduling = forceLocalScheduling;
         this.s3SelectPushdownEnabled = s3SelectPushdownEnabled;
-        this.transaction = requireNonNull(transaction, "transaction is null");
         this.minimumTargetSplitSizeInBytes = requireNonNull(minimumTargetSplitSize, "minimumTargetSplitSize is null").toBytes();
         checkArgument(minimumTargetSplitSizeInBytes > 0, "minimumTargetSplitSize must be > 0, found: %s", minimumTargetSplitSize);
     }
@@ -201,13 +199,7 @@ public class InternalHiveSplitFactory
             blocks = ImmutableList.of(new InternalHiveBlock(start, start + length, blocks.get(0).getAddresses()));
         }
 
-        int statementId = 0;
-
-        if (transaction.isDelete() || transaction.isUpdate()) {
-            int bucketNumberIndex = bucketNumber.orElse(0);
-            statementId = bucketStatementCounters.computeIfAbsent(bucketNumberIndex, index -> new AtomicInteger()).getAndIncrement();
-        }
-
+        int bucketNumberIndex = bucketNumber.orElse(0);
         return Optional.of(new InternalHiveSplit(
                 partitionName,
                 pathString,
@@ -219,7 +211,7 @@ public class InternalHiveSplitFactory
                 partitionKeys,
                 blocks,
                 bucketNumber,
-                statementId,
+                () -> bucketStatementCounters.computeIfAbsent(bucketNumberIndex, index -> new AtomicInteger()).getAndIncrement(),
                 splittable,
                 forceLocalScheduling && allBlocksHaveAddress(blocks),
                 tableToPartitionMapping,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSplitSource.java
@@ -347,7 +347,7 @@ public class TestHiveSplitSource
                     ImmutableList.of(),
                     ImmutableList.of(new InternalHiveBlock(0, fileSize.toBytes(), ImmutableList.of())),
                     bucketNumber,
-                    0,
+                    () -> 0,
                     true,
                     false,
                     TableToPartitionMapping.empty(),

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -863,6 +863,19 @@ public class TestHiveTransactionalTable
         });
     }
 
+    @Test(groups = HIVE_TRANSACTIONAL, timeOut = TEST_TIMEOUT)
+    public void testDeleteOverManySplits()
+    {
+        withTemporaryTable("delete_select", true, false, NONE, tableName -> {
+            onTrino().executeQuery(format("CREATE TABLE %s WITH (transactional = true) AS SELECT * FROM tpch.sf10.orders", tableName));
+
+            log.info("About to delete selected rows");
+            onTrino().executeQuery(format("DELETE FROM %s WHERE clerk = 'Clerk#000004942'", tableName));
+
+            verifySelectForTrinoAndHive("SELECT COUNT(*) FROM " + tableName, "clerk = 'Clerk#000004942'", row(0));
+        });
+    }
+
     @Test(groups = HIVE_TRANSACTIONAL, dataProvider = "inserterAndDeleterProvider", timeOut = TEST_TIMEOUT)
     public void testCorrectSelectCountStar(Engine inserter, Engine deleter)
     {


### PR DESCRIPTION
Though this bug was originally described as an "original
files bug", the root cause of the bug was a DELETE operation
on a bucket so large that it was partitioned into multiple
splits, all with the same statement number.  The bug was fixed
by passing a lambda to InternalHiveSplit that hands out
successive statementIds for each bucket number.

NOTE: This bug causes failure but not data corruption.  A DELETE
transaction that displays this bug never commits, nor does it appear
to succeed.  Instead, it fails with an exception, and is rolled back
in commit abort processing.