### PR TITLE
Remove compiler warning for reserved identifier in future JDKs

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/ExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExchangeClient.java
@@ -200,7 +200,7 @@ public class ExchangeClient
                     return ProcessState.blocked(blocked);
                 }
 
-                return ProcessState.yield();
+                return ProcessState.yielded();
             }
 
             return ProcessState.ofResult(page);

--- a/core/trino-main/src/main/java/io/trino/operator/PageBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PageBuffer.java
@@ -24,7 +24,7 @@ import static io.trino.operator.Operator.NOT_BLOCKED;
 import static io.trino.operator.WorkProcessor.ProcessState.blocked;
 import static io.trino.operator.WorkProcessor.ProcessState.finished;
 import static io.trino.operator.WorkProcessor.ProcessState.ofResult;
-import static io.trino.operator.WorkProcessor.ProcessState.yield;
+import static io.trino.operator.WorkProcessor.ProcessState.yielded;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -67,7 +67,7 @@ public class PageBuffer
                 return ofResult(result);
             }
 
-            return yield();
+            return yielded();
         });
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -360,7 +360,7 @@ public class ScanFilterAndProjectOperator
             }
             else {
                 outputMemoryContext.setBytes(pageBuilder.getRetainedSizeInBytes());
-                return ProcessState.yield();
+                return ProcessState.yielded();
             }
         }
     }
@@ -395,7 +395,7 @@ public class ScanFilterAndProjectOperator
                     return ProcessState.finished();
                 }
                 else {
-                    return ProcessState.yield();
+                    return ProcessState.yielded();
                 }
             }
 

--- a/core/trino-main/src/main/java/io/trino/operator/TableScanWorkProcessorOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TableScanWorkProcessorOperator.java
@@ -295,7 +295,7 @@ public class TableScanWorkProcessorOperator
                     return ProcessState.finished();
                 }
                 else {
-                    return ProcessState.yield();
+                    return ProcessState.yielded();
                 }
             }
 

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessor.java
@@ -177,7 +177,7 @@ public interface WorkProcessor<T>
          * @return the current transformation state, optionally bearing a result
          * @see TransformationState#needsMoreData()
          * @see TransformationState#blocked(ListenableFuture)
-         * @see TransformationState#yield()
+         * @see TransformationState#yielded()
          * @see TransformationState#ofResult(Object)
          * @see TransformationState#ofResult(Object, boolean)
          * @see TransformationState#finished()
@@ -192,7 +192,7 @@ public interface WorkProcessor<T>
          *
          * @return the current state, optionally bearing a result
          * @see ProcessState#blocked(ListenableFuture)
-         * @see ProcessState#yield()
+         * @see ProcessState#yielded()
          * @see ProcessState#ofResult(Object)
          * @see ProcessState#finished()
          */
@@ -254,7 +254,7 @@ public interface WorkProcessor<T>
          * Signals that transformation has yielded. {@link #process()} will be called again with the same input element.
          */
         @SuppressWarnings("unchecked")
-        public static <T> TransformationState<T> yield()
+        public static <T> TransformationState<T> yielded()
         {
             return (TransformationState<T>) YIELD_STATE;
         }
@@ -349,7 +349,7 @@ public interface WorkProcessor<T>
          * Signals that process has yielded. {@link #process()} will be called again later.
          */
         @SuppressWarnings("unchecked")
-        public static <T> ProcessState<T> yield()
+        public static <T> ProcessState<T> yielded()
         {
             return (ProcessState<T>) YIELD_STATE;
         }

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorUtils.java
@@ -131,7 +131,7 @@ public final class WorkProcessorUtils
                         return ProcessState.blocked(processor.getBlockedFuture());
                     }
                     else {
-                        return ProcessState.yield();
+                        return ProcessState.yielded();
                     }
 
                     if (processorIterator.hasNext()) {
@@ -174,7 +174,7 @@ public final class WorkProcessorUtils
         {
             if (!lastProcessYielded && yieldSignal.getAsBoolean()) {
                 lastProcessYielded = true;
-                return ProcessState.yield();
+                return ProcessState.yielded();
             }
             lastProcessYielded = false;
 
@@ -230,7 +230,7 @@ public final class WorkProcessorUtils
             return ProcessState.blocked(processor.getBlockedFuture());
         }
 
-        return ProcessState.yield();
+        return ProcessState.yielded();
     }
 
     static <T, R> WorkProcessor<R> flatMap(WorkProcessor<T> processor, Function<T, WorkProcessor<R>> mapper)
@@ -286,7 +286,7 @@ public final class WorkProcessorUtils
                 return TransformationState.blocked(nestedProcessor.getBlockedFuture());
             }
 
-            return TransformationState.yield();
+            return TransformationState.yielded();
         });
     }
 
@@ -312,7 +312,7 @@ public final class WorkProcessorUtils
                             return ProcessState.blocked(processor.getBlockedFuture());
                         }
                         else {
-                            return ProcessState.yield();
+                            return ProcessState.yielded();
                         }
                     }
 
@@ -331,7 +331,7 @@ public final class WorkProcessorUtils
                         case BLOCKED:
                             return ProcessState.blocked(state.getBlocked());
                         case YIELD:
-                            return ProcessState.yield();
+                            return ProcessState.yielded();
                         case RESULT:
                             return ProcessState.ofResult(state.getResult());
                         case FINISHED:
@@ -353,7 +353,7 @@ public final class WorkProcessorUtils
         @Nullable
         WorkProcessor.Process<T> process;
         // set initial state to yield as it will cause processor computations to progress
-        ProcessState<T> state = ProcessState.yield();
+        ProcessState<T> state = ProcessState.yielded();
 
         ProcessWorkProcessor(WorkProcessor.Process<T> process)
         {

--- a/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSource.java
+++ b/core/trino-main/src/main/java/io/trino/operator/exchange/LocalExchangeSource.java
@@ -111,7 +111,7 @@ public class LocalExchangeSource
                     return ProcessState.blocked(blocked);
                 }
 
-                return ProcessState.yield();
+                return ProcessState.yielded();
             }
 
             return ProcessState.ofResult(page);

--- a/core/trino-main/src/main/java/io/trino/operator/join/DefaultPageJoiner.java
+++ b/core/trino-main/src/main/java/io/trino/operator/join/DefaultPageJoiner.java
@@ -53,7 +53,7 @@ import static io.trino.operator.WorkProcessor.TransformationState.blocked;
 import static io.trino.operator.WorkProcessor.TransformationState.finished;
 import static io.trino.operator.WorkProcessor.TransformationState.needsMoreData;
 import static io.trino.operator.WorkProcessor.TransformationState.ofResult;
-import static io.trino.operator.WorkProcessor.TransformationState.yield;
+import static io.trino.operator.WorkProcessor.TransformationState.yielded;
 import static io.trino.operator.join.LookupJoinOperatorFactory.JoinType.FULL_OUTER;
 import static io.trino.operator.join.LookupJoinOperatorFactory.JoinType.PROBE_OUTER;
 import static io.trino.operator.join.PartitionedLookupSourceFactory.NO_SPILL_EPOCH;
@@ -205,7 +205,7 @@ public class DefaultPageJoiner
                 return ofResult(buildOutputPage(), false);
             }
 
-            return yield();
+            return yielded();
         }
 
         if (!pageBuilder.isEmpty() || finishing) {

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -45,7 +45,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.operator.PageUtils.recordMaterializedBytes;
 import static io.trino.operator.WorkProcessor.ProcessState.finished;
 import static io.trino.operator.WorkProcessor.ProcessState.ofResult;
-import static io.trino.operator.WorkProcessor.ProcessState.yield;
+import static io.trino.operator.WorkProcessor.ProcessState.yielded;
 import static io.trino.operator.project.SelectedPositions.positionsRange;
 import static io.trino.spi.block.DictionaryId.randomDictionaryId;
 import static java.util.Objects.requireNonNull;
@@ -209,7 +209,7 @@ public class PageProcessor
                     lastComputeYielded = true;
                     lastComputeBatchSize = batchSize;
                     updateRetainedSize();
-                    return yield();
+                    return yielded();
                 }
 
                 if (result.isPageTooLarge()) {

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessor.java
@@ -64,7 +64,7 @@ public class TestWorkProcessor
     public void testIteratorFailsWhenWorkProcessorHasYielded()
     {
         // iterator should fail if underlying work has yielded
-        WorkProcessor<Integer> processor = processorFrom(ImmutableList.of(ProcessState.yield()));
+        WorkProcessor<Integer> processor = processorFrom(ImmutableList.of(ProcessState.yielded()));
         Iterator<Integer> iterator = processor.iterator();
         //noinspection ResultOfMethodCallIgnored
         assertThatThrownBy(iterator::hasNext)
@@ -90,7 +90,7 @@ public class TestWorkProcessor
         List<ProcessState<Integer>> firstStream = ImmutableList.of(
                 ProcessState.ofResult(1),
                 ProcessState.ofResult(3),
-                ProcessState.yield(),
+                ProcessState.yielded(),
                 ProcessState.ofResult(5),
                 ProcessState.finished());
 
@@ -139,7 +139,7 @@ public class TestWorkProcessor
         SettableFuture<Void> firstFuture = SettableFuture.create();
         List<ProcessState<Integer>> firstStream = ImmutableList.of(
                 ProcessState.blocked(firstFuture),
-                ProcessState.yield(),
+                ProcessState.yielded(),
                 ProcessState.finished());
 
         SettableFuture<Void> secondFuture = SettableFuture.create();
@@ -240,7 +240,7 @@ public class TestWorkProcessor
 
         List<ProcessState<Integer>> baseScenario = ImmutableList.of(
                 ProcessState.ofResult(1),
-                ProcessState.yield(),
+                ProcessState.yielded(),
                 ProcessState.blocked(future),
                 ProcessState.finished());
 
@@ -266,7 +266,7 @@ public class TestWorkProcessor
 
         List<ProcessState<Integer>> scenario = ImmutableList.of(
                 ProcessState.ofResult(1),
-                ProcessState.yield(),
+                ProcessState.yielded(),
                 ProcessState.blocked(future),
                 ProcessState.ofResult(2));
 
@@ -326,7 +326,7 @@ public class TestWorkProcessor
                 ProcessState.ofResult(1.0),
                 ProcessState.blocked(baseFuture),
                 ProcessState.ofResult(2.0),
-                ProcessState.yield(),
+                ProcessState.yielded(),
                 ProcessState.ofResult(3.0),
                 ProcessState.ofResult(4.0),
                 ProcessState.finished());
@@ -334,7 +334,7 @@ public class TestWorkProcessor
         SettableFuture<Void> mappedFuture1 = SettableFuture.create();
         List<ProcessState<Integer>> mappedScenario1 = ImmutableList.of(
                 ProcessState.ofResult(1),
-                ProcessState.yield(),
+                ProcessState.yielded(),
                 ProcessState.blocked(mappedFuture1),
                 ProcessState.ofResult(2),
                 ProcessState.finished());
@@ -411,7 +411,7 @@ public class TestWorkProcessor
         SettableFuture<Void> baseFuture = SettableFuture.create();
         List<ProcessState<Integer>> baseScenario = ImmutableList.of(
                 ProcessState.ofResult(1),
-                ProcessState.yield(),
+                ProcessState.yielded(),
                 ProcessState.blocked(baseFuture),
                 ProcessState.ofResult(2),
                 ProcessState.ofResult(3),
@@ -422,7 +422,7 @@ public class TestWorkProcessor
                 Transform.of(Optional.of(1), TransformationState.needsMoreData()),
                 Transform.of(Optional.of(2), TransformationState.ofResult("foo")),
                 Transform.of(Optional.of(3), TransformationState.blocked(transformationFuture)),
-                Transform.of(Optional.of(3), TransformationState.yield()),
+                Transform.of(Optional.of(3), TransformationState.yielded()),
                 Transform.of(Optional.of(3), TransformationState.ofResult("bar", false)),
                 Transform.of(Optional.of(3), TransformationState.ofResult("zoo", true)),
                 Transform.of(Optional.empty(), TransformationState.ofResult("car", false)),
@@ -474,10 +474,10 @@ public class TestWorkProcessor
     {
         SettableFuture<Void> future = SettableFuture.create();
         List<ProcessState<Integer>> scenario = ImmutableList.of(
-                ProcessState.yield(),
+                ProcessState.yielded(),
                 ProcessState.ofResult(1),
                 ProcessState.blocked(future),
-                ProcessState.yield(),
+                ProcessState.yielded(),
                 ProcessState.ofResult(2),
                 ProcessState.finished());
         WorkProcessor<Integer> processor = processorFrom(scenario);


### PR DESCRIPTION
`yield` will be a reserved identifier in future JDK versions. On JDK 17 compiler generates warning for that name.