### PR TITLE
Guard Hive's OPTIMIZE table procedure with session property

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveSessionProperties.java
@@ -113,6 +113,7 @@ public final class HiveSessionProperties
     private static final String LEGACY_HIVE_VIEW_TRANSLATION = "legacy_hive_view_translation";
     public static final String SIZE_BASED_SPLIT_WEIGHTS_ENABLED = "size_based_split_weights_enabled";
     public static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
+    public static final String NON_TRANSACTIONAL_OPTIMIZE_ENABLED = "non_transactional_optimize_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -476,6 +477,11 @@ public final class HiveSessionProperties
                                 throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s must be > 0 and <= 1.0: %s", MINIMUM_ASSIGNED_SPLIT_WEIGHT, value));
                             }
                         },
+                        false),
+                booleanProperty(
+                        NON_TRANSACTIONAL_OPTIMIZE_ENABLED,
+                        "Enable OPTIMIZE table procedure",
+                        false,
                         false));
     }
 
@@ -792,5 +798,10 @@ public final class HiveSessionProperties
     public static double getMinimumAssignedSplitWeight(ConnectorSession session)
     {
         return session.getProperty(MINIMUM_ASSIGNED_SPLIT_WEIGHT, Double.class);
+    }
+
+    public static boolean isNonTransactionalOptimizeEnabled(ConnectorSession session)
+    {
+        return session.getProperty(NON_TRANSACTIONAL_OPTIMIZE_ENABLED, Boolean.class);
     }
 }


### PR DESCRIPTION
OPTIMIZE procedure is disabled by default; even
though code is written in a way to avoid data loss, calling procedure
is inherently unsafe due to non transactional nature of
committing changes done to Hive table. If Trino looses connectivity to
HDFS cluster while deleting post-optimize data files duplicate rows will be
left in table and manual cleanup from user will be required.