### PR TITLE
Reduce allocations related to OperatorStats

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
@@ -381,11 +381,6 @@ public class DriverContext
             outputPositions = 0;
         }
 
-        long physicalWrittenDataSize = operators.stream()
-                .map(OperatorStats::getPhysicalWrittenDataSize)
-                .mapToLong(DataSize::toBytes)
-                .sum();
-
         long startNanos = this.startNanos.get();
         if (startNanos < createNanos) {
             startNanos = System.nanoTime();
@@ -402,8 +397,9 @@ public class DriverContext
         }
 
         ImmutableSet.Builder<BlockedReason> builder = ImmutableSet.builder();
-
+        long physicalWrittenDataSize = 0;
         for (OperatorStats operator : operators) {
+            physicalWrittenDataSize += operator.getPhysicalWrittenDataSize().toBytes();
             if (operator.getBlockedReason().isPresent()) {
                 builder.add(operator.getBlockedReason().get());
             }

--- a/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
@@ -144,9 +144,10 @@ public class DriverContext
 
     public void startProcessTimer()
     {
-        if (startNanos.compareAndSet(0, System.nanoTime())) {
-            pipelineContext.start();
+        // Must update startNanos first so that the value is valid once executionStartTime is not null
+        if (executionStartTime.get() == null && startNanos.compareAndSet(0, System.nanoTime())) {
             executionStartTime.set(DateTime.now());
+            pipelineContext.start();
         }
     }
 
@@ -175,8 +176,9 @@ public class DriverContext
             // already finished
             return;
         }
-        executionEndTime.set(DateTime.now());
+        // Must update endNanos first, so that the value is valid after executionEndTime is not null
         endNanos.set(System.nanoTime());
+        executionEndTime.set(DateTime.now());
 
         pipelineContext.driverFinished(this);
     }
@@ -322,6 +324,14 @@ public class DriverContext
             totalBlockedTime += blockedMonitor.getBlockedTime();
         }
 
+        // startNanos is always valid once executionStartTime is not null
+        DateTime executionStartTime = this.executionStartTime.get();
+        Duration queuedTime = new Duration(nanosBetween(createNanos, executionStartTime == null ? System.nanoTime() : startNanos.get()), NANOSECONDS);
+
+        // endNanos is always valid once executionStartTime is not null
+        DateTime executionEndTime = this.executionEndTime.get();
+        Duration elapsedTime = new Duration(nanosBetween(createNanos, executionEndTime == null ? System.nanoTime() : endNanos.get()), NANOSECONDS);
+
         List<OperatorStats> operators = getOperatorStats();
         OperatorStats inputOperator = getFirst(operators, null);
 
@@ -381,21 +391,6 @@ public class DriverContext
             outputPositions = 0;
         }
 
-        long startNanos = this.startNanos.get();
-        if (startNanos < createNanos) {
-            startNanos = System.nanoTime();
-        }
-        Duration queuedTime = new Duration(startNanos - createNanos, NANOSECONDS);
-
-        long endNanos = this.endNanos.get();
-        Duration elapsedTime;
-        if (endNanos >= startNanos) {
-            elapsedTime = new Duration(endNanos - createNanos, NANOSECONDS);
-        }
-        else {
-            elapsedTime = new Duration(System.nanoTime() - createNanos, NANOSECONDS);
-        }
-
         ImmutableSet.Builder<BlockedReason> builder = ImmutableSet.builder();
         long physicalWrittenDataSize = 0;
         for (OperatorStats operator : operators) {
@@ -408,8 +403,8 @@ public class DriverContext
         return new DriverStats(
                 lifespan,
                 createdTime,
-                executionStartTime.get(),
-                executionEndTime.get(),
+                executionStartTime,
+                executionEndTime,
                 queuedTime.convertToMostSuccinctTimeUnit(),
                 elapsedTime.convertToMostSuccinctTimeUnit(),
                 succinctBytes(driverMemoryContext.getUserMemory()),

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.stats.CounterStat;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.memory.QueryContextVisitor;
@@ -46,7 +47,6 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
-import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.operator.BlockedReason.WAITING_FOR_MEMORY;
 import static io.trino.operator.Operator.NOT_BLOCKED;
 import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -546,26 +546,26 @@ public class OperatorContext
                 addInputTiming.getCalls(),
                 new Duration(addInputTiming.getWallNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 new Duration(addInputTiming.getCpuNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                succinctBytes(physicalInputDataSize.getTotalCount()),
+                DataSize.ofBytes(physicalInputDataSize.getTotalCount()),
                 physicalInputPositions.getTotalCount(),
-                succinctBytes(internalNetworkInputDataSize.getTotalCount()),
+                DataSize.ofBytes(internalNetworkInputDataSize.getTotalCount()),
                 internalNetworkPositions.getTotalCount(),
-                succinctBytes(physicalInputDataSize.getTotalCount() + internalNetworkInputDataSize.getTotalCount()),
-                succinctBytes(inputDataSize.getTotalCount()),
+                DataSize.ofBytes(physicalInputDataSize.getTotalCount() + internalNetworkInputDataSize.getTotalCount()),
+                DataSize.ofBytes(inputDataSize.getTotalCount()),
                 inputPositionsCount,
                 (double) inputPositionsCount * inputPositionsCount,
 
                 getOutputTiming.getCalls(),
                 new Duration(getOutputTiming.getWallNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 new Duration(getOutputTiming.getCpuNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                succinctBytes(outputDataSize.getTotalCount()),
+                DataSize.ofBytes(outputDataSize.getTotalCount()),
                 outputPositions.getTotalCount(),
 
                 dynamicFilterSplitsProcessed.get(),
                 metrics.get(),
                 connectorMetrics.get(),
 
-                succinctBytes(physicalWrittenDataSize.get()),
+                DataSize.ofBytes(physicalWrittenDataSize.get()),
 
                 new Duration(blockedWallNanos.get(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
 
@@ -573,16 +573,16 @@ public class OperatorContext
                 new Duration(finishTiming.getWallNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 new Duration(finishTiming.getCpuNanos(), NANOSECONDS).convertToMostSuccinctTimeUnit(),
 
-                succinctBytes(operatorMemoryContext.getUserMemory()),
-                succinctBytes(getReservedRevocableBytes()),
-                succinctBytes(operatorMemoryContext.getSystemMemory()),
+                DataSize.ofBytes(operatorMemoryContext.getUserMemory()),
+                DataSize.ofBytes(getReservedRevocableBytes()),
+                DataSize.ofBytes(operatorMemoryContext.getSystemMemory()),
 
-                succinctBytes(peakUserMemoryReservation.get()),
-                succinctBytes(peakSystemMemoryReservation.get()),
-                succinctBytes(peakRevocableMemoryReservation.get()),
-                succinctBytes(peakTotalMemoryReservation.get()),
+                DataSize.ofBytes(peakUserMemoryReservation.get()),
+                DataSize.ofBytes(peakSystemMemoryReservation.get()),
+                DataSize.ofBytes(peakRevocableMemoryReservation.get()),
+                DataSize.ofBytes(peakTotalMemoryReservation.get()),
 
-                succinctBytes(spillContext.getSpilledBytes()),
+                DataSize.ofBytes(spillContext.getSpilledBytes()),
 
                 memoryFuture.get().isDone() ? Optional.empty() : Optional.of(WAITING_FOR_MEMORY),
                 info);

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
@@ -86,6 +86,7 @@ public class OperatorStats
 
     private final Optional<BlockedReason> blockedReason;
 
+    @Nullable
     private final OperatorInfo info;
 
     @JsonCreator
@@ -140,6 +141,7 @@ public class OperatorStats
 
             @JsonProperty("blockedReason") Optional<BlockedReason> blockedReason,
 
+            @Nullable
             @JsonProperty("info") OperatorInfo info)
     {
         this.stageId = stageId;
@@ -623,6 +625,10 @@ public class OperatorStats
 
     public OperatorStats summarize()
     {
+        if (info == null || info.isFinal()) {
+            return this;
+        }
+        OperatorInfo info = null;
         return new OperatorStats(
                 stageId,
                 pipelineId,
@@ -663,6 +669,6 @@ public class OperatorStats
                 peakTotalMemoryReservation,
                 spilledDataSize,
                 blockedReason,
-                (info != null && info.isFinal()) ? info : null);
+                info);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
@@ -443,9 +443,9 @@ public class OperatorStats
         return info;
     }
 
-    public OperatorStats add(OperatorStats... operators)
+    public OperatorStats add(OperatorStats operatorStats)
     {
-        return add(ImmutableList.copyOf(operators));
+        return add(ImmutableList.of(operatorStats));
     }
 
     public OperatorStats add(Iterable<OperatorStats> operators)

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorStats.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
-import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -564,26 +563,26 @@ public class OperatorStats
                 addInputCalls,
                 new Duration(addInputWall, NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 new Duration(addInputCpu, NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                succinctBytes(physicalInputDataSize),
+                DataSize.ofBytes(physicalInputDataSize),
                 physicalInputPositions,
-                succinctBytes(internalNetworkInputDataSize),
+                DataSize.ofBytes(internalNetworkInputDataSize),
                 internalNetworkInputPositions,
-                succinctBytes(rawInputDataSize),
-                succinctBytes(inputDataSize),
+                DataSize.ofBytes(rawInputDataSize),
+                DataSize.ofBytes(inputDataSize),
                 inputPositions,
                 sumSquaredInputPositions,
 
                 getOutputCalls,
                 new Duration(getOutputWall, NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 new Duration(getOutputCpu, NANOSECONDS).convertToMostSuccinctTimeUnit(),
-                succinctBytes(outputDataSize),
+                DataSize.ofBytes(outputDataSize),
                 outputPositions,
 
                 dynamicFilterSplitsProcessed,
                 metricsAccumulator.get(),
                 connectorMetricsAccumulator.get(),
 
-                succinctBytes(physicalWrittenDataSize),
+                DataSize.ofBytes(physicalWrittenDataSize),
 
                 new Duration(blockedWall, NANOSECONDS).convertToMostSuccinctTimeUnit(),
 
@@ -591,15 +590,15 @@ public class OperatorStats
                 new Duration(finishWall, NANOSECONDS).convertToMostSuccinctTimeUnit(),
                 new Duration(finishCpu, NANOSECONDS).convertToMostSuccinctTimeUnit(),
 
-                succinctBytes(memoryReservation),
-                succinctBytes(revocableMemoryReservation),
-                succinctBytes(systemMemoryReservation),
-                succinctBytes(peakUserMemory),
-                succinctBytes(peakSystemMemory),
-                succinctBytes(peakRevocableMemory),
-                succinctBytes(peakTotalMemory),
+                DataSize.ofBytes(memoryReservation),
+                DataSize.ofBytes(revocableMemoryReservation),
+                DataSize.ofBytes(systemMemoryReservation),
+                DataSize.ofBytes(peakUserMemory),
+                DataSize.ofBytes(peakSystemMemory),
+                DataSize.ofBytes(peakRevocableMemory),
+                DataSize.ofBytes(peakTotalMemory),
 
-                succinctBytes(spilledDataSize),
+                DataSize.ofBytes(spilledDataSize),
 
                 blockedReason,
 

--- a/core/trino-main/src/main/java/io/trino/operator/PipelineStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PipelineStats.java
@@ -27,7 +27,6 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -488,9 +487,17 @@ public class PipelineStats
                 outputDataSize,
                 outputPositions,
                 physicalWrittenDataSize,
-                operatorSummaries.stream()
-                        .map(OperatorStats::summarize)
-                        .collect(Collectors.toList()),
+                summarizeOperatorStats(operatorSummaries),
                 ImmutableList.of());
+    }
+
+    private static List<OperatorStats> summarizeOperatorStats(List<OperatorStats> operatorSummaries)
+    {
+        // Use an exact size ImmutableList builder to avoid a redundant copy in the PipelineStats constructor
+        ImmutableList.Builder<OperatorStats> results = ImmutableList.builderWithExpectedSize(operatorSummaries.size());
+        for (OperatorStats operatorStats : operatorSummaries) {
+            results.add(operatorStats.summarize());
+        }
+        return results.build();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -598,8 +597,16 @@ public class TaskStats
                 physicalWrittenDataSize,
                 fullGcCount,
                 fullGcTime,
-                pipelines.stream()
-                        .map(PipelineStats::summarize)
-                        .collect(Collectors.toList()));
+                summarizePipelineStats(pipelines));
+    }
+
+    private static List<PipelineStats> summarizePipelineStats(List<PipelineStats> pipelines)
+    {
+        // Use an exact size ImmutableList builder to avoid a redundant copy in the TaskStats constructor
+        ImmutableList.Builder<PipelineStats> results = ImmutableList.builderWithExpectedSize(pipelines.size());
+        for (PipelineStats pipeline : pipelines) {
+            results.add(pipeline.summarize());
+        }
+        return results.build();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestOperatorStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestOperatorStats.java
@@ -13,6 +13,7 @@
  */
 package io.trino.operator;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;
@@ -196,7 +197,7 @@ public class TestOperatorStats
     @Test
     public void testAdd()
     {
-        OperatorStats actual = EXPECTED.add(EXPECTED, EXPECTED);
+        OperatorStats actual = EXPECTED.add(ImmutableList.of(EXPECTED, EXPECTED));
 
         assertEquals(actual.getStageId(), 0);
         assertEquals(actual.getOperatorId(), 41);
@@ -246,7 +247,7 @@ public class TestOperatorStats
     @Test
     public void testAddMergeable()
     {
-        OperatorStats actual = MERGEABLE.add(MERGEABLE, MERGEABLE);
+        OperatorStats actual = MERGEABLE.add(ImmutableList.of(MERGEABLE, MERGEABLE));
 
         assertEquals(actual.getStageId(), 0);
         assertEquals(actual.getOperatorId(), 41);


### PR DESCRIPTION
Adapted from https://github.com/prestodb/presto/pull/16894 with an additional commit related to `DataSize` succinctness.

- Replaces calls to `succinctBytes` with `DataSize.ofBytes` in `OperatorContext` and `OperatorStats`. This avoids a potential double heap allocation per call and the overhead of computing the "succinct" unit for data size fields that will be discarded in JSON serialization anyway. This only affects the output of `DataSize#toString()` and might be useful to do in other stats entities, but I did not include those here as it seemed more likely that those values could end up being stringified in an log line or exception message somewhere and would get an unhelpful representation should that occur.
- Avoids creating new instance inside of `OperatorStats#summarize()` when possible
- Modifies `PipelineContext` to merge running and completed `OperatorStats` directly instead of performing incremental pairwise merges
- Avoids redundant OperatorStats creation, DriverContext traversals, volatile reads, and intermediate collections in `PipelineContext#getPipelineStats`
- Creates known sized ImmutableList instances instead of creating `ArrayList` instances via streams when the result is immediately passed to a constructor that will call `ImmutableList#copyOf`