### PR TITLE
Update AWS SDK version to 1.12.85

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dep.antlr.version>4.9.2</dep.antlr.version>
         <dep.airlift.version>208</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.aws-sdk.version>1.11.946</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.12.85</dep.aws-sdk.version>
         <dep.okhttp.version>3.14.9</dep.okhttp.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
         <dep.drift.version>1.14</dep.drift.version>


### PR DESCRIPTION
Last release of 1.11.* was on June 4th.