### PR TITLE
Avoid dynamic filter current predicate computation when not used

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -370,7 +370,10 @@ public class BackgroundHiveSplitLoader
         TupleDomain<HiveColumnHandle> effectivePredicate = compactEffectivePredicate.transformKeys(HiveColumnHandle.class::cast);
 
         List<HiveColumnHandle> partitionColumns = getPartitionKeyColumnHandles(table, typeManager);
-        BooleanSupplier partitionMatchSupplier = () -> partitionMatches(partitionColumns, dynamicFilter.getCurrentPredicate(), hivePartition);
+        BooleanSupplier partitionMatchSupplier =
+                partitionColumns.stream().noneMatch(dynamicFilter.getColumnsCovered()::contains)
+                        ? () -> true
+                        : () -> partitionMatches(partitionColumns, dynamicFilter.getCurrentPredicate(), hivePartition);
         if (!partitionMatchSupplier.getAsBoolean()) {
             // Avoid listing files and creating splits from a partition if it has been pruned due to dynamic filters
             return COMPLETED_FUTURE;


### PR DESCRIPTION
`DynamicFilter.getCurrentPredicate` is not free to call. Do not call it
when results wouldn't be used.

The edge case, where `getCurrentPredicate()` returns
`TupleDomain.none()` is not worth optimizing for. In the future, it can
be handled by the engine instead.

cc @losipiuk @alexjo2144 