### PR TITLE
Fix user mapping with oauth2 authenticator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -65,6 +65,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -210,6 +211,17 @@ public class AccessControlManager
                 ImmutableList.<SystemAccessControl>builder()
                         .addAll(currentControls)
                         .add(systemAccessControl)
+                        .build());
+    }
+
+    @VisibleForTesting
+    public void removeSystemAccessControl(SystemAccessControl systemAccessControl)
+    {
+        systemAccessControls.getAndUpdate(currentControls ->
+                ImmutableList.<SystemAccessControl>builder()
+                        .addAll(currentControls.stream()
+                                .filter(systemAccessControlItem -> systemAccessControlItem != systemAccessControl)
+                                .collect(Collectors.toList()))
                         .build());
     }
 

--- a/core/trino-main/src/main/java/io/trino/server/security/AbstractBearerAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/AbstractBearerAuthenticator.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static io.trino.server.security.AuthenticationUtils.checkAndRewriteUserHeaderToMappedUserWhenRequired;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -52,7 +53,9 @@ public abstract class AbstractBearerAuthenticator
                 throw needAuthentication(request, "Invalid credentials");
             }
 
-            String authenticatedUser = userMapping.mapUser(principal.get().getName());
+            String username = principal.get().getName();
+            String authenticatedUser = userMapping.mapUser(username);
+            checkAndRewriteUserHeaderToMappedUserWhenRequired(username, request.getHeaders(), authenticatedUser);
             return Identity.forUser(authenticatedUser)
                     .withPrincipal(principal.get())
                     .build();

--- a/core/trino-main/src/main/java/io/trino/server/security/AuthenticationUtils.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/AuthenticationUtils.java
@@ -32,6 +32,19 @@ public final class AuthenticationUtils
     public static void checkAndRewriteUserHeaderToMappedUserWhenRequired(
             String username,
             MultivaluedMap<String, String> headers,
+            String userName)
+    {
+        checkAndRewriteUserHeaderToMappedUserWhenRequired(username, headers, userName, Optional.empty());
+    }
+
+    /**
+     * @deprecated due to alternative user header name deprecation.
+     * Use {@link AuthenticationUtils#checkAndRewriteUserHeaderToMappedUserWhenRequired(String, MultivaluedMap, String)}
+     */
+    @Deprecated
+    public static void checkAndRewriteUserHeaderToMappedUserWhenRequired(
+            String username,
+            MultivaluedMap<String, String> headers,
             String authenticatedUser,
             Optional<String> alternativeUserHeaderName)
     {

--- a/core/trino-main/src/main/java/io/trino/server/security/AuthenticationUtils.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/AuthenticationUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security;
+
+import io.trino.client.ProtocolDetectionException;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import java.util.Optional;
+
+import static io.trino.client.ProtocolHeaders.detectProtocol;
+
+public final class AuthenticationUtils
+{
+    private AuthenticationUtils() {}
+
+    /**
+     * When username from authentication header matches the `x-trino-user` header, we assume that the client does
+     * not want to force the runtime username, and only wanted to communicate the authentication user.
+     */
+    public static void rewriteUserHeaderToMappedUser(
+            String username,
+            MultivaluedMap<String, String> headers,
+            String authenticatedUser,
+            Optional<String> alternativeUserHeaderName)
+    {
+        String userHeader;
+        try {
+            userHeader = detectProtocol(alternativeUserHeaderName, headers.keySet()).requestUser();
+        }
+        catch (ProtocolDetectionException ignored) {
+            // this shouldn't fail here, but ignore and it will be handled elsewhere
+            return;
+        }
+        if (username.equals(headers.getFirst(userHeader))) {
+            headers.putSingle(userHeader, authenticatedUser);
+        }
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/server/security/AuthenticationUtils.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/AuthenticationUtils.java
@@ -29,7 +29,7 @@ public final class AuthenticationUtils
      * When username from authentication header matches the `x-trino-user` header, we assume that the client does
      * not want to force the runtime username, and only wanted to communicate the authentication user.
      */
-    public static void rewriteUserHeaderToMappedUser(
+    public static void checkAndRewriteUserHeaderToMappedUserWhenRequired(
             String username,
             MultivaluedMap<String, String> headers,
             String authenticatedUser,

--- a/core/trino-main/src/main/java/io/trino/server/security/PasswordAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/PasswordAuthenticator.java
@@ -24,7 +24,7 @@ import java.security.Principal;
 import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
-import static io.trino.server.security.AuthenticationUtils.rewriteUserHeaderToMappedUser;
+import static io.trino.server.security.AuthenticationUtils.checkAndRewriteUserHeaderToMappedUserWhenRequired;
 import static io.trino.server.security.BasicAuthCredentials.extractBasicAuthCredentials;
 import static io.trino.server.security.UserMapping.createUserMapping;
 import static java.util.Objects.requireNonNull;
@@ -64,7 +64,7 @@ public class PasswordAuthenticator
                 String authenticatedUser = userMapping.mapUser(principal.toString());
 
                 // rewrite the original "unmapped" user header to the mapped user (see method Javadoc for more details)
-                rewriteUserHeaderToMappedUser(user, request.getHeaders(), authenticatedUser, alternateHeaderName);
+                checkAndRewriteUserHeaderToMappedUserWhenRequired(user, request.getHeaders(), authenticatedUser, alternateHeaderName);
                 return Identity.forUser(authenticatedUser)
                         .withPrincipal(principal)
                         .build();

--- a/core/trino-main/src/main/java/io/trino/server/security/PasswordAuthenticator.java
+++ b/core/trino-main/src/main/java/io/trino/server/security/PasswordAuthenticator.java
@@ -13,20 +13,18 @@
  */
 package io.trino.server.security;
 
-import io.trino.client.ProtocolDetectionException;
 import io.trino.server.ProtocolConfig;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.Identity;
 
 import javax.inject.Inject;
 import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.core.MultivaluedMap;
 
 import java.security.Principal;
 import java.util.Optional;
 
 import static com.google.common.base.Verify.verify;
-import static io.trino.client.ProtocolHeaders.detectProtocol;
+import static io.trino.server.security.AuthenticationUtils.rewriteUserHeaderToMappedUser;
 import static io.trino.server.security.BasicAuthCredentials.extractBasicAuthCredentials;
 import static io.trino.server.security.UserMapping.createUserMapping;
 import static java.util.Objects.requireNonNull;
@@ -66,7 +64,7 @@ public class PasswordAuthenticator
                 String authenticatedUser = userMapping.mapUser(principal.toString());
 
                 // rewrite the original "unmapped" user header to the mapped user (see method Javadoc for more details)
-                rewriteUserHeaderToMappedUser(basicAuthCredentials, request.getHeaders(), authenticatedUser);
+                rewriteUserHeaderToMappedUser(user, request.getHeaders(), authenticatedUser, alternateHeaderName);
                 return Identity.forUser(authenticatedUser)
                         .withPrincipal(principal)
                         .build();
@@ -86,25 +84,6 @@ public class PasswordAuthenticator
 
         verify(exception != null, "exception not set");
         throw exception;
-    }
-
-    /**
-     * When the user in the basic authentication header matches the x-trino-user header, we assume that the client does
-     * not want to force the runtime user name, and only wanted to communicate the authentication user.
-     */
-    private void rewriteUserHeaderToMappedUser(BasicAuthCredentials basicAuthCredentials, MultivaluedMap<String, String> headers, String authenticatedUser)
-    {
-        String userHeader;
-        try {
-            userHeader = detectProtocol(alternateHeaderName, headers.keySet()).requestUser();
-        }
-        catch (ProtocolDetectionException ignored) {
-            // this shouldn't fail here, but ignore and it will be handled elsewhere
-            return;
-        }
-        if (basicAuthCredentials.getUser().equals(headers.getFirst(userHeader))) {
-            headers.putSingle(userHeader, authenticatedUser);
-        }
     }
 
     private static AuthenticationException needAuthentication(String message)

--- a/core/trino-main/src/test/java/io/trino/server/security/TestSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestSystemAccessControl.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security;
+
+import io.trino.plugin.base.security.AllowAllSystemAccessControl;
+import io.trino.spi.security.SystemSecurityContext;
+
+import static io.trino.spi.security.AccessDeniedException.denyImpersonateUser;
+import static io.trino.spi.security.AccessDeniedException.denyReadSystemInformationAccess;
+
+public class TestSystemAccessControl
+        extends AllowAllSystemAccessControl
+{
+    public static final TestSystemAccessControl WITH_IMPERSONATION = new TestSystemAccessControl(false);
+    public static final TestSystemAccessControl NO_IMPERSONATION = new TestSystemAccessControl(true);
+
+    public static final String MANAGEMENT_USER = "management-user";
+
+    private final boolean allowImpersonation;
+
+    private TestSystemAccessControl(boolean allowImpersonation)
+    {
+        this.allowImpersonation = allowImpersonation;
+    }
+
+    @Override
+    public void checkCanImpersonateUser(SystemSecurityContext context, String userName)
+    {
+        if (!allowImpersonation) {
+            denyImpersonateUser(context.getIdentity().getUser(), userName);
+        }
+    }
+
+    @Override
+    public void checkCanReadSystemInformation(SystemSecurityContext context)
+    {
+        if (!context.getIdentity().getUser().equals(MANAGEMENT_USER)) {
+            denyReadSystemInformationAccess();
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/server/security/TestSystemAccessResource.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/TestSystemAccessResource.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.server.security;
+
+import com.google.common.collect.ImmutableSet;
+import io.trino.security.AccessControl;
+import io.trino.server.HttpRequestSessionContextFactory;
+import io.trino.spi.security.AccessDeniedException;
+import io.trino.spi.security.Identity;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.GET;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+
+import java.util.Optional;
+
+import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.server.security.ResourceSecurity.AccessType.AUTHENTICATED_USER;
+
+@javax.ws.rs.Path("/username")
+public class TestSystemAccessResource
+{
+    private final HttpRequestSessionContextFactory sessionContextFactory;
+
+    @Inject
+    public TestSystemAccessResource(AccessControl accessControl)
+    {
+        this.sessionContextFactory = new HttpRequestSessionContextFactory(createTestMetadataManager(), ImmutableSet::of, accessControl);
+    }
+
+    @ResourceSecurity(AUTHENTICATED_USER)
+    @GET
+    public javax.ws.rs.core.Response echoToken(@Context HttpServletRequest servletRequest, @Context HttpHeaders httpHeaders)
+    {
+        try {
+            Identity identity = sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, Optional.empty());
+            return javax.ws.rs.core.Response.ok()
+                    .header("user", identity.getUser())
+                    .build();
+        }
+        catch (AccessDeniedException e) {
+            throw new ForbiddenException(e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
This PR aligns bearer authenticators to password authenticator behaviour added with this commit: https://github.com/trinodb/trino/commit/bcf6c581dea7c9b1b9c678e6f867510fa51ff63d
When the user name from authentication header matches the `X-Trino-User` header, we assume that the client does
not want to force the runtime user name, and only wanted to communicate the authentication user.
So we rewrite the original "unmapped" user header to the mapped user.