### PR TITLE
SQL Read Only Mode

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -103,6 +103,7 @@ public final class SystemSessionProperties
     public static final String PUSH_AGGREGATION_THROUGH_OUTER_JOIN = "push_aggregation_through_outer_join";
     public static final String PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN = "push_partial_aggregation_through_join";
     public static final String PARSE_DECIMAL_LITERALS_AS_DOUBLE = "parse_decimal_literals_as_double";
+    public static final String PARSE_READ_ONLY_SQL_STATEMENTS = "parse_read_only_sql_statements";
     public static final String FORCE_SINGLE_NODE_OUTPUT = "force_single_node_output";
     public static final String FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE = "filter_and_project_min_output_page_size";
     public static final String FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT = "filter_and_project_min_output_page_row_count";
@@ -440,6 +441,11 @@ public final class SystemSessionProperties
                         PARSE_DECIMAL_LITERALS_AS_DOUBLE,
                         "Parse decimal literals as DOUBLE instead of DECIMAL",
                         featuresConfig.isParseDecimalLiteralsAsDouble(),
+                        false),
+                booleanProperty(
+                        PARSE_READ_ONLY_SQL_STATEMENTS,
+                        "Parse read only SQL statements",
+                        featuresConfig.isParseReadOnlySqlStatements(),
                         false),
                 booleanProperty(
                         FORCE_SINGLE_NODE_OUTPUT,
@@ -936,6 +942,11 @@ public final class SystemSessionProperties
     public static boolean isParseDecimalLiteralsAsDouble(Session session)
     {
         return session.getSystemProperty(PARSE_DECIMAL_LITERALS_AS_DOUBLE, Boolean.class);
+    }
+
+    public static boolean isParseReadOnlySqlStatements(Session session)
+    {
+        return session.getSystemProperty(PARSE_READ_ONLY_SQL_STATEMENTS, Boolean.class);
     }
 
     public static boolean isForceSingleNodeOutput(Session session)

--- a/core/trino-main/src/main/java/io/trino/sql/ParsingUtil.java
+++ b/core/trino-main/src/main/java/io/trino/sql/ParsingUtil.java
@@ -17,14 +17,19 @@ import io.trino.Session;
 import io.trino.sql.parser.ParsingOptions;
 
 import static io.trino.SystemSessionProperties.isParseDecimalLiteralsAsDouble;
+import static io.trino.SystemSessionProperties.isParseReadOnlySqlStatements;
 import static io.trino.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL;
 import static io.trino.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
+import static io.trino.sql.parser.ParsingOptions.SqlParserMode.CRUD;
+import static io.trino.sql.parser.ParsingOptions.SqlParserMode.READ_ONLY;
 
 public final class ParsingUtil
 {
     public static ParsingOptions createParsingOptions(Session session)
     {
-        return new ParsingOptions(isParseDecimalLiteralsAsDouble(session) ? AS_DOUBLE : AS_DECIMAL);
+        System.out.println(isParseReadOnlySqlStatements(session));
+        return new ParsingOptions(isParseDecimalLiteralsAsDouble(session) ? AS_DOUBLE : AS_DECIMAL,
+                isParseReadOnlySqlStatements(session) ? READ_ONLY : CRUD);
     }
 
     private ParsingUtil() {}

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/FeaturesConfig.java
@@ -120,6 +120,7 @@ public class FeaturesConfig
     private double memoryRevokingTarget = 0.5;
     private double memoryRevokingThreshold = 0.9;
     private boolean parseDecimalLiteralsAsDouble;
+    private boolean parseReadOnlySqlStatements;
     private boolean useMarkDistinct = true;
     private boolean preferPartialAggregation = true;
     private boolean optimizeTopNRanking = true;
@@ -850,6 +851,18 @@ public class FeaturesConfig
     public FeaturesConfig setParseDecimalLiteralsAsDouble(boolean parseDecimalLiteralsAsDouble)
     {
         this.parseDecimalLiteralsAsDouble = parseDecimalLiteralsAsDouble;
+        return this;
+    }
+
+    public boolean isParseReadOnlySqlStatements()
+    {
+        return parseReadOnlySqlStatements;
+    }
+
+    @Config("parser.read-only")
+    public FeaturesConfig setParseReadOnlySqlStatements(boolean parseReadOnlySqlStatements)
+    {
+        this.parseReadOnlySqlStatements = parseReadOnlySqlStatements;
         return this;
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -314,6 +314,7 @@ class AstBuilder
     @Override
     public Node visitUse(SqlBaseParser.UseContext context)
     {
+        restrictNode();
         return new Use(
                 getLocation(context),
                 visitIfPresent(context.catalog, Identifier.class),
@@ -323,6 +324,7 @@ class AstBuilder
     @Override
     public Node visitCreateSchema(SqlBaseParser.CreateSchemaContext context)
     {
+        restrictNode();
         Optional<PrincipalSpecification> principal = Optional.empty();
         if (context.AUTHORIZATION() != null) {
             principal = Optional.of(getPrincipalSpecification(context.principal()));
@@ -344,6 +346,7 @@ class AstBuilder
     @Override
     public Node visitDropSchema(SqlBaseParser.DropSchemaContext context)
     {
+        restrictNode();
         return new DropSchema(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -354,6 +357,7 @@ class AstBuilder
     @Override
     public Node visitRenameSchema(SqlBaseParser.RenameSchemaContext context)
     {
+        restrictNode();
         return new RenameSchema(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -363,6 +367,7 @@ class AstBuilder
     @Override
     public Node visitSetSchemaAuthorization(SqlBaseParser.SetSchemaAuthorizationContext context)
     {
+        restrictNode();
         return new SetSchemaAuthorization(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -372,6 +377,7 @@ class AstBuilder
     @Override
     public Node visitCreateTableAsSelect(SqlBaseParser.CreateTableAsSelectContext context)
     {
+        restrictNode();
         Optional<String> comment = Optional.empty();
         if (context.COMMENT() != null) {
             comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
@@ -401,6 +407,7 @@ class AstBuilder
     @Override
     public Node visitCreateTable(SqlBaseParser.CreateTableContext context)
     {
+        restrictNode();
         Optional<String> comment = Optional.empty();
         if (context.COMMENT() != null) {
             comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
@@ -421,6 +428,7 @@ class AstBuilder
     @Override
     public Node visitCreateMaterializedView(SqlBaseParser.CreateMaterializedViewContext context)
     {
+        restrictNode();
         Optional<String> comment = Optional.empty();
         if (context.COMMENT() != null) {
             comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
@@ -444,6 +452,7 @@ class AstBuilder
     @Override
     public Node visitRefreshMaterializedView(SqlBaseParser.RefreshMaterializedViewContext context)
     {
+        restrictNode();
         return new RefreshMaterializedView(Optional.of(getLocation(context)),
                 getQualifiedName(context.qualifiedName()));
     }
@@ -451,6 +460,7 @@ class AstBuilder
     @Override
     public Node visitDropMaterializedView(SqlBaseParser.DropMaterializedViewContext context)
     {
+        restrictNode();
         return new DropMaterializedView(
                 getLocation(context), getQualifiedName(context.qualifiedName()), context.EXISTS() != null);
     }
@@ -458,24 +468,28 @@ class AstBuilder
     @Override
     public Node visitShowCreateTable(SqlBaseParser.ShowCreateTableContext context)
     {
+        restrictNode();
         return new ShowCreate(getLocation(context), ShowCreate.Type.TABLE, getQualifiedName(context.qualifiedName()));
     }
 
     @Override
     public Node visitDropTable(SqlBaseParser.DropTableContext context)
     {
+        restrictNode();
         return new DropTable(getLocation(context), getQualifiedName(context.qualifiedName()), context.EXISTS() != null);
     }
 
     @Override
     public Node visitDropView(SqlBaseParser.DropViewContext context)
     {
+        restrictNode();
         return new DropView(getLocation(context), getQualifiedName(context.qualifiedName()), context.EXISTS() != null);
     }
 
     @Override
     public Node visitInsertInto(SqlBaseParser.InsertIntoContext context)
     {
+        restrictNode();
         Optional<List<Identifier>> columnAliases = Optional.empty();
         if (context.columnAliases() != null) {
             columnAliases = Optional.of(visit(context.columnAliases().identifier(), Identifier.class));
@@ -490,6 +504,7 @@ class AstBuilder
     @Override
     public Node visitDelete(SqlBaseParser.DeleteContext context)
     {
+        restrictNode();
         return new Delete(
                 getLocation(context),
                 new Table(getLocation(context), getQualifiedName(context.qualifiedName())),
@@ -499,6 +514,7 @@ class AstBuilder
     @Override
     public Node visitUpdate(SqlBaseParser.UpdateContext context)
     {
+        restrictNode();
         return new Update(
                 getLocation(context),
                 new Table(getLocation(context), getQualifiedName(context.qualifiedName())),
@@ -509,12 +525,14 @@ class AstBuilder
     @Override
     public Node visitUpdateAssignment(SqlBaseParser.UpdateAssignmentContext context)
     {
+        restrictNode();
         return new UpdateAssignment((Identifier) visit(context.identifier()), (Expression) visit(context.expression()));
     }
 
     @Override
     public Node visitMerge(SqlBaseParser.MergeContext context)
     {
+        restrictNode();
         return new Merge(
                 getLocation(context),
                 new Table(getLocation(context), getQualifiedName(context.qualifiedName())),
@@ -527,6 +545,7 @@ class AstBuilder
     @Override
     public Node visitMergeInsert(SqlBaseParser.MergeInsertContext context)
     {
+        restrictNode();
         return new MergeInsert(
                 getLocation(context),
                 visitIfPresent(context.condition, Expression.class),
@@ -544,6 +563,7 @@ class AstBuilder
     @Override
     public Node visitMergeUpdate(SqlBaseParser.MergeUpdateContext context)
     {
+        restrictNode();
         ImmutableList.Builder<MergeUpdate.Assignment> assignments = ImmutableList.builder();
         for (int i = 0; i < context.targets.size(); i++) {
             assignments.add(new MergeUpdate.Assignment(
@@ -557,12 +577,14 @@ class AstBuilder
     @Override
     public Node visitMergeDelete(SqlBaseParser.MergeDeleteContext context)
     {
+        restrictNode();
         return new MergeDelete(getLocation(context), visitIfPresent(context.condition, Expression.class));
     }
 
     @Override
     public Node visitRenameTable(SqlBaseParser.RenameTableContext context)
     {
+        restrictNode();
         return new RenameTable(getLocation(context), getQualifiedName(context.from), getQualifiedName(context.to), context.EXISTS() != null);
     }
 
@@ -580,6 +602,7 @@ class AstBuilder
     @Override
     public Node visitCommentTable(SqlBaseParser.CommentTableContext context)
     {
+        restrictNode();
         Optional<String> comment = Optional.empty();
 
         if (context.string() != null) {
@@ -592,6 +615,7 @@ class AstBuilder
     @Override
     public Node visitCommentColumn(SqlBaseParser.CommentColumnContext context)
     {
+        restrictNode();
         Optional<String> comment = Optional.empty();
 
         if (context.string() != null) {
@@ -604,6 +628,7 @@ class AstBuilder
     @Override
     public Node visitRenameColumn(SqlBaseParser.RenameColumnContext context)
     {
+        restrictNode();
         return new RenameColumn(
                 getLocation(context),
                 getQualifiedName(context.tableName),
@@ -616,6 +641,7 @@ class AstBuilder
     @Override
     public Node visitAnalyze(SqlBaseParser.AnalyzeContext context)
     {
+        restrictNode();
         List<Property> properties = ImmutableList.of();
         if (context.properties() != null) {
             properties = visit(context.properties().property(), Property.class);
@@ -629,6 +655,7 @@ class AstBuilder
     @Override
     public Node visitAddColumn(SqlBaseParser.AddColumnContext context)
     {
+        restrictNode();
         return new AddColumn(getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 (ColumnDefinition) visit(context.columnDefinition()),
@@ -639,6 +666,7 @@ class AstBuilder
     @Override
     public Node visitSetTableAuthorization(SqlBaseParser.SetTableAuthorizationContext context)
     {
+        restrictNode();
         return new SetTableAuthorization(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -648,6 +676,7 @@ class AstBuilder
     @Override
     public Node visitDropColumn(SqlBaseParser.DropColumnContext context)
     {
+        restrictNode();
         return new DropColumn(getLocation(context),
                 getQualifiedName(context.tableName),
                 (Identifier) visit(context.column),
@@ -658,6 +687,7 @@ class AstBuilder
     @Override
     public Node visitCreateView(SqlBaseParser.CreateViewContext context)
     {
+        restrictNode();
         Optional<String> comment = Optional.empty();
         if (context.COMMENT() != null) {
             comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
@@ -683,6 +713,7 @@ class AstBuilder
     @Override
     public Node visitRenameView(SqlBaseParser.RenameViewContext context)
     {
+        restrictNode();
         return new RenameView(getLocation(context), getQualifiedName(context.from), getQualifiedName(context.to));
     }
 
@@ -695,6 +726,7 @@ class AstBuilder
     @Override
     public Node visitSetViewAuthorization(SqlBaseParser.SetViewAuthorizationContext context)
     {
+        restrictNode();
         return new SetViewAuthorization(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -704,60 +736,70 @@ class AstBuilder
     @Override
     public Node visitStartTransaction(SqlBaseParser.StartTransactionContext context)
     {
+        restrictNode();
         return new StartTransaction(visit(context.transactionMode(), TransactionMode.class));
     }
 
     @Override
     public Node visitCommit(SqlBaseParser.CommitContext context)
     {
+        restrictNode();
         return new Commit(getLocation(context));
     }
 
     @Override
     public Node visitRollback(SqlBaseParser.RollbackContext context)
     {
+        restrictNode();
         return new Rollback(getLocation(context));
     }
 
     @Override
     public Node visitTransactionAccessMode(SqlBaseParser.TransactionAccessModeContext context)
     {
+        restrictNode();
         return new TransactionAccessMode(getLocation(context), context.accessMode.getType() == SqlBaseLexer.ONLY);
     }
 
     @Override
     public Node visitIsolationLevel(SqlBaseParser.IsolationLevelContext context)
     {
+        restrictNode();
         return visit(context.levelOfIsolation());
     }
 
     @Override
     public Node visitReadUncommitted(SqlBaseParser.ReadUncommittedContext context)
     {
+        restrictNode();
         return new Isolation(getLocation(context), Isolation.Level.READ_UNCOMMITTED);
     }
 
     @Override
     public Node visitReadCommitted(SqlBaseParser.ReadCommittedContext context)
     {
+        restrictNode();
         return new Isolation(getLocation(context), Isolation.Level.READ_COMMITTED);
     }
 
     @Override
     public Node visitRepeatableRead(SqlBaseParser.RepeatableReadContext context)
     {
+        restrictNode();
         return new Isolation(getLocation(context), Isolation.Level.REPEATABLE_READ);
     }
 
     @Override
     public Node visitSerializable(SqlBaseParser.SerializableContext context)
     {
+        restrictNode();
         return new Isolation(getLocation(context), Isolation.Level.SERIALIZABLE);
     }
 
     @Override
     public Node visitCall(SqlBaseParser.CallContext context)
     {
+        restrictNode();
         return new Call(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -793,6 +835,7 @@ class AstBuilder
     @Override
     public Node visitDescribeOutput(SqlBaseParser.DescribeOutputContext context)
     {
+        restrictNode();
         return new DescribeOutput(
                 getLocation(context),
                 (Identifier) visit(context.identifier()));
@@ -801,6 +844,7 @@ class AstBuilder
     @Override
     public Node visitDescribeInput(SqlBaseParser.DescribeInputContext context)
     {
+        restrictNode();
         return new DescribeInput(
                 getLocation(context),
                 (Identifier) visit(context.identifier()));
@@ -1095,18 +1139,21 @@ class AstBuilder
     @Override
     public Node visitExplain(SqlBaseParser.ExplainContext context)
     {
+        restrictNode();
         return new Explain(getLocation(context), (Statement) visit(context.statement()), visit(context.explainOption(), ExplainOption.class));
     }
 
     @Override
     public Node visitExplainAnalyze(SqlBaseParser.ExplainAnalyzeContext context)
     {
+        restrictNode();
         return new ExplainAnalyze(getLocation(context), context.VERBOSE() != null, (Statement) visit(context.statement()));
     }
 
     @Override
     public Node visitExplainFormat(SqlBaseParser.ExplainFormatContext context)
     {
+        restrictNode();
         switch (context.value.getType()) {
             case SqlBaseLexer.GRAPHVIZ:
                 return new ExplainFormat(getLocation(context), ExplainFormat.Type.GRAPHVIZ);
@@ -1122,6 +1169,7 @@ class AstBuilder
     @Override
     public Node visitExplainType(SqlBaseParser.ExplainTypeContext context)
     {
+        restrictNode();
         switch (context.value.getType()) {
             case SqlBaseLexer.LOGICAL:
                 return new ExplainType(getLocation(context), ExplainType.Type.LOGICAL);
@@ -1186,12 +1234,14 @@ class AstBuilder
     @Override
     public Node visitShowStats(SqlBaseParser.ShowStatsContext context)
     {
+        restrictNode();
         return new ShowStats(Optional.of(getLocation(context)), new Table(getQualifiedName(context.qualifiedName())));
     }
 
     @Override
     public Node visitShowStatsForQuery(SqlBaseParser.ShowStatsForQueryContext context)
     {
+        restrictNode();
         Query query = (Query) visit(context.query());
         return new ShowStats(Optional.of(getLocation(context)), new TableSubquery(query));
     }
@@ -1199,18 +1249,21 @@ class AstBuilder
     @Override
     public Node visitShowCreateSchema(SqlBaseParser.ShowCreateSchemaContext context)
     {
+        restrictNode();
         return new ShowCreate(getLocation(context), ShowCreate.Type.SCHEMA, getQualifiedName(context.qualifiedName()));
     }
 
     @Override
     public Node visitShowCreateView(SqlBaseParser.ShowCreateViewContext context)
     {
+        restrictNode();
         return new ShowCreate(getLocation(context), ShowCreate.Type.VIEW, getQualifiedName(context.qualifiedName()));
     }
 
     @Override
     public Node visitShowCreateMaterializedView(SqlBaseParser.ShowCreateMaterializedViewContext context)
     {
+        restrictNode();
         return new ShowCreate(getLocation(context), ShowCreate.Type.MATERIALIZED_VIEW, getQualifiedName(context.qualifiedName()));
     }
 
@@ -1227,6 +1280,7 @@ class AstBuilder
     @Override
     public Node visitShowSession(SqlBaseParser.ShowSessionContext context)
     {
+        restrictNode();
         return new ShowSession(getLocation(context),
                 getTextIfPresent(context.pattern)
                         .map(AstBuilder::unquote),
@@ -1237,18 +1291,21 @@ class AstBuilder
     @Override
     public Node visitSetSession(SqlBaseParser.SetSessionContext context)
     {
+        restrictNode();
         return new SetSession(getLocation(context), getQualifiedName(context.qualifiedName()), (Expression) visit(context.expression()));
     }
 
     @Override
     public Node visitResetSession(SqlBaseParser.ResetSessionContext context)
     {
+        restrictNode();
         return new ResetSession(getLocation(context), getQualifiedName(context.qualifiedName()));
     }
 
     @Override
     public Node visitCreateRole(SqlBaseParser.CreateRoleContext context)
     {
+        restrictNode();
         return new CreateRole(
                 getLocation(context),
                 (Identifier) visit(context.name),
@@ -1259,6 +1316,7 @@ class AstBuilder
     @Override
     public Node visitDropRole(SqlBaseParser.DropRoleContext context)
     {
+        restrictNode();
         return new DropRole(
                 getLocation(context),
                 (Identifier) visit(context.name),
@@ -1268,6 +1326,7 @@ class AstBuilder
     @Override
     public Node visitGrantRoles(SqlBaseParser.GrantRolesContext context)
     {
+        restrictNode();
         return new GrantRoles(
                 getLocation(context),
                 ImmutableSet.copyOf(getIdentifiers(context.roles().identifier())),
@@ -1280,6 +1339,7 @@ class AstBuilder
     @Override
     public Node visitRevokeRoles(SqlBaseParser.RevokeRolesContext context)
     {
+        restrictNode();
         return new RevokeRoles(
                 getLocation(context),
                 ImmutableSet.copyOf(getIdentifiers(context.roles().identifier())),
@@ -1292,6 +1352,7 @@ class AstBuilder
     @Override
     public Node visitSetRole(SqlBaseParser.SetRoleContext context)
     {
+        restrictNode();
         SetRole.Type type = SetRole.Type.ROLE;
         if (context.ALL() != null) {
             type = SetRole.Type.ALL;
@@ -1309,6 +1370,7 @@ class AstBuilder
     @Override
     public Node visitGrant(SqlBaseParser.GrantContext context)
     {
+        restrictNode();
         Optional<List<String>> privileges;
         if (context.ALL() != null) {
             privileges = Optional.empty();
@@ -1342,6 +1404,7 @@ class AstBuilder
     @Override
     public Node visitRevoke(SqlBaseParser.RevokeContext context)
     {
+        restrictNode();
         Optional<List<String>> privileges;
         if (context.ALL() != null) {
             privileges = Optional.empty();
@@ -1375,6 +1438,7 @@ class AstBuilder
     @Override
     public Node visitShowGrants(SqlBaseParser.ShowGrantsContext context)
     {
+        restrictNode();
         Optional<QualifiedName> tableName = Optional.empty();
 
         if (context.qualifiedName() != null) {
@@ -1390,6 +1454,7 @@ class AstBuilder
     @Override
     public Node visitShowRoles(SqlBaseParser.ShowRolesContext context)
     {
+        restrictNode();
         return new ShowRoles(
                 getLocation(context),
                 getIdentifierIfPresent(context.identifier()),
@@ -1399,6 +1464,7 @@ class AstBuilder
     @Override
     public Node visitShowRoleGrants(SqlBaseParser.ShowRoleGrantsContext context)
     {
+        restrictNode();
         return new ShowRoleGrants(
                 getLocation(context),
                 getIdentifierIfPresent(context.identifier()));
@@ -1407,12 +1473,14 @@ class AstBuilder
     @Override
     public Node visitSetPath(SqlBaseParser.SetPathContext context)
     {
+        restrictNode();
         return new SetPath(getLocation(context), (PathSpecification) visit(context.pathSpecification()));
     }
 
     @Override
     public Node visitSetTimeZone(SqlBaseParser.SetTimeZoneContext context)
     {
+        restrictNode();
         Optional<Expression> timeZone = Optional.empty();
         if (context.expression() != null) {
             timeZone = Optional.of((Expression) visit(context.expression()));
@@ -3179,5 +3247,16 @@ class AstBuilder
     private static ParsingException parseError(String message, ParserRuleContext context)
     {
         return new ParsingException(message, null, context.getStart().getLine(), context.getStart().getCharPositionInLine() + 1);
+    }
+
+    public void restrictNode()
+    {
+        switch (parsingOptions.getSqlParserMode()) {
+            case CRUD:
+                return;
+            case READ_ONLY:
+                throw new ParsingException("Unexpected CRUD operation. Read Only mode is enabled.");
+        }
+        throw new AssertionError("Unreachable");
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -314,7 +314,6 @@ class AstBuilder
     @Override
     public Node visitUse(SqlBaseParser.UseContext context)
     {
-        restrictNode();
         return new Use(
                 getLocation(context),
                 visitIfPresent(context.catalog, Identifier.class),
@@ -324,7 +323,6 @@ class AstBuilder
     @Override
     public Node visitCreateSchema(SqlBaseParser.CreateSchemaContext context)
     {
-        restrictNode();
         Optional<PrincipalSpecification> principal = Optional.empty();
         if (context.AUTHORIZATION() != null) {
             principal = Optional.of(getPrincipalSpecification(context.principal()));
@@ -346,7 +344,6 @@ class AstBuilder
     @Override
     public Node visitDropSchema(SqlBaseParser.DropSchemaContext context)
     {
-        restrictNode();
         return new DropSchema(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -357,7 +354,6 @@ class AstBuilder
     @Override
     public Node visitRenameSchema(SqlBaseParser.RenameSchemaContext context)
     {
-        restrictNode();
         return new RenameSchema(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -367,7 +363,6 @@ class AstBuilder
     @Override
     public Node visitSetSchemaAuthorization(SqlBaseParser.SetSchemaAuthorizationContext context)
     {
-        restrictNode();
         return new SetSchemaAuthorization(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -377,7 +372,6 @@ class AstBuilder
     @Override
     public Node visitCreateTableAsSelect(SqlBaseParser.CreateTableAsSelectContext context)
     {
-        restrictNode();
         Optional<String> comment = Optional.empty();
         if (context.COMMENT() != null) {
             comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
@@ -407,7 +401,6 @@ class AstBuilder
     @Override
     public Node visitCreateTable(SqlBaseParser.CreateTableContext context)
     {
-        restrictNode();
         Optional<String> comment = Optional.empty();
         if (context.COMMENT() != null) {
             comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
@@ -428,7 +421,6 @@ class AstBuilder
     @Override
     public Node visitCreateMaterializedView(SqlBaseParser.CreateMaterializedViewContext context)
     {
-        restrictNode();
         Optional<String> comment = Optional.empty();
         if (context.COMMENT() != null) {
             comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
@@ -452,7 +444,6 @@ class AstBuilder
     @Override
     public Node visitRefreshMaterializedView(SqlBaseParser.RefreshMaterializedViewContext context)
     {
-        restrictNode();
         return new RefreshMaterializedView(Optional.of(getLocation(context)),
                 getQualifiedName(context.qualifiedName()));
     }
@@ -460,7 +451,6 @@ class AstBuilder
     @Override
     public Node visitDropMaterializedView(SqlBaseParser.DropMaterializedViewContext context)
     {
-        restrictNode();
         return new DropMaterializedView(
                 getLocation(context), getQualifiedName(context.qualifiedName()), context.EXISTS() != null);
     }
@@ -468,28 +458,24 @@ class AstBuilder
     @Override
     public Node visitShowCreateTable(SqlBaseParser.ShowCreateTableContext context)
     {
-        restrictNode();
         return new ShowCreate(getLocation(context), ShowCreate.Type.TABLE, getQualifiedName(context.qualifiedName()));
     }
 
     @Override
     public Node visitDropTable(SqlBaseParser.DropTableContext context)
     {
-        restrictNode();
         return new DropTable(getLocation(context), getQualifiedName(context.qualifiedName()), context.EXISTS() != null);
     }
 
     @Override
     public Node visitDropView(SqlBaseParser.DropViewContext context)
     {
-        restrictNode();
         return new DropView(getLocation(context), getQualifiedName(context.qualifiedName()), context.EXISTS() != null);
     }
 
     @Override
     public Node visitInsertInto(SqlBaseParser.InsertIntoContext context)
     {
-        restrictNode();
         Optional<List<Identifier>> columnAliases = Optional.empty();
         if (context.columnAliases() != null) {
             columnAliases = Optional.of(visit(context.columnAliases().identifier(), Identifier.class));
@@ -504,7 +490,6 @@ class AstBuilder
     @Override
     public Node visitDelete(SqlBaseParser.DeleteContext context)
     {
-        restrictNode();
         return new Delete(
                 getLocation(context),
                 new Table(getLocation(context), getQualifiedName(context.qualifiedName())),
@@ -514,7 +499,6 @@ class AstBuilder
     @Override
     public Node visitUpdate(SqlBaseParser.UpdateContext context)
     {
-        restrictNode();
         return new Update(
                 getLocation(context),
                 new Table(getLocation(context), getQualifiedName(context.qualifiedName())),
@@ -525,14 +509,12 @@ class AstBuilder
     @Override
     public Node visitUpdateAssignment(SqlBaseParser.UpdateAssignmentContext context)
     {
-        restrictNode();
         return new UpdateAssignment((Identifier) visit(context.identifier()), (Expression) visit(context.expression()));
     }
 
     @Override
     public Node visitMerge(SqlBaseParser.MergeContext context)
     {
-        restrictNode();
         return new Merge(
                 getLocation(context),
                 new Table(getLocation(context), getQualifiedName(context.qualifiedName())),
@@ -545,7 +527,6 @@ class AstBuilder
     @Override
     public Node visitMergeInsert(SqlBaseParser.MergeInsertContext context)
     {
-        restrictNode();
         return new MergeInsert(
                 getLocation(context),
                 visitIfPresent(context.condition, Expression.class),
@@ -563,7 +544,6 @@ class AstBuilder
     @Override
     public Node visitMergeUpdate(SqlBaseParser.MergeUpdateContext context)
     {
-        restrictNode();
         ImmutableList.Builder<MergeUpdate.Assignment> assignments = ImmutableList.builder();
         for (int i = 0; i < context.targets.size(); i++) {
             assignments.add(new MergeUpdate.Assignment(
@@ -577,14 +557,12 @@ class AstBuilder
     @Override
     public Node visitMergeDelete(SqlBaseParser.MergeDeleteContext context)
     {
-        restrictNode();
         return new MergeDelete(getLocation(context), visitIfPresent(context.condition, Expression.class));
     }
 
     @Override
     public Node visitRenameTable(SqlBaseParser.RenameTableContext context)
     {
-        restrictNode();
         return new RenameTable(getLocation(context), getQualifiedName(context.from), getQualifiedName(context.to), context.EXISTS() != null);
     }
 
@@ -602,7 +580,6 @@ class AstBuilder
     @Override
     public Node visitCommentTable(SqlBaseParser.CommentTableContext context)
     {
-        restrictNode();
         Optional<String> comment = Optional.empty();
 
         if (context.string() != null) {
@@ -615,7 +592,6 @@ class AstBuilder
     @Override
     public Node visitCommentColumn(SqlBaseParser.CommentColumnContext context)
     {
-        restrictNode();
         Optional<String> comment = Optional.empty();
 
         if (context.string() != null) {
@@ -628,7 +604,6 @@ class AstBuilder
     @Override
     public Node visitRenameColumn(SqlBaseParser.RenameColumnContext context)
     {
-        restrictNode();
         return new RenameColumn(
                 getLocation(context),
                 getQualifiedName(context.tableName),
@@ -641,7 +616,6 @@ class AstBuilder
     @Override
     public Node visitAnalyze(SqlBaseParser.AnalyzeContext context)
     {
-        restrictNode();
         List<Property> properties = ImmutableList.of();
         if (context.properties() != null) {
             properties = visit(context.properties().property(), Property.class);
@@ -655,7 +629,6 @@ class AstBuilder
     @Override
     public Node visitAddColumn(SqlBaseParser.AddColumnContext context)
     {
-        restrictNode();
         return new AddColumn(getLocation(context),
                 getQualifiedName(context.qualifiedName()),
                 (ColumnDefinition) visit(context.columnDefinition()),
@@ -666,7 +639,6 @@ class AstBuilder
     @Override
     public Node visitSetTableAuthorization(SqlBaseParser.SetTableAuthorizationContext context)
     {
-        restrictNode();
         return new SetTableAuthorization(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -676,7 +648,6 @@ class AstBuilder
     @Override
     public Node visitDropColumn(SqlBaseParser.DropColumnContext context)
     {
-        restrictNode();
         return new DropColumn(getLocation(context),
                 getQualifiedName(context.tableName),
                 (Identifier) visit(context.column),
@@ -687,7 +658,6 @@ class AstBuilder
     @Override
     public Node visitCreateView(SqlBaseParser.CreateViewContext context)
     {
-        restrictNode();
         Optional<String> comment = Optional.empty();
         if (context.COMMENT() != null) {
             comment = Optional.of(((StringLiteral) visit(context.string())).getValue());
@@ -713,7 +683,6 @@ class AstBuilder
     @Override
     public Node visitRenameView(SqlBaseParser.RenameViewContext context)
     {
-        restrictNode();
         return new RenameView(getLocation(context), getQualifiedName(context.from), getQualifiedName(context.to));
     }
 
@@ -726,7 +695,6 @@ class AstBuilder
     @Override
     public Node visitSetViewAuthorization(SqlBaseParser.SetViewAuthorizationContext context)
     {
-        restrictNode();
         return new SetViewAuthorization(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -736,70 +704,60 @@ class AstBuilder
     @Override
     public Node visitStartTransaction(SqlBaseParser.StartTransactionContext context)
     {
-        restrictNode();
         return new StartTransaction(visit(context.transactionMode(), TransactionMode.class));
     }
 
     @Override
     public Node visitCommit(SqlBaseParser.CommitContext context)
     {
-        restrictNode();
         return new Commit(getLocation(context));
     }
 
     @Override
     public Node visitRollback(SqlBaseParser.RollbackContext context)
     {
-        restrictNode();
         return new Rollback(getLocation(context));
     }
 
     @Override
     public Node visitTransactionAccessMode(SqlBaseParser.TransactionAccessModeContext context)
     {
-        restrictNode();
         return new TransactionAccessMode(getLocation(context), context.accessMode.getType() == SqlBaseLexer.ONLY);
     }
 
     @Override
     public Node visitIsolationLevel(SqlBaseParser.IsolationLevelContext context)
     {
-        restrictNode();
         return visit(context.levelOfIsolation());
     }
 
     @Override
     public Node visitReadUncommitted(SqlBaseParser.ReadUncommittedContext context)
     {
-        restrictNode();
         return new Isolation(getLocation(context), Isolation.Level.READ_UNCOMMITTED);
     }
 
     @Override
     public Node visitReadCommitted(SqlBaseParser.ReadCommittedContext context)
     {
-        restrictNode();
         return new Isolation(getLocation(context), Isolation.Level.READ_COMMITTED);
     }
 
     @Override
     public Node visitRepeatableRead(SqlBaseParser.RepeatableReadContext context)
     {
-        restrictNode();
         return new Isolation(getLocation(context), Isolation.Level.REPEATABLE_READ);
     }
 
     @Override
     public Node visitSerializable(SqlBaseParser.SerializableContext context)
     {
-        restrictNode();
         return new Isolation(getLocation(context), Isolation.Level.SERIALIZABLE);
     }
 
     @Override
     public Node visitCall(SqlBaseParser.CallContext context)
     {
-        restrictNode();
         return new Call(
                 getLocation(context),
                 getQualifiedName(context.qualifiedName()),
@@ -835,7 +793,6 @@ class AstBuilder
     @Override
     public Node visitDescribeOutput(SqlBaseParser.DescribeOutputContext context)
     {
-        restrictNode();
         return new DescribeOutput(
                 getLocation(context),
                 (Identifier) visit(context.identifier()));
@@ -844,7 +801,6 @@ class AstBuilder
     @Override
     public Node visitDescribeInput(SqlBaseParser.DescribeInputContext context)
     {
-        restrictNode();
         return new DescribeInput(
                 getLocation(context),
                 (Identifier) visit(context.identifier()));
@@ -1139,21 +1095,18 @@ class AstBuilder
     @Override
     public Node visitExplain(SqlBaseParser.ExplainContext context)
     {
-        restrictNode();
         return new Explain(getLocation(context), (Statement) visit(context.statement()), visit(context.explainOption(), ExplainOption.class));
     }
 
     @Override
     public Node visitExplainAnalyze(SqlBaseParser.ExplainAnalyzeContext context)
     {
-        restrictNode();
         return new ExplainAnalyze(getLocation(context), context.VERBOSE() != null, (Statement) visit(context.statement()));
     }
 
     @Override
     public Node visitExplainFormat(SqlBaseParser.ExplainFormatContext context)
     {
-        restrictNode();
         switch (context.value.getType()) {
             case SqlBaseLexer.GRAPHVIZ:
                 return new ExplainFormat(getLocation(context), ExplainFormat.Type.GRAPHVIZ);
@@ -1169,7 +1122,6 @@ class AstBuilder
     @Override
     public Node visitExplainType(SqlBaseParser.ExplainTypeContext context)
     {
-        restrictNode();
         switch (context.value.getType()) {
             case SqlBaseLexer.LOGICAL:
                 return new ExplainType(getLocation(context), ExplainType.Type.LOGICAL);
@@ -1234,14 +1186,12 @@ class AstBuilder
     @Override
     public Node visitShowStats(SqlBaseParser.ShowStatsContext context)
     {
-        restrictNode();
         return new ShowStats(Optional.of(getLocation(context)), new Table(getQualifiedName(context.qualifiedName())));
     }
 
     @Override
     public Node visitShowStatsForQuery(SqlBaseParser.ShowStatsForQueryContext context)
     {
-        restrictNode();
         Query query = (Query) visit(context.query());
         return new ShowStats(Optional.of(getLocation(context)), new TableSubquery(query));
     }
@@ -1249,21 +1199,18 @@ class AstBuilder
     @Override
     public Node visitShowCreateSchema(SqlBaseParser.ShowCreateSchemaContext context)
     {
-        restrictNode();
         return new ShowCreate(getLocation(context), ShowCreate.Type.SCHEMA, getQualifiedName(context.qualifiedName()));
     }
 
     @Override
     public Node visitShowCreateView(SqlBaseParser.ShowCreateViewContext context)
     {
-        restrictNode();
         return new ShowCreate(getLocation(context), ShowCreate.Type.VIEW, getQualifiedName(context.qualifiedName()));
     }
 
     @Override
     public Node visitShowCreateMaterializedView(SqlBaseParser.ShowCreateMaterializedViewContext context)
     {
-        restrictNode();
         return new ShowCreate(getLocation(context), ShowCreate.Type.MATERIALIZED_VIEW, getQualifiedName(context.qualifiedName()));
     }
 
@@ -1280,7 +1227,6 @@ class AstBuilder
     @Override
     public Node visitShowSession(SqlBaseParser.ShowSessionContext context)
     {
-        restrictNode();
         return new ShowSession(getLocation(context),
                 getTextIfPresent(context.pattern)
                         .map(AstBuilder::unquote),
@@ -1291,21 +1237,18 @@ class AstBuilder
     @Override
     public Node visitSetSession(SqlBaseParser.SetSessionContext context)
     {
-        restrictNode();
         return new SetSession(getLocation(context), getQualifiedName(context.qualifiedName()), (Expression) visit(context.expression()));
     }
 
     @Override
     public Node visitResetSession(SqlBaseParser.ResetSessionContext context)
     {
-        restrictNode();
         return new ResetSession(getLocation(context), getQualifiedName(context.qualifiedName()));
     }
 
     @Override
     public Node visitCreateRole(SqlBaseParser.CreateRoleContext context)
     {
-        restrictNode();
         return new CreateRole(
                 getLocation(context),
                 (Identifier) visit(context.name),
@@ -1316,7 +1259,6 @@ class AstBuilder
     @Override
     public Node visitDropRole(SqlBaseParser.DropRoleContext context)
     {
-        restrictNode();
         return new DropRole(
                 getLocation(context),
                 (Identifier) visit(context.name),
@@ -1326,7 +1268,6 @@ class AstBuilder
     @Override
     public Node visitGrantRoles(SqlBaseParser.GrantRolesContext context)
     {
-        restrictNode();
         return new GrantRoles(
                 getLocation(context),
                 ImmutableSet.copyOf(getIdentifiers(context.roles().identifier())),
@@ -1339,7 +1280,6 @@ class AstBuilder
     @Override
     public Node visitRevokeRoles(SqlBaseParser.RevokeRolesContext context)
     {
-        restrictNode();
         return new RevokeRoles(
                 getLocation(context),
                 ImmutableSet.copyOf(getIdentifiers(context.roles().identifier())),
@@ -1352,7 +1292,6 @@ class AstBuilder
     @Override
     public Node visitSetRole(SqlBaseParser.SetRoleContext context)
     {
-        restrictNode();
         SetRole.Type type = SetRole.Type.ROLE;
         if (context.ALL() != null) {
             type = SetRole.Type.ALL;
@@ -1370,7 +1309,6 @@ class AstBuilder
     @Override
     public Node visitGrant(SqlBaseParser.GrantContext context)
     {
-        restrictNode();
         Optional<List<String>> privileges;
         if (context.ALL() != null) {
             privileges = Optional.empty();
@@ -1404,7 +1342,6 @@ class AstBuilder
     @Override
     public Node visitRevoke(SqlBaseParser.RevokeContext context)
     {
-        restrictNode();
         Optional<List<String>> privileges;
         if (context.ALL() != null) {
             privileges = Optional.empty();
@@ -1438,7 +1375,6 @@ class AstBuilder
     @Override
     public Node visitShowGrants(SqlBaseParser.ShowGrantsContext context)
     {
-        restrictNode();
         Optional<QualifiedName> tableName = Optional.empty();
 
         if (context.qualifiedName() != null) {
@@ -1454,7 +1390,6 @@ class AstBuilder
     @Override
     public Node visitShowRoles(SqlBaseParser.ShowRolesContext context)
     {
-        restrictNode();
         return new ShowRoles(
                 getLocation(context),
                 getIdentifierIfPresent(context.identifier()),
@@ -1464,7 +1399,6 @@ class AstBuilder
     @Override
     public Node visitShowRoleGrants(SqlBaseParser.ShowRoleGrantsContext context)
     {
-        restrictNode();
         return new ShowRoleGrants(
                 getLocation(context),
                 getIdentifierIfPresent(context.identifier()));
@@ -1473,14 +1407,12 @@ class AstBuilder
     @Override
     public Node visitSetPath(SqlBaseParser.SetPathContext context)
     {
-        restrictNode();
         return new SetPath(getLocation(context), (PathSpecification) visit(context.pathSpecification()));
     }
 
     @Override
     public Node visitSetTimeZone(SqlBaseParser.SetTimeZoneContext context)
     {
-        restrictNode();
         Optional<Expression> timeZone = Optional.empty();
         if (context.expression() != null) {
             timeZone = Optional.of((Expression) visit(context.expression()));
@@ -3249,14 +3181,8 @@ class AstBuilder
         return new ParsingException(message, null, context.getStart().getLine(), context.getStart().getCharPositionInLine() + 1);
     }
 
-    public void restrictNode()
+    public ParsingOptions getParsingOptions()
     {
-        switch (parsingOptions.getSqlParserMode()) {
-            case CRUD:
-                return;
-            case READ_ONLY:
-                throw new ParsingException("Unexpected CRUD operation. Read Only mode is enabled.");
-        }
-        throw new AssertionError("Unreachable");
+        return this.parsingOptions;
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilderFactory.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilderFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.parser;
+
+public class AstBuilderFactory
+{
+    private AstBuilderFactory(){}
+
+    public static AstBuilder create(ParsingOptions parsingOptions)
+    {
+        switch (parsingOptions.getSqlParserMode()) {
+            case CRUD:
+                return new AstBuilder(parsingOptions);
+            case READ_ONLY:
+                return new AstRestrictedBuilder(parsingOptions);
+        }
+        throw new AssertionError("Unreachable");
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstRestrictedBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstRestrictedBuilder.java
@@ -1,0 +1,422 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.sql.parser;
+
+import io.trino.sql.tree.Node;
+
+import static java.lang.String.format;
+
+public class AstRestrictedBuilder
+        extends AstBuilder
+{
+    private final ParsingException restrictedNodeException;
+
+    AstRestrictedBuilder(ParsingOptions parsingOptions)
+    {
+        super(parsingOptions);
+        restrictedNodeException = new ParsingException(format("Unexpected CRUD operation. %s mode is enabled", parsingOptions.getSqlParserMode().toString()));
+    }
+
+    // ******************* restricted statements **********************
+
+    @Override
+    public Node visitUse(SqlBaseParser.UseContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitCreateSchema(SqlBaseParser.CreateSchemaContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitDropSchema(SqlBaseParser.DropSchemaContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitRenameSchema(SqlBaseParser.RenameSchemaContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitSetSchemaAuthorization(SqlBaseParser.SetSchemaAuthorizationContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitCreateTableAsSelect(SqlBaseParser.CreateTableAsSelectContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitCreateTable(SqlBaseParser.CreateTableContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitCreateMaterializedView(SqlBaseParser.CreateMaterializedViewContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitRefreshMaterializedView(SqlBaseParser.RefreshMaterializedViewContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitDropMaterializedView(SqlBaseParser.DropMaterializedViewContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitShowCreateTable(SqlBaseParser.ShowCreateTableContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitDropTable(SqlBaseParser.DropTableContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitDropView(SqlBaseParser.DropViewContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitInsertInto(SqlBaseParser.InsertIntoContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitDelete(SqlBaseParser.DeleteContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitUpdate(SqlBaseParser.UpdateContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitUpdateAssignment(SqlBaseParser.UpdateAssignmentContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitMerge(SqlBaseParser.MergeContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitMergeInsert(SqlBaseParser.MergeInsertContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitMergeUpdate(SqlBaseParser.MergeUpdateContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitMergeDelete(SqlBaseParser.MergeDeleteContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitRenameTable(SqlBaseParser.RenameTableContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitCommentTable(SqlBaseParser.CommentTableContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitCommentColumn(SqlBaseParser.CommentColumnContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitRenameColumn(SqlBaseParser.RenameColumnContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitAnalyze(SqlBaseParser.AnalyzeContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitAddColumn(SqlBaseParser.AddColumnContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitSetTableAuthorization(SqlBaseParser.SetTableAuthorizationContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitDropColumn(SqlBaseParser.DropColumnContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitCreateView(SqlBaseParser.CreateViewContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitRenameView(SqlBaseParser.RenameViewContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitSetViewAuthorization(SqlBaseParser.SetViewAuthorizationContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitStartTransaction(SqlBaseParser.StartTransactionContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitCommit(SqlBaseParser.CommitContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitRollback(SqlBaseParser.RollbackContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitTransactionAccessMode(SqlBaseParser.TransactionAccessModeContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitIsolationLevel(SqlBaseParser.IsolationLevelContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitCall(SqlBaseParser.CallContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitDescribeOutput(SqlBaseParser.DescribeOutputContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitDescribeInput(SqlBaseParser.DescribeInputContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitExplain(SqlBaseParser.ExplainContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitExplainAnalyze(SqlBaseParser.ExplainAnalyzeContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitExplainFormat(SqlBaseParser.ExplainFormatContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitExplainType(SqlBaseParser.ExplainTypeContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitShowSession(SqlBaseParser.ShowSessionContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitSetSession(SqlBaseParser.SetSessionContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitResetSession(SqlBaseParser.ResetSessionContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitCreateRole(SqlBaseParser.CreateRoleContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitDropRole(SqlBaseParser.DropRoleContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitGrantRoles(SqlBaseParser.GrantRolesContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitRevokeRoles(SqlBaseParser.RevokeRolesContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitSetRole(SqlBaseParser.SetRoleContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitGrant(SqlBaseParser.GrantContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitRevoke(SqlBaseParser.RevokeContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitShowGrants(SqlBaseParser.ShowGrantsContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitShowRoles(SqlBaseParser.ShowRolesContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitShowRoleGrants(SqlBaseParser.ShowRoleGrantsContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitSetPath(SqlBaseParser.SetPathContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitSetTimeZone(SqlBaseParser.SetTimeZoneContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitShowStats(SqlBaseParser.ShowStatsContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitShowStatsForQuery(SqlBaseParser.ShowStatsForQueryContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitShowCreateSchema(SqlBaseParser.ShowCreateSchemaContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitShowCreateView(SqlBaseParser.ShowCreateViewContext context)
+    {
+        return restrictNode();
+    }
+
+    @Override
+    public Node visitShowCreateMaterializedView(SqlBaseParser.ShowCreateMaterializedViewContext context)
+    {
+        return restrictNode();
+    }
+
+    public Node restrictNode() throws ParsingException
+    {
+        throw restrictedNodeException;
+    }
+}

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/ParsingOptions.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/ParsingOptions.java
@@ -24,7 +24,14 @@ public class ParsingOptions
         REJECT
     }
 
+    public enum SqlParserMode
+    {
+        READ_ONLY,
+        CRUD
+    }
+
     private final DecimalLiteralTreatment decimalLiteralTreatment;
+    private final SqlParserMode parserMode;
 
     public ParsingOptions()
     {
@@ -33,11 +40,23 @@ public class ParsingOptions
 
     public ParsingOptions(DecimalLiteralTreatment decimalLiteralTreatment)
     {
+        this.parserMode = requireNonNull(SqlParserMode.CRUD, "parserMode is null");
+        this.decimalLiteralTreatment = requireNonNull(decimalLiteralTreatment, "decimalLiteralTreatment is null");
+    }
+
+    public ParsingOptions(DecimalLiteralTreatment decimalLiteralTreatment, SqlParserMode parserMode)
+    {
+        this.parserMode = requireNonNull(parserMode, "parserMode is null");
         this.decimalLiteralTreatment = requireNonNull(decimalLiteralTreatment, "decimalLiteralTreatment is null");
     }
 
     public DecimalLiteralTreatment getDecimalLiteralTreatment()
     {
         return decimalLiteralTreatment;
+    }
+
+    public SqlParserMode getSqlParserMode()
+    {
+        return parserMode;
     }
 }

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/SqlParser.java
@@ -153,7 +153,7 @@ public class SqlParser
                 tree = parseFunction.apply(parser);
             }
 
-            return new AstBuilder(parsingOptions).visit(tree);
+            return AstBuilderFactory.create(parsingOptions).visit(tree);
         }
         catch (StackOverflowError e) {
             throw new ParsingException(name + " is too large (stack overflow while parsing)");

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/ParserAssert.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/ParserAssert.java
@@ -28,7 +28,9 @@ import java.util.function.Function;
 
 import static io.trino.sql.SqlFormatter.formatSql;
 import static io.trino.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DECIMAL;
+import static io.trino.sql.parser.ParsingOptions.SqlParserMode.READ_ONLY;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class ParserAssert
         extends RecursiveComparisonAssert<ParserAssert>
@@ -75,6 +77,11 @@ public class ParserAssert
         return new SqlParser().createStatement(statement, new ParsingOptions(AS_DECIMAL));
     }
 
+    private static Statement createReadOnlyStatement(String statement)
+    {
+        return new SqlParser().createStatement(statement, new ParsingOptions(AS_DECIMAL, READ_ONLY));
+    }
+
     public static ThrowableAssertAlternative<ParsingException> assertExpressionIsInvalid(String sql)
     {
         return assertThatExceptionOfType(ParsingException.class)
@@ -87,6 +94,19 @@ public class ParserAssert
         return assertThatExceptionOfType(ParsingException.class)
                 .as("statement: %s", sql)
                 .isThrownBy(() -> createStatement(sql));
+    }
+
+    public static ThrowableAssertAlternative<ParsingException> assertRestrictedStatementInReadOnlyMode(String sql)
+    {
+        return assertThatExceptionOfType(ParsingException.class)
+                .as("Unexpected %s statement when READ_ONLY mode is enabled", sql)
+                .isThrownBy(() -> createReadOnlyStatement(sql));
+    }
+
+    public static void assertAllowedStatementsInReadOnlyMode(String sql)
+    {
+        assertThatNoException()
+                .isThrownBy(() -> createReadOnlyStatement(sql));
     }
 
     private ParserAssert(Node actual, RecursiveComparisonConfiguration recursiveComparisonConfiguration)


### PR DESCRIPTION
A new config property `parser.read-only` enables control over which SQL queries should be parsed successfully.

When enabled (read-only mode), a subset of SQL is restricted and attempts to execute restricted queries (considered non read-only) result in ParsingExceptions.  

Implementation: The SQL Syntax Tree Builder is extended by a 'restricted' one, which throws exceptions for some chosen nodes. The list of @Overridden methods in the AstRestrictedBuilder correspond to the restricted nodes.