### PR TITLE
Not implement GroupedAccumulator in generateGroupedStateClass

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/StateCompiler.java
@@ -35,7 +35,6 @@ import io.trino.array.IntBigArray;
 import io.trino.array.LongBigArray;
 import io.trino.array.ObjectBigArray;
 import io.trino.array.SliceBigArray;
-import io.trino.operator.aggregation.GroupedAccumulator;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.function.AccumulatorStateFactory;
@@ -478,8 +477,7 @@ public final class StateCompiler
                 a(PUBLIC, FINAL),
                 makeClassName("Grouped" + clazz.getSimpleName()),
                 type(AbstractGroupedAccumulatorState.class),
-                type(clazz),
-                type(GroupedAccumulator.class));
+                type(clazz));
 
         FieldDefinition instanceSize = generateInstanceSize(definition);
 


### PR DESCRIPTION
There is no need to implement GroupedAccumulator when defining Concrete GroupedAccumulatorState Class, also generateGroupedStateClass() does not define any methods from GroupedAccumulator.Probably the original developer forgot to remove it.If this is right, we should merge this pr as soon as possible, otherwise the old code will mislead other developers.