### PR TITLE
Make IcebergSplit immutable

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -264,7 +264,7 @@ public class IcebergMetadata
 
             Iterable<TupleDomain<ColumnHandle>> discreteTupleDomain = Iterables.transform(files, fileScan -> {
                 // Extract partition values in the data file
-                Map<Integer, String> partitionColumnValueStrings = getPartitionKeys(fileScan);
+                Map<Integer, Optional<String>> partitionColumnValueStrings = getPartitionKeys(fileScan);
                 Map<ColumnHandle, NullableValue> partitionValues = partitionSourceIds.stream()
                         .filter(partitionColumnValueStrings::containsKey)
                         .collect(toImmutableMap(
@@ -273,7 +273,7 @@ public class IcebergMetadata
                                     IcebergColumnHandle column = columns.get(columnId);
                                     Object prestoValue = deserializePartitionValue(
                                             column.getType(),
-                                            partitionColumnValueStrings.get(columnId),
+                                            partitionColumnValueStrings.get(columnId).orElse(null),
                                             column.getName(),
                                             session.getTimeZoneKey());
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSource.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.OptionalLong;
 
 import static com.google.common.base.Throwables.throwIfInstanceOf;
@@ -42,7 +43,7 @@ public class IcebergPageSource
 
     public IcebergPageSource(
             List<IcebergColumnHandle> columns,
-            Map<Integer, String> partitionKeys,
+            Map<Integer, Optional<String>> partitionKeys,
             ConnectorPageSource delegate,
             TimeZoneKey timeZoneKey)
     {
@@ -57,7 +58,7 @@ public class IcebergPageSource
         int delegateIndex = 0;
         for (IcebergColumnHandle column : columns) {
             if (partitionKeys.containsKey(column.getId())) {
-                String partitionValue = partitionKeys.get(column.getId());
+                String partitionValue = partitionKeys.get(column.getId()).orElse(null);
                 Type type = column.getType();
                 Object prefilledValue = deserializePartitionValue(type, partitionValue, column.getName(), timeZoneKey);
                 prefilledBlocks[outputIndex] = Utils.nativeValueToBlock(type, prefilledValue);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergPageSourceProvider.java
@@ -164,7 +164,7 @@ public class IcebergPageSourceProvider
                 .map(IcebergColumnHandle.class::cast)
                 .collect(toImmutableList());
 
-        Map<Integer, String> partitionKeys = split.getPartitionKeys();
+        Map<Integer, Optional<String>> partitionKeys = split.getPartitionKeys();
 
         List<IcebergColumnHandle> regularColumns = columns.stream()
                 .map(IcebergColumnHandle.class::cast)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplit.java
@@ -21,9 +21,9 @@ import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 import org.apache.iceberg.FileFormat;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -37,7 +37,7 @@ public class IcebergSplit
     private final long fileSize;
     private final FileFormat fileFormat;
     private final List<HostAddress> addresses;
-    private final Map<Integer, String> partitionKeys;
+    private final Map<Integer, Optional<String>> partitionKeys;
 
     @JsonCreator
     public IcebergSplit(
@@ -47,7 +47,7 @@ public class IcebergSplit
             @JsonProperty("fileSize") long fileSize,
             @JsonProperty("fileFormat") FileFormat fileFormat,
             @JsonProperty("addresses") List<HostAddress> addresses,
-            @JsonProperty("partitionKeys") Map<Integer, String> partitionKeys)
+            @JsonProperty("partitionKeys") Map<Integer, Optional<String>> partitionKeys)
     {
         this.path = requireNonNull(path, "path is null");
         this.start = start;
@@ -55,7 +55,7 @@ public class IcebergSplit
         this.fileSize = fileSize;
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
         this.addresses = ImmutableList.copyOf(requireNonNull(addresses, "addresses is null"));
-        this.partitionKeys = Collections.unmodifiableMap(requireNonNull(partitionKeys, "partitionKeys is null"));
+        this.partitionKeys = ImmutableMap.copyOf(requireNonNull(partitionKeys, "partitionKeys is null"));
     }
 
     @Override
@@ -102,7 +102,7 @@ public class IcebergSplit
     }
 
     @JsonProperty
-    public Map<Integer, String> getPartitionKeys()
+    public Map<Integer, Optional<String>> getPartitionKeys()
     {
         return partitionKeys;
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -262,7 +263,7 @@ public class IcebergSplitSource
     @VisibleForTesting
     static boolean partitionMatchesPredicate(
             Set<IcebergColumnHandle> identityPartitionColumns,
-            Map<Integer, String> partitionKeys,
+            Map<Integer, Optional<String>> partitionKeys,
             TupleDomain<IcebergColumnHandle> dynamicFilterPredicate,
             TimeZoneKey timeZoneKey)
     {
@@ -274,7 +275,7 @@ public class IcebergSplitSource
         for (IcebergColumnHandle partitionColumn : identityPartitionColumns) {
             Domain allowedDomain = domains.get(partitionColumn);
             if (allowedDomain != null) {
-                Object partitionValue = deserializePartitionValue(partitionColumn.getType(), partitionKeys.get(partitionColumn.getId()), partitionColumn.getName(), timeZoneKey);
+                Object partitionValue = deserializePartitionValue(partitionColumn.getType(), partitionKeys.get(partitionColumn.getId()).orElse(null), partitionColumn.getName(), timeZoneKey);
                 if (!allowedDomain.includesNullableValue(partitionValue)) {
                     return false;
                 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSplitSource.java
@@ -179,17 +179,17 @@ public class TestIcebergSplitSource
         IcebergColumnHandle bigintColumn = IcebergColumnHandle.primitiveIcebergColumnHandle(1, "name", BIGINT, Optional.empty());
         assertFalse(IcebergSplitSource.partitionMatchesPredicate(
                 ImmutableSet.of(bigintColumn),
-                ImmutableMap.of(1, "1000"),
+                ImmutableMap.of(1, Optional.of("1000")),
                 TupleDomain.fromFixedValues(ImmutableMap.of(bigintColumn, NullableValue.of(BIGINT, 100L))),
                 TimeZoneKey.UTC_KEY));
         assertTrue(IcebergSplitSource.partitionMatchesPredicate(
                 ImmutableSet.of(bigintColumn),
-                ImmutableMap.of(1, "1000"),
+                ImmutableMap.of(1, Optional.of("1000")),
                 TupleDomain.fromFixedValues(ImmutableMap.of(bigintColumn, NullableValue.of(BIGINT, 1000L))),
                 TimeZoneKey.UTC_KEY));
         assertFalse(IcebergSplitSource.partitionMatchesPredicate(
                 ImmutableSet.of(bigintColumn),
-                ImmutableMap.of(1, "1000"),
+                ImmutableMap.of(1, Optional.of("1000")),
                 TupleDomain.fromFixedValues(ImmutableMap.of(bigintColumn, NullableValue.asNull(BIGINT))),
                 TimeZoneKey.UTC_KEY));
     }


### PR DESCRIPTION
Let `IcebergSplit` make a defensive copy of `partitionKeys` map. Since
map can contain values for null partition keys, this also wraps values
with `Optional`.

In current code, `IcebergSplit` was created from an effectively
immutable collection, so immutability was guaranteed by the caller. Now
it's guaranteed by the class itself.