### PR TITLE
Report nested varbinary value in tests

### DIFF
--- a/core/trino-main/src/main/java/io/trino/testing/Bytes.java
+++ b/core/trino-main/src/main/java/io/trino/testing/Bytes.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
+
+/**
+ * Value-based, immutable {@code byte[]} equivalent.
+ */
+public final class Bytes
+{
+    public static Bytes fromBytes(byte... bytes)
+    {
+        return new Bytes(bytes);
+    }
+
+    private final byte[] bytes;
+
+    private Bytes(byte[] bytes)
+    {
+        this.bytes = bytes.clone();
+    }
+
+    public byte[] getBytes()
+    {
+        return bytes.clone();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Bytes other = (Bytes) o;
+        return Arrays.equals(bytes, other.bytes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Arrays.hashCode(bytes);
+    }
+
+    @Override
+    public String toString()
+    {
+        return IntStream.range(0, bytes.length)
+                .mapToObj(i -> format("%02x", bytes[i] & 0xFF))
+                .collect(joining(" ", "X'", "'"));
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/testing/MaterializedRow.java
+++ b/core/trino-main/src/main/java/io/trino/testing/MaterializedRow.java
@@ -15,7 +15,6 @@ package io.trino.testing;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -77,7 +76,7 @@ public class MaterializedRow
             return map;
         }
         if (value instanceof byte[]) {
-            return ByteBuffer.wrap((byte[]) value);
+            return Bytes.fromBytes((byte[]) value);
         }
         return value;
     }
@@ -122,8 +121,8 @@ public class MaterializedRow
             }
             return map;
         }
-        if (value instanceof ByteBuffer) {
-            return ((ByteBuffer) value).array();
+        if (value instanceof Bytes) {
+            return ((Bytes) value).getBytes();
         }
 
         return value;

--- a/core/trino-main/src/test/java/io/trino/testing/TestBytes.java
+++ b/core/trino-main/src/test/java/io/trino/testing/TestBytes.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.testing;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestBytes
+{
+    @Test
+    public void testToString()
+    {
+        assertEquals(Bytes.fromBytes(new byte[] {1, 2, 22, -22}).toString(), "X'01 02 16 ea'");
+    }
+}

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestCassandraConnectorTest.java
@@ -20,6 +20,7 @@ import io.airlift.units.Duration;
 import io.trino.Session;
 import io.trino.spi.type.Type;
 import io.trino.testing.BaseConnectorTest;
+import io.trino.testing.Bytes;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
@@ -938,7 +939,7 @@ public class TestCassandraConnectorTest
                     format("00000000-0000-0000-0000-%012d", rowNumber),
                     rowNumber,
                     rowNumber + 1000L,
-                    ByteBuffer.wrap(Ints.toByteArray(rowNumber)),
+                    Bytes.fromBytes(Ints.toByteArray(rowNumber)),
                     TIMESTAMP_VALUE,
                     "ansi " + rowNumber,
                     rowNumber % 2 == 0,


### PR DESCRIPTION
Previously something like `java.nio.HeapByteBuffer[pos=0 lim=6 cap=6]`
was returned.