### PR TITLE
Fail rename materialized view across schemas

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
@@ -98,6 +98,9 @@ public class RenameMaterializedViewTask
         if (!materializedViewName.getCatalogName().equals(target.getCatalogName())) {
             throw semanticException(NOT_SUPPORTED, statement, "Materialized View rename across catalogs is not supported");
         }
+        if (!materializedViewName.getSchemaName().equals(target.getSchemaName())) {
+            throw semanticException(NOT_SUPPORTED, statement, "Materialized View rename across schemas is not supported");
+        }
 
         accessControl.checkCanRenameMaterializedView(session.toSecurityContext(), materializedViewName, target);
 


### PR DESCRIPTION
Currently, the iceberg connector does not support renaming materialized views across schemas but it fails silently.
This PR adds an explicit check for a rename to a different schema.