### PR TITLE
Fix reading fixed_len_byte_array of length 9-16 in parquet

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -246,7 +246,7 @@ public final class ParquetTypeUtils
     public static long getShortDecimalValue(byte[] bytes)
     {
         long value = 0;
-        if ((bytes[0] & 0x80) != 0) {
+        if (bytes[0] < 0) {
             for (int i = 0; i < 8 - bytes.length; ++i) {
                 value |= 0xFFL << (8 * (7 - i));
             }

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/ParquetTypeUtils.java
@@ -245,15 +245,20 @@ public final class ParquetTypeUtils
     // copied from trino-hive DecimalUtils
     public static long getShortDecimalValue(byte[] bytes)
     {
+        return getShortDecimalValue(bytes, 0, bytes.length);
+    }
+
+    public static long getShortDecimalValue(byte[] bytes, int startOffset, int length)
+    {
         long value = 0;
-        if (bytes[0] < 0) {
-            for (int i = 0; i < 8 - bytes.length; ++i) {
+        if (bytes[startOffset] < 0) {
+            for (int i = 0; i < 8 - length; ++i) {
                 value |= 0xFFL << (8 * (7 - i));
             }
         }
 
-        for (int i = 0; i < bytes.length; i++) {
-            value |= (bytes[bytes.length - i - 1] & 0xFFL) << (8 * i);
+        for (int i = 0; i < length; i++) {
+            value |= (bytes[startOffset + length - i - 1] & 0xFFL) << (8 * i);
         }
 
         return value;


### PR DESCRIPTION
If the extra bytes are all zeros or all -1 for negative values,
then the remaining bytes can be decoded as a short decimal.

Currently incorrect results are returned when a negative value is 
stored in fixed_len_byte_array of size 9-16 and read as a short decimal.