### PR TITLE
Set SMP as 1 in scylladb container

### DIFF
--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestingScyllaServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/TestingScyllaServer.java
@@ -52,6 +52,7 @@ public class TestingScyllaServer
     public TestingScyllaServer(String version)
     {
         container = new GenericContainer<>("scylladb/scylla:" + version)
+                .withCommand("--smp", "1") // Limit SMP to run in a machine having many cores https://github.com/scylladb/scylla/issues/5638
                 .withExposedPorts(PORT);
         container.start();
 


### PR DESCRIPTION
Fixes #9842

https://hub.docker.com/r/scylladb/scylla/
> --smp COUNT
> The --smp command line option restricts Scylla to COUNT number of CPUs. The option does not, however, mandate a specific placement of CPUs. See the --cpuset command line option if you need Scylla to run on specific CPUs.
