### PR TITLE
Add connector metrics to EXPLAIN ANALYZE verbose output

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/HashCollisionPlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/HashCollisionPlanNodeStats.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.planprinter;
 
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import java.util.Map;
@@ -39,7 +40,8 @@ public class HashCollisionPlanNodeStats
             DataSize planNodeOutputDataSize,
             DataSize planNodeSpilledDataSize,
             Map<String, OperatorInputStats> operatorInputStats,
-            Map<String, OperatorHashCollisionsStats> operatorHashCollisionsStats)
+            Map<String, OperatorHashCollisionsStats> operatorHashCollisionsStats,
+            Metrics metrics)
     {
         super(
                 planNodeId,
@@ -50,7 +52,9 @@ public class HashCollisionPlanNodeStats
                 planNodeOutputPositions,
                 planNodeOutputDataSize,
                 planNodeSpilledDataSize,
-                operatorInputStats);
+                operatorInputStats,
+                metrics,
+                Metrics.EMPTY);
         this.operatorHashCollisionsStats = requireNonNull(operatorHashCollisionsStats, "operatorHashCollisionsStats is null");
     }
 
@@ -104,6 +108,7 @@ public class HashCollisionPlanNodeStats
                 merged.getPlanNodeOutputDataSize(),
                 merged.getPlanNodeSpilledDataSize(),
                 merged.operatorInputStats,
-                operatorHashCollisionsStats);
+                operatorHashCollisionsStats,
+                merged.getMetrics());
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
@@ -18,6 +18,8 @@ import io.airlift.units.DataSize;
 import io.trino.cost.PlanCostEstimate;
 import io.trino.cost.PlanNodeStatsAndCostSummary;
 import io.trino.cost.PlanNodeStatsEstimate;
+import io.trino.spi.metrics.Metric;
+import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.planprinter.NodeRepresentation.TypedSymbol;
 
@@ -27,6 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
@@ -135,6 +138,8 @@ public class TextRenderer
         }
         output.append("\n");
 
+        printMetrics(output, "connector metrics:", nodeStats.getConnectorMetrics());
+        printMetrics(output, "metrics:", nodeStats.getMetrics());
         printDistributions(output, nodeStats);
         printCollisions(output, nodeStats);
 
@@ -143,6 +148,16 @@ public class TextRenderer
         }
 
         return output.toString();
+    }
+
+    private void printMetrics(StringBuilder output, String label, Metrics metrics)
+    {
+        if (!verbose || metrics.getMetrics().isEmpty()) {
+            return;
+        }
+        output.append(label).append("\n");
+        Map<String, Metric<?>> sortedMap = new TreeMap<>(metrics.getMetrics());
+        sortedMap.forEach((name, metric) -> output.append(format("  '%s' = %s\n", name, metric)));
     }
 
     private void printDistributions(StringBuilder output, PlanNodeStats stats)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/WindowPlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/WindowPlanNodeStats.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.planprinter;
 
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import java.util.Map;
@@ -34,7 +35,8 @@ public class WindowPlanNodeStats
             DataSize planNodeOutputDataSize,
             DataSize planNodeSpilledDataSize,
             Map<String, OperatorInputStats> operatorInputStats,
-            WindowOperatorStats windowOperatorStats)
+            WindowOperatorStats windowOperatorStats,
+            Metrics metrics)
     {
         super(
                 planNodeId,
@@ -45,7 +47,9 @@ public class WindowPlanNodeStats
                 planNodeOutputPositions,
                 planNodeOutputDataSize,
                 planNodeSpilledDataSize,
-                operatorInputStats);
+                operatorInputStats,
+                metrics,
+                Metrics.EMPTY);
         this.windowOperatorStats = windowOperatorStats;
     }
 
@@ -69,6 +73,7 @@ public class WindowPlanNodeStats
                 merged.getPlanNodeOutputDataSize(),
                 merged.getPlanNodeSpilledDataSize(),
                 merged.operatorInputStats,
-                windowOperatorStats);
+                windowOperatorStats,
+                merged.getMetrics());
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/metrics/Metrics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/metrics/Metrics.java
@@ -75,6 +75,9 @@ public class Metrics
 
         public Metrics get()
         {
+            if (merged.isEmpty()) {
+                return EMPTY;
+            }
             return new Metrics(merged);
         }
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
@@ -25,7 +25,10 @@ import io.trino.spi.metrics.Distribution;
 
 import java.util.Base64;
 
+import static com.google.common.base.MoreObjects.ToStringHelper;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.lang.String.format;
 
 public class TDigestHistogram
         implements Distribution<TDigestHistogram>
@@ -64,6 +67,16 @@ public class TDigestHistogram
     public double getPercentile(double percentile)
     {
         return digest.valueAt(percentile / 100.0);
+    }
+
+    @Override
+    public String toString()
+    {
+        ToStringHelper helper = toStringHelper(this).add("count", digest.getCount());
+        for (int q = 0; q <= 100; q += 10) {
+            helper.add(format("p%d", q), getPercentile(q));
+        }
+        return helper.toString();
     }
 
     public static class TDigestToBase64Converter

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/metrics/TestMetrics.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/metrics/TestMetrics.java
@@ -61,6 +61,7 @@ public class TestMetrics
         assertThat(merged.getTotal()).isEqualTo(3L);
         assertThat(merged.getPercentile(0)).isEqualTo(5.0);
         assertThat(merged.getPercentile(100)).isEqualTo(10.0);
+        assertThat(merged.toString()).matches("TDigestHistogram\\{count=3.0, p0=5\\.0, p10=5\\.0, .*, p90=10\\.0, p100=10\\.0\\}");
     }
 
     @Test

--- a/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
+++ b/plugin/trino-memory/src/test/java/io/trino/plugin/memory/TestMemoryConnectorTest.java
@@ -164,6 +164,22 @@ public class TestMemoryConnectorTest
         assertThat(((Count<?>) metrics.getMetrics().get("finished")).getTotal()).isGreaterThan(0);
     }
 
+    @Test
+    public void testExplainCustomMetricsScanOnly()
+    {
+        assertExplainAnalyze(
+                "EXPLAIN ANALYZE VERBOSE SELECT partkey FROM part",
+                "'rows' = LongCount\\{total=2000}");
+    }
+
+    @Test
+    public void testExplainCustomMetricsScanFilter()
+    {
+        assertExplainAnalyze(
+                "EXPLAIN ANALYZE VERBOSE SELECT partkey FROM part WHERE partkey % 1000 > 0",
+                "'rows' = LongCount\\{total=2000}");
+    }
+
     private Metrics collectCustomMetrics(String sql)
     {
         DistributedQueryRunner runner = (DistributedQueryRunner) getQueryRunner();


### PR DESCRIPTION
It should allow us to get quick feedback on a specific query
(without the need to "dig" into the QueryInfo JSON).