### PR TITLE
Make grantee and table optional in GrantInfo

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -329,11 +329,11 @@ public class InformationSchemaPageSource
             addRecord(
                     grant.getGrantor().map(TrinoPrincipal::getName).orElse(null),
                     grant.getGrantor().map(principal -> principal.getType().toString()).orElse(null),
-                    grant.getGrantee().getName(),
-                    grant.getGrantee().getType().toString(),
+                    grant.getGrantee().map(TrinoPrincipal::getName).orElse(null),
+                    grant.getGrantee().map(principal -> principal.getType().toString()).orElse(null),
                     prefix.getCatalogName(),
-                    grant.getSchemaTableName().getSchemaName(),
-                    grant.getSchemaTableName().getTableName(),
+                    grant.getSchemaTablePrefix().getSchema().orElse(null),
+                    grant.getSchemaTablePrefix().getTable().orElse(null),
                     grant.getPrivilegeInfo().getPrivilege().name(),
                     grant.getPrivilegeInfo().isGrantOption() ? "YES" : "NO",
                     grant.getWithHierarchy().map(withHierarchy -> withHierarchy ? "YES" : "NO").orElse(null));

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -29,6 +29,7 @@ import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.GrantInfo;
+import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.spi.type.Type;
@@ -373,8 +374,8 @@ public class InformationSchemaPageSource
                     grant.getRoleName(),
                     null, // grantor
                     null, // grantor type
-                    grant.getGrantee().getName(),
-                    grant.getGrantee().getType().toString(),
+                    grant.getGrantee().map(TrinoPrincipal::getName).orElse(null),
+                    grant.getGrantee().map(TrinoPrincipal::getType).map(PrincipalType::toString).orElse(null),
                     grant.isGrantable() ? "YES" : "NO");
             if (isLimitExhausted()) {
                 return;
@@ -386,8 +387,8 @@ public class InformationSchemaPageSource
     {
         for (RoleGrant grant : metadata.listApplicableRoles(session, new TrinoPrincipal(USER, session.getUser()), Optional.of(catalogName))) {
             addRecord(
-                    grant.getGrantee().getName(),
-                    grant.getGrantee().getType().toString(),
+                    grant.getGrantee().map(TrinoPrincipal::getName).orElse(null),
+                    grant.getGrantee().map(TrinoPrincipal::getType).map(PrincipalType::toString).orElse(null),
                     grant.getRoleName(),
                     grant.isGrantable() ? "YES" : "NO");
             if (isLimitExhausted()) {

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -64,6 +64,7 @@ import io.trino.spi.connector.TopNApplicationResult;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.expression.ConnectorExpression;
 import io.trino.spi.procedure.Procedure;
+import io.trino.spi.security.GrantInfo;
 import io.trino.spi.security.Privilege;
 import io.trino.spi.security.RoleGrant;
 import io.trino.spi.security.TrinoPrincipal;
@@ -119,6 +120,7 @@ public class MockConnector
     private final BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties;
     private final Supplier<Iterable<EventListener>> eventListeners;
     private final MockConnectorFactory.ListRoleGrants roleGrants;
+    private final MockConnectorFactory.ListTablePrivileges listTablePrivileges;
     private final Optional<MockConnectorAccessControl> accessControl;
     private final Function<SchemaTableName, List<List<?>>> data;
     private final Set<Procedure> procedures;
@@ -145,6 +147,7 @@ public class MockConnector
             BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties,
             Supplier<Iterable<EventListener>> eventListeners,
             MockConnectorFactory.ListRoleGrants roleGrants,
+            MockConnectorFactory.ListTablePrivileges listTablePrivileges,
             Optional<MockConnectorAccessControl> accessControl,
             Function<SchemaTableName, List<List<?>>> data,
             Set<Procedure> procedures)
@@ -170,6 +173,7 @@ public class MockConnector
         this.getTableProperties = requireNonNull(getTableProperties, "getTableProperties is null");
         this.eventListeners = requireNonNull(eventListeners, "eventListeners is null");
         this.roleGrants = requireNonNull(roleGrants, "roleGrants is null");
+        this.listTablePrivileges = requireNonNull(listTablePrivileges, "listTablePrivileges is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.data = requireNonNull(data, "data is null");
         this.procedures = requireNonNull(procedures, "procedures is null");
@@ -609,6 +613,12 @@ public class MockConnector
         public void revokeTablePrivileges(ConnectorSession session, SchemaTableName tableName, Set<Privilege> privileges, TrinoPrincipal revokee, boolean grantOption)
         {
             getAccessControl().revokeTablePrivileges(tableName, privileges, revokee, grantOption);
+        }
+
+        @Override
+        public List<GrantInfo> listTablePrivileges(ConnectorSession session, SchemaTablePrefix prefix)
+        {
+            return listTablePrivileges.apply(session, prefix);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -565,7 +565,7 @@ public class MockConnector
         {
             return roleGrants.apply(session, Optional.empty(), Optional.empty(), OptionalLong.empty())
                     .stream()
-                    .filter(grant -> grant.getGrantee().equals(principal))
+                    .filter(grant -> grant.getGrantee().isEmpty() || grant.getGrantee().get().equals(principal))
                     .collect(toImmutableSet());
         }
 

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorAccessControl.java
@@ -85,7 +85,7 @@ class MockConnectorAccessControl
     public Set<SchemaTableName> filterTables(ConnectorSecurityContext context, Set<SchemaTableName> tableNames)
     {
         return tableNames.stream()
-                .filter(tableName -> canAccessSchema(context.getIdentity(), tableName.getSchemaName()) || canAccessTable(context.getIdentity(), tableName))
+                .filter(tableName -> canAccessSchema(context.getIdentity(), tableName.getSchemaName()) && canAccessTable(context.getIdentity(), tableName))
                 .collect(toImmutableSet());
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/security/GrantInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/GrantInfo.java
@@ -13,7 +13,7 @@
  */
 package io.trino.spi.security;
 
-import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SchemaTablePrefix;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -23,16 +23,16 @@ import static java.util.Objects.requireNonNull;
 public class GrantInfo
 {
     private final PrivilegeInfo privilegeInfo;
-    private final TrinoPrincipal grantee;
-    private final SchemaTableName schemaTableName;
+    private final Optional<TrinoPrincipal> grantee;
+    private final SchemaTablePrefix schemaTablePrefix;
     private final Optional<TrinoPrincipal> grantor;
     private final Optional<Boolean> withHierarchy;
 
-    public GrantInfo(PrivilegeInfo privilegeInfo, TrinoPrincipal grantee, SchemaTableName schemaTableName, Optional<TrinoPrincipal> grantor, Optional<Boolean> withHierarchy)
+    public GrantInfo(PrivilegeInfo privilegeInfo, Optional<TrinoPrincipal> grantee, SchemaTablePrefix schemaTablePrefix, Optional<TrinoPrincipal> grantor, Optional<Boolean> withHierarchy)
     {
         this.privilegeInfo = requireNonNull(privilegeInfo, "privilegeInfo is null");
         this.grantee = requireNonNull(grantee, "grantee is null");
-        this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
+        this.schemaTablePrefix = requireNonNull(schemaTablePrefix, "schemaTablePrefix is null");
         this.grantor = requireNonNull(grantor, "grantor is null");
         this.withHierarchy = requireNonNull(withHierarchy, "withHierarchy is null");
     }
@@ -42,14 +42,14 @@ public class GrantInfo
         return privilegeInfo;
     }
 
-    public TrinoPrincipal getGrantee()
+    public Optional<TrinoPrincipal> getGrantee()
     {
         return grantee;
     }
 
-    public SchemaTableName getSchemaTableName()
+    public SchemaTablePrefix getSchemaTablePrefix()
     {
-        return schemaTableName;
+        return schemaTablePrefix;
     }
 
     public Optional<TrinoPrincipal> getGrantor()
@@ -65,7 +65,7 @@ public class GrantInfo
     @Override
     public int hashCode()
     {
-        return Objects.hash(privilegeInfo, grantee, schemaTableName, grantor, withHierarchy);
+        return Objects.hash(privilegeInfo, grantee, schemaTablePrefix, grantor, withHierarchy);
     }
 
     @Override
@@ -80,7 +80,7 @@ public class GrantInfo
         GrantInfo grantInfo = (GrantInfo) o;
         return Objects.equals(privilegeInfo, grantInfo.getPrivilegeInfo()) &&
                 Objects.equals(grantee, grantInfo.getGrantee()) &&
-                Objects.equals(schemaTableName, grantInfo.getSchemaTableName()) &&
+                Objects.equals(schemaTablePrefix, grantInfo.getSchemaTablePrefix()) &&
                 Objects.equals(grantor, grantInfo.getGrantor()) &&
                 Objects.equals(withHierarchy, grantInfo.getWithHierarchy());
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/RoleGrant.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/RoleGrant.java
@@ -17,18 +17,24 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 public class RoleGrant
 {
-    private final TrinoPrincipal grantee;
+    private final Optional<TrinoPrincipal> grantee;
     private final String roleName;
     private final boolean grantable;
 
+    public RoleGrant(TrinoPrincipal grantee, String roleName, boolean grantable)
+    {
+        this(Optional.of(grantee), roleName, grantable);
+    }
+
     @JsonCreator
-    public RoleGrant(@JsonProperty("grantee") TrinoPrincipal grantee, @JsonProperty("roleName") String roleName, @JsonProperty("grantable") boolean grantable)
+    public RoleGrant(@JsonProperty("grantee") Optional<TrinoPrincipal> grantee, @JsonProperty("roleName") String roleName, @JsonProperty("grantable") boolean grantable)
     {
         this.grantee = requireNonNull(grantee, "grantee is null");
         this.roleName = requireNonNull(roleName, "roleName is null").toLowerCase(ENGLISH);
@@ -42,7 +48,7 @@ public class RoleGrant
     }
 
     @JsonProperty
-    public TrinoPrincipal getGrantee()
+    public Optional<TrinoPrincipal> getGrantee()
     {
         return grantee;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -934,7 +934,7 @@ public class FileHiveMetastore
             }
         }
         result.addAll(listRoleGrantsSanitized().stream()
-                .filter(grant -> HivePrincipal.from(grant.getGrantee()).equals(principal))
+                .filter(grant -> getGrantee(grant).equals(principal))
                 .collect(toSet()));
         return result.build();
     }
@@ -950,7 +950,7 @@ public class FileHiveMetastore
     {
         Map<RoleGranteeTuple, RoleGrant> map = new HashMap<>();
         for (RoleGrant grant : grants) {
-            RoleGranteeTuple tuple = new RoleGranteeTuple(grant.getRoleName(), HivePrincipal.from(grant.getGrantee()));
+            RoleGranteeTuple tuple = new RoleGranteeTuple(grant.getRoleName(), getGrantee(grant));
             map.merge(tuple, grant, (first, second) -> first.isGrantable() ? first : second);
         }
         return ImmutableSet.copyOf(map.values());
@@ -963,7 +963,7 @@ public class FileHiveMetastore
             if (!existingRoles.contains(grant.getRoleName())) {
                 continue;
             }
-            HivePrincipal grantee = HivePrincipal.from(grant.getGrantee());
+            HivePrincipal grantee = getGrantee(grant);
             if (grantee.getType() == ROLE && !existingRoles.contains(grantee.getName())) {
                 continue;
             }
@@ -1431,5 +1431,10 @@ public class FileHiveMetastore
                     .add("grantee", grantee)
                     .toString();
         }
+    }
+
+    private static HivePrincipal getGrantee(RoleGrant grant)
+    {
+        return HivePrincipal.from(grant.getGrantee().orElseThrow(() -> new IllegalStateException("Missing role grant grantee")));
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControlMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControlMetadata.java
@@ -23,6 +23,7 @@ import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SchemaTablePrefix;
 import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.security.GrantInfo;
 import io.trino.spi.security.PrincipalType;
@@ -237,8 +238,8 @@ public class SqlStandardAccessControlMetadata
             for (PrivilegeInfo prestoPrivilege : prestoPrivileges) {
                 GrantInfo grant = new GrantInfo(
                         prestoPrivilege,
-                        hivePrivilege.getGrantee().toTrinoPrincipal(),
-                        tableName,
+                        Optional.of(hivePrivilege.getGrantee().toTrinoPrincipal()),
+                        new SchemaTablePrefix(tableName.getSchemaName(), tableName.getTableName()),
                         Optional.of(hivePrivilege.getGrantor().toTrinoPrincipal()),
                         Optional.empty());
                 result.add(grant);

--- a/testing/trino-tests/src/test/java/io/trino/security/TestingSystemSecurityMetadata.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestingSystemSecurityMetadata.java
@@ -160,7 +160,7 @@ class TestingSystemSecurityMetadata
     private Set<RoleGrant> getRoleGrants(TrinoPrincipal principal)
     {
         return roleGrants.stream()
-                .filter(roleGrant -> roleGrant.getGrantee().equals(principal))
+                .filter(roleGrant -> roleGrant.getGrantee().isEmpty() || roleGrant.getGrantee().get().equals(principal))
                 .collect(toImmutableSet());
     }
 


### PR DESCRIPTION
Make grantee and table optional in GrantInfo

Grant can be added for all principals and it could be given for tables
in schema or even all tables in catalog.
