### PR TITLE
Execute checkCanExecuteFunction against canonical function name

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/ExpressionAnalyzer.java
@@ -1187,11 +1187,11 @@ public class ExpressionAnalyzer
                     coerceType(expression, actualType, expectedType, format("Function %s argument %d", function, i));
                 }
             }
-            accessControl.checkCanExecuteFunction(SecurityContext.of(session), node.getName().toString());
+            FunctionMetadata functionMetadata = metadata.getFunctionMetadata(function);
 
+            accessControl.checkCanExecuteFunction(SecurityContext.of(session), functionMetadata.getCanonicalName());
             resolvedFunctions.put(NodeRef.of(node), function);
 
-            FunctionMetadata functionMetadata = metadata.getFunctionMetadata(function);
             if (functionMetadata.isDeprecated()) {
                 warningCollector.add(new TrinoWarning(DEPRECATED_FUNCTION,
                         format("Use of deprecated function: %s: %s",

--- a/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
@@ -125,6 +125,10 @@ public class TestAccessControl
         assertAccessAllowed("SHOW CREATE TABLE lineitem", privilege("orders", SHOW_CREATE_TABLE));
         assertAccessDenied("SELECT abs(1)", "Cannot execute function abs", privilege("abs", EXECUTE_FUNCTION));
         assertAccessAllowed("SELECT abs(1)", privilege("max", EXECUTE_FUNCTION));
+        // test an access to "every" function which is an alias of "bool_and"
+        assertAccessDenied("SELECT every(x) FROM (VALUES true, true, true) t(x)", "Cannot execute function bool_and", privilege("bool_and", EXECUTE_FUNCTION));
+        assertAccessDenied("SELECT bool_and(x) FROM (VALUES true, true, true) t(x)", "Cannot execute function bool_and", privilege("bool_and", EXECUTE_FUNCTION));
+        assertAccessAllowed("SELECT every(x) FROM (VALUES true, true, true) t(x)", privilege("max", EXECUTE_FUNCTION));
         assertAccessAllowed("SHOW STATS FOR lineitem");
         assertAccessAllowed("SHOW STATS FOR lineitem", privilege("orders", SELECT_COLUMN));
         assertAccessAllowed("SHOW STATS FOR (SELECT * FROM lineitem)");


### PR DESCRIPTION
I guess that it would make sens to use canonical function name in the security context as well. Follow-up to https://github.com/trinodb/trino/pull/6042