### PR TITLE
Allow Hive and other connectors use system roles

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ConnectorAccessControlModule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ConnectorAccessControlModule.java
@@ -15,15 +15,16 @@ package io.trino.plugin.base.security;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import com.google.inject.Scopes;
 import io.trino.spi.connector.ConnectorAccessControl;
 
-public class AllowAllAccessControlModule
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
+
+public class ConnectorAccessControlModule
         implements Module
 {
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(ConnectorAccessControl.class).to(AllowAllAccessControl.class).in(Scopes.SINGLETON);
+        newOptionalBinder(binder, ConnectorAccessControl.class);
     }
 }

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnector.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnector.java
@@ -24,6 +24,8 @@ import io.trino.spi.transaction.IsolationLevel;
 
 import javax.inject.Inject;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 public class AtopConnector
@@ -33,7 +35,7 @@ public class AtopConnector
     private final AtopMetadata metadata;
     private final AtopSplitManager splitManager;
     private final AtopPageSourceProvider pageSourceProvider;
-    private final ConnectorAccessControl accessControl;
+    private final Optional<ConnectorAccessControl> accessControl;
 
     @Inject
     public AtopConnector(
@@ -41,7 +43,7 @@ public class AtopConnector
             AtopMetadata metadata,
             AtopSplitManager splitManager,
             AtopPageSourceProvider pageSourceProvider,
-            ConnectorAccessControl accessControl)
+            Optional<ConnectorAccessControl> accessControl)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
@@ -77,7 +79,7 @@ public class AtopConnector
     @Override
     public ConnectorAccessControl getAccessControl()
     {
-        return accessControl;
+        return accessControl.orElseThrow(UnsupportedOperationException::new);
     }
 
     @Override

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorConfig.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorConfig.java
@@ -30,13 +30,13 @@ public class AtopConnectorConfig
 {
     public enum AtopSecurity
     {
-        NONE,
+        ALLOW_ALL,
         FILE,
     }
 
     private String executablePath = "atop";
     private String timeZone = ZoneId.systemDefault().getId();
-    private AtopSecurity security = AtopSecurity.NONE;
+    private AtopSecurity security = AtopSecurity.ALLOW_ALL;
     private Duration readTimeout = new Duration(5, MINUTES);
     private int concurrentReadersPerNode = 1;
     private int maxHistoryDays = 30;

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
@@ -70,7 +70,7 @@ public class AtopConnectorFactory
                     new CatalogNameModule(catalogName),
                     conditionalModule(
                             AtopConnectorConfig.class,
-                            config -> config.getSecurity() == AtopSecurity.NONE,
+                            config -> config.getSecurity() == AtopSecurity.ALLOW_ALL,
                             new AllowAllAccessControlModule()),
                     conditionalModule(
                             AtopConnectorConfig.class,

--- a/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
+++ b/plugin/trino-atop/src/main/java/io/trino/plugin/atop/AtopConnectorFactory.java
@@ -18,7 +18,7 @@ import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
 import io.trino.plugin.atop.AtopConnectorConfig.AtopSecurity;
 import io.trino.plugin.base.CatalogNameModule;
-import io.trino.plugin.base.security.AllowAllAccessControlModule;
+import io.trino.plugin.base.security.ConnectorAccessControlModule;
 import io.trino.plugin.base.security.FileBasedAccessControlModule;
 import io.trino.spi.classloader.ThreadContextClassLoader;
 import io.trino.spi.connector.Connector;
@@ -68,10 +68,7 @@ public class AtopConnectorFactory
                             context.getNodeManager(),
                             context.getNodeManager().getEnvironment()),
                     new CatalogNameModule(catalogName),
-                    conditionalModule(
-                            AtopConnectorConfig.class,
-                            config -> config.getSecurity() == AtopSecurity.ALLOW_ALL,
-                            new AllowAllAccessControlModule()),
+                    new ConnectorAccessControlModule(),
                     conditionalModule(
                             AtopConnectorConfig.class,
                             config -> config.getSecurity() == AtopSecurity.FILE,

--- a/plugin/trino-atop/src/test/java/io/trino/plugin/atop/TestAtopConnectorConfig.java
+++ b/plugin/trino-atop/src/test/java/io/trino/plugin/atop/TestAtopConnectorConfig.java
@@ -37,7 +37,7 @@ public class TestAtopConnectorConfig
         assertRecordedDefaults(recordDefaults(AtopConnectorConfig.class)
                 .setExecutablePath("atop")
                 .setConcurrentReadersPerNode(1)
-                .setSecurity(AtopSecurity.NONE)
+                .setSecurity(AtopSecurity.ALLOW_ALL)
                 .setReadTimeout(new Duration(5, MINUTES))
                 .setMaxHistoryDays(30)
                 .setTimeZone(TimeZone.getDefault().getID()));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
@@ -62,7 +62,7 @@ public class HiveConnector
     private final List<PropertyMetadata<?>> analyzeProperties;
     private final List<PropertyMetadata<?>> materializedViewProperties;
 
-    private final ConnectorAccessControl accessControl;
+    private final Optional<ConnectorAccessControl> accessControl;
     private final ClassLoader classLoader;
 
     private final HiveTransactionManager transactionManager;
@@ -83,7 +83,7 @@ public class HiveConnector
             List<PropertyMetadata<?>> tableProperties,
             List<PropertyMetadata<?>> analyzeProperties,
             List<PropertyMetadata<?>> materializedViewProperties,
-            ConnectorAccessControl accessControl,
+            Optional<ConnectorAccessControl> accessControl,
             ClassLoader classLoader)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
@@ -196,7 +196,7 @@ public class HiveConnector
     @Override
     public ConnectorAccessControl getAccessControl()
     {
-        return accessControl;
+        return accessControl.orElseThrow(UnsupportedOperationException::new);
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveModule.java
@@ -34,7 +34,6 @@ import io.trino.plugin.hive.parquet.ParquetWriterConfig;
 import io.trino.plugin.hive.rcfile.RcFilePageSourceFactory;
 import io.trino.plugin.hive.s3select.S3SelectRecordCursorProvider;
 import io.trino.plugin.hive.s3select.TrinoS3ClientFactory;
-import io.trino.plugin.hive.security.SystemTableAwareAccessControl;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
@@ -86,7 +85,6 @@ public class HiveModule
         Multibinder<SystemTableProvider> systemTableProviders = newSetBinder(binder, SystemTableProvider.class);
         systemTableProviders.addBinding().to(PartitionsSystemTableProvider.class).in(Scopes.SINGLETON);
         systemTableProviders.addBinding().to(PropertiesSystemTableProvider.class).in(Scopes.SINGLETON);
-        binder.bind(SystemTableAwareAccessControl.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, HiveRedirectionsProvider.class)
                 .setDefault().to(NoneHiveRedirectionsProvider.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, HiveMaterializedViewMetadataFactory.class)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
@@ -131,13 +131,16 @@ public final class InternalHiveConnectorFactory
             HiveTableProperties hiveTableProperties = injector.getInstance(HiveTableProperties.class);
             HiveAnalyzeProperties hiveAnalyzeProperties = injector.getInstance(HiveAnalyzeProperties.class);
             HiveMaterializedViewPropertiesProvider hiveMaterializedViewPropertiesProvider = injector.getInstance(HiveMaterializedViewPropertiesProvider.class);
-            ConnectorAccessControl accessControl = new ClassLoaderSafeConnectorAccessControl(injector.getInstance(SystemTableAwareAccessControl.class), classLoader);
             Set<Procedure> procedures = injector.getInstance(Key.get(new TypeLiteral<Set<Procedure>>() {}));
             Set<SystemTable> systemTables = injector.getInstance(Key.get(new TypeLiteral<Set<SystemTable>>() {}));
             Set<EventListener> eventListeners = injector.getInstance(Key.get(new TypeLiteral<Set<EventListener>>() {}))
                     .stream()
                     .map(listener -> new ClassLoaderSafeEventListener(listener, classLoader))
                     .collect(toImmutableSet());
+            Set<SystemTableProvider> systemTableProviders = injector.getInstance(Key.get(new TypeLiteral<Set<SystemTableProvider>>() {}));
+            Optional<ConnectorAccessControl> hiveAccessControl = injector.getInstance(Key.get(new TypeLiteral<Optional<ConnectorAccessControl>>() {}))
+                    .map(accessControl -> new SystemTableAwareAccessControl(accessControl, systemTableProviders))
+                    .map(accessControl -> new ClassLoaderSafeConnectorAccessControl(accessControl, classLoader));
 
             return new HiveConnector(
                     lifeCycleManager,
@@ -155,7 +158,7 @@ public final class InternalHiveConnectorFactory
                     hiveTableProperties.getTableProperties(),
                     hiveAnalyzeProperties.getAnalyzeProperties(),
                     hiveMaterializedViewPropertiesProvider.getMaterializedViewProperties(),
-                    accessControl,
+                    hiveAccessControl,
                     classLoader);
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/AllowAllSecurityModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/AllowAllSecurityModule.java
@@ -15,9 +15,6 @@ package io.trino.plugin.hive.security;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import com.google.inject.Scopes;
-import io.trino.plugin.base.security.AllowAllAccessControl;
-import io.trino.spi.connector.ConnectorAccessControl;
 
 public class AllowAllSecurityModule
         implements Module
@@ -25,7 +22,6 @@ public class AllowAllSecurityModule
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(ConnectorAccessControl.class).to(AllowAllAccessControl.class).in(Scopes.SINGLETON);
         binder.bind(AccessControlMetadataFactory.class).toInstance(metastore -> new AccessControlMetadata() {});
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/HiveSecurityModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/HiveSecurityModule.java
@@ -25,26 +25,32 @@ import static io.airlift.configuration.ConfigurationAwareModule.combine;
 public class HiveSecurityModule
         extends AbstractConfigurationAwareModule
 {
+    public static final String LEGACY = "legacy";
+    public static final String FILE = "file";
+    public static final String READ_ONLY = "read-only";
+    public static final String SQL_STANDARD = "sql-standard";
+    public static final String ALLOW_ALL = "allow-all";
+
     @Override
     protected void setup(Binder binder)
     {
         bindSecurityModule(
-                "legacy",
+                LEGACY,
                 combine(
                         new LegacySecurityModule(),
                         new StaticAccessControlMetadataModule()));
         bindSecurityModule(
-                "file",
+                FILE,
                 combine(
                         new FileBasedAccessControlModule(),
                         new StaticAccessControlMetadataModule()));
         bindSecurityModule(
-                "read-only",
+                READ_ONLY,
                 combine(
                         new ReadOnlySecurityModule(),
                         new StaticAccessControlMetadataModule()));
-        bindSecurityModule("sql-standard", new SqlStandardSecurityModule());
-        bindSecurityModule("allow-all", new AllowAllSecurityModule());
+        bindSecurityModule(SQL_STANDARD, new SqlStandardSecurityModule());
+        bindSecurityModule(ALLOW_ALL, new AllowAllSecurityModule());
     }
 
     private void bindSecurityModule(String name, Module module)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/HiveSecurityModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/HiveSecurityModule.java
@@ -16,6 +16,7 @@ package io.trino.plugin.hive.security;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.base.security.ConnectorAccessControlModule;
 import io.trino.plugin.base.security.FileBasedAccessControlModule;
 import io.trino.plugin.base.security.ReadOnlySecurityModule;
 
@@ -34,6 +35,7 @@ public class HiveSecurityModule
     @Override
     protected void setup(Binder binder)
     {
+        install(new ConnectorAccessControlModule());
         bindSecurityModule(
                 LEGACY,
                 combine(

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SecurityConfig.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SecurityConfig.java
@@ -17,9 +17,11 @@ import io.airlift.configuration.Config;
 
 import javax.validation.constraints.NotNull;
 
+import static io.trino.plugin.hive.security.HiveSecurityModule.LEGACY;
+
 public class SecurityConfig
 {
-    private String securitySystem = "legacy";
+    private String securitySystem = LEGACY;
 
     @NotNull
     public String getSecuritySystem()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -49,6 +49,7 @@ import static com.google.inject.util.Modules.EMPTY_MODULE;
 import static io.airlift.log.Level.WARN;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.plugin.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+import static io.trino.plugin.hive.security.HiveSecurityModule.SQL_STANDARD;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.security.SelectedRole.Type.ROLE;
 import static io.trino.testing.QueryAssertions.copyTpchTables;
@@ -171,7 +172,7 @@ public final class HiveQueryRunner
                     hiveProperties.put("hive.parquet.time-zone", TIME_ZONE.getID());
                 }
                 hiveProperties.put("hive.max-partitions-per-scan", "1000");
-                hiveProperties.put("hive.security", "sql-standard");
+                hiveProperties.put("hive.security", SQL_STANDARD);
                 hiveProperties.putAll(this.hiveProperties);
 
                 Map<String, String> hiveBucketedProperties = ImmutableMap.<String, String>builder()

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java
@@ -60,7 +60,7 @@ public class IcebergConnector
     private final List<PropertyMetadata<?>> sessionProperties;
     private final List<PropertyMetadata<?>> schemaProperties;
     private final List<PropertyMetadata<?>> tableProperties;
-    private final ConnectorAccessControl accessControl;
+    private final Optional<ConnectorAccessControl> accessControl;
     private final Set<Procedure> procedures;
 
     public IcebergConnector(
@@ -75,7 +75,7 @@ public class IcebergConnector
             Set<SessionPropertiesProvider> sessionPropertiesProviders,
             List<PropertyMetadata<?>> schemaProperties,
             List<PropertyMetadata<?>> tableProperties,
-            ConnectorAccessControl accessControl,
+            Optional<ConnectorAccessControl> accessControl,
             Set<Procedure> procedures)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
@@ -177,7 +177,7 @@ public class IcebergConnector
     @Override
     public ConnectorAccessControl getAccessControl()
     {
-        return accessControl;
+        return accessControl.orElseThrow(UnsupportedOperationException::new);
     }
 
     @Override

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -17,7 +17,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
-import io.trino.plugin.base.security.AllowAllAccessControl;
+import io.trino.plugin.base.security.ConnectorAccessControlModule;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.HiveConfig;
@@ -27,7 +27,6 @@ import io.trino.plugin.hive.orc.OrcReaderConfig;
 import io.trino.plugin.hive.orc.OrcWriterConfig;
 import io.trino.plugin.hive.parquet.ParquetReaderConfig;
 import io.trino.plugin.hive.parquet.ParquetWriterConfig;
-import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
@@ -80,6 +79,6 @@ public class IcebergModule
         Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
         procedures.addBinding().toProvider(RollbackToSnapshotProcedure.class).in(Scopes.SINGLETON);
 
-        newOptionalBinder(binder, ConnectorAccessControl.class).setDefault().to(AllowAllAccessControl.class).in(Scopes.SINGLETON);
+        binder.install(new ConnectorAccessControlModule());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
@@ -111,7 +111,7 @@ public final class InternalIcebergConnectorFactory
             Set<SessionPropertiesProvider> sessionPropertiesProviders = injector.getInstance(Key.get(new TypeLiteral<Set<SessionPropertiesProvider>>() {}));
             IcebergTableProperties icebergTableProperties = injector.getInstance(IcebergTableProperties.class);
             Set<Procedure> procedures = injector.getInstance(Key.get(new TypeLiteral<Set<Procedure>>() {}));
-            ConnectorAccessControl accessControl = injector.getInstance(ConnectorAccessControl.class);
+            Optional<ConnectorAccessControl> accessControl = injector.getInstance(Key.get(new TypeLiteral<Optional<ConnectorAccessControl>>() {}));
 
             return new IcebergConnector(
                     lifeCycleManager,

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorConnector.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/RaptorConnector.java
@@ -38,6 +38,7 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -69,7 +70,7 @@ public class RaptorConnector
     private final List<PropertyMetadata<?>> tableProperties;
     private final Set<SystemTable> systemTables;
     private final MetadataDao dao;
-    private final ConnectorAccessControl accessControl;
+    private final Optional<ConnectorAccessControl> accessControl;
     private final boolean coordinator;
 
     private final ConcurrentMap<ConnectorTransactionHandle, RaptorMetadata> transactions = new ConcurrentHashMap<>();
@@ -91,7 +92,7 @@ public class RaptorConnector
             RaptorSessionProperties sessionProperties,
             RaptorTableProperties tableProperties,
             Set<SystemTable> systemTables,
-            ConnectorAccessControl accessControl,
+            Optional<ConnectorAccessControl> accessControl,
             @ForMetadata Jdbi dbi)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
@@ -194,7 +195,7 @@ public class RaptorConnector
     @Override
     public ConnectorAccessControl getAccessControl()
     {
-        return accessControl;
+        return accessControl.orElseThrow(UnsupportedOperationException::new);
     }
 
     @Override

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurity.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurity.java
@@ -13,24 +13,9 @@
  */
 package io.trino.plugin.raptor.legacy.security;
 
-import io.airlift.configuration.Config;
-
-import javax.validation.constraints.NotNull;
-
-public class RaptorSecurityConfig
+public enum RaptorSecurity
 {
-    private RaptorSecurity securitySystem = RaptorSecurity.NONE;
-
-    @NotNull
-    public RaptorSecurity getSecuritySystem()
-    {
-        return securitySystem;
-    }
-
-    @Config("raptor.security")
-    public RaptorSecurityConfig setSecuritySystem(RaptorSecurity securitySystem)
-    {
-        this.securitySystem = securitySystem;
-        return this;
-    }
+    NONE,
+    FILE,
+    READ_ONLY,
 }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurity.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurity.java
@@ -15,7 +15,7 @@ package io.trino.plugin.raptor.legacy.security;
 
 public enum RaptorSecurity
 {
-    NONE,
+    ALLOW_ALL,
     FILE,
     READ_ONLY,
 }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurityConfig.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurityConfig.java
@@ -19,7 +19,7 @@ import javax.validation.constraints.NotNull;
 
 public class RaptorSecurityConfig
 {
-    private RaptorSecurity securitySystem = RaptorSecurity.NONE;
+    private RaptorSecurity securitySystem = RaptorSecurity.ALLOW_ALL;
 
     @NotNull
     public RaptorSecurity getSecuritySystem()

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurityModule.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurityModule.java
@@ -21,8 +21,8 @@ import io.trino.plugin.base.security.FileBasedAccessControlModule;
 import io.trino.plugin.base.security.ReadOnlySecurityModule;
 
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.ALLOW_ALL;
 import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.FILE;
-import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.NONE;
 import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.READ_ONLY;
 
 public class RaptorSecurityModule
@@ -31,7 +31,7 @@ public class RaptorSecurityModule
     @Override
     protected void setup(Binder binder)
     {
-        bindSecurityModule(NONE, new AllowAllAccessControlModule());
+        bindSecurityModule(ALLOW_ALL, new AllowAllAccessControlModule());
         bindSecurityModule(READ_ONLY, new ReadOnlySecurityModule());
         bindSecurityModule(FILE, new FileBasedAccessControlModule());
     }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurityModule.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurityModule.java
@@ -16,12 +16,11 @@ package io.trino.plugin.raptor.legacy.security;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
-import io.trino.plugin.base.security.AllowAllAccessControlModule;
+import io.trino.plugin.base.security.ConnectorAccessControlModule;
 import io.trino.plugin.base.security.FileBasedAccessControlModule;
 import io.trino.plugin.base.security.ReadOnlySecurityModule;
 
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
-import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.ALLOW_ALL;
 import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.FILE;
 import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.READ_ONLY;
 
@@ -31,7 +30,7 @@ public class RaptorSecurityModule
     @Override
     protected void setup(Binder binder)
     {
-        bindSecurityModule(ALLOW_ALL, new AllowAllAccessControlModule());
+        install(new ConnectorAccessControlModule());
         bindSecurityModule(READ_ONLY, new ReadOnlySecurityModule());
         bindSecurityModule(FILE, new FileBasedAccessControlModule());
     }

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurityModule.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/security/RaptorSecurityModule.java
@@ -21,6 +21,9 @@ import io.trino.plugin.base.security.FileBasedAccessControlModule;
 import io.trino.plugin.base.security.ReadOnlySecurityModule;
 
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.FILE;
+import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.NONE;
+import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.READ_ONLY;
 
 public class RaptorSecurityModule
         extends AbstractConfigurationAwareModule
@@ -28,16 +31,16 @@ public class RaptorSecurityModule
     @Override
     protected void setup(Binder binder)
     {
-        bindSecurityModule("none", new AllowAllAccessControlModule());
-        bindSecurityModule("read-only", new ReadOnlySecurityModule());
-        bindSecurityModule("file", new FileBasedAccessControlModule());
+        bindSecurityModule(NONE, new AllowAllAccessControlModule());
+        bindSecurityModule(READ_ONLY, new ReadOnlySecurityModule());
+        bindSecurityModule(FILE, new FileBasedAccessControlModule());
     }
 
-    private void bindSecurityModule(String name, Module module)
+    private void bindSecurityModule(RaptorSecurity raptorSecurity, Module module)
     {
         install(conditionalModule(
                 RaptorSecurityConfig.class,
-                security -> name.equalsIgnoreCase(security.getSecuritySystem()),
+                security -> raptorSecurity.equals(security.getSecuritySystem()),
                 module));
     }
 }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorConnector.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/TestRaptorConnector.java
@@ -22,7 +22,6 @@ import io.airlift.slice.Slice;
 import io.trino.PagesIndexPageSorter;
 import io.trino.operator.PagesIndex;
 import io.trino.plugin.base.CatalogName;
-import io.trino.plugin.base.security.AllowAllAccessControl;
 import io.trino.plugin.raptor.legacy.metadata.MetadataDao;
 import io.trino.plugin.raptor.legacy.metadata.ShardManager;
 import io.trino.plugin.raptor.legacy.storage.StorageManager;
@@ -55,6 +54,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.Optional;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -112,7 +112,7 @@ public class TestRaptorConnector
                 new RaptorSessionProperties(config),
                 new RaptorTableProperties(typeManager),
                 ImmutableSet.of(),
-                new AllowAllAccessControl(),
+                Optional.empty(),
                 dbi);
     }
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/security/TestRaptorSecurityConfig.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/security/TestRaptorSecurityConfig.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.NONE;
+import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.READ_ONLY;
 
 public class TestRaptorSecurityConfig
 {
@@ -28,7 +30,7 @@ public class TestRaptorSecurityConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(RaptorSecurityConfig.class)
-                .setSecuritySystem("none"));
+                .setSecuritySystem(NONE));
     }
 
     @Test
@@ -39,7 +41,7 @@ public class TestRaptorSecurityConfig
                 .build();
 
         RaptorSecurityConfig expected = new RaptorSecurityConfig()
-                .setSecuritySystem("read-only");
+                .setSecuritySystem(READ_ONLY);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/security/TestRaptorSecurityConfig.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/security/TestRaptorSecurityConfig.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
-import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.NONE;
+import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.ALLOW_ALL;
 import static io.trino.plugin.raptor.legacy.security.RaptorSecurity.READ_ONLY;
 
 public class TestRaptorSecurityConfig
@@ -30,7 +30,7 @@ public class TestRaptorSecurityConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(RaptorSecurityConfig.class)
-                .setSecuritySystem(NONE));
+                .setSecuritySystem(ALLOW_ALL));
     }
 
     @Test


### PR DESCRIPTION
Allow Hive and other connectors use system roles

In order for catalog to use system roles, a connector is required to
**not** to provide connector access control. Otherwise, catalog roles will be
used.

To allow usage of system roles for hive and other connectors, allow-all security
can not bind any access control.
