### PR TITLE
Allow a connector to subsume functional predicate

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1708,10 +1708,14 @@ public final class MetadataManager
 
         ConnectorSession connectorSession = session.toConnectorSession(catalogName);
         return metadata.applyFilter(connectorSession, table.getConnectorHandle(), constraint)
-                .map(result -> new ConstraintApplicationResult<>(
-                        new TableHandle(catalogName, result.getHandle(), table.getTransaction(), Optional.empty()),
-                        result.getRemainingFilter(),
-                        result.isPrecalculateStatistics()));
+                .map(result -> {
+                    checkState(!result.isPredicateSubsumed() || constraint.predicate().isPresent(), "Connector declared it subsumed predicate even though no predicate has been provided");
+                    return new ConstraintApplicationResult<>(
+                            new TableHandle(catalogName, result.getHandle(), table.getTransaction(), Optional.empty()),
+                            result.getRemainingFilter(),
+                            result.isPredicateSubsumed(),
+                            result.isPrecalculateStatistics());
+                });
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -912,7 +912,7 @@ public class PlanOptimizers
                 costCalculator,
                 ImmutableSet.<Rule<?>>builder()
                         .addAll(simplifyOptimizerRules) // Should be always run after PredicatePushDown
-                        .add(new PushPredicateIntoTableScan(metadata, typeOperators, typeAnalyzer))
+                        .add(new PushPredicateIntoTableScan(metadata, typeOperators, typeAnalyzer, true))
                         .build()));
         builder.add(inlineProjections);
         builder.add(new UnaliasSymbolReferences(metadata)); // Run unalias after merging projections to simplify projections more efficiently

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantTableScanPredicate.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantTableScanPredicate.java
@@ -153,6 +153,7 @@ public class RemoveRedundantTableScanPredicate
                 typeAnalyzer,
                 domainTranslator.toPredicate(unenforcedDomain.transformKeys(assignments::get)),
                 nonDeterministicPredicate,
+                TRUE_LITERAL,
                 decomposedPredicate.getRemainingExpression());
 
         if (!TRUE_LITERAL.equals(resultingPredicate)) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/sanity/DynamicFiltersChecker.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/sanity/DynamicFiltersChecker.java
@@ -16,6 +16,7 @@ package io.trino.sql.planner.sanity;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
+import io.trino.cost.StatsAndCosts;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.type.TypeOperators;
@@ -44,6 +45,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Sets.difference;
 import static com.google.common.collect.Sets.intersection;
+import static io.trino.sql.planner.planprinter.PlanPrinter.textLogicalPlan;
 
 /**
  * When dynamic filter assignments are present on a Join node, they should be consumed by a Filter node on it's probe side
@@ -60,6 +62,24 @@ public class DynamicFiltersChecker
             TypeAnalyzer typeAnalyzer,
             TypeProvider types,
             WarningCollector warningCollector)
+    {
+        try {
+            validate(plan);
+        }
+        catch (RuntimeException e) {
+            try {
+                int nestLevel = 4; // so that it renders reasonably within exception stacktrace
+                String explain = textLogicalPlan(plan, types, metadata, StatsAndCosts.empty(), session, nestLevel, false);
+                e.addSuppressed(new Exception("Current plan:\n" + explain));
+            }
+            catch (RuntimeException ignore) {
+                // ignored
+            }
+            throw e;
+        }
+    }
+
+    private void validate(PlanNode plan)
     {
         plan.accept(new PlanVisitor<Set<DynamicFilterId>, Void>()
         {

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConstraintApplicationResult.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConstraintApplicationResult.java
@@ -38,8 +38,14 @@ public class ConstraintApplicationResult<T>
     public ConstraintApplicationResult(T handle, TupleDomain<ColumnHandle> remainingFilter, boolean predicateSubsumed, boolean precalculateStatistics)
     {
         this.handle = requireNonNull(handle, "handle is null");
-        this.remainingFilter = requireNonNull(remainingFilter, "remainingFilter is null");
+
+        requireNonNull(remainingFilter, "remainingFilter is null");
+        if (predicateSubsumed && !remainingFilter.isAll()) {
+            throw new IllegalArgumentException("Invalid remaining filter when predicate is subsumed: " + remainingFilter);
+        }
+        this.remainingFilter = remainingFilter;
         this.predicateSubsumed = predicateSubsumed;
+
         this.precalculateStatistics = precalculateStatistics;
     }
 

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConstraintApplicationResult.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConstraintApplicationResult.java
@@ -21,16 +21,25 @@ public class ConstraintApplicationResult<T>
 {
     private final T handle;
     private final TupleDomain<ColumnHandle> remainingFilter;
+    private final boolean predicateSubsumed;
     private final boolean precalculateStatistics;
 
+    @Deprecated
+    public ConstraintApplicationResult(T handle, TupleDomain<ColumnHandle> remainingFilter, boolean precalculateStatistics)
+    {
+        this(handle, remainingFilter, false, precalculateStatistics);
+    }
+
     /**
+     * @param predicateSubsumed Indicates whether connector subsumed {@link Constraint#predicate()}
      * @param precalculateStatistics Indicates whether engine should consider calculating statistics based on the plan before pushdown,
      * as the connector may be unable to provide good table statistics for {@code handle}.
      */
-    public ConstraintApplicationResult(T handle, TupleDomain<ColumnHandle> remainingFilter, boolean precalculateStatistics)
+    public ConstraintApplicationResult(T handle, TupleDomain<ColumnHandle> remainingFilter, boolean predicateSubsumed, boolean precalculateStatistics)
     {
         this.handle = requireNonNull(handle, "handle is null");
         this.remainingFilter = requireNonNull(remainingFilter, "remainingFilter is null");
+        this.predicateSubsumed = predicateSubsumed;
         this.precalculateStatistics = precalculateStatistics;
     }
 
@@ -42,6 +51,11 @@ public class ConstraintApplicationResult<T>
     public TupleDomain<ColumnHandle> getRemainingFilter()
     {
         return remainingFilter;
+    }
+
+    public boolean isPredicateSubsumed()
+    {
+        return predicateSubsumed;
     }
 
     public boolean isPrecalculateStatistics()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2249,7 +2249,11 @@ public class HiveMetadata
             return Optional.empty();
         }
 
-        return Optional.of(new ConstraintApplicationResult<>(newHandle, partitionResult.getUnenforcedConstraint(), false));
+        return Optional.of(new ConstraintApplicationResult<>(
+                newHandle,
+                partitionResult.getUnenforcedConstraint(),
+                partitionResult.isSubsumedFunctionalPredicate(),
+                false));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2245,7 +2245,8 @@ public class HiveMetadata
         if (handle.getPartitions().equals(newHandle.getPartitions()) &&
                 handle.getCompactEffectivePredicate().equals(newHandle.getCompactEffectivePredicate()) &&
                 handle.getBucketFilter().equals(newHandle.getBucketFilter()) &&
-                handle.getConstraintColumns().equals(newHandle.getConstraintColumns())) {
+                handle.getConstraintColumns().equals(newHandle.getConstraintColumns()) &&
+                !partitionResult.isSubsumedFunctionalPredicate()) {
             return Optional.empty();
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionResult.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePartitionResult.java
@@ -38,6 +38,7 @@ public class HivePartitionResult
     private final TupleDomain<HiveColumnHandle> compactEffectivePredicate;
     private final TupleDomain<ColumnHandle> unenforcedConstraint;
     private final TupleDomain<ColumnHandle> enforcedConstraint;
+    private final boolean subsumedFunctionalPredicate;
     private final Optional<HiveBucketHandle> bucketHandle;
     private final Optional<HiveBucketFilter> bucketFilter;
 
@@ -47,6 +48,7 @@ public class HivePartitionResult
             TupleDomain<HiveColumnHandle> compactEffectivePredicate,
             TupleDomain<ColumnHandle> unenforcedConstraint,
             TupleDomain<ColumnHandle> enforcedConstraint,
+            boolean subsumedFunctionalPredicate,
             Optional<HiveBucketHandle> bucketHandle,
             Optional<HiveBucketFilter> bucketFilter)
     {
@@ -55,6 +57,7 @@ public class HivePartitionResult
         this.compactEffectivePredicate = requireNonNull(compactEffectivePredicate, "compactEffectivePredicate is null");
         this.unenforcedConstraint = requireNonNull(unenforcedConstraint, "unenforcedConstraint is null");
         this.enforcedConstraint = requireNonNull(enforcedConstraint, "enforcedConstraint is null");
+        this.subsumedFunctionalPredicate = subsumedFunctionalPredicate;
         this.bucketHandle = requireNonNull(bucketHandle, "bucketHandle is null");
         this.bucketFilter = requireNonNull(bucketFilter, "bucketFilter is null");
     }
@@ -82,6 +85,11 @@ public class HivePartitionResult
     public TupleDomain<ColumnHandle> getEnforcedConstraint()
     {
         return enforcedConstraint;
+    }
+
+    public boolean isSubsumedFunctionalPredicate()
+    {
+        return subsumedFunctionalPredicate;
     }
 
     public Optional<HiveBucketHandle> getBucketHandle()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
@@ -142,8 +142,7 @@ public class TestHivePlans
                 "SELECT * FROM table_str_partitioned WHERE str_part LIKE 't%'",
                 output(
                         exchange(REMOTE, GATHER,
-                                filter("\"like\"(STR_PART, \"$like_pattern\"('t%'))",
-                                        tableScan("table_str_partitioned", Map.of("INT_COL", "int_col", "STR_PART", "str_part"))))));
+                                tableScan("table_str_partitioned", Map.of("INT_COL", "int_col", "STR_PART", "str_part")))));
     }
 
     @Test

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
@@ -162,7 +162,7 @@ public class TestHivePlans
                                 join(INNER, List.of(equiJoinClause("L_STR_PART", "R_STR_COL")),
                                         exchange(REMOTE, REPARTITION,
                                                 project(
-                                                        filter("\"like\"(L_STR_PART, \"$like_pattern\"('t%'))",
+                                                        filter("true", // dynamic filter
                                                                 tableScan("table_str_partitioned", Map.of("L_INT_COL", "int_col", "L_STR_PART", "str_part"))))),
                                         exchange(LOCAL,
                                                 exchange(REMOTE, REPARTITION,
@@ -233,7 +233,7 @@ public class TestHivePlans
                                 join(INNER, List.of(equiJoinClause("L_INT_PART", "R_INT_COL")),
                                         exchange(REMOTE, REPARTITION,
                                                 project(
-                                                        filter("substring(L_STR_COL, BIGINT '2') != CAST('hree' AS varchar(5))",
+                                                        filter("substring(L_STR_COL, BIGINT '2') != CAST('hree' AS varchar(5)) AND L_INT_PART IN (2, 3, 4)",
                                                                 tableScan("table_int_partitioned", Map.of("L_INT_PART", "int_part", "L_STR_COL", "str_col"))))),
                                         exchange(LOCAL,
                                                 exchange(REMOTE, REPARTITION,
@@ -257,7 +257,7 @@ public class TestHivePlans
                                 join(INNER, List.of(equiJoinClause("L_INT_PART", "R_INT_COL")),
                                         exchange(REMOTE, REPARTITION,
                                                 project(
-                                                        filter("L_INT_PART % 2 = 0",
+                                                        filter("true", // dynamic filter
                                                                 tableScan("table_int_partitioned", Map.of("L_INT_PART", "int_part", "L_STR_COL", "str_col"))))),
                                         exchange(LOCAL,
                                                 exchange(REMOTE, REPARTITION,


### PR DESCRIPTION
Let connector declare whether it was able to fully evaluate
`Constraint#predicate` and thus the filter can be simplified in the
plan.