### PR TITLE
Change the order of the parameters in the input function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/listagg/ListaggAggregationFunction.java
@@ -66,7 +66,7 @@ public class ListaggAggregationFunction
 {
     public static final ListaggAggregationFunction LISTAGG = new ListaggAggregationFunction();
     public static final String NAME = "listagg";
-    private static final MethodHandle INPUT_FUNCTION = methodHandle(ListaggAggregationFunction.class, "input", Type.class, ListaggAggregationState.class, Block.class, Slice.class, boolean.class, Slice.class, boolean.class, int.class);
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(ListaggAggregationFunction.class, "input", Type.class, ListaggAggregationState.class, Block.class, int.class, Slice.class, boolean.class, Slice.class, boolean.class);
     private static final MethodHandle COMBINE_FUNCTION = methodHandle(ListaggAggregationFunction.class, "combine", Type.class, ListaggAggregationState.class, ListaggAggregationState.class);
     private static final MethodHandle OUTPUT_FUNCTION = methodHandle(ListaggAggregationFunction.class, "output", Type.class, ListaggAggregationState.class, BlockBuilder.class);
 
@@ -128,11 +128,11 @@ public class ListaggAggregationFunction
         List<ParameterMetadata> inputParameterMetadata = ImmutableList.of(
                 new ParameterMetadata(STATE),
                 new ParameterMetadata(NULLABLE_BLOCK_INPUT_CHANNEL, type),
+                new ParameterMetadata(BLOCK_INDEX),
                 new ParameterMetadata(INPUT_CHANNEL, VARCHAR),
                 new ParameterMetadata(INPUT_CHANNEL, BOOLEAN),
                 new ParameterMetadata(INPUT_CHANNEL, VARCHAR),
-                new ParameterMetadata(INPUT_CHANNEL, BOOLEAN),
-                new ParameterMetadata(BLOCK_INDEX));
+                new ParameterMetadata(INPUT_CHANNEL, BOOLEAN));
 
         MethodHandle inputFunction = INPUT_FUNCTION.bindTo(type);
         MethodHandle combineFunction = COMBINE_FUNCTION.bindTo(type);
@@ -156,7 +156,7 @@ public class ListaggAggregationFunction
         return new InternalAggregationFunction(NAME, inputTypes, ImmutableList.of(intermediateType), outputType, factory);
     }
 
-    public static void input(Type type, ListaggAggregationState state, Block value, Slice separator, boolean overflowError, Slice overflowFiller, boolean showOverflowEntryCount, int position)
+    public static void input(Type type, ListaggAggregationState state, Block value, int position, Slice separator, boolean overflowError, Slice overflowFiller, boolean showOverflowEntryCount)
     {
         if (state.isEmpty()) {
             if (overflowFiller.length() > MAX_OVERFLOW_FILLER_LENGTH) {

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/listagg/TestListaggAggregationFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/listagg/TestListaggAggregationFunction.java
@@ -46,11 +46,11 @@ public class TestListaggAggregationFunction
         ListaggAggregationFunction.input(VARCHAR,
                 state,
                 value,
+                0,
                 separator,
                 false,
                 overflowFiller,
-                true,
-                0);
+                true);
 
         assertFalse(state.isEmpty());
         assertEquals(state.getSeparator(), separator);
@@ -78,11 +78,11 @@ public class TestListaggAggregationFunction
         assertThatThrownBy(() -> ListaggAggregationFunction.input(VARCHAR,
                 state,
                 createStringsBlock("value1"),
+                0,
                 utf8Slice(","),
                 false,
                 utf8Slice(overflowFillerTooLong),
-                false,
-                0))
+                false))
                 .isInstanceOf(TrinoException.class)
                 .matches(throwable -> ((TrinoException) throwable).getErrorCode() == INVALID_FUNCTION_ARGUMENT.toErrorCode());
     }


### PR DESCRIPTION
Because the parameters:

- `Block value`
- `int position`

 are closely related, they are moved next to each other in the signature
 of the input function.