### PR TITLE
Security cleanup for system roles

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SessionRepresentation.java
+++ b/core/trino-main/src/main/java/io/trino/SessionRepresentation.java
@@ -309,6 +309,22 @@ public final class SessionRepresentation
         return timeZoneKey.getId();
     }
 
+    public Identity toIdentity()
+    {
+        return toIdentity(emptyMap());
+    }
+
+    public Identity toIdentity(Map<String, String> extraCredentials)
+    {
+        return Identity.forUser(user)
+                .withGroups(groups)
+                .withPrincipal(principal.map(BasicPrincipal::new))
+                .withEnabledRoles(enabledRoles)
+                .withConnectorRoles(catalogRoles)
+                .withExtraCredentials(extraCredentials)
+                .build();
+    }
+
     public Session toSession(SessionPropertyManager sessionPropertyManager)
     {
         return toSession(sessionPropertyManager, emptyMap());
@@ -320,13 +336,7 @@ public final class SessionRepresentation
                 new QueryId(queryId),
                 transactionId,
                 clientTransactionSupport,
-                Identity.forUser(user)
-                        .withGroups(groups)
-                        .withPrincipal(principal.map(BasicPrincipal::new))
-                        .withEnabledRoles(enabledRoles)
-                        .withConnectorRoles(catalogRoles)
-                        .withExtraCredentials(extraCredentials)
-                        .build(),
+                toIdentity(extraCredentials),
                 source,
                 catalog,
                 schema,

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -358,7 +358,7 @@ public class InformationSchemaMetadata
                             .map(table -> new QualifiedObjectName(catalogName, prefix.getSchemaName().get(), table)))
                     .filter(objectName -> {
                         if (!isColumnsEnumeratingTable(informationSchemaTable) ||
-                                metadata.getMaterializedView(session, objectName).isPresent() ||
+                                metadata.isMaterializedView(session, objectName) ||
                                 metadata.isView(session, objectName)) {
                             return true;
                         }

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaMetadata.java
@@ -359,7 +359,7 @@ public class InformationSchemaMetadata
                     .filter(objectName -> {
                         if (!isColumnsEnumeratingTable(informationSchemaTable) ||
                                 metadata.getMaterializedView(session, objectName).isPresent() ||
-                                metadata.getView(session, objectName).isPresent()) {
+                                metadata.isView(session, objectName)) {
                             return true;
                         }
 

--- a/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
+++ b/core/trino-main/src/main/java/io/trino/connector/informationschema/InformationSchemaPageSource.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedTablePrefix;
+import io.trino.metadata.ViewInfo;
 import io.trino.security.AccessControl;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
@@ -25,7 +26,6 @@ import io.trino.spi.block.Block;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorPageSource;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.GrantInfo;
@@ -299,7 +299,7 @@ public class InformationSchemaPageSource
 
     private void addViewsRecords(QualifiedTablePrefix prefix)
     {
-        for (Map.Entry<SchemaTableName, ConnectorViewDefinition> entry : getViews(session, metadata, accessControl, prefix).entrySet()) {
+        for (Map.Entry<SchemaTableName, ViewInfo> entry : getViews(session, metadata, accessControl, prefix).entrySet()) {
             addRecord(
                     prefix.getCatalogName(),
                     entry.getKey().getSchemaName(),

--- a/core/trino-main/src/main/java/io/trino/connector/system/KillQueryProcedure.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/KillQueryProcedure.java
@@ -66,7 +66,7 @@ public class KillQueryProcedure
             checkState(dispatchManager.isPresent(), "No dispatch manager is set. kill_query procedure should be executed on coordinator.");
             DispatchQuery dispatchQuery = dispatchManager.get().getQuery(query);
 
-            checkCanKillQueryOwnedBy(((FullConnectorSession) session).getSession().getIdentity(), dispatchQuery.getSession().getUser(), accessControl);
+            checkCanKillQueryOwnedBy(((FullConnectorSession) session).getSession().getIdentity(), dispatchQuery.getSession().getIdentity(), accessControl);
 
             // check before killing to provide the proper error message (this is racy)
             if (dispatchQuery.isDone()) {

--- a/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
@@ -58,7 +58,6 @@ public class MaterializedViewSystemTable
             .column("storage_schema", createUnboundedVarcharType())
             .column("storage_table", createUnboundedVarcharType())
             .column("is_fresh", BOOLEAN)
-            .column("owner", createUnboundedVarcharType())
             .column("comment", createUnboundedVarcharType())
             .column("definition", createUnboundedVarcharType())
             .build();
@@ -140,7 +139,6 @@ public class MaterializedViewSystemTable
                         .map(storageTable -> storageTable.getSchemaTableName().getTableName())
                         .orElse(""),
                 freshness.isMaterializedViewFresh(),
-                definition.getOwner(),
                 definition.getComment().orElse(""),
                 definition.getOriginalSql()
         };

--- a/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/MaterializedViewSystemTable.java
@@ -18,9 +18,9 @@ import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.QualifiedTablePrefix;
+import io.trino.metadata.ViewInfo;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.CatalogSchemaTableName;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
@@ -123,7 +123,7 @@ public class MaterializedViewSystemTable
     private static Object[] createMaterializedViewRow(
             QualifiedObjectName name,
             MaterializedViewFreshness freshness,
-            ConnectorMaterializedViewDefinition definition)
+            ViewInfo definition)
     {
         return new Object[] {
                 name.getCatalogName(),

--- a/core/trino-main/src/main/java/io/trino/connector/system/TableCommentSystemTable.java
+++ b/core/trino-main/src/main/java/io/trino/connector/system/TableCommentSystemTable.java
@@ -21,13 +21,12 @@ import io.trino.Session;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.QualifiedTablePrefix;
+import io.trino.metadata.ViewInfo;
 import io.trino.security.AccessControl;
 import io.trino.spi.TrinoException;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.InMemoryRecordSet;
 import io.trino.spi.connector.InMemoryRecordSet.Builder;
 import io.trino.spi.connector.RecordCursor;
@@ -103,8 +102,8 @@ public class TableCommentSystemTable
             QualifiedTablePrefix prefix = tablePrefix(catalog, schemaFilter, tableFilter);
 
             Set<SchemaTableName> names = ImmutableSet.of();
-            Map<SchemaTableName, ConnectorViewDefinition> views = ImmutableMap.of();
-            Map<SchemaTableName, ConnectorMaterializedViewDefinition> materializedViews = ImmutableMap.of();
+            Map<SchemaTableName, ViewInfo> views = ImmutableMap.of();
+            Map<SchemaTableName, ViewInfo> materializedViews = ImmutableMap.of();
             try {
                 materializedViews = getMaterializedViews(session, metadata, accessControl, prefix);
                 views = getViews(session, metadata, accessControl, prefix);
@@ -137,16 +136,16 @@ public class TableCommentSystemTable
             Session session,
             QualifiedTablePrefix prefix,
             SchemaTableName name,
-            Map<SchemaTableName, ConnectorViewDefinition> views,
-            Map<SchemaTableName, ConnectorMaterializedViewDefinition> materializedViews)
+            Map<SchemaTableName, ViewInfo> views,
+            Map<SchemaTableName, ViewInfo> materializedViews)
     {
-        ConnectorMaterializedViewDefinition materializedViewDefinition = materializedViews.get(name);
+        ViewInfo materializedViewDefinition = materializedViews.get(name);
         if (materializedViewDefinition != null) {
             return materializedViewDefinition.getComment();
         }
-        ConnectorViewDefinition viewDefinition = views.get(name);
-        if (viewDefinition != null) {
-            return viewDefinition.getComment();
+        ViewInfo viewInfo = views.get(name);
+        if (viewInfo != null) {
+            return viewInfo.getComment();
         }
         QualifiedObjectName tableName = new QualifiedObjectName(prefix.getCatalogName(), name.getSchemaName(), name.getTableName());
         return metadata.getRedirectionAwareTableHandle(session, tableName).getTableHandle()

--- a/core/trino-main/src/main/java/io/trino/execution/DropMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropMaterializedViewTask.java
@@ -20,7 +20,6 @@ import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.sql.tree.DropMaterializedView;
 import io.trino.sql.tree.Expression;
 import io.trino.transaction.TransactionManager;
@@ -55,8 +54,7 @@ public class DropMaterializedViewTask
         Session session = stateMachine.getSession();
         QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
 
-        Optional<ConnectorMaterializedViewDefinition> materializedView = metadata.getMaterializedView(session, name);
-        if (materializedView.isEmpty()) {
+        if (!metadata.isMaterializedView(session, name)) {
             if (!statement.isExists()) {
                 if (metadata.isView(session, name)) {
                     throw semanticException(

--- a/core/trino-main/src/main/java/io/trino/execution/DropMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropMaterializedViewTask.java
@@ -21,7 +21,6 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.sql.tree.DropMaterializedView;
 import io.trino.sql.tree.Expression;
 import io.trino.transaction.TransactionManager;
@@ -59,8 +58,7 @@ public class DropMaterializedViewTask
         Optional<ConnectorMaterializedViewDefinition> materializedView = metadata.getMaterializedView(session, name);
         if (materializedView.isEmpty()) {
             if (!statement.isExists()) {
-                Optional<ConnectorViewDefinition> view = metadata.getView(session, name);
-                if (view.isPresent()) {
+                if (metadata.isView(session, name)) {
                     throw semanticException(
                             TABLE_NOT_FOUND,
                             statement,

--- a/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
@@ -21,7 +21,6 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.sql.tree.DropTable;
 import io.trino.sql.tree.Expression;
 import io.trino.transaction.TransactionManager;
@@ -67,8 +66,7 @@ public class DropTableTask
             return immediateVoidFuture();
         }
 
-        Optional<ConnectorViewDefinition> view = metadata.getView(session, tableName);
-        if (view.isPresent()) {
+        if (metadata.isView(session, tableName)) {
             if (!statement.isExists()) {
                 throw semanticException(
                         TABLE_NOT_FOUND,

--- a/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
@@ -20,7 +20,6 @@ import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.sql.tree.DropTable;
 import io.trino.sql.tree.Expression;
 import io.trino.transaction.TransactionManager;
@@ -55,8 +54,7 @@ public class DropTableTask
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
 
-        Optional<ConnectorMaterializedViewDefinition> materializedView = metadata.getMaterializedView(session, tableName);
-        if (materializedView.isPresent()) {
+        if (metadata.isMaterializedView(session, tableName)) {
             if (!statement.isExists()) {
                 throw semanticException(
                         TABLE_NOT_FOUND,

--- a/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
@@ -21,7 +21,6 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.sql.tree.DropView;
 import io.trino.sql.tree.Expression;
 import io.trino.transaction.TransactionManager;
@@ -67,8 +66,7 @@ public class DropViewTask
             return immediateVoidFuture();
         }
 
-        Optional<ConnectorViewDefinition> view = metadata.getView(session, name);
-        if (view.isEmpty()) {
+        if (!metadata.isView(session, name)) {
             if (!statement.isExists()) {
                 Optional<TableHandle> table = metadata.getTableHandle(session, name);
                 if (table.isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
@@ -20,7 +20,6 @@ import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.sql.tree.DropView;
 import io.trino.sql.tree.Expression;
 import io.trino.transaction.TransactionManager;
@@ -55,8 +54,7 @@ public class DropViewTask
         Session session = stateMachine.getSession();
         QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
 
-        Optional<ConnectorMaterializedViewDefinition> materializedView = metadata.getMaterializedView(session, name);
-        if (materializedView.isPresent()) {
+        if (metadata.isMaterializedView(session, name)) {
             if (!statement.isExists()) {
                 throw semanticException(
                         TABLE_NOT_FOUND,

--- a/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
@@ -20,7 +20,6 @@ import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameMaterializedView;
 import io.trino.transaction.TransactionManager;
@@ -57,8 +56,7 @@ public class RenameMaterializedViewTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName materializedViewName = createQualifiedObjectName(session, statement, statement.getSource());
-        Optional<ConnectorMaterializedViewDefinition> materializedView = metadata.getMaterializedView(session, materializedViewName);
-        if (materializedView.isEmpty()) {
+        if (!metadata.isMaterializedView(session, materializedViewName)) {
             if (metadata.isView(session, materializedViewName)) {
                 throw semanticException(
                         TABLE_NOT_FOUND,
@@ -84,7 +82,7 @@ public class RenameMaterializedViewTask
         if (metadata.getCatalogHandle(session, target.getCatalogName()).isEmpty()) {
             throw semanticException(CATALOG_NOT_FOUND, statement, "Target catalog '%s' does not exist", target.getCatalogName());
         }
-        if (metadata.getMaterializedView(session, target).isPresent()) {
+        if (metadata.isMaterializedView(session, target)) {
             throw semanticException(TABLE_ALREADY_EXISTS, statement, "Target materialized view '%s' already exists", target);
         }
         if (metadata.isView(session, target)) {

--- a/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
@@ -21,7 +21,6 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameMaterializedView;
 import io.trino.transaction.TransactionManager;
@@ -60,8 +59,7 @@ public class RenameMaterializedViewTask
         QualifiedObjectName materializedViewName = createQualifiedObjectName(session, statement, statement.getSource());
         Optional<ConnectorMaterializedViewDefinition> materializedView = metadata.getMaterializedView(session, materializedViewName);
         if (materializedView.isEmpty()) {
-            Optional<ConnectorViewDefinition> view = metadata.getView(session, materializedViewName);
-            if (view.isPresent()) {
+            if (metadata.isView(session, materializedViewName)) {
                 throw semanticException(
                         TABLE_NOT_FOUND,
                         statement,
@@ -89,7 +87,7 @@ public class RenameMaterializedViewTask
         if (metadata.getMaterializedView(session, target).isPresent()) {
             throw semanticException(TABLE_ALREADY_EXISTS, statement, "Target materialized view '%s' already exists", target);
         }
-        if (metadata.getView(session, target).isPresent()) {
+        if (metadata.isView(session, target)) {
             throw semanticException(TABLE_ALREADY_EXISTS, statement, "Target materialized view '%s' does not exist, but a view with that name exists.", target);
         }
         if (metadata.getTableHandle(session, target).isPresent()) {

--- a/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
@@ -20,7 +20,6 @@ import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameTable;
 import io.trino.transaction.TransactionManager;
@@ -58,8 +57,7 @@ public class RenameTableTask
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getSource());
 
-        Optional<ConnectorMaterializedViewDefinition> materializedView = metadata.getMaterializedView(session, tableName);
-        if (materializedView.isPresent()) {
+        if (metadata.isMaterializedView(session, tableName)) {
             if (!statement.isExists()) {
                 throw semanticException(
                         TABLE_NOT_FOUND,

--- a/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
@@ -21,7 +21,6 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameTable;
 import io.trino.transaction.TransactionManager;
@@ -70,8 +69,7 @@ public class RenameTableTask
             return immediateVoidFuture();
         }
 
-        Optional<ConnectorViewDefinition> view = metadata.getView(session, tableName);
-        if (view.isPresent()) {
+        if (metadata.isView(session, tableName)) {
             if (!statement.isExists()) {
                 throw semanticException(
                         TABLE_NOT_FOUND,

--- a/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
@@ -21,7 +21,6 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameView;
 import io.trino.transaction.TransactionManager;
@@ -66,8 +65,7 @@ public class RenameViewTask
                     "View '%s' does not exist, but a materialized view with that name exists. Did you mean ALTER MATERIALIZED VIEW %s RENAME ...?", viewName, viewName);
         }
 
-        Optional<ConnectorViewDefinition> viewDefinition = metadata.getView(session, viewName);
-        if (viewDefinition.isEmpty()) {
+        if (!metadata.isView(session, viewName)) {
             Optional<TableHandle> table = metadata.getTableHandle(session, viewName);
             if (table.isPresent()) {
                 throw semanticException(
@@ -83,7 +81,7 @@ public class RenameViewTask
         if (metadata.getCatalogHandle(session, target.getCatalogName()).isEmpty()) {
             throw semanticException(CATALOG_NOT_FOUND, statement, "Target catalog '%s' does not exist", target.getCatalogName());
         }
-        if (metadata.getView(session, target).isPresent()) {
+        if (metadata.isView(session, target)) {
             throw semanticException(TABLE_ALREADY_EXISTS, statement, "Target view '%s' already exists", target);
         }
         if (!viewName.getCatalogName().equals(target.getCatalogName())) {

--- a/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
@@ -20,7 +20,6 @@ import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameView;
 import io.trino.transaction.TransactionManager;
@@ -57,8 +56,7 @@ public class RenameViewTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName viewName = createQualifiedObjectName(session, statement, statement.getSource());
-        Optional<ConnectorMaterializedViewDefinition> materializedView = metadata.getMaterializedView(session, viewName);
-        if (materializedView.isPresent()) {
+        if (metadata.isMaterializedView(session, viewName)) {
             throw semanticException(
                     TABLE_NOT_FOUND,
                     statement,

--- a/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
@@ -82,7 +82,7 @@ public class SetPropertiesTask
 
     private void setTableProperties(SetProperties statement, QualifiedObjectName tableName, Metadata metadata, AccessControl accessControl, Session session, Map<String, Object> properties)
     {
-        if (metadata.getMaterializedView(session, tableName).isPresent()) {
+        if (metadata.isMaterializedView(session, tableName)) {
             throw semanticException(NOT_SUPPORTED, statement, "Cannot set properties to a materialized view in ALTER TABLE");
         }
 

--- a/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetPropertiesTask.java
@@ -86,7 +86,7 @@ public class SetPropertiesTask
             throw semanticException(NOT_SUPPORTED, statement, "Cannot set properties to a materialized view in ALTER TABLE");
         }
 
-        if (metadata.getView(session, tableName).isPresent()) {
+        if (metadata.isView(session, tableName)) {
             throw semanticException(NOT_SUPPORTED, statement, "Cannot set properties to a view in ALTER TABLE");
         }
 

--- a/core/trino-main/src/main/java/io/trino/execution/SetViewAuthorizationTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetViewAuthorizationTask.java
@@ -57,7 +57,7 @@ public class SetViewAuthorizationTask
         Session session = stateMachine.getSession();
         QualifiedObjectName viewName = createQualifiedObjectName(session, statement, statement.getSource());
         getRequiredCatalogHandle(metadata, session, statement, viewName.getCatalogName());
-        if (metadata.getView(session, viewName).isEmpty()) {
+        if (!metadata.isView(session, viewName)) {
             throw semanticException(TABLE_NOT_FOUND, statement, "View '%s' does not exist", viewName);
         }
 

--- a/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
@@ -21,7 +21,6 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.TruncateTable;
 import io.trino.transaction.TransactionManager;
@@ -62,8 +61,7 @@ public class TruncateTableTask
             throw semanticException(NOT_SUPPORTED, statement, "Cannot truncate a materialized view");
         }
 
-        Optional<ConnectorViewDefinition> view = metadata.getView(session, tableName);
-        if (view.isPresent()) {
+        if (metadata.isView(session, tableName)) {
             throw semanticException(NOT_SUPPORTED, statement, "Cannot truncate a view");
         }
 

--- a/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
@@ -20,7 +20,6 @@ import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.TruncateTable;
 import io.trino.transaction.TransactionManager;
@@ -56,8 +55,7 @@ public class TruncateTableTask
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTableName());
 
-        Optional<ConnectorMaterializedViewDefinition> materializedView = metadata.getMaterializedView(session, tableName);
-        if (materializedView.isPresent()) {
+        if (metadata.isMaterializedView(session, tableName)) {
             throw semanticException(NOT_SUPPORTED, statement, "Cannot truncate a materialized view");
         }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/DisabledSystemSecurityMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DisabledSystemSecurityMetadata.java
@@ -161,6 +161,24 @@ public class DisabledSystemSecurityMetadata
         throw notSupportedException(view.getCatalogName());
     }
 
+    @Override
+    public void schemaCreated(Session session, CatalogSchemaName schema) {}
+
+    @Override
+    public void schemaRenamed(Session session, CatalogSchemaName sourceSchema, CatalogSchemaName targetSchema) {}
+
+    @Override
+    public void schemaDropped(Session session, CatalogSchemaName schema) {}
+
+    @Override
+    public void tableCreated(Session session, CatalogSchemaTableName table) {}
+
+    @Override
+    public void tableRenamed(Session session, CatalogSchemaTableName sourceTable, CatalogSchemaTableName targetTable) {}
+
+    @Override
+    public void tableDropped(Session session, CatalogSchemaTableName table) {}
+
     private static TrinoException notSupportedException(String catalogName)
     {
         return new TrinoException(NOT_SUPPORTED, "Catalog does not support permission management: " + catalogName);

--- a/core/trino-main/src/main/java/io/trino/metadata/DisabledSystemSecurityMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/DisabledSystemSecurityMetadata.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.security.GrantInfo;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.Privilege;
@@ -28,7 +29,6 @@ import java.util.OptionalLong;
 import java.util.Set;
 
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
-import static java.lang.String.format;
 
 public class DisabledSystemSecurityMetadata
         implements SystemSecurityMetadata
@@ -100,7 +100,7 @@ public class DisabledSystemSecurityMetadata
             Set<Privilege> privileges,
             TrinoPrincipal grantee, boolean grantOption)
     {
-        throw new TrinoException(NOT_SUPPORTED, format("Catalog '%s' does not support permission management", schemaName.getCatalogName()));
+        throw notSupportedException(schemaName.getCatalogName());
     }
 
     @Override
@@ -110,24 +110,59 @@ public class DisabledSystemSecurityMetadata
             Set<Privilege> privileges,
             TrinoPrincipal grantee, boolean grantOption)
     {
-        throw new TrinoException(NOT_SUPPORTED, format("Catalog '%s' does not support permission management", schemaName.getCatalogName()));
+        throw notSupportedException(schemaName.getCatalogName());
     }
 
     @Override
     public void grantTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
     {
-        throw new TrinoException(NOT_SUPPORTED, format("Catalog '%s' does not support permission management", tableName.getCatalogName()));
+        throw notSupportedException(tableName.getCatalogName());
     }
 
     @Override
     public void revokeTablePrivileges(Session session, QualifiedObjectName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
     {
-        throw new TrinoException(NOT_SUPPORTED, format("Catalog '%s' does not support permission management", tableName.getCatalogName()));
+        throw notSupportedException(tableName.getCatalogName());
     }
 
     @Override
     public Set<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix)
     {
         return ImmutableSet.of();
+    }
+
+    @Override
+    public Optional<TrinoPrincipal> getSchemaOwner(Session session, CatalogSchemaName schema)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public void setSchemaOwner(Session session, CatalogSchemaName schema, TrinoPrincipal principal)
+    {
+        throw notSupportedException(schema.getCatalogName());
+    }
+
+    @Override
+    public void setTableOwner(Session session, CatalogSchemaTableName table, TrinoPrincipal principal)
+    {
+        throw notSupportedException(table.getCatalogName());
+    }
+
+    @Override
+    public Optional<Identity> getViewRunAsIdentity(Session session, CatalogSchemaTableName view)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public void setViewOwner(Session session, CatalogSchemaTableName view, TrinoPrincipal principal)
+    {
+        throw notSupportedException(view.getCatalogName());
+    }
+
+    private static TrinoException notSupportedException(String catalogName)
+    {
+        return new TrinoException(NOT_SUPPORTED, "Catalog does not support permission management: " + catalogName);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
@@ -101,4 +101,18 @@ public class MaterializedViewDefinition
                 .add("properties", properties)
                 .toString();
     }
+
+    @Override
+    public MaterializedViewDefinition withOwner(Identity owner)
+    {
+        return new MaterializedViewDefinition(
+                getOriginalSql(),
+                getCatalog(),
+                getSchema(),
+                getColumns(),
+                getComment(),
+                owner,
+                storageTable,
+                properties);
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
+import io.trino.spi.security.Identity;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class MaterializedViewDefinition
+        extends ViewDefinition
+{
+    private final Optional<CatalogSchemaTableName> storageTable;
+    private final Map<String, Object> properties;
+
+    public MaterializedViewDefinition(
+            String originalSql,
+            Optional<String> catalog,
+            Optional<String> schema,
+            List<ViewColumn> columns,
+            Optional<String> comment,
+            Identity owner,
+            Optional<CatalogSchemaTableName> storageTable,
+            Map<String, Object> properties)
+    {
+        super(originalSql, catalog, schema, columns, comment, Optional.of(owner));
+        this.storageTable = requireNonNull(storageTable, "storageTable is null");
+        this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
+    }
+
+    public MaterializedViewDefinition(ConnectorMaterializedViewDefinition view)
+    {
+        super(
+                view.getOriginalSql(),
+                view.getCatalog(),
+                view.getSchema(),
+                view.getColumns().stream()
+                        .map(column -> new ViewColumn(column.getName(), column.getType()))
+                        .collect(toImmutableList()),
+                view.getComment(),
+                Optional.of(Identity.ofUser(view.getOwner())));
+        this.storageTable = view.getStorageTable();
+        this.properties = ImmutableMap.copyOf(view.getProperties());
+    }
+
+    public Optional<CatalogSchemaTableName> getStorageTable()
+    {
+        return storageTable;
+    }
+
+    public Map<String, Object> getProperties()
+    {
+        return properties;
+    }
+
+    public ConnectorMaterializedViewDefinition toConnectorMaterializedViewDefinition()
+    {
+        return new ConnectorMaterializedViewDefinition(
+                getOriginalSql(),
+                storageTable,
+                getCatalog(),
+                getSchema(),
+                getColumns().stream()
+                        .map(column -> new ConnectorMaterializedViewDefinition.Column(column.getName(), column.getType()))
+                        .collect(toImmutableList()),
+                getComment(),
+                getRunAsIdentity().orElseThrow().getUser(),
+                properties);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this).omitNullValues()
+                .add("originalSql", getOriginalSql())
+                .add("catalog", getCatalog().orElse(null))
+                .add("schema", getSchema().orElse(null))
+                .add("columns", getColumns())
+                .add("comment", getComment().orElse(null))
+                .add("runAsIdentity", getRunAsIdentity())
+                .add("storageTable", storageTable.orElse(null))
+                .add("properties", properties)
+                .toString();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -406,7 +406,7 @@ public interface Metadata
     /**
      * Get the view definitions that match the specified table prefix (never null).
      */
-    Map<QualifiedObjectName, ConnectorViewDefinition> getViews(Session session, QualifiedTablePrefix prefix);
+    Map<QualifiedObjectName, ViewInfo> getViews(Session session, QualifiedTablePrefix prefix);
 
     /**
      * Is the specified table a view.
@@ -713,7 +713,7 @@ public interface Metadata
     /**
      * Get the materialized view definitions that match the specified table prefix (never null).
      */
-    Map<QualifiedObjectName, ConnectorMaterializedViewDefinition> getMaterializedViews(Session session, QualifiedTablePrefix prefix);
+    Map<QualifiedObjectName, ViewInfo> getMaterializedViews(Session session, QualifiedTablePrefix prefix);
 
     /**
      * Is the specified table a materialized view.

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -29,10 +29,8 @@ import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorCapabilities;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorOutputMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.JoinApplicationResult;
@@ -419,7 +417,7 @@ public interface Metadata
     /**
      * Returns the view definition for the specified view name.
      */
-    Optional<ConnectorViewDefinition> getView(Session session, QualifiedObjectName viewName);
+    Optional<ViewDefinition> getView(Session session, QualifiedObjectName viewName);
 
     /**
      * Gets the schema properties for the specified schema.
@@ -434,7 +432,7 @@ public interface Metadata
     /**
      * Creates the specified view with the specified view definition.
      */
-    void createView(Session session, QualifiedObjectName viewName, ConnectorViewDefinition definition, boolean replace);
+    void createView(Session session, QualifiedObjectName viewName, ViewDefinition definition, boolean replace);
 
     /**
      * Rename the specified view.
@@ -698,7 +696,7 @@ public interface Metadata
     /**
      * Creates the specified materialized view with the specified view definition.
      */
-    void createMaterializedView(Session session, QualifiedObjectName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting);
+    void createMaterializedView(Session session, QualifiedObjectName viewName, MaterializedViewDefinition definition, boolean replace, boolean ignoreExisting);
 
     /**
      * Drops the specified materialized view.
@@ -726,7 +724,7 @@ public interface Metadata
     /**
      * Returns the materialized view definition for the specified view name.
      */
-    Optional<ConnectorMaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName);
+    Optional<MaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName);
 
     /**
      * Method to get difference between the states of table at two different points in time/or as of given token-ids.

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -716,6 +716,14 @@ public interface Metadata
     Map<QualifiedObjectName, ConnectorMaterializedViewDefinition> getMaterializedViews(Session session, QualifiedTablePrefix prefix);
 
     /**
+     * Is the specified table a materialized view.
+     */
+    default boolean isMaterializedView(Session session, QualifiedObjectName viewName)
+    {
+        return getMaterializedView(session, viewName).isPresent();
+    }
+
+    /**
      * Returns the materialized view definition for the specified view name.
      */
     Optional<ConnectorMaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName);

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -409,6 +409,14 @@ public interface Metadata
     Map<QualifiedObjectName, ConnectorViewDefinition> getViews(Session session, QualifiedTablePrefix prefix);
 
     /**
+     * Is the specified table a view.
+     */
+    default boolean isView(Session session, QualifiedObjectName viewName)
+    {
+        return getView(session, viewName).isPresent();
+    }
+
+    /**
      * Returns the view definition for the specified view name.
      */
     Optional<ConnectorViewDefinition> getView(Session session, QualifiedObjectName viewName);

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
@@ -22,8 +22,6 @@ import io.trino.connector.CatalogName;
 import io.trino.security.AccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnMetadata;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableColumnsMetadata;
 import io.trino.spi.security.GrantInfo;
@@ -130,9 +128,9 @@ public final class MetadataListing
         return accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), tableNames);
     }
 
-    public static Map<SchemaTableName, ConnectorViewDefinition> getViews(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
+    public static Map<SchemaTableName, ViewInfo> getViews(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
-        Map<SchemaTableName, ConnectorViewDefinition> views = metadata.getViews(session, prefix).entrySet().stream()
+        Map<SchemaTableName, ViewInfo> views = metadata.getViews(session, prefix).entrySet().stream()
                 .collect(toImmutableMap(entry -> entry.getKey().asSchemaTableName(), Entry::getValue));
 
         Set<SchemaTableName> accessible = accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), views.keySet());
@@ -150,9 +148,9 @@ public final class MetadataListing
         return accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), tableNames);
     }
 
-    public static Map<SchemaTableName, ConnectorMaterializedViewDefinition> getMaterializedViews(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
+    public static Map<SchemaTableName, ViewInfo> getMaterializedViews(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
-        Map<SchemaTableName, ConnectorMaterializedViewDefinition> materializedViews = metadata.getMaterializedViews(session, prefix).entrySet().stream()
+        Map<SchemaTableName, ViewInfo> materializedViews = metadata.getMaterializedViews(session, prefix).entrySet().stream()
                 .collect(toImmutableMap(entry -> entry.getKey().asSchemaTableName(), Entry::getValue));
 
         Set<SchemaTableName> accessible = accessControl.filterTables(session.toSecurityContext(), prefix.getCatalogName(), materializedViews.keySet());

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -701,7 +701,7 @@ public final class MetadataManager
 
     private boolean isExistingRelation(Session session, QualifiedObjectName name)
     {
-        if (getMaterializedView(session, name).isPresent()) {
+        if (isMaterializedView(session, name)) {
             return true;
         }
         if (isView(session, name)) {
@@ -1383,9 +1383,7 @@ public final class MetadataManager
 
         Optional<QualifiedObjectName> objectName = prefix.asQualifiedObjectName();
         if (objectName.isPresent()) {
-            return getMaterializedView(session, objectName.get())
-                    .map(handle -> ImmutableList.of(objectName.get()))
-                    .orElseGet(ImmutableList::of);
+            return isMaterializedView(session, objectName.get()) ? ImmutableList.of(objectName.get()) : ImmutableList.of();
         }
 
         Optional<CatalogMetadata> catalog = getOptionalCatalogMetadata(session, prefix.getCatalogName());

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -704,7 +704,7 @@ public final class MetadataManager
         if (getMaterializedView(session, name).isPresent()) {
             return true;
         }
-        if (getView(session, name).isPresent()) {
+        if (isView(session, name)) {
             return true;
         }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1293,7 +1293,7 @@ public final class MetadataManager
     }
 
     @Override
-    public Optional<ConnectorViewDefinition> getView(Session session, QualifiedObjectName viewName)
+    public Optional<ViewDefinition> getView(Session session, QualifiedObjectName viewName)
     {
         if (viewName.getCatalogName().isEmpty() || viewName.getSchemaName().isEmpty() || viewName.getObjectName().isEmpty()) {
             // View cannot exist
@@ -1307,19 +1307,20 @@ public final class MetadataManager
             ConnectorMetadata metadata = catalogMetadata.getMetadataFor(catalogName);
 
             ConnectorSession connectorSession = session.toConnectorSession(catalogName);
-            return metadata.getView(connectorSession, viewName.asSchemaTableName());
+            return metadata.getView(connectorSession, viewName.asSchemaTableName())
+                    .map(view -> new ViewDefinition(viewName, view));
         }
         return Optional.empty();
     }
 
     @Override
-    public void createView(Session session, QualifiedObjectName viewName, ConnectorViewDefinition definition, boolean replace)
+    public void createView(Session session, QualifiedObjectName viewName, ViewDefinition definition, boolean replace)
     {
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, viewName.getCatalogName());
         CatalogName catalogName = catalogMetadata.getCatalogName();
         ConnectorMetadata metadata = catalogMetadata.getMetadata();
 
-        metadata.createView(session.toConnectorSession(catalogName), viewName.asSchemaTableName(), definition, replace);
+        metadata.createView(session.toConnectorSession(catalogName), viewName.asSchemaTableName(), definition.toConnectorViewDefinition(), replace);
     }
 
     @Override
@@ -1356,13 +1357,18 @@ public final class MetadataManager
     }
 
     @Override
-    public void createMaterializedView(Session session, QualifiedObjectName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(Session session, QualifiedObjectName viewName, MaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
     {
         CatalogMetadata catalogMetadata = getCatalogMetadataForWrite(session, viewName.getCatalogName());
         CatalogName catalogName = catalogMetadata.getCatalogName();
         ConnectorMetadata metadata = catalogMetadata.getMetadata();
 
-        metadata.createMaterializedView(session.toConnectorSession(catalogName), viewName.asSchemaTableName(), definition, replace, ignoreExisting);
+        metadata.createMaterializedView(
+                session.toConnectorSession(catalogName),
+                viewName.asSchemaTableName(),
+                definition.toConnectorMaterializedViewDefinition(),
+                replace,
+                ignoreExisting);
     }
 
     @Override
@@ -1442,7 +1448,7 @@ public final class MetadataManager
     }
 
     @Override
-    public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
+    public Optional<MaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
     {
         if (viewName.getCatalogName().isEmpty() || viewName.getSchemaName().isEmpty() || viewName.getObjectName().isEmpty()) {
             // View cannot exist
@@ -1456,7 +1462,8 @@ public final class MetadataManager
             ConnectorMetadata metadata = catalogMetadata.getMetadataFor(catalogName);
 
             ConnectorSession connectorSession = session.toConnectorSession(catalogName);
-            return metadata.getMaterializedView(connectorSession, viewName.asSchemaTableName());
+            return metadata.getMaterializedView(connectorSession, viewName.asSchemaTableName())
+                    .map(MaterializedViewDefinition::new);
         }
         return Optional.empty();
     }

--- a/core/trino-main/src/main/java/io/trino/metadata/SystemSecurityMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemSecurityMetadata.java
@@ -135,4 +135,34 @@ public interface SystemSecurityMetadata
      * Set the owner of the specified view
      */
     void setViewOwner(Session session, CatalogSchemaTableName view, TrinoPrincipal principal);
+
+    /**
+     * A schema was created
+     */
+    void schemaCreated(Session session, CatalogSchemaName schema);
+
+    /**
+     * A schema was renamed
+     */
+    void schemaRenamed(Session session, CatalogSchemaName sourceSchema, CatalogSchemaName targetSchema);
+
+    /**
+     * A schema was dropped
+     */
+    void schemaDropped(Session session, CatalogSchemaName schema);
+
+    /**
+     * A table or view was created
+     */
+    void tableCreated(Session session, CatalogSchemaTableName table);
+
+    /**
+     * A table or view was renamed
+     */
+    void tableRenamed(Session session, CatalogSchemaTableName sourceTable, CatalogSchemaTableName targetTable);
+
+    /**
+     * A table or view was dropped
+     */
+    void tableDropped(Session session, CatalogSchemaTableName table);
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/SystemSecurityMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/SystemSecurityMetadata.java
@@ -15,6 +15,7 @@ package io.trino.metadata;
 
 import io.trino.Session;
 import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.security.GrantInfo;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.Privilege;
@@ -108,4 +109,30 @@ public interface SystemSecurityMetadata
      * Gets the privileges for the specified table available to the given grantee considering the selected session role
      */
     Set<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix);
+
+    /**
+     * Set the owner of the specified schema
+     */
+    Optional<TrinoPrincipal> getSchemaOwner(Session session, CatalogSchemaName schema);
+
+    /**
+     * Set the owner of the specified schema
+     */
+    void setSchemaOwner(Session session, CatalogSchemaName schema, TrinoPrincipal principal);
+
+    /**
+     * Set the owner of the specified table
+     */
+    void setTableOwner(Session session, CatalogSchemaTableName table, TrinoPrincipal principal);
+
+    /**
+     * Get the identity to run the view as
+     * @return
+     */
+    Optional<Identity> getViewRunAsIdentity(Session session, CatalogSchemaTableName viewName);
+
+    /**
+     * Set the owner of the specified view
+     */
+    void setViewOwner(Session session, CatalogSchemaTableName view, TrinoPrincipal principal);
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/ViewColumn.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ViewColumn.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import io.trino.spi.type.TypeId;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public final class ViewColumn
+{
+    private final String name;
+    private final TypeId type;
+
+    public ViewColumn(String name, TypeId type)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public TypeId getType()
+    {
+        return type;
+    }
+
+    @Override
+    public String toString()
+    {
+        return name + " " + type;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ViewColumn that = (ViewColumn) o;
+        return Objects.equals(name, that.name) && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, type);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/ViewDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ViewDefinition.java
@@ -95,6 +95,11 @@ public class ViewDefinition
         return comment;
     }
 
+    public boolean isRunAsInvoker()
+    {
+        return runAsIdentity.isEmpty();
+    }
+
     public Optional<Identity> getRunAsIdentity()
     {
         return runAsIdentity;
@@ -125,5 +130,16 @@ public class ViewDefinition
                 .add("comment", comment.orElse(null))
                 .add("runAsIdentity", runAsIdentity.orElse(null))
                 .toString();
+    }
+
+    public ViewDefinition withOwner(Identity owner)
+    {
+        return new ViewDefinition(
+                originalSql,
+                catalog,
+                schema,
+                columns,
+                comment,
+                Optional.of(owner));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/ViewDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ViewDefinition.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorViewDefinition;
+import io.trino.spi.security.Identity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.StandardErrorCode.INVALID_VIEW;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ViewDefinition
+{
+    private final String originalSql;
+    private final Optional<String> catalog;
+    private final Optional<String> schema;
+    private final List<ViewColumn> columns;
+    private final Optional<String> comment;
+    private final Optional<Identity> runAsIdentity;
+
+    public ViewDefinition(
+            String originalSql,
+            Optional<String> catalog,
+            Optional<String> schema,
+            List<ViewColumn> columns,
+            Optional<String> comment,
+            Optional<Identity> runAsIdentity)
+    {
+        this.originalSql = requireNonNull(originalSql, "originalSql is null");
+        this.catalog = requireNonNull(catalog, "catalog is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.columns = List.copyOf(requireNonNull(columns, "columns is null"));
+        this.comment = requireNonNull(comment, "comment is null");
+        this.runAsIdentity = requireNonNull(runAsIdentity, "runAsIdentity is null");
+        checkArgument(schema.isEmpty() || catalog.isPresent(), "catalog must be present if schema is present");
+        checkArgument(!columns.isEmpty(), "columns list is empty");
+    }
+
+    public ViewDefinition(QualifiedObjectName viewName, ConnectorViewDefinition view)
+    {
+        requireNonNull(view, "view is null");
+        if (!view.isRunAsInvoker() && view.getOwner().isEmpty()) {
+            throw new TrinoException(INVALID_VIEW, format("Owner must be present in view '%s' with SECURITY DEFINER mode", viewName));
+        }
+        this.originalSql = view.getOriginalSql();
+        this.catalog = view.getCatalog();
+        this.schema = view.getSchema();
+        this.columns = view.getColumns().stream()
+                .map(column -> new ViewColumn(column.getName(), column.getType()))
+                .collect(toImmutableList());
+        this.comment = view.getComment();
+        this.runAsIdentity = view.getOwner().map(Identity::ofUser);
+    }
+
+    public String getOriginalSql()
+    {
+        return originalSql;
+    }
+
+    public Optional<String> getCatalog()
+    {
+        return catalog;
+    }
+
+    public Optional<String> getSchema()
+    {
+        return schema;
+    }
+
+    public List<ViewColumn> getColumns()
+    {
+        return columns;
+    }
+
+    public Optional<String> getComment()
+    {
+        return comment;
+    }
+
+    public Optional<Identity> getRunAsIdentity()
+    {
+        return runAsIdentity;
+    }
+
+    public ConnectorViewDefinition toConnectorViewDefinition()
+    {
+        return new ConnectorViewDefinition(
+                originalSql,
+                catalog,
+                schema,
+                columns.stream()
+                        .map(column -> new ConnectorViewDefinition.ViewColumn(column.getName(), column.getType()))
+                        .collect(toImmutableList()),
+                comment,
+                runAsIdentity.map(Identity::getUser),
+                runAsIdentity.isEmpty());
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this).omitNullValues()
+                .add("originalSql", originalSql)
+                .add("catalog", catalog.orElse(null))
+                .add("schema", schema.orElse(null))
+                .add("columns", columns)
+                .add("comment", comment.orElse(null))
+                .add("runAsIdentity", runAsIdentity.orElse(null))
+                .toString();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/metadata/ViewInfo.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/ViewInfo.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.metadata;
+
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
+import io.trino.spi.connector.ConnectorViewDefinition;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public final class ViewInfo
+{
+    private final String originalSql;
+    private final List<ViewColumn> columns;
+    private final Optional<String> comment;
+    private final Optional<CatalogSchemaTableName> storageTable;
+
+    public ViewInfo(ConnectorViewDefinition viewDefinition)
+    {
+        this.originalSql = viewDefinition.getOriginalSql();
+        this.columns = viewDefinition.getColumns().stream()
+                .map(column -> new ViewColumn(column.getName(), column.getType()))
+                .collect(toImmutableList());
+        this.comment = viewDefinition.getComment();
+        this.storageTable = Optional.empty();
+    }
+
+    public ViewInfo(ConnectorMaterializedViewDefinition viewDefinition)
+    {
+        this.originalSql = viewDefinition.getOriginalSql();
+        this.columns = viewDefinition.getColumns().stream()
+                .map(column -> new ViewColumn(column.getName(), column.getType()))
+                .collect(toImmutableList());
+        this.comment = viewDefinition.getComment();
+        this.storageTable = viewDefinition.getStorageTable();
+    }
+
+    public String getOriginalSql()
+    {
+        return originalSql;
+    }
+
+    public List<ViewColumn> getColumns()
+    {
+        return columns;
+    }
+
+    public Optional<String> getComment()
+    {
+        return comment;
+    }
+
+    public Optional<CatalogSchemaTableName> getStorageTable()
+    {
+        return storageTable;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this).omitNullValues()
+                .add("originalSql", originalSql)
+                .add("columns", columns)
+                .add("comment", comment.orElse(null))
+                .add("storageTable", storageTable.orElse(null))
+                .toString();
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/security/AccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControl.java
@@ -26,6 +26,7 @@ import io.trino.spi.security.ViewExpression;
 import io.trino.spi.type.Type;
 
 import java.security.Principal;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -81,13 +82,14 @@ public interface AccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    void checkCanViewQueryOwnedBy(Identity identity, String queryOwner);
+    void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner);
 
     /**
      * Filter the list of users to those the identity view query owned by the user.  The method
      * will not be called with the current user in the set.
+     * @return
      */
-    Set<String> filterQueriesOwnedBy(Identity identity, Set<String> queryOwners);
+    Collection<Identity> filterQueriesOwnedBy(Identity identity, Collection<Identity> queryOwners);
 
     /**
      * Checks if identity can kill a query owned by the specified user.  The method
@@ -95,7 +97,7 @@ public interface AccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    void checkCanKillQueryOwnedBy(Identity identity, String queryOwner);
+    void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner);
 
     /**
      * Filter the list of catalogs to those visible to the identity.

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlManager.java
@@ -56,6 +56,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.security.Principal;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -263,7 +264,7 @@ public class AccessControlManager
     }
 
     @Override
-    public void checkCanViewQueryOwnedBy(Identity identity, String queryOwner)
+    public void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner)
     {
         requireNonNull(identity, "identity is null");
 
@@ -271,16 +272,16 @@ public class AccessControlManager
     }
 
     @Override
-    public Set<String> filterQueriesOwnedBy(Identity identity, Set<String> queryOwners)
+    public Collection<Identity> filterQueriesOwnedBy(Identity identity, Collection<Identity> queryOwners)
     {
         for (SystemAccessControl systemAccessControl : getSystemAccessControls()) {
-            queryOwners = systemAccessControl.filterViewQueryOwnedBy(new SystemSecurityContext(identity, Optional.empty()), queryOwners);
+            queryOwners = systemAccessControl.filterViewQuery(new SystemSecurityContext(identity, Optional.empty()), queryOwners);
         }
         return queryOwners;
     }
 
     @Override
-    public void checkCanKillQueryOwnedBy(Identity identity, String queryOwner)
+    public void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner)
     {
         requireNonNull(identity, "identity is null");
         requireNonNull(queryOwner, "queryOwner is null");

--- a/core/trino-main/src/main/java/io/trino/security/AccessControlUtil.java
+++ b/core/trino-main/src/main/java/io/trino/security/AccessControlUtil.java
@@ -13,12 +13,13 @@
  */
 package io.trino.security;
 
-import com.google.common.collect.ImmutableSet;
 import io.trino.SessionRepresentation;
 import io.trino.server.BasicQueryInfo;
 import io.trino.spi.security.Identity;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -28,9 +29,9 @@ public final class AccessControlUtil
 {
     private AccessControlUtil() {}
 
-    public static void checkCanViewQueryOwnedBy(Identity identity, String queryOwner, AccessControl accessControl)
+    public static void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner, AccessControl accessControl)
     {
-        if (identity.getUser().equals(queryOwner)) {
+        if (identity.getUser().equals(queryOwner.getUser())) {
             return;
         }
         accessControl.checkCanViewQueryOwnedBy(identity, queryOwner);
@@ -38,28 +39,75 @@ public final class AccessControlUtil
 
     public static List<BasicQueryInfo> filterQueries(Identity identity, List<BasicQueryInfo> queries, AccessControl accessControl)
     {
-        String currentUser = identity.getUser();
-        Set<String> owners = queries.stream()
+        Collection<Identity> owners = queries.stream()
                 .map(BasicQueryInfo::getSession)
-                .map(SessionRepresentation::getUser)
-                .filter(owner -> !owner.equals(currentUser))
-                .collect(toImmutableSet());
+                .map(SessionRepresentation::toIdentity)
+                .filter(owner -> !owner.getUser().equals(identity.getUser()))
+                .map(FullIdentityEquality::new)
+                .distinct()
+                .map(FullIdentityEquality::getIdentity)
+                .collect(toImmutableList());
         owners = accessControl.filterQueriesOwnedBy(identity, owners);
 
-        Set<String> allowedOwners = ImmutableSet.<String>builder()
-                .add(currentUser)
-                .addAll(owners)
-                .build();
+        Set<FullIdentityEquality> allowedOwners = owners.stream()
+                .map(FullIdentityEquality::new)
+                .collect(toImmutableSet());
         return queries.stream()
-                .filter(queryInfo -> allowedOwners.contains(queryInfo.getSession().getUser()))
+                .filter(queryInfo -> {
+                    Identity queryIdentity = queryInfo.getSession().toIdentity();
+                    return queryIdentity.getUser().equals(identity.getUser()) || allowedOwners.contains(new FullIdentityEquality(queryIdentity));
+                })
                 .collect(toImmutableList());
     }
 
-    public static void checkCanKillQueryOwnedBy(Identity identity, String queryOwner, AccessControl accessControl)
+    public static void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner, AccessControl accessControl)
     {
-        if (identity.getUser().equals(queryOwner)) {
+        if (identity.getUser().equals(queryOwner.getUser())) {
             return;
         }
         accessControl.checkCanKillQueryOwnedBy(identity, queryOwner);
+    }
+
+    private static class FullIdentityEquality
+    {
+        private final Identity identity;
+
+        public FullIdentityEquality(Identity identity)
+        {
+            this.identity = identity;
+        }
+
+        public Identity getIdentity()
+        {
+            return identity;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            FullIdentityEquality that = (FullIdentityEquality) o;
+            return Objects.equals(identity.getUser(), that.identity.getUser()) &&
+                    Objects.equals(identity.getGroups(), that.identity.getGroups()) &&
+                    Objects.equals(identity.getPrincipal(), that.identity.getPrincipal()) &&
+                    Objects.equals(identity.getEnabledRoles(), that.identity.getEnabledRoles()) &&
+                    Objects.equals(identity.getCatalogRoles(), that.identity.getCatalogRoles());
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(
+                    identity.getUser(),
+                    identity.getGroups(),
+                    identity.getPrincipal(),
+                    identity.getEnabledRoles(),
+                    identity.getCatalogRoles());
+        }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/security/AllowAllAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/AllowAllAccessControl.java
@@ -22,6 +22,7 @@ import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 
 import java.security.Principal;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -55,18 +56,18 @@ public class AllowAllAccessControl
     }
 
     @Override
-    public void checkCanViewQueryOwnedBy(Identity identity, String queryOwner)
+    public void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner)
     {
     }
 
     @Override
-    public Set<String> filterQueriesOwnedBy(Identity identity, Set<String> queryOwners)
+    public Collection<Identity> filterQueriesOwnedBy(Identity identity, Collection<Identity> queryOwners)
     {
         return queryOwners;
     }
 
     @Override
-    public void checkCanKillQueryOwnedBy(Identity identity, String queryOwner)
+    public void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner)
     {
     }
 

--- a/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/DenyAllAccessControl.java
@@ -13,6 +13,7 @@
  */
 package io.trino.security;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.spi.connector.CatalogSchemaName;
@@ -23,6 +24,7 @@ import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 
 import java.security.Principal;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -121,19 +123,19 @@ public class DenyAllAccessControl
     }
 
     @Override
-    public void checkCanViewQueryOwnedBy(Identity identity, String queryOwner)
+    public void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner)
     {
         denyViewQuery();
     }
 
     @Override
-    public Set<String> filterQueriesOwnedBy(Identity identity, Set<String> queryOwners)
+    public Collection<Identity> filterQueriesOwnedBy(Identity identity, Collection<Identity> queryOwners)
     {
-        return ImmutableSet.of();
+        return ImmutableList.of();
     }
 
     @Override
-    public void checkCanKillQueryOwnedBy(Identity identity, String queryOwner)
+    public void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner)
     {
         denyKillQuery();
     }

--- a/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ForwardingAccessControl.java
@@ -24,6 +24,7 @@ import io.trino.spi.security.ViewExpression;
 import io.trino.spi.type.Type;
 
 import java.security.Principal;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -82,19 +83,19 @@ public abstract class ForwardingAccessControl
     }
 
     @Override
-    public void checkCanViewQueryOwnedBy(Identity identity, String queryOwner)
+    public void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner)
     {
         delegate().checkCanViewQueryOwnedBy(identity, queryOwner);
     }
 
     @Override
-    public Set<String> filterQueriesOwnedBy(Identity identity, Set<String> queryOwners)
+    public Collection<Identity> filterQueriesOwnedBy(Identity identity, Collection<Identity> queryOwners)
     {
         return delegate().filterQueriesOwnedBy(identity, queryOwners);
     }
 
     @Override
-    public void checkCanKillQueryOwnedBy(Identity identity, String queryOwner)
+    public void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner)
     {
         delegate().checkCanKillQueryOwnedBy(identity, queryOwner);
     }

--- a/core/trino-main/src/main/java/io/trino/server/QueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/QueryResource.java
@@ -100,7 +100,7 @@ public class QueryResource
             return Response.status(Status.GONE).build();
         }
         try {
-            checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.get().getSession().getUser(), accessControl);
+            checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.get().getSession().toIdentity(), accessControl);
             return Response.ok(queryInfo.get()).build();
         }
         catch (AccessDeniedException e) {
@@ -117,7 +117,7 @@ public class QueryResource
 
         try {
             BasicQueryInfo queryInfo = dispatchManager.getQueryInfo(queryId);
-            checkCanKillQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.getSession().getUser(), accessControl);
+            checkCanKillQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.getSession().toIdentity(), accessControl);
             dispatchManager.cancelQuery(queryId);
         }
         catch (AccessDeniedException e) {
@@ -150,7 +150,7 @@ public class QueryResource
         try {
             BasicQueryInfo queryInfo = dispatchManager.getQueryInfo(queryId);
 
-            checkCanKillQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.getSession().getUser(), accessControl);
+            checkCanKillQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.getSession().toIdentity(), accessControl);
 
             // check before killing to provide the proper error code (this is racy)
             if (queryInfo.getState().isDone()) {

--- a/core/trino-main/src/main/java/io/trino/server/QueryStateInfoResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/QueryStateInfoResource.java
@@ -116,7 +116,7 @@ public class QueryStateInfoResource
     {
         try {
             BasicQueryInfo queryInfo = dispatchManager.getQueryInfo(new QueryId(queryId));
-            checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.getSession().getUser(), accessControl);
+            checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.getSession().toIdentity(), accessControl);
             return getQueryStateInfo(queryInfo);
         }
         catch (AccessDeniedException e) {

--- a/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
@@ -97,7 +97,7 @@ public class UiQueryResource
         Optional<QueryInfo> queryInfo = dispatchManager.getFullQueryInfo(queryId);
         if (queryInfo.isPresent()) {
             try {
-                checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.get().getSession().getUser(), accessControl);
+                checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.get().getSession().toIdentity(), accessControl);
                 return Response.ok(queryInfo.get()).build();
             }
             catch (AccessDeniedException e) {
@@ -130,7 +130,7 @@ public class UiQueryResource
         try {
             BasicQueryInfo queryInfo = dispatchManager.getQueryInfo(queryId);
 
-            checkCanKillQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.getSession().getUser(), accessControl);
+            checkCanKillQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.getSession().toIdentity(), accessControl);
 
             // check before killing to provide the proper error code (this is racy)
             if (queryInfo.getState().isDone()) {

--- a/core/trino-main/src/main/java/io/trino/server/ui/WorkerResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/WorkerResource.java
@@ -113,7 +113,7 @@ public class WorkerResource
         Optional<QueryInfo> queryInfo = dispatchManager.getFullQueryInfo(queryId);
         if (queryInfo.isPresent()) {
             try {
-                checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.get().getSession().getUser(), accessControl);
+                checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.get().getSession().toIdentity(), accessControl);
                 return proxyJsonResponse(nodeId, "v1/task/" + task);
             }
             catch (AccessDeniedException e) {

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -416,7 +416,7 @@ class StatementAnalyzer
                 throw semanticException(NOT_SUPPORTED, insert, "Inserting into materialized views is not supported");
             }
 
-            if (metadata.getView(session, targetTable).isPresent()) {
+            if (metadata.isView(session, targetTable)) {
                 throw semanticException(NOT_SUPPORTED, insert, "Inserting into views is not supported");
             }
 
@@ -668,7 +668,7 @@ class StatementAnalyzer
         {
             Table table = node.getTable();
             QualifiedObjectName originalName = createQualifiedObjectName(session, table, table.getName());
-            if (metadata.getView(session, originalName).isPresent()) {
+            if (metadata.isView(session, originalName)) {
                 throw semanticException(NOT_SUPPORTED, node, "Deleting from views is not supported");
             }
 
@@ -716,7 +716,7 @@ class StatementAnalyzer
             analysis.setUpdateTarget(tableName, Optional.empty(), Optional.empty());
 
             // verify the target table exists and it's not a view
-            if (metadata.getView(session, tableName).isPresent()) {
+            if (metadata.isView(session, tableName)) {
                 throw semanticException(NOT_SUPPORTED, node, "Analyzing views is not supported");
             }
 
@@ -1013,7 +1013,7 @@ class StatementAnalyzer
                 throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for materialized views");
             }
 
-            if (metadata.getView(session, originalName).isPresent()) {
+            if (metadata.isView(session, originalName)) {
                 throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for views");
             }
 
@@ -2374,7 +2374,7 @@ class StatementAnalyzer
         {
             Table table = update.getTable();
             QualifiedObjectName originalName = createQualifiedObjectName(session, table, table.getName());
-            if (metadata.getView(session, originalName).isPresent()) {
+            if (metadata.isView(session, originalName)) {
                 throw semanticException(NOT_SUPPORTED, update, "Updating through views is not supported");
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -412,7 +412,7 @@ class StatementAnalyzer
         {
             QualifiedObjectName targetTable = createQualifiedObjectName(session, insert, insert.getTarget());
 
-            if (metadata.getMaterializedView(session, targetTable).isPresent()) {
+            if (metadata.isMaterializedView(session, targetTable)) {
                 throw semanticException(NOT_SUPPORTED, insert, "Inserting into materialized views is not supported");
             }
 
@@ -1009,7 +1009,7 @@ class StatementAnalyzer
             QualifiedObjectName originalName = createQualifiedObjectName(session, table, table.getName());
             String procedureName = node.getProcedureName().getCanonicalValue();
 
-            if (metadata.getMaterializedView(session, originalName).isPresent()) {
+            if (metadata.isMaterializedView(session, originalName)) {
                 throw semanticException(NOT_SUPPORTED, node, "ALTER TABLE EXECUTE is not supported for materialized views");
             }
 

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -409,7 +409,7 @@ final class ShowQueriesRewrite
                 throw semanticException(SCHEMA_NOT_FOUND, showColumns, "Schema '%s' does not exist", tableName.getSchemaName());
             }
 
-            boolean isMaterializedView = metadata.getMaterializedView(session, tableName).isPresent();
+            boolean isMaterializedView = metadata.isMaterializedView(session, tableName);
             boolean isView = false;
             QualifiedObjectName targetTableName = tableName;
             Optional<TableHandle> tableHandle = Optional.empty();
@@ -545,7 +545,7 @@ final class ShowQueriesRewrite
             if (node.getType() == VIEW) {
                 QualifiedObjectName objectName = createQualifiedObjectName(session, node, node.getName());
 
-                if (metadata.getMaterializedView(session, objectName).isPresent()) {
+                if (metadata.isMaterializedView(session, objectName)) {
                     throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a materialized view, not a view", objectName);
                 }
 
@@ -580,7 +580,7 @@ final class ShowQueriesRewrite
             if (node.getType() == TABLE) {
                 QualifiedObjectName objectName = createQualifiedObjectName(session, node, node.getName());
 
-                if (metadata.getMaterializedView(session, objectName).isPresent()) {
+                if (metadata.isMaterializedView(session, objectName)) {
                     throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a materialized view, not a table", objectName);
                 }
 

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -566,7 +566,7 @@ final class ShowQueriesRewrite
 
                 accessControl.checkCanShowCreateTable(session.toSecurityContext(), new QualifiedObjectName(catalogName.getValue(), schemaName.getValue(), tableName.getValue()));
 
-                CreateView.Security security = viewDefinition.get().getRunAsIdentity().isEmpty() ? INVOKER : DEFINER;
+                CreateView.Security security = viewDefinition.get().isRunAsInvoker() ? INVOKER : DEFINER;
                 String sql = formatSql(new CreateView(
                         QualifiedName.of(ImmutableList.of(catalogName, schemaName, tableName)),
                         query,

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowQueriesRewrite.java
@@ -244,7 +244,7 @@ final class ShowQueriesRewrite
             if (tableName.isPresent()) {
                 QualifiedObjectName qualifiedTableName = createQualifiedObjectName(session, showGrants, tableName.get());
 
-                if (metadata.getView(session, qualifiedTableName).isEmpty() &&
+                if (!metadata.isView(session, qualifiedTableName) &&
                         metadata.getTableHandle(session, qualifiedTableName).isEmpty()) {
                     throw semanticException(TABLE_NOT_FOUND, showGrants, "Table '%s' does not exist", tableName);
                 }
@@ -415,7 +415,7 @@ final class ShowQueriesRewrite
             Optional<TableHandle> tableHandle = Optional.empty();
             // Check for view if materialized view is not present
             if (!isMaterializedView) {
-                isView = metadata.getView(session, tableName).isPresent();
+                isView = metadata.isView(session, tableName);
                 // Check for table if view is not present
                 if (!isView) {
                     RedirectionAwareTableHandle redirection = metadata.getRedirectionAwareTableHandle(session, tableName);
@@ -512,7 +512,7 @@ final class ShowQueriesRewrite
                 Optional<ConnectorMaterializedViewDefinition> viewDefinition = metadata.getMaterializedView(session, objectName);
 
                 if (viewDefinition.isEmpty()) {
-                    if (metadata.getView(session, objectName).isPresent()) {
+                    if (metadata.isView(session, objectName)) {
                         throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a view, not a materialized view", objectName);
                     }
 
@@ -584,7 +584,7 @@ final class ShowQueriesRewrite
                     throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a materialized view, not a table", objectName);
                 }
 
-                if (metadata.getView(session, objectName).isPresent()) {
+                if (metadata.isView(session, objectName)) {
                     throw semanticException(NOT_SUPPORTED, node, "Relation '%s' is a view, not a table", objectName);
                 }
 

--- a/core/trino-main/src/main/java/io/trino/testing/AllowAllAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/AllowAllAccessControlManager.java
@@ -24,6 +24,7 @@ import io.trino.spi.security.Privilege;
 import io.trino.spi.security.TrinoPrincipal;
 
 import java.security.Principal;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -47,16 +48,16 @@ public class AllowAllAccessControlManager
     public void checkCanExecuteQuery(Identity identity) {}
 
     @Override
-    public void checkCanViewQueryOwnedBy(Identity identity, String queryOwner) {}
+    public void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner) {}
 
     @Override
-    public Set<String> filterQueriesOwnedBy(Identity identity, Set<String> queryOwners)
+    public Collection<Identity> filterQueriesOwnedBy(Identity identity, Collection<Identity> queryOwners)
     {
         return queryOwners;
     }
 
     @Override
-    public void checkCanKillQueryOwnedBy(Identity identity, String queryOwner) {}
+    public void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner) {}
 
     @Override
     public Set<String> filterCatalogs(Identity identity, Set<String> catalogs)

--- a/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingAccessControlManager.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 
 import java.security.Principal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -254,7 +255,7 @@ public class TestingAccessControlManager
     }
 
     @Override
-    public void checkCanViewQueryOwnedBy(Identity identity, String queryOwner)
+    public void checkCanViewQueryOwnedBy(Identity identity, Identity queryOwner)
     {
         if (shouldDenyPrivilege(identity.getUser(), "query", VIEW_QUERY)) {
             denyViewQuery();
@@ -265,7 +266,7 @@ public class TestingAccessControlManager
     }
 
     @Override
-    public Set<String> filterQueriesOwnedBy(Identity identity, Set<String> owners)
+    public Collection<Identity> filterQueriesOwnedBy(Identity identity, Collection<Identity> owners)
     {
         if (shouldDenyPrivilege(identity.getUser(), "query", VIEW_QUERY)) {
             return ImmutableSet.of();
@@ -277,7 +278,7 @@ public class TestingAccessControlManager
     }
 
     @Override
-    public void checkCanKillQueryOwnedBy(Identity identity, String queryOwner)
+    public void checkCanKillQueryOwnedBy(Identity identity, Identity queryOwner)
     {
         if (shouldDenyPrivilege(identity.getUser(), "query", KILL_QUERY)) {
             denyKillQuery();

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -24,6 +24,7 @@ import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorInsertTableHandle;
 import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorMetadata;
@@ -119,7 +120,7 @@ public class MockConnector
     private final BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties;
     private final Supplier<Iterable<EventListener>> eventListeners;
     private final MockConnectorFactory.ListRoleGrants roleGrants;
-    private final Optional<MockConnectorAccessControl> accessControl;
+    private final ConnectorAccessControl accessControl;
     private final Function<SchemaTableName, List<List<?>>> data;
     private final Set<Procedure> procedures;
 
@@ -145,7 +146,7 @@ public class MockConnector
             BiFunction<ConnectorSession, ConnectorTableHandle, ConnectorTableProperties> getTableProperties,
             Supplier<Iterable<EventListener>> eventListeners,
             MockConnectorFactory.ListRoleGrants roleGrants,
-            Optional<MockConnectorAccessControl> accessControl,
+            ConnectorAccessControl accessControl,
             Function<SchemaTableName, List<List<?>>> data,
             Set<Procedure> procedures)
     {
@@ -219,9 +220,9 @@ public class MockConnector
     }
 
     @Override
-    public MockConnectorAccessControl getAccessControl()
+    public ConnectorAccessControl getAccessControl()
     {
-        return accessControl.orElseThrow(() -> new UnsupportedOperationException("Access control for mock connector is not set"));
+        return accessControl;
     }
 
     @Override
@@ -596,25 +597,30 @@ public class MockConnector
         @Override
         public void grantSchemaPrivileges(ConnectorSession session, String schemaName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
         {
-            getAccessControl().grantSchemaPrivileges(schemaName, privileges, grantee, grantOption);
+            getMockAccessControl().grantSchemaPrivileges(schemaName, privileges, grantee, grantOption);
         }
 
         @Override
         public void revokeSchemaPrivileges(ConnectorSession session, String schemaName, Set<Privilege> privileges, TrinoPrincipal revokee, boolean grantOption)
         {
-            getAccessControl().revokeSchemaPrivileges(schemaName, privileges, revokee, grantOption);
+            getMockAccessControl().revokeSchemaPrivileges(schemaName, privileges, revokee, grantOption);
         }
 
         @Override
         public void grantTablePrivileges(ConnectorSession session, SchemaTableName tableName, Set<Privilege> privileges, TrinoPrincipal grantee, boolean grantOption)
         {
-            getAccessControl().grantTablePrivileges(tableName, privileges, grantee, grantOption);
+            getMockAccessControl().grantTablePrivileges(tableName, privileges, grantee, grantOption);
         }
 
         @Override
         public void revokeTablePrivileges(ConnectorSession session, SchemaTableName tableName, Set<Privilege> privileges, TrinoPrincipal revokee, boolean grantOption)
         {
-            getAccessControl().revokeTablePrivileges(tableName, privileges, revokee, grantOption);
+            getMockAccessControl().revokeTablePrivileges(tableName, privileges, revokee, grantOption);
+        }
+
+        private MockConnectorAccessControl getMockAccessControl()
+        {
+            return (MockConnectorAccessControl) accessControl;
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -16,12 +16,14 @@ package io.trino.connector;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.trino.plugin.base.security.AllowAllAccessControl;
 import io.trino.spi.connector.AggregateFunction;
 import io.trino.spi.connector.AggregationApplicationResult;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.Connector;
+import io.trino.spi.connector.ConnectorAccessControl;
 import io.trino.spi.connector.ConnectorContext;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.spi.connector.ConnectorHandleResolver;
@@ -94,7 +96,7 @@ public class MockConnectorFactory
 
     // access control
     private final ListRoleGrants roleGrants;
-    private final Optional<MockConnectorAccessControl> accessControl;
+    private final ConnectorAccessControl accessControl;
 
     private MockConnectorFactory(
             Function<ConnectorSession, List<String>> listSchemaNames,
@@ -120,7 +122,7 @@ public class MockConnectorFactory
             Function<SchemaTableName, List<List<?>>> data,
             Set<Procedure> procedures,
             ListRoleGrants roleGrants,
-            Optional<MockConnectorAccessControl> accessControl)
+            ConnectorAccessControl accessControl)
     {
         this.listSchemaNames = requireNonNull(listSchemaNames, "listSchemaNames is null");
         this.listTables = requireNonNull(listTables, "listTables is null");
@@ -471,9 +473,9 @@ public class MockConnectorFactory
 
         public MockConnectorFactory build()
         {
-            Optional<MockConnectorAccessControl> accessControl = Optional.empty();
+            ConnectorAccessControl accessControl = new AllowAllAccessControl();
             if (provideAccessControl) {
-                accessControl = Optional.of(new MockConnectorAccessControl(schemaGrants, tableGrants, rowFilter, columnMask));
+                accessControl = new MockConnectorAccessControl(schemaGrants, tableGrants, rowFilter, columnMask);
             }
             return new MockConnectorFactory(
                     listSchemaNames,

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
@@ -23,6 +23,7 @@ import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.AbstractMockMetadata;
 import io.trino.metadata.Catalog;
 import io.trino.metadata.CatalogManager;
+import io.trino.metadata.MaterializedViewDefinition;
 import io.trino.metadata.MaterializedViewPropertyManager;
 import io.trino.metadata.MetadataManager;
 import io.trino.metadata.QualifiedObjectName;
@@ -30,15 +31,14 @@ import io.trino.metadata.TableHandle;
 import io.trino.metadata.TableMetadata;
 import io.trino.metadata.TablePropertyManager;
 import io.trino.metadata.TableSchema;
+import io.trino.metadata.ViewDefinition;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
 import io.trino.security.AccessControl;
 import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorTableMetadata;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TestingColumnHandle;
 import io.trino.spi.resourcegroups.ResourceGroupId;
@@ -232,7 +232,7 @@ public class TestCreateMaterializedViewTask
         private final TablePropertyManager tablePropertyManager;
         private final MaterializedViewPropertyManager materializedViewPropertyManager;
         private final CatalogName catalogHandle;
-        private final Map<SchemaTableName, ConnectorMaterializedViewDefinition> materializedViews = new ConcurrentHashMap<>();
+        private final Map<SchemaTableName, MaterializedViewDefinition> materializedViews = new ConcurrentHashMap<>();
 
         public MockMetadata(
                 TablePropertyManager tablePropertyManager,
@@ -245,7 +245,7 @@ public class TestCreateMaterializedViewTask
         }
 
         @Override
-        public void createMaterializedView(Session session, QualifiedObjectName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+        public void createMaterializedView(Session session, QualifiedObjectName viewName, MaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
         {
             materializedViews.put(viewName.asSchemaTableName(), definition);
             if (!ignoreExisting) {
@@ -316,13 +316,13 @@ public class TestCreateMaterializedViewTask
         }
 
         @Override
-        public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
+        public Optional<MaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
         {
             return Optional.ofNullable(materializedViews.get(viewName.asSchemaTableName()));
         }
 
         @Override
-        public Optional<ConnectorViewDefinition> getView(Session session, QualifiedObjectName viewName)
+        public Optional<ViewDefinition> getView(Session session, QualifiedObjectName viewName)
         {
             return Optional.empty();
         }

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropMaterializedViewTask.java
@@ -36,10 +36,10 @@ public class TestDropMaterializedViewTask
     {
         QualifiedObjectName viewName = qualifiedObjectName("existing_materialized_view");
         metadata.createMaterializedView(testSession, viewName, someMaterializedView(), false, false);
-        assertThat(metadata.getMaterializedView(testSession, viewName)).isPresent();
+        assertThat(metadata.isMaterializedView(testSession, viewName)).isTrue();
 
         getFutureValue(executeDropMaterializedView(asQualifiedName(viewName), false));
-        assertThat(metadata.getMaterializedView(testSession, viewName)).isEmpty();
+        assertThat(metadata.isMaterializedView(testSession, viewName)).isFalse();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropViewTask.java
@@ -36,10 +36,10 @@ public class TestDropViewTask
     {
         QualifiedObjectName viewName = qualifiedObjectName("existing_view");
         metadata.createView(testSession, viewName, someView(), false);
-        assertThat(metadata.getView(testSession, viewName)).isPresent();
+        assertThat(metadata.isView(testSession, viewName)).isTrue();
 
         getFutureValue(executeDropView(asQualifiedName(viewName), false));
-        assertThat(metadata.getView(testSession, viewName)).isEmpty();
+        assertThat(metadata.isView(testSession, viewName)).isFalse();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
@@ -40,8 +40,8 @@ public class TestRenameMaterializedViewTask
         metadata.createMaterializedView(testSession, materializedViewName, someMaterializedView(), false, false);
 
         getFutureValue(executeRenameMaterializedView(asQualifiedName(materializedViewName), asQualifiedName(newMaterializedViewName)));
-        assertThat(metadata.getMaterializedView(testSession, materializedViewName)).isEmpty();
-        assertThat(metadata.getMaterializedView(testSession, newMaterializedViewName)).isPresent();
+        assertThat(metadata.isMaterializedView(testSession, materializedViewName)).isFalse();
+        assertThat(metadata.isMaterializedView(testSession, newMaterializedViewName)).isTrue();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
@@ -39,8 +39,8 @@ public class TestRenameViewTask
         metadata.createView(testSession, viewName, someView(), false);
 
         getFutureValue(executeRenameView(asQualifiedName(viewName), asQualifiedName(newViewName)));
-        assertThat(metadata.getView(testSession, viewName)).isEmpty();
-        assertThat(metadata.getView(testSession, newViewName)).isPresent();
+        assertThat(metadata.isView(testSession, viewName)).isFalse();
+        assertThat(metadata.isView(testSession, newViewName)).isTrue();
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -500,7 +500,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public Map<QualifiedObjectName, ConnectorViewDefinition> getViews(Session session, QualifiedTablePrefix prefix)
+    public Map<QualifiedObjectName, ViewInfo> getViews(Session session, QualifiedTablePrefix prefix)
     {
         throw new UnsupportedOperationException();
     }
@@ -940,7 +940,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public Map<QualifiedObjectName, ConnectorMaterializedViewDefinition> getMaterializedViews(Session session, QualifiedTablePrefix prefix)
+    public Map<QualifiedObjectName, ViewInfo> getMaterializedViews(Session session, QualifiedTablePrefix prefix)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -34,10 +34,8 @@ import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorCapabilities;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.ConnectorOutputMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.JoinApplicationResult;
@@ -506,7 +504,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public Optional<ConnectorViewDefinition> getView(Session session, QualifiedObjectName viewName)
+    public Optional<ViewDefinition> getView(Session session, QualifiedObjectName viewName)
     {
         throw new UnsupportedOperationException();
     }
@@ -524,7 +522,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void createView(Session session, QualifiedObjectName viewName, ConnectorViewDefinition definition, boolean replace)
+    public void createView(Session session, QualifiedObjectName viewName, ViewDefinition definition, boolean replace)
     {
         throw new UnsupportedOperationException();
     }
@@ -922,7 +920,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public void createMaterializedView(Session session, QualifiedObjectName viewName, ConnectorMaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
+    public void createMaterializedView(Session session, QualifiedObjectName viewName, MaterializedViewDefinition definition, boolean replace, boolean ignoreExisting)
     {
         throw new UnsupportedOperationException();
     }
@@ -946,7 +944,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public Optional<ConnectorMaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
+    public Optional<MaterializedViewDefinition> getMaterializedView(Session session, QualifiedObjectName viewName)
     {
         throw new UnsupportedOperationException();
     }

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestAnalyzer.java
@@ -34,10 +34,13 @@ import io.trino.metadata.Catalog.SecurityManagement;
 import io.trino.metadata.CatalogManager;
 import io.trino.metadata.InMemoryNodeManager;
 import io.trino.metadata.InternalNodeManager;
+import io.trino.metadata.MaterializedViewDefinition;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.SessionPropertyManager;
 import io.trino.metadata.TableHandle;
+import io.trino.metadata.ViewColumn;
+import io.trino.metadata.ViewDefinition;
 import io.trino.plugin.base.security.AllowAllSystemAccessControl;
 import io.trino.plugin.base.security.DefaultSystemAccessControl;
 import io.trino.security.AccessControl;
@@ -47,13 +50,11 @@ import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.Connector;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition.Column;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
-import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.security.Identity;
 import io.trino.spi.session.PropertyMetadata;
 import io.trino.spi.transaction.IsolationLevel;
 import io.trino.spi.type.ArrayType;
@@ -141,7 +142,6 @@ import static io.trino.spi.StandardErrorCode.TOO_MANY_GROUPING_SETS;
 import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
 import static io.trino.spi.StandardErrorCode.VIEW_IS_RECURSIVE;
 import static io.trino.spi.StandardErrorCode.VIEW_IS_STALE;
-import static io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
 import static io.trino.spi.session.PropertyMetadata.integerProperty;
 import static io.trino.spi.session.PropertyMetadata.stringProperty;
 import static io.trino.spi.type.BigintType.BIGINT;
@@ -4997,70 +4997,65 @@ public class TestAnalyzer
                 false));
 
         // materialized view referencing table in same schema
-        ConnectorMaterializedViewDefinition materializedViewData1 = new ConnectorMaterializedViewDefinition(
-                "select a from t1",
-                Optional.empty(),
-                Optional.of(TPCH_CATALOG),
-                Optional.of("s1"),
-                ImmutableList.of(new ConnectorMaterializedViewDefinition.Column("a", BIGINT.getTypeId())),
-                Optional.of("comment"),
-                "user",
-                ImmutableMap.of());
-        inSetupTransaction(session -> metadata.createMaterializedView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "mv1"), materializedViewData1, false, true));
-
-        // valid view referencing table in same schema
-        ConnectorViewDefinition viewData1 = new ConnectorViewDefinition(
+        MaterializedViewDefinition materializedViewData1 = new MaterializedViewDefinition(
                 "select a from t1",
                 Optional.of(TPCH_CATALOG),
                 Optional.of("s1"),
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
                 Optional.of("comment"),
-                Optional.of("user"),
-                false);
+                Identity.ofUser("user"),
+                Optional.empty(),
+                ImmutableMap.of());
+        inSetupTransaction(session -> metadata.createMaterializedView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "mv1"), materializedViewData1, false, true));
+
+        // valid view referencing table in same schema
+        ViewDefinition viewData1 = new ViewDefinition(
+                "select a from t1",
+                Optional.of(TPCH_CATALOG),
+                Optional.of("s1"),
+                ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
+                Optional.of("comment"),
+                Optional.of(Identity.ofUser("user")));
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v1"), viewData1, false));
 
         // stale view (different column type)
-        ConnectorViewDefinition viewData2 = new ConnectorViewDefinition(
+        ViewDefinition viewData2 = new ViewDefinition(
                 "select a from t1",
                 Optional.of(TPCH_CATALOG),
                 Optional.of("s1"),
                 ImmutableList.of(new ViewColumn("a", VARCHAR.getTypeId())),
                 Optional.of("comment"),
-                Optional.of("user"),
-                false);
+                Optional.of(Identity.ofUser("user")));
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v2"), viewData2, false));
 
         // view referencing table in different schema from itself and session
-        ConnectorViewDefinition viewData3 = new ConnectorViewDefinition(
+        ViewDefinition viewData3 = new ViewDefinition(
                 "select a from t4",
                 Optional.of(SECOND_CATALOG),
                 Optional.of("s2"),
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
                 Optional.of("comment"),
-                Optional.of("owner"),
-                false);
+                Optional.of(Identity.ofUser("owner")));
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(THIRD_CATALOG, "s3", "v3"), viewData3, false));
 
         // valid view with uppercase column name
-        ConnectorViewDefinition viewData4 = new ConnectorViewDefinition(
+        ViewDefinition viewData4 = new ViewDefinition(
                 "select A from t1",
                 Optional.of("tpch"),
                 Optional.of("s1"),
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
                 Optional.of("comment"),
-                Optional.of("user"),
-                false);
+                Optional.of(Identity.ofUser("user")));
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName("tpch", "s1", "v4"), viewData4, false));
 
         // recursive view referencing to itself
-        ConnectorViewDefinition viewData5 = new ConnectorViewDefinition(
+        ViewDefinition viewData5 = new ViewDefinition(
                 "select * from v5",
                 Optional.of(TPCH_CATALOG),
                 Optional.of("s1"),
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
                 Optional.of("comment"),
-                Optional.of("user"),
-                false);
+                Optional.of(Identity.ofUser("user")));
         inSetupTransaction(session -> metadata.createView(session, new QualifiedObjectName(TPCH_CATALOG, "s1", "v5"), viewData5, false));
 
         // type analysis for INSERT
@@ -5130,25 +5125,24 @@ public class TestAnalyzer
         inSetupTransaction(session -> metadata.createMaterializedView(
                 session,
                 tableViewAndMaterializedView,
-                new ConnectorMaterializedViewDefinition(
+                new MaterializedViewDefinition(
                         "SELECT a FROM t1",
-                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t1")),
                         Optional.of(TPCH_CATALOG),
                         Optional.of("s1"),
-                        ImmutableList.of(new Column("a", BIGINT.getTypeId())),
+                        ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
                         Optional.empty(),
-                        "some user",
+                        Identity.ofUser("some user"),
+                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t1")),
                         ImmutableMap.of()),
                 false,
                 false));
-        ConnectorViewDefinition viewDefinition = new ConnectorViewDefinition(
+        ViewDefinition viewDefinition = new ViewDefinition(
                 "SELECT a FROM t2",
                 Optional.of(TPCH_CATALOG),
                 Optional.of("s1"),
                 ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
                 Optional.empty(),
-                Optional.empty(),
-                true);
+                Optional.empty());
         inSetupTransaction(session -> metadata.createView(
                 session,
                 tableViewAndMaterializedView,
@@ -5180,15 +5174,15 @@ public class TestAnalyzer
         inSetupTransaction(session -> metadata.createMaterializedView(
                 session,
                 freshMaterializedView,
-                new ConnectorMaterializedViewDefinition(
+                new MaterializedViewDefinition(
                         "SELECT a, b FROM t1",
-                        // t3 has a, b column and hidden column x
-                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t3")),
                         Optional.of(TPCH_CATALOG),
                         Optional.of("s1"),
-                        ImmutableList.of(new Column("a", BIGINT.getTypeId()), new Column("b", BIGINT.getTypeId())),
+                        ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId()), new ViewColumn("b", BIGINT.getTypeId())),
                         Optional.empty(),
-                        "some user",
+                        Identity.ofUser("some user"),
+                        // t3 has a, b column and hidden column x
+                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t3")),
                         ImmutableMap.of()),
                 false,
                 false));
@@ -5198,14 +5192,14 @@ public class TestAnalyzer
         inSetupTransaction(session -> metadata.createMaterializedView(
                 session,
                 freshMaterializedViewMismatchedColumnCount,
-                new ConnectorMaterializedViewDefinition(
+                new MaterializedViewDefinition(
                         "SELECT a FROM t1",
-                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2")),
                         Optional.of(TPCH_CATALOG),
                         Optional.of("s1"),
-                        ImmutableList.of(new Column("a", BIGINT.getTypeId())),
+                        ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId())),
                         Optional.empty(),
-                        "some user",
+                        Identity.ofUser("some user"),
+                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2")),
                         ImmutableMap.of()),
                 false,
                 false));
@@ -5215,14 +5209,14 @@ public class TestAnalyzer
         inSetupTransaction(session -> metadata.createMaterializedView(
                 session,
                 freshMaterializedMismatchedColumnName,
-                new ConnectorMaterializedViewDefinition(
+                new MaterializedViewDefinition(
                         "SELECT a, b as c FROM t1",
-                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2")),
                         Optional.of(TPCH_CATALOG),
                         Optional.of("s1"),
-                        ImmutableList.of(new Column("a", BIGINT.getTypeId()), new Column("c", BIGINT.getTypeId())),
+                        ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId()), new ViewColumn("c", BIGINT.getTypeId())),
                         Optional.empty(),
-                        "some user",
+                        Identity.ofUser("some user"),
+                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2")),
                         ImmutableMap.of()),
                 false,
                 false));
@@ -5232,14 +5226,14 @@ public class TestAnalyzer
         inSetupTransaction(session -> metadata.createMaterializedView(
                 session,
                 freshMaterializedMismatchedColumnType,
-                new ConnectorMaterializedViewDefinition(
+                new MaterializedViewDefinition(
                         "SELECT a, null b FROM t1",
-                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2")),
                         Optional.of(TPCH_CATALOG),
                         Optional.of("s1"),
-                        ImmutableList.of(new Column("a", BIGINT.getTypeId()), new Column("b", RowType.anonymousRow(TINYINT).getTypeId())),
+                        ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId()), new ViewColumn("b", RowType.anonymousRow(TINYINT).getTypeId())),
                         Optional.empty(),
-                        "some user",
+                        Identity.ofUser("some user"),
+                        Optional.of(new CatalogSchemaTableName(TPCH_CATALOG, "s1", "t2")),
                         ImmutableMap.of()),
                 false,
                 false));

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestMaterializedViews.java
@@ -23,17 +23,18 @@ import io.trino.metadata.Catalog;
 import io.trino.metadata.Catalog.SecurityManagement;
 import io.trino.metadata.InMemoryNodeManager;
 import io.trino.metadata.InternalNodeManager;
+import io.trino.metadata.MaterializedViewDefinition;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.ViewColumn;
 import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.Connector;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition.Column;
 import io.trino.spi.connector.ConnectorMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.ConnectorTransactionHandle;
 import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.security.Identity;
 import io.trino.spi.security.ViewExpression;
 import io.trino.spi.transaction.IsolationLevel;
 import io.trino.sql.planner.assertions.BasePlanTest;
@@ -119,14 +120,14 @@ public class TestMaterializedViews
         });
 
         QualifiedObjectName freshMaterializedView = new QualifiedObjectName(CATALOG, SCHEMA, "fresh_materialized_view");
-        ConnectorMaterializedViewDefinition materializedViewDefinition = new ConnectorMaterializedViewDefinition(
+        MaterializedViewDefinition materializedViewDefinition = new MaterializedViewDefinition(
                 "SELECT a, b FROM test_table",
-                Optional.of(new CatalogSchemaTableName(CATALOG, SCHEMA, "storage_table")),
                 Optional.of(CATALOG),
                 Optional.of(SCHEMA),
-                ImmutableList.of(new Column("a", BIGINT.getTypeId()), new Column("b", BIGINT.getTypeId())),
+                ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId()), new ViewColumn("b", BIGINT.getTypeId())),
                 Optional.empty(),
-                "some user",
+                Identity.ofUser("some user"),
+                Optional.of(new CatalogSchemaTableName(CATALOG, SCHEMA, "storage_table")),
                 ImmutableMap.of());
         queryRunner.inTransaction(session -> {
             metadata.createMaterializedView(
@@ -150,14 +151,14 @@ public class TestMaterializedViews
             return null;
         });
 
-        ConnectorMaterializedViewDefinition materializedViewDefinitionWithCasts = new ConnectorMaterializedViewDefinition(
+        MaterializedViewDefinition materializedViewDefinitionWithCasts = new MaterializedViewDefinition(
                 "SELECT a, b FROM test_table",
-                Optional.of(new CatalogSchemaTableName(CATALOG, SCHEMA, "storage_table_with_casts")),
                 Optional.of(CATALOG),
                 Optional.of(SCHEMA),
-                ImmutableList.of(new Column("a", BIGINT.getTypeId()), new Column("b", BIGINT.getTypeId())),
+                ImmutableList.of(new ViewColumn("a", BIGINT.getTypeId()), new ViewColumn("b", BIGINT.getTypeId())),
                 Optional.empty(),
-                "some user",
+                Identity.ofUser("some user"),
+                Optional.of(new CatalogSchemaTableName(CATALOG, SCHEMA, "storage_table_with_casts")),
                 ImmutableMap.of());
         QualifiedObjectName materializedViewWithCasts = new QualifiedObjectName(CATALOG, SCHEMA, "materialized_view_with_casts");
         queryRunner.inTransaction(session -> {

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestAllowAllSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestAllowAllSystemAccessControl.java
@@ -13,8 +13,13 @@
  */
 package io.trino.plugin.base.security;
 
+import com.google.common.collect.ImmutableSet;
+import io.trino.spi.security.Identity;
 import io.trino.spi.security.SystemAccessControl;
+import io.trino.spi.security.SystemSecurityContext;
 import org.testng.annotations.Test;
+
+import java.util.Collection;
 
 import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 
@@ -22,7 +27,11 @@ public class TestAllowAllSystemAccessControl
 {
     @Test
     public void testEverythingImplemented()
+            throws ReflectiveOperationException
     {
-        assertAllMethodsOverridden(SystemAccessControl.class, AllowAllSystemAccessControl.class);
+        assertAllMethodsOverridden(SystemAccessControl.class, AllowAllSystemAccessControl.class, ImmutableSet.of(
+                AllowAllSystemAccessControl.class.getMethod("checkCanViewQueryOwnedBy", SystemSecurityContext.class, Identity.class),
+                AllowAllSystemAccessControl.class.getMethod("filterViewQuery", SystemSecurityContext.class, Collection.class),
+                AllowAllSystemAccessControl.class.getMethod("checkCanKillQueryOwnedBy", SystemSecurityContext.class, Identity.class)));
     }
 }

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestFileBasedSystemAccessControl.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 import javax.security.auth.kerberos.KerberosPrincipal;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
@@ -1249,8 +1250,12 @@ public class TestFileBasedSystemAccessControl
 
     @Test
     public void testEverythingImplemented()
+            throws NoSuchMethodException
     {
-        assertAllMethodsOverridden(SystemAccessControl.class, FileBasedSystemAccessControl.class);
+        assertAllMethodsOverridden(SystemAccessControl.class, FileBasedSystemAccessControl.class, ImmutableSet.of(
+                FileBasedSystemAccessControl.class.getMethod("checkCanViewQueryOwnedBy", SystemSecurityContext.class, Identity.class),
+                FileBasedSystemAccessControl.class.getMethod("filterViewQuery", SystemSecurityContext.class, Collection.class),
+                FileBasedSystemAccessControl.class.getMethod("checkCanKillQueryOwnedBy", SystemSecurityContext.class, Identity.class)));
     }
 
     @Test

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestForwardingSystemAccessControl.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/security/TestForwardingSystemAccessControl.java
@@ -13,8 +13,13 @@
  */
 package io.trino.plugin.base.security;
 
+import com.google.common.collect.ImmutableSet;
+import io.trino.spi.security.Identity;
 import io.trino.spi.security.SystemAccessControl;
+import io.trino.spi.security.SystemSecurityContext;
 import org.testng.annotations.Test;
+
+import java.util.Collection;
 
 import static io.trino.spi.testing.InterfaceTestUtils.assertAllMethodsOverridden;
 
@@ -22,7 +27,11 @@ public class TestForwardingSystemAccessControl
 {
     @Test
     public void testEverythingDelegated()
+            throws ReflectiveOperationException
     {
-        assertAllMethodsOverridden(SystemAccessControl.class, ForwardingSystemAccessControl.class);
+        assertAllMethodsOverridden(SystemAccessControl.class, ForwardingSystemAccessControl.class, ImmutableSet.of(
+                ForwardingSystemAccessControl.class.getMethod("checkCanViewQueryOwnedBy", SystemSecurityContext.class, Identity.class),
+                ForwardingSystemAccessControl.class.getMethod("filterViewQuery", SystemSecurityContext.class, Collection.class),
+                ForwardingSystemAccessControl.class.getMethod("checkCanKillQueryOwnedBy", SystemSecurityContext.class, Identity.class)));
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewDefinition.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMaterializedViewDefinition.java
@@ -47,7 +47,6 @@ public class IcebergMaterializedViewDefinition
     private final Optional<String> schema;
     private final List<Column> columns;
     private final Optional<String> comment;
-    private final String owner;
 
     public static String encodeMaterializedViewData(IcebergMaterializedViewDefinition definition)
     {
@@ -75,8 +74,7 @@ public class IcebergMaterializedViewDefinition
                 definition.getColumns().stream()
                         .map(column -> new Column(column.getName(), column.getType()))
                         .collect(toImmutableList()),
-                definition.getComment(),
-                definition.getOwner());
+                definition.getComment());
     }
 
     @JsonCreator
@@ -85,15 +83,13 @@ public class IcebergMaterializedViewDefinition
             @JsonProperty("catalog") Optional<String> catalog,
             @JsonProperty("schema") Optional<String> schema,
             @JsonProperty("columns") List<Column> columns,
-            @JsonProperty("comment") Optional<String> comment,
-            @JsonProperty("owner") String owner)
+            @JsonProperty("comment") Optional<String> comment)
     {
         this.originalSql = requireNonNull(originalSql, "originalSql is null");
         this.catalog = requireNonNull(catalog, "catalog is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.columns = List.copyOf(requireNonNull(columns, "columns is null"));
         this.comment = requireNonNull(comment, "comment is null");
-        this.owner = requireNonNull(owner, "owner is null");
 
         if (catalog.isEmpty() && schema.isPresent()) {
             throw new IllegalArgumentException("catalog must be present if schema is present");
@@ -133,12 +129,6 @@ public class IcebergMaterializedViewDefinition
         return comment;
     }
 
-    @JsonProperty
-    public String getOwner()
-    {
-        return owner;
-    }
-
     @Override
     public String toString()
     {
@@ -148,7 +138,6 @@ public class IcebergMaterializedViewDefinition
         schema.ifPresent(value -> joiner.add("schema=" + value));
         joiner.add("columns=" + columns);
         comment.ifPresent(value -> joiner.add("comment=" + value));
-        joiner.add("owner=" + owner);
         return getClass().getSimpleName() + joiner;
     }
 

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -234,7 +234,6 @@ public abstract class BaseIcebergConnectorTest
     {
         assertThat(computeActual("SHOW CREATE SCHEMA tpch").getOnlyValue().toString())
                 .matches("CREATE SCHEMA iceberg.tpch\n" +
-                        "AUTHORIZATION USER user\n" +
                         "WITH \\(\n" +
                         "\\s+location = '.*/iceberg_data/tpch'\n" +
                         "\\)");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedViews.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedViews.java
@@ -15,8 +15,8 @@ package io.trino.plugin.iceberg;
 
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
+import io.trino.metadata.MaterializedViewDefinition;
 import io.trino.metadata.QualifiedObjectName;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.sql.tree.ExplainType;
 import io.trino.testing.AbstractTestQueryFramework;
@@ -513,7 +513,7 @@ public class TestIcebergMaterializedViews
         TransactionManager transactionManager = getQueryRunner().getTransactionManager();
         TransactionId transactionId = transactionManager.beginTransaction(false);
         Session session = getSession().beginTransactionId(transactionId, transactionManager, getQueryRunner().getAccessControl());
-        Optional<ConnectorMaterializedViewDefinition> materializedView = getQueryRunner().getMetadata()
+        Optional<MaterializedViewDefinition> materializedView = getQueryRunner().getMetadata()
                 .getMaterializedView(session, new QualifiedObjectName(catalogName, schemaName, objectName));
         assertThat(materializedView).isPresent();
         return materializedView.get().getStorageTable().get().getSchemaTableName();

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetadataListing.java
@@ -16,6 +16,7 @@ package io.trino.plugin.iceberg;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
+import io.trino.metadata.MaterializedViewDefinition;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.plugin.hive.HdfsConfig;
 import io.trino.plugin.hive.HdfsConfiguration;
@@ -29,7 +30,6 @@ import io.trino.plugin.hive.metastore.HiveMetastore;
 import io.trino.plugin.hive.metastore.MetastoreConfig;
 import io.trino.plugin.hive.metastore.file.FileHiveMetastore;
 import io.trino.plugin.hive.metastore.file.FileHiveMetastoreConfig;
-import io.trino.spi.connector.ConnectorMaterializedViewDefinition;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.SelectedRole;
@@ -175,7 +175,7 @@ public class TestIcebergMetadataListing
         TransactionManager transactionManager = getQueryRunner().getTransactionManager();
         TransactionId transactionId = transactionManager.beginTransaction(false);
         Session session = getSession().beginTransactionId(transactionId, transactionManager, getQueryRunner().getAccessControl());
-        Optional<ConnectorMaterializedViewDefinition> materializedView = getQueryRunner().getMetadata()
+        Optional<MaterializedViewDefinition> materializedView = getQueryRunner().getMetadata()
                 .getMaterializedView(session, new QualifiedObjectName(catalogName, schemaName, objectName));
         assertThat(materializedView).isPresent();
         return materializedView.get().getStorageTable().get().getSchemaTableName();

--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/system/selectInformationSchemaColumns.result
@@ -64,7 +64,6 @@ system| metadata| materialized_views| storage_catalog| varchar| YES| null| null|
 system| metadata| materialized_views| storage_schema| varchar| YES| null| null|
 system| metadata| materialized_views| storage_table| varchar| YES| null| null|
 system| metadata| materialized_views| is_fresh| boolean| YES| null| null|
-system| metadata| materialized_views| owner| varchar| YES| null| null|
 system| metadata| materialized_views| comment| varchar| YES| null| null|
 system| metadata| materialized_views| definition| varchar| YES| null| null|
 system| metadata| schema_properties| catalog_name| varchar| YES| null| null|

--- a/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java
@@ -770,11 +770,10 @@ public abstract class BaseConnectorTest
     private String getTestingMaterializedViewsResultRow(QualifiedObjectName materializedView, String comment)
     {
         return format(
-                "VALUES ('%s', '%s', '%s', '%s', '%s', 'SELECT *\nFROM\n  nation\n')",
+                "VALUES ('%s', '%s', '%s', '%s', 'SELECT *\nFROM\n  nation\n')",
                 materializedView.getCatalogName(),
                 materializedView.getSchemaName(),
                 materializedView.getObjectName(),
-                getSession().getUser(),
                 comment);
     }
 
@@ -782,21 +781,18 @@ public abstract class BaseConnectorTest
             QualifiedObjectName materializedView,
             QualifiedObjectName otherMaterializedView)
     {
-        String user = getSession().getUser();
         String viewDefinitionSql = "SELECT *\nFROM\n  nation\n";
 
         return format(
-                "VALUES ('%s', '%s', '%s', '%s', '', '%s')," +
-                        "('%s', '%s', '%s', '%s', 'sarcastic comment', '%s')",
+                "VALUES ('%s', '%s', '%s', '', '%s')," +
+                        "('%s', '%s', '%s', 'sarcastic comment', '%s')",
                 materializedView.getCatalogName(),
                 materializedView.getSchemaName(),
                 materializedView.getObjectName(),
-                user,
                 viewDefinitionSql,
                 otherMaterializedView.getCatalogName(),
                 otherMaterializedView.getSchemaName(),
                 otherMaterializedView.getObjectName(),
-                user,
                 viewDefinitionSql);
     }
 
@@ -806,7 +802,6 @@ public abstract class BaseConnectorTest
                 "   catalog_name," +
                 "   schema_name," +
                 "   name," +
-                "   owner," +
                 "   comment," +
                 "   definition " +
                 "FROM system.metadata.materialized_views " +

--- a/testing/trino-tests/src/test/java/io/trino/security/TestingSystemSecurityMetadata.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestingSystemSecurityMetadata.java
@@ -19,6 +19,7 @@ import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.QualifiedTablePrefix;
 import io.trino.metadata.SystemSecurityMetadata;
 import io.trino.spi.connector.CatalogSchemaName;
+import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.security.GrantInfo;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.Privilege;
@@ -190,6 +191,36 @@ class TestingSystemSecurityMetadata
 
     @Override
     public Set<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<TrinoPrincipal> getSchemaOwner(Session session, CatalogSchemaName schema)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public void setSchemaOwner(Session session, CatalogSchemaName schema, TrinoPrincipal principal)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTableOwner(Session session, CatalogSchemaTableName table, TrinoPrincipal principal)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Identity> getViewRunAsIdentity(Session session, CatalogSchemaTableName viewName)
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public void setViewOwner(Session session, CatalogSchemaTableName view, TrinoPrincipal principal)
     {
         throw new UnsupportedOperationException();
     }

--- a/testing/trino-tests/src/test/java/io/trino/security/TestingSystemSecurityMetadata.java
+++ b/testing/trino-tests/src/test/java/io/trino/security/TestingSystemSecurityMetadata.java
@@ -224,4 +224,22 @@ class TestingSystemSecurityMetadata
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void schemaCreated(Session session, CatalogSchemaName schema) {}
+
+    @Override
+    public void schemaRenamed(Session session, CatalogSchemaName sourceSchema, CatalogSchemaName targetSchema) {}
+
+    @Override
+    public void schemaDropped(Session session, CatalogSchemaName schema) {}
+
+    @Override
+    public void tableCreated(Session session, CatalogSchemaTableName table) {}
+
+    @Override
+    public void tableRenamed(Session session, CatalogSchemaTableName sourceTable, CatalogSchemaTableName targetTable) {}
+
+    @Override
+    public void tableDropped(Session session, CatalogSchemaTableName table) {}
 }


### PR DESCRIPTION
* Send get and set owner calls to `SystemSecurityMetadata` for catalogs using system security
* Add full identity to 'ViewDefinition' in engine instead of only user name
* Add full identity to view/kill query access control checks
* Add callbacks for create, drop, and rename of tables and schemas to `SystemSecurityMetadata` for catalogs using system security
* Remove owner from materialized view system table to align with other system tables (and because it can be expensive to fetch owner)