### PR TITLE
Log container image name before start

### DIFF
--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Environment.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/Environment.java
@@ -124,6 +124,10 @@ public final class Environment
             container.reset();
         }
 
+        for (DockerContainer container : containers) {
+            log.info("Will start container '%s' from image '%s'", container.getLogicalName(), container.getDockerImageName());
+        }
+
         // Create new network when environment tries to start
         try (Network network = createNetwork(name)) {
             attachNetwork(containers, network);


### PR DESCRIPTION
Upon successful start, we log image name along with other information.
Log the image name in case startup fails later.