### PR TITLE
Fix flaky Docker image pulls in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ env:
   MAVEN_FAST_INSTALL: "-B --strict-checksums -V --quiet -T C1 -DskipTests -Dair.check.skip-all"
   MAVEN_TEST: "-B --strict-checksums -Dair.check.skip-all --fail-at-end"
   RETRY: .github/bin/retry
+  # Testcontainers kills image pulls if they don't make progress for > 30s and retries for 2m before failing. This means
+  # that if an image doesn't download all it's layers within ~2m then any other concurrent pull will be killed because
+  # the Docker daemon only downloads 3 layers concurrently which prevents the other pull from making any progress.
+  # This value should be greater than the time taken for the longest image pull.
+  TESTCONTAINERS_PULL_PAUSE_TIMEOUT: 600
 
 # Cancel previous PR builds.
 concurrency:


### PR DESCRIPTION
Testcontainers kills image pulls if they don't make progress for > 30
seconds and retries for 2 mins before giving up.

This is not sufficient if multiple Docker images are being downloaded
concurrently because the Docker daemon can only download 3 layers
concurrently (by default). This means that if the first image doesn't
download all it's layers within ~2 mins then the other concurrent pull
will be killed by Testcontainers because it looks stuck.

So we increase the amount of time Testcontainers should wait before
considering a pull to be hung to 5 mins which is greater than the time
taken to download any single image on CI (HDP3.1 is the largest at ~2
min).

Fixes #9444.