### PR TITLE
Fix incorrect LEFT to INNER conversion

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/DynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/DynamicFilters.java
@@ -20,6 +20,7 @@ import io.airlift.slice.Slice;
 import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.ResolvedFunction;
+import io.trino.spi.function.IsNull;
 import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
@@ -342,28 +343,28 @@ public final class DynamicFilters
 
         @TypeParameter("T")
         @SqlType(BOOLEAN)
-        public static boolean dynamicFilter(@SqlType("T") Object input, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id, @SqlType(BOOLEAN) boolean nullAllowed)
+        public static boolean dynamicFilter(@SqlType("T") Object input, @IsNull boolean inputNull, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id, @SqlType(BOOLEAN) boolean nullAllowed)
         {
             throw new UnsupportedOperationException();
         }
 
         @TypeParameter("T")
         @SqlType(BOOLEAN)
-        public static boolean dynamicFilter(@SqlType("T") long input, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id, @SqlType(BOOLEAN) boolean nullAllowed)
+        public static boolean dynamicFilter(@SqlType("T") long input, @IsNull boolean inputNull, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id, @SqlType(BOOLEAN) boolean nullAllowed)
         {
             throw new UnsupportedOperationException();
         }
 
         @TypeParameter("T")
         @SqlType(BOOLEAN)
-        public static boolean dynamicFilter(@SqlType("T") boolean input, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id, @SqlType(BOOLEAN) boolean nullAllowed)
+        public static boolean dynamicFilter(@SqlType("T") boolean input, @IsNull boolean inputNull, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id, @SqlType(BOOLEAN) boolean nullAllowed)
         {
             throw new UnsupportedOperationException();
         }
 
         @TypeParameter("T")
         @SqlType(BOOLEAN)
-        public static boolean dynamicFilter(@SqlType("T") double input, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id, @SqlType(BOOLEAN) boolean nullAllowed)
+        public static boolean dynamicFilter(@SqlType("T") double input, @IsNull boolean inputNull, @SqlType(VARCHAR) Slice operator, @SqlType(VARCHAR) Slice id, @SqlType(BOOLEAN) boolean nullAllowed)
         {
             throw new UnsupportedOperationException();
         }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/AbstractPredicatePushdownTest.java
@@ -487,7 +487,7 @@ public abstract class AbstractPredicatePushdownTest
                                 ImmutableList.of(equiJoinClause("o_custkey", "c_custkey")),
                                 anyTree(
                                         join(
-                                                enableDynamicFiltering ? INNER : LEFT, // TODO (https://github.com/trinodb/trino/issues/2392) this should be INNER also when dynamic filtering is off
+                                                LEFT, // TODO (https://github.com/trinodb/trino/issues/2392) this should be INNER
                                                 ImmutableList.of(equiJoinClause("l_orderkey", "o_orderkey")),
                                                 anyTree(tableScan("lineitem", ImmutableMap.of("l_orderkey", "orderkey"))),
                                                 anyTree(tableScan("orders", ImmutableMap.of("o_orderkey", "orderkey", "o_custkey", "custkey"))))),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestDynamicFilter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestDynamicFilter.java
@@ -368,6 +368,25 @@ public class TestDynamicFilter
     }
 
     @Test
+    public void testNotDistinctFromLeftJoin()
+    {
+        assertPlan("SELECT 1 FROM (SELECT o.orderkey FROM nation n LEFT JOIN orders o ON n.nationkey = o.orderkey) o JOIN lineitem l ON o.orderkey IS NOT DISTINCT FROM l.orderkey",
+                anyTree(join(
+                        INNER,
+                        ImmutableList.of(),
+                        join(
+                                LEFT,
+                                ImmutableList.of(equiJoinClause("nationkey", "ORDERS_OK")),
+                                anyTree(
+                                        tableScan("nation", ImmutableMap.of("nationkey", "nationkey"))),
+                                exchange(
+                                        anyTree(
+                                                tableScan("orders", ImmutableMap.of("ORDERS_OK", "orderkey"))))),
+                        exchange(
+                                tableScan("lineitem", ImmutableMap.of("LINEITEM_OK", "orderkey"))))));
+    }
+
+    @Test
     public void testJoinOnCast()
     {
         assertPlan("SELECT o.orderkey FROM orders o, lineitem l WHERE cast(l.orderkey as int) = cast(o.orderkey as int)",


### PR DESCRIPTION
Makes dynamic filter expression nullable to not trigger LEFT to INNER conversion if there are no other expressions that would trigger it.

Fix for https://github.com/trinodb/trino/issues/9154.

This change has one regression. Previously dynamic filters would trigger the conversion to INNER, even if it would not be triggered without DF. If the conversion was valid and now it won't be triggered, it may cause a performance regression (see `AbstractPredicatePushdownTest#testNormalizeOuterJoinToInner`).
IMO this should be fixed outside of DF (i.e. it should work even if DF are disabled).

There is another option. Add "NullableFunction" similar to `io.trino.sql.DynamicFilters.Function`that would avoid this regression but it is messier and fixes a problem, DF should not care about.