### PR TITLE
Improve hashes for expressions without fields

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentCatalog.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentCatalog.java
@@ -16,7 +16,6 @@ package io.trino.sql.tree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public class CurrentCatalog
@@ -47,7 +46,7 @@ public class CurrentCatalog
     @Override
     public int hashCode()
     {
-        return Objects.hash();
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentPath.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentPath.java
@@ -16,7 +16,6 @@ package io.trino.sql.tree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public class CurrentPath
@@ -47,7 +46,7 @@ public class CurrentPath
     @Override
     public int hashCode()
     {
-        return Objects.hash();
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentSchema.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentSchema.java
@@ -16,7 +16,6 @@ package io.trino.sql.tree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public class CurrentSchema
@@ -47,7 +46,7 @@ public class CurrentSchema
     @Override
     public int hashCode()
     {
-        return Objects.hash();
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentUser.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/CurrentUser.java
@@ -16,7 +16,6 @@ package io.trino.sql.tree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public class CurrentUser
@@ -52,7 +51,7 @@ public class CurrentUser
     @Override
     public int hashCode()
     {
-        return Objects.hash();
+        return getClass().hashCode();
     }
 
     @Override


### PR DESCRIPTION
Previous implementation returned hash value of 1 (hash of empty array) for all expression types without children nodes. We change it to use hash from class to decrease number of hash collisions.