### PR TITLE
Make map and array functions use IS DISTINCT semantics as appropriate

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/MultimapAggregationFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/MultimapAggregationFunction.java
@@ -30,8 +30,8 @@ import io.trino.spi.type.ArrayType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.TypeSignature;
 import io.trino.type.BlockTypeOperators;
-import io.trino.type.BlockTypeOperators.BlockPositionEqual;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
+import io.trino.type.BlockTypeOperators.BlockPositionIsDistinctFrom;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -40,7 +40,7 @@ import java.util.Optional;
 import static io.trino.metadata.FunctionKind.AGGREGATE;
 import static io.trino.metadata.Signature.comparableTypeParameter;
 import static io.trino.metadata.Signature.typeVariable;
-import static io.trino.operator.aggregation.TypedSet.createEqualityTypedSet;
+import static io.trino.operator.aggregation.TypedSet.createDistinctTypedSet;
 import static io.trino.spi.type.TypeSignature.arrayType;
 import static io.trino.spi.type.TypeSignature.mapType;
 import static io.trino.spi.type.TypeSignature.rowType;
@@ -57,7 +57,7 @@ public class MultimapAggregationFunction
             MultimapAggregationFunction.class,
             "output",
             Type.class,
-            BlockPositionEqual.class,
+            BlockPositionIsDistinctFrom.class,
             BlockPositionHashCode.class,
             Type.class,
             MultimapAggregationState.class,
@@ -103,7 +103,7 @@ public class MultimapAggregationFunction
     public AggregationMetadata specialize(BoundSignature boundSignature)
     {
         Type keyType = boundSignature.getArgumentType(0);
-        BlockPositionEqual keyEqual = blockTypeOperators.getEqualOperator(keyType);
+        BlockPositionIsDistinctFrom keyDistinctOperator = blockTypeOperators.getDistinctFromOperator(keyType);
         BlockPositionHashCode keyHashCode = blockTypeOperators.getHashCodeOperator(keyType);
 
         Type valueType = boundSignature.getArgumentType(1);
@@ -114,7 +114,7 @@ public class MultimapAggregationFunction
                 INPUT_FUNCTION,
                 Optional.empty(),
                 Optional.of(COMBINE_FUNCTION),
-                MethodHandles.insertArguments(OUTPUT_FUNCTION, 0, keyType, keyEqual, keyHashCode, valueType),
+                MethodHandles.insertArguments(OUTPUT_FUNCTION, 0, keyType, keyDistinctOperator, keyHashCode, valueType),
                 ImmutableList.of(new AccumulatorStateDescriptor<>(
                         MultimapAggregationState.class,
                         stateSerializer,
@@ -131,7 +131,7 @@ public class MultimapAggregationFunction
         state.merge(otherState);
     }
 
-    public static void output(Type keyType, BlockPositionEqual keyEqual, BlockPositionHashCode keyHashCode, Type valueType, MultimapAggregationState state, BlockBuilder out)
+    public static void output(Type keyType, BlockPositionIsDistinctFrom keyDistinctOperator, BlockPositionHashCode keyHashCode, Type valueType, MultimapAggregationState state, BlockBuilder out)
     {
         if (state.isEmpty()) {
             out.appendNull();
@@ -141,7 +141,7 @@ public class MultimapAggregationFunction
             ObjectBigArray<BlockBuilder> valueArrayBlockBuilders = new ObjectBigArray<>();
             valueArrayBlockBuilders.ensureCapacity(state.getEntryCount());
             BlockBuilder distinctKeyBlockBuilder = keyType.createBlockBuilder(null, state.getEntryCount(), expectedValueSize(keyType, 100));
-            TypedSet keySet = createEqualityTypedSet(keyType, keyEqual, keyHashCode, state.getEntryCount(), NAME);
+            TypedSet keySet = createDistinctTypedSet(keyType, keyDistinctOperator, keyHashCode, state.getEntryCount(), NAME);
 
             state.forEach((key, value, keyValueIndex) -> {
                 // Merge values of the same key into an array

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayExceptFunction.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/ArrayExceptFunction.java
@@ -23,15 +23,14 @@ import io.trino.spi.function.ScalarFunction;
 import io.trino.spi.function.SqlType;
 import io.trino.spi.function.TypeParameter;
 import io.trino.spi.type.Type;
-import io.trino.type.BlockTypeOperators.BlockPositionEqual;
 import io.trino.type.BlockTypeOperators.BlockPositionHashCode;
+import io.trino.type.BlockTypeOperators.BlockPositionIsDistinctFrom;
 
-import static io.trino.operator.aggregation.TypedSet.createEqualityTypedSet;
+import static io.trino.operator.aggregation.TypedSet.createDistinctTypedSet;
 import static io.trino.spi.function.InvocationConvention.InvocationArgumentConvention.BLOCK_POSITION;
 import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.FAIL_ON_NULL;
-import static io.trino.spi.function.InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN;
-import static io.trino.spi.function.OperatorType.EQUAL;
 import static io.trino.spi.function.OperatorType.HASH_CODE;
+import static io.trino.spi.function.OperatorType.IS_DISTINCT_FROM;
 
 @ScalarFunction("array_except")
 @Description("Returns an array of elements that are in the first array but not the second, without duplicates.")
@@ -44,9 +43,9 @@ public final class ArrayExceptFunction
     public static Block except(
             @TypeParameter("E") Type type,
             @OperatorDependency(
-                    operator = EQUAL,
+                    operator = IS_DISTINCT_FROM,
                     argumentTypes = {"E", "E"},
-                    convention = @Convention(arguments = {BLOCK_POSITION, BLOCK_POSITION}, result = NULLABLE_RETURN)) BlockPositionEqual elementEqual,
+                    convention = @Convention(arguments = {BLOCK_POSITION, BLOCK_POSITION}, result = FAIL_ON_NULL)) BlockPositionIsDistinctFrom isDistinctOperator,
             @OperatorDependency(
                     operator = HASH_CODE,
                     argumentTypes = "E",
@@ -61,7 +60,7 @@ public final class ArrayExceptFunction
             return leftArray;
         }
 
-        TypedSet typedSet = createEqualityTypedSet(type, elementEqual, elementHashCode, leftPositionCount, "array_except");
+        TypedSet typedSet = createDistinctTypedSet(type, isDistinctOperator, elementHashCode, leftPositionCount, "array_except");
         BlockBuilder distinctElementBlockBuilder = type.createBlockBuilder(null, leftPositionCount);
         for (int i = 0; i < rightPositionCount; i++) {
             typedSet.add(rightArray, i);

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestMultimapAggAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestMultimapAggAggregation.java
@@ -89,6 +89,13 @@ public class TestMultimapAggAggregation
     }
 
     @Test
+    public void testKeysUseIsDistinctSemantics()
+    {
+        testMultimapAgg(DOUBLE, ImmutableList.of(Double.NaN, Double.NaN), BIGINT, ImmutableList.of(1L, 1L));
+        testMultimapAgg(DOUBLE, ImmutableList.of(Double.NaN, Double.NaN, Double.NaN), BIGINT, ImmutableList.of(2L, 1L, 2L));
+    }
+
+    @Test
     public void testDoubleMapMultimap()
     {
         Type mapType = mapType(VARCHAR, BIGINT);
@@ -177,6 +184,11 @@ public class TestMultimapAggAggregation
         return FUNCTION_RESOLUTION.getAggregateFunction(QualifiedName.of(MultimapAggregationFunction.NAME), fromTypes(keyType, valueType));
     }
 
+    /**
+     * Given a list of keys and a list of corresponding values, manually
+     * aggregate them into a map of list and check that Trino's aggregation has
+     * the same results.
+     */
     private static <K, V> void testMultimapAgg(Type keyType, List<K> expectedKeys, Type valueType, List<V> expectedValues)
     {
         checkState(expectedKeys.size() == expectedValues.size(), "expectedKeys and expectedValues should have equal size");

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayExceptFunction.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestArrayExceptFunction.java
@@ -66,4 +66,11 @@ public class TestArrayExceptFunction
         assertFunction("array_except(ARRAY[VARCHAR 'x', 'x', 'y', 'z'], ARRAY['x', 'y', 'x'])", new ArrayType(VARCHAR), ImmutableList.of("z"));
         assertFunction("array_except(ARRAY[true, false, null, true, false, null], ARRAY[true, true, true])", new ArrayType(BOOLEAN), asList(false, null));
     }
+
+    @Test
+    public void testNonDistinctNonEqualValues()
+    {
+        assertFunction("array_except(ARRAY[NaN()], ARRAY[NaN()])", new ArrayType(DOUBLE), ImmutableList.of());
+        assertFunction("array_except(ARRAY[1, NaN(), 3], ARRAY[NaN(), 3])", new ArrayType(DOUBLE), ImmutableList.of(1.0));
+    }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestArrayOperators.java
@@ -1422,6 +1422,8 @@ public class TestArrayOperators
         assertFunction("ARRAY_UNION(ARRAY [8.3E0, 1.6E0, 4.1E0, 5.2E0], ARRAY [4.0E0, 5.2E0, 8.3E0, 9.7E0, 3.5E0])", new ArrayType(DOUBLE), ImmutableList.of(8.3, 1.6, 4.1, 5.2, 4.0, 9.7, 3.5));
         assertFunction("ARRAY_UNION(ARRAY [5.1E0, 7, 3.0E0, 4.8E0, 10], ARRAY [6.5E0, 10.0E0, 1.9E0, 5.1E0, 3.9E0, 4.8E0])", new ArrayType(DOUBLE), ImmutableList.of(5.1, 7.0, 3.0, 4.8, 10.0, 6.5, 1.9, 3.9));
         assertFunction("ARRAY_UNION(ARRAY [ARRAY [4, 5], ARRAY [6, 7]], ARRAY [ARRAY [4, 5], ARRAY [6, 8]])", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of(ImmutableList.of(4, 5), ImmutableList.of(6, 7), ImmutableList.of(6, 8)));
+        assertFunction("ARRAY_UNION(ARRAY [NaN()], ARRAY [NaN()])", new ArrayType(DOUBLE), ImmutableList.of(NaN)); // results unique based on IS DISTINCT semantics
+        assertFunction("ARRAY_UNION(ARRAY [1, NaN(), 3], ARRAY [1, NaN()])", new ArrayType(DOUBLE), ImmutableList.of(1.0, NaN, 3.0));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestMapOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestMapOperators.java
@@ -878,6 +878,14 @@ public class TestMapOperators
                         decimal("2.2", createDecimalType(2, 1)),
                         decimal("5.1", createDecimalType(2, 1)),
                         decimal("2.2", createDecimalType(2, 1))));
+
+        // Compare keys with IS DISTINCT semantics
+        assertFunction("MAP_CONCAT("
+                        + "MAP(ARRAY[NaN()], ARRAY[1]),"
+                        + "MAP(ARRAY[NaN()], ARRAY[2]),"
+                        + "MAP(ARRAY[NaN()], ARRAY[3]))",
+                mapType(DOUBLE, INTEGER),
+                ImmutableMap.of(Double.NaN, 3));
     }
 
     @Test
@@ -950,6 +958,8 @@ public class TestMapOperators
         assertInvalidFunction("map_from_entries(ARRAY[(1.0, 1), (1.0, 2)])", "Duplicate keys (1.0) are not allowed");
         assertInvalidFunction("map_from_entries(ARRAY[(ARRAY[1, 2], 1), (ARRAY[1, 2], 2)])", "Duplicate keys ([1, 2]) are not allowed");
         assertInvalidFunction("map_from_entries(ARRAY[(MAP(ARRAY[1], ARRAY[2]), 1), (MAP(ARRAY[1], ARRAY[2]), 2)])", "Duplicate keys ({1=2}) are not allowed");
+        assertInvalidFunction("map_from_entries(ARRAY[(NaN(), 1), (NaN(), 2)])", "Duplicate keys (NaN) are not allowed");
+
         assertInvalidFunction("map_from_entries(ARRAY[(null, 1), (null, 2)])", "map key cannot be null");
         assertInvalidFunction("map_from_entries(ARRAY[null])", "map entry cannot be null");
         assertInvalidFunction("map_from_entries(ARRAY[(1, 2), null])", "map entry cannot be null");
@@ -984,6 +994,11 @@ public class TestMapOperators
                         "x", ImmutableList.of(1.0, 1.5),
                         "y", ImmutableList.of(2.0, 2.5),
                         "z", singletonList(null)));
+
+        assertFunction(
+                "multimap_from_entries(ARRAY[(NaN(), 1), (NaN(), 2)])",
+                mapType(DOUBLE, new ArrayType(INTEGER)),
+                ImmutableMap.of(Double.NaN, ImmutableList.of(1, 2)));
 
         // invalid invocation
         assertInvalidFunction("multimap_from_entries(ARRAY[(null, 1), (null, 2)])", "map key cannot be null");

--- a/core/trino-main/src/test/java/io/trino/type/TestMapOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestMapOperators.java
@@ -917,6 +917,7 @@ public class TestMapOperators
 
         assertInvalidCast("CAST(MAP(ARRAY[1, 2], ARRAY[6, 9]) AS MAP<boolean, bigint>)", "duplicate keys");
         assertInvalidCast("CAST(MAP(ARRAY[json 'null'], ARRAY[1]) AS MAP<bigint, bigint>)", "map key is null");
+        assertInvalidCast("CAST(MAP(ARRAY['NaN', ' NaN '], ARRAY[1, 2]) AS MAP<double, integer>)", "duplicate keys");
     }
 
     @Test


### PR DESCRIPTION
This addresses #560.

Release note:
```markdown
# General
* Compare with "is distinct" semantics in `array_except`, `array_union`, `map_concat`, `map_from_entries`, `multimap_from_entries`, and `multimap_agg`. ({issue}`560`)
```