### PR TITLE
Avoid regex in QueryId.*

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/QueryId.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/QueryId.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -28,8 +27,8 @@ public final class QueryId
     @JsonCreator
     public static QueryId valueOf(String queryId)
     {
-        List<String> ids = parseDottedId(queryId, 1, "queryId");
-        return new QueryId(ids.get(0));
+        // ID is verified in the constructor
+        return new QueryId(queryId);
     }
 
     private final String id;
@@ -74,13 +73,27 @@ public final class QueryId
     // Id helper methods
     //
 
-    private static final Pattern ID_PATTERN = Pattern.compile("[_a-z0-9]+");
+    // Check if the string matches [_a-z0-9]+ , but without the overhead of regex
+    private static final boolean isValidId(String id)
+    {
+        if (id.length() == 0) {
+            return false;
+        }
+
+        for (int i = 0; i < id.length(); i++) {
+            char c = id.charAt(i);
+            if (!(c == '_' || c >= 'a' && c <= 'z' || c >= '0' && c <= '9')) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     public static String validateId(String id)
     {
         requireNonNull(id, "id is null");
         checkArgument(!id.isEmpty(), "id is empty");
-        checkArgument(ID_PATTERN.matcher(id).matches(), "Invalid id %s", id);
+        checkArgument(isValidId(id), "Invalid id %s", id);
         return id;
     }
 
@@ -95,7 +108,7 @@ public final class QueryId
 
         for (String part : ids) {
             checkArgument(!part.isEmpty(), "Invalid id %s", id);
-            checkArgument(ID_PATTERN.matcher(part).matches(), "Invalid id %s", id);
+            checkArgument(isValidId(part), "Invalid id %s", id);
         }
         return ids;
     }


### PR DESCRIPTION
Comparable change: prestodb/presto#16832

This function's regex matching and splitting brought observable overhead according to allocation profiling. This PR fixes this overhead.