### PR TITLE
Drop parens from ALTER TABLE SET PROPERTIES

### DIFF
--- a/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
+++ b/core/trino-parser/src/main/antlr4/io/trino/sql/parser/SqlBase.g4
@@ -70,7 +70,8 @@ statement
     | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
         DROP COLUMN (IF EXISTS)? column=qualifiedName                  #dropColumn
     | ALTER TABLE tableName=qualifiedName SET AUTHORIZATION principal  #setTableAuthorization
-    | ALTER TABLE tableName=qualifiedName SET PROPERTIES properties    #setTableProperties
+    | ALTER TABLE tableName=qualifiedName
+        SET PROPERTIES propertyAssignments                             #setTableProperties
     | ALTER TABLE tableName=qualifiedName
         EXECUTE procedureName=identifier
         ('(' (callArgument (',' callArgument)*)? ')')?
@@ -185,7 +186,11 @@ likeClause
     ;
 
 properties
-    : '(' property (',' property)* ')'
+    : '(' propertyAssignments ')'
+    ;
+
+propertyAssignments
+    : property (',' property)*
     ;
 
 property

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -1324,9 +1324,8 @@ public final class SqlFormatter
         {
             builder.append("ALTER TABLE ");
             builder.append(node.getName())
-                    .append(" SET PROPERTIES ( ");
+                    .append(" SET PROPERTIES ");
             builder.append(joinProperties(node.getProperties()));
-            builder.append(" )");
 
             return null;
         }

--- a/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/parser/AstBuilder.java
@@ -331,7 +331,7 @@ class AstBuilder
 
         List<Property> properties = ImmutableList.of();
         if (context.properties() != null) {
-            properties = visit(context.properties().property(), Property.class);
+            properties = visit(context.properties().propertyAssignments().property(), Property.class);
         }
 
         return new CreateSchema(
@@ -385,7 +385,7 @@ class AstBuilder
 
         List<Property> properties = ImmutableList.of();
         if (context.properties() != null) {
-            properties = visit(context.properties().property(), Property.class);
+            properties = visit(context.properties().propertyAssignments().property(), Property.class);
         }
 
         return new CreateTableAsSelect(
@@ -408,7 +408,7 @@ class AstBuilder
         }
         List<Property> properties = ImmutableList.of();
         if (context.properties() != null) {
-            properties = visit(context.properties().property(), Property.class);
+            properties = visit(context.properties().propertyAssignments().property(), Property.class);
         }
         return new CreateTable(
                 getLocation(context),
@@ -429,7 +429,7 @@ class AstBuilder
 
         List<Property> properties = ImmutableList.of();
         if (context.properties() != null) {
-            properties = visit(context.properties().property(), Property.class);
+            properties = visit(context.properties().propertyAssignments().property(), Property.class);
         }
 
         return new CreateMaterializedView(
@@ -571,8 +571,8 @@ class AstBuilder
     public Node visitSetTableProperties(SqlBaseParser.SetTablePropertiesContext context)
     {
         List<Property> properties = ImmutableList.of();
-        if (context.properties() != null) {
-            properties = visit(context.properties().property(), Property.class);
+        if (context.propertyAssignments() != null) {
+            properties = visit(context.propertyAssignments().property(), Property.class);
         }
 
         return new SetProperties(getLocation(context), SetProperties.Type.TABLE, getQualifiedName(context.qualifiedName()), properties);
@@ -619,7 +619,7 @@ class AstBuilder
     {
         List<Property> properties = ImmutableList.of();
         if (context.properties() != null) {
-            properties = visit(context.properties().property(), Property.class);
+            properties = visit(context.properties().propertyAssignments().property(), Property.class);
         }
         return new Analyze(
                 getLocation(context),
@@ -2296,7 +2296,7 @@ class AstBuilder
 
         List<Property> properties = ImmutableList.of();
         if (context.properties() != null) {
-            properties = visit(context.properties().property(), Property.class);
+            properties = visit(context.properties().propertyAssignments().property(), Property.class);
         }
 
         boolean nullable = context.NOT() == null;

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestSqlParser.java
@@ -1809,14 +1809,18 @@ public class TestSqlParser
     @Test
     public void testSetTableProperties()
     {
-        assertStatement("ALTER TABLE a SET PROPERTIES (foo='bar')", new SetProperties(SetProperties.Type.TABLE, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier("foo"), new StringLiteral("bar")))));
-        assertStatement("ALTER TABLE a SET PROPERTIES (foo=true)", new SetProperties(SetProperties.Type.TABLE, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier("foo"), new BooleanLiteral("true")))));
-        assertStatement("ALTER TABLE a SET PROPERTIES (foo=123)", new SetProperties(SetProperties.Type.TABLE, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier("foo"), new LongLiteral("123")))));
-        assertStatement("ALTER TABLE a SET PROPERTIES (foo=123, bar=456)", new SetProperties(SetProperties.Type.TABLE, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier("foo"), new LongLiteral("123")), new Property(new Identifier("bar"), new LongLiteral("456")))));
-        assertStatement("ALTER TABLE a SET PROPERTIES (\" s p a c e \"='bar')", new SetProperties(SetProperties.Type.TABLE, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier(" s p a c e "), new StringLiteral("bar")))));
+        assertStatement("ALTER TABLE a SET PROPERTIES foo='bar'", new SetProperties(SetProperties.Type.TABLE, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier("foo"), new StringLiteral("bar")))));
+        assertStatement("ALTER TABLE a SET PROPERTIES foo=true", new SetProperties(SetProperties.Type.TABLE, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier("foo"), new BooleanLiteral("true")))));
+        assertStatement("ALTER TABLE a SET PROPERTIES foo=123", new SetProperties(SetProperties.Type.TABLE, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier("foo"), new LongLiteral("123")))));
+        assertStatement("ALTER TABLE a SET PROPERTIES foo=123, bar=456", new SetProperties(SetProperties.Type.TABLE, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier("foo"), new LongLiteral("123")), new Property(new Identifier("bar"), new LongLiteral("456")))));
+        assertStatement("ALTER TABLE a SET PROPERTIES \" s p a c e \"='bar'", new SetProperties(SetProperties.Type.TABLE, QualifiedName.of("a"), ImmutableList.of(new Property(new Identifier(" s p a c e "), new StringLiteral("bar")))));
 
+        assertStatementIsInvalid("ALTER TABLE a SET PROPERTIES")
+                .withMessage("line 1:29: mismatched input '<EOF>'. Expecting: <identifier>");
         assertStatementIsInvalid("ALTER TABLE a SET PROPERTIES ()")
-                .withMessage("line 1:31: mismatched input ')'. Expecting: <identifier>");
+                .withMessage("line 1:30: mismatched input '('. Expecting: <identifier>");
+        assertStatementIsInvalid("ALTER TABLE a SET PROPERTIES (foo='bar')")
+                .withMessage("line 1:30: mismatched input '('. Expecting: <identifier>");
     }
 
     @Test

--- a/core/trino-parser/src/test/java/io/trino/sql/parser/TestStatementBuilder.java
+++ b/core/trino-parser/src/test/java/io/trino/sql/parser/TestStatementBuilder.java
@@ -205,8 +205,8 @@ public class TestStatementBuilder
 
         printStatement("alter table a.b.c rename column x to y");
 
-        printStatement("alter table foo set properties (a='1')");
-        printStatement("alter table a.b.c set properties (a=true, b=123, c='x')");
+        printStatement("alter table foo set properties a='1'");
+        printStatement("alter table a.b.c set properties a=true, b=123, c='x'");
 
         printStatement("alter table a.b.c add column x bigint");
 

--- a/docs/src/main/sphinx/sql/alter-table.rst
+++ b/docs/src/main/sphinx/sql/alter-table.rst
@@ -14,7 +14,7 @@ Synopsis
     ALTER TABLE [ IF EXISTS ] name DROP COLUMN [ IF EXISTS ] column_name
     ALTER TABLE [ IF EXISTS ] name RENAME COLUMN [ IF EXISTS ] old_name TO new_name
     ALTER TABLE name SET AUTHORIZATION ( user | USER user | ROLE role )
-    ALTER TABLE SET PROPERTIES ( property_name = expression [, ...] )
+    ALTER TABLE name SET PROPERTIES property_name = expression [, ...]
     ALTER TABLE name EXECUTE command [ ( parameter => expression [, ... ] ) ]
         [ WHERE expression ]
 
@@ -84,7 +84,7 @@ Allow everyone with role public to drop and alter table ``people``::
 
 Set table properties (``x=y``) to table ``users``::
 
-    ALTER TABLE people SET PROPERTIES (x = 'y')
+    ALTER TABLE people SET PROPERTIES x = 'y'
 
 Collapse files in a table that are over 10 megabytes in size, as supported by
 the Hive connector::

--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestClickHouseConnectorTest.java
@@ -348,7 +348,7 @@ public class TestClickHouseConnectorTest
                             "primary_key", "p1, p2",
                             "sample_by", ""));
 
-            assertUpdate("ALTER TABLE " + table.getName() + " SET PROPERTIES (sample_by = 'p2')");
+            assertUpdate("ALTER TABLE " + table.getName() + " SET PROPERTIES sample_by = 'p2'");
             assertThat(getTableProperties("tpch", table.getName()))
                     .containsExactlyEntriesOf(ImmutableMap.of(
                             "engine", "MergeTree",
@@ -367,7 +367,7 @@ public class TestClickHouseConnectorTest
                 "test_alter_table_properties",
                 "(p1 int NOT NULL, p2 int NOT NULL, x VARCHAR) WITH (engine = 'MergeTree', order_by = ARRAY['p1', 'p2'], primary_key = ARRAY['p1', 'p2'])")) {
             assertQueryFails(
-                    "ALTER TABLE " + table.getName() + " SET PROPERTIES (invalid_property = 'p2')",
+                    "ALTER TABLE " + table.getName() + " SET PROPERTIES invalid_property = 'p2'",
                     "Catalog 'clickhouse' does not support table property 'invalid_property'");
         }
     }

--- a/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestAccessControl.java
@@ -99,7 +99,7 @@ public class TestAccessControl
         assertAccessDenied("INSERT INTO orders SELECT * FROM orders", "Cannot insert into table .*.orders.*", privilege("orders", INSERT_TABLE));
         assertAccessDenied("DELETE FROM orders", "Cannot delete from table .*.orders.*", privilege("orders", DELETE_TABLE));
         assertAccessDenied("CREATE TABLE foo AS SELECT * FROM orders", "Cannot create table .*.foo.*", privilege("foo", CREATE_TABLE));
-        assertAccessDenied("ALTER TABLE orders SET PROPERTIES (field_length = 32)", "Cannot set table properties to .*.orders.*", privilege("orders", SET_TABLE_PROPERTIES));
+        assertAccessDenied("ALTER TABLE orders SET PROPERTIES field_length = 32", "Cannot set table properties to .*.orders.*", privilege("orders", SET_TABLE_PROPERTIES));
         assertAccessDenied("SELECT * FROM nation", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
         assertAccessDenied("SELECT * FROM (SELECT * FROM nation)", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
         assertAccessDenied("SELECT name FROM (SELECT * FROM nation)", "Cannot select from columns \\[nationkey, regionkey, name, comment] in table .*.nation.*", privilege("nation.nationkey", SELECT_COLUMN));
@@ -306,8 +306,8 @@ public class TestAccessControl
     @Test
     public void testSetTableProperties()
     {
-        assertAccessDenied("ALTER TABLE orders SET PROPERTIES (field_length = 32)", "Cannot set table properties to .*.orders.*", privilege("orders", SET_TABLE_PROPERTIES));
-        assertThatThrownBy(() -> getQueryRunner().execute(getSession(), "ALTER TABLE orders SET PROPERTIES (field_length = 32)"))
+        assertAccessDenied("ALTER TABLE orders SET PROPERTIES field_length = 32", "Cannot set table properties to .*.orders.*", privilege("orders", SET_TABLE_PROPERTIES));
+        assertThatThrownBy(() -> getQueryRunner().execute(getSession(), "ALTER TABLE orders SET PROPERTIES field_length = 32"))
                 .hasMessageContaining("This connector does not support setting table properties");
     }
 
@@ -337,7 +337,7 @@ public class TestAccessControl
         assertAccessDenied("CREATE TABLE foo (pk bigint)", "Cannot create table .*.foo.*", privilege("foo", CREATE_TABLE));
         assertAccessDenied("DROP TABLE orders", "Cannot drop table .*.orders.*", privilege("orders", DROP_TABLE));
         assertAccessDenied("ALTER TABLE orders RENAME TO foo", "Cannot rename table .*.orders.* to .*.foo.*", privilege("orders", RENAME_TABLE));
-        assertAccessDenied("ALTER TABLE orders SET PROPERTIES (field_length = 32)", "Cannot set table properties to .*.orders.*", privilege("orders", SET_TABLE_PROPERTIES));
+        assertAccessDenied("ALTER TABLE orders SET PROPERTIES field_length = 32", "Cannot set table properties to .*.orders.*", privilege("orders", SET_TABLE_PROPERTIES));
         assertAccessDenied("ALTER TABLE orders ADD COLUMN foo bigint", "Cannot add a column to table .*.orders.*", privilege("orders", ADD_COLUMN));
         assertAccessDenied("ALTER TABLE orders DROP COLUMN foo", "Cannot drop a column from table .*.orders.*", privilege("orders", DROP_COLUMN));
         assertAccessDenied("ALTER TABLE orders RENAME COLUMN orderkey TO foo", "Cannot rename a column in table .*.orders.*", privilege("orders", RENAME_COLUMN));

--- a/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/AbstractTestEngineOnlyQueries.java
@@ -1479,7 +1479,7 @@ public abstract class AbstractTestEngineOnlyQueries
         assertDescribeOutputEmpty("ALTER TABLE foo ADD COLUMN y bigint");
         assertDescribeOutputEmpty("ALTER TABLE foo SET AUTHORIZATION bar");
         assertDescribeOutputEmpty("ALTER TABLE foo RENAME TO bar");
-        assertDescribeOutputEmpty("ALTER TABLE foo SET PROPERTIES ( x = 'y' )");
+        assertDescribeOutputEmpty("ALTER TABLE foo SET PROPERTIES x = 'y'");
         assertDescribeOutputEmpty("DROP TABLE foo");
         assertDescribeOutputEmpty("CREATE VIEW foo AS SELECT * FROM nation");
         assertDescribeOutputEmpty("DROP VIEW foo");


### PR DESCRIPTION
Per maintainers' discussion and under https://github.com/trinodb/trino/pull/9765.