### PR TITLE
Speed up avg by using divideRoundUp vs BigDecimal

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/UnscaledDecimal128Arithmetic.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/UnscaledDecimal128Arithmetic.java
@@ -1333,7 +1333,7 @@ public final class UnscaledDecimal128Arithmetic
                 getRawLong(divisor, 0), getRawLong(divisor, 1));
     }
 
-    private static Slice divideRoundUp(long dividendLow, long dividendHigh, int dividendScaleFactor, long divisorLow, long divisorHigh)
+    public static Slice divideRoundUp(long dividendLow, long dividendHigh, int dividendScaleFactor, long divisorLow, long divisorHigh)
     {
         Slice quotient = unscaledDecimal();
         Slice remainder = unscaledDecimal();


### PR DESCRIPTION
jmh benchmark results.
The targeted benchmark of the `average` method shows clear improvement (50% for LongDecimal and 20% for Short).
The improvements is smaller in the more holistic benchmark (`BenchmarkDecimalAggregation`)


```
Benchmark                                           (function)  (groupCount)  (type)  (useBigDecimal)  Mode  Cnt          Score         Error  Units
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg            10   SHORT             true  avgt   90       2104.165 ±      18.746  ns/op
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg            10   SHORT            false  avgt   90       2083.770 ±      19.855  ns/op
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg            10    LONG             true  avgt   90       2295.552 ±      19.400  ns/op
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg            10    LONG            false  avgt   90       2170.413 ±      10.903  ns/op
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg          1000   SHORT             true  avgt   90      83475.493 ±     452.819  ns/op
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg          1000   SHORT            false  avgt   90      74812.440 ±     932.034  ns/op
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg          1000    LONG             true  avgt   90     104369.094 ±     742.228  ns/op
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg          1000    LONG            false  avgt   90      75741.085 ±     504.816  ns/op
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg       1000000   SHORT             true  avgt   90  189032568.685 ±  447817.493  ns/op
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg       1000000   SHORT            false  avgt   90  189839406.294 ± 1166765.264  ns/op
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg       1000000    LONG             true  avgt   90  204093954.254 ± 1173322.934  ns/op
BenchmarkDecimalAggregation.benchmarkEvaluateFinal         avg       1000000    LONG            false  avgt   90  189802466.535 ±  639884.392  ns/op

targeted outputLongDecimal, outputShortDecimal benchmark
-- 
Benchmark                                                Mode  Cnt    Score   Error  Units
BenchmarkOutputAverageDecimal.divideBigDecimalLong                     avgt   60  260.063 ± 0.775  ns/op
BenchmarkOutputAverageDecimal.divideBigDecimalShort                    avgt   60  102.802 ± 0.646  ns/op
BenchmarkOutputAverageDecimal.divideUnscaledDecimal128ArithmeticLong   avgt   60  130.957 ± 1.645  ns/op
BenchmarkOutputAverageDecimal.divideUnscaledDecimal128ArithmeticShort  avgt   60   79.789 ± 0.483  ns/op
```