### PR TITLE
Wrap JdbcConnector's ConnectorMetadata

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnector.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcConnector.java
@@ -15,6 +15,7 @@ package io.trino.plugin.jdbc;
 
 import com.google.common.collect.ImmutableSet;
 import io.airlift.bootstrap.LifeCycleManager;
+import io.trino.plugin.base.classloader.ClassLoaderSafeConnectorMetadata;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorAccessControl;
@@ -100,7 +101,7 @@ public class JdbcConnector
     {
         JdbcMetadata metadata = transactions.get(transaction);
         checkArgument(metadata != null, "no such transaction: %s", transaction);
-        return metadata;
+        return new ClassLoaderSafeConnectorMetadata(metadata, getClass().getClassLoader());
     }
 
     @Override


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/9909. The fix is patterned after `IcebergConnector. getMetadata`

https://github.com/trinodb/trino/blob/2c3775773cdfc809bf2c22eb5e87fd9230115d73/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergConnector.java#L114
