### PR TITLE
Consolidate transactional SQL support info

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -81,21 +81,6 @@ configuration file ``hive-site.xml`` (and restart the metastore service):
         <value>org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader</value>
     </property>
 
-Supported table types
----------------------
-
-Transactional and ACID tables
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-When connecting to a Hive metastore version 3.x, the Hive connector supports
-reading from and writing to insert-only and ACID tables, with full support for
-partitioning and bucketing. Row-level DELETE is supported for ACID tables,
-as well as SQL UPDATE.  UPDATE of partition key columns and bucket columns is
-not supported.
-
-ACID tables created with `Hive Streaming Ingest <https://cwiki.apache.org/confluence/display/Hive/Streaming+Data+Ingest>`_
-are not supported.
-
 Materialized views
 ------------------
 
@@ -679,6 +664,10 @@ The :ref:`sql-data-management` functionality includes support for ``INSERT``,
 ``UPDATE``, and ``DELETE`` statements, with the exact support depending on the
 storage system, file format, and metastore:
 
+When connecting to a Hive metastore version 3.x, the Hive connector supports
+reading from and writing to insert-only and ACID tables, with full support for
+partitioning and bucketing.
+
 :doc:`/sql/delete` applied to non-transactional tables is only supported if the
 table is partitioned and the ``WHERE`` clause matches entire partitions.
 Transactional Hive tables with ORC format support "row-by-row" deletion, in
@@ -686,6 +675,9 @@ which the ``WHERE`` clause may match arbitrary sets of rows.
 
 :doc:`/sql/update` is only supported for transactional Hive tables with format
 ORC. ``UPDATE`` of partition or bucket columns is not supported.
+
+ACID tables created with `Hive Streaming Ingest <https://cwiki.apache.org/confluence/display/Hive/Streaming+Data+Ingest>`_
+are not supported.
 
 Table statistics
 ----------------


### PR DESCRIPTION
Collapsing the transaction table info in the SQL support section and removing duplicate info as requested by @willmostly 