### PR TITLE
Fix RangeView#formatRange for single value

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -1163,9 +1163,8 @@ public final class SortedRangeSet
 
         public String formatRange(ConnectorSession session)
         {
-            Optional<Object> singleValue = getSingleValue();
-            if (singleValue.isPresent()) {
-                return format("[%s]", singleValue.get());
+            if (isSingleValue()) {
+                return format("[%s]", type.getObjectValue(session, lowValueBlock, lowValuePosition));
             }
 
             Object lowValue = isLowUnbounded()

--- a/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/predicate/TestSortedRangeSet.java
@@ -91,6 +91,10 @@ public class TestSortedRangeSet
         assertTrue(rangeSet.containsValue(10L));
         assertFalse(rangeSet.containsValue(9L));
         assertEquals(rangeSet.toString(), "SortedRangeSet[type=bigint, ranges=1, {[10]}]");
+
+        assertEquals(
+                SortedRangeSet.of(Range.equal(VARCHAR, utf8Slice("LARGE PLATED NICKEL"))).toString(),
+                "SortedRangeSet[type=varchar, ranges=1, {[LARGE PLATED NICKEL]}]");
     }
 
     @Test


### PR DESCRIPTION
Currently we print output like
[Slice{base=[B@11cd5fc6, address=65, length=10}]
instead of the actual value