### PR TITLE
Introduce scale parameter for tpch q11 query

### DIFF
--- a/testing/trino-benchto-benchmarks/src/main/resources/benchmarks/presto/tpch.yaml
+++ b/testing/trino-benchto-benchmarks/src/main/resources/benchmarks/presto/tpch.yaml
@@ -16,17 +16,20 @@ variables:
   1:
     query: q05, q07, q08, q09, q17, q18, q21
     schema: ${tpch_300}
+    scale: 300
     join_reordering_strategy: ELIMINATE_CROSS_JOINS, AUTOMATIC
     join_distribution_type: PARTITIONED, AUTOMATIC
 
   2:
     query: q01, q02, q03, q04, q10, q12, q13, q15, q20
     schema: ${tpch_1000}
+    scale: 1000
     join_reordering_strategy: ELIMINATE_CROSS_JOINS, AUTOMATIC
     join_distribution_type: PARTITIONED, AUTOMATIC
 
   3:
     query: q06, q11, q14, q16, q19, q22
     schema: ${tpch_3000}
+    scale: 3000
     join_reordering_strategy: ELIMINATE_CROSS_JOINS, AUTOMATIC
     join_distribution_type: PARTITIONED, AUTOMATIC

--- a/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpch/q11.sql
+++ b/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpch/q11.sql
@@ -14,7 +14,7 @@ GROUP BY
 HAVING 
   sum(ps.supplycost*ps.availqty) > (
     SELECT 
-      sum(ps.supplycost*ps.availqty) * 0.0001000000
+      sum(ps.supplycost*ps.availqty) * 0.0001000000 / ${scale}
     FROM 
       "${database}"."${schema}"."${prefix}partsupp" ps,
       "${database}"."${schema}"."${prefix}supplier" s,

--- a/testing/trino-benchto-benchmarks/src/test/java/io/trino/sql/planner/AbstractCostBasedPlanTest.java
+++ b/testing/trino-benchto-benchmarks/src/test/java/io/trino/sql/planner/AbstractCostBasedPlanTest.java
@@ -114,7 +114,8 @@ public abstract class AbstractCostBasedPlanTest
     {
         String sql = query.replaceAll("\\s+;\\s+$", "")
                 .replace("${database}.${schema}.", "")
-                .replace("\"${database}\".\"${schema}\".\"${prefix}", "\"");
+                .replace("\"${database}\".\"${schema}\".\"${prefix}", "\"")
+                .replace("${scale}", "1");
         Plan plan = plan(sql, OPTIMIZED_AND_VALIDATED, false);
 
         JoinOrderPrinter joinOrderPrinter = new JoinOrderPrinter();


### PR DESCRIPTION
TPC-H specification requires query 11 to be parametrized based on scale factor. Without proper scale query returns no rows and skips part of the processing.

Closes: https://github.com/trinodb/trino/issues/9790