### PR TITLE
Allow overriding scale variable for tpch benchmark

### DIFF
--- a/testing/trino-benchto-benchmarks/src/main/resources/benchmarks/presto/tpch.yaml
+++ b/testing/trino-benchto-benchmarks/src/main/resources/benchmarks/presto/tpch.yaml
@@ -7,8 +7,11 @@ before-execution: sleep-4s, presto/session_set_cbo_flags.sql
 frequency: 7
 database: hive
 tpch_300: tpch_sf300_orc
+scale_300: 300
 tpch_1000: tpch_sf1000_orc
+scale_1000: 1000
 tpch_3000: tpch_sf3000_orc
+scale_3000: 3000
 prefix: ""
 variables:
 # queries are assigned to groups so they execute within 15-60s each (for an arbitrary benchmark cluster)
@@ -16,20 +19,20 @@ variables:
   1:
     query: q05, q07, q08, q09, q17, q18, q21
     schema: ${tpch_300}
-    scale: 300
+    scale: ${scale_300}
     join_reordering_strategy: ELIMINATE_CROSS_JOINS, AUTOMATIC
     join_distribution_type: PARTITIONED, AUTOMATIC
 
   2:
     query: q01, q02, q03, q04, q10, q12, q13, q15, q20
     schema: ${tpch_1000}
-    scale: 1000
+    scale: ${scale_1000}
     join_reordering_strategy: ELIMINATE_CROSS_JOINS, AUTOMATIC
     join_distribution_type: PARTITIONED, AUTOMATIC
 
   3:
     query: q06, q11, q14, q16, q19, q22
     schema: ${tpch_3000}
-    scale: 3000
+    scale: ${scale_3000}
     join_reordering_strategy: ELIMINATE_CROSS_JOINS, AUTOMATIC
     join_distribution_type: PARTITIONED, AUTOMATIC


### PR DESCRIPTION
We need a way to override scale variable in benchto benchmark configuration, so it can match selected schema.