### PR TITLE
Support Iceberg default warehouse location config

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConfig.java
@@ -17,10 +17,13 @@ import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
 import io.airlift.units.Duration;
 import io.trino.plugin.hive.HiveCompressionCodec;
+import io.trino.spi.function.Description;
 import org.apache.iceberg.FileFormat;
 
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+
+import java.util.Optional;
 
 import static io.trino.plugin.hive.HiveCompressionCodec.GZIP;
 import static io.trino.plugin.iceberg.CatalogType.HIVE_METASTORE;
@@ -35,6 +38,7 @@ public class IcebergConfig
     private int maxPartitionsPerWriter = 100;
     private boolean uniqueTableLocation;
     private CatalogType catalogType = HIVE_METASTORE;
+    private Optional<String> catalogWarehouse = Optional.empty();
     private Duration dynamicFilteringWaitTimeout = new Duration(0, SECONDS);
     private boolean tableStatisticsEnabled = true;
     private boolean projectionPushdownEnabled = true;
@@ -48,6 +52,20 @@ public class IcebergConfig
     public IcebergConfig setCatalogType(CatalogType catalogType)
     {
         this.catalogType = catalogType;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getCatalogWarehouse()
+    {
+        return catalogWarehouse;
+    }
+
+    @Config("iceberg.catalog.warehouse")
+    @Description("Iceberg default warehouse location, used to generate default table location")
+    public IcebergConfig setCatalogWarehouse(String warehouse)
+    {
+        this.catalogWarehouse = Optional.ofNullable(warehouse);
         return this;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoCatalogFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoCatalogFactory.java
@@ -23,6 +23,8 @@ import io.trino.spi.type.TypeManager;
 
 import javax.inject.Inject;
 
+import java.util.Optional;
+
 import static io.trino.plugin.hive.metastore.cache.CachingHiveMetastore.memoizeMetastore;
 import static io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity.SYSTEM;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -37,6 +39,7 @@ public class TrinoCatalogFactory
     private final IcebergTableOperationsProvider tableOperationsProvider;
     private final String trinoVersion;
     private final CatalogType catalogType;
+    private final Optional<String> catalogWarehouse;
     private final boolean isUniqueTableLocation;
     private final boolean isUsingSystemSecurity;
 
@@ -59,6 +62,7 @@ public class TrinoCatalogFactory
         this.trinoVersion = requireNonNull(nodeVersion, "trinoVersion is null").toString();
         requireNonNull(config, "config is null");
         this.catalogType = config.getCatalogType();
+        this.catalogWarehouse = config.getCatalogWarehouse();
         this.isUniqueTableLocation = config.isUniqueTableLocation();
         this.isUsingSystemSecurity = securityConfig.getSecuritySystem() == SYSTEM;
     }
@@ -75,6 +79,7 @@ public class TrinoCatalogFactory
                         typeManager,
                         tableOperationsProvider,
                         trinoVersion,
+                        catalogWarehouse,
                         isUniqueTableLocation,
                         isUsingSystemSecurity);
             case GLUE:

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConfig.java
@@ -42,6 +42,7 @@ public class TestIcebergConfig
                 .setMaxPartitionsPerWriter(100)
                 .setUniqueTableLocation(false)
                 .setCatalogType(HIVE_METASTORE)
+                .setCatalogWarehouse(null)
                 .setDynamicFilteringWaitTimeout(new Duration(0, MINUTES))
                 .setTableStatisticsEnabled(true)
                 .setProjectionPushdownEnabled(true));
@@ -60,6 +61,7 @@ public class TestIcebergConfig
                 .put("iceberg.dynamic-filtering.wait-timeout", "1h")
                 .put("iceberg.table-statistics-enabled", "false")
                 .put("iceberg.projection-pushdown-enabled", "false")
+                .put("iceberg.catalog.warehouse", "/tmp")
                 .build();
 
         IcebergConfig expected = new IcebergConfig()
@@ -71,7 +73,8 @@ public class TestIcebergConfig
                 .setCatalogType(GLUE)
                 .setDynamicFilteringWaitTimeout(Duration.valueOf("1h"))
                 .setTableStatisticsEnabled(false)
-                .setProjectionPushdownEnabled(false);
+                .setProjectionPushdownEnabled(false)
+                .setCatalogWarehouse("/tmp");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Support using a configurable warehouse location to determine the default table location.

This is to match the Iceberg side catalog behavior: https://github.com/apache/iceberg/blob/master/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java#L452-L459.

@losipiuk @findepi 