### PR TITLE
Use AccessControl functionality to filter columns from SELECT *…

### DIFF
--- a/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
@@ -145,6 +145,8 @@ public class FeaturesConfig
     private boolean disableSetPropertiesSecurityCheckForCreateDdl;
     private boolean incrementalHashArrayLoadFactorEnabled = true;
 
+    private boolean hideInaccesibleColumns;
+
     public enum JoinReorderingStrategy
     {
         NONE,
@@ -1106,6 +1108,19 @@ public class FeaturesConfig
     public FeaturesConfig setIncrementalHashArrayLoadFactorEnabled(boolean incrementalHashArrayLoadFactorEnabled)
     {
         this.incrementalHashArrayLoadFactorEnabled = incrementalHashArrayLoadFactorEnabled;
+        return this;
+    }
+
+    public boolean isHideInaccesibleColumns()
+    {
+        return hideInaccesibleColumns;
+    }
+
+    @Config("hide-inaccessible-columns")
+    @ConfigDescription("When enabled non-accessible columns are silently filtered from results from SELECT * statements")
+    public FeaturesConfig setHideInaccesibleColumns(boolean hideInaccesibleColumns)
+    {
+        this.hideInaccesibleColumns = hideInaccesibleColumns;
         return this;
     }
 }

--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -149,6 +149,7 @@ public final class SystemSessionProperties
     public static final String RETRY_ATTEMPTS = "retry_attempts";
     public static final String RETRY_INITIAL_DELAY = "retry_initial_delay";
     public static final String RETRY_MAX_DELAY = "retry_max_delay";
+    public static final String HIDE_INACCESSIBLE_COLUMNS = "hide_inaccessible_columns";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -692,6 +693,12 @@ public final class SystemSessionProperties
                         RETRY_MAX_DELAY,
                         "Maximum delay before initiating a retry attempt. Delay increases exponentially for each subsequent attempt starting from 'retry_initial_delay'",
                         queryManagerConfig.getRetryMaxDelay(),
+                        false),
+                booleanProperty(
+                        HIDE_INACCESSIBLE_COLUMNS,
+                        "When enabled non-accessible columns are silently filtered from results from SELECT * statements",
+                        featuresConfig.isHideInaccesibleColumns(),
+                        value -> validateHideInaccesibleColumns(value, featuresConfig.isHideInaccesibleColumns()),
                         false));
     }
 
@@ -1030,6 +1037,13 @@ public final class SystemSessionProperties
         return session.getSystemProperty(MAX_GROUPING_SETS, Integer.class);
     }
 
+    private static void validateHideInaccesibleColumns(boolean value, boolean defaultValue)
+    {
+        if (defaultValue == true && value == false) {
+            throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s cannot be disabled with session property when it was enabled with configuration", HIDE_INACCESSIBLE_COLUMNS));
+        }
+    }
+
     public static OptionalInt getMaxDriversPerTask(Session session)
     {
         Integer value = session.getSystemProperty(MAX_DRIVERS_PER_TASK, Integer.class);
@@ -1240,5 +1254,10 @@ public final class SystemSessionProperties
     public static Duration getRetryMaxDelay(Session session)
     {
         return session.getSystemProperty(RETRY_MAX_DELAY, Duration.class);
+    }
+
+    public static boolean isHideInaccesibleColumns(Session session)
+    {
+        return session.getSystemProperty(HIDE_INACCESSIBLE_COLUMNS, Boolean.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
+++ b/core/trino-main/src/main/java/io/trino/security/ViewAccessControl.java
@@ -14,6 +14,7 @@
 package io.trino.security;
 
 import io.trino.metadata.QualifiedObjectName;
+import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.security.AccessDeniedException;
 import io.trino.spi.security.Identity;
 import io.trino.spi.security.ViewExpression;
@@ -51,6 +52,12 @@ public class ViewAccessControl
         // This means that the owner of the view is effectively granting permissions to the user running the query,
         // and thus must have the equivalent of the SQL standard "GRANT ... WITH GRANT OPTION".
         wrapAccessDeniedException(() -> delegate.checkCanCreateViewWithSelectFromColumns(context, tableName, columnNames));
+    }
+
+    @Override
+    public Set<String> filterColumns(SecurityContext context, CatalogSchemaTableName tableName, Set<String> columns)
+    {
+        return delegate.filterColumns(context, tableName, columns);
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
+++ b/core/trino-main/src/test/java/io/trino/sql/analyzer/TestFeaturesConfig.java
@@ -115,7 +115,8 @@ public class TestFeaturesConfig
                 .setMergeProjectWithValues(true)
                 .setLegacyCatalogRoles(false)
                 .setDisableSetPropertiesSecurityCheckForCreateDdl(false)
-                .setIncrementalHashArrayLoadFactorEnabled(true));
+                .setIncrementalHashArrayLoadFactorEnabled(true)
+                .setHideInaccesibleColumns(false));
     }
 
     @Test
@@ -195,6 +196,7 @@ public class TestFeaturesConfig
                 .put("deprecated.legacy-catalog-roles", "true")
                 .put("deprecated.disable-set-properties-security-check-for-create-ddl", "true")
                 .put("incremental-hash-array-load-factor.enabled", "false")
+                .put("hide-inaccessible-columns", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -270,7 +272,8 @@ public class TestFeaturesConfig
                 .setMergeProjectWithValues(false)
                 .setLegacyCatalogRoles(true)
                 .setDisableSetPropertiesSecurityCheckForCreateDdl(true)
-                .setIncrementalHashArrayLoadFactorEnabled(false);
+                .setIncrementalHashArrayLoadFactorEnabled(false)
+                .setHideInaccesibleColumns(true);
         assertFullMapping(properties, expected);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterHideInacessibleColumnsSession.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterHideInacessibleColumnsSession.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import io.trino.FeaturesConfig;
+import io.trino.SystemSessionProperties;
+import io.trino.execution.DynamicFilterConfig;
+import io.trino.execution.QueryManagerConfig;
+import io.trino.execution.TaskManagerConfig;
+import io.trino.execution.scheduler.NodeSchedulerConfig;
+import io.trino.memory.MemoryManagerConfig;
+import io.trino.memory.NodeMemoryConfig;
+import io.trino.metadata.SessionPropertyManager;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestFilterHideInacessibleColumnsSession
+{
+    @Test
+    public void testDisableWhenEnabledByDefault()
+    {
+        FeaturesConfig featuresConfig = new FeaturesConfig();
+        featuresConfig.setHideInaccesibleColumns(true);
+        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(new SystemSessionProperties(
+                new QueryManagerConfig(),
+                new TaskManagerConfig(),
+                new MemoryManagerConfig(),
+                featuresConfig,
+                new NodeMemoryConfig(),
+                new DynamicFilterConfig(),
+                new NodeSchedulerConfig()));
+        assertThatThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "false"))
+                .hasMessage("hide_inaccessible_columns cannot be disabled with session property when it was enabled with configuration");
+    }
+
+    @Test
+    public void testEnableWhenAlreadyEnabledByDefault()
+    {
+        FeaturesConfig featuresConfig = new FeaturesConfig();
+        featuresConfig.setHideInaccesibleColumns(true);
+        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(new SystemSessionProperties(
+                new QueryManagerConfig(),
+                new TaskManagerConfig(),
+                new MemoryManagerConfig(),
+                featuresConfig,
+                new NodeMemoryConfig(),
+                new DynamicFilterConfig(),
+                new NodeSchedulerConfig()));
+        assertThatNoException().isThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "true"));
+    }
+
+    @Test
+    public void testDisableWhenAlreadyDisabledByDefault()
+    {
+        FeaturesConfig featuresConfig = new FeaturesConfig();
+        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(new SystemSessionProperties(
+                new QueryManagerConfig(),
+                new TaskManagerConfig(),
+                new MemoryManagerConfig(),
+                featuresConfig,
+                new NodeMemoryConfig(),
+                new DynamicFilterConfig(),
+                new NodeSchedulerConfig()));
+        assertThatNoException().isThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "false"));
+    }
+
+    @Test
+    public void testEnableWhenDisabledByDefault()
+    {
+        FeaturesConfig featuresConfig = new FeaturesConfig();
+        SessionPropertyManager sessionPropertyManager = new SessionPropertyManager(new SystemSessionProperties(
+                new QueryManagerConfig(),
+                new TaskManagerConfig(),
+                new MemoryManagerConfig(),
+                featuresConfig,
+                new NodeMemoryConfig(),
+                new DynamicFilterConfig(),
+                new NodeSchedulerConfig()));
+        assertThatNoException().isThrownBy(() -> sessionPropertyManager.validateSystemSessionProperty(SystemSessionProperties.HIDE_INACCESSIBLE_COLUMNS, "true"));
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestFilterInaccessibleColumns.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import com.google.common.collect.ImmutableMap;
+import io.trino.FeaturesConfig;
+import io.trino.Session;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.plugin.tpch.TpchConnectorFactory;
+import io.trino.spi.security.Identity;
+import io.trino.spi.security.ViewExpression;
+import io.trino.testing.LocalQueryRunner;
+import io.trino.testing.TestingAccessControlManager;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
+import static io.trino.testing.TestingAccessControlManager.privilege;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Test(singleThreaded = true) // shared access control
+public class TestFilterInaccessibleColumns
+{
+    private static final String CATALOG = "local";
+    private static final String USER = "user";
+    private static final String ADMIN = "admin";
+
+    private static final Session SESSION = testSessionBuilder()
+            .setCatalog(CATALOG)
+            .setSchema(TINY_SCHEMA_NAME)
+            .setSystemProperty("hide_inaccessible_columns", "true")
+            .setIdentity(Identity.forUser(USER).build())
+            .build();
+
+    private QueryAssertions assertions;
+    private TestingAccessControlManager accessControl;
+
+    @BeforeClass
+    public void init()
+    {
+        LocalQueryRunner runner = LocalQueryRunner.builder(SESSION)
+                .withFeaturesConfig(new FeaturesConfig().setHideInaccesibleColumns(true))
+                .build();
+
+        runner.createCatalog(CATALOG, new TpchConnectorFactory(1), ImmutableMap.of());
+        assertions = new QueryAssertions(runner);
+        accessControl = assertions.getQueryRunner().getAccessControl();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @BeforeMethod
+    public void beforeMethod()
+    {
+        accessControl.reset();
+    }
+
+    @Test
+    public void testSelectBaseline()
+    {
+        // No filtering baseline
+        assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3', CAST('refully final requests. regular, ironi' AS VARCHAR(152)))");
+    }
+
+    @Test
+    public void testSimpleTableSchemaFilter()
+    {
+        accessControl.deny(privilege(USER, "nation.comment", SELECT_COLUMN));
+        assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3')");
+    }
+
+    @Test
+    public void testDescribeBaseline()
+    {
+        assertThat(assertions.query("DESCRIBE nation"))
+                .matches(materializedRows -> materializedRows
+                        .getMaterializedRows().stream()
+                        .filter(materializedRow -> materializedRow.getField(0).equals("comment"))
+                        .findFirst()
+                        .isPresent());
+    }
+
+    @Test
+    public void testDescribe()
+    {
+        accessControl.deny(privilege(USER, "nation.comment", SELECT_COLUMN));
+        assertThat(assertions.query("DESCRIBE nation"))
+                .matches(materializedRows -> materializedRows
+                        .getMaterializedRows().stream()
+                        .filter(materializedRow -> materializedRow.getField(0).equals("comment"))
+                        .findFirst()
+                        .isEmpty());
+    }
+
+    @Test
+    public void testShowColumnsBaseline()
+    {
+        assertThat(assertions.query("SHOW COLUMNS FROM nation"))
+                .matches(materializedRows -> materializedRows
+                        .getMaterializedRows().stream()
+                        .filter(materializedRow -> materializedRow.getField(0).equals("comment"))
+                        .findFirst()
+                        .isPresent());
+    }
+
+    @Test
+    public void testShowColumns()
+    {
+        accessControl.deny(privilege("nation.comment", SELECT_COLUMN));
+        assertThat(assertions.query("SHOW COLUMNS FROM nation"))
+                .matches(materializedRows -> materializedRows
+                        .getMaterializedRows().stream()
+                        .filter(materializedRow -> materializedRow.getField(0).equals("comment"))
+                        .findFirst()
+                        .isEmpty());
+    }
+
+    /**
+     * Test filtering when columns are explicitly specified in SELECT
+     */
+    @Test
+    public void testFilterExplicitSelect()
+    {
+        // Select the columns that are available to us explicitly
+        accessControl.deny(privilege(USER, "nation.comment", SELECT_COLUMN));
+        assertThat(assertions.query("SELECT nationkey, name, regionkey FROM nation WHERE name = 'FRANCE'"))
+                .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3')");
+
+        // Select all columns explicitly
+        assertThatThrownBy(() -> assertions.query("SELECT nationkey, name, regionkey, comment FROM nation WHERE name = 'FRANCE'"))
+                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view local.tiny.nation");
+    }
+
+    @Test
+    public void testRowFilterOnNotAccessibleColumn()
+    {
+        accessControl.rowFilter(new QualifiedObjectName(CATALOG, TINY_SCHEMA_NAME, "nation"),
+                USER,
+                new ViewExpression(ADMIN, Optional.of(CATALOG), Optional.of(TINY_SCHEMA_NAME), "comment IS NOT null"));
+        accessControl.deny(privilege(USER, "nation.comment", SELECT_COLUMN));
+        assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .matches("VALUES (BIGINT '6', CAST('FRANCE' AS VARCHAR(25)), BIGINT '3')");
+    }
+
+    @Test
+    public void testRowFilterOnNotAccessibleColumnKO()
+    {
+        accessControl.rowFilter(new QualifiedObjectName(CATALOG, TINY_SCHEMA_NAME, "nation"),
+                USER,
+                new ViewExpression(USER, Optional.of(CATALOG), Optional.of(TINY_SCHEMA_NAME), "comment IS NOT null"));
+        accessControl.deny(privilege(USER, "nation.comment", SELECT_COLUMN));
+        assertThatThrownBy(() -> assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view local.tiny.nation");
+    }
+
+    @Test
+    public void testMaskingOnAccessibleColumn()
+    {
+        accessControl.columnMask(new QualifiedObjectName(CATALOG, TINY_SCHEMA_NAME, "nation"),
+                "nationkey",
+                USER,
+                new ViewExpression(ADMIN, Optional.of(CATALOG), Optional.of(TINY_SCHEMA_NAME), "-nationkey"));
+        assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .matches("VALUES (BIGINT '-6',CAST('FRANCE' AS VARCHAR(25)), BIGINT '3', CAST('refully final requests. regular, ironi' AS VARCHAR(152)))");
+    }
+
+    @Test
+    public void testMaskingWithCaseOnNotAccessibleColumnKO()
+    {
+        accessControl.deny(privilege(USER, "nation.nationkey", SELECT_COLUMN));
+        accessControl.columnMask(new QualifiedObjectName(CATALOG, TINY_SCHEMA_NAME, "nation"),
+                "comment",
+                USER,
+                new ViewExpression(USER, Optional.of(CATALOG), Optional.of(TINY_SCHEMA_NAME), "CASE nationkey WHEN 6 THEN 'masked-comment' ELSE comment END"));
+
+        assertThatThrownBy(() -> assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view local.tiny.nation");
+    }
+
+    @Test
+    public void testMaskingWithCaseOnNotAccessibleColumn()
+    {
+        accessControl.deny(privilege(USER, "nation.nationkey", SELECT_COLUMN));
+        accessControl.columnMask(new QualifiedObjectName(CATALOG, TINY_SCHEMA_NAME, "nation"),
+                "comment",
+                USER,
+                new ViewExpression(ADMIN, Optional.of(CATALOG), Optional.of(TINY_SCHEMA_NAME), "CASE nationkey WHEN 6 THEN 'masked-comment' ELSE comment END"));
+
+        assertThat(assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .matches("VALUES (CAST('FRANCE' AS VARCHAR(25)), BIGINT '3', CAST('masked-comment' AS VARCHAR(152)))");
+
+        assertThat(assertions.query("SELECT * FROM nation WHERE name = 'CANADA'"))
+                .matches("VALUES (CAST('CANADA' AS VARCHAR(25)), BIGINT '1', CAST('eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold' AS VARCHAR(152)))");
+    }
+
+    @Test
+    public void testPredicateOnInaccessibleColumn()
+    {
+        // Hide name but use it in the query predicate
+        accessControl.deny(privilege(USER, "nation.name", SELECT_COLUMN));
+        assertThatThrownBy(() -> assertions.query("SELECT * FROM nation WHERE name = 'FRANCE'"))
+                .hasMessage("Access Denied: Cannot select from columns [nationkey, regionkey, name, comment] in table or view local.tiny.nation");
+    }
+
+    @Test
+    public void testJoinBaseline()
+    {
+        assertThat(assertions.query("SELECT * FROM nation,customer WHERE customer.nationkey = nation.nationkey AND nation.name = 'FRANCE' AND customer.name='Customer#000001477'"))
+                .matches(materializedRows ->
+                    materializedRows.getMaterializedRows().get(0).getField(11).equals("ites nag blithely alongside of the ironic accounts. accounts use. carefully silent deposits"));
+    }
+
+    @Test
+    public void testJoin()
+    {
+        accessControl.deny(privilege(USER, "nation.comment", SELECT_COLUMN));
+        assertThat(assertions.query("SELECT * FROM nation,customer WHERE customer.nationkey = nation.nationkey AND nation.name = 'FRANCE' AND customer.name='Customer#000001477'"))
+                .matches(materializedRows ->
+                        materializedRows.getMaterializedRows().get(0).getFields().size() == 11);
+    }
+
+    @Test
+    public void testConstantFields()
+    {
+        assertThat(assertions.query("SELECT * FROM (SELECT 'test')"))
+                .matches("VALUES ('test')");
+    }
+
+    @Test
+    public void testFunctionFields()
+    {
+        assertThat(assertions.query("SELECT * FROM (SELECT concat(name,'-test') FROM nation WHERE name = 'FRANCE')"))
+                .matches("VALUES (CAST('FRANCE-test' AS VARCHAR))");
+    }
+
+    @Test
+    public void testFunctionOnInaccessibleColumn()
+    {
+        accessControl.deny(privilege(USER, "nation.name", SELECT_COLUMN));
+        assertThatThrownBy(() -> assertions.query("SELECT * FROM (SELECT concat(name,'-test') FROM nation WHERE name = 'FRANCE')"))
+                .hasMessage("Access Denied: Cannot select from columns [name] in table or view local.tiny.nation");
+    }
+}

--- a/docs/src/main/sphinx/security/overview.rst
+++ b/docs/src/main/sphinx/security/overview.rst
@@ -124,6 +124,17 @@ In addition, Trino :doc:`provides an API </develop/system-access-control>` that
 allows you to create a custom access control method, or to extend an existing
 one.
 
+The access control can limit access to columns of a table. The default behavior
+of an unqualified access to all columns with a ``SELECT *`` statement is to
+deny access to all inaccessible columns.
+
+You can change the behavior to silently hide inaccessible columns with the
+global property ``hide-inaccessible-columns`` in set in :ref:`config_properties`:
+
+.. code-block:: properties
+
+    hide-inaccessible-columns = true
+
 .. _security-inside-cluster:
 
 Securing inside the cluster


### PR DESCRIPTION
I Implemented the feature without modify the access control and making it configurable (by default is off).
The implementation allow also to create a rowfilter on a column that is inaccessible. This could be useful when you need to partition data between user but you would not to show the discrimination column.

fixes https://github.com/trinodb/trino/issues/7461