### PR TITLE
Fix for incorrect LEFT to INNER conversion

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionRegistry.java
@@ -563,6 +563,7 @@ public class FunctionRegistry
                 .scalar(TryFunction.class)
                 .scalar(ConcatWsFunction.ConcatArrayWs.class)
                 .scalar(DynamicFilters.Function.class)
+                .scalar(DynamicFilters.NullableFunction.class)
                 .functions(ZIP_WITH_FUNCTION, MAP_ZIP_WITH_FUNCTION)
                 .functions(ZIP_FUNCTIONS)
                 .functions(ARRAY_JOIN, ARRAY_JOIN_WITH_NULL_REPLACEMENT)


### PR DESCRIPTION
Makes dynamic filter expression nullable for `IS NOT DISTINCT FROM` to not trigger LEFT to INNER conversion if there are no other expressions that would trigger it.

Fixes https://github.com/trinodb/trino/issues/9154