### PR TITLE
Add SYSTEM security type to Hive and Iceberg

### DIFF
--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHivePlugin.java
@@ -362,6 +362,22 @@ public class TestHivePlugin
                 .shutdown();
     }
 
+    @Test
+    public void testSystemAccessControl()
+    {
+        ConnectorFactory connectorFactory = getHiveConnectorFactory();
+
+        Connector connector = connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.metastore.uri", "thrift://foo:1234")
+                        .put("hive.security", "system")
+                        .build(),
+                new TestingConnectorContext());
+        assertThatThrownBy(connector::getAccessControl).isInstanceOf(UnsupportedOperationException.class);
+        connector.shutdown();
+    }
+
     private static ConnectorFactory getHiveConnectorFactory()
     {
         Plugin plugin = new HivePlugin();

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/HiveSecurityModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/HiveSecurityModule.java
@@ -31,6 +31,7 @@ public class HiveSecurityModule
     public static final String READ_ONLY = "read-only";
     public static final String SQL_STANDARD = "sql-standard";
     public static final String ALLOW_ALL = "allow-all";
+    public static final String SYSTEM = "system";
 
     @Override
     protected void setup(Binder binder)
@@ -53,6 +54,7 @@ public class HiveSecurityModule
                         new StaticAccessControlMetadataModule()));
         bindSecurityModule(SQL_STANDARD, new SqlStandardSecurityModule());
         bindSecurityModule(ALLOW_ALL, new AllowAllSecurityModule());
+        bindSecurityModule(SYSTEM, new SystemSecurityModule());
     }
 
     private void bindSecurityModule(String name, Module module)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SystemSecurityModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SystemSecurityModule.java
@@ -15,17 +15,14 @@ package io.trino.plugin.hive.security;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import com.google.inject.Scopes;
-import io.trino.plugin.base.security.AllowAllAccessControl;
-import io.trino.spi.connector.ConnectorAccessControl;
 
-public class AllowAllSecurityModule
+public class SystemSecurityModule
         implements Module
 {
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(ConnectorAccessControl.class).to(AllowAllAccessControl.class).in(Scopes.SINGLETON);
+        // do not bind an ConnectorAccessControl so the engine will use system security with system roles
         binder.bind(AccessControlMetadataFactory.class).toInstance(metastore -> new AccessControlMetadata() {});
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/AllowAllSecurityModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/AllowAllSecurityModule.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.trino.plugin.base.security.AllowAllAccessControl;
+import io.trino.spi.connector.ConnectorAccessControl;
+
+public class AllowAllSecurityModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(ConnectorAccessControl.class).to(AllowAllAccessControl.class).in(Scopes.SINGLETON);
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergModule.java
@@ -17,7 +17,6 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
-import io.trino.plugin.base.security.ConnectorAccessControlModule;
 import io.trino.plugin.base.session.SessionPropertiesProvider;
 import io.trino.plugin.hive.FileFormatDataSourceStats;
 import io.trino.plugin.hive.HiveConfig;
@@ -77,7 +76,5 @@ public class IcebergModule
 
         Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
         procedures.addBinding().toProvider(RollbackToSnapshotProcedure.class).in(Scopes.SINGLETON);
-
-        binder.install(new ConnectorAccessControlModule());
     }
 }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import io.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+public class IcebergSecurityConfig
+{
+    public enum IcebergSecurity
+    {
+        ALLOW_ALL,
+        READ_ONLY,
+    }
+
+    private IcebergSecurity securitySystem = IcebergSecurity.ALLOW_ALL;
+
+    @NotNull
+    public IcebergSecurity getSecuritySystem()
+    {
+        return securitySystem;
+    }
+
+    @Config("iceberg.security")
+    public IcebergSecurityConfig setSecuritySystem(IcebergSecurity securitySystem)
+    {
+        this.securitySystem = securitySystem;
+        return this;
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityConfig.java
@@ -23,6 +23,7 @@ public class IcebergSecurityConfig
     {
         ALLOW_ALL,
         READ_ONLY,
+        SYSTEM,
     }
 
     private IcebergSecurity securitySystem = IcebergSecurity.ALLOW_ALL;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityModule.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import io.airlift.configuration.AbstractConfigurationAwareModule;
+import io.trino.plugin.base.security.ConnectorAccessControlModule;
+import io.trino.plugin.base.security.ReadOnlySecurityModule;
+import io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity;
+
+import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity.READ_ONLY;
+
+public class IcebergSecurityModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        install(new ConnectorAccessControlModule());
+        bindSecurityModule(READ_ONLY, new ReadOnlySecurityModule());
+        // ALLOW_ALL: do not bind an ConnectorAccessControl so the engine will use system security with system roles
+    }
+
+    private void bindSecurityModule(IcebergSecurity icebergSecurity, Module module)
+    {
+        install(conditionalModule(
+                IcebergSecurityConfig.class,
+                security -> icebergSecurity == security.getSecuritySystem(),
+                module));
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityModule.java
@@ -21,6 +21,7 @@ import io.trino.plugin.base.security.ReadOnlySecurityModule;
 import io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity;
 
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
+import static io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity.ALLOW_ALL;
 import static io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity.READ_ONLY;
 
 public class IcebergSecurityModule
@@ -30,8 +31,9 @@ public class IcebergSecurityModule
     protected void setup(Binder binder)
     {
         install(new ConnectorAccessControlModule());
+        bindSecurityModule(ALLOW_ALL, new AllowAllSecurityModule());
         bindSecurityModule(READ_ONLY, new ReadOnlySecurityModule());
-        // ALLOW_ALL: do not bind an ConnectorAccessControl so the engine will use system security with system roles
+        // SYSTEM: do not bind an ConnectorAccessControl so the engine will use system security with system roles
     }
 
     private void bindSecurityModule(IcebergSecurity icebergSecurity, Module module)

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/InternalIcebergConnectorFactory.java
@@ -77,6 +77,7 @@ public final class InternalIcebergConnectorFactory
                     new ConnectorObjectNameGeneratorModule(catalogName, "io.trino.plugin.iceberg", "trino.plugin.iceberg"),
                     new JsonModule(),
                     new IcebergModule(),
+                    new IcebergSecurityModule(),
                     new IcebergCatalogModule(metastore),
                     new HiveHdfsModule(),
                     new HiveS3Module(),

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -234,6 +234,7 @@ public abstract class BaseIcebergConnectorTest
     {
         assertThat(computeActual("SHOW CREATE SCHEMA tpch").getOnlyValue().toString())
                 .matches("CREATE SCHEMA iceberg.tpch\n" +
+                        "AUTHORIZATION USER user\n" +
                         "WITH \\(\n" +
                         "\\s+location = '.*/iceberg_data/tpch'\n" +
                         "\\)");

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -114,16 +114,15 @@ public class TestIcebergPlugin
     {
         ConnectorFactory connectorFactory = getConnectorFactory();
 
-        Connector connector = connectorFactory.create(
+        connectorFactory.create(
                 "test",
                 ImmutableMap.<String, String>builder()
                         .put("iceberg.catalog.type", "HIVE_METASTORE")
                         .put("hive.metastore.uri", "thrift://foo:1234")
                         .put("iceberg.security", "allow-all")
                         .build(),
-                new TestingConnectorContext());
-        assertThatThrownBy(connector::getAccessControl).isInstanceOf(UnsupportedOperationException.class);
-        connector.shutdown();
+                new TestingConnectorContext())
+                .shutdown();
     }
 
     @Test
@@ -140,6 +139,23 @@ public class TestIcebergPlugin
                         .build(),
                 new TestingConnectorContext())
                 .shutdown();
+    }
+
+    @Test
+    public void testSystemAccessControl()
+    {
+        ConnectorFactory connectorFactory = getConnectorFactory();
+
+        Connector connector = connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("iceberg.catalog.type", "HIVE_METASTORE")
+                        .put("hive.metastore.uri", "thrift://foo:1234")
+                        .put("iceberg.security", "system")
+                        .build(),
+                new TestingConnectorContext());
+        assertThatThrownBy(connector::getAccessControl).isInstanceOf(UnsupportedOperationException.class);
+        connector.shutdown();
     }
 
     private static ConnectorFactory getConnectorFactory()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergPlugin.java
@@ -13,6 +13,8 @@
  */
 package io.trino.plugin.iceberg;
 
+import com.google.common.collect.ImmutableMap;
+import io.trino.spi.connector.Connector;
 import io.trino.spi.connector.ConnectorFactory;
 import io.trino.testing.TestingConnectorContext;
 import org.testng.annotations.Test;
@@ -105,6 +107,39 @@ public class TestIcebergPlugin
                 new TestingConnectorContext()))
                 .hasMessageContaining("Configuration property 'hive.metastore-recording-path' was not used")
                 .hasMessageContaining("Configuration property 'hive.metastore.glue.region' was not used");
+    }
+
+    @Test
+    public void testAllowAllAccessControl()
+    {
+        ConnectorFactory connectorFactory = getConnectorFactory();
+
+        Connector connector = connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("iceberg.catalog.type", "HIVE_METASTORE")
+                        .put("hive.metastore.uri", "thrift://foo:1234")
+                        .put("iceberg.security", "allow-all")
+                        .build(),
+                new TestingConnectorContext());
+        assertThatThrownBy(connector::getAccessControl).isInstanceOf(UnsupportedOperationException.class);
+        connector.shutdown();
+    }
+
+    @Test
+    public void testReadOnlyAllAccessControl()
+    {
+        ConnectorFactory connectorFactory = getConnectorFactory();
+
+        connectorFactory.create(
+                "test",
+                ImmutableMap.<String, String>builder()
+                        .put("iceberg.catalog.type", "HIVE_METASTORE")
+                        .put("hive.metastore.uri", "thrift://foo:1234")
+                        .put("iceberg.security", "read-only")
+                        .build(),
+                new TestingConnectorContext())
+                .shutdown();
     }
 
     private static ConnectorFactory getConnectorFactory()

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSecurityConfig.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergSecurityConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static io.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static io.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+import static io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity.ALLOW_ALL;
+import static io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity.READ_ONLY;
+
+public class TestIcebergSecurityConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(IcebergSecurityConfig.class)
+                .setSecuritySystem(ALLOW_ALL));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("iceberg.security", "read-only")
+                .build();
+
+        IcebergSecurityConfig expected = new IcebergSecurityConfig()
+                .setSecuritySystem(READ_ONLY);
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
Change Hive and Iceberg `ALLOW_ALL` security back to using connector
security, so owner can be managed in Hive metastore.  Add `SYSTEM`
security which uses system managed security, so owner can be managed in
the system security metadata system.

Also, add `ALLOW_ALL` and `READ_ONLY` security to Iceberg.