### PR TITLE
Add group-based and owner-based query access rules

### DIFF
--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -339,6 +339,8 @@ owned by any user. If no rule matches, query management is denied. Each rule is 
 of the following fields:
 
 * ``user`` (optional): regex to match against user name. Defaults to ``.*``.
+* ``role`` (optional): regex to match against role names. Defaults to ``.*``.
+* ``group`` (optional): regex to match against group names. Defaults to ``.*``.
 * ``owner`` (optional): regex to match against the query owner name. Defaults to ``.*``.
 * ``allow`` (required): set of query permissions granted to user. Values: ``execute``, ``view``, ``kill``
 
@@ -347,8 +349,8 @@ of the following fields:
     Users always have permission to view or kill their own queries.
 
 For example, if you want to allow the role ``admin`` full query access, allow the user ``alice``
-to execute and kill queries, any user to execute queries, and deny all other access, you can use
-the following rules:
+to execute and kill queries, allow members of the group ``contractors`` to view all queries, allow any
+user to execute queries, and deny all other access, you can use the following rules:
 
 .. literalinclude:: query-access.json
     :language: json

--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -341,16 +341,20 @@ of the following fields:
 * ``user`` (optional): regex to match against user name. Defaults to ``.*``.
 * ``role`` (optional): regex to match against role names. Defaults to ``.*``.
 * ``group`` (optional): regex to match against group names. Defaults to ``.*``.
-* ``owner`` (optional): regex to match against the query owner name. Defaults to ``.*``.
+* ``queryOwner`` (optional): regex to match against the query owner name. Defaults to ``.*``.
 * ``allow`` (required): set of query permissions granted to user. Values: ``execute``, ``view``, ``kill``
 
 .. note::
 
     Users always have permission to view or kill their own queries.
 
+    A rule that includes ``owner`` may not include the ``execute`` access mode. Queries are only owned
+    by a user once their execution has begun.
+
 For example, if you want to allow the role ``admin`` full query access, allow the user ``alice``
-to execute and kill queries, allow members of the group ``contractors`` to view all queries, allow any
-user to execute queries, and deny all other access, you can use the following rules:
+to execute and kill queries, allow members of the group ``contractors`` to view queries owned by
+users ``alice`` or ``dave``, allow any user to execute queries, and deny all other access, you can
+use the following rules:
 
 .. literalinclude:: query-access.json
     :language: json

--- a/docs/src/main/sphinx/security/query-access.json
+++ b/docs/src/main/sphinx/security/query-access.json
@@ -9,6 +9,10 @@
       "allow": ["execute", "kill"]
     },
     {
+      "group": "contractors",
+      "allow": ["execute", "view"]
+    },
+    {
       "allow": ["execute"]
     }
   ]

--- a/docs/src/main/sphinx/security/query-access.json
+++ b/docs/src/main/sphinx/security/query-access.json
@@ -10,7 +10,8 @@
     },
     {
       "group": "contractors",
-      "allow": ["execute", "view"]
+      "queryOwner": "alice|dave",
+      "allow": ["view"]
     },
     {
       "allow": ["execute"]

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/FileBasedSystemAccessControl.java
@@ -366,7 +366,7 @@ public class FileBasedSystemAccessControl
             return true;
         }
         for (QueryAccessRule rule : queryAccessRules.get()) {
-            Optional<Set<QueryAccessRule.AccessMode>> accessMode = rule.match(identity.getUser(), identity.getEnabledRoles());
+            Optional<Set<QueryAccessRule.AccessMode>> accessMode = rule.match(identity.getUser(), identity.getEnabledRoles(), identity.getGroups());
             if (accessMode.isPresent()) {
                 return accessMode.get().contains(requiredAccess);
             }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/QueryAccessRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/QueryAccessRule.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Arrays.stream;
 import static java.util.Objects.requireNonNull;
@@ -36,25 +37,32 @@ public class QueryAccessRule
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> roleRegex;
     private final Optional<Pattern> groupRegex;
+    private final Optional<Pattern> queryOwnerRegex;
 
     @JsonCreator
     public QueryAccessRule(
             @JsonProperty("allow") Set<AccessMode> allow,
             @JsonProperty("user") Optional<Pattern> userRegex,
             @JsonProperty("role") Optional<Pattern> roleRegex,
-            @JsonProperty("group") Optional<Pattern> groupRegex)
+            @JsonProperty("group") Optional<Pattern> groupRegex,
+            @JsonProperty("queryOwner") Optional<Pattern> queryOwnerRegex)
     {
         this.allow = ImmutableSet.copyOf(requireNonNull(allow, "allow is null"));
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
         this.roleRegex = requireNonNull(roleRegex, "roleRegex is null");
         this.groupRegex = requireNonNull(groupRegex, "groupRegex is null");
+        this.queryOwnerRegex = requireNonNull(queryOwnerRegex, "ownerRegex is null");
+        checkState(
+                queryOwnerRegex.isEmpty() || !allow.contains(AccessMode.EXECUTE),
+                "A valid query rule cannot combine an queryOwner condition with access mode 'execute'");
     }
 
-    public Optional<Set<AccessMode>> match(String user, Set<String> roles, Set<String> groups)
+    public Optional<Set<AccessMode>> match(String user, Set<String> roles, Set<String> groups, Optional<String> queryOwner)
     {
         if (userRegex.map(regex -> regex.matcher(user).matches()).orElse(true) &&
                 roleRegex.map(regex -> roles.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true) &&
-                groupRegex.map(regex -> groups.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true)) {
+                groupRegex.map(regex -> groups.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true) &&
+                ((queryOwner.isEmpty() && queryOwnerRegex.isEmpty()) || (queryOwner.isPresent() && queryOwnerRegex.map(regex -> regex.matcher(queryOwner.get()).matches()).orElse(true)))) {
             return Optional.of(allow);
         }
         return Optional.empty();
@@ -69,6 +77,7 @@ public class QueryAccessRule
                 .add("userRegex", userRegex.orElse(null))
                 .add("roleRegex", roleRegex.orElse(null))
                 .add("groupRegex", groupRegex.orElse(null))
+                .add("ownerRegex", queryOwnerRegex.orElse(null))
                 .toString();
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/QueryAccessRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/QueryAccessRule.java
@@ -35,22 +35,26 @@ public class QueryAccessRule
     private final Set<AccessMode> allow;
     private final Optional<Pattern> userRegex;
     private final Optional<Pattern> roleRegex;
+    private final Optional<Pattern> groupRegex;
 
     @JsonCreator
     public QueryAccessRule(
             @JsonProperty("allow") Set<AccessMode> allow,
             @JsonProperty("user") Optional<Pattern> userRegex,
-            @JsonProperty("role") Optional<Pattern> roleRegex)
+            @JsonProperty("role") Optional<Pattern> roleRegex,
+            @JsonProperty("group") Optional<Pattern> groupRegex)
     {
         this.allow = ImmutableSet.copyOf(requireNonNull(allow, "allow is null"));
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
         this.roleRegex = requireNonNull(roleRegex, "roleRegex is null");
+        this.groupRegex = requireNonNull(groupRegex, "groupRegex is null");
     }
 
-    public Optional<Set<AccessMode>> match(String user, Set<String> roles)
+    public Optional<Set<AccessMode>> match(String user, Set<String> roles, Set<String> groups)
     {
         if (userRegex.map(regex -> regex.matcher(user).matches()).orElse(true) &&
-                roleRegex.map(regex -> roles.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true)) {
+                roleRegex.map(regex -> roles.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true) &&
+                groupRegex.map(regex -> groups.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true)) {
             return Optional.of(allow);
         }
         return Optional.empty();
@@ -64,6 +68,7 @@ public class QueryAccessRule
                 .add("allow", allow)
                 .add("userRegex", userRegex.orElse(null))
                 .add("roleRegex", roleRegex.orElse(null))
+                .add("groupRegex", groupRegex.orElse(null))
                 .toString();
     }
 

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
@@ -754,10 +754,27 @@ public class TestFileBasedSystemAccessControl
         accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(bob, queryId), "any");
 
         accessControlManager.checkCanExecuteQuery(new SystemSecurityContext(dave, queryId));
-        accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "any");
+        accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "alice");
+        accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "dave");
         assertEquals(accessControlManager.filterViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), ImmutableSet.of("alice", "bob", "dave", "admin")),
-                ImmutableSet.of("alice", "bob", "dave", "admin"));
-        assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(dave, queryId), "any"))
+                ImmutableSet.of("alice", "dave"));
+        assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(dave, queryId), "alice"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Access Denied: Cannot view query");
+        assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(dave, queryId), "bob"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Access Denied: Cannot view query");
+        assertThatThrownBy(() -> accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "bob"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Access Denied: Cannot view query");
+        assertThatThrownBy(() -> accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "admin"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Access Denied: Cannot view query");
+
+        Identity contractor = Identity.forUser("some-other-contractor").withGroups(ImmutableSet.of("contractors")).build();
+        accessControlManager.checkCanExecuteQuery(new SystemSecurityContext(contractor, queryId));
+        accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(contractor, queryId), "dave");
+        assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(contractor, queryId), "dave"))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot view query");
 
@@ -765,6 +782,13 @@ public class TestFileBasedSystemAccessControl
         accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(nonAsciiUser, queryId), "any");
         assertEquals(accessControlManager.filterViewQueryOwnedBy(new SystemSecurityContext(nonAsciiUser, queryId), ImmutableSet.of("a", "b")), ImmutableSet.of("a", "b"));
         accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(nonAsciiUser, queryId), "any");
+    }
+
+    @Test
+    public void testInvalidQuery()
+    {
+        assertThatThrownBy(() -> newFileBasedSystemAccessControl("query-invalid.json"))
+                .getRootCause().hasMessage("A valid query rule cannot combine an queryOwner condition with access mode 'execute'");
     }
 
     @Test
@@ -806,10 +830,27 @@ public class TestFileBasedSystemAccessControl
                 .hasMessage("Access Denied: Cannot view query");
 
         accessControlManager.checkCanExecuteQuery(new SystemSecurityContext(dave, queryId));
-        accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "any");
+        accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "alice");
+        accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "dave");
         assertEquals(accessControlManager.filterViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), ImmutableSet.of("alice", "bob", "dave", "admin")),
-                ImmutableSet.of("alice", "bob", "dave", "admin"));
-        assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(dave, queryId), "any"))
+                ImmutableSet.of("alice", "dave"));
+        assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(dave, queryId), "alice"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Access Denied: Cannot view query");
+        assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(dave, queryId), "bob"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Access Denied: Cannot view query");
+        assertThatThrownBy(() -> accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "bob"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Access Denied: Cannot view query");
+        assertThatThrownBy(() -> accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "admin"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Access Denied: Cannot view query");
+
+        Identity contractor = Identity.forUser("some-other-contractor").withGroups(ImmutableSet.of("contractors")).build();
+        accessControlManager.checkCanExecuteQuery(new SystemSecurityContext(contractor, queryId));
+        accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(contractor, queryId), "dave");
+        assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(contractor, queryId), "dave"))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot view query");
     }

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
@@ -72,6 +72,7 @@ public class TestFileBasedSystemAccessControl
     private static final Optional<QueryId> queryId = Optional.empty();
 
     private static final Identity charlie = Identity.forUser("charlie").withGroups(ImmutableSet.of("guests")).build();
+    private static final Identity dave = Identity.forUser("dave").withGroups(ImmutableSet.of("contractors")).build();
     private static final Identity joe = Identity.ofUser("joe");
     private static final SystemSecurityContext ADMIN = new SystemSecurityContext(admin, queryId);
     private static final SystemSecurityContext BOB = new SystemSecurityContext(bob, queryId);
@@ -752,6 +753,14 @@ public class TestFileBasedSystemAccessControl
         assertEquals(accessControlManager.filterViewQueryOwnedBy(new SystemSecurityContext(bob, queryId), ImmutableSet.of("a", "b")), ImmutableSet.of());
         accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(bob, queryId), "any");
 
+        accessControlManager.checkCanExecuteQuery(new SystemSecurityContext(dave, queryId));
+        accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "any");
+        assertEquals(accessControlManager.filterViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), ImmutableSet.of("alice", "bob", "dave", "admin")),
+                ImmutableSet.of("alice", "bob", "dave", "admin"));
+        assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(dave, queryId), "any"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Access Denied: Cannot view query");
+
         accessControlManager.checkCanExecuteQuery(new SystemSecurityContext(nonAsciiUser, queryId));
         accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(nonAsciiUser, queryId), "any");
         assertEquals(accessControlManager.filterViewQueryOwnedBy(new SystemSecurityContext(nonAsciiUser, queryId), ImmutableSet.of("a", "b")), ImmutableSet.of("a", "b"));
@@ -793,6 +802,14 @@ public class TestFileBasedSystemAccessControl
                 .hasMessage("Access Denied: Cannot view query");
         assertEquals(accessControlManager.filterViewQueryOwnedBy(new SystemSecurityContext(bob, queryId), ImmutableSet.of("a", "b")), ImmutableSet.of());
         assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(bob, queryId), "any"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessage("Access Denied: Cannot view query");
+
+        accessControlManager.checkCanExecuteQuery(new SystemSecurityContext(dave, queryId));
+        accessControlManager.checkCanViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), "any");
+        assertEquals(accessControlManager.filterViewQueryOwnedBy(new SystemSecurityContext(dave, queryId), ImmutableSet.of("alice", "bob", "dave", "admin")),
+                ImmutableSet.of("alice", "bob", "dave", "admin"));
+        assertThatThrownBy(() -> accessControlManager.checkCanKillQueryOwnedBy(new SystemSecurityContext(dave, queryId), "any"))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessage("Access Denied: Cannot view query");
     }

--- a/lib/trino-plugin-toolkit/src/test/resources/query-invalid.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/query-invalid.json
@@ -1,0 +1,9 @@
+{
+  "queries": [
+    {
+      "group": "contractors",
+      "queryOwner": "alice|dave",
+      "allow": ["execute"]
+    }
+  ]
+}

--- a/lib/trino-plugin-toolkit/src/test/resources/query.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/query.json
@@ -14,7 +14,12 @@
     },
     {
       "group": "contractors",
-      "allow": ["execute", "view"]
+      "queryOwner": "alice|dave",
+      "allow": ["view"]
+    },
+    {
+      "group": "contractors",
+      "allow": ["execute"]
     },
     {
       "user": "\u0194\u0194\u0194",

--- a/lib/trino-plugin-toolkit/src/test/resources/query.json
+++ b/lib/trino-plugin-toolkit/src/test/resources/query.json
@@ -13,6 +13,10 @@
       "allow": ["kill"]
     },
     {
+      "group": "contractors",
+      "allow": ["execute", "view"]
+    },
+    {
       "user": "\u0194\u0194\u0194",
       "allow": ["execute", "view", "kill"]
     }


### PR DESCRIPTION
Fixes #9484.
QueryAccessRule now supports a `group` regex to enable rules based on group membership and an `owner` regex to enable rules based on the query's owner.