### PR TITLE
Create TaskStatus before stats when reporting taskInfo to coordinator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTask.java
@@ -379,10 +379,11 @@ public class SqlTask
 
     private TaskInfo createTaskInfo(TaskHolder taskHolder)
     {
+        // create task status first to prevent potentially seeing incomplete stats for a done task state
+        TaskStatus taskStatus = createTaskStatus(taskHolder);
         TaskStats taskStats = getTaskStats(taskHolder);
         Set<PlanNodeId> noMoreSplits = getNoMoreSplits(taskHolder);
 
-        TaskStatus taskStatus = createTaskStatus(taskHolder);
         return new TaskInfo(
                 taskStatus,
                 lastHeartbeat.get(),


### PR DESCRIPTION
Task may have its stats populated and state updated to FINISHED during
the createTaskInfo() call, which could potentially create TaskInfo with
FINISHED state, but with some of the stats missing.
Creating TaskStatus first makes sure that stats are already present.

Fixes #5172