### PR TITLE
Added toggle for Parquet V1 and V2 formats

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriter.java
@@ -50,7 +50,6 @@ import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.util.Objects.requireNonNull;
-import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
 
 public class ParquetWriter
         implements Closeable
@@ -90,7 +89,7 @@ public class ParquetWriter
         requireNonNull(compressionCodecName, "compressionCodecName is null");
 
         ParquetProperties parquetProperties = ParquetProperties.builder()
-                .withWriterVersion(PARQUET_2_0)
+                .withWriterVersion(writerOption.getWriterVersion())
                 .withPageSize(writerOption.getMaxPageSize())
                 .build();
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriterOptions.java
@@ -14,6 +14,7 @@
 package io.trino.parquet.writer;
 
 import io.airlift.units.DataSize;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.hadoop.ParquetWriter;
 
 import static java.lang.Math.toIntExact;
@@ -24,6 +25,7 @@ public class ParquetWriterOptions
     private static final DataSize DEFAULT_MAX_ROW_GROUP_SIZE = DataSize.ofBytes(ParquetWriter.DEFAULT_BLOCK_SIZE);
     private static final DataSize DEFAULT_MAX_PAGE_SIZE = DataSize.ofBytes(ParquetWriter.DEFAULT_PAGE_SIZE);
     public static final int DEFAULT_BATCH_SIZE = 10_000;
+    private static final WriterVersion DEFAULT_WRITER_VERSION = WriterVersion.PARQUET_2_0;
 
     public static ParquetWriterOptions.Builder builder()
     {
@@ -33,12 +35,14 @@ public class ParquetWriterOptions
     private final int maxRowGroupSize;
     private final int maxPageSize;
     private final int batchSize;
+    private final WriterVersion writerVersion;
 
-    private ParquetWriterOptions(DataSize maxBlockSize, DataSize maxPageSize, int batchSize)
+    private ParquetWriterOptions(DataSize maxBlockSize, DataSize maxPageSize, int batchSize, WriterVersion writerVersion)
     {
         this.maxRowGroupSize = toIntExact(requireNonNull(maxBlockSize, "maxBlockSize is null").toBytes());
         this.maxPageSize = toIntExact(requireNonNull(maxPageSize, "maxPageSize is null").toBytes());
         this.batchSize = batchSize;
+        this.writerVersion = requireNonNull(writerVersion, "writerVersion is null");
     }
 
     public long getMaxRowGroupSize()
@@ -56,11 +60,17 @@ public class ParquetWriterOptions
         return batchSize;
     }
 
+    public WriterVersion getWriterVersion()
+    {
+        return writerVersion;
+    }
+
     public static class Builder
     {
         private DataSize maxBlockSize = DEFAULT_MAX_ROW_GROUP_SIZE;
         private DataSize maxPageSize = DEFAULT_MAX_PAGE_SIZE;
         private int batchSize = DEFAULT_BATCH_SIZE;
+        private WriterVersion writerVersion = DEFAULT_WRITER_VERSION;
 
         public Builder setMaxBlockSize(DataSize maxBlockSize)
         {
@@ -80,9 +90,15 @@ public class ParquetWriterOptions
             return this;
         }
 
+        public Builder setWriterVersion(WriterVersion writerVersion)
+        {
+            this.writerVersion = writerVersion;
+            return this;
+        }
+
         public ParquetWriterOptions build()
         {
-            return new ParquetWriterOptions(maxBlockSize, maxPageSize, batchSize);
+            return new ParquetWriterOptions(maxBlockSize, maxPageSize, batchSize, writerVersion);
         }
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -26,6 +26,7 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.type.ArrayType;
+import org.apache.parquet.column.ParquetProperties;
 
 import javax.inject.Inject;
 
@@ -87,6 +88,7 @@ public final class HiveSessionProperties
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
+    private static final String PARQUET_WRITER_VERSION = "parquet_writer_version";
     private static final String MAX_SPLIT_SIZE = "max_split_size";
     private static final String MAX_INITIAL_SPLIT_SIZE = "max_initial_split_size";
     private static final String RCFILE_OPTIMIZED_WRITER_VALIDATE = "rcfile_optimized_writer_validate";
@@ -330,6 +332,12 @@ public final class HiveSessionProperties
                         PARQUET_WRITER_BATCH_SIZE,
                         "Parquet: Maximum number of rows passed to the writer in each batch",
                         parquetWriterConfig.getBatchSize(),
+                        false),
+                enumProperty(
+                        PARQUET_WRITER_VERSION,
+                        "Parquet: Writer version",
+                        ParquetProperties.WriterVersion.class,
+                        ParquetProperties.WriterVersion.PARQUET_2_0,
                         false),
                 dataSizeProperty(
                         MAX_SPLIT_SIZE,
@@ -642,6 +650,11 @@ public final class HiveSessionProperties
     public static int getParquetBatchSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_BATCH_SIZE, Integer.class);
+    }
+
+    public static ParquetProperties.WriterVersion getParquetWriterVersion(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_VERSION, ParquetProperties.WriterVersion.class);
     }
 
     public static DataSize getMaxSplitSize(ConnectorSession session)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -93,6 +93,7 @@ public class ParquetFileWriterFactory
                 .setMaxPageSize(HiveSessionProperties.getParquetWriterPageSize(session))
                 .setMaxBlockSize(HiveSessionProperties.getParquetWriterBlockSize(session))
                 .setBatchSize(HiveSessionProperties.getParquetBatchSize(session))
+                .setWriterVersion(HiveSessionProperties.getParquetWriterVersion(session))
                 .build();
 
         CompressionCodecName compressionCodecName = getCompression(conf);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergFileWriterFactory.java
@@ -65,6 +65,7 @@ import static io.trino.plugin.iceberg.IcebergSessionProperties.getOrcWriterValid
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterBatchSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterBlockSize;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterPageSize;
+import static io.trino.plugin.iceberg.IcebergSessionProperties.getParquetWriterVersion;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isOrcWriterValidate;
 import static io.trino.plugin.iceberg.TypeConverter.toOrcType;
 import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
@@ -148,6 +149,7 @@ public class IcebergFileWriterFactory
                     .setMaxPageSize(getParquetWriterPageSize(session))
                     .setMaxBlockSize(getParquetWriterBlockSize(session))
                     .setBatchSize(getParquetWriterBatchSize(session))
+                    .setWriterVersion(getParquetWriterVersion(session))
                     .build();
 
             return new IcebergParquetFileWriter(

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSessionProperties.java
@@ -25,6 +25,7 @@ import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.session.PropertyMetadata;
+import org.apache.parquet.column.ParquetProperties;
 
 import javax.inject.Inject;
 
@@ -64,6 +65,7 @@ public final class IcebergSessionProperties
     private static final String PARQUET_WRITER_BLOCK_SIZE = "parquet_writer_block_size";
     private static final String PARQUET_WRITER_PAGE_SIZE = "parquet_writer_page_size";
     private static final String PARQUET_WRITER_BATCH_SIZE = "parquet_writer_batch_size";
+    private static final String PARQUET_WRITER_VERSION = "parquet_writer_version";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -190,6 +192,12 @@ public final class IcebergSessionProperties
                         "Parquet: Maximum number of rows passed to the writer in each batch",
                         parquetWriterConfig.getBatchSize(),
                         false))
+                .add(enumProperty(
+                        PARQUET_WRITER_VERSION,
+                        "Parquet: Writer version",
+                        ParquetProperties.WriterVersion.class,
+                        ParquetProperties.WriterVersion.PARQUET_2_0,
+                        false))
                 .build();
     }
 
@@ -309,5 +317,10 @@ public final class IcebergSessionProperties
     public static int getParquetWriterBatchSize(ConnectorSession session)
     {
         return session.getProperty(PARQUET_WRITER_BATCH_SIZE, Integer.class);
+    }
+
+    public static ParquetProperties.WriterVersion getParquetWriterVersion(ConnectorSession session)
+    {
+        return session.getProperty(PARQUET_WRITER_VERSION, ParquetProperties.WriterVersion.class);
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveSparkCompatibility.java
@@ -14,7 +14,6 @@
 package io.trino.tests.product.hive;
 
 import io.trino.tempto.ProductTest;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -36,7 +35,6 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestHiveSparkCompatibility
         extends ProductTest
@@ -215,11 +213,9 @@ public class TestHiveSparkCompatibility
     public void testReadTrinoCreatedParquetTableWithNativeWriter()
     {
         onTrino().executeQuery("SET SESSION " + TRINO_CATALOG + ".experimental_parquet_optimized_writer_enabled = true");
-        // TODO (https://github.com/trinodb/trino/issues/6377) Native Parquet Writer writes Parquet V2 files that are not compatible with Spark's vectorized reader, see https://github.com/trinodb/trino/issues/7953 for more details
-        assertThatThrownBy(() -> testReadTrinoCreatedTable("using_native_parquet", "PARQUET"))
-                .hasStackTraceContaining("at org.apache.hive.jdbc.HiveStatement.execute")
-                .extracting(Throwable::toString, InstanceOfAssertFactories.STRING)
-                .matches("\\Qio.trino.tempto.query.QueryExecutionException: java.sql.SQLException: Error running query: java.lang.UnsupportedOperationException: Unsupported encoding: RLE\\E");
+        // TODO (https://github.com/trinodb/trino/issues/6377) Native Parquet Writer writes Parquet V2 files by default that are not compatible with Spark's vectorized reader, see https://github.com/trinodb/trino/issues/7953 for more details
+        onTrino().executeQuery("SET SESSION " + TRINO_CATALOG + ".parquet_writer_version = 'PARQUET_1_0'");
+        testReadTrinoCreatedTable("using_native_parquet", "PARQUET");
     }
 
     private void testReadTrinoCreatedTable(String tableName, String tableFormat)


### PR DESCRIPTION
This PR creates a toggle to write data in the Parquet V1 format using the native writer. The default version remains the same to ensure that there are no compatibility issues here. 

With this change:
- Hive cannot read Parquet V1 files created with the native Trino writer due to `org.apache.hadoop.io.BytesWritable cannot be cast to org.apache.hadoop.hive.serde2.io.HiveVarcharWritable` for all tested Hive versions (there are mixed errors for Parquet V2 files)
- Spark can read Parquet V2 files created with the native Trino writer with Spark's vectorized reader turned off
- Spark can read Parquet V1 files created with the native Trino writer with Spark's vectorized reader turned on or off

Why does this seem to work? (TBH I wouldn't have expected it to)
- `ValuesWriter` is injected into `PrimitiveColumnWriter` [here](https://github.com/trinodb/trino/blob/c9e33dc64fa832072b8acc82176e69ea0a0ac09a/lib/trino-parquet/src/main/java/io/trino/parquet/writer/ParquetWriters.java#L150).
- `valuesWriterFactory` creates a new `ValuesWriter` [here](https://github.com/apache/parquet-mr/blob/master/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java#L162-L164).
- Trino's native parquet writer still uses `DefaultValuesWriterFactory` [here](https://github.com/apache/parquet-mr/blob/master/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java#L63)
- `DefaultValuesWriterFactory` respects the Parquet V1 or V2 flag for constructing `ValuesWriter`s [here](https://github.com/apache/parquet-mr/blob/1695d92cc07288713a9f2230f3aac61e2dc6a8e4/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactory.java#L39-L48).

This PR is still a WIP, but I wanted to post this for discussion. 