### PR TITLE
Fix flaky TestIcebergOrcConnectorTest.testAllAvailableTypes

### DIFF
--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -2566,7 +2566,7 @@ public abstract class BaseIcebergConnectorTest
                         }
                         else {
                             assertEqualsIgnoreOrder(result, computeActual("VALUES " +
-                                    "  ('a_boolean', NULL, 0e0, NULL, NULL, NULL), " +
+                                    "  ('a_boolean', NULL, 0e0, NULL, 'true', 'true'), " +
                                     "  ('an_integer', NULL, 0e0, NULL, '1', '1'), " +
                                     "  ('a_bigint', NULL, 0e0, NULL, '1', '1'), " +
                                     "  ('a_real', NULL, 0e0, NULL, '1.0', '1.0'), " +


### PR DESCRIPTION
The test missed update in 2e9c40e663a0c1634676861f6c372ae3f355afa9 (https://github.com/trinodb/trino/pull/9763)
because Iceberg stats are currently non-deterministic (https://github.com/trinodb/trino/issues/9716).

Fixes https://github.com/trinodb/trino/pull/9847#issuecomment-959447625 

cc @hashhar @alexjo2144 