### PR TITLE
Fix failure when validating pre-sorted input properties

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
@@ -6171,6 +6171,14 @@ public abstract class AbstractTestEngineOnlyQueries
                 "ORDER BY orderkey " +
                 "LIMIT 1"))
                 .matches("VALUES (BIGINT '1', BIGINT '370')");
+
+        assertThat(query("SELECT " +
+                "         'name' as name, " +
+                "         'age' as age " +
+                "         FROM customer " +
+                "         ORDER BY age, name " +
+                "         LIMIT 1"))
+                .matches("VALUES ('name', 'age')");
     }
 
     private static ZonedDateTime zonedDateTime(String value)


### PR DESCRIPTION
Continuation of d5e3a9aaabf7f9fe22af36e93b74545e997b2dec to handle the
case where multiple constant columns appear in a different order.