### PR TITLE
Support reading empty numeric value as NULL in Elasticsearch

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/BigintDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/BigintDecoder.java
@@ -48,8 +48,13 @@ public class BigintDecoder
             BIGINT.writeLong(output, ((Number) value).longValue());
         }
         else if (value instanceof String) {
+            String stringValue = (String) value;
+            if (stringValue.isEmpty()) {
+                output.appendNull();
+                return;
+            }
             try {
-                BIGINT.writeLong(output, Long.parseLong((String) value));
+                BIGINT.writeLong(output, Long.parseLong(stringValue));
             }
             catch (NumberFormatException e) {
                 throw new TrinoException(TYPE_MISMATCH, format("Cannot parse value for field '%s' as BIGINT: %s", path, value));

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/DoubleDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/DoubleDecoder.java
@@ -51,8 +51,13 @@ public class DoubleDecoder
             decoded = ((Number) value).doubleValue();
         }
         else if (value instanceof String) {
+            String stringValue = (String) value;
+            if (stringValue.isEmpty()) {
+                output.appendNull();
+                return;
+            }
             try {
-                decoded = Double.parseDouble((String) value);
+                decoded = Double.parseDouble(stringValue);
             }
             catch (NumberFormatException e) {
                 throw new TrinoException(TYPE_MISMATCH, format("Cannot parse value for field '%s' as DOUBLE: %s", path, value));

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/IntegerDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/IntegerDecoder.java
@@ -52,8 +52,13 @@ public class IntegerDecoder
             decoded = ((Number) value).longValue();
         }
         else if (value instanceof String) {
+            String stringValue = (String) value;
+            if (stringValue.isEmpty()) {
+                output.appendNull();
+                return;
+            }
             try {
-                decoded = Long.parseLong((String) value);
+                decoded = Long.parseLong(stringValue);
             }
             catch (NumberFormatException e) {
                 throw new TrinoException(TYPE_MISMATCH, format("Cannot parse value for field '%s' as INTEGER: %s", path, value));

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/RealDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/RealDecoder.java
@@ -51,8 +51,13 @@ public class RealDecoder
             decoded = ((Number) value).floatValue();
         }
         else if (value instanceof String) {
+            String stringValue = (String) value;
+            if (stringValue.isEmpty()) {
+                output.appendNull();
+                return;
+            }
             try {
-                decoded = Float.parseFloat((String) value);
+                decoded = Float.parseFloat(stringValue);
             }
             catch (NumberFormatException e) {
                 throw new TrinoException(TYPE_MISMATCH, format("Cannot parse value for field '%s' as REAL: %s", path, value));

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/SmallintDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/SmallintDecoder.java
@@ -51,8 +51,13 @@ public class SmallintDecoder
             decoded = ((Number) value).longValue();
         }
         else if (value instanceof String) {
+            String stringValue = (String) value;
+            if (stringValue.isEmpty()) {
+                output.appendNull();
+                return;
+            }
             try {
-                decoded = Long.parseLong((String) value);
+                decoded = Long.parseLong(stringValue);
             }
             catch (NumberFormatException e) {
                 throw new TrinoException(TYPE_MISMATCH, format("Cannot parse value for field '%s' as SMALLINT: %s", path, value));

--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TinyintDecoder.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/decoders/TinyintDecoder.java
@@ -51,8 +51,13 @@ public class TinyintDecoder
             decoded = ((Number) value).longValue();
         }
         else if (value instanceof String) {
+            String stringValue = (String) value;
+            if (stringValue.isEmpty()) {
+                output.appendNull();
+                return;
+            }
             try {
-                decoded = Long.parseLong((String) value);
+                decoded = Long.parseLong(stringValue);
             }
             catch (NumberFormatException e) {
                 throw new TrinoException(TYPE_MISMATCH, format("Cannot parse value for field '%s' as TINYINT: %s", path, value));

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -956,6 +956,44 @@ public abstract class BaseElasticsearchConnectorTest
     }
 
     @Test
+    public void testEmptyNumericFields()
+            throws IOException
+    {
+        String indexName = "emptynumeric";
+
+        @Language("JSON")
+        String mapping = "" +
+                "{" +
+                "  \"properties\": { " +
+                "    \"byte_column\":         {\"type\": \"byte\"}," +
+                "    \"short_column\":        {\"type\": \"short\"}," +
+                "    \"integer_column\":      {\"type\": \"integer\"}," +
+                "    \"long_column\":         {\"type\": \"long\"}," +
+                "    \"float_column\":        {\"type\": \"float\"}," +
+                "    \"scaled_float_column\": {\"type\": \"scaled_float\", \"scaling_factor\": 100}," +
+                "    \"double_column\":       {\"type\": \"double\"}" +
+                "  }" +
+                "}";
+
+        createIndex(indexName, mapping);
+        index(indexName, ImmutableMap.<String, Object>builder()
+                .put("byte_column", "")
+                .put("short_column", "")
+                .put("integer_column", "")
+                .put("long_column", "")
+                .put("float_column", "")
+                .put("scaled_float_column", "")
+                .put("double_column", "")
+                .build());
+
+        assertQuery(
+                "SELECT byte_column, short_column, integer_column, long_column, float_column, scaled_float_column, double_column FROM emptynumeric",
+                "VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL)");
+
+        deleteIndex(indexName);
+    }
+
+    @Test
     public void testEmptyObjectFields()
             throws IOException
     {


### PR DESCRIPTION
SELECT query failed when empty values exist in Elasticsearch numeric columns. Please let me know if I should add a switch and also map `Nan` in `DoubleDecoder` & `RealDecoder`. 