### PR TITLE
Update dynamic filter ids after un-aliasing

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/DynamicFilters.java
+++ b/core/trino-main/src/main/java/io/trino/sql/DynamicFilters.java
@@ -154,6 +154,24 @@ public final class DynamicFilters
         return Symbol.from(((Cast) dynamicFilterExpression).getExpression());
     }
 
+    public static Expression replaceDynamicFilterId(FunctionCall dynamicFilterFunctionCall, DynamicFilterId newId)
+    {
+        return new FunctionCall(
+                dynamicFilterFunctionCall.getLocation(),
+                dynamicFilterFunctionCall.getName(),
+                dynamicFilterFunctionCall.getWindow(),
+                dynamicFilterFunctionCall.getFilter(),
+                dynamicFilterFunctionCall.getOrderBy(),
+                dynamicFilterFunctionCall.isDistinct(),
+                dynamicFilterFunctionCall.getNullTreatment(),
+                dynamicFilterFunctionCall.getProcessingMode(),
+                ImmutableList.of(
+                        dynamicFilterFunctionCall.getArguments().get(0),
+                        dynamicFilterFunctionCall.getArguments().get(1),
+                        new StringLiteral(newId.toString()), // dynamic filter id is the 3rd argument
+                        dynamicFilterFunctionCall.getArguments().get(3)));
+    }
+
     public static boolean isDynamicFilter(Expression expression)
     {
         return getDescriptor(expression).isPresent();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -24,6 +24,7 @@ import io.trino.cost.PlanNodeStatsEstimate;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.spi.connector.ColumnHandle;
+import io.trino.sql.DynamicFilters;
 import io.trino.sql.planner.DeterminismEvaluator;
 import io.trino.sql.planner.NodeAndMappings;
 import io.trino.sql.planner.OrderingScheme;
@@ -63,6 +64,7 @@ import io.trino.sql.planner.plan.RemoteSourceNode;
 import io.trino.sql.planner.plan.RowNumberNode;
 import io.trino.sql.planner.plan.SampleNode;
 import io.trino.sql.planner.plan.SemiJoinNode;
+import io.trino.sql.planner.plan.SimplePlanRewriter;
 import io.trino.sql.planner.plan.SortNode;
 import io.trino.sql.planner.plan.SpatialJoinNode;
 import io.trino.sql.planner.plan.StatisticsWriterNode;
@@ -79,6 +81,7 @@ import io.trino.sql.planner.plan.UpdateNode;
 import io.trino.sql.planner.plan.ValuesNode;
 import io.trino.sql.planner.plan.WindowNode;
 import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.FunctionCall;
 import io.trino.sql.tree.NullLiteral;
 import io.trino.sql.tree.Row;
 import io.trino.sql.tree.SymbolReference;
@@ -98,9 +101,14 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static io.trino.sql.DynamicFilters.getDescriptor;
+import static io.trino.sql.DynamicFilters.replaceDynamicFilterId;
+import static io.trino.sql.ExpressionUtils.combineConjuncts;
+import static io.trino.sql.ExpressionUtils.extractConjuncts;
 import static io.trino.sql.planner.optimizations.SymbolMapper.symbolMapper;
 import static io.trino.sql.planner.optimizations.SymbolMapper.symbolReallocator;
 import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.sql.planner.plan.SimplePlanRewriter.rewriteWith;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -133,7 +141,9 @@ public class UnaliasSymbolReferences
         requireNonNull(symbolAllocator, "symbolAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        return plan.accept(new Visitor(metadata, SymbolMapper::symbolMapper), UnaliasContext.empty()).getRoot();
+        Visitor visitor = new Visitor(metadata, SymbolMapper::symbolMapper);
+        PlanAndMappings result = plan.accept(visitor, UnaliasContext.empty());
+        return updateDynamicFilterIds(result.getRoot(), visitor.getDynamicFilterIdMap());
     }
 
     /**
@@ -148,8 +158,17 @@ public class UnaliasSymbolReferences
         requireNonNull(fields, "fields is null");
         requireNonNull(symbolAllocator, "symbolAllocator is null");
 
-        PlanAndMappings result = plan.accept(new Visitor(metadata, mapping -> symbolReallocator(mapping, symbolAllocator)), UnaliasContext.empty());
-        return new NodeAndMappings(result.getRoot(), symbolMapper(result.getMappings()).map(fields));
+        Visitor visitor = new Visitor(metadata, mapping -> symbolReallocator(mapping, symbolAllocator));
+        PlanAndMappings result = plan.accept(visitor, UnaliasContext.empty());
+        return new NodeAndMappings(updateDynamicFilterIds(result.getRoot(), visitor.getDynamicFilterIdMap()), symbolMapper(result.getMappings()).map(fields));
+    }
+
+    private PlanNode updateDynamicFilterIds(PlanNode resultNode, Map<DynamicFilterId, DynamicFilterId> dynamicFilterIdMap)
+    {
+        if (!dynamicFilterIdMap.isEmpty()) {
+            resultNode = rewriteWith(new DynamicFilterVisitor(metadata, dynamicFilterIdMap), resultNode);
+        }
+        return resultNode;
     }
 
     private static class Visitor
@@ -157,6 +176,7 @@ public class UnaliasSymbolReferences
     {
         private final Metadata metadata;
         private final Function<Map<Symbol, Symbol>, SymbolMapper> mapperProvider;
+        private final Map<DynamicFilterId, DynamicFilterId> dynamicFilterIdMap = new HashMap<>();
 
         public Visitor(Metadata metadata, Function<Map<Symbol, Symbol>, SymbolMapper> mapperProvider)
         {
@@ -167,6 +187,11 @@ public class UnaliasSymbolReferences
         private SymbolMapper symbolMapper(Map<Symbol, Symbol> mappings)
         {
             return mapperProvider.apply(mappings);
+        }
+
+        public Map<DynamicFilterId, DynamicFilterId> getDynamicFilterIdMap()
+        {
+            return ImmutableMap.copyOf(dynamicFilterIdMap);
         }
 
         @Override
@@ -996,12 +1021,16 @@ public class UnaliasSymbolReferences
             Optional<Symbol> newRightHashSymbol = node.getRightHashSymbol().map(mapper::map);
 
             // rewrite dynamic filters
-            Set<Symbol> added = new HashSet<>();
+            Map<Symbol, DynamicFilterId> canonicalDynamicFilters = new HashMap<>();
             ImmutableMap.Builder<DynamicFilterId, Symbol> filtersBuilder = ImmutableMap.builder();
             for (Map.Entry<DynamicFilterId, Symbol> entry : node.getDynamicFilters().entrySet()) {
                 Symbol canonical = mapper.map(entry.getValue());
-                if (added.add(canonical)) {
+                DynamicFilterId canonicalDynamicFilterId = canonicalDynamicFilters.putIfAbsent(canonical, entry.getKey());
+                if (canonicalDynamicFilterId == null) {
                     filtersBuilder.put(entry.getKey(), canonical);
+                }
+                else {
+                    dynamicFilterIdMap.put(entry.getKey(), canonicalDynamicFilterId);
                 }
             }
             Map<DynamicFilterId, Symbol> newDynamicFilters = filtersBuilder.build();
@@ -1301,6 +1330,61 @@ public class UnaliasSymbolReferences
         public Map<Symbol, Symbol> getMappings()
         {
             return mappings;
+        }
+    }
+
+    private static class DynamicFilterVisitor
+            extends SimplePlanRewriter<Void>
+    {
+        private final Metadata metadata;
+        private final Map<DynamicFilterId, DynamicFilterId> dynamicFilterIdMap;
+
+        private DynamicFilterVisitor(Metadata metadata, Map<DynamicFilterId, DynamicFilterId> dynamicFilterIdMap)
+        {
+            this.metadata = requireNonNull(metadata, "metadata is null");
+            this.dynamicFilterIdMap = requireNonNull(dynamicFilterIdMap, "dynamicFilterIdMap is null");
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, RewriteContext<Void> context)
+        {
+            PlanNode rewrittenSource = context.rewrite(node.getSource());
+            Expression rewrittenPredicate = updateDynamicFilterIds(dynamicFilterIdMap, node.getPredicate());
+
+            if (rewrittenSource == node.getSource() && rewrittenPredicate == node.getPredicate()) {
+                return node;
+            }
+            return new FilterNode(
+                    node.getId(),
+                    rewrittenSource,
+                    rewrittenPredicate);
+        }
+
+        private Expression updateDynamicFilterIds(Map<DynamicFilterId, DynamicFilterId> dynamicFilterIdMap, Expression predicate)
+        {
+            List<Expression> conjuncts = extractConjuncts(predicate);
+            boolean updated = false;
+            ImmutableList.Builder<Expression> newConjuncts = ImmutableList.builder();
+            for (Expression conjunct : conjuncts) {
+                Optional<DynamicFilters.Descriptor> descriptor = getDescriptor(conjunct);
+                if (descriptor.isEmpty()) {
+                    // not DF
+                    newConjuncts.add(conjunct);
+                    continue;
+                }
+                DynamicFilterId mappedId = dynamicFilterIdMap.get(descriptor.get().getId());
+                Expression newConjunct = conjunct;
+                if (mappedId != null) {
+                    // DF was remapped
+                    newConjunct = replaceDynamicFilterId((FunctionCall) conjunct, mappedId);
+                    updated = true;
+                }
+                newConjuncts.add(newConjunct);
+            }
+            if (updated) {
+                return combineConjuncts(metadata, newConjuncts.build());
+            }
+            return predicate;
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.planner.optimizations;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.Session;
+import io.trino.connector.CatalogName;
+import io.trino.cost.StatsAndCosts;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.Metadata;
+import io.trino.metadata.TableHandle;
+import io.trino.plugin.tpch.TpchColumnHandle;
+import io.trino.plugin.tpch.TpchTableHandle;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.type.BigintType;
+import io.trino.sql.ExpressionUtils;
+import io.trino.sql.planner.Plan;
+import io.trino.sql.planner.PlanNodeIdAllocator;
+import io.trino.sql.planner.Symbol;
+import io.trino.sql.planner.SymbolAllocator;
+import io.trino.sql.planner.assertions.BasePlanTest;
+import io.trino.sql.planner.assertions.PlanAssert;
+import io.trino.sql.planner.assertions.PlanMatchPattern;
+import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
+import io.trino.sql.planner.plan.Assignments;
+import io.trino.sql.planner.plan.DynamicFilterId;
+import io.trino.sql.planner.plan.PlanNode;
+import io.trino.sql.tree.Expression;
+import io.trino.testing.LocalQueryRunner;
+import io.trino.testing.TestingTransactionHandle;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCALE_FACTOR;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.DynamicFilters.createDynamicFilterExpression;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.join;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.trino.sql.planner.plan.JoinNode.Type.INNER;
+import static io.trino.sql.tree.BooleanLiteral.TRUE_LITERAL;
+
+public class TestUnaliasSymbolReferences
+        extends BasePlanTest
+{
+    @Test
+    public void testDynamicFilterIdUnAliased()
+    {
+        String probeTable = "supplier";
+        String buildTable = "nation";
+        assertOptimizedPlan(
+                new UnaliasSymbolReferences(getQueryRunner().getMetadata()),
+                (p, session, metadata) -> {
+                    ColumnHandle column = new TpchColumnHandle("nationkey", BIGINT);
+                    Symbol buildColumnSymbol = p.symbol("nationkey");
+                    Symbol buildAlias1 = p.symbol("buildAlias1");
+                    Symbol buildAlias2 = p.symbol("buildAlias2");
+                    Symbol probeColumn1 = p.symbol("s_nationkey");
+                    Symbol probeColumn2 = p.symbol("s_suppkey");
+                    DynamicFilterId dynamicFilterId1 = new DynamicFilterId("df1");
+                    DynamicFilterId dynamicFilterId2 = new DynamicFilterId("df2");
+
+                    return p.join(
+                            INNER,
+                            p.filter(
+                                    TRUE_LITERAL, // additional filter to test recursive call
+                                    p.filter(
+                                            ExpressionUtils.and(
+                                                    dynamicFilterExpression(metadata, session, probeColumn1, dynamicFilterId1),
+                                                    dynamicFilterExpression(metadata, session, probeColumn2, dynamicFilterId2)),
+                                            p.tableScan(
+                                                    tableHandle(session, probeTable),
+                                                    ImmutableList.of(probeColumn1, probeColumn2),
+                                                    ImmutableMap.of(
+                                                            probeColumn1, new TpchColumnHandle("nationkey", BIGINT),
+                                                            probeColumn2, new TpchColumnHandle("suppkey", BIGINT))))),
+                            p.project(
+                                    Assignments.of(buildAlias1, buildColumnSymbol.toSymbolReference(), buildAlias2, buildColumnSymbol.toSymbolReference()),
+                                    p.tableScan(tableHandle(session, buildTable), ImmutableList.of(buildColumnSymbol), ImmutableMap.of(buildColumnSymbol, column))),
+                            ImmutableList.of(),
+                            ImmutableList.of(),
+                            ImmutableList.of(buildAlias1, buildAlias2),
+                            Optional.empty(),
+                            Optional.empty(),
+                            Optional.empty(),
+                            ImmutableMap.of(dynamicFilterId1, buildAlias1, dynamicFilterId2, buildAlias2));
+                },
+                join(
+                        INNER,
+                        ImmutableList.of(),
+                        ImmutableMap.of("probeColumn1", "column", "probeColumn2", "column"),
+                        filter(
+                                TRUE_LITERAL,
+                                filter(
+                                        TRUE_LITERAL,
+                                        tableScan(
+                                                probeTable,
+                                                ImmutableMap.of("probeColumn1", "suppkey", "probeColumn2", "nationkey")))),
+                        project(tableScan(buildTable, ImmutableMap.of("column", "nationkey")))));
+    }
+
+    private void assertOptimizedPlan(PlanOptimizer optimizer, PlanCreator planCreator, PlanMatchPattern pattern)
+    {
+        LocalQueryRunner queryRunner = getQueryRunner();
+        queryRunner.inTransaction(session -> {
+            Metadata metadata = queryRunner.getMetadata();
+            session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
+            PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+            PlanBuilder planBuilder = new PlanBuilder(idAllocator, metadata, session);
+
+            SymbolAllocator symbolAllocator = new SymbolAllocator();
+            PlanNode plan = planCreator.create(planBuilder, session, metadata);
+            PlanNode optimized = optimizer.optimize(
+                    plan,
+                    session,
+                    planBuilder.getTypes(),
+                    symbolAllocator,
+                    idAllocator,
+                    WarningCollector.NOOP);
+
+            Plan actual = new Plan(optimized, planBuilder.getTypes(), StatsAndCosts.empty());
+            PlanAssert.assertPlan(session, queryRunner.getMetadata(), queryRunner.getStatsCalculator(), actual, pattern);
+            return null;
+        });
+    }
+
+    private Expression dynamicFilterExpression(Metadata metadata, Session session, Symbol symbol, DynamicFilterId id)
+    {
+        return createDynamicFilterExpression(session, metadata, id, BigintType.BIGINT, symbol.toSymbolReference());
+    }
+
+    private TableHandle tableHandle(Session session, String tableName)
+    {
+        return new TableHandle(
+                new CatalogName(session.getCatalog().get()),
+                new TpchTableHandle(tableName, TINY_SCALE_FACTOR),
+                TestingTransactionHandle.create(),
+                Optional.empty());
+    }
+
+    interface PlanCreator
+    {
+        PlanNode create(PlanBuilder planBuilder, Session session, Metadata metadata);
+    }
+}


### PR DESCRIPTION
Since UnaliasSymbolReferences de-duplicates dynamic filters, it also has to update references to the removed dynamic filter ids