### PR TITLE
Avoid constant hashcode

### DIFF
--- a/core/trino-parser/src/main/java/io/trino/sql/tree/AllRows.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/AllRows.java
@@ -60,7 +60,7 @@ public class AllRows
     @Override
     public int hashCode()
     {
-        return 0;
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Commit.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Commit.java
@@ -51,7 +51,7 @@ public final class Commit
     @Override
     public int hashCode()
     {
-        return 0;
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/NaturalJoin.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/NaturalJoin.java
@@ -34,7 +34,7 @@ public class NaturalJoin
     @Override
     public int hashCode()
     {
-        return 0;
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/NullLiteral.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/NullLiteral.java
@@ -50,7 +50,7 @@ public class NullLiteral
     @Override
     public int hashCode()
     {
-        return 0;
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/Rollback.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/Rollback.java
@@ -52,7 +52,7 @@ public final class Rollback
     @Override
     public int hashCode()
     {
-        return 0;
+        return getClass().hashCode();
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/NotPartitionedPartitionHandle.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/NotPartitionedPartitionHandle.java
@@ -30,6 +30,6 @@ public final class NotPartitionedPartitionHandle
     @Override
     public int hashCode()
     {
-        return 0;
+        return getClass().hashCode();
     }
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/SingletonIdentityCacheMapping.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/SingletonIdentityCacheMapping.java
@@ -32,7 +32,7 @@ public final class SingletonIdentityCacheMapping
         @Override
         public int hashCode()
         {
-            return 0;
+            return getClass().hashCode();
         }
 
         @Override


### PR DESCRIPTION
It's correct for hashcode to be 0, but using hashcode that's
class-specific reduces collisions, should two such objects be used
together in a hash map.