### PR TITLE
 Allow NON-ASCII Chars on extra credentials values and session property values.

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/ClientOptions.java
@@ -279,7 +279,6 @@ public class ClientOptions
             checkArgument(!estimate.isEmpty(), "Resource estimate is empty");
             checkArgument(PRINTABLE_ASCII.matchesAllOf(resource), "Resource contains spaces or is not ASCII: %s", resource);
             checkArgument(resource.indexOf('=') < 0, "Resource must not contain '=': %s", resource);
-            checkArgument(PRINTABLE_ASCII.matchesAllOf(estimate), "Resource estimate contains spaces or is not ASCII: %s", resource);
         }
 
         @VisibleForTesting
@@ -370,7 +369,6 @@ public class ClientOptions
             checkArgument(PRINTABLE_ASCII.matchesAllOf(catalog.orElse("")), "Session property catalog contains spaces or is not ASCII: %s", name);
             checkArgument(name.indexOf('=') < 0, "Session property name must not contain '=': %s", name);
             checkArgument(PRINTABLE_ASCII.matchesAllOf(name), "Session property name contains spaces or is not ASCII: %s", name);
-            checkArgument(PRINTABLE_ASCII.matchesAllOf(value), "Session property value contains spaces or is not ASCII: %s", value);
         }
 
         public Optional<String> getCatalog()

--- a/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
+++ b/client/trino-cli/src/test/java/io/trino/cli/TestClientOptions.java
@@ -202,12 +202,6 @@ public class TestClientOptions
         new ClientSessionProperty("\u2603=value");
     }
 
-    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "\\QSession property value contains spaces or is not ASCII: ☃\\E")
-    public void testInvalidCharsetPropertyValue()
-    {
-        new ClientSessionProperty("name=\u2603");
-    }
-
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "\\QSession property catalog must not contain '=': name\\E")
     public void testEqualSignNoAllowedInPropertyCatalog()
     {

--- a/client/trino-client/src/main/java/io/trino/client/ClientSession.java
+++ b/client/trino-client/src/main/java/io/trino/client/ClientSession.java
@@ -126,7 +126,6 @@ public class ClientSession
             checkArgument(!entry.getKey().isEmpty(), "Session property name is empty");
             checkArgument(entry.getKey().indexOf('=') < 0, "Session property name must not contain '=': %s", entry.getKey());
             checkArgument(charsetEncoder.canEncode(entry.getKey()), "Session property name is not US_ASCII: %s", entry.getKey());
-            checkArgument(charsetEncoder.canEncode(entry.getValue()), "Session property value is not US_ASCII: %s", entry.getValue());
         }
 
         // verify the extra credentials are valid
@@ -134,7 +133,6 @@ public class ClientSession
             checkArgument(!entry.getKey().isEmpty(), "Credential name is empty");
             checkArgument(entry.getKey().indexOf('=') < 0, "Credential name must not contain '=': %s", entry.getKey());
             checkArgument(charsetEncoder.canEncode(entry.getKey()), "Credential name is not US_ASCII: %s", entry.getKey());
-            checkArgument(charsetEncoder.canEncode(entry.getValue()), "Credential value is not US_ASCII: %s", entry.getValue());
         }
     }
 

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/ConnectionProperties.java
@@ -580,7 +580,6 @@ final class ConnectionProperties
 
             checkArgument(PRINTABLE_ASCII.matchesAllOf(key), "%s key '%s' contains spaces or is not printable ASCII", mapName, key);
             // do not log value as it may contain sensitive information
-            checkArgument(PRINTABLE_ASCII.matchesAllOf(value), "%s value for key '%s' contains spaces or is not printable ASCII", mapName, key);
             return immutableEntry(key, value);
         }
     }


### PR DESCRIPTION
Both Session property values and Extra Credentials values are already URL encoded and decoded unconditionally server side using UTF-8.

- On Client side these values are encoded on **StatementClientV1** 
- On Server side they are decoded on **HttpRequestSessionContext**

There's no good reason to filter those values on the client side since they will be encoded before transmission and decoded on receipt.

This would solve cases where Session property values and Extra Credentials values have non-ASCII chars, but wouldn't solve the problem with X-Trino-User header as mentioned: https://github.com/trinodb/trino/issues/9291

Why can't we unconditionally encode and decode the user header as we are already doing with the other session properties and extra credentials?

