### PR TITLE
Change width for materialized_views table documentation

### DIFF
--- a/docs/src/main/sphinx/connector/system.rst
+++ b/docs/src/main/sphinx/connector/system.rst
@@ -59,7 +59,7 @@ The materialized views table contains the following information about all
 :ref:`materialized views <sql-materialized-views-management>`:
 
 .. list-table:: Metadata for materialized views
-  :widths: 50, 50
+  :widths: 30, 70
   :header-rows: 1
 
   * - Column


### PR DESCRIPTION
<img width="847" alt="Screen Shot 2021-10-02 at 11 16 23" src="https://user-images.githubusercontent.com/6237050/135783252-b7277ea4-a095-4ff5-8b5a-b5c907dd6dc2.png">

#

<img width="852" alt="Screen Shot 2021-10-02 at 11 17 55" src="https://user-images.githubusercontent.com/6237050/135783257-ee1e8eae-b933-4e86-a809-c33b6c0ec768.png">

Follow-up of #9314