### PR TITLE
Remove obsolete property override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,6 @@
         <dep.docker-java.version>3.2.11</dep.docker-java.version>
         <dep.coral.version>1.0.120</dep.coral.version>
         <dep.confluent.version>5.5.2</dep.confluent.version>
-        <!-- TODO: update after moving to Airbase 112 -->
-        <dep.jackson.version>2.12.3</dep.jackson.version>
         <dep.parquet.version>1.11.1</dep.parquet.version>
 
         <!--


### PR DESCRIPTION
We're already on Airbase 112, which declares this exact version of Jackson, so this override is no longer necessary.