### PR TITLE
Support accumulator state copying

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/Accumulator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/Accumulator.java
@@ -29,6 +29,11 @@ public interface Accumulator
 
     Type getIntermediateType();
 
+    default Accumulator copy()
+    {
+        throw new UnsupportedOperationException("copy not implemented for " + getClass());
+    }
+
     void addInput(Page page);
 
     void addInput(WindowIndex index, List<Integer> channels, int startPosition, int endPosition);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/BlockBuilderCopier.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/BlockBuilderCopier.java
@@ -11,14 +11,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.trino.spi.function;
+package io.trino.operator.aggregation;
 
-public interface AccumulatorState
+import io.trino.spi.block.BlockBuilder;
+
+public class BlockBuilderCopier
 {
-    long getEstimatedSize();
+    private BlockBuilderCopier() {}
 
-    default AccumulatorState copy()
+    public static BlockBuilder copyBlockBuilder(BlockBuilder blockBuilder)
     {
-        throw new UnsupportedOperationException("copy not implemented for " + getClass());
+        if (blockBuilder == null) {
+            return null;
+        }
+
+        BlockBuilder copy = blockBuilder.newBlockBuilderLike(null);
+        for (int i = 0; i < blockBuilder.getPositionCount(); i++) {
+            copy.appendStructure(blockBuilder.getSingleValueBlock(i));
+        }
+
+        return copy;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/GenericAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/GenericAccumulatorFactory.java
@@ -279,6 +279,12 @@ public class GenericAccumulatorFactory
         }
 
         @Override
+        public Accumulator copy()
+        {
+            return accumulator.copy();
+        }
+
+        @Override
         public void addInput(Page page)
         {
             // 1. filter out positions based on mask, if present
@@ -506,6 +512,12 @@ public class GenericAccumulatorFactory
         public Type getIntermediateType()
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Accumulator copy()
+        {
+            return accumulator.copy();
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/KeyValuePairs.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/KeyValuePairs.java
@@ -82,6 +82,31 @@ public class KeyValuePairs
         deserialize(requireNonNull(serialized, "serialized is null"));
     }
 
+    // for copying
+    private KeyValuePairs(
+            BlockBuilder keyBlockBuilder,
+            Type keyType,
+            BlockPositionEqual keyEqualOperator,
+            BlockPositionHashCode keyHashCodeOperator,
+            BlockBuilder valueBlockBuilder,
+            Type valueType,
+            int[] keyPositionByHash,
+            int hashCapacity,
+            int maxFill,
+            int hashMask)
+    {
+        this.keyBlockBuilder = keyBlockBuilder;
+        this.keyType = keyType;
+        this.keyEqualOperator = keyEqualOperator;
+        this.keyHashCodeOperator = keyHashCodeOperator;
+        this.valueBlockBuilder = valueBlockBuilder;
+        this.valueType = valueType;
+        this.keyPositionByHash = keyPositionByHash;
+        this.hashCapacity = hashCapacity;
+        this.maxFill = maxFill;
+        this.hashMask = hashMask;
+    }
+
     public Block getKeys()
     {
         return keyBlockBuilder.build();
@@ -199,5 +224,28 @@ public class KeyValuePairs
     private int getMaskedHash(long rawHash)
     {
         return (int) (rawHash & hashMask);
+    }
+
+    public KeyValuePairs copy()
+    {
+        BlockBuilder keyBlockBuilderCopy = null;
+        if (keyBlockBuilder != null) {
+            keyBlockBuilderCopy = (BlockBuilder) keyBlockBuilder.copyRegion(0, keyBlockBuilder.getPositionCount());
+        }
+        BlockBuilder valueBlockBuilderCopy = null;
+        if (valueBlockBuilder != null) {
+            valueBlockBuilderCopy = (BlockBuilder) valueBlockBuilder.copyRegion(0, valueBlockBuilder.getPositionCount());
+        }
+        return new KeyValuePairs(
+                keyBlockBuilderCopy,
+                keyType,
+                keyEqualOperator,
+                keyHashCodeOperator,
+                valueBlockBuilderCopy,
+                valueType,
+                keyPositionByHash.clone(),
+                hashCapacity,
+                maxFill,
+                hashMask);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/TypedHeap.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/TypedHeap.java
@@ -48,6 +48,17 @@ public class TypedHeap
         this.heapBlockBuilder = type.createBlockBuilder(null, capacity);
     }
 
+    // for copying
+    private TypedHeap(MethodHandle greaterThanMethod, Type type, int capacity, int positionCount, int[] heapIndex, BlockBuilder heapBlockBuilder)
+    {
+        this.greaterThanMethod = greaterThanMethod;
+        this.type = type;
+        this.capacity = capacity;
+        this.positionCount = positionCount;
+        this.heapIndex = heapIndex;
+        this.heapBlockBuilder = heapBlockBuilder;
+    }
+
     public int getCapacity()
     {
         return capacity;
@@ -191,5 +202,14 @@ public class TypedHeap
             Throwables.throwIfUnchecked(throwable);
             throw new RuntimeException(throwable);
         }
+    }
+
+    public TypedHeap copy()
+    {
+        BlockBuilder heapBlockBuilderCopy = null;
+        if (heapBlockBuilder != null) {
+            heapBlockBuilderCopy = (BlockBuilder) heapBlockBuilder.copyRegion(0, heapBlockBuilder.getPositionCount());
+        }
+        return new TypedHeap(greaterThanMethod, type, capacity, positionCount, heapIndex.clone(), heapBlockBuilderCopy);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/TypedKeyValueHeap.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/TypedKeyValueHeap.java
@@ -57,6 +57,19 @@ public class TypedKeyValueHeap
         this.valueBlockBuilder = valueType.createBlockBuilder(null, capacity);
     }
 
+    // for copying
+    private TypedKeyValueHeap(MethodHandle keyGreaterThan, Type keyType, Type valueType, int capacity, int positionCount, int[] heapIndex, BlockBuilder keyBlockBuilder, BlockBuilder valueBlockBuilder)
+    {
+        this.keyGreaterThan = keyGreaterThan;
+        this.keyType = keyType;
+        this.valueType = valueType;
+        this.capacity = capacity;
+        this.positionCount = positionCount;
+        this.heapIndex = heapIndex;
+        this.keyBlockBuilder = keyBlockBuilder;
+        this.valueBlockBuilder = valueBlockBuilder;
+    }
+
     public static Type getSerializedType(Type keyType, Type valueType)
     {
         return RowType.anonymous(ImmutableList.of(BIGINT, new ArrayType(keyType), new ArrayType(valueType)));
@@ -233,5 +246,26 @@ public class TypedKeyValueHeap
             Throwables.throwIfUnchecked(throwable);
             throw new RuntimeException(throwable);
         }
+    }
+
+    public TypedKeyValueHeap copy()
+    {
+        BlockBuilder keyBlockBuilderCopy = null;
+        if (keyBlockBuilder != null) {
+            keyBlockBuilderCopy = (BlockBuilder) keyBlockBuilder.copyRegion(0, keyBlockBuilder.getPositionCount());
+        }
+        BlockBuilder valueBlockBuilderCopy = null;
+        if (valueBlockBuilder != null) {
+            valueBlockBuilderCopy = (BlockBuilder) valueBlockBuilder.copyRegion(0, valueBlockBuilder.getPositionCount());
+        }
+        return new TypedKeyValueHeap(
+                keyGreaterThan,
+                keyType,
+                valueType,
+                capacity,
+                positionCount,
+                heapIndex.clone(),
+                keyBlockBuilderCopy,
+                valueBlockBuilderCopy);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/SingleArrayAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/arrayagg/SingleArrayAggregationState.java
@@ -15,10 +15,12 @@ package io.trino.operator.aggregation.arrayagg;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
 import static com.google.common.base.Verify.verify;
+import static io.trino.operator.aggregation.BlockBuilderCopier.copyBlockBuilder;
 import static java.util.Objects.requireNonNull;
 
 public class SingleArrayAggregationState
@@ -31,6 +33,13 @@ public class SingleArrayAggregationState
     public SingleArrayAggregationState(Type type)
     {
         this.type = requireNonNull(type, "type is null");
+    }
+
+    // for copying
+    private SingleArrayAggregationState(BlockBuilder blockBuilder, Type type)
+    {
+        this.blockBuilder = blockBuilder;
+        this.type = type;
     }
 
     @Override
@@ -78,5 +87,11 @@ public class SingleArrayAggregationState
     public void reset()
     {
         blockBuilder = null;
+    }
+
+    @Override
+    public AccumulatorState copy()
+    {
+        return new SingleArrayAggregationState(copyBlockBuilder(blockBuilder), type);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxby/MinMaxByNStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/minmaxby/MinMaxByNStateFactory.java
@@ -16,6 +16,7 @@ package io.trino.operator.aggregation.minmaxby;
 import io.trino.array.ObjectBigArray;
 import io.trino.operator.aggregation.TypedKeyValueHeap;
 import io.trino.operator.aggregation.state.AbstractGroupedAccumulatorState;
+import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.AccumulatorStateFactory;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -96,6 +97,14 @@ public class MinMaxByNStateFactory
         private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleMinMaxByNState.class).instanceSize();
         private TypedKeyValueHeap typedKeyValueHeap;
 
+        public SingleMinMaxByNState() {}
+
+        // for copying
+        private SingleMinMaxByNState(TypedKeyValueHeap typedKeyValueHeap)
+        {
+            this.typedKeyValueHeap = typedKeyValueHeap;
+        }
+
         @Override
         public long getEstimatedSize()
         {
@@ -121,6 +130,16 @@ public class MinMaxByNStateFactory
         @Override
         public void addMemoryUsage(long memory)
         {
+        }
+
+        @Override
+        public AccumulatorState copy()
+        {
+            TypedKeyValueHeap typedKeyValueHeapCopy = null;
+            if (typedKeyValueHeap != null) {
+                typedKeyValueHeapCopy = typedKeyValueHeap.copy();
+            }
+            return new SingleMinMaxByNState(typedKeyValueHeapCopy);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/SingleMultimapAggregationState.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/multimapagg/SingleMultimapAggregationState.java
@@ -15,9 +15,11 @@ package io.trino.operator.aggregation.multimapagg;
 
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
 
+import static io.trino.operator.aggregation.BlockBuilderCopier.copyBlockBuilder;
 import static io.trino.type.TypeUtils.expectedValueSize;
 import static java.util.Objects.requireNonNull;
 
@@ -38,6 +40,15 @@ public class SingleMultimapAggregationState
         this.valueType = requireNonNull(valueType);
         keyBlockBuilder = keyType.createBlockBuilder(null, EXPECTED_ENTRIES, expectedValueSize(keyType, EXPECTED_ENTRY_SIZE));
         valueBlockBuilder = valueType.createBlockBuilder(null, EXPECTED_ENTRIES, expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
+    }
+
+    // for copying
+    private SingleMultimapAggregationState(Type keyType, Type valueType, BlockBuilder keyBlockBuilder, BlockBuilder valueBlockBuilder)
+    {
+        this.keyType = keyType;
+        this.valueType = valueType;
+        this.keyBlockBuilder = keyBlockBuilder;
+        this.valueBlockBuilder = valueBlockBuilder;
     }
 
     @Override
@@ -80,5 +91,11 @@ public class SingleMultimapAggregationState
         // Thus reset() will be called for each group (via MultimapAggregationStateSerializer#deserialize)
         keyBlockBuilder = keyBlockBuilder.newBlockBuilderLike(null);
         valueBlockBuilder = valueBlockBuilder.newBlockBuilderLike(null);
+    }
+
+    @Override
+    public AccumulatorState copy()
+    {
+        return new SingleMultimapAggregationState(keyType, valueType, copyBlockBuilder(keyBlockBuilder), copyBlockBuilder(valueBlockBuilder));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/KeyValuePairsStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/KeyValuePairsStateFactory.java
@@ -15,6 +15,7 @@ package io.trino.operator.aggregation.state;
 
 import io.trino.array.ObjectBigArray;
 import io.trino.operator.aggregation.KeyValuePairs;
+import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.AccumulatorStateFactory;
 import io.trino.spi.type.Type;
 import org.openjdk.jol.info.ClassLayout;
@@ -138,6 +139,14 @@ public class KeyValuePairsStateFactory
             this.valueType = valueType;
         }
 
+        // for copying
+        private SingleState(Type keyType, Type valueType, KeyValuePairs pair)
+        {
+            this.keyType = keyType;
+            this.valueType = valueType;
+            this.pair = pair;
+        }
+
         @Override
         public KeyValuePairs get()
         {
@@ -175,6 +184,16 @@ public class KeyValuePairsStateFactory
                 estimatedSize += pair.estimatedInMemorySize();
             }
             return estimatedSize;
+        }
+
+        @Override
+        public AccumulatorState copy()
+        {
+            KeyValuePairs pairCopy = null;
+            if (pair != null) {
+                pairCopy = pair.copy();
+            }
+            return new SingleState(keyType, valueType, pairCopy);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
@@ -14,6 +14,7 @@
 package io.trino.operator.aggregation.state;
 
 import io.trino.array.LongBigArray;
+import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.AccumulatorStateFactory;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -91,6 +92,14 @@ public class LongDecimalWithOverflowAndLongStateFactory
 
         protected long longValue;
 
+        public SingleLongDecimalWithOverflowAndLongState() {}
+
+        // for copying
+        private SingleLongDecimalWithOverflowAndLongState(long longValue)
+        {
+            this.longValue = longValue;
+        }
+
         @Override
         public long getLong()
         {
@@ -113,6 +122,12 @@ public class LongDecimalWithOverflowAndLongStateFactory
         public long getEstimatedSize()
         {
             return INSTANCE_SIZE + SIZE;
+        }
+
+        @Override
+        public AccumulatorState copy()
+        {
+            return new SingleLongDecimalWithOverflowAndLongState(longValue);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
@@ -15,12 +15,14 @@ package io.trino.operator.aggregation.state;
 
 import io.trino.array.BooleanBigArray;
 import io.trino.array.LongBigArray;
+import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.AccumulatorStateFactory;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
 import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.System.arraycopy;
 
 public class LongDecimalWithOverflowStateFactory
         implements AccumulatorStateFactory<LongDecimalWithOverflowState>
@@ -150,6 +152,16 @@ public class LongDecimalWithOverflowStateFactory
         protected boolean isNotNull;
         protected long overflow;
 
+        public SingleLongDecimalWithOverflowState() {}
+
+        // for copying
+        private SingleLongDecimalWithOverflowState(long[] unscaledDecimal, boolean isNotNull, long overflow)
+        {
+            arraycopy(unscaledDecimal, 0, this.unscaledDecimal, 0, 2);
+            this.isNotNull = isNotNull;
+            this.overflow = overflow;
+        }
+
         @Override
         public boolean isNotNull()
         {
@@ -196,6 +208,12 @@ public class LongDecimalWithOverflowStateFactory
         public long getEstimatedSize()
         {
             return INSTANCE_SIZE + SIZE;
+        }
+
+        @Override
+        public AccumulatorState copy()
+        {
+            return new SingleLongDecimalWithOverflowState(unscaledDecimal, isNotNull, overflow);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/state/MinMaxNStateFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/state/MinMaxNStateFactory.java
@@ -15,6 +15,7 @@ package io.trino.operator.aggregation.state;
 
 import io.trino.array.ObjectBigArray;
 import io.trino.operator.aggregation.TypedHeap;
+import io.trino.spi.function.AccumulatorState;
 import io.trino.spi.function.AccumulatorStateFactory;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -95,6 +96,14 @@ public class MinMaxNStateFactory
         private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleMinMaxNState.class).instanceSize();
         private TypedHeap typedHeap;
 
+        public SingleMinMaxNState() {}
+
+        // for copying
+        private SingleMinMaxNState(TypedHeap typedHeap)
+        {
+            this.typedHeap = typedHeap;
+        }
+
         @Override
         public long getEstimatedSize()
         {
@@ -120,6 +129,16 @@ public class MinMaxNStateFactory
         @Override
         public void addMemoryUsage(long memory)
         {
+        }
+
+        @Override
+        public AccumulatorState copy()
+        {
+            TypedHeap typedHeapCopy = null;
+            if (typedHeap != null) {
+                typedHeapCopy = typedHeap.copy();
+            }
+            return new SingleMinMaxNState(typedHeapCopy);
         }
     }
 }


### PR DESCRIPTION
This is needed for forking threads in row pattern matching.
This change introduces a copy() method in `Accumulator`
and `AccumulatorState`. The method is implemented:
- for generated `AccumulatorState` classes
- for certain existing implementations, including
array_agg, min/max N, min_by/max_by N, multimap_agg,
map_agg, map_union, decimal avg, and decimal sum