### PR TITLE
[WIP] Arbitrary table properties

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/system/AbstractPropertiesSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/AbstractPropertiesSystemTable.java
@@ -13,22 +13,22 @@
  */
 package io.trino.connector.system;
 
-import com.google.common.collect.ImmutableMap;
 import io.trino.connector.CatalogName;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.InMemoryRecordSet;
+import io.trino.spi.connector.PropertyProvider;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
-import io.trino.spi.session.PropertyMetadata;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
 
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 
@@ -43,9 +43,9 @@ abstract class AbstractPropertiesSystemTable
 {
     private final ConnectorTableMetadata tableMetadata;
     private final TransactionManager transactionManager;
-    private final Supplier<Map<CatalogName, Map<String, PropertyMetadata<?>>>> propertySupplier;
+    private final Supplier<Map<CatalogName, PropertyProvider>> propertySupplier;
 
-    protected AbstractPropertiesSystemTable(String tableName, TransactionManager transactionManager, Supplier<Map<CatalogName, Map<String, PropertyMetadata<?>>>> propertySupplier)
+    protected AbstractPropertiesSystemTable(String tableName, TransactionManager transactionManager, Supplier<Map<CatalogName, PropertyProvider>> propertySupplier)
     {
         this.tableMetadata = tableMetadataBuilder(new SchemaTableName("metadata", tableName))
                 .column("catalog_name", createUnboundedVarcharType())
@@ -76,18 +76,20 @@ abstract class AbstractPropertiesSystemTable
         TransactionId transactionId = ((GlobalSystemTransactionHandle) transactionHandle).getTransactionId();
 
         InMemoryRecordSet.Builder table = InMemoryRecordSet.builder(tableMetadata);
-        Map<CatalogName, Map<String, PropertyMetadata<?>>> connectorProperties = propertySupplier.get();
+        Map<CatalogName, PropertyProvider> connectorProperties = propertySupplier.get();
         for (Entry<String, CatalogName> entry : new TreeMap<>(transactionManager.getCatalogNames(transactionId)).entrySet()) {
-            String catalog = entry.getKey();
-            Map<String, PropertyMetadata<?>> properties = new TreeMap<>(connectorProperties.getOrDefault(entry.getValue(), ImmutableMap.of()));
-            for (PropertyMetadata<?> propertyMetadata : properties.values()) {
-                table.addRow(
-                        catalog,
-                        propertyMetadata.getName(),
-                        firstNonNull(propertyMetadata.getDefaultValue(), "").toString(),
-                        propertyMetadata.getSqlType().toString(),
-                        propertyMetadata.getDescription());
-            }
+            PropertyProvider propertyProvider = connectorProperties.get(entry.getValue());
+            propertyProvider.getKnownPropertyNames().stream()
+                    .sorted()
+                    .map(propertyProvider::getProperty)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .forEach(propertyMetadata -> table.addRow(
+                            entry.getKey(),
+                            propertyMetadata.getName(),
+                            firstNonNull(propertyMetadata.getDefaultValue(), "").toString(),
+                            propertyMetadata.getSqlType().toString(),
+                            propertyMetadata.getDescription()));
         }
         return table.build().cursor();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Connector.java
@@ -134,10 +134,20 @@ public interface Connector
 
     /**
      * @return the table properties for this connector
+     * @deprecated use getTablePropertyProvider
      */
+    @Deprecated
     default List<PropertyMetadata<?>> getTableProperties()
     {
         return emptyList();
+    }
+
+    /**
+     * @return the table properties for this connector
+     */
+    default PropertyProvider getTablePropertyProvider()
+    {
+        return new FixedPropertyProvider(getTableProperties());
     }
 
     /**

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/FixedPropertyProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/FixedPropertyProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+public class FixedPropertyProvider
+        implements PropertyProvider
+{
+    private final Map<String, PropertyMetadata<?>> properties;
+
+    public FixedPropertyProvider(Collection<PropertyMetadata<?>> properties)
+    {
+        requireNonNull(properties, "properties is null");
+        this.properties = properties.stream()
+                .collect(Collectors.toUnmodifiableMap(PropertyMetadata::getName, identity()));
+    }
+
+    @Override
+    public Set<String> getKnownPropertyNames()
+    {
+        return properties.keySet();
+    }
+
+    @Override
+    public Optional<PropertyMetadata<?>> getProperty(String name)
+    {
+        return Optional.ofNullable(properties.get(name));
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/PropertyProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/PropertyProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+import io.trino.spi.session.PropertyMetadata;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface PropertyProvider
+{
+    Set<String> getKnownPropertyNames();
+
+    Optional<PropertyMetadata<?>> getProperty(String name);
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveConnector.java
@@ -28,6 +28,7 @@ import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
 import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.PropertyProvider;
 import io.trino.spi.connector.SystemTable;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.procedure.Procedure;
@@ -58,7 +59,7 @@ public class HiveConnector
     private final Set<EventListener> eventListeners;
     private final List<PropertyMetadata<?>> sessionProperties;
     private final List<PropertyMetadata<?>> schemaProperties;
-    private final List<PropertyMetadata<?>> tableProperties;
+    private final HiveTableProperties tableProperties;
     private final List<PropertyMetadata<?>> analyzeProperties;
     private final List<PropertyMetadata<?>> materializedViewProperties;
 
@@ -80,7 +81,7 @@ public class HiveConnector
             Set<EventListener> eventListeners,
             Set<SessionPropertiesProvider> sessionPropertiesProviders,
             List<PropertyMetadata<?>> schemaProperties,
-            List<PropertyMetadata<?>> tableProperties,
+            HiveTableProperties tableProperties,
             List<PropertyMetadata<?>> analyzeProperties,
             List<PropertyMetadata<?>> materializedViewProperties,
             ConnectorAccessControl accessControl,
@@ -100,7 +101,7 @@ public class HiveConnector
                 .flatMap(sessionPropertiesProvider -> sessionPropertiesProvider.getSessionProperties().stream())
                 .collect(toImmutableList());
         this.schemaProperties = ImmutableList.copyOf(requireNonNull(schemaProperties, "schemaProperties is null"));
-        this.tableProperties = ImmutableList.copyOf(requireNonNull(tableProperties, "tableProperties is null"));
+        this.tableProperties = requireNonNull(tableProperties, "tableProperties is null");
         this.analyzeProperties = ImmutableList.copyOf(requireNonNull(analyzeProperties, "analyzeProperties is null"));
         this.materializedViewProperties = requireNonNull(materializedViewProperties, "materializedViewProperties is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
@@ -176,7 +177,7 @@ public class HiveConnector
     }
 
     @Override
-    public List<PropertyMetadata<?>> getTableProperties()
+    public PropertyProvider getTablePropertyProvider()
     {
         return tableProperties;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
@@ -152,7 +152,7 @@ public final class InternalHiveConnectorFactory
                     eventListeners,
                     sessionPropertiesProviders,
                     HiveSchemaProperties.SCHEMA_PROPERTIES,
-                    hiveTableProperties.getTableProperties(),
+                    hiveTableProperties,
                     hiveAnalyzeProperties.getAnalyzeProperties(),
                     hiveMaterializedViewPropertiesProvider.getMaterializedViewProperties(),
                     accessControl,


### PR DESCRIPTION
Add support for arbitrary table properties in Hive connector.
```
trino:tpch> create table example (id bigint) with (extra_property_food = 'taco');
CREATE TABLE
trino:tpch> show create table example;
           Create Table           
----------------------------------
 CREATE TABLE hive.tpch.example ( 
    id bigint                     
 )                                
 WITH (                           
    extra_property_food = 'taco', 
    format = 'ORC'                
 )                                
(1 row)
```

This PR will need:
* review of SPI changes
* review of naming convention in Hive
* better error handling in Hive changes
* maybe better prevention of aliasing known Hive properties
* a review of unmanaged Hive properties for security issues
* a flag to diisable extra properties
* tests
* documentation

Resolves #955
Alternative to #9475