### PR TITLE
Update TPCH plugin to accurately reflect the accessed schema in IO Metadata.

### DIFF
--- a/core/trino-main/src/test/java/io/trino/cost/TestCostCalculator.java
+++ b/core/trino-main/src/test/java/io/trino/cost/TestCostCalculator.java
@@ -791,7 +791,7 @@ public class TestCostCalculator
             assignments.put(symbol, new TpchColumnHandle("orderkey", BIGINT));
         }
 
-        TpchTableHandle tableHandle = new TpchTableHandle("orders", 1.0);
+        TpchTableHandle tableHandle = new TpchTableHandle("sf1", "orders", 1.0);
         return new TableScanNode(
                 new PlanNodeId(id),
                 new TableHandle(new CatalogName("tpch"), tableHandle, INSTANCE, Optional.of(new TpchTableLayoutHandle(tableHandle, TupleDomain.all()))),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneCountAggregationOverScalar.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneCountAggregationOverScalar.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCALE_FACTOR;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.planner.iterative.rule.test.PlanBuilder.expressions;
@@ -162,7 +163,7 @@ public class TestPruneCountAggregationOverScalar
                                             p.tableScan(
                                                     new TableHandle(
                                                             new CatalogName("local"),
-                                                            new TpchTableHandle("orders", TINY_SCALE_FACTOR),
+                                                            new TpchTableHandle(TINY_SCHEMA_NAME, "orders", TINY_SCALE_FACTOR),
                                                             TpchTransactionHandle.INSTANCE,
                                                             Optional.empty()),
                                                     ImmutableList.of(totalPrice),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneIndexSourceColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneIndexSourceColumns.java
@@ -35,6 +35,7 @@ import java.util.function.Predicate;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCALE_FACTOR;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.constrainedIndexSource;
@@ -82,7 +83,7 @@ public class TestPruneIndexSourceColumns
                 p.indexSource(
                         new TableHandle(
                                 new CatalogName("local"),
-                                new TpchTableHandle("orders", TINY_SCALE_FACTOR),
+                                new TpchTableHandle(TINY_SCHEMA_NAME, "orders", TINY_SCALE_FACTOR),
                                 TpchTransactionHandle.INSTANCE,
                                 Optional.empty()),
                         ImmutableSet.of(orderkey, custkey),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTableScanColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneTableScanColumns.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCALE_FACTOR;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.DateType.DATE;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.strictConstrainedTableScan;
@@ -74,7 +75,7 @@ public class TestPruneTableScanColumns
                             p.tableScan(
                                     new TableHandle(
                                             new CatalogName("local"),
-                                            new TpchTableHandle("orders", TINY_SCALE_FACTOR),
+                                            new TpchTableHandle(TINY_SCHEMA_NAME, "orders", TINY_SCALE_FACTOR),
                                             TpchTransactionHandle.INSTANCE,
                                             Optional.empty()),
                                     ImmutableList.of(orderdate, totalprice),
@@ -102,7 +103,7 @@ public class TestPruneTableScanColumns
                             p.tableScan(
                                     new TableHandle(
                                             new CatalogName("local"),
-                                            new TpchTableHandle("orders", TINY_SCALE_FACTOR),
+                                            new TpchTableHandle(TINY_SCHEMA_NAME, "orders", TINY_SCALE_FACTOR),
                                             TpchTransactionHandle.INSTANCE,
                                             Optional.empty()),
                                     List.of(orderdate, totalprice),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDownDereferencesRules.java
@@ -299,7 +299,7 @@ public class TestPushDownDereferencesRules
     {
         TableHandle testTable = new TableHandle(
                 new CatalogName(CATALOG_ID),
-                new TpchTableHandle("orders", 1.0),
+                new TpchTableHandle("sf1", "orders", 1.0),
                 TestingTransactionHandle.create(),
                 Optional.empty());
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushPredicateIntoTableScan.java
@@ -101,14 +101,14 @@ public class TestPushPredicateIntoTableScan
         CatalogName catalogName = tester().getCurrentConnectorId();
         tester().getQueryRunner().createCatalog(MOCK_CATALOG, createMockFactory(), ImmutableMap.of());
 
-        TpchTableHandle nation = new TpchTableHandle("nation", 1.0);
+        TpchTableHandle nation = new TpchTableHandle("sf1", "nation", 1.0);
         nationTableHandle = new TableHandle(
                 catalogName,
                 nation,
                 TpchTransactionHandle.INSTANCE,
                 Optional.of(new TpchTableLayoutHandle(nation, TupleDomain.all())));
 
-        TpchTableHandle orders = new TpchTableHandle("orders", 1.0);
+        TpchTableHandle orders = new TpchTableHandle("sf1", "orders", 1.0);
         ordersTableHandle = new TableHandle(
                 catalogName,
                 orders,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveEmptyDeleteRuleSet.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveEmptyDeleteRuleSet.java
@@ -43,7 +43,7 @@ public class TestRemoveEmptyDeleteRuleSet
                 .on(p -> p.tableDelete(
                         new SchemaTableName("sch", "tab"),
                         p.tableScan(
-                                new TableHandle(CONNECTOR_ID, new TpchTableHandle("nation", 1.0), TpchTransactionHandle.INSTANCE, Optional.empty()),
+                                new TableHandle(CONNECTOR_ID, new TpchTableHandle("sf1", "nation", 1.0), TpchTransactionHandle.INSTANCE, Optional.empty()),
                                 ImmutableList.of(),
                                 ImmutableMap.of()),
                         p.symbol("a", BigintType.BIGINT)))
@@ -52,7 +52,7 @@ public class TestRemoveEmptyDeleteRuleSet
                 .on(p -> p.tableWithExchangeDelete(
                         new SchemaTableName("sch", "tab"),
                         p.tableScan(
-                                new TableHandle(CONNECTOR_ID, new TpchTableHandle("nation", 1.0), TpchTransactionHandle.INSTANCE, Optional.empty()),
+                                new TableHandle(CONNECTOR_ID, new TpchTableHandle("sf1", "nation", 1.0), TpchTransactionHandle.INSTANCE, Optional.empty()),
                                 ImmutableList.of(),
                                 ImmutableMap.of()),
                         p.symbol("a", BigintType.BIGINT)))

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTableScanPredicate.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTableScanPredicate.java
@@ -61,14 +61,14 @@ public class TestRemoveRedundantTableScanPredicate
     {
         removeRedundantTableScanPredicate = new RemoveRedundantTableScanPredicate(tester().getMetadata(), new TypeOperators(), tester().getTypeAnalyzer());
         CatalogName catalogName = tester().getCurrentConnectorId();
-        TpchTableHandle nation = new TpchTableHandle("nation", 1.0);
+        TpchTableHandle nation = new TpchTableHandle("sf1", "nation", 1.0);
         nationTableHandle = new TableHandle(
                 catalogName,
                 nation,
                 TpchTransactionHandle.INSTANCE,
                 Optional.of(new TpchTableLayoutHandle(nation, TupleDomain.all())));
 
-        TpchTableHandle orders = new TpchTableHandle("orders", 1.0);
+        TpchTableHandle orders = new TpchTableHandle("sf1", "orders", 1.0);
         ordersTableHandle = new TableHandle(
                 catalogName,
                 orders,

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedSingleRowSubqueryToProject.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestTransformCorrelatedSingleRowSubqueryToProject.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCALE_FACTOR;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.tableScan;
@@ -54,7 +55,7 @@ public class TestTransformCorrelatedSingleRowSubqueryToProject
                                 p.tableScan(
                                         new TableHandle(
                                                 new CatalogName("local"),
-                                                new TpchTableHandle("nation", TINY_SCALE_FACTOR),
+                                                new TpchTableHandle(TINY_SCHEMA_NAME, "nation", TINY_SCALE_FACTOR),
                                                 TpchTransactionHandle.INSTANCE,
                                                 Optional.empty()),
                                         ImmutableList.of(p.symbol("l_nationkey")),

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TestRuleTester.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/test/TestRuleTester.java
@@ -95,7 +95,7 @@ public class TestRuleTester
                             (node, captures, context) -> Result.empty()))
                     .on(p ->
                             p.tableScan(
-                                    new TableHandle(tester.getCurrentConnectorId(), new TpchTableHandle("nation", 1.0), TestingTransactionHandle.create(), Optional.empty()),
+                                    new TableHandle(tester.getCurrentConnectorId(), new TpchTableHandle("sf1", "nation", 1.0), TestingTransactionHandle.create(), Optional.empty()),
                                     List.of(p.symbol("x")),
                                     Map.of(p.symbol("x"), new TestingColumnHandle("column"))));
 

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestRemoveUnsupportedDynamicFilters.java
@@ -86,7 +86,7 @@ public class TestRemoveUnsupportedDynamicFilters
         CatalogName catalogName = getCurrentConnectorId();
         lineitemTableHandle = new TableHandle(
                 catalogName,
-                new TpchTableHandle("lineitem", 1.0),
+                new TpchTableHandle("sf1", "lineitem", 1.0),
                 TestingTransactionHandle.create(),
                 Optional.empty());
         lineitemOrderKeySymbol = builder.symbol("LINEITEM_OK", BIGINT);
@@ -94,7 +94,7 @@ public class TestRemoveUnsupportedDynamicFilters
 
         TableHandle ordersTableHandle = new TableHandle(
                 catalogName,
-                new TpchTableHandle("orders", 1.0),
+                new TpchTableHandle("sf1", "orders", 1.0),
                 TestingTransactionHandle.create(),
                 Optional.empty());
         ordersOrderKeySymbol = builder.symbol("ORDERS_OK", BIGINT);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/optimizations/TestUnaliasSymbolReferences.java
@@ -45,6 +45,7 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static io.trino.plugin.tpch.TpchMetadata.TINY_SCALE_FACTOR;
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.sql.DynamicFilters.createDynamicFilterExpression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.filter;
@@ -147,7 +148,7 @@ public class TestUnaliasSymbolReferences
     {
         return new TableHandle(
                 new CatalogName(session.getCatalog().get()),
-                new TpchTableHandle(tableName, TINY_SCALE_FACTOR),
+                new TpchTableHandle(TINY_SCHEMA_NAME, tableName, TINY_SCALE_FACTOR),
                 TestingTransactionHandle.create(),
                 Optional.empty());
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestDynamicFiltersChecker.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestDynamicFiltersChecker.java
@@ -68,7 +68,7 @@ public class TestDynamicFiltersChecker
         CatalogName catalogName = getCurrentConnectorId();
         TableHandle lineitemTableHandle = new TableHandle(
                 catalogName,
-                new TpchTableHandle("lineitem", 1.0),
+                new TpchTableHandle("sf1", "lineitem", 1.0),
                 TestingTransactionHandle.create(),
                 Optional.empty());
         lineitemOrderKeySymbol = builder.symbol("LINEITEM_OK", BIGINT);
@@ -76,7 +76,7 @@ public class TestDynamicFiltersChecker
 
         TableHandle ordersTableHandle = new TableHandle(
                 catalogName,
-                new TpchTableHandle("orders", 1.0),
+                new TpchTableHandle("sf1", "orders", 1.0),
                 TestingTransactionHandle.create(),
                 Optional.empty());
         ordersOrderKeySymbol = builder.symbol("ORDERS_OK", BIGINT);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateAggregationsWithDefaultValues.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateAggregationsWithDefaultValues.java
@@ -66,7 +66,7 @@ public class TestValidateAggregationsWithDefaultValues
         CatalogName catalogName = getCurrentConnectorId();
         TableHandle nationTableHandle = new TableHandle(
                 catalogName,
-                new TpchTableHandle("nation", 1.0),
+                new TpchTableHandle("sf1", "nation", 1.0),
                 TestingTransactionHandle.create(),
                 Optional.empty());
         TpchColumnHandle nationkeyColumnHandle = new TpchColumnHandle("nationkey", BIGINT);

--- a/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateStreamingAggregations.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/sanity/TestValidateStreamingAggregations.java
@@ -57,7 +57,7 @@ public class TestValidateStreamingAggregations
         CatalogName catalogName = getCurrentConnectorId();
         nationTableHandle = new TableHandle(
                 catalogName,
-                new TpchTableHandle("nation", 1.0),
+                new TpchTableHandle("sf1", "nation", 1.0),
                 TpchTransactionHandle.INSTANCE,
                 Optional.empty());
     }

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchMetadata.java
@@ -197,7 +197,7 @@ public class TpchMetadata
             return null;
         }
 
-        return new TpchTableHandle(tableName.getTableName(), scaleFactor);
+        return new TpchTableHandle(tableName.getSchemaName(), tableName.getTableName(), scaleFactor);
     }
 
     @Override
@@ -220,9 +220,8 @@ public class TpchMetadata
         TpchTableHandle tpchTableHandle = (TpchTableHandle) tableHandle;
 
         TpchTable<?> tpchTable = TpchTable.getTable(tpchTableHandle.getTableName());
-        String schemaName = scaleFactorSchemaName(tpchTableHandle.getScaleFactor());
 
-        return getTableMetadata(schemaName, tpchTable, columnNaming);
+        return getTableMetadata(tpchTableHandle.getSchemaName(), tpchTable, columnNaming);
     }
 
     private ConnectorTableMetadata getTableMetadata(String schemaName, TpchTable<?> tpchTable, ColumnNaming columnNaming)
@@ -519,6 +518,7 @@ public class TpchMetadata
 
         return Optional.of(new ConstraintApplicationResult<>(
                 new TpchTableHandle(
+                        handle.getSchemaName(),
                         handle.getTableName(),
                         handle.getScaleFactor(),
                         oldDomain.intersect(predicate)),
@@ -536,7 +536,7 @@ public class TpchMetadata
 
         CatalogSchemaTableName destinationTable = new CatalogSchemaTableName(
                 destinationCatalog.get(),
-                destinationSchema.orElse(scaleFactorSchemaName(handle.getScaleFactor())),
+                destinationSchema.orElse(handle.getSchemaName()),
                 handle.getTableName());
         return Optional.of(
                 new TableScanRedirectApplicationResult(
@@ -568,11 +568,6 @@ public class TpchMetadata
             return ImmutableList.of(schemaName.get());
         }
         return ImmutableList.of();
-    }
-
-    private static String scaleFactorSchemaName(double scaleFactor)
-    {
-        return "sf" + scaleFactor;
     }
 
     public static double schemaNameToScaleFactor(String schemaName)

--- a/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchTableHandle.java
+++ b/plugin/trino-tpch/src/main/java/io/trino/plugin/tpch/TpchTableHandle.java
@@ -27,25 +27,34 @@ import static java.util.Objects.requireNonNull;
 public class TpchTableHandle
         implements ConnectorTableHandle
 {
+    private final String schemaName;
     private final String tableName;
     private final double scaleFactor;
     private final TupleDomain<ColumnHandle> constraint;
 
-    public TpchTableHandle(String tableName, double scaleFactor)
+    public TpchTableHandle(String schemaName, String tableName, double scaleFactor)
     {
-        this(tableName, scaleFactor, TupleDomain.all());
+        this(schemaName, tableName, scaleFactor, TupleDomain.all());
     }
 
     @JsonCreator
     public TpchTableHandle(
+            @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("scaleFactor") double scaleFactor,
             @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
     {
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         checkArgument(scaleFactor > 0, "Scale factor must be larger than 0");
         this.scaleFactor = scaleFactor;
         this.constraint = requireNonNull(constraint, "constraint is null");
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaName;
     }
 
     @JsonProperty
@@ -69,13 +78,13 @@ public class TpchTableHandle
     @Override
     public String toString()
     {
-        return tableName + ":sf" + scaleFactor;
+        return schemaName + ":" + tableName;
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(tableName, scaleFactor, constraint);
+        return Objects.hash(schemaName, tableName, scaleFactor, constraint);
     }
 
     @Override
@@ -88,7 +97,8 @@ public class TpchTableHandle
             return false;
         }
         TpchTableHandle other = (TpchTableHandle) obj;
-        return Objects.equals(this.tableName, other.tableName) &&
+        return Objects.equals(this.schemaName, other.schemaName) &&
+                Objects.equals(this.tableName, other.tableName) &&
                 Objects.equals(this.scaleFactor, other.scaleFactor) &&
                 Objects.equals(this.constraint, other.constraint);
     }

--- a/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/TestTpchMetadata.java
+++ b/plugin/trino-tpch/src/test/java/io/trino/plugin/tpch/TestTpchMetadata.java
@@ -19,6 +19,7 @@ import io.trino.plugin.tpch.util.PredicateUtils;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableHandle;
+import io.trino.spi.connector.ConnectorTableMetadata;
 import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.SchemaTableName;
@@ -127,6 +128,30 @@ public class TestTpchMetadata
             testTableStats(schema, ORDERS, constraint(ORDER_STATUS, "F", "NO SUCH STATUS"), 730_400 * scaleFactor);
             testTableStats(schema, ORDERS, constraint(ORDER_STATUS, "F", "O", "P"), 1_500_000 * scaleFactor);
         });
+    }
+
+    @Test
+    public void testGetTableMetadata()
+    {
+        Stream.of("sf0.01", "tiny", "sf1.0", "sf1.000", "sf2.01", "sf3.1", "sf10.0", "sf100.0", "sf30000.0", "sf30000.2").forEach(
+                schemaName -> {
+                    testGetTableMetadata(schemaName, REGION);
+                    testGetTableMetadata(schemaName, NATION);
+                    testGetTableMetadata(schemaName, SUPPLIER);
+                    testGetTableMetadata(schemaName, CUSTOMER);
+                    testGetTableMetadata(schemaName, PART);
+                    testGetTableMetadata(schemaName, PART_SUPPLIER);
+                    testGetTableMetadata(schemaName, ORDERS);
+                    testGetTableMetadata(schemaName, LINE_ITEM);
+                });
+    }
+
+    private void testGetTableMetadata(String schema, TpchTable<?> table)
+    {
+        TpchTableHandle tableHandle = tpchMetadata.getTableHandle(session, new SchemaTableName(schema, table.getTableName()));
+        ConnectorTableMetadata tableMetadata = tpchMetadata.getTableMetadata(session, tableHandle);
+        assertEquals(tableMetadata.getTableSchema().getTable().getTableName(), table.getTableName());
+        assertEquals(tableMetadata.getTableSchema().getTable().getSchemaName(), schema);
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchConnectorTest.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/tpch/TestTpchConnectorTest.java
@@ -91,7 +91,7 @@ public class TestTpchConnectorTest
         EstimatedStatsAndCost scanEstimate = new EstimatedStatsAndCost(15000.0, 1597294.0, 1597294.0, 0.0, 0.0);
         EstimatedStatsAndCost totalEstimate = new EstimatedStatsAndCost(15000.0, 1597294.0, 1597294.0, 0.0, 1597294.0);
         IoPlanPrinter.IoPlan.TableColumnInfo input = new IoPlanPrinter.IoPlan.TableColumnInfo(
-                new CatalogSchemaTableName("tpch", "sf0.01", "orders"),
+                new CatalogSchemaTableName("tpch", "tiny", "orders"),
                 ImmutableSet.of(
                         new IoPlanPrinter.ColumnConstraint(
                                 "orderstatus",


### PR DESCRIPTION
Before this commit, the TPCH plugin would return schema names by concatenating a scale factor, which is a `double`, to the string `sf`. This results in schema names like `sf1.0` or `sf0.01`. These schema names differ from what a user sees, which would be `sf1`, or `tiny` in this example.

This commit changes the logic to avoid mapping a `double` scaling factor back to the expected schema name.
Now, we save the original schema name in `TpchTableHandle`.