### PR TITLE
Add schema access requirement to JDBC driver doc

### DIFF
--- a/docs/src/main/sphinx/installation/jdbc.rst
+++ b/docs/src/main/sphinx/installation/jdbc.rst
@@ -10,8 +10,11 @@ as those used for reporting and database development, use the JDBC driver.
 Requirements
 ------------
 
-The JDBC driver is compatible with Java versions 8 or higher, and can be used with
-applications running on Java virtual machines version 8 or higher.
+The Trino JDBC driver has the following requirements:
+
+* Java version 8 or higher.
+* All users that connect to Trino with the JDBC driver must be granted access to
+  query tables in the ``system.jdbc`` schema.
 
 Installing
 ----------


### PR DESCRIPTION
The JDBC driver requires access to the `system.jdbc` schema. Since this applies to any users or client applications using the driver, we ought to add the requirement for all users to be granted access to this schema.