### PR TITLE
Add specialization for merging row count only pages

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -132,6 +132,10 @@ public class PageProcessor
                 return WorkProcessor.create(new ProjectSelectedPositions(session, yieldSignal, memoryContext, page, selectedPositions, avoidPageMaterialization));
             }
         }
+        else if (projections.isEmpty()) {
+            // retained memory for empty page is negligible
+            return WorkProcessor.of(new Page(page.getPositionCount()));
+        }
 
         return WorkProcessor.create(new ProjectSelectedPositions(session, yieldSignal, memoryContext, page, positionsRange(0, page.getPositionCount()), avoidPageMaterialization));
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/Page.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/Page.java
@@ -69,7 +69,16 @@ public final class Page
     {
         requireNonNull(blocks, "blocks is null");
         this.positionCount = positionCount;
-        this.blocks = blocksCopyRequired ? blocks.clone() : blocks;
+        if (blocks.length == 0) {
+            this.blocks = EMPTY_BLOCKS;
+            this.sizeInBytes = 0;
+            this.logicalSizeInBytes = 0;
+            // Empty blocks are not considered "retained" by any particular page
+            this.retainedSizeInBytes = INSTANCE_SIZE;
+        }
+        else {
+            this.blocks = blocksCopyRequired ? blocks.clone() : blocks;
+        }
     }
 
     public int getChannelCount()

--- a/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/TestPage.java
@@ -61,6 +61,15 @@ public class TestPage
     }
 
     @Test
+    public void testSizesForNoColumnPage()
+    {
+        Page page = new Page(100);
+        assertEquals(page.getSizeInBytes(), 0);
+        assertEquals(page.getLogicalSizeInBytes(), 0);
+        assertEquals(page.getRetainedSizeInBytes(), Page.INSTANCE_SIZE); // does not include the blocks array
+    }
+
+    @Test
     public void testCompactDictionaryBlocks()
     {
         int positionCount = 100;


### PR DESCRIPTION
Adds special case handling for merging pages that have no columns (only contain their row count), which otherwise would never fill up their `PageBuiler` and therefore never flush until the last input was seen at which point the entire contents would flush as a single `Page`.