### PR TITLE
Bump Coral to 1.0.120

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dep.errorprone.version>2.9.0</dep.errorprone.version>
         <dep.testcontainers.version>1.16.0</dep.testcontainers.version>
         <dep.docker-java.version>3.2.11</dep.docker-java.version>
-        <dep.coral.version>1.0.89</dep.coral.version>
+        <dep.coral.version>1.0.120</dep.coral.version>
         <dep.confluent.version>5.5.2</dep.confluent.version>
         <!-- TODO: update after moving to Airbase 112 -->
         <dep.jackson.version>2.12.3</dep.jackson.version>
@@ -1046,7 +1046,7 @@
             <dependency>
                 <groupId>com.linkedin.calcite</groupId>
                 <artifactId>calcite-core</artifactId>
-                <version>1.21.0.150</version>
+                <version>1.21.0.151</version>
                 <classifier>shaded</classifier>
                 <exclusions>
                     <exclusion>


### PR DESCRIPTION
It also adds test for CAST(timestamp AS DECIMAL()); which apparently is
not working great.