### PR TITLE
Simplify all types test 

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -618,25 +618,21 @@ public abstract class BaseIcebergConnectorTest
                 "   _x bigint\n" +
                 ")\n" +
                 "WITH (\n" +
-                "   format = '%s'\n" +
+                "   format = '" + format + "'\n" +
                 ")";
-        @Language("SQL") String createTableSql = format(createTableTemplate, "test table comment", format);
+        String createTableSql = format(createTableTemplate, "test table comment", format);
         assertUpdate(createTableSql);
-        MaterializedResult resultOfCreate = computeActual("SHOW CREATE TABLE test_table_comments");
-        assertEquals(getOnlyElement(resultOfCreate.getOnlyColumnAsSet()), createTableSql);
+        assertEquals(computeScalar("SHOW CREATE TABLE test_table_comments"), createTableSql);
 
         assertUpdate("COMMENT ON TABLE test_table_comments IS 'different test table comment'");
-        MaterializedResult resultOfCommentChange = computeActual("SHOW CREATE TABLE test_table_comments");
-        String afterChangeSql = format(createTableTemplate, "different test table comment", format);
-        assertEquals(getOnlyElement(resultOfCommentChange.getOnlyColumnAsSet()), afterChangeSql);
+        assertEquals(computeScalar("SHOW CREATE TABLE test_table_comments"), format(createTableTemplate, "different test table comment", format));
 
         assertUpdate("COMMENT ON TABLE test_table_comments IS NULL");
-        MaterializedResult resultOfRemovingComment = computeActual("SHOW CREATE TABLE test_table_comments");
-        assertEquals(getOnlyElement(resultOfRemovingComment.getOnlyColumnAsSet()), format(createTableWithoutComment, format));
+        assertEquals(computeScalar("SHOW CREATE TABLE test_table_comments"), createTableWithoutComment);
         dropTable("iceberg.tpch.test_table_comments");
 
-        assertUpdate(format(createTableWithoutComment, format));
-        assertEquals(computeScalar("SHOW CREATE TABLE test_table_comments"), format(createTableWithoutComment, format));
+        assertUpdate(createTableWithoutComment);
+        assertEquals(computeScalar("SHOW CREATE TABLE test_table_comments"), createTableWithoutComment);
 
         dropTable("iceberg.tpch.test_table_comments");
     }


### PR DESCRIPTION
Use query-based test instead of much more verbose
`MaterializedResult`-based assertion.