### PR TITLE
Improve ColumnarRow null handling

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -116,6 +116,16 @@ public class DictionaryBlock
         this.isSequentialIds = isSequentialIds;
     }
 
+    int[] getRawIds()
+    {
+        return ids;
+    }
+
+    int getRawIdsOffset()
+    {
+        return idsOffset;
+    }
+
     @Override
     public int getSliceLength(int position)
     {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HivePageSource.java
@@ -492,11 +492,14 @@ public class HivePageSource
                     fields[i] = new DictionaryBlock(nullBlocks[i], ids);
                 }
             }
-            boolean[] valueIsNull = new boolean[rowBlock.getPositionCount()];
-            for (int i = 0; i < rowBlock.getPositionCount(); i++) {
-                valueIsNull[i] = rowBlock.isNull(i);
+            boolean[] valueIsNull = null;
+            if (rowBlock.mayHaveNull()) {
+                valueIsNull = new boolean[rowBlock.getPositionCount()];
+                for (int i = 0; i < rowBlock.getPositionCount(); i++) {
+                    valueIsNull[i] = rowBlock.isNull(i);
+                }
             }
-            return RowBlock.fromFieldBlocks(valueIsNull.length, Optional.of(valueIsNull), fields);
+            return RowBlock.fromFieldBlocks(rowBlock.getPositionCount(), Optional.ofNullable(valueIsNull), fields);
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveUpdatablePageSource.java
@@ -126,8 +126,10 @@ public class HiveUpdatablePageSource
     private void deleteRowsInternal(ColumnarRow columnarRow)
     {
         int positionCount = columnarRow.getPositionCount();
-        for (int position = 0; position < positionCount; position++) {
-            checkArgument(!columnarRow.isNull(position), "In the delete rowIds, found null row at position %s", position);
+        if (columnarRow.mayHaveNull()) {
+            for (int position = 0; position < positionCount; position++) {
+                checkArgument(!columnarRow.isNull(position), "In the delete rowIds, found null row at position %s", position);
+            }
         }
 
         Block originalTransactionChannel = columnarRow.getField(ORIGINAL_TRANSACTION_CHANNEL);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderProjectionsAdapter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ReaderProjectionsAdapter.java
@@ -150,6 +150,10 @@ public class ReaderProjectionsAdapter
 
         private Block adaptNulls(ColumnarRow columnarRow, Block loadedInternalBlock)
         {
+            if (!columnarRow.mayHaveNull()) {
+                return loadedInternalBlock;
+            }
+
             // TODO: The current implementation copies over data to a new block builder when a null row element is found.
             //  We can optimize this by using a Block implementation that uses a null vector of the parent row block and
             //  the block for the field.


### PR DESCRIPTION
- Adds `ColumnarRow#mayHaveNull()` and updates various usage sites to reference it when applicable
- Avoids expensive dictionaryId remapping when converting `DictionaryBlock` values into `ColumnarRow`
- Detects when `RowBlock` instances selected no null positions as part of `copyPositions` and discards null masks in those scenarios