### PR TITLE
Use default etc-dir catalog folder (`/etc/trino/catalog`/) in Hive connector docs

### DIFF
--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -164,7 +164,7 @@ functionality:
 Configuration
 -------------
 
-Create ``etc/catalog/hive.properties`` with the following contents
+Create ``/etc/trino/catalog/hive.properties`` with the following contents
 to mount the ``hive`` connector as the ``hive`` catalog,
 replacing ``example.net:9083`` with the correct host and port
 for your Hive metastore Thrift service:


### PR DESCRIPTION
While following this documentation to set up Hive connector, I got confused by the `hive.properties` location - I put it in `/etc/catalog/hive.properties`, which was not picked up by Trino. It turns out, Trino by default reads catalogs from the `/etc/trino/catalog/` folder, as per the [run-trino](https://github.com/trinodb/trino/blob/master/core/docker/bin/run-trino#L15) script.

I think using the default etc-dir location in the docs will help users set things up correctly.