### PR TITLE
Remove usage of @test with exceptions in metadata tests

### DIFF
--- a/core/trino-main/src/test/java/io/trino/metadata/TestFunctionRegistry.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestFunctionRegistry.java
@@ -89,7 +89,7 @@ public class TestFunctionRegistry
         assertTrue(foundOperator);
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "\\QFunction already registered: custom_add(bigint,bigint):bigint\\E")
+    @Test
     public void testDuplicateFunctions()
     {
         List<SqlFunction> functions = new FunctionListBuilder()
@@ -101,17 +101,21 @@ public class TestFunctionRegistry
 
         Metadata metadata = createTestMetadataManager();
         metadata.addFunctions(functions);
-        metadata.addFunctions(functions);
+        assertThatThrownBy(() -> metadata.addFunctions(functions))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageMatching("\\QFunction already registered: custom_add(bigint,bigint):bigint\\E");
     }
 
-    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "'sum' is both an aggregation and a scalar function")
+    @Test
     public void testConflictingScalarAggregation()
     {
         List<SqlFunction> functions = new FunctionListBuilder()
                 .scalars(ScalarSum.class)
                 .getFunctions();
 
-        createTestMetadataManager().addFunctions(functions);
+        assertThatThrownBy(() -> createTestMetadataManager().addFunctions(functions))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("'sum' is both an aggregation and a scalar function");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/metadata/TestSignatureBinder.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestSignatureBinder.java
@@ -296,7 +296,7 @@ public class TestSignatureBinder
                 .fails();
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class)
+    @Test
     public void testNoVariableReuseAcrossTypes()
     {
         TypeSignature leftType = new TypeSignature("decimal", TypeSignatureParameter.typeVariable("p1"), TypeSignatureParameter.typeVariable("s"));
@@ -307,9 +307,11 @@ public class TestSignatureBinder
                 .argumentTypes(leftType, rightType)
                 .build();
 
-        assertThat(function)
+        assertThatThrownBy(() -> assertThat(function)
                 .boundTo(createDecimalType(2, 1), createDecimalType(3, 1))
-                .produces(NO_BOUND_VARIABLES);
+                .produces(NO_BOUND_VARIABLES))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Literal parameters may not be shared across different types");
     }
 
     @Test


### PR DESCRIPTION
Linked to `@Test(expectedExceptions...)` cleanup issue #6974