### PR TITLE
Fix unknown snapshot id when rollback iceberg snapshot

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RollbackToSnapshotProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RollbackToSnapshotProcedure.java
@@ -40,12 +40,12 @@ public class RollbackToSnapshotProcedure
             String.class,
             Long.class);
 
-    private final TrinoCatalog catalog;
+    private final TrinoCatalogFactory catalogFactory;
 
     @Inject
     public RollbackToSnapshotProcedure(TrinoCatalogFactory catalogFactory)
     {
-        this.catalog = requireNonNull(catalogFactory, "catalogFactory is null").create();
+        this.catalogFactory = requireNonNull(catalogFactory, "catalogFactory is null");
     }
 
     @Override
@@ -64,7 +64,7 @@ public class RollbackToSnapshotProcedure
     public void rollbackToSnapshot(ConnectorSession clientSession, String schema, String table, Long snapshotId)
     {
         SchemaTableName schemaTableName = new SchemaTableName(schema, table);
-        Table icebergTable = catalog.loadTable(clientSession, schemaTableName);
+        Table icebergTable = catalogFactory.create().loadTable(clientSession, schemaTableName);
         icebergTable.rollback().toSnapshotId(snapshotId).commit();
     }
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -1005,6 +1005,15 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate(format("CALL system.rollback_to_snapshot('tpch', 'test_rollback', %s)", afterCreateTableId));
         assertEquals((long) computeActual("SELECT COUNT(*) FROM test_rollback").getOnlyValue(), 0);
 
+        assertUpdate("INSERT INTO test_rollback (col0, col1) VALUES (789, CAST(987 AS BIGINT))", 1);
+        long afterSecondInsertId = getLatestSnapshotId("test_rollback");
+
+        // extra insert which should be dropped on rollback
+        assertUpdate("INSERT INTO test_rollback (col0, col1) VALUES (999, CAST(999 AS BIGINT))", 1);
+
+        assertUpdate(format("CALL system.rollback_to_snapshot('tpch', 'test_rollback', %s)", afterSecondInsertId));
+        assertQuery("SELECT * FROM test_rollback ORDER BY col0", "VALUES (789, CAST(987 AS BIGINT))");
+
         dropTable("test_rollback");
     }
 


### PR DESCRIPTION
## Changes

initialize `TrinoCatalog` when we call `rollbackToSnapshot` 

## Current behavior

When we do `rollbackToSnapshot`, then insert data, and try to rollback to the latest snapshot, trino show error `Cannot roll back to unknown snapshot id` . The root cause is `TrinoHiveCatalog.loadTable` do cache in `tableMetadataCache` which make `rollbackToSnapshot` always use the cached table instead of the new one.

## Example

### Before

The last rollback operation failed.

```shell
trino> create table iceberg.test.test1(col1) as select 1;

trino> select committed_at, snapshot_id, parent_id from iceberg.test."test1$snapshots" order by committed_at desc;
            committed_at             |     snapshot_id     |      parent_id      
-------------------------------------+---------------------+---------------------
 2021-11-10 00:08:34.912 Asia/Taipei | 5187825981766018374 |        NULL         

trino> CALL iceberg.system.rollback_to_snapshot('test', 'test1', 5187825981766018374);

trino> insert into iceberg.test.test1 values (2);

trino> select committed_at, snapshot_id, parent_id from iceberg.test."test1$snapshots" order by committed_at desc;
            committed_at             |     snapshot_id     |      parent_id      
-------------------------------------+---------------------+---------------------
 2021-11-10 00:10:15.257 Asia/Taipei | 1689060708599718008 | 5187825981766018374 
 2021-11-10 00:08:34.912 Asia/Taipei | 5187825981766018374 |        NULL         

trino> CALL iceberg.system.rollback_to_snapshot('test', 'test1', 1689060708599718008);
Query 20211109_161034_00010_r8uza failed: Cannot roll back to unknown snapshot id: 1689060708599718008
```

### After

The last rollback operation succeed.

```shell
trino> create table iceberg.test.test1(col1) as select 1;

trino> select committed_at, snapshot_id, parent_id from iceberg.test."test1$snapshots" order by committed_at desc;
            committed_at             |     snapshot_id     |      parent_id      
-------------------------------------+---------------------+---------------------
 2021-11-10 00:08:34.912 Asia/Taipei | 5187825981766018374 |        NULL         

trino> CALL iceberg.system.rollback_to_snapshot('test', 'test1', 5187825981766018374);

trino> insert into iceberg.test.test1 values (2);

trino> select committed_at, snapshot_id, parent_id from iceberg.test."test1$snapshots" order by committed_at desc;
            committed_at             |     snapshot_id     |      parent_id      
-------------------------------------+---------------------+---------------------
 2021-11-10 00:10:15.257 Asia/Taipei | 1689060708599718008 | 5187825981766018374 
 2021-11-10 00:08:34.912 Asia/Taipei | 5187825981766018374 |        NULL         

trino> CALL iceberg.system.rollback_to_snapshot('test', 'test1', 1689060708599718008);
```