### PR TITLE
Improve performance/memory overhead for Spatial Join

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -305,11 +305,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.locationtech.jts</groupId>
-            <artifactId>jts-core</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
         </dependency>

--- a/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesIndex.java
@@ -21,6 +21,7 @@ import io.airlift.units.DataSize;
 import io.trino.FeaturesConfig;
 import io.trino.Session;
 import io.trino.geospatial.Rectangle;
+import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.SpatialIndexBuilderOperator.SpatialPredicate;
 import io.trino.operator.join.JoinHashSupplier;
 import io.trino.operator.join.LookupSource;
@@ -495,11 +496,12 @@ public class PagesIndex
             SpatialPredicate spatialRelationshipTest,
             Optional<JoinFilterFunctionFactory> filterFunctionFactory,
             List<Integer> outputChannels,
-            Map<Integer, Rectangle> partitions)
+            Map<Integer, Rectangle> partitions,
+            LocalMemoryContext localUserMemoryContext)
     {
         // TODO probably shouldn't copy to reduce memory and for memory accounting's sake
         List<List<Block>> channels = ImmutableList.copyOf(this.channels);
-        return new PagesSpatialIndexSupplier(session, valueAddresses, types, outputChannels, channels, geometryChannel, radiusChannel, partitionChannel, spatialRelationshipTest, filterFunctionFactory, partitions);
+        return new PagesSpatialIndexSupplier(session, valueAddresses, types, outputChannels, channels, geometryChannel, radiusChannel, partitionChannel, spatialRelationshipTest, filterFunctionFactory, partitions, localUserMemoryContext);
     }
 
     public LookupSourceSupplier createLookupSourceSupplier(

--- a/core/trino-main/src/main/java/io/trino/operator/PagesSpatialIndexSupplier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PagesSpatialIndexSupplier.java
@@ -22,16 +22,15 @@ import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
 import io.trino.Session;
 import io.trino.geospatial.Rectangle;
+import io.trino.geospatial.rtree.Flatbush;
+import io.trino.memory.context.LocalMemoryContext;
 import io.trino.operator.PagesRTreeIndex.GeometryWithPosition;
 import io.trino.operator.SpatialIndexBuilderOperator.SpatialPredicate;
 import io.trino.spi.block.Block;
 import io.trino.spi.type.Type;
 import io.trino.sql.gen.JoinFilterFunctionCompiler;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
-import org.locationtech.jts.geom.Envelope;
-import org.locationtech.jts.index.strtree.AbstractNode;
-import org.locationtech.jts.index.strtree.ItemBoundable;
-import org.locationtech.jts.index.strtree.STRtree;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
@@ -47,14 +46,13 @@ import static io.trino.operator.SyntheticAddress.decodeSliceIndex;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
 
 public class PagesSpatialIndexSupplier
         implements Supplier<PagesSpatialIndex>
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(PagesSpatialIndexSupplier.class).instanceSize();
-    private static final int ENVELOPE_INSTANCE_SIZE = ClassLayout.parseClass(Envelope.class).instanceSize();
-    private static final int STRTREE_INSTANCE_SIZE = ClassLayout.parseClass(STRtree.class).instanceSize();
-    private static final int ABSTRACT_NODE_INSTANCE_SIZE = ClassLayout.parseClass(AbstractNode.class).instanceSize();
+    private static final int MEMORY_USAGE_UPDATE_INCREMENT_BYTES = 100 * 1024 * 1024;   // 100 MB
 
     private final Session session;
     private final LongArrayList addresses;
@@ -64,7 +62,7 @@ public class PagesSpatialIndexSupplier
     private final Optional<Integer> radiusChannel;
     private final SpatialPredicate spatialRelationshipTest;
     private final Optional<JoinFilterFunctionCompiler.JoinFilterFunctionFactory> filterFunctionFactory;
-    private final STRtree rtree;
+    private final Flatbush<GeometryWithPosition> rtree;
     private final Map<Integer, Rectangle> partitions;
     private final long memorySizeInBytes;
 
@@ -79,8 +77,10 @@ public class PagesSpatialIndexSupplier
             Optional<Integer> partitionChannel,
             SpatialPredicate spatialRelationshipTest,
             Optional<JoinFilterFunctionCompiler.JoinFilterFunctionFactory> filterFunctionFactory,
-            Map<Integer, Rectangle> partitions)
+            Map<Integer, Rectangle> partitions,
+            LocalMemoryContext localUserMemoryContext)
     {
+        requireNonNull(localUserMemoryContext, "localUserMemoryContext is null");
         this.session = session;
         this.addresses = addresses;
         this.types = types;
@@ -90,16 +90,19 @@ public class PagesSpatialIndexSupplier
         this.filterFunctionFactory = filterFunctionFactory;
         this.partitions = partitions;
 
-        this.rtree = buildRTree(addresses, channels, geometryChannel, radiusChannel, partitionChannel);
+        this.rtree = buildRTree(addresses, channels, geometryChannel, radiusChannel, partitionChannel, localUserMemoryContext);
         this.radiusChannel = radiusChannel;
-        this.memorySizeInBytes = INSTANCE_SIZE +
-                (rtree.isEmpty() ? 0 : STRTREE_INSTANCE_SIZE + computeMemorySizeInBytes(rtree.getRoot()));
+        this.memorySizeInBytes = INSTANCE_SIZE + rtree.getEstimatedSizeInBytes();
     }
 
-    private static STRtree buildRTree(LongArrayList addresses, List<List<Block>> channels, int geometryChannel, Optional<Integer> radiusChannel, Optional<Integer> partitionChannel)
+    private static Flatbush<GeometryWithPosition> buildRTree(LongArrayList addresses, List<List<Block>> channels, int geometryChannel, Optional<Integer> radiusChannel, Optional<Integer> partitionChannel, LocalMemoryContext localUserMemoryContext)
     {
-        STRtree rtree = new STRtree();
         Operator relateOperator = OperatorFactoryLocal.getInstance().getOperator(Operator.Type.Relate);
+
+        ObjectArrayList<GeometryWithPosition> geometries = new ObjectArrayList<>();
+
+        long recordedSizeInBytes = localUserMemoryContext.getBytes();
+        long addedSizeInBytes = 0;
 
         for (int position = 0; position < addresses.size(); position++) {
             long pageAddress = addresses.getLong(position);
@@ -135,32 +138,18 @@ public class PagesSpatialIndexSupplier
                 partition = toIntExact(INTEGER.getLong(partitionBlock, blockPosition));
             }
 
-            rtree.insert(getEnvelope(ogcGeometry, radius), new GeometryWithPosition(ogcGeometry, partition, position));
+            GeometryWithPosition geometryWithPosition = new GeometryWithPosition(ogcGeometry, partition, position, radius);
+            geometries.add(geometryWithPosition);
+
+            addedSizeInBytes += geometryWithPosition.getEstimatedSizeInBytes();
+
+            if (addedSizeInBytes >= MEMORY_USAGE_UPDATE_INCREMENT_BYTES) {
+                localUserMemoryContext.setBytes(recordedSizeInBytes + addedSizeInBytes);
+                recordedSizeInBytes += addedSizeInBytes;
+                addedSizeInBytes = 0;
+            }
         }
-
-        rtree.build();
-        return rtree;
-    }
-
-    private static Envelope getEnvelope(OGCGeometry ogcGeometry, double radius)
-    {
-        com.esri.core.geometry.Envelope envelope = new com.esri.core.geometry.Envelope();
-        ogcGeometry.getEsriGeometry().queryEnvelope(envelope);
-
-        return new Envelope(envelope.getXMin() - radius, envelope.getXMax() + radius, envelope.getYMin() - radius, envelope.getYMax() + radius);
-    }
-
-    private long computeMemorySizeInBytes(AbstractNode root)
-    {
-        if (root.getLevel() == 0) {
-            return ABSTRACT_NODE_INSTANCE_SIZE + ENVELOPE_INSTANCE_SIZE + root.getChildBoundables().stream().mapToLong(child -> computeMemorySizeInBytes((ItemBoundable) child)).sum();
-        }
-        return ABSTRACT_NODE_INSTANCE_SIZE + ENVELOPE_INSTANCE_SIZE + root.getChildBoundables().stream().mapToLong(child -> computeMemorySizeInBytes((AbstractNode) child)).sum();
-    }
-
-    private long computeMemorySizeInBytes(ItemBoundable item)
-    {
-        return ENVELOPE_INSTANCE_SIZE + ((GeometryWithPosition) item.getItem()).getEstimatedMemorySizeInBytes();
+        return new Flatbush<>(geometries.toArray(new GeometryWithPosition[] {}));
     }
 
     private static void accelerateGeometry(OGCGeometry ogcGeometry, Operator relateOperator)

--- a/core/trino-main/src/main/java/io/trino/operator/SpatialIndexBuilderOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/SpatialIndexBuilderOperator.java
@@ -230,7 +230,8 @@ public class SpatialIndexBuilderOperator
         }
 
         finishing = true;
-        PagesSpatialIndexSupplier spatialIndex = index.createPagesSpatialIndex(operatorContext.getSession(), indexChannel, radiusChannel, partitionChannel, spatialRelationshipTest, filterFunctionFactory, outputChannels, partitions);
+        localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes());
+        PagesSpatialIndexSupplier spatialIndex = index.createPagesSpatialIndex(operatorContext.getSession(), indexChannel, radiusChannel, partitionChannel, spatialRelationshipTest, filterFunctionFactory, outputChannels, partitions, localUserMemoryContext);
         localUserMemoryContext.setBytes(index.getEstimatedSize().toBytes() + spatialIndex.getEstimatedSize().toBytes());
         indexNotNeeded = pagesSpatialIndexFactory.lendPagesSpatialIndex(spatialIndex);
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -372,10 +372,6 @@ public class ExtractSpatialJoins
             PageSourceManager pageSourceManager,
             TypeAnalyzer typeAnalyzer)
     {
-        // TODO Add support for distributed left spatial joins
-        Optional<String> spatialPartitioningTableName = joinNode.getType() == INNER ? getSpatialPartitioningTableName(context.getSession()) : Optional.empty();
-        Optional<KdbTree> kdbTree = spatialPartitioningTableName.map(tableName -> loadKdbTree(tableName, context.getSession(), plannerContext.getMetadata(), splitManager, pageSourceManager));
-
         List<Expression> arguments = spatialFunction.getArguments();
         verify(arguments.size() == 2);
 
@@ -395,6 +391,9 @@ public class ExtractSpatialJoins
             return Result.empty();
         }
 
+        // If either firstArgument or secondArgument is not a
+        // VariableReferenceExpression, will replace the left/right join node
+        // with a projection that adds the argument as a variable.
         Optional<Symbol> newFirstSymbol = newGeometrySymbol(context, firstArgument, plannerContext.getTypeManager());
         Optional<Symbol> newSecondSymbol = newGeometrySymbol(context, secondArgument, plannerContext.getTypeManager());
 
@@ -421,6 +420,13 @@ public class ExtractSpatialJoins
         Expression newFirstArgument = toExpression(newFirstSymbol, firstArgument);
         Expression newSecondArgument = toExpression(newSecondSymbol, secondArgument);
 
+        // Implement partitioned spatial joins:
+        // If the session parameter points to a valid spatial partitioning, use
+        // that to assign to each probe and build rows the partitions that the
+        // geometry intersects.  This is a projection that adds an array of ints
+        // which is subsequently unnested.
+        Optional<String> spatialPartitioningTableName = joinNode.getType() == INNER ? getSpatialPartitioningTableName(context.getSession()) : Optional.empty();
+        Optional<KdbTree> kdbTree = spatialPartitioningTableName.map(tableName -> loadKdbTree(tableName, context.getSession(), plannerContext.getMetadata(), splitManager, pageSourceManager));
         Optional<Symbol> leftPartitionSymbol = Optional.empty();
         Optional<Symbol> rightPartitionSymbol = Optional.empty();
         if (kdbTree.isPresent()) {
@@ -454,6 +460,48 @@ public class ExtractSpatialJoins
                 leftPartitionSymbol,
                 rightPartitionSymbol,
                 kdbTree.map(KdbTreeUtils::toJson)));
+    }
+
+    private static boolean canPartitionSpatialJoin(JoinNode joinNode)
+    {
+        /*
+         * Unlike equijoins, partitioned spatial joins can send a row to more
+         * than one join worker. Extended geometries (such as polygons) can
+         * intersect more than one spatial partition, but points will be sent
+         * to only one partition. For INNER joins, we only care about matches,
+         * so this is acceptable.  In the case of extended geometries on both
+         * probe and build side, we can disambiguate using the upper-left corner
+         * of the intersection of the envelopes.  Only the worker whose
+         * partition contains that point is responsible for the join.
+         *
+         * For OUTER joins we need to know if a row has not found a match.
+         * If a row in an OUTER side is on more than one worker in a distributed
+         * join (broadcast or partitioned), you cannot determine a non-match
+         * using only local information.  Not matching on one worker does not
+         * tell you if there isn't a match on another worker, so the worker
+         * doesn't know whether to emit a NULL for the non-match.
+         *
+         * This can happen if:
+         * 1. A side is broadcast, and it's OUTER on that side (including FULL).
+         * 2. A side is partitioned, the object is extended (ie, not a Point),
+         *    and it's OUTER on that side (including FULL).
+         *
+         * We assume that the right node is the build side.  The CBO is disabled
+         * for spatial joins, so this should be a good assumption.  Then we have:
+         * 1. INNER joins are OK.
+         * 2. LEFT joins when the left node is a Point are OK.
+         * 3. RIGHT joins when the right node is a Point are OK.
+         * 4. FULL joins when the left and right nodes are Points are OK.
+         * 5. If one side is extended by a radius (for ST_Distance), that side
+         *    is no longer considered a point.
+         *
+         * For now, we are only implementing the INNER case. Partitioned OUTER
+         * joins are future work.
+         *
+         * Caveat implementor: Letting the CBO change these joins requires
+         * thought about outer joins on broadcast sides, so consider carefully.
+         */
+        return joinNode.getType() == INNER;
     }
 
     private static KdbTree loadKdbTree(String tableName, Session session, Metadata metadata, SplitManager splitManager, PageSourceManager pageSourceManager)

--- a/lib/trino-geospatial-toolkit/pom.xml
+++ b/lib/trino-geospatial-toolkit/pom.xml
@@ -18,6 +18,11 @@
     <dependencies>
         <dependency>
             <groupId>io.trino</groupId>
+            <artifactId>trino-array</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.trino</groupId>
             <artifactId>trino-spi</artifactId>
         </dependency>
 
@@ -60,6 +65,11 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
         </dependency>
 
         <dependency>

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/GeometryUtils.java
@@ -119,6 +119,38 @@ public final class GeometryUtils
         }
     }
 
+    /**
+     * Get the bounding box for an OGCGeometry.
+     * <p>
+     * If the geometry is empty, return a Retangle with NaN coordinates.
+     *
+     * @param ogcGeometry
+     * @return Rectangle bounding box
+     */
+    public static Rectangle getExtent(OGCGeometry ogcGeometry)
+    {
+        return getExtent(ogcGeometry, 0.0);
+    }
+
+    /**
+     * Get the bounding box for an OGCGeometry, inflated by radius.
+     * <p>
+     * If the geometry is empty, return a Retangle with NaN coordinates.
+     *
+     * @param ogcGeometry
+     * @return Rectangle bounding box
+     */
+    public static Rectangle getExtent(OGCGeometry ogcGeometry, double radius)
+    {
+        com.esri.core.geometry.Envelope envelope = getEnvelope(ogcGeometry);
+
+        return new Rectangle(
+                envelope.getXMin() - radius,
+                envelope.getYMin() - radius,
+                envelope.getXMax() + radius,
+                envelope.getYMax() + radius);
+    }
+
     public static boolean disjoint(Envelope envelope, OGCGeometry ogcGeometry)
     {
         GeometryCursor cursor = ogcGeometry.getEsriGeometryCursor();

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/Rectangle.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/Rectangle.java
@@ -15,6 +15,7 @@ package io.trino.geospatial;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.trino.geospatial.rtree.HasExtent;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
@@ -26,8 +27,14 @@ import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
 public final class Rectangle
+        implements HasExtent
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(Rectangle.class).instanceSize();
+    private static final Rectangle UNIVERSE_RECTANGLE = new Rectangle(
+            Double.NEGATIVE_INFINITY,
+            Double.NEGATIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Double.POSITIVE_INFINITY);
 
     private final double xMin;
     private final double yMin;
@@ -47,6 +54,11 @@ public final class Rectangle
         this.yMin = yMin;
         this.xMax = xMax;
         this.yMax = yMax;
+    }
+
+    public static Rectangle getUniverseRectangle()
+    {
+        return UNIVERSE_RECTANGLE;
     }
 
     @JsonProperty
@@ -104,7 +116,30 @@ public final class Rectangle
         return new Rectangle(min(this.xMin, other.xMin), min(this.yMin, other.yMin), max(this.xMax, other.xMax), max(this.yMax, other.yMax));
     }
 
-    public int estimateMemorySize()
+    public boolean contains(double x, double y)
+    {
+        return xMin <= x && x <= xMax
+                && yMin <= y && y <= yMax;
+    }
+
+    /**
+     * Returns if this Rectangle contains only a single point.
+     *
+     * @return if xMax==xMin and yMax==yMin
+     */
+    public boolean isPointlike()
+    {
+        return xMin == xMax && yMin == yMax;
+    }
+
+    @Override
+    public Rectangle getExtent()
+    {
+        return this;
+    }
+
+    @Override
+    public long getEstimatedSizeInBytes()
     {
         return INSTANCE_SIZE;
     }

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/rtree/Flatbush.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/rtree/Flatbush.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.geospatial.rtree;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.trino.array.DoubleBigArray;
+import io.trino.geospatial.Rectangle;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A fast, low memory footprint static RTree.
+ * <p>
+ * Packed Hilbert RTrees -- aka Flatbushes -- create very few objects, instead
+ * storing the tree in a flat array.  They support the standard RTree queries,
+ * but cannot be modified once built. It is quite possible to semi-efficiently
+ * remove objects.
+ * <p>
+ * Consider an RTree with branching factor `b`.  Each non-leaf node has two
+ * pieces of information:
+ * 1. The minimum bounding box of all descendants, and
+ * 2. Pointers to its children.
+ * <p>
+ * The former is simply four doubles.  The latter can be derived from the
+ * node's level and which sibling it is.  This means we can actually flatten
+ * the tree into a single array of doubles, four per node.  We can
+ * programmatically find the indices of a node's children (it will be faster if
+ * we pre-compute level offsets), and do envelope checks with just float
+ * operations.  "padded" empty nodes will have NaN entries, which will naturally
+ * return false for all comparison operators, thus being automatically not
+ * selected.
+ * <p>
+ * A critical choice in RTree implementation is how to group leaf nodes as
+ * children (and recursively, their parents).  One method that is very efficient
+ * to construct and comparable to best lookup performance is sorting by an
+ * object's Hilbert curve index.  Hilbert curves are naturally hierarchical, so
+ * successively grouping children and their parents will give a naturally nested
+ * structure.  This means we only need to sort the items once.
+ * <p>
+ * If sort time is a problem, we actually just need to "partition" into groups
+ * of `degree`, since the order of the children of a single parent doesn't
+ * matter.  This could be done with quicksort, stopping once all items at index
+ * `n * degree` are correctly placed.
+ * <p>
+ * Original implementation in Javascript: https://github.com/mourner/flatbush
+ */
+public class Flatbush<T extends HasExtent>
+{
+    // Number of coordinates to define an envelope
+    @VisibleForTesting
+    static final int ENVELOPE_SIZE = 4;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(Flatbush.class).instanceSize();
+    private static final int DEFAULT_DEGREE = 16;
+    // Number of children per node
+    private final int degree;
+    // Offsets in tree for each level
+    private final int[] levelOffsets;
+    // Each node has four doubles: xMin, yMin, xMax, yMax
+    private final DoubleBigArray tree;
+    private final T[] items;
+
+    /**
+     * Build Flatbush RTree for `items`.
+     *
+     * @param items Items to index.
+     * @param degree Number of children for each intermediate node.
+     */
+    public Flatbush(T[] items, int degree)
+    {
+        checkArgument(degree > 0, "degree must be positive");
+        this.degree = degree;
+        this.items = requireNonNull(items, "items is null");
+        this.levelOffsets = calculateLevelOffsets(items.length, degree);
+        this.tree = buildTree();
+    }
+
+    /**
+     * Build Flatbush RTree for `items` with default number of children per node.
+     * <p>
+     * This will use the default degree.
+     *
+     * @param items Items to index.
+     */
+    public Flatbush(T[] items)
+    {
+        this(items, DEFAULT_DEGREE);
+    }
+
+    /**
+     * Calculate the indices for each level.
+     *
+     * A given level contains a certain number of items.  We give it a capacity
+     * equal to the next multiple of `degree`, so that each parent will have
+     * an equal number (`degree`) of children.  This means the next level will
+     * have `capacity/degree` nodes, which yields a capacity equal to the next
+     * multiple, and so on, until the number of items is 1.
+     *
+     * Since we are storing each node as 4 doubles, we will actually multiply
+     * every index by 4.
+     */
+    private static int[] calculateLevelOffsets(int numItems, int degree)
+    {
+        List<Integer> offsets = new ArrayList<>();
+        // Leaf nodes start at 0, root is the last element.
+        offsets.add(0);
+        int level = 0;
+        while (numItems > 1) {
+            // The number of children will be the smallest multiple of degree >= numItems
+            int numChildren = (int) Math.ceil(1.0 * numItems / degree) * degree;
+            offsets.add(offsets.get(level) + ENVELOPE_SIZE * numChildren);
+            numItems = numChildren / degree;
+            level += 1;
+        }
+        return offsets.stream().mapToInt(Integer::intValue).toArray();
+    }
+
+    private DoubleBigArray buildTree()
+    {
+        // We initialize it to NaN, because all comparisons with NaN are false.
+        // Thus the normal intersection logic will not select uninitialized
+        // nodes.
+        DoubleBigArray tree = new DoubleBigArray(Double.NaN);
+        tree.ensureCapacity(levelOffsets[levelOffsets.length - 1] + ENVELOPE_SIZE);
+
+        if (items.length > degree) {
+            sortByHilbertIndex(items);
+        }
+
+        int writeOffset = 0;
+        for (T item : items) {
+            tree.set(writeOffset++, item.getExtent().getXMin());
+            tree.set(writeOffset++, item.getExtent().getYMin());
+            tree.set(writeOffset++, item.getExtent().getXMax());
+            tree.set(writeOffset++, item.getExtent().getYMax());
+        }
+
+        int numChildren = items.length;
+        for (int level = 0; level < levelOffsets.length - 1; level++) {
+            int readOffset = levelOffsets[level];
+            writeOffset = levelOffsets[level + 1];
+            int numParents = 0;
+            double xMin = Double.POSITIVE_INFINITY;
+            double yMin = Double.POSITIVE_INFINITY;
+            double xMax = Double.NEGATIVE_INFINITY;
+            double yMax = Double.NEGATIVE_INFINITY;
+            int child = 0;
+            for (; child < numChildren; child++) {
+                xMin = min(xMin, tree.get(readOffset++));
+                yMin = min(yMin, tree.get(readOffset++));
+                xMax = max(xMax, tree.get(readOffset++));
+                yMax = max(yMax, tree.get(readOffset++));
+
+                if ((child + 1) % degree == 0) {
+                    numParents++;
+                    tree.set(writeOffset++, xMin);
+                    tree.set(writeOffset++, yMin);
+                    tree.set(writeOffset++, xMax);
+                    tree.set(writeOffset++, yMax);
+                    xMin = Double.POSITIVE_INFINITY;
+                    yMin = Double.POSITIVE_INFINITY;
+                    xMax = Double.NEGATIVE_INFINITY;
+                    yMax = Double.NEGATIVE_INFINITY;
+                }
+            }
+
+            if (child % degree != 0) {
+                numParents++;
+                tree.set(writeOffset++, xMin);
+                tree.set(writeOffset++, yMin);
+                tree.set(writeOffset++, xMax);
+                tree.set(writeOffset++, yMax);
+            }
+            numChildren = numParents;
+        }
+
+        return tree;
+    }
+
+    /**
+     * Find intersection candidates for `query` rectangle.
+     * <p>
+     * This will feed to `consumer` each object in the rtree whose bounding
+     * rectangle intersects the query rectangle.  The actual intersection
+     * check will need to be performed by the caller.
+     *
+     * @param query Rectangle for which to search for intersection.
+     * @param consumer Function to call for each intersection candidate.
+     */
+    public void findIntersections(Rectangle query, Consumer<T> consumer)
+    {
+        IntArrayList todoNodes = new IntArrayList(levelOffsets.length * degree);
+        IntArrayList todoLevels = new IntArrayList(levelOffsets.length * degree);
+
+        int rootLevel = levelOffsets.length - 1;
+        int rootIndex = levelOffsets[rootLevel];
+        if (doesIntersect(query, rootIndex)) {
+            todoNodes.push(rootIndex);
+            todoLevels.push(rootLevel);
+        }
+
+        while (!todoNodes.isEmpty()) {
+            int nodeIndex = todoNodes.popInt();
+            int level = todoLevels.popInt();
+
+            if (level == 0) {
+                // This is a leaf node
+                consumer.accept(items[nodeIndex / ENVELOPE_SIZE]);
+            }
+            else {
+                int childrenOffset = getChildrenOffset(nodeIndex, level);
+                for (int i = 0; i < degree; i++) {
+                    int childIndex = childrenOffset + ENVELOPE_SIZE * i;
+                    if (doesIntersect(query, childIndex)) {
+                        todoNodes.push(childIndex);
+                        todoLevels.push(level - 1);
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean doesIntersect(Rectangle query, int nodeIndex)
+    {
+        return query.getXMax() >= tree.get(nodeIndex) // xMin
+                && query.getYMax() >= tree.get(nodeIndex + 1) // yMin
+                && query.getXMin() <= tree.get(nodeIndex + 2) // xMax
+                && query.getYMin() <= tree.get(nodeIndex + 3); // yMax
+    }
+
+    /**
+     * Get the offset of the first child for the node.
+     *
+     * @param nodeIndex Index in tree of first entry for node
+     * @param level Level of node
+     */
+    @VisibleForTesting
+    int getChildrenOffset(int nodeIndex, int level)
+    {
+        int indexInLevel = nodeIndex - levelOffsets[level];
+        return levelOffsets[level - 1] + degree * indexInLevel;
+    }
+
+    @VisibleForTesting
+    int getHeight()
+    {
+        return levelOffsets.length;
+    }
+
+    /*
+     * Sorts items in-place by the Hilbert index of the envelope center.
+     */
+    private void sortByHilbertIndex(T[] items)
+    {
+        if (items == null || items.length < 2) {
+            return;
+        }
+
+        Rectangle totalExtent = items[0].getExtent();
+        for (int i = 1; i < items.length; i++) {
+            totalExtent = totalExtent.merge(items[i].getExtent());
+        }
+
+        HilbertIndex hilbert = new HilbertIndex(totalExtent);
+        Arrays.parallelSort(items, Comparator.comparing(item ->
+                hilbert.indexOf(
+                        (item.getExtent().getXMin() + item.getExtent().getXMax()) / 2,
+                        (item.getExtent().getYMin() + item.getExtent().getYMax()) / 2)));
+    }
+
+    public boolean isEmpty()
+    {
+        return items.length == 0;
+    }
+
+    public long getEstimatedSizeInBytes()
+    {
+        long result = INSTANCE_SIZE + sizeOf(levelOffsets) + tree.sizeOf();
+        for (T item : items) {
+            result += item.getEstimatedSizeInBytes();
+        }
+        return result;
+    }
+}

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/rtree/HasExtent.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/rtree/HasExtent.java
@@ -11,27 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.plugin.geospatial;
+package io.trino.geospatial.rtree;
 
 import io.trino.geospatial.Rectangle;
-import io.trino.spi.function.AccumulatorState;
-import io.trino.spi.function.AccumulatorStateMetadata;
 
-import java.util.List;
-
-@AccumulatorStateMetadata(stateSerializerClass = SpatialPartitioningStateSerializer.class, stateFactoryClass = SpatialPartitioningStateFactory.class)
-public interface SpatialPartitioningState
-        extends AccumulatorState
+public interface HasExtent
 {
-    int getPartitionCount();
+    Rectangle getExtent();
 
-    void setPartitionCount(int partitionCount);
-
-    long getCount();
-
-    void setCount(long count);
-
-    List<Rectangle> getSamples();
-
-    void setSamples(List<Rectangle> samples);
+    long getEstimatedSizeInBytes();
 }

--- a/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/rtree/HilbertIndex.java
+++ b/lib/trino-geospatial-toolkit/src/main/java/io/trino/geospatial/rtree/HilbertIndex.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.geospatial.rtree;
+
+import io.trino.geospatial.Rectangle;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A class that can calculate Hilbert indices.
+ * <p>
+ * A Hilbert index is the index on a Hilbert curve; a Hilbert curve is a
+ * space-filling curve in a rectangle.  This class is instantiated with the
+ * rectangle within which it can calculate the index.
+ * <p>
+ * The (fast) index algorithm is adapted from the C++ from
+ * https://github.com/rawrunprotected/hilbert_curves ,
+ * original algorithm by http://threadlocalmutex.com/?p=126 .
+ */
+public class HilbertIndex
+{
+    private static final int HILBERT_BITS = 16;
+    private static final double HILBERT_MAX = (1 << HILBERT_BITS) - 1;
+
+    private final Rectangle rectangle;
+    private final double xScale;
+    private final double yScale;
+
+    /**
+     * @param rectangle Rectangle defining bounds of Hilbert curve
+     */
+    public HilbertIndex(Rectangle rectangle)
+    {
+        this.rectangle = requireNonNull(rectangle, "rectangle is null");
+        if (rectangle.getXMax() == rectangle.getXMin()) {
+            this.xScale = 0;
+        }
+        else {
+            this.xScale = HILBERT_MAX / (rectangle.getXMax() - rectangle.getXMin());
+        }
+        if (rectangle.getYMax() == rectangle.getYMin()) {
+            this.yScale = 0;
+        }
+        else {
+            this.yScale = HILBERT_MAX / (rectangle.getYMax() - rectangle.getYMin());
+        }
+    }
+
+    /**
+     * Calculate Hilbert index of coordinates in rectangle.
+     * <p>
+     * This gives a reasonable index for coordinates contained in the bounding
+     * rectangle; coordinates not in the box will return `Long.MAX_VALUE`.
+     *
+     * @param x
+     * @param y
+     * @return Hilbert curve index, relative to rectangle
+     */
+    public long indexOf(double x, double y)
+    {
+        if (!rectangle.contains(x, y)) {
+            // Put things outside the box at the end
+            // This will also handle infinities and NaNs
+            return Long.MAX_VALUE;
+        }
+
+        int xInt = (int) (xScale * (x - rectangle.getXMin()));
+        int yInt = (int) (yScale * (y - rectangle.getYMin()));
+        return discreteIndexOf(xInt, yInt);
+    }
+
+    /**
+     * Calculate the Hilbert index of a discrete coordinate.
+     * <p>
+     * Since Java doesn't have unsigned ints, we put incoming ints into the
+     * lower 32 bits of a long and do the calculations there.
+     *
+     * @param x discrete positive x coordinate
+     * @param y discrete positive y coordinate
+     * @return Hilbert curve index
+     */
+    private long discreteIndexOf(int x, int y)
+    {
+        int a = x ^ y;
+        int b = 0x0000FFFF ^ a;
+        int c = 0x0000FFFF ^ (x | y);
+        int d = x & (y ^ 0x0000FFFF);
+
+        int e = a | (b >>> 1);
+        int f = (a >>> 1) ^ a;
+        int g = ((c >>> 1) ^ (b & (d >>> 1))) ^ c;
+        int h = ((a & (c >>> 1)) ^ (d >>> 1)) ^ d;
+
+        a = e;
+        b = f;
+        c = g;
+        d = h;
+        e = (a & (a >>> 2)) ^ (b & (b >>> 2));
+        f = (a & (b >>> 2)) ^ (b & ((a ^ b) >>> 2));
+        g ^= (a & (c >>> 2)) ^ (b & (d >>> 2));
+        h ^= (b & (c >>> 2)) ^ ((a ^ b) & (d >>> 2));
+
+        a = e;
+        b = f;
+        c = g;
+        d = h;
+        e = (a & (a >>> 4)) ^ (b & (b >>> 4));
+        f = (a & (b >>> 4)) ^ (b & ((a ^ b) >>> 4));
+        g ^= (a & (c >>> 4)) ^ (b & (d >>> 4));
+        h ^= (b & (c >>> 4)) ^ ((a ^ b) & (d >>> 4));
+
+        a = e;
+        b = f;
+        c = g;
+        d = h;
+        g ^= (a & (c >>> 8)) ^ (b & (d >>> 8));
+        h ^= (b & (c >>> 8)) ^ ((a ^ b) & (d >>> 8));
+
+        a = (g ^ (g >>> 1));
+        b = (h ^ (h >>> 1));
+
+        int i0 = (x ^ y);
+        int i1 = (b | (0x0000FFFF ^ (i0 | a)));
+
+        i0 = (i0 | (i0 << 8)) & 0x00FF00FF;
+        i0 = (i0 | (i0 << 4)) & 0x0F0F0F0F;
+        i0 = (i0 | (i0 << 2)) & 0x33333333;
+        i0 = (i0 | (i0 << 1)) & 0x55555555;
+
+        i1 = (i1 | (i1 << 8)) & 0x00FF00FF;
+        i1 = (i1 | (i1 << 4)) & 0x0F0F0F0F;
+        i1 = (i1 | (i1 << 2)) & 0x33333333;
+        i1 = (i1 | (i1 << 1)) & 0x55555555;
+
+        return (((long) ((i1 << 1) | i0)) << 32) >>> 32;
+    }
+}

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/TestGeometryUtils.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/TestGeometryUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.geospatial;
+import com.esri.core.geometry.ogc.OGCGeometry;
+import org.testng.annotations.Test;
+
+import static io.trino.geospatial.GeometryUtils.getExtent;
+import static org.testng.Assert.assertEquals;
+
+public class TestGeometryUtils
+{
+    @Test
+    public void testGetExtent()
+    {
+        assertGetExtent(
+                "POINT (-23.4 12.2)",
+                new Rectangle(-23.4, 12.2, -23.4, 12.2));
+        assertGetExtent(
+                "LINESTRING (-75.9375 23.6359, -75.9375 23.6364)",
+                new Rectangle(-75.9375, 23.6359, -75.9375, 23.6364));
+        assertGetExtent(
+                "GEOMETRYCOLLECTION (" +
+                        "  LINESTRING (-75.9375 23.6359, -75.9375 23.6364)," +
+                        "  MULTIPOLYGON (((-75.9375 23.45520, -75.9371 23.4554, -75.9375 23.46023325, -75.9375 23.45520)))" +
+                        ")",
+                new Rectangle(-75.9375, 23.4552, -75.9371, 23.6364));
+    }
+
+    private void assertGetExtent(String wkt, Rectangle expected)
+    {
+        assertEquals(getExtent(OGCGeometry.fromText(wkt)), expected);
+    }
+}

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/TestKdbTree.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/TestKdbTree.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static io.trino.geospatial.KdbTree.buildKdbTree;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.POSITIVE_INFINITY;
 import static org.testng.Assert.assertEquals;
 
 public class TestKdbTree
@@ -29,7 +31,6 @@ public class TestKdbTree
     @Test
     public void testSerde()
     {
-        Rectangle extent = new Rectangle(0, 0, 9, 4);
         ImmutableList.Builder<Rectangle> rectangles = ImmutableList.builder();
         for (double x = 0; x < 10; x += 1) {
             for (double y = 0; y < 5; y += 1) {
@@ -37,9 +38,9 @@ public class TestKdbTree
             }
         }
 
-        testSerializationRoundtrip(buildKdbTree(100, extent, rectangles.build()));
-        testSerializationRoundtrip(buildKdbTree(20, extent, rectangles.build()));
-        testSerializationRoundtrip(buildKdbTree(10, extent, rectangles.build()));
+        testSerializationRoundtrip(buildKdbTree(100, rectangles.build()));
+        testSerializationRoundtrip(buildKdbTree(20, rectangles.build()));
+        testSerializationRoundtrip(buildKdbTree(10, rectangles.build()));
     }
 
     private void testSerializationRoundtrip(KdbTree tree)
@@ -57,7 +58,6 @@ public class TestKdbTree
 
     private void testSinglePartition(double width, double height)
     {
-        Rectangle extent = new Rectangle(0, 0, 9, 4);
         ImmutableList.Builder<Rectangle> rectangles = ImmutableList.builder();
         for (double x = 0; x < 10; x += 1) {
             for (double y = 0; y < 5; y += 1) {
@@ -65,13 +65,13 @@ public class TestKdbTree
             }
         }
 
-        KdbTree tree = buildKdbTree(100, extent, rectangles.build());
+        KdbTree tree = buildKdbTree(100, rectangles.build());
 
         assertEquals(tree.getLeaves().size(), 1);
 
         Map.Entry<Integer, Rectangle> entry = Iterables.getOnlyElement(tree.getLeaves().entrySet());
         assertEquals(entry.getKey().intValue(), 0);
-        assertEquals(entry.getValue(), extent);
+        assertEquals(entry.getValue(), Rectangle.getUniverseRectangle());
     }
 
     @Test
@@ -83,7 +83,6 @@ public class TestKdbTree
 
     private void testSplitVertically(double width, double height)
     {
-        Rectangle extent = new Rectangle(0, 0, 9, 4);
         ImmutableList.Builder<Rectangle> rectangles = ImmutableList.builder();
         for (int x = 0; x < 10; x++) {
             for (int y = 0; y < 5; y++) {
@@ -91,16 +90,22 @@ public class TestKdbTree
             }
         }
 
-        KdbTree treeCopy = buildKdbTree(25, extent, rectangles.build());
+        KdbTree tree = buildKdbTree(25, rectangles.build());
 
-        Map<Integer, Rectangle> leafNodes = treeCopy.getLeaves();
+        Map<Integer, Rectangle> leafNodes = tree.getLeaves();
         assertEquals(leafNodes.size(), 2);
         assertEquals(leafNodes.keySet(), ImmutableSet.of(0, 1));
-        assertEquals(leafNodes.get(0), new Rectangle(0, 0, 4.5, 4));
-        assertEquals(leafNodes.get(1), new Rectangle(4.5, 0, 9, 4));
+        assertEquals(leafNodes.get(0), new Rectangle(NEGATIVE_INFINITY, NEGATIVE_INFINITY, 4.5, POSITIVE_INFINITY));
+        assertEquals(leafNodes.get(1), new Rectangle(4.5, NEGATIVE_INFINITY, POSITIVE_INFINITY, POSITIVE_INFINITY));
 
-        assertPartitions(treeCopy, new Rectangle(1, 1, 2, 2), ImmutableSet.of(0));
-        assertPartitions(treeCopy, new Rectangle(1, 1, 5, 2), ImmutableSet.of(0, 1));
+        assertPartitions(tree, new Rectangle(1, 1, 2, 2), ImmutableSet.of(0));
+        assertPartitions(tree, new Rectangle(1, 1, 5, 2), ImmutableSet.of(0, 1));
+        assertPartitions(tree, new Rectangle(5, 1, 5, 2), ImmutableSet.of(1));
+        // Partitions do not contain right or top border, but contain left and bottom borders
+        assertPartitions(tree, new Rectangle(4.5, 0, 4.5, 0), ImmutableSet.of(1));
+        // "Outside" partitions
+        assertPartitions(tree, new Rectangle(-6, 2, -6, 2), ImmutableSet.of(0));
+        assertPartitions(tree, new Rectangle(20, 2, 20, 2), ImmutableSet.of(1));
     }
 
     @Test
@@ -112,7 +117,6 @@ public class TestKdbTree
 
     private void testSplitHorizontally(double width, double height)
     {
-        Rectangle extent = new Rectangle(0, 0, 4, 9);
         ImmutableList.Builder<Rectangle> rectangles = ImmutableList.builder();
         for (int x = 0; x < 5; x++) {
             for (int y = 0; y < 10; y++) {
@@ -120,27 +124,31 @@ public class TestKdbTree
             }
         }
 
-        KdbTree tree = buildKdbTree(25, extent, rectangles.build());
+        KdbTree tree = buildKdbTree(25, rectangles.build());
 
         Map<Integer, Rectangle> leafNodes = tree.getLeaves();
-        assertEquals(leafNodes.size(), 2);
-        assertEquals(leafNodes.keySet(), ImmutableSet.of(0, 1));
-        assertEquals(leafNodes.get(0), new Rectangle(0, 0, 4, 4.5));
-        assertEquals(leafNodes.get(1), new Rectangle(0, 4.5, 4, 9));
+        assertEquals(leafNodes.size(), 3);
+        assertEquals(leafNodes.keySet(), ImmutableSet.of(0, 1, 2));
+        assertEquals(leafNodes.get(0), new Rectangle(NEGATIVE_INFINITY, NEGATIVE_INFINITY, 2.5, 4.5));
+        assertEquals(leafNodes.get(1), new Rectangle(NEGATIVE_INFINITY, 4.5, 2.5, POSITIVE_INFINITY));
+        assertEquals(leafNodes.get(2), new Rectangle(2.5, NEGATIVE_INFINITY, POSITIVE_INFINITY, POSITIVE_INFINITY));
 
         // points inside and outside partitions
         assertPartitions(tree, new Rectangle(1, 1, 1, 1), ImmutableSet.of(0));
         assertPartitions(tree, new Rectangle(1, 6, 1, 6), ImmutableSet.of(1));
-        assertPartitions(tree, new Rectangle(5, 1, 5, 1), ImmutableSet.of());
+        assertPartitions(tree, new Rectangle(5, 1, 5, 1), ImmutableSet.of(2));
 
         // point on the border separating two partitions
-        assertPartitions(tree, new Rectangle(1, 4.5, 1, 4.5), ImmutableSet.of(0, 1));
+        assertPartitions(tree, new Rectangle(1, 4.5, 1, 4.5), ImmutableSet.of(1));
+        assertPartitions(tree, new Rectangle(2.5, 4.5, 2.5, 4.5), ImmutableSet.of(2));
+        assertPartitions(tree, new Rectangle(2.5, 1, 2.5, 1), ImmutableSet.of(2));
+        assertPartitions(tree, new Rectangle(2.5, 5, 2.5, 5), ImmutableSet.of(2));
 
         // rectangles
         assertPartitions(tree, new Rectangle(1, 1, 2, 2), ImmutableSet.of(0));
         assertPartitions(tree, new Rectangle(1, 6, 2, 7), ImmutableSet.of(1));
         assertPartitions(tree, new Rectangle(1, 1, 2, 5), ImmutableSet.of(0, 1));
-        assertPartitions(tree, new Rectangle(5, 1, 6, 2), ImmutableSet.of());
+        assertPartitions(tree, new Rectangle(5, 1, 6, 2), ImmutableSet.of(2));
     }
 
     private void assertPartitions(KdbTree kdbTree, Rectangle envelope, Set<Integer> partitions)
@@ -159,7 +167,6 @@ public class TestKdbTree
 
     private void testEvenDistribution(double width, double height)
     {
-        Rectangle extent = new Rectangle(0, 0, 9, 4);
         ImmutableList.Builder<Rectangle> rectangles = ImmutableList.builder();
         for (int x = 0; x < 10; x++) {
             for (int y = 0; y < 5; y++) {
@@ -167,17 +174,17 @@ public class TestKdbTree
             }
         }
 
-        KdbTree tree = buildKdbTree(10, extent, rectangles.build());
+        KdbTree tree = buildKdbTree(10, rectangles.build());
 
         Map<Integer, Rectangle> leafNodes = tree.getLeaves();
         assertEquals(leafNodes.size(), 6);
         assertEquals(leafNodes.keySet(), ImmutableSet.of(0, 1, 2, 3, 4, 5));
-        assertEquals(leafNodes.get(0), new Rectangle(0, 0, 2.5, 2.5));
-        assertEquals(leafNodes.get(1), new Rectangle(0, 2.5, 2.5, 4));
-        assertEquals(leafNodes.get(2), new Rectangle(2.5, 0, 4.5, 4));
-        assertEquals(leafNodes.get(3), new Rectangle(4.5, 0, 7.5, 2.5));
-        assertEquals(leafNodes.get(4), new Rectangle(4.5, 2.5, 7.5, 4));
-        assertEquals(leafNodes.get(5), new Rectangle(7.5, 0, 9, 4));
+        assertEquals(leafNodes.get(0), new Rectangle(NEGATIVE_INFINITY, NEGATIVE_INFINITY, 2.5, 2.5));
+        assertEquals(leafNodes.get(1), new Rectangle(2.5, NEGATIVE_INFINITY, 4.5, 2.5));
+        assertEquals(leafNodes.get(2), new Rectangle(NEGATIVE_INFINITY, 2.5, 4.5, POSITIVE_INFINITY));
+        assertEquals(leafNodes.get(3), new Rectangle(4.5, NEGATIVE_INFINITY, 7.5, 2.5));
+        assertEquals(leafNodes.get(4), new Rectangle(7.5, NEGATIVE_INFINITY, POSITIVE_INFINITY, 2.5));
+        assertEquals(leafNodes.get(5), new Rectangle(4.5, 2.5, POSITIVE_INFINITY, POSITIVE_INFINITY));
     }
 
     @Test
@@ -189,7 +196,6 @@ public class TestKdbTree
 
     private void testSkewedDistribution(double width, double height)
     {
-        Rectangle extent = new Rectangle(0, 0, 9, 4);
         ImmutableList.Builder<Rectangle> rectangles = ImmutableList.builder();
         for (int x = 0; x < 10; x++) {
             for (int y = 0; y < 5; y++) {
@@ -203,20 +209,20 @@ public class TestKdbTree
             }
         }
 
-        KdbTree tree = buildKdbTree(10, extent, rectangles.build());
+        KdbTree tree = buildKdbTree(10, rectangles.build());
 
         Map<Integer, Rectangle> leafNodes = tree.getLeaves();
         assertEquals(leafNodes.size(), 9);
         assertEquals(leafNodes.keySet(), ImmutableSet.of(0, 1, 2, 3, 4, 5, 6, 7, 8));
-        assertEquals(leafNodes.get(0), new Rectangle(0, 0, 1.5, 2.5));
-        assertEquals(leafNodes.get(1), new Rectangle(1.5, 0, 3.5, 2.5));
-        assertEquals(leafNodes.get(2), new Rectangle(0, 2.5, 3.5, 4));
-        assertEquals(leafNodes.get(3), new Rectangle(3.5, 0, 5.1, 1.75));
-        assertEquals(leafNodes.get(4), new Rectangle(3.5, 1.75, 5.1, 4));
-        assertEquals(leafNodes.get(5), new Rectangle(5.1, 0, 5.9, 1.75));
-        assertEquals(leafNodes.get(6), new Rectangle(5.9, 0, 9, 1.75));
-        assertEquals(leafNodes.get(7), new Rectangle(5.1, 1.75, 7.5, 4));
-        assertEquals(leafNodes.get(8), new Rectangle(7.5, 1.75, 9, 4));
+        assertEquals(leafNodes.get(0), new Rectangle(NEGATIVE_INFINITY, NEGATIVE_INFINITY, 1.5, 2.5));
+        assertEquals(leafNodes.get(1), new Rectangle(1.5, NEGATIVE_INFINITY, 3.5, 2.5));
+        assertEquals(leafNodes.get(2), new Rectangle(3.5, NEGATIVE_INFINITY, 5.1, 2.5));
+        assertEquals(leafNodes.get(3), new Rectangle(NEGATIVE_INFINITY, 2.5, 2.5, POSITIVE_INFINITY));
+        assertEquals(leafNodes.get(4), new Rectangle(2.5, 2.5, 5.1, POSITIVE_INFINITY));
+        assertEquals(leafNodes.get(5), new Rectangle(5.1, NEGATIVE_INFINITY, 5.9, 1.75));
+        assertEquals(leafNodes.get(6), new Rectangle(5.9, NEGATIVE_INFINITY, POSITIVE_INFINITY, 1.75));
+        assertEquals(leafNodes.get(7), new Rectangle(5.1, 1.75, 7.5, POSITIVE_INFINITY));
+        assertEquals(leafNodes.get(8), new Rectangle(7.5, 1.75, POSITIVE_INFINITY, POSITIVE_INFINITY));
     }
 
     @Test
@@ -228,7 +234,6 @@ public class TestKdbTree
 
     private void testCantSplitVertically(double width, double height)
     {
-        Rectangle extent = new Rectangle(0, 0, 9 + width, 4 + height);
         ImmutableList.Builder<Rectangle> rectangles = ImmutableList.builder();
         for (int y = 0; y < 5; y++) {
             for (int i = 0; i < 10; i++) {
@@ -237,21 +242,21 @@ public class TestKdbTree
             }
         }
 
-        KdbTree tree = buildKdbTree(10, extent, rectangles.build());
+        KdbTree tree = buildKdbTree(10, rectangles.build());
 
         Map<Integer, Rectangle> leafNodes = tree.getLeaves();
         assertEquals(leafNodes.size(), 10);
         assertEquals(leafNodes.keySet(), ImmutableSet.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9));
-        assertEquals(leafNodes.get(0), new Rectangle(0, 0, 4.5, 0.5));
-        assertEquals(leafNodes.get(1), new Rectangle(0, 0.5, 4.5, 1.5));
-        assertEquals(leafNodes.get(2), new Rectangle(0, 1.5, 4.5, 2.5));
-        assertEquals(leafNodes.get(3), new Rectangle(0, 2.5, 4.5, 3.5));
-        assertEquals(leafNodes.get(4), new Rectangle(0, 3.5, 4.5, 4 + height));
-        assertEquals(leafNodes.get(5), new Rectangle(4.5, 0, 9 + width, 0.5));
-        assertEquals(leafNodes.get(6), new Rectangle(4.5, 0.5, 9 + width, 1.5));
-        assertEquals(leafNodes.get(7), new Rectangle(4.5, 1.5, 9 + width, 2.5));
-        assertEquals(leafNodes.get(8), new Rectangle(4.5, 2.5, 9 + width, 3.5));
-        assertEquals(leafNodes.get(9), new Rectangle(4.5, 3.5, 9 + width, 4 + height));
+        assertEquals(leafNodes.get(0), new Rectangle(NEGATIVE_INFINITY, NEGATIVE_INFINITY, 4.5, 0.5));
+        assertEquals(leafNodes.get(1), new Rectangle(NEGATIVE_INFINITY, 0.5, 4.5, 1.5));
+        assertEquals(leafNodes.get(2), new Rectangle(NEGATIVE_INFINITY, 1.5, 4.5, 2.5));
+        assertEquals(leafNodes.get(3), new Rectangle(NEGATIVE_INFINITY, 2.5, 4.5, 3.5));
+        assertEquals(leafNodes.get(4), new Rectangle(NEGATIVE_INFINITY, 3.5, 4.5, POSITIVE_INFINITY));
+        assertEquals(leafNodes.get(5), new Rectangle(4.5, NEGATIVE_INFINITY, POSITIVE_INFINITY, 0.5));
+        assertEquals(leafNodes.get(6), new Rectangle(4.5, 0.5, POSITIVE_INFINITY, 1.5));
+        assertEquals(leafNodes.get(7), new Rectangle(4.5, 1.5, POSITIVE_INFINITY, 2.5));
+        assertEquals(leafNodes.get(8), new Rectangle(4.5, 2.5, POSITIVE_INFINITY, 3.5));
+        assertEquals(leafNodes.get(9), new Rectangle(4.5, 3.5, POSITIVE_INFINITY, POSITIVE_INFINITY));
     }
 
     @Test
@@ -263,7 +268,6 @@ public class TestKdbTree
 
     private void testCantSplit(double width, double height)
     {
-        Rectangle extent = new Rectangle(0, 0, 9 + width, 4 + height);
         ImmutableList.Builder<Rectangle> rectangles = ImmutableList.builder();
         for (int i = 0; i < 10; i++) {
             for (int j = 0; j < 5; j++) {
@@ -272,12 +276,12 @@ public class TestKdbTree
             }
         }
 
-        KdbTree tree = buildKdbTree(10, extent, rectangles.build());
+        KdbTree tree = buildKdbTree(10, rectangles.build());
 
         Map<Integer, Rectangle> leafNodes = tree.getLeaves();
         assertEquals(leafNodes.size(), 2);
         assertEquals(leafNodes.keySet(), ImmutableSet.of(0, 1));
-        assertEquals(leafNodes.get(0), new Rectangle(0, 0, 4.5, 4 + height));
-        assertEquals(leafNodes.get(1), new Rectangle(4.5, 0, 9 + width, 4 + height));
+        assertEquals(leafNodes.get(0), new Rectangle(NEGATIVE_INFINITY, NEGATIVE_INFINITY, 4.5, POSITIVE_INFINITY));
+        assertEquals(leafNodes.get(1), new Rectangle(4.5, NEGATIVE_INFINITY, POSITIVE_INFINITY, POSITIVE_INFINITY));
     }
 }

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/BenchmarkFlatbushBuild.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/BenchmarkFlatbushBuild.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.geospatial.rtree;
+
+import io.trino.geospatial.Rectangle;
+import io.trino.jmh.Benchmarks;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.options.WarmupMode;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.geospatial.rtree.RtreeTestUtils.makeRectangles;
+import static org.testng.Assert.assertEquals;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkFlatbushBuild
+{
+    private static final int SEED = 613;
+
+    @Benchmark
+    public Flatbush buildRtree(BenchmarkData data)
+    {
+        return new Flatbush<>(
+                data.getBuildRectangles().toArray(new Rectangle[] {}),
+                data.getRtreeDegree());
+    }
+
+    @Test
+    public void testBuildRtree()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        Flatbush benchmarkResult = buildRtree(data);
+
+        List<Rectangle> buildRectangles = makeRectangles(new Random(SEED), 1000);
+        Flatbush flatbush = new Flatbush(buildRectangles.toArray(new Rectangle[] {}), 8);
+
+        assertEquals(benchmarkResult.getEstimatedSizeInBytes(), flatbush.getEstimatedSizeInBytes());
+        assertEquals(benchmarkResult.getHeight(), flatbush.getHeight());
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"8", "16", "32"})
+        private int rtreeDegree = 8;
+        @Param({"1000", "3000", "10000", "30000", "100000", "300000", "1000000"})
+        private int numBuildRectangles = 1000;
+
+        private List<Rectangle> buildRectangles;
+
+        @Setup
+        public void setup()
+        {
+            Random random = new Random(SEED);
+            buildRectangles = makeRectangles(random, numBuildRectangles);
+        }
+
+        public int getRtreeDegree()
+        {
+            return rtreeDegree;
+        }
+
+        public List<Rectangle> getBuildRectangles()
+        {
+            return buildRectangles;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        new BenchmarkFlatbushBuild().testBuildRtree();
+
+        Benchmarks.benchmark(BenchmarkFlatbushBuild.class, WarmupMode.BULK).run();
+    }
+}

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/BenchmarkFlatbushQuery.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/BenchmarkFlatbushQuery.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.geospatial.rtree;
+
+import io.trino.geospatial.Rectangle;
+import io.trino.jmh.Benchmarks;
+import org.locationtech.jts.index.ItemVisitor;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.options.WarmupMode;
+import org.testng.annotations.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static io.trino.geospatial.rtree.RtreeTestUtils.makeRectangles;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(2)
+@Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkFlatbushQuery
+{
+    private static final int SEED = 613;
+    private static final int NUM_PROBE_RECTANGLES = 1000;
+
+    @Benchmark
+    @OperationsPerInvocation(NUM_PROBE_RECTANGLES)
+    public void rtreeQuery(BenchmarkData data, Blackhole blackhole)
+    {
+        rtreeQueryProbe(data, blackhole::consume);
+    }
+
+    private void rtreeQueryProbe(BenchmarkData data, ItemVisitor visitor)
+    {
+        for (Rectangle query : data.getProbeRectangles()) {
+            data.getRtree().findIntersections(query, visitor::visitItem);
+        }
+    }
+
+    @Test
+    public void testRtreeQuery()
+    {
+        for (int i = 0; i < 1000; i++) {
+            TestVisitor visitor1 = new TestVisitor();
+            BenchmarkData data = new BenchmarkData();
+            data.setup();
+            rtreeQueryProbe(data, visitor1::visit);
+
+            TestVisitor visitor2 = new TestVisitor();
+            Random random = new Random(SEED);
+            List<Rectangle> probeRectangles = makeRectangles(random, NUM_PROBE_RECTANGLES);
+            Flatbush<Rectangle> rtree = new Flatbush<>(makeRectangles(random, 1000).toArray(new Rectangle[] {}), 8);
+            for (Rectangle query : probeRectangles) {
+                rtree.findIntersections(query, visitor2::visit);
+            }
+
+            assertEquals(visitor1.getSize(), visitor2.getSize());
+        }
+    }
+
+    public static class TestVisitor
+    {
+        private List<Rectangle> recs = new LinkedList<>();
+
+        public void visit(Object obj)
+        {
+            assertEquals(obj.getClass(), Rectangle.class);
+            Rectangle rec = (Rectangle) obj;
+            assertFalse(rec.contains(110f, 110f));
+            recs.add(rec);
+        }
+
+        public int getSize()
+        {
+            return recs.size();
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"8", "16", "32"})
+        private int rtreeDegree = 8;
+        @Param({"1000", "3000", "10000", "30000", "100000", "300000", "1000000"})
+        private int numBuildRectangles = 1000;
+
+        private List<Rectangle> probeRectangles;
+        private Flatbush<Rectangle> rtree;
+
+        @Setup
+        public void setup()
+        {
+            Random random = new Random(SEED);
+            probeRectangles = makeRectangles(random, NUM_PROBE_RECTANGLES);
+            rtree = buildRtree(makeRectangles(random, numBuildRectangles));
+        }
+
+        public List<Rectangle> getProbeRectangles()
+        {
+            return probeRectangles;
+        }
+
+        public Flatbush<Rectangle> getRtree()
+        {
+            return rtree;
+        }
+
+        private Flatbush<Rectangle> buildRtree(List<Rectangle> rectangles)
+        {
+            return new Flatbush<>(rectangles.toArray(new Rectangle[] {}), rtreeDegree);
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        new BenchmarkFlatbushQuery().testRtreeQuery();
+
+        Benchmarks.benchmark(BenchmarkFlatbushQuery.class, WarmupMode.BULK).run();
+    }
+}

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/BenchmarkJtsStrTreeBuild.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/BenchmarkJtsStrTreeBuild.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.geospatial.rtree;
+
+import io.trino.jmh.Benchmarks;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.index.strtree.STRtree;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.options.WarmupMode;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static io.trino.geospatial.rtree.RtreeTestUtils.makeRectangles;
+import static org.testng.Assert.assertEquals;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(2)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkJtsStrTreeBuild
+{
+    private static final int SEED = 613;
+
+    @Benchmark
+    public STRtree buildRtree(BenchmarkData data)
+    {
+        STRtree rtree = new STRtree();
+        for (Envelope envelope : data.getBuildEnvelopes()) {
+            rtree.insert(envelope, envelope);
+        }
+        rtree.build();
+        return rtree;
+    }
+
+    @Test
+    public void testBuildRtree()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        STRtree benchmarkResult = buildRtree(data);
+
+        STRtree rtree = new STRtree();
+        List<Envelope> buildEnvelopes = makeRectangles(new Random(SEED), 100).stream()
+                .map(rectangle -> new Envelope(rectangle.getXMin(), rectangle.getXMax(), rectangle.getYMin(), rectangle.getYMax()))
+                .collect(Collectors.toList());
+        for (Envelope envelope : buildEnvelopes) {
+            rtree.insert(envelope, envelope);
+        }
+        rtree.build();
+
+        assertEquals(benchmarkResult.size(), rtree.size());
+        assertEquals(benchmarkResult.depth(), rtree.depth());
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"1000", "3000", "10000", "30000", "100000", "300000", "1000000"})
+        private int numBuildEnvelopes = 100;
+
+        private List<Envelope> buildEnvelopes;
+
+        @Setup
+        public void setup()
+        {
+            buildEnvelopes = makeRectangles(new Random(SEED), numBuildEnvelopes).stream()
+                    .map(rectangle -> new Envelope(rectangle.getXMin(), rectangle.getXMax(), rectangle.getYMin(), rectangle.getYMax()))
+                    .collect(Collectors.toList());
+        }
+
+        public List<Envelope> getBuildEnvelopes()
+        {
+            return buildEnvelopes;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        new BenchmarkJtsStrTreeBuild().testBuildRtree();
+
+        Benchmarks.benchmark(BenchmarkJtsStrTreeBuild.class, WarmupMode.BULK).run();
+    }
+}

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/BenchmarkJtsStrTreeQuery.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/BenchmarkJtsStrTreeQuery.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.geospatial.rtree;
+
+import io.trino.jmh.Benchmarks;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.index.ItemVisitor;
+import org.locationtech.jts.index.strtree.STRtree;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.options.WarmupMode;
+import org.testng.annotations.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static io.trino.geospatial.rtree.RtreeTestUtils.makeRectangles;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(2)
+@Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkJtsStrTreeQuery
+{
+    private static final int SEED = 613;
+    private static final int NUM_PROBE_RECTANGLES = 1000;
+
+    @Benchmark
+    @OperationsPerInvocation(NUM_PROBE_RECTANGLES)
+    public void rtreeQuery(BenchmarkData data, Blackhole blackhole)
+    {
+        rtreeQueryProbe(data, blackhole::consume);
+    }
+
+    private void rtreeQueryProbe(BenchmarkData data, ItemVisitor visitor)
+    {
+        for (Envelope query : data.getProbeEnvs()) {
+            data.getRtree().query(query, visitor);
+        }
+    }
+
+    @Test
+    public void testRtreeQuery()
+    {
+        TestVisitor visitor1 = new TestVisitor();
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        rtreeQueryProbe(data, visitor1::visit);
+
+        TestVisitor visitor2 = new TestVisitor();
+        Random random = new Random(SEED);
+        List<Envelope> probeEnvs = makeRectangles(random, NUM_PROBE_RECTANGLES).stream()
+                .map(rect -> new Envelope(rect.getXMin(), rect.getXMax(), rect.getYMin(), rect.getYMax()))
+                .collect(Collectors.toList());
+        List<Envelope> buildEnvs = makeRectangles(random, 100).stream()
+                .map(rect -> new Envelope(rect.getXMin(), rect.getXMax(), rect.getYMin(), rect.getYMax()))
+                .collect(Collectors.toList());
+        STRtree rtree = new STRtree();
+        for (Envelope env : buildEnvs) {
+            rtree.insert(env, env);
+        }
+        rtree.build();
+        for (Envelope query : probeEnvs) {
+            rtree.query(query, visitor2::visit);
+        }
+
+        assertEquals(visitor1.getSize(), visitor2.getSize());
+    }
+
+    public static class TestVisitor
+    {
+        private List<Envelope> envs = new LinkedList<>();
+
+        public void visit(Object obj)
+        {
+            assertEquals(obj.getClass(), Envelope.class);
+            Envelope env = (Envelope) obj;
+            assertFalse(env.contains(100f, 100f));
+            envs.add(env);
+        }
+
+        public int getSize()
+        {
+            return envs.size();
+        }
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        @Param({"1000", "3000", "10000", "30000", "100000", "300000", "1000000"})
+        private int numBuildRectangles = 100;
+
+        private List<Envelope> probeEnvs;
+        private STRtree rtree;
+
+        @Setup
+        public void setup()
+        {
+            Random random = new Random(SEED);
+            probeEnvs = makeRectangles(random, NUM_PROBE_RECTANGLES).stream()
+                    .map(rect -> new Envelope(rect.getXMin(), rect.getXMax(), rect.getYMin(), rect.getYMax()))
+                    .collect(Collectors.toList());
+            List<Envelope> buildEnvs = makeRectangles(random, numBuildRectangles).stream()
+                    .map(rect -> new Envelope(rect.getXMin(), rect.getXMax(), rect.getYMin(), rect.getYMax()))
+                    .collect(Collectors.toList());
+            rtree = buildRtree(buildEnvs);
+        }
+
+        public List<Envelope> getProbeEnvs()
+        {
+            return probeEnvs;
+        }
+
+        public STRtree getRtree()
+        {
+            return rtree;
+        }
+
+        private STRtree buildRtree(List<Envelope> envs)
+        {
+            STRtree rtree = new STRtree();
+            for (Envelope env : envs) {
+                rtree.insert(env, env);
+            }
+            rtree.build();
+            return rtree;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        new BenchmarkJtsStrTreeQuery().testRtreeQuery();
+
+        Benchmarks.benchmark(BenchmarkJtsStrTreeQuery.class, WarmupMode.BULK).run();
+    }
+}

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/RtreeTestUtils.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/RtreeTestUtils.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.geospatial.rtree;
+
+import io.trino.geospatial.Rectangle;
+
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class RtreeTestUtils
+{
+    private RtreeTestUtils() {}
+
+    public static List<Rectangle> makeRectangles(Random random, int numRectangles)
+    {
+        return IntStream.range(0, numRectangles)
+                .mapToObj(i -> makeRectangle(random))
+                .collect(Collectors.toList());
+    }
+
+    /*
+     * Make a random rectangle at a random origin of size < 10.
+     */
+    private static Rectangle makeRectangle(Random random)
+    {
+        double minX = randomDouble(random, -100, 100);
+        double minY = randomDouble(random, -100, 100);
+        double sizeX = randomDouble(random, 0.0, 10);
+        double sizeY = randomDouble(random, 0.0, 10);
+        return new Rectangle(minX, minY, minX + sizeX, minY + sizeY);
+    }
+
+    private static double randomDouble(Random random, double min, double max)
+    {
+        return min + random.nextDouble() * (max - min);
+    }
+}

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/TestFlatbush.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/TestFlatbush.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.geospatial.rtree;
+
+import com.esri.core.geometry.Point;
+import com.esri.core.geometry.ogc.OGCGeometry;
+import com.esri.core.geometry.ogc.OGCPoint;
+import com.google.common.collect.ImmutableList;
+import io.trino.geospatial.GeometryUtils;
+import io.trino.geospatial.Rectangle;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.geospatial.rtree.Flatbush.ENVELOPE_SIZE;
+import static io.trino.geospatial.rtree.RtreeTestUtils.makeRectangles;
+import static java.lang.Double.NEGATIVE_INFINITY;
+import static java.lang.Double.POSITIVE_INFINITY;
+import static java.util.stream.Collectors.toList;
+import static org.testng.Assert.assertEquals;
+
+public class TestFlatbush
+{
+    private static final Rectangle EVERYTHING = new Rectangle(NEGATIVE_INFINITY, NEGATIVE_INFINITY, POSITIVE_INFINITY, POSITIVE_INFINITY);
+
+    private static final Comparator<Rectangle> RECTANGLE_COMPARATOR = Comparator
+            .comparing(Rectangle::getXMin)
+            .thenComparing(Rectangle::getYMin)
+            .thenComparing(Rectangle::getXMax)
+            .thenComparing(Rectangle::getYMax);
+
+    //  2 intersecting polygons: A and B
+    private static final OGCGeometry POLYGON_A = OGCGeometry.fromText("POLYGON ((0 0, -0.5 2.5, 0 5, 2.5 5.5, 5 5, 5.5 2.5, 5 0, 2.5 -0.5, 0 0))");
+    private static final OGCGeometry POLYGON_B = OGCGeometry.fromText("POLYGON ((4 4, 3.5 7, 4 10, 7 10.5, 10 10, 10.5 7, 10 4, 7 3.5, 4 4))");
+
+    // A set of points: X in A, Y in A and B, Z in B, W outside of A and B
+    private static final OGCGeometry POINT_X = new OGCPoint(new Point(1.0, 1.0), null);
+    private static final OGCGeometry POINT_Y = new OGCPoint(new Point(4.5, 4.5), null);
+    private static final OGCGeometry POINT_Z = new OGCPoint(new Point(6.0, 6.0), null);
+    private static final OGCGeometry POINT_W = new OGCPoint(new Point(20.0, 20.0), null);
+
+    @Test
+    public void testEmptyFlatbush()
+    {
+        Flatbush<Rectangle> rtree = new Flatbush<>(new Rectangle[] {});
+        assertEquals(findIntersections(rtree, EVERYTHING), ImmutableList.of());
+    }
+
+    @Test
+    public void testSingletonFlatbush()
+    {
+        List<Rectangle> items = ImmutableList.of(new Rectangle(0, 0, 1, 1));
+        Flatbush<Rectangle> rtree = new Flatbush<>(items.toArray(new Rectangle[] {}));
+
+        assertEquals(findIntersections(rtree, EVERYTHING), items);
+        // hit
+        assertEquals(findIntersections(rtree, new Rectangle(1, 1, 2, 2)), items);
+        // miss
+        assertEquals(findIntersections(rtree, new Rectangle(-1, -1, -0.1, -0.1)), ImmutableList.of());
+    }
+
+    @Test
+    public void testSingletonFlatbushXY()
+    {
+        // Because mixing up x and y is easy to do...
+        List<Rectangle> items = ImmutableList.of(new Rectangle(0, 10, 1, 11));
+        Flatbush<Rectangle> rtree = new Flatbush<>(items.toArray(new Rectangle[] {}));
+
+        // hit
+        assertEquals(findIntersections(rtree, new Rectangle(1, 11, 2, 12)), items);
+        // miss
+        assertEquals(findIntersections(rtree, new Rectangle(11, 1, 12, 2)), ImmutableList.of());
+    }
+
+    @Test
+    public void testDoubletonFlatbush()
+    {
+        // This is the smallest Rtree with height > 1
+        // Also test for some degeneracies
+        Rectangle rect0 = new Rectangle(1, 1, 1, 1);
+        Rectangle rect1 = new Rectangle(-1, -2, -1, -1);
+        List<Rectangle> items = ImmutableList.of(rect0, rect1);
+
+        Flatbush<Rectangle> rtree = new Flatbush<>(items.toArray(new Rectangle[] {}));
+
+        List<Rectangle> allResults = findIntersections(rtree, EVERYTHING);
+        assertEqualsSorted(allResults, items, RECTANGLE_COMPARATOR);
+
+        assertEquals(findIntersections(rtree, new Rectangle(1, 1, 2, 2)), ImmutableList.of(rect0));
+        assertEquals(findIntersections(rtree, new Rectangle(-2, -2, -1, -2)), ImmutableList.of(rect1));
+        // This should test missing at the root level
+        assertEquals(findIntersections(rtree, new Rectangle(10, 10, 12, 12)), ImmutableList.of());
+        // This should test missing at the leaf level
+        assertEquals(findIntersections(rtree, new Rectangle(0, 0, 0, 0)), ImmutableList.of());
+    }
+
+    @Test
+    public void testTwoLevelFlatbush()
+    {
+        // This is the smallest Rtree with height > 2
+        // Also test for NaN behavior
+        Rectangle rect0 = new Rectangle(1, 1, 1, 1);
+        Rectangle rect1 = new Rectangle(-1, -1, -1, -1);
+        Rectangle rect2 = new Rectangle(1, -1, 1, -1);
+        List<Rectangle> items = ImmutableList.of(rect0, rect1, rect2);
+
+        Flatbush<Rectangle> rtree = new Flatbush<>(items.toArray(new Rectangle[] {}), 2);
+
+        List<Rectangle> allResults = findIntersections(rtree, EVERYTHING);
+        assertEqualsSorted(allResults, items, RECTANGLE_COMPARATOR);
+
+        assertEquals(findIntersections(rtree, new Rectangle(1, 1, 1, 1)), ImmutableList.of(rect0));
+        assertEquals(findIntersections(rtree, new Rectangle(-1, -1, -1, -1)), ImmutableList.of(rect1));
+        assertEquals(findIntersections(rtree, new Rectangle(1, -1, 1, -1)), ImmutableList.of(rect2));
+        // Test hitting across parent nodes
+        List<Rectangle> results12 = findIntersections(rtree, new Rectangle(-1, -1, 1, -1));
+        assertEqualsSorted(results12, ImmutableList.of(rect1, rect2), RECTANGLE_COMPARATOR);
+
+        // This should test missing at the root level
+        assertEquals(findIntersections(rtree, new Rectangle(10, 10, 12, 12)), ImmutableList.of());
+        // This should test missing at the leaf level
+        assertEquals(findIntersections(rtree, new Rectangle(0, 0, 0, 0)), ImmutableList.of());
+    }
+
+    @Test
+    public void testOctagonQuery()
+    {
+        OGCGeometryWrapper octagonA = new OGCGeometryWrapper(POLYGON_A);
+        OGCGeometryWrapper octagonB = new OGCGeometryWrapper(POLYGON_B);
+
+        OGCGeometryWrapper pointX = new OGCGeometryWrapper(POINT_X);
+        OGCGeometryWrapper pointY = new OGCGeometryWrapper(POINT_Y);
+        OGCGeometryWrapper pointZ = new OGCGeometryWrapper(POINT_Z);
+        OGCGeometryWrapper pointW = new OGCGeometryWrapper(POINT_W);
+
+        Flatbush<OGCGeometryWrapper> rtree = new Flatbush<>(new OGCGeometryWrapper[] {pointX, pointY, pointZ, pointW});
+
+        List<OGCGeometryWrapper> resultsA = findIntersections(rtree, octagonA.getExtent());
+        assertEqualsSorted(resultsA, ImmutableList.of(pointX, pointY), Comparator.naturalOrder());
+
+        List<OGCGeometryWrapper> resultsB = findIntersections(rtree, octagonB.getExtent());
+        assertEqualsSorted(resultsB, ImmutableList.of(pointY, pointZ), Comparator.naturalOrder());
+    }
+
+    @Test
+    public void testOctagonTree()
+    {
+        OGCGeometryWrapper octagonA = new OGCGeometryWrapper(POLYGON_A);
+        OGCGeometryWrapper octagonB = new OGCGeometryWrapper(POLYGON_B);
+
+        OGCGeometryWrapper pointX = new OGCGeometryWrapper(POINT_X);
+        OGCGeometryWrapper pointY = new OGCGeometryWrapper(POINT_Y);
+        OGCGeometryWrapper pointZ = new OGCGeometryWrapper(POINT_Z);
+        OGCGeometryWrapper pointW = new OGCGeometryWrapper(POINT_W);
+
+        Flatbush<OGCGeometryWrapper> rtree = new Flatbush<>(new OGCGeometryWrapper[] {octagonA, octagonB});
+
+        assertEquals(findIntersections(rtree, pointX.getExtent()), ImmutableList.of(octagonA));
+
+        List<OGCGeometryWrapper> results = findIntersections(rtree, pointY.getExtent());
+        assertEqualsSorted(results, ImmutableList.of(octagonA, octagonB), Comparator.naturalOrder());
+
+        assertEquals(findIntersections(rtree, pointZ.getExtent()), ImmutableList.of(octagonB));
+
+        assertEquals(findIntersections(rtree, pointW.getExtent()), ImmutableList.of());
+    }
+
+    @DataProvider(name = "rectangle-counts")
+    public Object[][] rectangleCounts()
+    {
+        return new Object[][] {{100, 1000, 42}, {1000, 10_000, 123}, {5000, 50_000, 321}};
+    }
+
+    @Test(dataProvider = "rectangle-counts")
+    public void testRectangleCollection(int numBuildRectangles, int numProbeRectangles, int seed)
+    {
+        Random random = new Random(seed);
+        List<Rectangle> buildRectangles = makeRectangles(random, numBuildRectangles);
+        List<Rectangle> probeRectangles = makeRectangles(random, numProbeRectangles);
+
+        Flatbush<Rectangle> rtree = new Flatbush<>(buildRectangles.toArray(new Rectangle[] {}));
+        for (Rectangle query : probeRectangles) {
+            List<Rectangle> actual = findIntersections(rtree, query);
+            List<Rectangle> expected = buildRectangles.stream()
+                    .filter(rect -> rect.intersects(query))
+                    .collect(toList());
+            assertEqualsSorted(actual, expected, RECTANGLE_COMPARATOR);
+        }
+    }
+
+    @Test
+    public void testChildrenOffsets()
+    {
+        int numRectangles = 10;
+        int degree = 8;
+        Random random = new Random(122);
+
+        int firstParentIndex = 2 * degree * ENVELOPE_SIZE;
+        int secondParentIndex = firstParentIndex + ENVELOPE_SIZE;
+        int grandparentIndex = 3 * degree * ENVELOPE_SIZE;
+
+        List<Rectangle> rectangles = makeRectangles(random, numRectangles);
+        Flatbush<Rectangle> rtree = new Flatbush<>(rectangles.toArray(new Rectangle[] {}), degree);
+        assertEquals(rtree.getHeight(), 3);
+        assertEquals(rtree.getChildrenOffset(firstParentIndex, 1), 0);
+        assertEquals(rtree.getChildrenOffset(secondParentIndex, 1), degree * ENVELOPE_SIZE);
+        assertEquals(rtree.getChildrenOffset(grandparentIndex, 2), 2 * degree * ENVELOPE_SIZE);
+    }
+
+    private static <T extends HasExtent> List<T> findIntersections(Flatbush<T> rtree, Rectangle rectangle)
+    {
+        List<T> results = new ArrayList<>();
+        rtree.findIntersections(rectangle, results::add);
+        return results;
+    }
+
+    /*
+     * Asserts the two lists of Rectangles are equal after sorting.
+     */
+    private static <T> void assertEqualsSorted(List<T> actual, List<T> expected, Comparator<T> comparator)
+    {
+        List<T> actualSorted = actual.stream().sorted(comparator).collect(toImmutableList());
+        List<T> expectedSorted = expected.stream().sorted(comparator).collect(toImmutableList());
+
+        assertEquals(actualSorted, expectedSorted);
+    }
+
+    private static final class OGCGeometryWrapper
+            implements HasExtent, Comparable<OGCGeometryWrapper>
+    {
+        private final OGCGeometry geometry;
+        private final Rectangle extent;
+
+        public OGCGeometryWrapper(OGCGeometry geometry)
+        {
+            this.geometry = geometry;
+            this.extent = GeometryUtils.getExtent(geometry);
+        }
+
+        public OGCGeometry getGeometry()
+        {
+            return geometry;
+        }
+
+        @Override
+        public Rectangle getExtent()
+        {
+            return extent;
+        }
+
+        @Override
+        public long getEstimatedSizeInBytes()
+        {
+            return geometry.estimateMemorySize();
+        }
+
+        @Override
+        public int compareTo(OGCGeometryWrapper other)
+        {
+            return RECTANGLE_COMPARATOR.compare(this.getExtent(), other.getExtent());
+        }
+    }
+}

--- a/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/TestHilbertIndex.java
+++ b/lib/trino-geospatial-toolkit/src/test/java/io/trino/geospatial/rtree/TestHilbertIndex.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.geospatial.rtree;
+
+import io.trino.geospatial.Rectangle;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestHilbertIndex
+{
+    @Test
+    public void testOrder()
+    {
+        HilbertIndex hilbert = new HilbertIndex(new Rectangle(0, 0, 4, 4));
+        long h0 = hilbert.indexOf(0., 0.);
+        long h1 = hilbert.indexOf(1., 1.);
+        long h2 = hilbert.indexOf(1., 3.);
+        long h3 = hilbert.indexOf(3., 3.);
+        long h4 = hilbert.indexOf(3., 1.);
+        assertTrue(h0 < h1);
+        assertTrue(h1 < h2);
+        assertTrue(h2 < h3);
+        assertTrue(h3 < h4);
+    }
+
+    @Test
+    public void testOutOfBounds()
+    {
+        HilbertIndex hilbert = new HilbertIndex(new Rectangle(0, 0, 1, 1));
+        assertEquals(hilbert.indexOf(2., 2.), Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testDegenerateRectangle()
+    {
+        HilbertIndex hilbert = new HilbertIndex(new Rectangle(0, 0, 0, 0));
+        assertEquals(hilbert.indexOf(0., 0.), 0);
+        assertEquals(hilbert.indexOf(2., 2.), Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testDegenerateHorizontalRectangle()
+    {
+        HilbertIndex hilbert = new HilbertIndex(new Rectangle(0, 0, 4, 0));
+        assertEquals(hilbert.indexOf(0., 0.), 0);
+        assertTrue(hilbert.indexOf(1., 0.) < hilbert.indexOf(2., 0.));
+        assertEquals(hilbert.indexOf(0., 2.), Long.MAX_VALUE);
+        assertEquals(hilbert.indexOf(2., 2.), Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testDegenerateVerticalRectangle()
+    {
+        HilbertIndex hilbert = new HilbertIndex(new Rectangle(0, 0, 0, 4));
+        assertEquals(hilbert.indexOf(0., 0.), 0);
+        assertTrue(hilbert.indexOf(0., 1.) < hilbert.indexOf(0., 2.));
+        assertEquals(hilbert.indexOf(2., 0.), Long.MAX_VALUE);
+        assertEquals(hilbert.indexOf(2., 2.), Long.MAX_VALUE);
+    }
+}

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/GeoFunctions.java
@@ -37,7 +37,6 @@ import com.esri.core.geometry.ogc.OGCMultiPolygon;
 import com.esri.core.geometry.ogc.OGCPoint;
 import com.esri.core.geometry.ogc.OGCPolygon;
 import com.google.common.base.Joiner;
-import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
@@ -1479,22 +1478,6 @@ public final class GeoFunctions
         Map<Integer, Rectangle> partitions = kdbTree.findIntersectingLeaves(envelope);
         if (partitions.isEmpty()) {
             return EMPTY_ARRAY_OF_INTS;
-        }
-
-        // For input rectangles that represent a single point, return at most one partition
-        // by excluding right and upper sides of partition rectangles. The logic that builds
-        // KDB tree needs to make sure to add some padding to the right and upper sides of the
-        // overall extent of the tree to avoid missing right-most and top-most points.
-        boolean point = (envelope.getWidth() == 0 && envelope.getHeight() == 0);
-        if (point) {
-            for (Map.Entry<Integer, Rectangle> partition : partitions.entrySet()) {
-                if (envelope.getXMin() < partition.getValue().getXMax() && envelope.getYMin() < partition.getValue().getYMax()) {
-                    BlockBuilder blockBuilder = IntegerType.INTEGER.createFixedSizeBlockBuilder(1);
-                    blockBuilder.writeInt(partition.getKey());
-                    return blockBuilder.build();
-                }
-            }
-            throw new VerifyException(format("Cannot find half-open partition extent for a point: (%s, %s)", envelope.getXMin(), envelope.getYMin()));
         }
 
         BlockBuilder blockBuilder = IntegerType.INTEGER.createFixedSizeBlockBuilder(partitions.size());

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningInternalAggregateFunction.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningInternalAggregateFunction.java
@@ -51,18 +51,13 @@ public final class SpatialPartitioningInternalAggregateFunction
             return;
         }
 
-        Rectangle extent = new Rectangle(envelope.getXMin(), envelope.getYMin(), envelope.getXMax(), envelope.getYMax());
-
         if (state.getCount() == 0) {
             state.setPartitionCount(toIntExact(partitionCount));
-            state.setExtent(extent);
             state.setSamples(new ArrayList<>());
-        }
-        else {
-            state.setExtent(state.getExtent().merge(extent));
         }
 
         // use reservoir sampling
+        Rectangle extent = new Rectangle(envelope.getXMin(), envelope.getYMin(), envelope.getXMax(), envelope.getYMax());
         List<Rectangle> samples = state.getSamples();
         if (samples.size() <= MAX_SAMPLE_COUNT) {
             samples.add(extent);
@@ -89,11 +84,6 @@ public final class SpatialPartitioningInternalAggregateFunction
 
         int partitionCount = state.getPartitionCount();
         int maxItemsPerNode = (samples.size() + partitionCount - 1) / partitionCount;
-        Rectangle envelope = state.getExtent();
-
-        // Add a small buffer on the right and upper sides
-        Rectangle paddedExtent = new Rectangle(envelope.getXMin(), envelope.getYMin(), Math.nextUp(envelope.getXMax()), Math.nextUp(envelope.getYMax()));
-
-        VARCHAR.writeString(out, KdbTreeUtils.toJson(buildKdbTree(maxItemsPerNode, paddedExtent, samples)));
+        VARCHAR.writeString(out, KdbTreeUtils.toJson(buildKdbTree(maxItemsPerNode, samples)));
     }
 }

--- a/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningStateFactory.java
+++ b/plugin/trino-geospatial/src/main/java/io/trino/plugin/geospatial/SpatialPartitioningStateFactory.java
@@ -30,6 +30,8 @@ import static java.lang.Math.toIntExact;
 public class SpatialPartitioningStateFactory
         implements AccumulatorStateFactory<SpatialPartitioningState>
 {
+    private static final int ENVELOPE_SIZE = toIntExact(new Envelope(1, 2, 3, 4).estimateMemorySize());
+
     @Override
     public SpatialPartitioningState createSingleState()
     {
@@ -46,14 +48,11 @@ public class SpatialPartitioningStateFactory
             implements GroupedAccumulatorState, SpatialPartitioningState
     {
         private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedSpatialPartitioningState.class).instanceSize();
-        private static final int ENVELOPE_SIZE = toIntExact(new Envelope(1, 2, 3, 4).estimateMemorySize());
 
         private long groupId;
         private final IntBigArray partitionCounts = new IntBigArray();
         private final LongBigArray counts = new LongBigArray();
-        private final ObjectBigArray<Rectangle> envelopes = new ObjectBigArray<>();
         private final ObjectBigArray<List<Rectangle>> samples = new ObjectBigArray<>();
-        private int envelopeCount;
         private int samplesCount;
 
         @Override
@@ -81,21 +80,6 @@ public class SpatialPartitioningStateFactory
         }
 
         @Override
-        public Rectangle getExtent()
-        {
-            return envelopes.get(groupId);
-        }
-
-        @Override
-        public void setExtent(Rectangle envelope)
-        {
-            if (envelopes.get(groupId) == null) {
-                envelopeCount++;
-            }
-            envelopes.set(groupId, envelope);
-        }
-
-        @Override
         public List<Rectangle> getSamples()
         {
             return samples.get(groupId);
@@ -115,7 +99,7 @@ public class SpatialPartitioningStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return INSTANCE_SIZE + partitionCounts.sizeOf() + counts.sizeOf() + envelopes.sizeOf() + samples.sizeOf() + ENVELOPE_SIZE * (envelopeCount + samplesCount);
+            return INSTANCE_SIZE + partitionCounts.sizeOf() + counts.sizeOf() + samples.sizeOf() + ENVELOPE_SIZE * samplesCount;
         }
 
         @Override
@@ -129,7 +113,6 @@ public class SpatialPartitioningStateFactory
         {
             partitionCounts.ensureCapacity(size);
             counts.ensureCapacity(size);
-            envelopes.ensureCapacity(size);
             samples.ensureCapacity(size);
         }
     }
@@ -141,7 +124,6 @@ public class SpatialPartitioningStateFactory
 
         private int partitionCount;
         private long count;
-        private Rectangle envelope;
         private List<Rectangle> samples = new ArrayList<>();
 
         @Override
@@ -169,18 +151,6 @@ public class SpatialPartitioningStateFactory
         }
 
         @Override
-        public Rectangle getExtent()
-        {
-            return envelope;
-        }
-
-        @Override
-        public void setExtent(Rectangle envelope)
-        {
-            this.envelope = envelope;
-        }
-
-        @Override
         public List<Rectangle> getSamples()
         {
             return samples;
@@ -195,7 +165,7 @@ public class SpatialPartitioningStateFactory
         @Override
         public long getEstimatedSize()
         {
-            return INSTANCE_SIZE + (envelope != null ? envelope.estimateMemorySize() * (1 + samples.size()) : 0);
+            return INSTANCE_SIZE + samples.size() * ENVELOPE_SIZE;
         }
     }
 }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestGeoFunctions.java
@@ -59,31 +59,32 @@ public class TestGeoFunctions
         assertSpatialPartitions(kdbTreeJson, "POINT EMPTY", null);
         // points inside partitions
         assertSpatialPartitions(kdbTreeJson, "POINT (0 0)", ImmutableList.of(0));
-        assertSpatialPartitions(kdbTreeJson, "POINT (3 1)", ImmutableList.of(2));
+        assertSpatialPartitions(kdbTreeJson, "POINT (3 1)", ImmutableList.of(1));
         // point on the border between two partitions
-        assertSpatialPartitions(kdbTreeJson, "POINT (1 2.5)", ImmutableList.of(1));
+        assertSpatialPartitions(kdbTreeJson, "POINT (1 2.5)", ImmutableList.of(2));
         // point at the corner of three partitions
-        assertSpatialPartitions(kdbTreeJson, "POINT (4.5 2.5)", ImmutableList.of(4));
+        assertSpatialPartitions(kdbTreeJson, "POINT (4.5 2.5)", ImmutableList.of(5));
         // points outside
-        assertSpatialPartitions(kdbTreeJson, "POINT (2 6)", ImmutableList.of());
-        assertSpatialPartitions(kdbTreeJson, "POINT (3 -1)", ImmutableList.of());
-        assertSpatialPartitions(kdbTreeJson, "POINT (10 3)", ImmutableList.of());
+        assertSpatialPartitions(kdbTreeJson, "POINT (-10 -10)", ImmutableList.of(0));
+        assertSpatialPartitions(kdbTreeJson, "POINT (-10 10)", ImmutableList.of(2));
+        assertSpatialPartitions(kdbTreeJson, "POINT (10 -10)", ImmutableList.of(4));
+        assertSpatialPartitions(kdbTreeJson, "POINT (10 10)", ImmutableList.of(5));
 
         // geometry within a partition
         assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (5 0.1, 6 2)", ImmutableList.of(3));
         // geometries spanning multiple partitions
-        assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (5 0.1, 5.5 3, 6 2)", ImmutableList.of(3, 4));
-        assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (3 2, 8 3)", ImmutableList.of(2, 3, 4, 5));
+        assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (5 0.1, 5.5 3, 6 2)", ImmutableList.of(5, 3));
+        assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (3 2, 8 3)", ImmutableList.of(5, 4, 3, 2, 1));
         // geometry outside
-        assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (2 6, 3 7)", ImmutableList.of());
+        assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (2 6, 5 7)", ImmutableList.of(5, 2));
 
         // with distance
         assertSpatialPartitions(kdbTreeJson, "POINT EMPTY", 1.2, null);
         assertSpatialPartitions(kdbTreeJson, "POINT (1 1)", 1.2, ImmutableList.of(0));
-        assertSpatialPartitions(kdbTreeJson, "POINT (1 1)", 2.3, ImmutableList.of(0, 1, 2));
+        assertSpatialPartitions(kdbTreeJson, "POINT (1 1)", 2.3, ImmutableList.of(2, 1, 0));
         assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (5 0.1, 6 2)", 0.2, ImmutableList.of(3));
-        assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (5 0.1, 6 2)", 1.2, ImmutableList.of(2, 3, 4));
-        assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (2 6, 3 7)", 1.2, ImmutableList.of());
+        assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (5 0.1, 6 2)", 1.2, ImmutableList.of(5, 3, 2, 1));
+        assertSpatialPartitions(kdbTreeJson, "MULTIPOINT (2 6, 3 7)", 1.2, ImmutableList.of(2));
     }
 
     private static String makeKdbTreeJson()
@@ -94,7 +95,7 @@ public class TestGeoFunctions
                 rectangles.add(new Rectangle(x, y, x + 1, y + 2));
             }
         }
-        return KdbTreeUtils.toJson(buildKdbTree(10, new Rectangle(0, 0, 9, 4), rectangles.build()));
+        return KdbTreeUtils.toJson(buildKdbTree(10, rectangles.build()));
     }
 
     private void assertSpatialPartitions(String kdbTreeJson, String wkt, List<Integer> expectedPartitions)

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestKdbTreeCasts.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestKdbTreeCasts.java
@@ -53,6 +53,6 @@ public class TestKdbTreeCasts
                 rectangles.add(new Rectangle(x, y, x + 1, y + 2));
             }
         }
-        return KdbTreeUtils.toJson(buildKdbTree(100, new Rectangle(0, 0, 9, 4), rectangles.build()));
+        return KdbTreeUtils.toJson(buildKdbTree(100, rectangles.build()));
     }
 }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperator.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoinOperator.java
@@ -39,6 +39,7 @@ import io.trino.operator.join.InternalJoinFilterFunction;
 import io.trino.operator.join.StandardJoinFilterFunction;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
+import io.trino.spi.block.Block;
 import io.trino.sql.gen.JoinFilterFunctionCompiler;
 import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.sql.planner.plan.SpatialJoinNode.Type;
@@ -60,10 +61,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.RowPagesBuilder.rowPagesBuilder;
 import static io.trino.SessionTestUtils.TEST_SESSION;
-import static io.trino.geospatial.KdbTree.Node.newInternal;
-import static io.trino.geospatial.KdbTree.Node.newLeaf;
-import static io.trino.operator.OperatorAssertion.assertOperatorEquals;
+import static io.trino.operator.OperatorAssertion.assertOperatorEqualsIgnoreOrder;
 import static io.trino.operator.OperatorAssertion.toPages;
+import static io.trino.plugin.geospatial.GeoFunctions.spatialPartitions;
 import static io.trino.plugin.geospatial.GeoFunctions.stGeometryFromText;
 import static io.trino.plugin.geospatial.GeoFunctions.stPoint;
 import static io.trino.plugin.geospatial.GeometryType.GEOMETRY;
@@ -84,22 +84,34 @@ import static org.testng.Assert.assertTrue;
 @Test(singleThreaded = true)
 public class TestSpatialJoinOperator
 {
-    private static final String KDB_TREE_JSON = KdbTreeUtils.toJson(
-            new KdbTree(newInternal(new Rectangle(-2, -2, 15, 15),
-                    newInternal(new Rectangle(-2, -2, 6, 15),
-                            newLeaf(new Rectangle(-2, -2, 6, 1), 1),
-                            newLeaf(new Rectangle(-2, 1, 6, 15), 2)),
-                    newLeaf(new Rectangle(6, -2, 15, 15), 0))));
+    private static final KdbTree KDB_TREE = KdbTree.buildKdbTree(
+            2,
+            ImmutableList.of(
+                    new Rectangle(-2, -2, -2, -2),
+                    new Rectangle(0, 0, 0, 0),
+                    new Rectangle(-1, -2, 4, 3),
+                    new Rectangle(6, 1, 6, 1),
+                    new Rectangle(3, 9, 3, 9),
+                    new Rectangle(15, 15, 15, 15)));
+    private static final String KDB_TREE_JSON = KdbTreeUtils.toJson(KDB_TREE);
 
     //  2 intersecting polygons: A and B
     private static final Slice POLYGON_A = stGeometryFromText(Slices.utf8Slice("POLYGON ((0 0, -0.5 2.5, 0 5, 2.5 5.5, 5 5, 5.5 2.5, 5 0, 2.5 -0.5, 0 0))"));
     private static final Slice POLYGON_B = stGeometryFromText(Slices.utf8Slice("POLYGON ((4 4, 3.5 7, 4 10, 7 10.5, 10 10, 10.5 7, 10 4, 7 3.5, 4 4))"));
+    private static final Slice POLYGON_C = stGeometryFromText(Slices.utf8Slice("POLYGON ((15 15, 15 14, 14 14, 14 15, 15 15))"));
+    private static final Slice POLYGON_D = stGeometryFromText(Slices.utf8Slice("POLYGON ((18 18, 18 19, 19 19, 19 18, 18 18))"));
 
     // A set of points: X in A, Y in A and B, Z in B, W outside of A and B
     private static final Slice POINT_X = stPoint(1, 1);
     private static final Slice POINT_Y = stPoint(4.5, 4.5);
     private static final Slice POINT_Z = stPoint(6, 6);
     private static final Slice POINT_W = stPoint(20, 20);
+    private static final Slice POINT_V = stPoint(15, 15);
+    private static final Slice MULTIPOINT_U = stGeometryFromText(Slices.utf8Slice("MULTIPOINT (15 15)"));
+    private static final Slice MULTIPOINT_T = stGeometryFromText(Slices.utf8Slice("MULTIPOINT (14.5 14.5, 16 16)"));
+    private static final Slice POINT_S = stPoint(18, 18);
+    private static final Slice MULTIPOINT_R = stGeometryFromText(Slices.utf8Slice("MULTIPOINT (15 15, 19 19)"));
+    private static final Slice POINT_Q = stPoint(28, 28);
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;
@@ -139,7 +151,9 @@ public class TestSpatialJoinOperator
                 .row(POLYGON_A, "A")
                 .row(null, "null")
                 .pageBreak()
-                .row(POLYGON_B, "B");
+                .row(POLYGON_B, "B")
+                .row(POLYGON_C, "C")
+                .row(POLYGON_D, "D");
 
         RowPagesBuilder probePages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR))
                 .row(POINT_X, "x")
@@ -148,13 +162,26 @@ public class TestSpatialJoinOperator
                 .pageBreak()
                 .row(POINT_Z, "z")
                 .pageBreak()
-                .row(POINT_W, "w");
+                .row(POINT_W, "w")
+                .row(POINT_V, "v")
+                .row(MULTIPOINT_U, "u")
+                .pageBreak()
+                .row(MULTIPOINT_T, "t")
+                .row(POINT_S, "s")
+                .row(MULTIPOINT_R, "r")
+                .row(POINT_Q, "q");
 
         MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.of(VARCHAR, VARCHAR))
                 .row("x", "A")
                 .row("y", "A")
                 .row("y", "B")
                 .row("z", "B")
+                .row("v", "C")
+                .row("u", "C")
+                .row("t", "C")
+                .row("s", "D")
+                .row("r", "C")
+                .row("r", "D")
                 .build();
 
         assertSpatialJoin(taskContext, INNER, buildPages, probePages, expected);
@@ -168,7 +195,9 @@ public class TestSpatialJoinOperator
                 .row(POLYGON_A, "A")
                 .row(null, "null")
                 .pageBreak()
-                .row(POLYGON_B, "B");
+                .row(POLYGON_B, "B")
+                .row(POLYGON_C, "C")
+                .row(POLYGON_D, "D");
 
         RowPagesBuilder probePages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR))
                 .row(POINT_X, "x")
@@ -177,7 +206,14 @@ public class TestSpatialJoinOperator
                 .pageBreak()
                 .row(POINT_Z, "z")
                 .pageBreak()
-                .row(POINT_W, "w");
+                .row(POINT_W, "w")
+                .row(POINT_V, "v")
+                .row(MULTIPOINT_U, "u")
+                .pageBreak()
+                .row(MULTIPOINT_T, "t")
+                .row(POINT_S, "s")
+                .row(MULTIPOINT_R, "r")
+                .row(POINT_Q, "q");
         MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.of(VARCHAR, VARCHAR))
                 .row("x", "A")
                 .row("null", null)
@@ -185,6 +221,13 @@ public class TestSpatialJoinOperator
                 .row("y", "B")
                 .row("z", "B")
                 .row("w", null)
+                .row("v", "C")
+                .row("u", "C")
+                .row("t", "C")
+                .row("s", "D")
+                .row("r", "C")
+                .row("r", "D")
+                .row("q", null)
                 .build();
 
         assertSpatialJoin(taskContext, LEFT, buildPages, probePages, expected);
@@ -193,9 +236,9 @@ public class TestSpatialJoinOperator
     private void assertSpatialJoin(TaskContext taskContext, Type joinType, RowPagesBuilder buildPages, RowPagesBuilder probePages, MaterializedResult expected)
     {
         DriverContext driverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();
-        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe, r) -> build.contains(probe), Optional.empty(), Optional.empty(), buildPages);
+        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe, r) -> build.intersects(probe), Optional.empty(), Optional.empty(), buildPages);
         OperatorFactory joinOperatorFactory = new SpatialJoinOperatorFactory(2, new PlanNodeId("test"), joinType, probePages.getTypes(), Ints.asList(1), 0, Optional.empty(), pagesSpatialIndexFactory);
-        assertOperatorEquals(joinOperatorFactory, driverContext, probePages.build(), expected);
+        assertOperatorEqualsIgnoreOrder(joinOperatorFactory, driverContext, probePages.build(), expected);
     }
 
     @Test
@@ -355,7 +398,7 @@ public class TestSpatialJoinOperator
         MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.of(VARCHAR, VARCHAR))
                 .row("0_1", "0_0")
                 .build();
-        assertOperatorEquals(firstFactory, probeDriver, probePages.build(), expected);
+        assertOperatorEqualsIgnoreOrder(firstFactory, probeDriver, probePages.build(), expected);
     }
 
     @DataProvider
@@ -402,7 +445,7 @@ public class TestSpatialJoinOperator
                 .row("10_1", "10_0")
                 .build();
 
-        assertOperatorEquals(joinOperatorFactory, driverContext, probePages.build(), expected);
+        assertOperatorEqualsIgnoreOrder(joinOperatorFactory, driverContext, probePages.build(), expected);
     }
 
     @Test
@@ -411,31 +454,45 @@ public class TestSpatialJoinOperator
         TaskContext taskContext = createTaskContext();
         DriverContext driverContext = taskContext.addPipelineContext(0, true, true, true).addDriverContext();
 
-        RowPagesBuilder buildPages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR, INTEGER))
-                .row(POLYGON_A, "A", 1)
-                .row(POLYGON_A, "A", 2)
-                .row(null, "null", null)
-                .pageBreak()
-                .row(POLYGON_B, "B", 0)
-                .row(POLYGON_B, "B", 2);
+        RowPagesBuilder buildPages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR, INTEGER));
+        addGeometryPartitionRows(buildPages, POLYGON_A, "A");
+        buildPages.row(null, "null", null);
+        buildPages.pageBreak();
+        addGeometryPartitionRows(buildPages, POLYGON_B, "B");
+        addGeometryPartitionRows(buildPages, POLYGON_C, "C");
+        addGeometryPartitionRows(buildPages, POLYGON_D, "D");
 
-        RowPagesBuilder probePages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR, INTEGER))
-                .row(POINT_X, "x", 2)
-                .row(null, "null", null)
-                .row(POINT_Y, "y", 2)
-                .pageBreak()
-                .row(POINT_Z, "z", 0);
+        RowPagesBuilder probePages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR, INTEGER));
+        addGeometryPartitionRows(probePages, POINT_X, "x");
+        probePages.row(null, "null", null);
+        addGeometryPartitionRows(probePages, POINT_Y, "y");
+        probePages.pageBreak();
+        addGeometryPartitionRows(probePages, POINT_Z, "z");
+        addGeometryPartitionRows(probePages, POINT_W, "w");
+        addGeometryPartitionRows(probePages, POINT_V, "v");
+        addGeometryPartitionRows(probePages, MULTIPOINT_U, "u");
+        probePages.pageBreak();
+        addGeometryPartitionRows(probePages, MULTIPOINT_T, "t");
+        addGeometryPartitionRows(probePages, POINT_S, "s");
+        addGeometryPartitionRows(probePages, MULTIPOINT_R, "r");
+        addGeometryPartitionRows(probePages, POINT_Q, "q");
 
         MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.of(VARCHAR, VARCHAR))
                 .row("x", "A")
                 .row("y", "A")
                 .row("y", "B")
                 .row("z", "B")
+                .row("v", "C")
+                .row("u", "C")
+                .row("t", "C")
+                .row("s", "D")
+                .row("r", "C")
+                .row("r", "D")
                 .build();
 
-        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe, r) -> build.contains(probe), Optional.empty(), Optional.of(2), Optional.of(KDB_TREE_JSON), Optional.empty(), buildPages);
+        PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe, r) -> build.intersects(probe), Optional.empty(), Optional.of(2), Optional.of(KDB_TREE_JSON), Optional.empty(), buildPages);
         OperatorFactory joinOperatorFactory = new SpatialJoinOperatorFactory(2, new PlanNodeId("test"), INNER, probePages.getTypes(), Ints.asList(1), 0, Optional.of(2), pagesSpatialIndexFactory);
-        assertOperatorEquals(joinOperatorFactory, driverContext, probePages.build(), expected);
+        assertOperatorEqualsIgnoreOrder(joinOperatorFactory, driverContext, probePages.build(), expected);
     }
 
     @Test
@@ -444,13 +501,11 @@ public class TestSpatialJoinOperator
         TaskContext taskContext = createTaskContext();
         DriverContext driverContext = taskContext.addPipelineContext(0, true, true, true).addDriverContext();
 
-        RowPagesBuilder pages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR, INTEGER))
-                .row(POLYGON_A, "A", 1)
-                .row(POLYGON_A, "A", 2)
-                .row(null, "null", null)
-                .pageBreak()
-                .row(POLYGON_B, "B", 0)
-                .row(POLYGON_B, "B", 2);
+        RowPagesBuilder pages = rowPagesBuilder(ImmutableList.of(GEOMETRY, VARCHAR, INTEGER));
+        addGeometryPartitionRows(pages, POLYGON_A, "A");
+        pages.row(null, "null", null);
+        pages.pageBreak();
+        addGeometryPartitionRows(pages, POLYGON_B, "B");
 
         MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.of(VARCHAR, VARCHAR))
                 .row("A", "A")
@@ -461,7 +516,16 @@ public class TestSpatialJoinOperator
 
         PagesSpatialIndexFactory pagesSpatialIndexFactory = buildIndex(driverContext, (build, probe, r) -> build.intersects(probe), Optional.empty(), Optional.of(2), Optional.of(KDB_TREE_JSON), Optional.empty(), pages);
         OperatorFactory joinOperatorFactory = new SpatialJoinOperatorFactory(2, new PlanNodeId("test"), INNER, pages.getTypes(), Ints.asList(1), 0, Optional.of(2), pagesSpatialIndexFactory);
-        assertOperatorEquals(joinOperatorFactory, driverContext, pages.build(), expected);
+        assertOperatorEqualsIgnoreOrder(joinOperatorFactory, driverContext, pages.build(), expected);
+    }
+
+    private void addGeometryPartitionRows(RowPagesBuilder pageBuilder, Slice geometry, String geometryName)
+    {
+        Block partitionIndices = spatialPartitions(KDB_TREE, geometry);
+        for (int position = 0; position < partitionIndices.getPositionCount(); position++) {
+            int partitionIndex = partitionIndices.getInt(position, 0);
+            pageBuilder.row(geometry, geometryName, partitionIndex);
+        }
     }
 
     private PagesSpatialIndexFactory buildIndex(DriverContext driverContext, SpatialPredicate spatialRelationshipTest, Optional<Integer> radiusChannel, Optional<InternalJoinFilterFunction> filterFunction, RowPagesBuilder buildPages)

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
@@ -75,8 +75,7 @@ public class TestSpatialPartitioningInternalAggregation
 
         Block partitionCountBlock = BlockAssertions.createRLEBlock(partitionCount, geometries.size());
 
-        Rectangle expectedExtent = new Rectangle(-10, -10, Math.nextUp(10.0), Math.nextUp(10.0));
-        String expectedValue = getSpatialPartitioning(expectedExtent, geometries, partitionCount);
+        String expectedValue = getSpatialPartitioning(geometries, partitionCount);
 
         AggregatorFactory aggregatorFactory = function.createAggregatorFactory(SINGLE, Ints.asList(0, 1), OptionalInt.empty());
         Page page = new Page(geometryBlock, partitionCountBlock);
@@ -138,7 +137,7 @@ public class TestSpatialPartitioningInternalAggregation
         return builder.build();
     }
 
-    private String getSpatialPartitioning(Rectangle extent, List<OGCGeometry> geometries, int partitionCount)
+    private String getSpatialPartitioning(List<OGCGeometry> geometries, int partitionCount)
     {
         ImmutableList.Builder<Rectangle> rectangles = ImmutableList.builder();
         for (OGCGeometry geometry : geometries) {
@@ -147,6 +146,6 @@ public class TestSpatialPartitioningInternalAggregation
             rectangles.add(new Rectangle(envelope.getXMin(), envelope.getYMin(), envelope.getXMax(), envelope.getYMax()));
         }
 
-        return KdbTreeUtils.toJson(buildKdbTree(roundToInt(geometries.size() * 1.0 / partitionCount, CEILING), extent, rectangles.build()));
+        return KdbTreeUtils.toJson(buildKdbTree(roundToInt(geometries.size() * 1.0 / partitionCount, CEILING), rectangles.build()));
     }
 }


### PR DESCRIPTION
Improve performance/memory overhead for Spatial Join.

### Comparable changes:
- Major Improvement
  - Use Flatbush RTree for Spatial Joins (prestodb/presto#13079)
- Bug fixes
  - prestodb/presto#13251
  - prestodb/presto#13403
  - prestodb/presto#14485
- Refactoring
  - prestodb/presto#14545
  - prestodb/presto#14856

This change enhance reliability and performance for Spatial Join by using Flatbush RTree instead of JTS STRTree. 

It reduces the amount of memory for building spatial join index significantly.

According to the local test scenario, the peak user memory reduced 96%.

According to the benchmark tests, the performance also improved like below,

- Original
Benchmark                           (numBuildEnvelopes)  Mode  Cnt     Score    Error  Units
BenchmarkJtsStrTreeQuery.rtreeQuery                1000  avgt   20     0.594 ±  0.006  us/op
BenchmarkJtsStrTreeQuery.rtreeQuery                3000  avgt   20     1.062 ±  0.102  us/op
BenchmarkJtsStrTreeQuery.rtreeQuery               10000  avgt   20     2.434 ±  0.106  us/op
BenchmarkJtsStrTreeQuery.rtreeQuery               30000  avgt   20     6.496 ±  0.055  us/op
BenchmarkJtsStrTreeQuery.rtreeQuery              100000  avgt   20    21.323 ±  1.238  us/op
BenchmarkJtsStrTreeQuery.rtreeQuery              300000  avgt   20   110.227 ± 19.660  us/op
BenchmarkJtsStrTreeQuery.rtreeQuery             1000000  avgt   20   458.004 ± 25.899  us/op

- Improved (degree 16)
Benchmark                           (numBuildEnvelopes)  Mode  Cnt     Score    Error  Units
BenchmarkFlatbushQuery.rtreeQuery                  1000  avgt   20     0.823 ±  0.029  us/op
BenchmarkFlatbushQuery.rtreeQuery                  3000  avgt   20     1.249 ±  0.034  us/op
BenchmarkFlatbushQuery.rtreeQuery                 10000  avgt   20     2.561 ±  0.104  us/op
BenchmarkFlatbushQuery.rtreeQuery                 30000  avgt   20     5.265 ±  0.222  us/op
BenchmarkFlatbushQuery.rtreeQuery                100000  avgt   20    14.124 ±  0.612  us/op
BenchmarkFlatbushQuery.rtreeQuery                300000  avgt   20    58.914 ±  1.750  us/op
BenchmarkFlatbushQuery.rtreeQuery               1000000  avgt   20   238.373 ±  4.453  us/op

- Original
Benchmark                           (numBuildEnvelopes)  Mode  Cnt     Score     Error  Units
BenchmarkJtsStrTreeBuild.buildRtree                1000  avgt   20     0.377 ±   0.009  ms/op
BenchmarkJtsStrTreeBuild.buildRtree                3000  avgt   20     1.368 ±   0.037  ms/op
BenchmarkJtsStrTreeBuild.buildRtree               10000  avgt   20     5.495 ±   0.108  ms/op
BenchmarkJtsStrTreeBuild.buildRtree               30000  avgt   20    19.546 ±   0.383  ms/op
BenchmarkJtsStrTreeBuild.buildRtree              100000  avgt   20    81.362 ±   2.989  ms/op
BenchmarkJtsStrTreeBuild.buildRtree              300000  avgt   20   357.022 ±   4.268  ms/op
BenchmarkJtsStrTreeBuild.buildRtree             1000000  avgt   20  1574.333 ±  48.949  ms/op

- Improved (degree 16)
Benchmark                           (numBuildEnvelopes)  Mode  Cnt     Score    Error  Units
BenchmarkFlatbushBuild.buildRtree                  1000  avgt   20     0.647 ±  0.015  ms/op
BenchmarkFlatbushBuild.buildRtree                  3000  avgt   20     2.164 ±  0.045  ms/op
BenchmarkFlatbushBuild.buildRtree                 10000  avgt   20     4.053 ±  0.152  ms/op
BenchmarkFlatbushBuild.buildRtree                 30000  avgt   20    12.564 ±  0.138  ms/op
BenchmarkFlatbushBuild.buildRtree                100000  avgt   20    32.279 ±  0.190  ms/op
BenchmarkFlatbushBuild.buildRtree                300000  avgt   20   109.482 ±  1.089  ms/op
BenchmarkFlatbushBuild.buildRtree              1000000  avgt    20   435.341 ±  4.130  ms/op
