### PR TITLE
Support reading DECIMAL columns with unspecified precision in Phoenix connector

### DIFF
--- a/docs/src/main/sphinx/connector/phoenix.rst
+++ b/docs/src/main/sphinx/connector/phoenix.rst
@@ -121,6 +121,20 @@ variable length ``VARBINARY`` data type. There is no way to create a
 Phoenix table in Trino that uses the ``BINARY`` data type, as Trino
 does not have an equivalent type.
 
+Decimal type handling
+^^^^^^^^^^^^^^^^^^^^^
+
+``DECIMAL`` types with un-specified precision defaults to 38 and un-specified scale defaults to 0. These defaults can
+be overridden by setting the ``decimal-mapping`` configuration property or the ``decimal_mapping`` session property to
+``allow_overflow``. The scale of the resulting type is controlled via the ``decimal-default-scale``
+configuration property or the ``decimal-rounding-mode`` session property. The precision is always 38.
+
+By default, values that require rounding or truncation to fit will cause a failure at runtime. This behavior
+is controlled via the ``decimal-rounding-mode`` configuration property or the ``decimal_rounding_mode`` session
+property, which can be set to ``UNNECESSARY`` (the default),
+``UP``, ``DOWN``, ``CEILING``, ``FLOOR``, ``HALF_UP``, ``HALF_DOWN``, or ``HALF_EVEN``
+(see `RoundingMode <https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/math/RoundingMode.html#enum.constant.summary>`_).
+
 .. include:: jdbc-type-mapping.fragment
 
 Table properties - Phoenix

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -107,6 +107,10 @@ import java.util.function.BiFunction;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRoundingMode;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
@@ -152,6 +156,8 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.DEFAULT_PRECISION;
+import static io.trino.spi.type.DecimalType.DEFAULT_SCALE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -391,8 +397,14 @@ public class PhoenixClient
                 return Optional.of(doubleColumnMapping());
 
             case Types.DECIMAL:
-                int precision = typeHandle.getRequiredColumnSize();
-                int decimalDigits = typeHandle.getDecimalDigits().orElseThrow(() -> new IllegalStateException("decimal digits not present"));
+                Optional<Integer> columnSize = typeHandle.getColumnSize();
+                int precision = columnSize.orElse(DEFAULT_PRECISION);
+                int decimalDigits = typeHandle.getDecimalDigits().orElse(DEFAULT_SCALE);
+                if (getDecimalRounding(session) == ALLOW_OVERFLOW) {
+                    if (columnSize.isEmpty()) {
+                        return Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, getDecimalDefaultScale(session)), getDecimalRoundingMode(session)));
+                    }
+                }
                 // TODO does phoenix support negative scale?
                 precision = precision + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
                 if (precision > Decimals.MAX_PRECISION) {

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClientModule.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClientModule.java
@@ -26,6 +26,7 @@ import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager;
 import io.trino.plugin.base.classloader.ForClassLoaderSafe;
 import io.trino.plugin.jdbc.ConfiguringConnectionFactory;
 import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DecimalModule;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.ForLazyConnectionFactory;
@@ -114,6 +115,7 @@ public class PhoenixClientModule
 
         install(new JdbcDiagnosticModule());
         install(new IdentifierMappingModule());
+        install(new DecimalModule());
     }
 
     private void checkConfiguration(String connectionUrl)

--- a/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixConnectorTest.java
@@ -315,6 +315,15 @@ public class TestPhoenixConnectorTest
         assertUpdate("DROP TABLE tpch.test_timestamp");
     }
 
+    @Test
+    public void testDefaultDecimalTable()
+            throws Exception
+    {
+        executeInPhoenix("CREATE TABLE tpch.test_null_decimal (pk bigint primary key, val1 decimal)");
+        executeInPhoenix("UPSERT INTO tpch.test_null_decimal (pk, val1) VALUES (1, 2)");
+        assertQuery("SELECT * FROM tpch.test_null_decimal", "VALUES (1, 2) ");
+    }
+
     private Session withUnsupportedType(UnsupportedTypeHandling unsupportedTypeHandling)
     {
         return Session.builder(getSession())

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -108,6 +108,10 @@ import java.util.function.BiFunction;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalDefaultScale;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRounding;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.getDecimalRoundingMode;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintColumnMapping;
 import static io.trino.plugin.jdbc.StandardColumnMappings.bigintWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.booleanColumnMapping;
@@ -153,6 +157,8 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DateType.DATE;
+import static io.trino.spi.type.DecimalType.DEFAULT_PRECISION;
+import static io.trino.spi.type.DecimalType.DEFAULT_SCALE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
@@ -383,8 +389,14 @@ public class PhoenixClient
                 return Optional.of(doubleColumnMapping());
 
             case Types.DECIMAL:
-                int precision = typeHandle.getRequiredColumnSize();
-                int decimalDigits = typeHandle.getDecimalDigits().orElseThrow(() -> new IllegalStateException("decimal digits not present"));
+                Optional<Integer> columnSize = typeHandle.getColumnSize();
+                int precision = columnSize.orElse(DEFAULT_PRECISION);
+                int decimalDigits = typeHandle.getDecimalDigits().orElse(DEFAULT_SCALE);
+                if (getDecimalRounding(session) == ALLOW_OVERFLOW) {
+                    if (columnSize.isEmpty()) {
+                        return Optional.of(decimalColumnMapping(createDecimalType(Decimals.MAX_PRECISION, getDecimalDefaultScale(session)), getDecimalRoundingMode(session)));
+                    }
+                }
                 // TODO does phoenix support negative scale?
                 precision = precision + max(-decimalDigits, 0); // Map decimal(p, -s) (negative scale) to decimal(p+s, 0).
                 if (precision > Decimals.MAX_PRECISION) {

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
@@ -26,6 +26,7 @@ import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorSplitManager;
 import io.trino.plugin.base.classloader.ForClassLoaderSafe;
 import io.trino.plugin.jdbc.ConfiguringConnectionFactory;
 import io.trino.plugin.jdbc.ConnectionFactory;
+import io.trino.plugin.jdbc.DecimalModule;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.ForLazyConnectionFactory;
@@ -114,6 +115,7 @@ public class PhoenixClientModule
 
         install(new JdbcDiagnosticModule());
         install(new IdentifierMappingModule());
+        install(new DecimalModule());
     }
 
     private void checkConfiguration(String connectionUrl)

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConnectorTest.java
@@ -332,6 +332,15 @@ public class TestPhoenixConnectorTest
         assertUpdate("DROP TABLE tpch.test_timestamp");
     }
 
+    @Test
+    public void testDefaultDecimalTable()
+            throws Exception
+    {
+        executeInPhoenix("CREATE TABLE tpch.test_null_decimal (pk bigint primary key, val1 decimal)");
+        executeInPhoenix("UPSERT INTO tpch.test_null_decimal (pk, val1) VALUES (1, 2)");
+        assertQuery("SELECT * FROM tpch.test_null_decimal", "VALUES (1, 2) ");
+    }
+
     private Session withUnsupportedType(UnsupportedTypeHandling unsupportedTypeHandling)
     {
         return Session.builder(getSession())

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixTypeMapping.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixTypeMapping.java
@@ -16,6 +16,7 @@ package io.trino.plugin.phoenix5;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.trino.Session;
+import io.trino.plugin.jdbc.UnsupportedTypeHandling;
 import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.TimeZoneKey;
 import io.trino.testing.AbstractTestQueryFramework;
@@ -26,11 +27,13 @@ import io.trino.testing.datatype.DataSetup;
 import io.trino.testing.datatype.DataType;
 import io.trino.testing.datatype.DataTypeTest;
 import io.trino.testing.datatype.SqlDataTypeTest;
+import io.trino.testing.sql.TestTable;
 import io.trino.testing.sql.TrinoSqlExecutor;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -41,6 +44,13 @@ import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
+import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.ALLOW_OVERFLOW;
+import static io.trino.plugin.jdbc.DecimalConfig.DecimalMapping.STRICT;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.DECIMAL_DEFAULT_SCALE;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.DECIMAL_MAPPING;
+import static io.trino.plugin.jdbc.DecimalSessionSessionProperties.DECIMAL_ROUNDING_MODE;
+import static io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties.UNSUPPORTED_TYPE_HANDLING;
+import static io.trino.plugin.jdbc.UnsupportedTypeHandling.CONVERT_TO_VARCHAR;
 import static io.trino.plugin.phoenix5.PhoenixQueryRunner.createPhoenixQueryRunner;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
@@ -58,6 +68,7 @@ import static io.trino.testing.datatype.DataType.smallintDataType;
 import static io.trino.testing.datatype.DataType.tinyintDataType;
 import static io.trino.testing.datatype.DataType.varcharDataType;
 import static java.lang.String.format;
+import static java.math.RoundingMode.HALF_UP;
 import static java.math.RoundingMode.UNNECESSARY;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -176,12 +187,14 @@ public class TestPhoenixTypeMapping
                 .addRoundTrip(dataTypeFactory.apply(3, 1), new BigDecimal("10.0"))
                 .addRoundTrip(dataTypeFactory.apply(3, 1), new BigDecimal("10.1"))
                 .addRoundTrip(dataTypeFactory.apply(3, 1), new BigDecimal("-10.1"))
+                .addRoundTrip(dataTypeFactory.apply(3, 2), new BigDecimal("3.14"))
                 .addRoundTrip(dataTypeFactory.apply(4, 2), new BigDecimal("2"))
                 .addRoundTrip(dataTypeFactory.apply(4, 2), new BigDecimal("2.3"))
                 .addRoundTrip(dataTypeFactory.apply(24, 2), new BigDecimal("2"))
                 .addRoundTrip(dataTypeFactory.apply(24, 2), new BigDecimal("2.3"))
                 .addRoundTrip(dataTypeFactory.apply(24, 2), new BigDecimal("123456789.3"))
                 .addRoundTrip(dataTypeFactory.apply(24, 4), new BigDecimal("12345678901234567890.31"))
+                .addRoundTrip(dataTypeFactory.apply(24, 23), new BigDecimal("3.12345678901234567890123"))
                 .addRoundTrip(dataTypeFactory.apply(30, 5), new BigDecimal("3141592653589793238462643.38327"))
                 .addRoundTrip(dataTypeFactory.apply(30, 5), new BigDecimal("-3141592653589793238462643.38327"))
                 .addRoundTrip(dataTypeFactory.apply(38, 0), new BigDecimal("27182818284590452353602874713526624977"))
@@ -196,6 +209,50 @@ public class TestPhoenixTypeMapping
                 createDecimalType(precision, scale),
                 bigDecimal -> format("CAST(%s AS %s)", bigDecimal, databaseType),
                 bigDecimal -> bigDecimal.setScale(scale, UNNECESSARY));
+    }
+
+    @Test
+    public void testDecimalUnspecifiedPrecision()
+    {
+        PhoenixSqlExecutor phoenixSqlExecutor = new PhoenixSqlExecutor(phoenixServer.getJdbcUrl());
+        try (TestTable testTable = new TestTable(
+                phoenixSqlExecutor,
+                "tpch.test_var_decimal",
+                "(pk bigint primary key, d_col decimal)",
+                asList("1, 1.12", "2, 123456.789", "3, -1.12", "4, -123456.789"))) {
+            assertQueryFails(
+                    sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 0),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "Rounding necessary");
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(HALF_UP, 0),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "VALUES (1), (123457), (-1), (-123457)");
+            assertQueryFails(
+                    sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 1),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "Rounding necessary");
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(HALF_UP, 1),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "VALUES (1.1), (123456.8), (-1.1), (-123456.8)");
+            assertQueryFails(
+                    sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 2),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "Rounding necessary");
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(HALF_UP, 2),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "VALUES (1.12), (123456.79), (-1.12), (-123456.79)");
+            assertQuery(
+                    sessionWithDecimalMappingAllowOverflow(UNNECESSARY, 3),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "VALUES (1.12), (123456.789), (-1.12), (-123456.789)");
+            assertQueryFails(
+                    sessionWithDecimalMappingStrict(CONVERT_TO_VARCHAR),
+                    "SELECT d_col FROM " + testTable.getName(),
+                    "Rounding necessary");
+        }
     }
 
     @Test
@@ -418,5 +475,22 @@ public class TestPhoenixTypeMapping
     private DataSetup phoenixCreateAndInsert(String tableNamePrefix)
     {
         return new CreateAndInsertDataSetup(new PhoenixSqlExecutor(phoenixServer.getJdbcUrl()), tableNamePrefix);
+    }
+
+    private Session sessionWithDecimalMappingAllowOverflow(RoundingMode roundingMode, int scale)
+    {
+        return Session.builder(getSession())
+                .setCatalogSessionProperty("phoenix", DECIMAL_MAPPING, ALLOW_OVERFLOW.name())
+                .setCatalogSessionProperty("phoenix", DECIMAL_ROUNDING_MODE, roundingMode.name())
+                .setCatalogSessionProperty("phoenix", DECIMAL_DEFAULT_SCALE, Integer.valueOf(scale).toString())
+                .build();
+    }
+
+    private Session sessionWithDecimalMappingStrict(UnsupportedTypeHandling unsupportedTypeHandling)
+    {
+        return Session.builder(getSession())
+                .setCatalogSessionProperty("phoenix", DECIMAL_MAPPING, STRICT.name())
+                .setCatalogSessionProperty("phoenix", UNSUPPORTED_TYPE_HANDLING, unsupportedTypeHandling.name())
+                .build();
     }
 }


### PR DESCRIPTION
Added default values for Phoenix Decimal Datatypes. More details #9795 
A note regarding unit tests: Tables created through Trino with a decimal data type will default to these values anyway, so couldn't really think of a way to bypass trino's default table creation.