### PR TITLE
Enable Error Prone check: StreamToString

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -2043,7 +2043,7 @@ public class SemiTransactionalHiveMetastore
                     logCleanupFailure("Failed to rollback: add_partition for partitions %s.%s %s",
                             partitionAdder.getSchemaName(),
                             partitionAdder.getTableName(),
-                            partitionsFailedToRollback.stream());
+                            partitionsFailedToRollback);
                 }
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -1736,6 +1736,7 @@
                                     -Xep:OptionalMapUnusedValue:ERROR
                                     -Xep:PreconditionsInvalidPlaceholder:ERROR
                                     -Xep:ReturnValueIgnored:ERROR
+                                    -Xep:StreamToString
                                     -Xep:StaticQualifiedUsingExpression:ERROR
                                     -Xep:ThrowIfUncheckedKnownChecked:ERROR
                                     -Xep:UnnecessaryCheckNotNull:ERROR


### PR DESCRIPTION
The one instance was probably intended to post-process the partitions list somehow, but it's not possible to infer how.

This check is ERROR by default and will be removed once we enable all checks.