### PR TITLE
Add openjdk-devel package to arm64 image

### DIFF
--- a/core/docker/arm64.dockerfile
+++ b/core/docker/arm64.dockerfile
@@ -16,7 +16,7 @@ FROM centos:centos8
 ENV JAVA_HOME /usr/lib/jvm/jre-11
 RUN \
     set -xeu && \
-    yum -y -q install python3 java-11-openjdk-headless && \
+    yum -y -q install python3 java-11-openjdk-headless java-11-openjdk-devel && \
     yum -q clean all && \
     rm -rf /var/cache/yum && \
     alternatives --set python /usr/bin/python3 && \


### PR DESCRIPTION
Compared to amd64, arm64 image lacks JDK tools such as jcmd, jps, jstack. Installing java-11-openjdk-devel adds these tools.

However, this brings some X11 dependencies, with total installed packages size of about 90 MB.