### PR TITLE
Make Hive expression pushdown future-proof

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveApplyProjectionUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveApplyProjectionUtil.java
@@ -47,8 +47,8 @@ final class HiveApplyProjectionUtil
         }
 
         // If the whole expression is not supported, look for a partially supported projection
-        if (expression instanceof FieldDereference) {
-            fillSupportedProjectedColumns(((FieldDereference) expression).getTarget(), supportedSubExpressions);
+        for (ConnectorExpression child : expression.getChildren()) {
+            fillSupportedProjectedColumns(child, supportedSubExpressions);
         }
     }
 


### PR DESCRIPTION
Make code more generic so that when more expression pushdown
capabilities are added in the engine, Hive connector does not have to be
updated.