### PR TITLE
Fix bug in iceberg connector with external table locations

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergUtil.java
@@ -385,7 +385,7 @@ public final class IcebergUtil
         Schema schema = toIcebergSchema(tableMetadata.getColumns());
         PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
         String targetPath = getTableLocation(tableMetadata.getProperties())
-                .orElse(catalog.defaultTableLocation(session, schemaTableName));
+                .orElseGet(() -> catalog.defaultTableLocation(session, schemaTableName));
 
         ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(2);
         FileFormat fileFormat = IcebergTableProperties.getFileFormat(tableMetadata.getProperties());


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/9732.

### Steps to reproduce

1. Create the schema with a dummy location
```sql
CREATE SCHEMA test_iceberg.test_schema
 WITH (
    location = 'gs://valid-bucket/foobar'
 )
```
2. Verify that the path was created
```bash
➜ gsutil ls gs://valid-bucket/
gs://valid-bucket/
gs://valid-bucket/foobar
gs://valid-bucket/some-real-data/
```
3. Delete the `/foobar` folder in GCS manually
4. Verify the folder was deleted in GCS
```bash
➜ gsutil ls gs://valid-bucket/
gs://valid-bucket/
gs://valid-bucket/some-real-data/
```
5. Try to create a table with an overridden **_VALID_** location
```sql
trino:test_schema> CREATE TABLE test_table_1 (c1 VARCHAR, c2 VARCHAR)
                         -> WITH (
                         ->   format = 'PARQUET',
                         ->   partitioning = ARRAY['c1', 'c2'],
                         ->   location = 'gs://valid-bucket/some-real-data'
                         -> );
Query 20211028_150354_00000_zt8fz failed: Database 'test_schema' location does not exist: gs://valid-bucket/foobar
```

So despite the location property of the `CREATE TABLE ...` being valid, it was still checking the default path of the schema and returning that it doesn't exist.

## The issue

The offending line in `IcebergUtil.java#newCreateTableTransaction`

```java
String targetPath = getTableLocation(tableMetadata.getProperties())
                .orElse(catalog.defaultTableLocation(session, schemaTableName));
```

The `catalog.defaultTableLocation(...)` is called regardless of the evaluation of the `getTableLocation(...)` and since the schema's default external location is invalid (aka does not exist) the `CREATE TABLE` fails when it should succeed.

## The fix

Use `Optional.orElseGet` which defers the execution of the `catalog.defaultTableLocation(...)` call until after the first expression is evaluated.

## Testing

Ran the new test with 

```bash
bin/ptl test run --environment singlenode-hdfs-impersonation -- -t TestIcebergCreateTable.testCreateExternalTableWithInaccessibleSchemaLocation
```

and it was successful with

```bash
tests               | 2021-10-29 20:24:56 INFO: SUCCESS     /    io.trino.tests.product.iceberg.TestIcebergCreateTable.testCreateExternalTableWithInaccessibleSchemaLocation (Groups: storage_formats, iceberg) took 17.7 seconds
```

## Benefits

You can create iceberg tables again regardless of the schema's default location and improved performance since there is one less call to the external location (in this example being GCS) for every `CREATE TABLE`.

## Related issues
- https://github.com/trinodb/trino/pull/4279