### PR TITLE
Use RowType in decimal aggregation serde

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -42,6 +42,7 @@ import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockEncoding;
 import io.trino.spi.block.BlockEncodingSerde;
 import io.trino.spi.block.ByteArrayBlockEncoding;
+import io.trino.spi.block.DecimalAggregationAccumulatorBlockEncoding;
 import io.trino.spi.block.DictionaryBlockEncoding;
 import io.trino.spi.block.Int128ArrayBlockEncoding;
 import io.trino.spi.block.Int96ArrayBlockEncoding;
@@ -282,6 +283,7 @@ public final class MetadataManager
         addBlockEncoding(new SingleRowBlockEncoding());
         addBlockEncoding(new RunLengthBlockEncoding());
         addBlockEncoding(new LazyBlockEncoding());
+        addBlockEncoding(new DecimalAggregationAccumulatorBlockEncoding());
 
         verifyTypes();
 

--- a/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/TypeRegistry.java
@@ -48,6 +48,8 @@ import static com.google.common.base.Throwables.throwIfUnchecked;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalAggregationAccumulatorType.LONG_DECIMAL_WITH_OVERFLOW;
+import static io.trino.spi.type.DecimalAggregationAccumulatorType.LONG_DECIMAL_WITH_OVERFLOW_AND_LONG;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.HyperLogLogType.HYPER_LOG_LOG;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -122,6 +124,8 @@ final class TypeRegistry
         addType(IPADDRESS);
         addType(UUID);
         addType(TDIGEST);
+        addType(LONG_DECIMAL_WITH_OVERFLOW_AND_LONG);
+        addType(LONG_DECIMAL_WITH_OVERFLOW);
         addParametricType(VarcharParametricType.VARCHAR);
         addParametricType(CharParametricType.CHAR);
         addParametricType(DecimalParametricType.DECIMAL);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalAverageAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalAverageAggregation.java
@@ -53,7 +53,6 @@ import static io.trino.spi.type.UnscaledDecimal128Arithmetic.addWithOverflow;
 import static io.trino.spi.type.UnscaledDecimal128Arithmetic.divideRoundUp;
 import static io.trino.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToBigInteger;
 import static io.trino.spi.type.UnscaledDecimal128Arithmetic.unscaledDecimalToUnscaledLong;
-import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.util.Reflection.methodHandle;
 import static java.math.BigDecimal.ROUND_HALF_UP;
 
@@ -89,7 +88,7 @@ public class DecimalAverageAggregation
                         AGGREGATE),
                 new AggregationFunctionMetadata(
                         false,
-                        VARBINARY.getTypeSignature()));
+                        LongDecimalWithOverflowAndLongStateSerializer.SERIALIZED_TYPE.getTypeSignature()));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalSumAggregation.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/DecimalSumAggregation.java
@@ -46,7 +46,6 @@ import static io.trino.spi.type.UnscaledDecimal128Arithmetic.SIGN_LONG_MASK;
 import static io.trino.spi.type.UnscaledDecimal128Arithmetic.addWithOverflow;
 import static io.trino.spi.type.UnscaledDecimal128Arithmetic.throwIfOverflows;
 import static io.trino.spi.type.UnscaledDecimal128Arithmetic.throwOverflowException;
-import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.util.Reflection.methodHandle;
 
 public class DecimalSumAggregation
@@ -76,7 +75,7 @@ public class DecimalSumAggregation
                         AGGREGATE),
                 new AggregationFunctionMetadata(
                         false,
-                        VARBINARY.getTypeSignature()));
+                        LongDecimalWithOverflowStateSerializer.SERIALIZED_TYPE.getTypeSignature()));
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/state/BenchmarkLongDecimalWithOverflowAndLongStateSerializer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/state/BenchmarkLongDecimalWithOverflowAndLongStateSerializer.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.state;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.jmh.Benchmarks;
+import io.trino.operator.aggregation.state.LongDecimalWithOverflowAndLongStateFactory.GroupedLongDecimalWithOverflowAndLongState;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AccumulatorStateSerializer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.stream.Collectors.toList;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(2)
+@Warmup(iterations = 10)
+@Measurement(iterations = 20)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkLongDecimalWithOverflowAndLongStateSerializer
+{
+    @Benchmark
+    public Object serialize(BenchmarkData data)
+    {
+        return data.serialize(new LongDecimalWithOverflowAndLongStateSerializer());
+    }
+
+    @Benchmark
+    public Object deserialize(BenchmarkData data)
+    {
+        return data.deserialize(new LongDecimalWithOverflowAndLongStateSerializer());
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private static final Random RANDOM = new Random(45624387);
+        private static final int GROUP_COUNT = 1024;
+
+        @Param({"0", "0.2", "0.5", "0.8"})
+        private float nullRate;
+
+        @Param({"0", "0.2", "0.5", "0.8"})
+        private float overflowRate;
+
+        private GroupedLongDecimalWithOverflowAndLongState inState;
+        private GroupedLongDecimalWithOverflowAndLongState outState;
+        private Block block;
+
+        @Setup
+        public void setup()
+        {
+            inState = new GroupedLongDecimalWithOverflowAndLongState();
+            inState.ensureCapacity(GROUP_COUNT);
+            Set<Integer> nullPositions = chooseRandomUnique(GROUP_COUNT, nullRate, ImmutableSet.of());
+            Set<Integer> overflowPositions = chooseRandomUnique(GROUP_COUNT, overflowRate, nullPositions);
+
+            for (int i = 0; i < GROUP_COUNT; i++) {
+                inState.setGroupId(i);
+                if (nullPositions.contains(i)) {
+                    continue;
+                }
+
+                inState.setNotNull();
+                inState.setLong(RANDOM.nextLong());
+                long[] decimalArray = inState.getDecimalArray();
+                decimalArray[0] = RANDOM.nextLong();
+                decimalArray[1] = RANDOM.nextLong();
+                if (overflowPositions.contains(i)) {
+                    inState.setOverflow(RANDOM.nextLong());
+                }
+            }
+
+            block = serialize(new LongDecimalWithOverflowAndLongStateSerializer()).build();
+            outState = new GroupedLongDecimalWithOverflowAndLongState();
+            outState.ensureCapacity(GROUP_COUNT);
+        }
+
+        private static Set<Integer> chooseRandomUnique(int bound, float rate, Set<Integer> taken)
+        {
+            int count = (int) (bound * rate);
+            if (count == 0) {
+                verify(rate == 0, "bound %s too small to have at least one  result with rate %s", (Object) count, rate);
+                return ImmutableSet.of();
+            }
+            verify(bound >= count + taken.size(), "Too many numbers already taken bound %s, count %s, taken %s", bound, count, taken.size());
+
+            List<Integer> availableNumbers = IntStream.range(0, bound).boxed()
+                    .filter(i -> !taken.contains(i))
+                    .collect(toList());
+            Collections.shuffle(availableNumbers, RANDOM);
+            return availableNumbers.stream()
+                    .limit(count)
+                    .collect(toImmutableSet());
+        }
+
+        public BlockBuilder serialize(AccumulatorStateSerializer<LongDecimalWithOverflowAndLongState> serializer)
+        {
+            BlockBuilder out = serializer.getSerializedType().createBlockBuilder(null, GROUP_COUNT);
+            GroupedLongDecimalWithOverflowAndLongState state = this.inState;
+            for (int i = 0; i < GROUP_COUNT; i++) {
+                state.setGroupId(i);
+                serializer.serialize(state, out);
+            }
+            return out;
+        }
+
+        private GroupedLongDecimalWithOverflowAndLongState deserialize(AccumulatorStateSerializer<LongDecimalWithOverflowAndLongState> serializer)
+        {
+            for (int i = 0; i < BenchmarkData.GROUP_COUNT; i++) {
+                outState.setGroupId(i);
+                serializer.deserialize(block, i, outState);
+            }
+            return outState;
+        }
+
+        public GroupedLongDecimalWithOverflowAndLongState getOutState()
+        {
+            return outState;
+        }
+    }
+
+    @Test
+    public void verifyBenchmark()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+
+        new BenchmarkLongDecimalWithOverflowAndLongStateSerializer().serialize(data);
+        new BenchmarkLongDecimalWithOverflowAndLongStateSerializer().deserialize(data);
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        // ensure the benchmarks are valid before running
+        new BenchmarkLongDecimalWithOverflowAndLongStateSerializer().verifyBenchmark();
+
+        Benchmarks.benchmark(BenchmarkLongDecimalWithOverflowAndLongStateSerializer.class).run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestLongDecimalWithOverflowAndLongStateSerializer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestLongDecimalWithOverflowAndLongStateSerializer.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.state;
+
+import io.trino.operator.aggregation.state.LongDecimalWithOverflowAndLongStateFactory.SingleLongDecimalWithOverflowAndLongState;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLongDecimalWithOverflowAndLongStateSerializer
+{
+    @Test
+    public void testSerializeDeserialize()
+    {
+        LongDecimalWithOverflowAndLongStateSerializer serializer = new LongDecimalWithOverflowAndLongStateSerializer();
+        BlockBuilder out = serializer.getSerializedType().createBlockBuilder(null, 2);
+
+        LongDecimalWithOverflowAndLongState[] states = {
+                createNotNullState(1, 1, 2, 3),
+                new SingleLongDecimalWithOverflowAndLongState(),
+                createNotNullState(1, 1, 2, 0),
+                createNotNullState(1, 2, 3, 4)
+        };
+
+        for (LongDecimalWithOverflowAndLongState state : states) {
+            serializer.serialize(state, out);
+        }
+        Block outBlock = out.build();
+
+        for (int i = 0; i < states.length; i++) {
+            deserializeAndVerify(serializer, states[i], outBlock, i);
+        }
+    }
+
+    private LongDecimalWithOverflowAndLongState createNotNullState(long count, int low, int high, int overflow)
+    {
+        LongDecimalWithOverflowAndLongState state = new SingleLongDecimalWithOverflowAndLongState();
+        state.setNotNull();
+        state.setLong(count);
+        state.getDecimalArray()[0] = low;
+        state.getDecimalArray()[1] = high;
+        state.setOverflow(overflow);
+        return state;
+    }
+
+    private void deserializeAndVerify(LongDecimalWithOverflowAndLongStateSerializer serializer, LongDecimalWithOverflowAndLongState state, Block outBlock, int position)
+    {
+        LongDecimalWithOverflowAndLongState outState = new SingleLongDecimalWithOverflowAndLongState();
+        serializer.deserialize(outBlock, position, outState);
+        assertThat(outState.isNotNull()).isEqualTo(state.isNotNull());
+        assertThat(outState.getLong()).isEqualTo(state.getLong());
+        assertThat(outState.getDecimalArray()).containsExactly(state.getDecimalArray());
+        assertThat(outState.getOverflow()).isEqualTo(state.getOverflow());
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestLongDecimalWithOverflowStateSerializer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/state/TestLongDecimalWithOverflowStateSerializer.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation.state;
+
+import io.trino.operator.aggregation.state.LongDecimalWithOverflowStateFactory.SingleLongDecimalWithOverflowState;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestLongDecimalWithOverflowStateSerializer
+{
+    @Test
+    public void testSerializeDeserialize()
+    {
+        LongDecimalWithOverflowStateSerializer serializer = new LongDecimalWithOverflowStateSerializer();
+        BlockBuilder out = serializer.getSerializedType().createBlockBuilder(null, 2);
+
+        LongDecimalWithOverflowState[] states = {
+                createNotNullState(1, 2, 3),
+                new SingleLongDecimalWithOverflowState(),
+                createNotNullState(1, 2, 0),
+                createNotNullState(2, 3, 4)
+        };
+
+        for (LongDecimalWithOverflowState state : states) {
+            serializer.serialize(state, out);
+        }
+        Block outBlock = out.build();
+
+        for (int i = 0; i < states.length; i++) {
+            deserializeAndVerify(serializer, states[i], outBlock, i);
+        }
+    }
+
+    private LongDecimalWithOverflowState createNotNullState(int low, int high, int overflow)
+    {
+        LongDecimalWithOverflowState state = new SingleLongDecimalWithOverflowState();
+        state.setNotNull();
+        state.getDecimalArray()[0] = low;
+        state.getDecimalArray()[1] = high;
+        state.setOverflow(overflow);
+        return state;
+    }
+
+    private void deserializeAndVerify(LongDecimalWithOverflowStateSerializer serializer, LongDecimalWithOverflowState state, Block outBlock, int position)
+    {
+        LongDecimalWithOverflowState outState = new SingleLongDecimalWithOverflowState();
+        serializer.deserialize(outBlock, position, outState);
+        assertThat(outState.isNotNull()).isEqualTo(state.isNotNull());
+        assertThat(outState.getDecimalArray()).containsExactly(state.getDecimalArray());
+        assertThat(outState.getOverflow()).isEqualTo(state.getOverflow());
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DecimalAggregationAccumulatorBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DecimalAggregationAccumulatorBlock.java
@@ -1,0 +1,330 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.block;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import static io.airlift.slice.SizeOf.sizeOf;
+import static io.trino.spi.block.BlockUtil.checkArrayRange;
+import static io.trino.spi.block.BlockUtil.checkValidRegion;
+import static io.trino.spi.block.BlockUtil.compactArray;
+import static io.trino.spi.block.BlockUtil.countUsedPositions;
+
+public class DecimalAggregationAccumulatorBlock
+        implements Block
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DecimalAggregationAccumulatorBlock.class).instanceSize();
+
+    private final int positionOffset;
+    private final int positionCount;
+    @Nullable
+    private final boolean[] valueIsNull;
+    private final long[] values;
+    @Nullable
+    private final long[] overflow;
+
+    private final long sizeInBytes;
+    private final long retainedSizeInBytes;
+    private final int numberOfNoOverflowValuesPerEntry;
+    private final int maxOffset;
+
+    public DecimalAggregationAccumulatorBlock(int positionCount, Optional<boolean[]> valueIsNull, long[] values, Optional<long[]> overflow, int numberOfNoOverflowValuesPerEntry)
+    {
+        this(0, positionCount, valueIsNull.orElse(null), values, overflow.orElse(null), numberOfNoOverflowValuesPerEntry);
+    }
+
+    DecimalAggregationAccumulatorBlock(int positionOffset, int positionCount, boolean[] valueIsNull, long[] values, long[] overflow, int numberOfNoOverflowValuesPerEntry)
+    {
+        if (positionOffset < 0) {
+            throw new IllegalArgumentException("positionOffset is negative");
+        }
+        this.positionOffset = positionOffset;
+        if (positionCount < 0) {
+            throw new IllegalArgumentException("positionCount is negative");
+        }
+        this.positionCount = positionCount;
+
+        this.numberOfNoOverflowValuesPerEntry = numberOfNoOverflowValuesPerEntry;
+
+        // offset used for overflow
+        this.maxOffset = 8 * numberOfNoOverflowValuesPerEntry;
+
+        if (values.length - (positionOffset * numberOfNoOverflowValuesPerEntry) < positionCount * numberOfNoOverflowValuesPerEntry) {
+            throw new IllegalArgumentException("values length is less than positionCount");
+        }
+        this.values = values;
+
+        if (valueIsNull != null && valueIsNull.length - positionOffset < positionCount) {
+            throw new IllegalArgumentException("isNull length is less than positionCount");
+        }
+        this.valueIsNull = valueIsNull;
+
+        if (overflow != null && overflow.length - positionOffset < positionCount) {
+            throw new IllegalArgumentException("overflow length is less than positionCount");
+        }
+        this.overflow = overflow;
+
+        sizeInBytes = (numberOfNoOverflowValuesPerEntry + Byte.BYTES + Long.BYTES) * (long) positionCount;
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values) + sizeOf(overflow);
+    }
+
+    @Override
+    public int getSliceLength(int position)
+    {
+        return getEntrySizeInBytes();
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return sizeInBytes;
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return getEntrySizeInBytes() * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return getEntrySizeInBytes() * (long) countUsedPositions(positions);
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : getEntrySizeInBytes();
+    }
+
+    private int getEntrySizeInBytes()
+    {
+        return numberOfNoOverflowValuesPerEntry * Long.BYTES + Long.BYTES;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        if (valueIsNull != null) {
+            consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        }
+        if (overflow != null) {
+            consumer.accept(overflow, sizeOf(overflow));
+        }
+        consumer.accept(this, (long) INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset == maxOffset) {
+            // overflow
+            return getOverflow(position);
+        }
+        if (offset < 0 || !isMultiplicationOf8(offset) || offset > maxOffset) {
+            throw new IllegalArgumentException("invalid offset " + offset);
+        }
+        int valuesOffset = offset / 8;
+
+        return values[((position + positionOffset) * numberOfNoOverflowValuesPerEntry) + valuesOffset];
+    }
+
+    static boolean isMultiplicationOf8(int number)
+    {
+        return (number & 7) == 0;
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return valueIsNull != null;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull != null && valueIsNull[position + positionOffset];
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        int startIndex = (position + positionOffset) * numberOfNoOverflowValuesPerEntry;
+        for (int i = 0; i < numberOfNoOverflowValuesPerEntry; i++) {
+            blockBuilder.writeLong(values[startIndex + i]);
+        }
+        blockBuilder.writeLong(getOverflow(position));
+        blockBuilder.closeEntry();
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        long overflowValue = getOverflow(position);
+        return new DecimalAggregationAccumulatorBlock(
+                0,
+                1,
+                isNull(position) ? new boolean[] {true} : null,
+                compactArray(values, (position + positionOffset) * numberOfNoOverflowValuesPerEntry, numberOfNoOverflowValuesPerEntry),
+                overflowValue != 0 ? new long[] {overflowValue} : null,
+                numberOfNoOverflowValuesPerEntry);
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        boolean[] newValueIsNull = null;
+        if (valueIsNull != null) {
+            newValueIsNull = new boolean[length];
+        }
+        long[] newValues = new long[length * numberOfNoOverflowValuesPerEntry];
+        long[] newOverflow = null;
+        if (overflow != null) {
+            newOverflow = new long[length];
+        }
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            if (valueIsNull != null) {
+                newValueIsNull[i] = valueIsNull[position + positionOffset];
+            }
+            for (int j = 0; j < numberOfNoOverflowValuesPerEntry; j++) {
+                newValues[(i * numberOfNoOverflowValuesPerEntry) + j] = values[((position + positionOffset) * numberOfNoOverflowValuesPerEntry) + j];
+            }
+            if (overflow != null) {
+                newOverflow[i] = overflow[position + positionOffset];
+            }
+        }
+        return new DecimalAggregationAccumulatorBlock(0, length, newValueIsNull, newValues, newOverflow, numberOfNoOverflowValuesPerEntry);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        return new DecimalAggregationAccumulatorBlock(positionOffset + this.positionOffset, length, valueIsNull, values, overflow, numberOfNoOverflowValuesPerEntry);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        positionOffset += this.positionOffset;
+        boolean[] newValueIsNull = valueIsNull == null ? null : compactArray(valueIsNull, positionOffset, length);
+        long[] newValues = compactArray(values, positionOffset * numberOfNoOverflowValuesPerEntry, length * numberOfNoOverflowValuesPerEntry);
+        long[] newOverflow = overflow == null ? null : compactArray(overflow, positionOffset, length);
+
+        if (newValueIsNull == valueIsNull && newValues == values && newOverflow == overflow) {
+            return this;
+        }
+        return new DecimalAggregationAccumulatorBlock(0, length, newValueIsNull, newValues, newOverflow, numberOfNoOverflowValuesPerEntry);
+    }
+
+    @Override
+    public Slice getSlice(int position, int offset, int length)
+    {
+        if (length != getEntrySizeInBytes()) {
+            throw new IllegalArgumentException("length different than entrySizeInBytes: " + length);
+        }
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero but got: " + offset);
+        }
+        int startIndex = (positionOffset + position) * numberOfNoOverflowValuesPerEntry;
+        long[] array = new long[numberOfNoOverflowValuesPerEntry + 1];
+        for (int i = 0; i < numberOfNoOverflowValuesPerEntry; i++) {
+            array[i] = values[startIndex + i];
+        }
+        array[numberOfNoOverflowValuesPerEntry] = getOverflow(position);
+        return Slices.wrappedLongArray(array);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return DecimalAggregationAccumulatorBlockEncoding.NAME;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder("DecimalAggregationAccumulatorBlock{");
+        sb.append("positionCount=").append(getPositionCount());
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public Slice getValuesSlice()
+    {
+        return Slices.wrappedLongArray(
+                values,
+                positionOffset * numberOfNoOverflowValuesPerEntry,
+                positionCount * numberOfNoOverflowValuesPerEntry);
+    }
+
+    public Slice getOverflowSlice()
+    {
+        return overflow == null ?
+                null :
+                Slices.wrappedLongArray(
+                        overflow,
+                        positionOffset,
+                        positionCount);
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+
+    public int getNumberOfNoOverflowValuesPerEntry()
+    {
+        return numberOfNoOverflowValuesPerEntry;
+    }
+
+    private long getOverflow(int position)
+    {
+        return overflow != null ? overflow[position + positionOffset] : 0;
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DecimalAggregationAccumulatorBlockBuilder.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DecimalAggregationAccumulatorBlockBuilder.java
@@ -1,0 +1,403 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.block;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.function.BiConsumer;
+
+import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static io.trino.spi.block.BlockUtil.calculateBlockResetSize;
+import static io.trino.spi.block.BlockUtil.checkArrayRange;
+import static io.trino.spi.block.BlockUtil.checkValidRegion;
+import static io.trino.spi.block.BlockUtil.compactArray;
+import static io.trino.spi.block.BlockUtil.countUsedPositions;
+import static io.trino.spi.block.DecimalAggregationAccumulatorBlock.isMultiplicationOf8;
+import static java.lang.Math.max;
+
+public class DecimalAggregationAccumulatorBlockBuilder
+        implements BlockBuilder
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(DecimalAggregationAccumulatorBlockBuilder.class).instanceSize();
+
+    @Nullable
+    private final BlockBuilderStatus blockBuilderStatus;
+    private final int entrySize;
+    private final int numberOfNoOverflowValuesPerEntry;
+    private final int maxOffset;
+
+    private boolean initialized;
+    private final int initialEntryCount;
+
+    private int positionCount;
+    private boolean hasNullValue;
+    private boolean hasNonNullValue;
+    private boolean hasNonZeroOverflowValue;
+
+    // it is assumed that valueIsNull and overflow arrays are the same length
+    private boolean[] valueIsNull = new boolean[0];
+    private long[] overflow = new long[0];
+
+    private long[] values = new long[0];
+
+    private long retainedSizeInBytes;
+
+    private int entryPositionCount;
+
+    public DecimalAggregationAccumulatorBlockBuilder(@Nullable BlockBuilderStatus blockBuilderStatus, int expectedEntries, int numberOfNoOverflowValuesPerEntry)
+    {
+        this.blockBuilderStatus = blockBuilderStatus;
+        this.initialEntryCount = max(expectedEntries, 1);
+        this.numberOfNoOverflowValuesPerEntry = numberOfNoOverflowValuesPerEntry;
+        this.entrySize = numberOfNoOverflowValuesPerEntry * Long.BYTES + Long.BYTES;
+        // offset used for overflow
+        this.maxOffset = 8 * numberOfNoOverflowValuesPerEntry;
+
+        updateDataSize();
+    }
+
+    @Override
+    public BlockBuilder writeLong(long value)
+    {
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+        if (entryPositionCount == numberOfNoOverflowValuesPerEntry) {
+            overflow[positionCount] = value;
+            hasNonZeroOverflowValue |= value != 0;
+        }
+        else {
+            values[(positionCount * numberOfNoOverflowValuesPerEntry) + entryPositionCount] = value;
+        }
+        entryPositionCount++;
+
+        hasNonNullValue = true;
+        return this;
+    }
+
+    @Override
+    public BlockBuilder closeEntry()
+    {
+        if (entryPositionCount != numberOfNoOverflowValuesPerEntry + 1) {
+            throw new IllegalStateException("Expected entry size to be exactly " + entrySize + " bytes but was " + (entryPositionCount * SIZE_OF_LONG));
+        }
+
+        positionCount++;
+        entryPositionCount = 0;
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + entrySize);
+        }
+        return this;
+    }
+
+    @Override
+    public BlockBuilder appendNull()
+    {
+        if (valueIsNull.length <= positionCount) {
+            growCapacity();
+        }
+        if (entryPositionCount != 0) {
+            throw new IllegalStateException("Current entry must be closed before a null can be written");
+        }
+
+        valueIsNull[positionCount] = true;
+
+        hasNullValue = true;
+        positionCount++;
+        if (blockBuilderStatus != null) {
+            blockBuilderStatus.addBytes(Byte.BYTES + entrySize);
+        }
+        return this;
+    }
+
+    @Override
+    public Block build()
+    {
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(nullValueBLock(entrySize), positionCount);
+        }
+        return new DecimalAggregationAccumulatorBlock(0, positionCount, hasNullValue ? valueIsNull : null, values, hasNonZeroOverflowValue ? overflow : null, numberOfNoOverflowValuesPerEntry);
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
+    {
+        return new DecimalAggregationAccumulatorBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount), numberOfNoOverflowValuesPerEntry);
+    }
+
+    private void growCapacity()
+    {
+        int newSize;
+        if (initialized) {
+            newSize = BlockUtil.calculateNewArraySize(valueIsNull.length);
+        }
+        else {
+            newSize = initialEntryCount;
+            initialized = true;
+        }
+
+        valueIsNull = Arrays.copyOf(valueIsNull, newSize);
+        values = Arrays.copyOf(values, newSize * numberOfNoOverflowValuesPerEntry);
+        overflow = Arrays.copyOf(overflow, newSize);
+        updateDataSize();
+    }
+
+    private void updateDataSize()
+    {
+        retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values) + sizeOf(overflow);
+        if (blockBuilderStatus != null) {
+            retainedSizeInBytes += BlockBuilderStatus.INSTANCE_SIZE;
+        }
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return (entrySize + Byte.BYTES) * (long) positionCount;
+    }
+
+    @Override
+    public long getRegionSizeInBytes(int position, int length)
+    {
+        return (entrySize + Byte.BYTES) * (long) length;
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] positions)
+    {
+        return (entrySize + Byte.BYTES) * (long) countUsedPositions(positions);
+    }
+
+    @Override
+    public long getRetainedSizeInBytes()
+    {
+        return retainedSizeInBytes;
+    }
+
+    @Override
+    public long getEstimatedDataSizeForStats(int position)
+    {
+        return isNull(position) ? 0 : entrySize;
+    }
+
+    @Override
+    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    {
+        consumer.accept(values, sizeOf(values));
+        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        consumer.accept(overflow, sizeOf(overflow));
+        consumer.accept(this, (long) INSTANCE_SIZE);
+    }
+
+    @Override
+    public int getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getLong(int position, int offset)
+    {
+        checkReadablePosition(position);
+        if (offset == maxOffset) {
+            // overflow
+            return overflow[position];
+        }
+        if (offset < 0 || !isMultiplicationOf8(offset) || offset > maxOffset) {
+            throw new IllegalArgumentException("invalid offset " + offset);
+        }
+        int valuesOffset = offset / 8;
+
+        return values[(position * numberOfNoOverflowValuesPerEntry) + valuesOffset];
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return hasNullValue;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull[position];
+    }
+
+    @Override
+    public void writePositionTo(int position, BlockBuilder blockBuilder)
+    {
+        checkReadablePosition(position);
+        int startIndex = position * numberOfNoOverflowValuesPerEntry;
+        for (int i = 0; i < numberOfNoOverflowValuesPerEntry; i++) {
+            blockBuilder.writeLong(values[startIndex + i]);
+        }
+        blockBuilder.writeLong(overflow[position]);
+        blockBuilder.closeEntry();
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        checkReadablePosition(position);
+        return new DecimalAggregationAccumulatorBlock(
+                0,
+                1,
+                isNull(position) ? new boolean[] {true} : null,
+                compactArray(values, position * numberOfNoOverflowValuesPerEntry, numberOfNoOverflowValuesPerEntry),
+                overflow[position] != 0 ? new long[] {overflow[position]} : null,
+                numberOfNoOverflowValuesPerEntry);
+    }
+
+    @Override
+    public Block copyPositions(int[] positions, int offset, int length)
+    {
+        checkArrayRange(positions, offset, length);
+
+        boolean[] newValueIsNull = null;
+        if (valueIsNull != null) {
+            newValueIsNull = new boolean[length];
+        }
+        long[] newValues = new long[length * numberOfNoOverflowValuesPerEntry];
+        long[] newOverflow = null;
+        if (overflow != null) {
+            newOverflow = new long[length];
+        }
+        for (int i = 0; i < length; i++) {
+            int position = positions[offset + i];
+            checkReadablePosition(position);
+            if (valueIsNull != null) {
+                newValueIsNull[i] = valueIsNull[position];
+            }
+            for (int j = 0; j < numberOfNoOverflowValuesPerEntry; j++) {
+                newValues[(i * numberOfNoOverflowValuesPerEntry) + j] = values[(position * numberOfNoOverflowValuesPerEntry) + j];
+            }
+            if (overflow != null) {
+                newOverflow[i] = overflow[position];
+            }
+        }
+        return new DecimalAggregationAccumulatorBlock(0, length, newValueIsNull, newValues, newOverflow, numberOfNoOverflowValuesPerEntry);
+    }
+
+    @Override
+    public Block getRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(nullValueBLock(entrySize), length);
+        }
+        return new DecimalAggregationAccumulatorBlock(positionOffset, length, hasNullValue ? valueIsNull : null, values, hasNonZeroOverflowValue ? overflow : null, numberOfNoOverflowValuesPerEntry);
+    }
+
+    @Override
+    public Block copyRegion(int positionOffset, int length)
+    {
+        checkValidRegion(getPositionCount(), positionOffset, length);
+
+        if (!hasNonNullValue) {
+            return new RunLengthEncodedBlock(nullValueBLock(entrySize), length);
+        }
+        boolean[] newValueIsNull = null;
+        if (hasNullValue) {
+            newValueIsNull = compactArray(valueIsNull, positionOffset, length);
+        }
+        long[] newOverflow = hasNonZeroOverflowValue ? compactArray(overflow, positionOffset, length) : null;
+        long[] newValues = compactArray(values, positionOffset * numberOfNoOverflowValuesPerEntry, length * numberOfNoOverflowValuesPerEntry);
+        return new DecimalAggregationAccumulatorBlock(0, length, newValueIsNull, newValues, newOverflow, numberOfNoOverflowValuesPerEntry);
+    }
+
+    @Override
+    public String getEncodingName()
+    {
+        return DecimalAggregationAccumulatorBlockEncoding.NAME;
+    }
+
+    @Override
+    public int getSliceLength(int position)
+    {
+        return getEntrySizeInBytes();
+    }
+
+    @Override
+    public Slice getSlice(int position, int offset, int length)
+    {
+        if (length != getEntrySizeInBytes()) {
+            throw new IllegalArgumentException("length different than entrySizeInBytes: " + length);
+        }
+        if (offset != 0) {
+            throw new IllegalArgumentException("offset must be zero but got: " + offset);
+        }
+        int startIndex = position * numberOfNoOverflowValuesPerEntry;
+        long[] array = new long[numberOfNoOverflowValuesPerEntry + 1];
+        for (int i = 0; i < numberOfNoOverflowValuesPerEntry; i++) {
+            array[i] = values[startIndex + i];
+        }
+        array[numberOfNoOverflowValuesPerEntry] = overflow[position];
+        return Slices.wrappedLongArray(array);
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder("DecimalAggregationAccumulatorBlockBuilder{");
+        sb.append("positionCount=").append(getPositionCount());
+        sb.append('}');
+        return sb.toString();
+    }
+
+    public Slice getValuesSlice()
+    {
+        return Slices.wrappedLongArray(values, 0, positionCount * numberOfNoOverflowValuesPerEntry);
+    }
+
+    public Slice getOverflowSlice()
+    {
+        return hasNonZeroOverflowValue ? Slices.wrappedLongArray(overflow, 0, positionCount) : null;
+    }
+
+    public int getNumberOfNoOverflowValuesPerEntry()
+    {
+        return numberOfNoOverflowValuesPerEntry;
+    }
+
+    private void checkReadablePosition(int position)
+    {
+        if (position < 0 || position >= getPositionCount()) {
+            throw new IllegalArgumentException("position is not valid");
+        }
+    }
+
+    private static DecimalAggregationAccumulatorBlock nullValueBLock(int numberOfNoOverflowValuesPerEntry)
+    {
+        return new DecimalAggregationAccumulatorBlock(
+                0,
+                1,
+                new boolean[] {true},
+                new long[numberOfNoOverflowValuesPerEntry],
+                new long[1],
+                numberOfNoOverflowValuesPerEntry);
+    }
+
+    private int getEntrySizeInBytes()
+    {
+        return numberOfNoOverflowValuesPerEntry * Long.BYTES + Long.BYTES;
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DecimalAggregationAccumulatorBlockEncoding.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DecimalAggregationAccumulatorBlockEncoding.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.block;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
+
+import static io.trino.spi.block.EncoderUtil.decodeNullBits;
+import static io.trino.spi.block.EncoderUtil.encodeNullsAsBits;
+
+public class DecimalAggregationAccumulatorBlockEncoding
+        implements BlockEncoding
+{
+    public static final String NAME = "DECIMAL_AGGREGATION_ACCUMULATOR";
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public void writeBlock(BlockEncodingSerde blockEncodingSerde, SliceOutput sliceOutput, Block block)
+    {
+        int positionCount = block.getPositionCount();
+        sliceOutput.appendInt(positionCount);
+        int numberOfNoOverflowValuesPerEntry = getNumberOfNoOverflowValuesPerEntry(block);
+        sliceOutput.appendInt(numberOfNoOverflowValuesPerEntry);
+
+        encodeNullsAsBits(sliceOutput, block);
+
+        if (!block.mayHaveNull()) {
+            sliceOutput.writeBytes(getValuesSlice(block));
+        }
+        else {
+            long[] valuesWithoutNull = new long[positionCount * numberOfNoOverflowValuesPerEntry];
+            int nonNullPositionCount = 0;
+            for (int i = 0; i < positionCount; i++) {
+                for (int j = 0; j < numberOfNoOverflowValuesPerEntry; j++) {
+                    valuesWithoutNull[nonNullPositionCount + j] = block.getLong(i, j * Long.BYTES);
+                }
+                int isNotNull = !block.isNull(i) ? 1 : 0;
+                nonNullPositionCount += numberOfNoOverflowValuesPerEntry * isNotNull;
+            }
+
+            sliceOutput.writeInt(nonNullPositionCount / numberOfNoOverflowValuesPerEntry);
+            sliceOutput.writeBytes(Slices.wrappedLongArray(valuesWithoutNull, 0, nonNullPositionCount));
+        }
+        Slice overflow = getOverflowSlice(block);
+        sliceOutput.writeBoolean(overflow != null);
+        if (overflow != null) {
+            sliceOutput.writeBytes(overflow);
+        }
+    }
+
+    @Override
+    public Block readBlock(BlockEncodingSerde blockEncodingSerde, SliceInput sliceInput)
+    {
+        int positionCount = sliceInput.readInt();
+        int numberOfNoOverflowValuesPerEntry = sliceInput.readInt();
+
+        boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
+
+        long[] values = new long[positionCount * numberOfNoOverflowValuesPerEntry];
+        if (valueIsNull == null) {
+            sliceInput.readBytes(Slices.wrappedLongArray(values));
+        }
+        else {
+            int nonNullPositionCount = sliceInput.readInt();
+            sliceInput.readBytes(Slices.wrappedLongArray(values, 0, nonNullPositionCount * numberOfNoOverflowValuesPerEntry));
+            int position = numberOfNoOverflowValuesPerEntry * (nonNullPositionCount - 1);
+            for (int i = positionCount - 1; i >= 0 && position >= 0; i--) {
+                System.arraycopy(values, position, values, numberOfNoOverflowValuesPerEntry * i, numberOfNoOverflowValuesPerEntry);
+                if (!valueIsNull[i]) {
+                    position -= numberOfNoOverflowValuesPerEntry;
+                }
+            }
+        }
+        boolean nonZeroOverflow = sliceInput.readBoolean();
+        long[] overflow = null;
+        if (nonZeroOverflow) {
+            overflow = new long[positionCount];
+            sliceInput.readBytes(Slices.wrappedLongArray(overflow));
+        }
+
+        return new DecimalAggregationAccumulatorBlock(
+                0,
+                positionCount,
+                valueIsNull,
+                values,
+                overflow,
+                numberOfNoOverflowValuesPerEntry);
+    }
+
+    private Slice getValuesSlice(Block block)
+    {
+        if (block instanceof DecimalAggregationAccumulatorBlock) {
+            return ((DecimalAggregationAccumulatorBlock) block).getValuesSlice();
+        }
+        else if (block instanceof DecimalAggregationAccumulatorBlockBuilder) {
+            return ((DecimalAggregationAccumulatorBlockBuilder) block).getValuesSlice();
+        }
+
+        throw new IllegalArgumentException("Unexpected block type " + block.getClass().getSimpleName());
+    }
+
+    private Slice getOverflowSlice(Block block)
+    {
+        if (block instanceof DecimalAggregationAccumulatorBlock) {
+            return ((DecimalAggregationAccumulatorBlock) block).getOverflowSlice();
+        }
+        else if (block instanceof DecimalAggregationAccumulatorBlockBuilder) {
+            return ((DecimalAggregationAccumulatorBlockBuilder) block).getOverflowSlice();
+        }
+
+        throw new IllegalArgumentException("Unexpected block type " + block.getClass().getSimpleName());
+    }
+
+    private int getNumberOfNoOverflowValuesPerEntry(Block block)
+    {
+        if (block instanceof DecimalAggregationAccumulatorBlock) {
+            return ((DecimalAggregationAccumulatorBlock) block).getNumberOfNoOverflowValuesPerEntry();
+        }
+        else if (block instanceof DecimalAggregationAccumulatorBlockBuilder) {
+            return ((DecimalAggregationAccumulatorBlockBuilder) block).getNumberOfNoOverflowValuesPerEntry();
+        }
+
+        throw new IllegalArgumentException("Unexpected block type " + block.getClass().getSimpleName());
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/type/DecimalAggregationAccumulatorType.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/DecimalAggregationAccumulatorType.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.BlockBuilderStatus;
+import io.trino.spi.block.DecimalAggregationAccumulatorBlockBuilder;
+import io.trino.spi.block.PageBuilderStatus;
+import io.trino.spi.connector.ConnectorSession;
+
+import static java.util.Collections.singletonList;
+
+public class DecimalAggregationAccumulatorType
+        extends AbstractType
+        implements FixedWidthType
+{
+    public static final String NAME = "DecimalAggregationAccumulator";
+    public static final Type LONG_DECIMAL_WITH_OVERFLOW = createDecimalAggregationAccumulatorType(2);
+    public static final Type LONG_DECIMAL_WITH_OVERFLOW_AND_LONG = createDecimalAggregationAccumulatorType(3);
+
+    private final int numberOfNoOverflowValues;
+
+    private DecimalAggregationAccumulatorType(int numberOfNoOverflowValues)
+    {
+        super(
+                new TypeSignature(
+                        NAME,
+                        singletonList(TypeSignatureParameter.numericParameter((long) numberOfNoOverflowValues))),
+                Slice.class);
+
+        if (numberOfNoOverflowValues < 0) {
+            throw new IllegalArgumentException("Invalid DecimalAggregationAccumulatorType numberOfNoOverflowValues " + numberOfNoOverflowValues);
+        }
+        this.numberOfNoOverflowValues = numberOfNoOverflowValues;
+    }
+
+    private static Type createDecimalAggregationAccumulatorType(int numberOfNoOverflowValues)
+    {
+        return new DecimalAggregationAccumulatorType(numberOfNoOverflowValues);
+    }
+
+    @Override
+    public int getFixedSize()
+    {
+        return numberOfNoOverflowValues * Long.BYTES + Long.BYTES;
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        int maxBlockSizeInBytes;
+        if (blockBuilderStatus == null) {
+            maxBlockSizeInBytes = PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
+        }
+        else {
+            maxBlockSizeInBytes = blockBuilderStatus.getMaxPageSizeInBytes();
+        }
+        return new DecimalAggregationAccumulatorBlockBuilder(
+                blockBuilderStatus,
+                Math.min(expectedEntries, maxBlockSizeInBytes / getFixedSize()), numberOfNoOverflowValues);
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return createBlockBuilder(blockBuilderStatus, expectedEntries, getFixedSize());
+    }
+
+    @Override
+    public Object getObjectValue(ConnectorSession session, Block block, int position)
+    {
+        if (block.isNull(position)) {
+            return null;
+        }
+        return new SqlVarbinary(getSlice(block, position).getBytes());
+    }
+
+    @Override
+    public BlockBuilder createFixedSizeBlockBuilder(int positionCount)
+    {
+        return new DecimalAggregationAccumulatorBlockBuilder(null, positionCount, numberOfNoOverflowValues);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            blockBuilder.appendNull();
+        }
+        else {
+            block.writePositionTo(position, blockBuilder);
+        }
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value)
+    {
+        writeSlice(blockBuilder, value, 0, value.length());
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
+    {
+        if (length != getFixedSize()) {
+            throw new IllegalStateException("Expected entry size to be exactly " + getFixedSize() + " but was " + length);
+        }
+        for (int i = 0; i <= numberOfNoOverflowValues; i++) {
+            blockBuilder.writeLong(value.getLong(offset + i * Long.BYTES));
+        }
+        blockBuilder.closeEntry();
+    }
+
+    @Override
+    public final Slice getSlice(Block block, int position)
+    {
+        return block.getSlice(position, 0, block.getSliceLength(position));
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestDecimalAggregationAccumulatorBlockEncoding.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestDecimalAggregationAccumulatorBlockEncoding.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.block;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.type.Type;
+
+import java.util.Random;
+
+import static io.trino.spi.type.DecimalAggregationAccumulatorType.LONG_DECIMAL_WITH_OVERFLOW_AND_LONG;
+
+public class TestDecimalAggregationAccumulatorBlockEncoding
+        extends BaseBlockEncodingTest<Slice>
+{
+    private static final Type TYPE = LONG_DECIMAL_WITH_OVERFLOW_AND_LONG;
+
+    @Override
+    protected Type getType()
+    {
+        return TYPE;
+    }
+
+    @Override
+    protected void write(BlockBuilder blockBuilder, Slice value)
+    {
+        TYPE.writeSlice(blockBuilder, value);
+    }
+
+    @Override
+    protected Slice randomValue(Random random)
+    {
+        return Slices.wrappedLongArray(random.nextLong(), random.nextLong(), random.nextLong(), random.nextLong());
+    }
+}

--- a/core/trino-spi/src/test/java/io/trino/spi/block/TestingBlockEncodingSerde.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/TestingBlockEncodingSerde.java
@@ -50,6 +50,7 @@ public final class TestingBlockEncodingSerde
         addBlockEncoding(new SingleRowBlockEncoding());
         addBlockEncoding(new RunLengthBlockEncoding());
         addBlockEncoding(new LazyBlockEncoding());
+        addBlockEncoding(new DecimalAggregationAccumulatorBlockEncoding());
     }
 
     private void addBlockEncoding(BlockEncoding blockEncoding)

--- a/core/trino-spi/src/test/java/io/trino/spi/type/TestDecimalAggregationAccumulatorType.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/type/TestDecimalAggregationAccumulatorType.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.type;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.block.DecimalAggregationAccumulatorBlock;
+import io.trino.spi.block.DecimalAggregationAccumulatorBlockBuilder;
+import org.testng.annotations.Test;
+
+import static io.trino.spi.type.DecimalAggregationAccumulatorType.LONG_DECIMAL_WITH_OVERFLOW_AND_LONG;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestDecimalAggregationAccumulatorType
+{
+    private static final Type TYPE = LONG_DECIMAL_WITH_OVERFLOW_AND_LONG;
+    private static final int OVERFLOW_OFFSET = 3 * Long.BYTES;
+
+    @Test
+    public void testWriteRead()
+    {
+        BlockBuilder blockBuilder = TYPE.createBlockBuilder(null, 2);
+        Slice entry = Slices.wrappedLongArray(1, 2, 3, 4);
+        TYPE.writeSlice(blockBuilder, entry);
+        blockBuilder.appendNull();
+        Block block = blockBuilder.build();
+
+        testWriteRead(entry, block);
+        testWriteRead(entry, blockBuilder);
+    }
+
+    private void testWriteRead(Slice entry, Block block)
+    {
+        assertEquals(block.getPositionCount(), 2);
+        assertEquals(block.getLong(0, 0), 1);
+        assertEquals(block.getLong(0, Long.BYTES), 2);
+        assertEquals(block.getLong(0, Long.BYTES * 2), 3);
+        assertEquals(block.getLong(0, Long.BYTES * 3), 4);
+        assertEquals(TYPE.getSlice(block, 0), entry);
+        assertEquals(TYPE.getObjectValue(null, block, 0), new SqlVarbinary(entry.getBytes()));
+
+        assertTrue(block.isNull(1));
+        assertNull(TYPE.getObjectValue(null, block, 1));
+
+        BlockBuilder newBlockBuilder = TYPE.createBlockBuilder(null, 2);
+        TYPE.appendTo(block, 0, newBlockBuilder);
+        TYPE.appendTo(block, 1, newBlockBuilder);
+        Block newBlock = newBlockBuilder.build();
+        assertEquals(TYPE.getSlice(block, 0), TYPE.getSlice(newBlock, 0));
+        assertNull(TYPE.getObjectValue(null, newBlock, 1));
+        assertTrue(newBlock.isNull(1));
+    }
+
+    @Test
+    public void testRegion()
+    {
+        int entries = 4;
+        BlockBuilder blockBuilder = TYPE.createBlockBuilder(null, entries);
+        TYPE.writeSlice(blockBuilder, entry(1));
+        blockBuilder.appendNull();
+        TYPE.writeSlice(blockBuilder, entry(2));
+        TYPE.writeSlice(blockBuilder, entry(3));
+        Block block = blockBuilder.build();
+
+        testRegion(block);
+        testRegion(blockBuilder);
+    }
+
+    private void testRegion(Block block)
+    {
+        DecimalAggregationAccumulatorBlock region = (DecimalAggregationAccumulatorBlock) block.getRegion(1, 2);
+        assertTrue(region.isNull(0));
+        assertEquals(TYPE.getSlice(region, 1), entry(2));
+        assertEquals(region.getValuesSlice(), Slices.wrappedLongArray(0, 0, 0, 2, 2, 2));
+        assertEquals(region.getOverflowSlice(), Slices.wrappedLongArray(0, 2));
+
+        DecimalAggregationAccumulatorBlock copiedRegion = (DecimalAggregationAccumulatorBlock) block.copyRegion(1, 2);
+        assertTrue(copiedRegion.isNull(0));
+        assertEquals(TYPE.getSlice(copiedRegion, 1), entry(2));
+        assertEquals(copiedRegion.getValuesSlice(), Slices.wrappedLongArray(0, 0, 0, 2, 2, 2));
+        assertEquals(copiedRegion.getOverflowSlice(), Slices.wrappedLongArray(0, 2));
+
+        DecimalAggregationAccumulatorBlock copiedPositions = (DecimalAggregationAccumulatorBlock) block.copyPositions(new int[] {1, 2}, 0, 2);
+        assertTrue(copiedPositions.isNull(0));
+        assertEquals(TYPE.getSlice(copiedPositions, 1), entry(2));
+        assertEquals(copiedPositions.getValuesSlice(), Slices.wrappedLongArray(0, 0, 0, 2, 2, 2));
+        assertEquals(copiedPositions.getOverflowSlice(), Slices.wrappedLongArray(0, 2));
+    }
+
+    @Test
+    public void testSingleValueBlock()
+    {
+        BlockBuilder blockBuilder = TYPE.createBlockBuilder(null, 2);
+        TYPE.writeSlice(blockBuilder, entry(1));
+        blockBuilder.appendNull();
+        TYPE.writeSlice(blockBuilder, noOverflowEntry(1));
+        Block block = blockBuilder.build();
+
+        testSingleValueBlock(block);
+        testSingleValueBlock(blockBuilder);
+    }
+
+    private void testSingleValueBlock(Block block)
+    {
+        Block notNullBlock = block.getSingleValueBlock(0);
+        assertEquals(notNullBlock.getPositionCount(), 1);
+        assertEquals(TYPE.getSlice(notNullBlock, 0), entry(1));
+
+        Block nullBlock = block.getSingleValueBlock(1);
+        assertEquals(nullBlock.getPositionCount(), 1);
+        assertTrue(nullBlock.isNull(0));
+
+        Block noOverflowBlock = block.getSingleValueBlock(2);
+        assertEquals(noOverflowBlock.getPositionCount(), 1);
+        assertEquals(TYPE.getSlice(noOverflowBlock, 0), noOverflowEntry(1));
+        assertEquals(noOverflowBlock.getLong(0, OVERFLOW_OFFSET), 0);
+    }
+
+    @Test
+    public void testOverflowSliceNull()
+    {
+        DecimalAggregationAccumulatorBlockBuilder blockBuilder = (DecimalAggregationAccumulatorBlockBuilder) TYPE.createBlockBuilder(null, 1);
+        TYPE.writeSlice(blockBuilder, noOverflowEntry(1));
+        DecimalAggregationAccumulatorBlock block = (DecimalAggregationAccumulatorBlock) blockBuilder.build();
+
+        assertNull(block.getOverflowSlice());
+        assertNull(blockBuilder.getOverflowSlice());
+    }
+
+    private Slice entry(int value)
+    {
+        return Slices.wrappedLongArray(value, value, value, value);
+    }
+
+    private Slice noOverflowEntry(int value)
+    {
+        return Slices.wrappedLongArray(value, value, value, 0);
+    }
+}


### PR DESCRIPTION
Currently, decimal aggregations are serialized as VARBINARY. However, each position has a fixed length. Hence we can encode decimal aggregation partial results are RowType with Long individual blocks. This way we can avoid Slice altogether.
We could also avoid serializing overflows if it's all null (https://github.com/trinodb/trino/issues/9676)
