### PR TITLE
Fix time with time zone type client type format

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
+++ b/core/trino-main/src/main/java/io/trino/server/protocol/Query.java
@@ -634,7 +634,7 @@ class Query
                     return TIME;
                 }
                 if (dataTimeType.getType() == DateTimeDataType.Type.TIME && dataTimeType.isWithTimeZone()) {
-                    return TIMESTAMP_WITH_TIME_ZONE;
+                    return TIME_WITH_TIME_ZONE;
                 }
             }
 


### PR DESCRIPTION
It looks like there's a typo of TIME_WITH_TIME_ZONE when output type is `time with time zone` at client type formatting