### PR TITLE
Tests Trino with Spark-created Iceberg V2 tables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <!-- TODO(https://github.com/airlift/airbase/pull/281): Required by testcontainers, remove when pulled from Airbase -->
         <dep.slf4j.version>1.7.32</dep.slf4j.version>
 
-        <dep.docker.images.version>50</dep.docker.images.version>
+        <dep.docker.images.version>51</dep.docker.images.version>
 
         <!--
           America/Bahia_Banderas has:


### PR DESCRIPTION
This adds test coverage for issue spotted [here](https://trinodb.slack.com/archives/CJ6UC075E/p1635454326021000) and fixed with https://github.com/trinodb/trino/pull/9108.
Verified that newly added tests pass now and are falling with https://github.com/trinodb/trino/pull/9108 reverted