### PR TITLE
Add test to assure impersonation not triggered on lowercase x-trino-user

### DIFF
--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/BaseOAuth2WebUiAuthenticationFilterTest.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/BaseOAuth2WebUiAuthenticationFilterTest.java
@@ -15,11 +15,13 @@ package io.trino.server.security.oauth2;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.configuration.ConfigurationAwareModule;
 import io.airlift.log.Level;
 import io.airlift.log.Logging;
 import io.airlift.testing.Closeables;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.impl.DefaultClaims;
+import io.trino.server.security.TestResourceSecurity.TestResource;
 import io.trino.server.testing.TestingTrinoServer;
 import io.trino.server.ui.OAuth2WebUiAuthenticationFilter;
 import io.trino.server.ui.WebUiModule;
@@ -49,6 +51,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
 import static io.trino.client.OkHttpUtil.setupInsecureSsl;
 import static io.trino.server.security.oauth2.TokenEndpointAuthMethod.CLIENT_SECRET_BASIC;
 import static io.trino.server.ui.OAuthWebUiCookie.OAUTH2_COOKIE;
@@ -64,9 +67,9 @@ public abstract class BaseOAuth2WebUiAuthenticationFilterTest
 {
     protected static final Duration TTL_ACCESS_TOKEN_IN_SECONDS = Duration.ofSeconds(5);
 
-    protected static final String TRINO_CLIENT_ID = "trino-client";
+    protected static final String TRINO_CLIENT_ID = "Trino-Client";
     protected static final String TRINO_CLIENT_SECRET = "trino-secret";
-    private static final String TRINO_AUDIENCE = TRINO_CLIENT_ID;
+    protected static final String TRINO_AUDIENCE = TRINO_CLIENT_ID;
     private static final String ADDITIONAL_AUDIENCE = "https://external-service.com";
     protected static final String TRUSTED_CLIENT_ID = "trusted-client";
     protected static final String TRUSTED_CLIENT_SECRET = "trusted-secret";
@@ -78,7 +81,7 @@ public abstract class BaseOAuth2WebUiAuthenticationFilterTest
     protected final OkHttpClient httpClient;
     protected TestingHydraIdentityProvider hydraIdP;
 
-    private TestingTrinoServer server;
+    protected TestingTrinoServer server;
     private URI serverUri;
     private URI uiUri;
 
@@ -102,7 +105,9 @@ public abstract class BaseOAuth2WebUiAuthenticationFilterTest
 
         server = TestingTrinoServer.builder()
                 .setCoordinator(true)
-                .setAdditionalModule(new WebUiModule())
+                .setAdditionalModule(ConfigurationAwareModule.combine(
+                        new WebUiModule(),
+                        binder -> jaxrsBinder(binder).bind(TestResource.class)))
                 .setProperties(getOAuth2Config(idpUrl))
                 .build();
         server.waitForNodeRefresh(Duration.ofSeconds(10));

--- a/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithJwt.java
+++ b/core/trino-main/src/test/java/io/trino/server/security/oauth2/TestOAuth2WebUiAuthenticationFilterWithJwt.java
@@ -13,20 +13,37 @@
  */
 package io.trino.server.security.oauth2;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
+import com.google.inject.Key;
 import io.airlift.http.client.HttpClientConfig;
 import io.airlift.http.client.jetty.JettyHttpClient;
+import io.airlift.http.server.HttpServerInfo;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.trino.server.security.jwt.JwkService;
 import io.trino.server.security.jwt.JwkSigningKeyResolver;
+import io.trino.testing.TestingAccessControlManager;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.HttpHeaders;
 
 import java.net.URI;
 
+import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static io.trino.server.security.oauth2.TokenEndpointAuthMethod.CLIENT_SECRET_BASIC;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.IMPERSONATE_USER;
+import static io.trino.testing.TestingAccessControlManager.privilege;
+import static java.util.Locale.ENGLISH;
+import static javax.ws.rs.core.Response.Status.OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
 
+@Test(singleThreaded = true)
 public class TestOAuth2WebUiAuthenticationFilterWithJwt
         extends BaseOAuth2WebUiAuthenticationFilterTest
 {
@@ -36,6 +53,7 @@ public class TestOAuth2WebUiAuthenticationFilterWithJwt
         return ImmutableMap.<String, String>builder()
                 .put("web-ui.enabled", "true")
                 .put("web-ui.authentication.type", "oauth2")
+                .put("http-server.authentication.type", "oauth2")
                 .put("http-server.https.enabled", "true")
                 .put("http-server.https.keystore.path", Resources.getResource("cert/localhost.pem").getPath())
                 .put("http-server.https.keystore.key", "")
@@ -46,7 +64,7 @@ public class TestOAuth2WebUiAuthenticationFilterWithJwt
                 .put("http-server.authentication.oauth2.client-id", TRINO_CLIENT_ID)
                 .put("http-server.authentication.oauth2.client-secret", TRINO_CLIENT_SECRET)
                 .put("http-server.authentication.oauth2.additional-audiences", TRUSTED_CLIENT_ID)
-                .put("http-server.authentication.oauth2.user-mapping.pattern", "(.*)(@.*)?")
+                .put("http-server.authentication.oauth2.user-mapping.file", Resources.getResource("user-mapping.json").getPath())
                 .put("oauth2-jwk.http-client.trust-store-path", Resources.getResource("cert/localhost.pem").getPath())
                 .build();
     }
@@ -76,5 +94,45 @@ public class TestOAuth2WebUiAuthenticationFilterWithJwt
         assertThat(claims.getSubject()).isEqualTo("foo@bar.com");
         assertThat(claims.get("client_id")).isEqualTo(TRINO_CLIENT_ID);
         assertThat(claims.getIssuer()).isEqualTo("https://localhost:4444/");
+    }
+
+    @Test
+    public void testLowercaseTrinoUserWillNotTriggerImpersonationWithAppropriateUserMapping()
+            throws Exception
+    {
+        String usernameUppercase = TRINO_CLIENT_ID.toUpperCase(ENGLISH);
+        String usernameLowerCase = TRINO_CLIENT_ID.toLowerCase(ENGLISH);
+        assertThat(usernameUppercase).isNotEqualTo(TRINO_CLIENT_ID);
+        assertThat(usernameLowerCase).isNotEqualTo(TRINO_CLIENT_ID);
+
+        hydraIdP.createClient(
+                usernameUppercase,
+                TRINO_CLIENT_SECRET,
+                CLIENT_SECRET_BASIC,
+                ImmutableList.of(TRINO_AUDIENCE),
+                server.getHttpsBaseUrl() + "/oauth2/callback");
+
+        HttpServerInfo httpServerInfo = server.getInstance(Key.get(HttpServerInfo.class));
+        TestingAccessControlManager accessControl = server.getAccessControl();
+
+        String token = hydraIdP.getToken(usernameUppercase, TRINO_CLIENT_SECRET, ImmutableList.of(TRINO_AUDIENCE));
+        try {
+            accessControl.deny(privilege(usernameLowerCase, IMPERSONATE_USER));
+            try (Response response = httpClient.newCall(new Request.Builder()
+                            .url(uriBuilderFrom(httpServerInfo.getHttpsUri())
+                                    .replacePath("/username")
+                                    .toString())
+                            .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                            .addHeader("X-Trino-User", usernameLowerCase)
+                            .build())
+                    .execute()) {
+                assertThat(response.code()).isEqualTo(OK.getStatusCode());
+                // We expect user-mapping rule '([^@]+)(@.*)?' to lowercase Principal name and skip impersonation as it matches Trino user.
+                assertEquals(response.header("user"), usernameLowerCase);
+            }
+        }
+        finally {
+            accessControl.reset();
+        }
     }
 }

--- a/core/trino-main/src/test/resources/user-mapping.json
+++ b/core/trino-main/src/test/resources/user-mapping.json
@@ -5,6 +5,11 @@
             "user": "$1_file"
         },
         {
+            "pattern": "([^@]+)(@.*)?",
+            "user": "$1$2",
+            "case": "lower"
+        },
+        {
             "pattern": "test",
             "allow": false
         },


### PR DESCRIPTION
Some access controls internally use only lowercase usernames. In those cases we can apply user mapping rule which converts uppercase usernames to lowercase. We need to be sure that impersonation will not be triggered then as effectively user shipped with credentials is not equal to Trino user.