### PR TITLE
Rename rule consuming preferred write partitioning

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -32,6 +32,8 @@ import io.trino.sql.planner.iterative.Rule;
 import io.trino.sql.planner.iterative.RuleStats;
 import io.trino.sql.planner.iterative.rule.AddExchangesBelowPartialAggregationOverGroupIdRuleSet;
 import io.trino.sql.planner.iterative.rule.AddIntermediateAggregations;
+import io.trino.sql.planner.iterative.rule.ApplyPreferredTableExecutePartitioning;
+import io.trino.sql.planner.iterative.rule.ApplyPreferredTableWriterPartitioning;
 import io.trino.sql.planner.iterative.rule.ApplyTableScanRedirection;
 import io.trino.sql.planner.iterative.rule.CanonicalizeExpressions;
 import io.trino.sql.planner.iterative.rule.CreatePartialTopN;
@@ -48,8 +50,6 @@ import io.trino.sql.planner.iterative.rule.DesugarLambdaExpression;
 import io.trino.sql.planner.iterative.rule.DesugarLike;
 import io.trino.sql.planner.iterative.rule.DesugarTryExpression;
 import io.trino.sql.planner.iterative.rule.DetermineJoinDistributionType;
-import io.trino.sql.planner.iterative.rule.DeterminePreferredTableExecutePartitioning;
-import io.trino.sql.planner.iterative.rule.DeterminePreferredWritePartitioning;
 import io.trino.sql.planner.iterative.rule.DetermineSemiJoinDistributionType;
 import io.trino.sql.planner.iterative.rule.DetermineTableScanNodePartitioning;
 import io.trino.sql.planner.iterative.rule.EliminateCrossJoins;
@@ -791,8 +791,8 @@ public class PlanOptimizers
                         statsCalculator,
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(
-                                new DeterminePreferredWritePartitioning(),
-                                new DeterminePreferredTableExecutePartitioning())),
+                                new ApplyPreferredTableWriterPartitioning(),
+                                new ApplyPreferredTableExecutePartitioning())),
                 // Because ReorderJoins runs only once,
                 // PredicatePushDown, columnPruningOptimizer and RemoveRedundantIdentityProjections
                 // need to run beforehand in order to produce an optimal join order

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyPreferredTableExecutePartitioning.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyPreferredTableExecutePartitioning.java
@@ -17,35 +17,30 @@ import io.trino.Session;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.planner.iterative.Rule;
-import io.trino.sql.planner.plan.TableWriterNode;
+import io.trino.sql.planner.plan.TableExecuteNode;
 
 import java.util.Optional;
 
 import static io.trino.SystemSessionProperties.getPreferredWritePartitioningMinNumberOfPartitions;
 import static io.trino.SystemSessionProperties.isUsePreferredWritePartitioning;
 import static io.trino.cost.AggregationStatsRule.getRowsCount;
-import static io.trino.sql.planner.plan.Patterns.tableWriterNode;
+import static io.trino.sql.planner.plan.Patterns.tableExecute;
 import static java.lang.Double.isNaN;
 
 /**
- * Rule verifies if preconditions for using preferred write partitioning are met:
- *  - expected number of partitions to be written (based on table stat) is greater
- *    than or equal to preferred_write_partitioning_min_number_of_partitions session property,
- *  - use_preferred_write_partitioning is set to true.
- *
- * If precondition are met the {@link TableWriterNode} is modified to mark the intention to use preferred write partitioning:
- * value of {@link TableWriterNode#getPreferredPartitioningScheme()} is set as result of {@link TableWriterNode#getPartitioningScheme()}.
+ * Replaces {@link TableExecuteNode} with {@link TableExecuteNode#getPreferredPartitioningScheme()}
+ * with a {@link TableExecuteNode} with {@link TableExecuteNode#getPartitioningScheme()} set.
  */
-public class DeterminePreferredWritePartitioning
-        implements Rule<TableWriterNode>
+public class ApplyPreferredTableExecutePartitioning
+        implements Rule<TableExecuteNode>
 {
-    public static final Pattern<TableWriterNode> WRITER_NODE_WITH_PREFERRED_PARTITIONING = tableWriterNode()
+    public static final Pattern<TableExecuteNode> TABLE_EXECUTE_NODE_WITH_PREFERRED_PARTITIONING = tableExecute()
             .matching(node -> node.getPreferredPartitioningScheme().isPresent());
 
     @Override
-    public Pattern<TableWriterNode> getPattern()
+    public Pattern<TableExecuteNode> getPattern()
     {
-        return WRITER_NODE_WITH_PREFERRED_PARTITIONING;
+        return TABLE_EXECUTE_NODE_WITH_PREFERRED_PARTITIONING;
     }
 
     @Override
@@ -55,7 +50,7 @@ public class DeterminePreferredWritePartitioning
     }
 
     @Override
-    public Result apply(TableWriterNode node, Captures captures, Context context)
+    public Result apply(TableExecuteNode node, Captures captures, Context context)
     {
         int minimumNumberOfPartitions = getPreferredWritePartitioningMinNumberOfPartitions(context.getSession());
         if (minimumNumberOfPartitions <= 1) {
@@ -74,9 +69,9 @@ public class DeterminePreferredWritePartitioning
         return enable(node);
     }
 
-    private Result enable(TableWriterNode node)
+    private static Result enable(TableExecuteNode node)
     {
-        return Result.ofPlanNode(new TableWriterNode(
+        return Result.ofPlanNode(new TableExecuteNode(
                 node.getId(),
                 node.getSource(),
                 node.getTarget(),
@@ -84,10 +79,7 @@ public class DeterminePreferredWritePartitioning
                 node.getFragmentSymbol(),
                 node.getColumns(),
                 node.getColumnNames(),
-                node.getNotNullColumnSymbols(),
                 node.getPreferredPartitioningScheme(),
-                Optional.empty(),
-                node.getStatisticsAggregation(),
-                node.getStatisticsAggregationDescriptor()));
+                Optional.empty()));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyPreferredTableWriterPartitioning.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ApplyPreferredTableWriterPartitioning.java
@@ -17,30 +17,35 @@ import io.trino.Session;
 import io.trino.matching.Captures;
 import io.trino.matching.Pattern;
 import io.trino.sql.planner.iterative.Rule;
-import io.trino.sql.planner.plan.TableExecuteNode;
+import io.trino.sql.planner.plan.TableWriterNode;
 
 import java.util.Optional;
 
 import static io.trino.SystemSessionProperties.getPreferredWritePartitioningMinNumberOfPartitions;
 import static io.trino.SystemSessionProperties.isUsePreferredWritePartitioning;
 import static io.trino.cost.AggregationStatsRule.getRowsCount;
-import static io.trino.sql.planner.plan.Patterns.tableExecute;
+import static io.trino.sql.planner.plan.Patterns.tableWriterNode;
 import static java.lang.Double.isNaN;
 
 /**
- * Replaces {@link TableExecuteNode} with {@link TableExecuteNode#getPreferredPartitioningScheme()}
- * with a {@link TableExecuteNode} with {@link TableExecuteNode#getPartitioningScheme()} set.
+ * Rule verifies if preconditions for using preferred write partitioning are met:
+ *  - expected number of partitions to be written (based on table stat) is greater
+ *    than or equal to preferred_write_partitioning_min_number_of_partitions session property,
+ *  - use_preferred_write_partitioning is set to true.
+ *
+ * If precondition are met the {@link TableWriterNode} is modified to mark the intention to use preferred write partitioning:
+ * value of {@link TableWriterNode#getPreferredPartitioningScheme()} is set as result of {@link TableWriterNode#getPartitioningScheme()}.
  */
-public class DeterminePreferredTableExecutePartitioning
-        implements Rule<TableExecuteNode>
+public class ApplyPreferredTableWriterPartitioning
+        implements Rule<TableWriterNode>
 {
-    public static final Pattern<TableExecuteNode> TABLE_EXECUTE_NODE_WITH_PREFERRED_PARTITIONING = tableExecute()
+    public static final Pattern<TableWriterNode> WRITER_NODE_WITH_PREFERRED_PARTITIONING = tableWriterNode()
             .matching(node -> node.getPreferredPartitioningScheme().isPresent());
 
     @Override
-    public Pattern<TableExecuteNode> getPattern()
+    public Pattern<TableWriterNode> getPattern()
     {
-        return TABLE_EXECUTE_NODE_WITH_PREFERRED_PARTITIONING;
+        return WRITER_NODE_WITH_PREFERRED_PARTITIONING;
     }
 
     @Override
@@ -50,7 +55,7 @@ public class DeterminePreferredTableExecutePartitioning
     }
 
     @Override
-    public Result apply(TableExecuteNode node, Captures captures, Context context)
+    public Result apply(TableWriterNode node, Captures captures, Context context)
     {
         int minimumNumberOfPartitions = getPreferredWritePartitioningMinNumberOfPartitions(context.getSession());
         if (minimumNumberOfPartitions <= 1) {
@@ -69,9 +74,9 @@ public class DeterminePreferredTableExecutePartitioning
         return enable(node);
     }
 
-    private static Result enable(TableExecuteNode node)
+    private Result enable(TableWriterNode node)
     {
-        return Result.ofPlanNode(new TableExecuteNode(
+        return Result.ofPlanNode(new TableWriterNode(
                 node.getId(),
                 node.getSource(),
                 node.getTarget(),
@@ -79,7 +84,10 @@ public class DeterminePreferredTableExecutePartitioning
                 node.getFragmentSymbol(),
                 node.getColumns(),
                 node.getColumnNames(),
+                node.getNotNullColumnSymbols(),
                 node.getPreferredPartitioningScheme(),
-                Optional.empty()));
+                Optional.empty(),
+                node.getStatisticsAggregation(),
+                node.getStatisticsAggregationDescriptor()));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestApplyPreferredTableWriterPartitioning.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestApplyPreferredTableWriterPartitioning.java
@@ -43,7 +43,7 @@ import static io.trino.sql.planner.iterative.rule.test.RuleTester.defaultRuleTes
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.Double.NaN;
 
-public class TestDeterminePreferredWritePartitioning
+public class TestApplyPreferredTableWriterPartitioning
 {
     private static final String MOCK_CATALOG = "mock_catalog";
     private static final String TEST_SCHEMA = "test_schema";
@@ -163,7 +163,7 @@ public class TestDeterminePreferredWritePartitioning
 
     private RuleAssert assertPreferredPartitioning(PartitioningScheme preferredPartitioningScheme)
     {
-        return tester.assertThat(new DeterminePreferredWritePartitioning())
+        return tester.assertThat(new ApplyPreferredTableWriterPartitioning())
                 .on(builder -> builder.tableWriter(
                         ImmutableList.of(),
                         ImmutableList.of(),


### PR DESCRIPTION
"determine preferred writer partitioning" suggested that the rule
determines what is the preferred partitioning. The rule determines
actual partitioning, taking preferred partitioning as the input.

Additionally, "Write" is replaced with "TableWriter" in rule name, to
indicate this works with `TableWriterNode`.