### PR TITLE
[not for merging] Reproduce "query already begun" error

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -51,6 +51,7 @@ import static java.lang.String.format;
 public final class SystemSessionProperties
         implements SystemSessionPropertiesProvider
 {
+    public static final String REPRODUCE_QUERY_ALREADY_BEGUN_BUG = "reproduce_query_already_begun_bug";
     public static final String OPTIMIZE_HASH_GENERATION = "optimize_hash_generation";
     public static final String JOIN_DISTRIBUTION_TYPE = "join_distribution_type";
     public static final String JOIN_MAX_BROADCAST_TABLE_SIZE = "join_max_broadcast_table_size";
@@ -163,6 +164,11 @@ public final class SystemSessionProperties
             NodeSchedulerConfig nodeSchedulerConfig)
     {
         sessionProperties = ImmutableList.of(
+                booleanProperty(
+                        REPRODUCE_QUERY_ALREADY_BEGUN_BUG,
+                        "Reproduce bug for query already begun failure",
+                        false,
+                        false),
                 stringProperty(
                         EXECUTION_POLICY,
                         "Policy used for scheduling query tasks",
@@ -673,6 +679,11 @@ public final class SystemSessionProperties
     public List<PropertyMetadata<?>> getSessionProperties()
     {
         return sessionProperties;
+    }
+
+    public static boolean isReproduceQueryAlreadyBegunBug(Session session)
+    {
+        return session.getSystemProperty(REPRODUCE_QUERY_ALREADY_BEGUN_BUG, Boolean.class);
     }
 
     public static String getExecutionPolicy(Session session)

--- a/plugin/trino-hive/pom.xml
+++ b/plugin/trino-hive/pom.xml
@@ -325,6 +325,19 @@
 
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-resource-group-managers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <!-- Duplicate resources coming from alluxio-shaded-client, TODO remove resources only -->
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestQueryAlreadyBegunError.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestQueryAlreadyBegunError.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.plugin.resourcegroups.ResourceGroupManagerPlugin;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static io.trino.tpch.TpchTable.NATION;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Test(singleThreaded = true)
+public class TestQueryAlreadyBegunError
+        extends AbstractTestQueryFramework
+{
+    private static final Session REPRODUCE_ERROR_SESSION = testSessionBuilder()
+            .setSystemProperty("reproduce_query_already_begun_bug", "true")
+            .build();
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = HiveQueryRunner.builder()
+                    .setInitialTables(ImmutableList.of(NATION))
+                    .build();
+
+        queryRunner.installPlugin(new ResourceGroupManagerPlugin());
+        queryRunner.getCoordinator().getResourceGroupManager().get()
+                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_zero_concurrent_queries.json")));
+
+        return queryRunner;
+    }
+
+    @Test
+    public void testQueryAlreadyBegun()
+    {
+        assertThatThrownBy(() -> query(REPRODUCE_ERROR_SESSION, "SELECT count(*) FROM hive.tpch.nation WHERE n_regionkey is not null"))
+                .hasMessageContaining("Query already begun");
+    }
+
+    private String getResourceFilePath(String fileName)
+    {
+        return this.getClass().getClassLoader().getResource(fileName).getPath();
+    }
+}

--- a/plugin/trino-hive/src/test/resources/resource_groups_zero_concurrent_queries.json
+++ b/plugin/trino-hive/src/test/resources/resource_groups_zero_concurrent_queries.json
@@ -1,0 +1,16 @@
+{
+    "rootGroups": [
+        {
+            "name": "fail-all-queries",
+            "softMemoryLimit": "10%",
+            "maxRunning": 0,
+            "maxQueued": 0
+        }
+    ],
+    "selectors": [
+        {
+            "group": "fail-all-queries"
+        }
+    ]
+}
+


### PR DESCRIPTION
The test in this PR uses a race condition between query analysis
and cleanup to reproduce the error.

Queries with these errors were typically accompanied by queries
that failed to queue, because that RG hit maxQueued limit. So the
queries hitting this error would likely also have failed with the
QUERY_QUEUE_FULL error anyway.

[we need to make sure to stop analysis for good, before cleanupQuery is called.] 