### PR TITLE
Do not set owner or permissions into Hive for system security 

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
@@ -83,7 +83,7 @@ public class MaterializedViewDefinition
                         .map(column -> new ConnectorMaterializedViewDefinition.Column(column.getName(), column.getType()))
                         .collect(toImmutableList()),
                 getComment(),
-                getRunAsIdentity().orElseThrow().getUser(),
+                getRunAsIdentity().map(Identity::getUser),
                 properties);
     }
 

--- a/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MaterializedViewDefinition.java
@@ -47,7 +47,7 @@ public class MaterializedViewDefinition
         this.properties = ImmutableMap.copyOf(requireNonNull(properties, "properties is null"));
     }
 
-    public MaterializedViewDefinition(ConnectorMaterializedViewDefinition view)
+    public MaterializedViewDefinition(ConnectorMaterializedViewDefinition view, Identity runAsIdentity)
     {
         super(
                 view.getOriginalSql(),
@@ -57,7 +57,7 @@ public class MaterializedViewDefinition
                         .map(column -> new ViewColumn(column.getName(), column.getType()))
                         .collect(toImmutableList()),
                 view.getComment(),
-                Optional.of(Identity.ofUser(view.getOwner())));
+                Optional.of(runAsIdentity));
         this.storageTable = view.getStorageTable();
         this.properties = ImmutableMap.copyOf(view.getProperties());
     }
@@ -100,19 +100,5 @@ public class MaterializedViewDefinition
                 .add("storageTable", storageTable.orElse(null))
                 .add("properties", properties)
                 .toString();
-    }
-
-    @Override
-    public MaterializedViewDefinition withOwner(Identity owner)
-    {
-        return new MaterializedViewDefinition(
-                getOriginalSql(),
-                getCatalog(),
-                getSchema(),
-                getColumns(),
-                getComment(),
-                owner,
-                storageTable,
-                properties);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1552,7 +1552,10 @@ public final class MetadataManager
     {
         Optional<ConnectorMaterializedViewDefinition> connectorView = getMaterializedViewInternal(session, viewName);
         if (connectorView.isEmpty() || isCatalogManagedSecurity(session, viewName.getCatalogName())) {
-            return connectorView.map(view -> new MaterializedViewDefinition(view, Identity.ofUser(view.getOwner())));
+            return connectorView.map(view -> {
+                String runAsUser = view.getOwner().orElseThrow(() -> new TrinoException(INVALID_VIEW, "Owner not set for a run-as invoker view: " + viewName));
+                return new MaterializedViewDefinition(view, Identity.ofUser(runAsUser));
+            });
         }
 
         Identity runAsIdentity = systemSecurityMetadata.getViewRunAsIdentity(session, viewName.asCatalogSchemaTableName())

--- a/core/trino-main/src/main/java/io/trino/testing/TestTestingMetadata.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestTestingMetadata.java
@@ -59,7 +59,7 @@ public class TestTestingMetadata
                 Optional.empty(),
                 ImmutableList.of(new Column("test", BIGINT.getTypeId())),
                 Optional.empty(),
-                "owner",
+                Optional.of("owner"),
                 ImmutableMap.of());
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestColumnMask.java
@@ -87,7 +87,7 @@ public class TestColumnMask
                         new ConnectorMaterializedViewDefinition.Column("regionkey", BigintType.BIGINT.getTypeId()),
                         new ConnectorMaterializedViewDefinition.Column("comment", VarcharType.createVarcharType(152).getTypeId())),
                 Optional.empty(),
-                VIEW_OWNER,
+                Optional.of(VIEW_OWNER),
                 ImmutableMap.of());
 
         ConnectorMaterializedViewDefinition freshMaterializedView = new ConnectorMaterializedViewDefinition(
@@ -101,7 +101,7 @@ public class TestColumnMask
                         new ConnectorMaterializedViewDefinition.Column("regionkey", BigintType.BIGINT.getTypeId()),
                         new ConnectorMaterializedViewDefinition.Column("comment", VarcharType.createVarcharType(152).getTypeId())),
                 Optional.empty(),
-                VIEW_OWNER,
+                Optional.of(VIEW_OWNER),
                 ImmutableMap.of());
 
         ConnectorMaterializedViewDefinition materializedViewWithCasts = new ConnectorMaterializedViewDefinition(
@@ -115,7 +115,7 @@ public class TestColumnMask
                         new ConnectorMaterializedViewDefinition.Column("regionkey", BigintType.BIGINT.getTypeId()),
                         new ConnectorMaterializedViewDefinition.Column("comment", VarcharType.createVarcharType(152).getTypeId())),
                 Optional.empty(),
-                VIEW_OWNER,
+                Optional.of(VIEW_OWNER),
                 ImmutableMap.of());
 
         MockConnectorFactory mock = MockConnectorFactory.builder()

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMaterializedViewDefinition.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMaterializedViewDefinition.java
@@ -31,7 +31,7 @@ public class ConnectorMaterializedViewDefinition
     private final Optional<String> schema;
     private final List<Column> columns;
     private final Optional<String> comment;
-    private final String owner;
+    private final Optional<String> owner;
     private final Map<String, Object> properties;
 
     public ConnectorMaterializedViewDefinition(
@@ -41,7 +41,7 @@ public class ConnectorMaterializedViewDefinition
             Optional<String> schema,
             List<Column> columns,
             Optional<String> comment,
-            String owner,
+            Optional<String> owner,
             Map<String, Object> properties)
     {
         this.originalSql = requireNonNull(originalSql, "originalSql is null");
@@ -91,7 +91,7 @@ public class ConnectorMaterializedViewDefinition
         return comment;
     }
 
-    public String getOwner()
+    public Optional<String> getOwner()
     {
         return owner;
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorViewDefinition.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorViewDefinition.java
@@ -103,6 +103,18 @@ public class ConnectorViewDefinition
         return runAsInvoker;
     }
 
+    public ConnectorViewDefinition withoutOwner()
+    {
+        return new ConnectorViewDefinition(
+                originalSql,
+                catalog,
+                schema,
+                columns,
+                comment,
+                Optional.empty(),
+                runAsInvoker);
+    }
+
     @Override
     public String toString()
     {

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoins.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialJoins.java
@@ -24,6 +24,7 @@ import io.trino.testing.DistributedQueryRunner;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.util.Optional;
 
 import static io.trino.SystemSessionProperties.SPATIAL_PARTITIONING_TABLE_NAME;
 import static io.trino.plugin.hive.metastore.file.FileHiveMetastore.createTestingFileHiveMetastore;
@@ -81,8 +82,8 @@ public class TestSpatialJoins
                 new HiveIdentity(SESSION),
                 Database.builder()
                         .setDatabaseName("default")
-                        .setOwnerName("public")
-                        .setOwnerType(PrincipalType.ROLE)
+                        .setOwnerName(Optional.of("public"))
+                        .setOwnerType(Optional.of(PrincipalType.ROLE))
                         .build());
         queryRunner.installPlugin(new TestingHivePlugin(metastore));
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -249,6 +249,7 @@ import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilege
 import static io.trino.plugin.hive.metastore.MetastoreUtil.getHiveSchema;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.getProtectMode;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.verifyOnline;
+import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.fromHivePrivilegeInfos;
 import static io.trino.plugin.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
 import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
@@ -793,8 +794,8 @@ public class HiveMetadata
         Database database = Database.builder()
                 .setDatabaseName(schemaName)
                 .setLocation(location)
-                .setOwnerType(owner.getType())
-                .setOwnerName(owner.getName())
+                .setOwnerType(accessControlMetadata.isUsingSystemSecurity() ? Optional.empty() : Optional.of(owner.getType()))
+                .setOwnerName(accessControlMetadata.isUsingSystemSecurity() ? Optional.empty() : Optional.of(owner.getName()))
                 .build();
 
         metastore.createDatabase(new HiveIdentity(session), database);
@@ -881,8 +882,9 @@ public class HiveMetadata
                 tableProperties,
                 targetPath,
                 external,
-                prestoVersion);
-        PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(table.getOwner());
+                prestoVersion,
+                accessControlMetadata.isUsingSystemSecurity());
+        PrincipalPrivileges principalPrivileges = accessControlMetadata.isUsingSystemSecurity() ? NO_PRIVILEGES : buildInitialPrivilegeSet(session.getUser());
         HiveBasicStatistics basicStatistics = (!external && table.getPartitionColumns().isEmpty()) ? createZeroStatistics() : createEmptyStatistics();
         metastore.createTable(
                 session,
@@ -1085,7 +1087,8 @@ public class HiveMetadata
             Map<String, String> additionalTableParameters,
             Optional<Path> targetPath,
             boolean external,
-            String prestoVersion)
+            String prestoVersion,
+            boolean usingSystemSecurity)
     {
         Map<String, HiveColumnHandle> columnHandlesByName = Maps.uniqueIndex(columnHandles, HiveColumnHandle::getName);
         List<Column> partitionColumns = partitionedBy.stream()
@@ -1120,7 +1123,7 @@ public class HiveMetadata
         Table.Builder tableBuilder = Table.builder()
                 .setDatabaseName(schemaName)
                 .setTableName(tableName)
-                .setOwner(tableOwner)
+                .setOwner(usingSystemSecurity ? Optional.empty() : Optional.of(tableOwner))
                 .setTableType((external ? EXTERNAL_TABLE : MANAGED_TABLE).name())
                 .setDataColumns(columns.build())
                 .setPartitionColumns(partitionColumns)
@@ -1388,8 +1391,9 @@ public class HiveMetadata
                 handle.getAdditionalTableParameters(),
                 Optional.of(writeInfo.getTargetPath()),
                 handle.isExternal(),
-                prestoVersion);
-        PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(handle.getTableOwner());
+                prestoVersion,
+                accessControlMetadata.isUsingSystemSecurity());
+        PrincipalPrivileges principalPrivileges = accessControlMetadata.isUsingSystemSecurity() ? NO_PRIVILEGES : buildInitialPrivilegeSet(handle.getTableOwner());
 
         partitionUpdates = PartitionUpdate.mergePartitionUpdates(partitionUpdates);
 
@@ -2164,6 +2168,10 @@ public class HiveMetadata
     @Override
     public void createView(ConnectorSession session, SchemaTableName viewName, ConnectorViewDefinition definition, boolean replace)
     {
+        if (accessControlMetadata.isUsingSystemSecurity()) {
+            definition = definition.withoutOwner();
+        }
+
         HiveIdentity identity = new HiveIdentity(session);
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put(TABLE_COMMENT, PRESTO_VIEW_COMMENT)
@@ -2178,7 +2186,7 @@ public class HiveMetadata
         Table.Builder tableBuilder = Table.builder()
                 .setDatabaseName(viewName.getSchemaName())
                 .setTableName(viewName.getTableName())
-                .setOwner(session.getUser())
+                .setOwner(accessControlMetadata.isUsingSystemSecurity() ? Optional.empty() : Optional.ofNullable(session.getUser()))
                 .setTableType(TableType.VIRTUAL_VIEW.name())
                 .setDataColumns(ImmutableList.of(dummyColumn))
                 .setPartitionColumns(ImmutableList.of())
@@ -2190,7 +2198,7 @@ public class HiveMetadata
                 .setStorageFormat(VIEW_STORAGE_FORMAT)
                 .setLocation("");
         Table table = tableBuilder.build();
-        PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(session.getUser());
+        PrincipalPrivileges principalPrivileges = accessControlMetadata.isUsingSystemSecurity() ? NO_PRIVILEGES : buildInitialPrivilegeSet(session.getUser());
 
         Optional<Table> existing = metastore.getTable(identity, viewName.getSchemaName(), viewName.getTableName());
         if (existing.isPresent()) {
@@ -2271,7 +2279,7 @@ public class HiveMetadata
 
         Optional<Database> database = metastore.getDatabase(schemaName.getSchemaName());
         if (database.isPresent()) {
-            return database.flatMap(db -> Optional.of(new TrinoPrincipal(db.getOwnerType(), db.getOwnerName())));
+            return database.flatMap(db -> db.getOwnerName().map(ownerName -> new TrinoPrincipal(db.getOwnerType().orElseThrow(), ownerName)));
         }
 
         throw new SchemaNotFoundException(schemaName.getSchemaName());
@@ -2316,14 +2324,14 @@ public class HiveMetadata
                     ConnectorViewDefinition definition = createViewReader(metastore, session, view, typeManager)
                             .decodeViewData(view.getViewOriginalText().get(), view, catalogName);
                     // use owner from table metadata if it exists
-                    if (view.getOwner() != null && !definition.isRunAsInvoker()) {
+                    if (view.getOwner().isPresent() && !definition.isRunAsInvoker()) {
                         definition = new ConnectorViewDefinition(
                                 definition.getOriginalSql(),
                                 definition.getCatalog(),
                                 definition.getSchema(),
                                 definition.getColumns(),
                                 definition.getComment(),
-                                Optional.of(view.getOwner()),
+                                view.getOwner(),
                                 false);
                     }
                     return definition;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LegacyHiveViewReader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/LegacyHiveViewReader.java
@@ -42,7 +42,7 @@ public class LegacyHiveViewReader
                         .map(column -> new ConnectorViewDefinition.ViewColumn(column.getName(), TypeId.of(column.getType().getTypeSignature().toString())))
                         .collect(toImmutableList()),
                 Optional.ofNullable(table.getParameters().get(TABLE_COMMENT)),
-                Optional.of(table.getOwner()),
+                table.getOwner(),
                 false); // don't run as invoker
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/CoralSemiTransactionalHiveMSCAdapter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/CoralSemiTransactionalHiveMSCAdapter.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.hive.metastore;
 
-import com.google.common.collect.ImmutableMultimap;
 import com.linkedin.coral.hive.hive2rel.HiveMetastoreClient;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil;
@@ -21,6 +20,7 @@ import org.apache.hadoop.hive.metastore.api.Database;
 
 import java.util.List;
 
+import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -63,7 +63,7 @@ public class CoralSemiTransactionalHiveMSCAdapter
     public org.apache.hadoop.hive.metastore.api.Table getTable(String dbName, String tableName)
     {
         return delegate.getTable(identity, dbName, tableName)
-                .map(value -> ThriftMetastoreUtil.toMetastoreApiTable(value, new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of())))
+                .map(value -> ThriftMetastoreUtil.toMetastoreApiTable(value, NO_PRIVILEGES))
                 .orElse(null);
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/Database.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/Database.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -35,8 +36,8 @@ public class Database
 
     private final String databaseName;
     private final Optional<String> location;
-    private final String ownerName;
-    private final PrincipalType ownerType;
+    private final Optional<String> ownerName;
+    private final Optional<PrincipalType> ownerType;
     private final Optional<String> comment;
     private final Map<String, String> parameters;
 
@@ -44,8 +45,8 @@ public class Database
     public Database(
             @JsonProperty("databaseName") String databaseName,
             @JsonProperty("location") Optional<String> location,
-            @JsonProperty("ownerName") String ownerName,
-            @JsonProperty("ownerType") PrincipalType ownerType,
+            @JsonProperty("ownerName") Optional<String> ownerName,
+            @JsonProperty("ownerType") Optional<PrincipalType> ownerType,
             @JsonProperty("comment") Optional<String> comment,
             @JsonProperty("parameters") Map<String, String> parameters)
     {
@@ -53,6 +54,7 @@ public class Database
         this.location = requireNonNull(location, "location is null");
         this.ownerName = requireNonNull(ownerName, "ownerName is null");
         this.ownerType = requireNonNull(ownerType, "ownerType is null");
+        checkArgument(ownerName.isPresent() == ownerType.isPresent(), "Both ownerName and ownerType must be present or empty");
         this.comment = requireNonNull(comment, "comment is null");
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
     }
@@ -70,13 +72,13 @@ public class Database
     }
 
     @JsonProperty
-    public String getOwnerName()
+    public Optional<String> getOwnerName()
     {
         return ownerName;
     }
 
     @JsonProperty
-    public PrincipalType getOwnerType()
+    public Optional<PrincipalType> getOwnerType()
     {
         return ownerType;
     }
@@ -107,8 +109,8 @@ public class Database
     {
         private String databaseName;
         private Optional<String> location = Optional.empty();
-        private String ownerName;
-        private PrincipalType ownerType;
+        private Optional<String> ownerName;
+        private Optional<PrincipalType> ownerType;
         private Optional<String> comment = Optional.empty();
         private Map<String, String> parameters = new LinkedHashMap<>();
 
@@ -138,14 +140,14 @@ public class Database
             return this;
         }
 
-        public Builder setOwnerName(String ownerName)
+        public Builder setOwnerName(Optional<String> ownerName)
         {
             requireNonNull(ownerName, "ownerName is null");
             this.ownerName = ownerName;
             return this;
         }
 
-        public Builder setOwnerType(PrincipalType ownerType)
+        public Builder setOwnerType(Optional<PrincipalType> ownerType)
         {
             requireNonNull(ownerType, "ownerType is null");
             this.ownerType = ownerType;
@@ -205,7 +207,7 @@ public class Database
         return Objects.equals(databaseName, database.databaseName) &&
                 Objects.equals(location, database.location) &&
                 Objects.equals(ownerName, database.ownerName) &&
-                ownerType == database.ownerType &&
+                Objects.equals(ownerType, database.ownerType) &&
                 Objects.equals(comment, database.comment) &&
                 Objects.equals(parameters, database.parameters);
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/PrincipalPrivileges.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/PrincipalPrivileges.java
@@ -13,6 +13,7 @@
  */
 package io.trino.plugin.hive.metastore;
 
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
@@ -27,6 +28,8 @@ import static java.util.function.Function.identity;
 
 public class PrincipalPrivileges
 {
+    public static final PrincipalPrivileges NO_PRIVILEGES = new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of());
+
     private final SetMultimap<String, HivePrivilegeInfo> userPrivileges;
     private final SetMultimap<String, HivePrivilegeInfo> rolePrivileges;
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/Table.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/Table.java
@@ -40,7 +40,7 @@ public class Table
 {
     private final String databaseName;
     private final String tableName;
-    private final String owner;
+    private final Optional<String> owner;
     private final String tableType; // This is not an enum because some Hive implementations define additional table types.
     private final List<Column> dataColumns;
     private final List<Column> partitionColumns;
@@ -54,7 +54,7 @@ public class Table
     public Table(
             @JsonProperty("databaseName") String databaseName,
             @JsonProperty("tableName") String tableName,
-            @JsonProperty("owner") String owner,
+            @JsonProperty("owner") Optional<String> owner,
             @JsonProperty("tableType") String tableType,
             @JsonProperty("storage") Storage storage,
             @JsonProperty("dataColumns") List<Column> dataColumns,
@@ -96,7 +96,7 @@ public class Table
     }
 
     @JsonProperty
-    public String getOwner()
+    public Optional<String> getOwner()
     {
         return owner;
     }
@@ -227,7 +227,7 @@ public class Table
         private final Storage.Builder storageBuilder;
         private String databaseName;
         private String tableName;
-        private String owner;
+        private Optional<String> owner;
         private String tableType;
         private List<Column> dataColumns = new ArrayList<>();
         private List<Column> partitionColumns = new ArrayList<>();
@@ -268,7 +268,7 @@ public class Table
             return this;
         }
 
-        public Builder setOwner(String owner)
+        public Builder setOwner(Optional<String> owner)
         {
             this.owner = owner;
             return this;

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/ProtoUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/alluxio/ProtoUtils.java
@@ -74,11 +74,13 @@ public final class ProtoUtils
 
     public static Database fromProto(alluxio.grpc.table.Database db)
     {
+        Optional<String> owner = Optional.ofNullable(db.getOwnerName());
+        Optional<io.trino.spi.security.PrincipalType> ownerType = owner.map(name -> db.getOwnerType() == PrincipalType.USER ? io.trino.spi.security.PrincipalType.USER : io.trino.spi.security.PrincipalType.ROLE);
         return Database.builder()
                 .setDatabaseName(db.getDbName())
                 .setLocation(db.hasLocation() ? Optional.of(db.getLocation()) : Optional.empty())
-                .setOwnerName(db.getOwnerName())
-                .setOwnerType(db.getOwnerType() == PrincipalType.USER ? io.trino.spi.security.PrincipalType.USER : io.trino.spi.security.PrincipalType.ROLE)
+                .setOwnerName(owner)
+                .setOwnerType(ownerType)
                 .setComment(db.hasComment() ? Optional.of(db.getComment()) : Optional.empty())
                 .setParameters(db.getParameterMap())
                 .build();
@@ -108,7 +110,7 @@ public final class ProtoUtils
             Table.Builder builder = Table.builder()
                     .setDatabaseName(table.getDbName())
                     .setTableName(table.getTableName())
-                    .setOwner(table.getOwner())
+                    .setOwner(Optional.ofNullable(table.getOwner()))
                     .setTableType(table.getType().toString())
                     .setDataColumns(dataColumns.stream()
                             .map(ProtoUtils::fromProto)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/DatabaseMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/DatabaseMetadata.java
@@ -27,16 +27,16 @@ import static java.util.Objects.requireNonNull;
 public class DatabaseMetadata
 {
     private final Optional<String> writerVersion;
-    private final String ownerName;
-    private final PrincipalType ownerType;
+    private final Optional<String> ownerName;
+    private final Optional<PrincipalType> ownerType;
     private final Optional<String> comment;
     private final Map<String, String> parameters;
 
     @JsonCreator
     public DatabaseMetadata(
             @JsonProperty("writerVersion") Optional<String> writerVersion,
-            @JsonProperty("ownerName") String ownerName,
-            @JsonProperty("ownerType") PrincipalType ownerType,
+            @JsonProperty("ownerName") Optional<String> ownerName,
+            @JsonProperty("ownerType") Optional<PrincipalType> ownerType,
             @JsonProperty("comment") Optional<String> comment,
             @JsonProperty("parameters") Map<String, String> parameters)
     {
@@ -63,13 +63,13 @@ public class DatabaseMetadata
     }
 
     @JsonProperty
-    public String getOwnerName()
+    public Optional<String> getOwnerName()
     {
         return ownerName;
     }
 
     @JsonProperty
-    public PrincipalType getOwnerType()
+    public Optional<PrincipalType> getOwnerType()
     {
         return ownerType;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/FileHiveMetastore.java
@@ -242,8 +242,8 @@ public class FileHiveMetastore
         Database database = getRequiredDatabase(databaseName);
         Path databaseMetadataDirectory = getDatabaseMetadataDirectory(database.getDatabaseName());
         Database newDatabase = Database.builder(database)
-                .setOwnerName(principal.getName())
-                .setOwnerType(principal.getType())
+                .setOwnerName(Optional.of(principal.getName()))
+                .setOwnerType(Optional.of(principal.getType()))
                 .build();
 
         writeSchemaFile(DATABASE, databaseMetadataDirectory, databaseCodec, new DatabaseMetadata(currentVersion, newDatabase), true);
@@ -356,7 +356,7 @@ public class FileHiveMetastore
         Table table = getRequiredTable(databaseName, tableName);
         Path tableMetadataDirectory = getTableMetadataDirectory(table);
         Table newTable = Table.builder(table)
-                .setOwner(principal.getName())
+                .setOwner(Optional.of(principal.getName()))
                 .build();
 
         writeSchemaFile(TABLE, tableMetadataDirectory, tableCodec, new TableMetadata(currentVersion, newTable), true);
@@ -1105,7 +1105,7 @@ public class FileHiveMetastore
                     .build();
         }
         ImmutableSet.Builder<HivePrivilegeInfo> result = ImmutableSet.builder();
-        if (principal.get().getType() == USER && table.getOwner().equals(principal.get().getName())) {
+        if (principal.get().getType() == USER && table.getOwner().orElseThrow().equals(principal.get().getName())) {
             result.add(new HivePrivilegeInfo(OWNERSHIP, true, principal.get(), principal.get()));
         }
         result.addAll(readPermissionsFile(getPermissionsPath(permissionsDirectory, principal.get())));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/TableMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/file/TableMetadata.java
@@ -39,7 +39,7 @@ import static java.util.Objects.requireNonNull;
 public class TableMetadata
 {
     private final Optional<String> writerVersion;
-    private final String owner;
+    private final Optional<String> owner;
     private final String tableType;
     private final List<Column> dataColumns;
     private final List<Column> partitionColumns;
@@ -59,7 +59,7 @@ public class TableMetadata
     @JsonCreator
     public TableMetadata(
             @JsonProperty("writerVersion") Optional<String> writerVersion,
-            @JsonProperty("owner") String owner,
+            @JsonProperty("owner") Optional<String> owner,
             @JsonProperty("tableType") String tableType,
             @JsonProperty("dataColumns") List<Column> dataColumns,
             @JsonProperty("partitionColumns") List<Column> partitionColumns,
@@ -131,7 +131,7 @@ public class TableMetadata
     }
 
     @JsonProperty
-    public String getOwner()
+    public Optional<String> getOwner()
     {
         return owner;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/converter/GlueInputConverter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/converter/GlueInputConverter.java
@@ -53,7 +53,7 @@ public final class GlueInputConverter
     {
         TableInput input = new TableInput();
         input.setName(table.getTableName());
-        input.setOwner(table.getOwner());
+        input.setOwner(table.getOwner().orElse(null));
         input.setTableType(table.getTableType());
         input.setStorageDescriptor(convertStorage(table.getStorage(), table.getDataColumns()));
         input.setPartitionKeys(table.getPartitionColumns().stream().map(GlueInputConverter::convertColumn).collect(toImmutableList()));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/converter/GlueToTrinoConverter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/converter/GlueToTrinoConverter.java
@@ -61,8 +61,8 @@ public final class GlueToTrinoConverter
                 .setLocation(Optional.ofNullable(glueDb.getLocationUri()))
                 .setComment(Optional.ofNullable(glueDb.getDescription()))
                 .setParameters(firstNonNull(glueDb.getParameters(), ImmutableMap.of()))
-                .setOwnerName(PUBLIC_OWNER)
-                .setOwnerType(PrincipalType.ROLE)
+                .setOwnerName(Optional.of(PUBLIC_OWNER))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
                 .build();
     }
 
@@ -75,7 +75,7 @@ public final class GlueToTrinoConverter
         Table.Builder tableBuilder = Table.builder()
                 .setDatabaseName(dbName)
                 .setTableName(glueTable.getName())
-                .setOwner(nullToEmpty(glueTable.getOwner()))
+                .setOwner(Optional.ofNullable(glueTable.getOwner()))
                 // Athena treats missing table type as EXTERNAL_TABLE.
                 .setTableType(firstNonNull(glueTable.getTableType(), EXTERNAL_TABLE.name()))
                 .setDataColumns(convertColumns(sd.getColumns(), sd.getSerdeInfo().getSerializationLibrary()))

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -191,8 +191,8 @@ public class BridgingHiveMetastore
                 .orElseThrow(() -> new SchemaNotFoundException(databaseName)));
 
         Database newDatabase = Database.builder(database)
-                .setOwnerName(principal.getName())
-                .setOwnerType(principal.getType())
+                .setOwnerName(Optional.of(principal.getName()))
+                .setOwnerType(Optional.of(principal.getType()))
                 .build();
 
         delegate.alterDatabase(identity, databaseName, toMetastoreApiDatabase(newDatabase));
@@ -259,7 +259,7 @@ public class BridgingHiveMetastore
                 .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName))));
 
         Table newTable = Table.builder(table)
-                .setOwner(principal.getName())
+                .setOwner(Optional.of(principal.getName()))
                 .build();
 
         delegate.alterTable(identity, databaseName, tableName, toMetastoreApiTable(newTable));

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -158,9 +158,9 @@ public final class ThriftMetastoreUtil
         org.apache.hadoop.hive.metastore.api.Database result = new org.apache.hadoop.hive.metastore.api.Database();
         result.setName(database.getDatabaseName());
         database.getLocation().ifPresent(result::setLocationUri);
-        result.setOwnerName(database.getOwnerName());
+        result.setOwnerName(database.getOwnerName().orElse(null));
 
-        result.setOwnerType(fromTrinoPrincipalType(database.getOwnerType()));
+        result.setOwnerType(database.getOwnerType().map(ThriftMetastoreUtil::fromTrinoPrincipalType).orElse(null));
         database.getComment().ifPresent(result::setDescription);
         result.setParameters(database.getParameters());
         return result;
@@ -178,7 +178,7 @@ public final class ThriftMetastoreUtil
         org.apache.hadoop.hive.metastore.api.Table result = new org.apache.hadoop.hive.metastore.api.Table();
         result.setDbName(table.getDatabaseName());
         result.setTableName(table.getTableName());
-        result.setOwner(table.getOwner());
+        result.setOwner(table.getOwner().orElse(null));
         result.setTableType(table.getTableType());
         result.setParameters(table.getParameters());
         result.setPartitionKeys(table.getPartitionColumns().stream().map(ThriftMetastoreUtil::toMetastoreApiFieldSchema).collect(toImmutableList()));
@@ -363,8 +363,8 @@ public final class ThriftMetastoreUtil
         return Database.builder()
                 .setDatabaseName(database.getName())
                 .setLocation(Optional.ofNullable(database.getLocationUri()))
-                .setOwnerName(ownerName)
-                .setOwnerType(ownerType)
+                .setOwnerName(Optional.of(ownerName))
+                .setOwnerType(Optional.of(ownerType))
                 .setComment(Optional.ofNullable(database.getDescription()))
                 .setParameters(parameters)
                 .build();
@@ -389,7 +389,7 @@ public final class ThriftMetastoreUtil
         Table.Builder tableBuilder = Table.builder()
                 .setDatabaseName(table.getDbName())
                 .setTableName(table.getTableName())
-                .setOwner(nullToEmpty(table.getOwner()))
+                .setOwner(Optional.ofNullable(table.getOwner()))
                 .setTableType(table.getTableType())
                 .setDataColumns(schema.stream()
                         .map(ThriftMetastoreUtil::fromMetastoreApiFieldSchema)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/AccessControlMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/AccessControlMetadata.java
@@ -30,6 +30,11 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 
 public interface AccessControlMetadata
 {
+    default boolean isUsingSystemSecurity()
+    {
+        return false;
+    }
+
     /**
      * Does the specified role exist.
      */

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/LegacyAccessControl.java
@@ -133,8 +133,9 @@ public class LegacyAccessControl
             denyDropTable(tableName.toString(), "Table not found");
         }
 
-        if (!context.getIdentity().getUser().equals(target.get().getOwner())) {
-            denyDropTable(tableName.toString(), format("Owner of the table ('%s') is different from session user ('%s')", target.get().getOwner(), context.getIdentity().getUser()));
+        String tableOwner = target.get().getOwner().orElse(null);
+        if (!context.getIdentity().getUser().equals(tableOwner)) {
+            denyDropTable(tableName.toString(), format("Owner of the table ('%s') is different from session user ('%s')", tableOwner, context.getIdentity().getUser()));
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SqlStandardAccessControl.java
@@ -592,11 +592,13 @@ public class SqlStandardAccessControl
 
         // a database can be owned by a user or role
         ConnectorIdentity identity = context.getIdentity();
-        if (database.getOwnerType() == USER && identity.getUser().equals(database.getOwnerName())) {
-            return true;
-        }
-        if (database.getOwnerType() == ROLE && isRoleEnabled(identity, hivePrincipal -> metastore.listRoleGrants(context, hivePrincipal), database.getOwnerName())) {
-            return true;
+        if (database.getOwnerName().isPresent()) {
+            if (database.getOwnerType().orElse(null) == USER && identity.getUser().equals(database.getOwnerName().get())) {
+                return true;
+            }
+            if (database.getOwnerType().orElse(null) == ROLE && isRoleEnabled(identity, hivePrincipal -> metastore.listRoleGrants(context, hivePrincipal), database.getOwnerName().get())) {
+                return true;
+            }
         }
         return false;
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SystemSecurityModule.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/security/SystemSecurityModule.java
@@ -23,6 +23,12 @@ public class SystemSecurityModule
     public void configure(Binder binder)
     {
         // do not bind an ConnectorAccessControl so the engine will use system security with system roles
-        binder.bind(AccessControlMetadataFactory.class).toInstance(metastore -> new AccessControlMetadata() {});
+        binder.bind(AccessControlMetadataFactory.class).toInstance(metastore -> new AccessControlMetadata() {
+            @Override
+            public boolean isUsingSystemSecurity()
+            {
+                return true;
+            }
+        });
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -851,7 +851,7 @@ public abstract class AbstractTestHive
                                 Optional.empty(),
                                 ImmutableList.of(new ConnectorMaterializedViewDefinition.Column("abc", TypeId.of("type"))),
                                 Optional.empty(),
-                                "alice",
+                                Optional.of("alice"),
                                 ImmutableMap.of()));
                     }
                 },
@@ -2535,7 +2535,7 @@ public abstract class AbstractTestHive
         return Table.builder()
                 .setDatabaseName(schemaName)
                 .setTableName(tableName)
-                .setOwner(tableOwner)
+                .setOwner(Optional.of(tableOwner))
                 .setTableType(TableType.MANAGED_TABLE.name())
                 .setParameters(ImmutableMap.of(
                         PRESTO_VERSION_NAME, TEST_SERVER_VERSION,
@@ -2869,7 +2869,7 @@ public abstract class AbstractTestHive
         Table.Builder table = Table.builder()
                 .setDatabaseName(tableName.getSchemaName())
                 .setTableName(tableName.getTableName())
-                .setOwner(session.getUser())
+                .setOwner(Optional.of(session.getUser()))
                 .setTableType(MANAGED_TABLE.name())
                 .setDataColumns(List.of(new Column("a_column", HIVE_STRING, Optional.empty())))
                 .setParameter(SPARK_TABLE_PROVIDER_KEY, DELTA_LAKE_PROVIDER);
@@ -3071,7 +3071,7 @@ public abstract class AbstractTestHive
             Table.Builder tableBuilder = Table.builder()
                     .setDatabaseName(schemaName)
                     .setTableName(tableName)
-                    .setOwner(tableOwner)
+                    .setOwner(Optional.of(tableOwner))
                     .setTableType(TableType.MANAGED_TABLE.name())
                     .setParameters(ImmutableMap.of(
                             PRESTO_VERSION_NAME, TEST_SERVER_VERSION,
@@ -5092,7 +5092,7 @@ public abstract class AbstractTestHive
             Table.Builder tableBuilder = Table.builder()
                     .setDatabaseName(schemaName)
                     .setTableName(tableName)
-                    .setOwner(tableOwner)
+                    .setOwner(Optional.of(tableOwner))
                     .setTableType(TableType.MANAGED_TABLE.name())
                     .setParameters(ImmutableMap.of(
                             PRESTO_VERSION_NAME, TEST_SERVER_VERSION,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -253,6 +253,7 @@ import static io.trino.plugin.hive.metastore.HiveColumnStatistics.createDecimalC
 import static io.trino.plugin.hive.metastore.HiveColumnStatistics.createDoubleColumnStatistics;
 import static io.trino.plugin.hive.metastore.HiveColumnStatistics.createIntegerColumnStatistics;
 import static io.trino.plugin.hive.metastore.HiveColumnStatistics.createStringColumnStatistics;
+import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.metastore.SortingColumn.Order.ASCENDING;
 import static io.trino.plugin.hive.metastore.SortingColumn.Order.DESCENDING;
 import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
@@ -2880,8 +2881,7 @@ public abstract class AbstractTestHive
                         hdfsEnvironment,
                         tableName.getSchemaName(),
                         tableName.getTableName()).toString());
-        PrincipalPrivileges principalPrivileges = new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of());
-        metastoreClient.createTable(identity, table.build(), principalPrivileges);
+        metastoreClient.createTable(identity, table.build(), NO_PRIVILEGES);
 
         try {
             // Verify the table was created as a Delta Lake table

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.hive;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 import io.airlift.concurrent.BoundedExecutor;
@@ -104,6 +103,7 @@ import static io.trino.plugin.hive.HiveTestUtils.getDefaultHiveRecordCursorProvi
 import static io.trino.plugin.hive.HiveTestUtils.getHiveSession;
 import static io.trino.plugin.hive.HiveTestUtils.getHiveSessionProperties;
 import static io.trino.plugin.hive.HiveTestUtils.getTypes;
+import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.util.HiveWriteUtils.getRawFileSystem;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.MaterializedResult.materializeSourceDataStream;
@@ -579,7 +579,7 @@ public abstract class AbstractTestHiveFileSystem
                 tableBuilder.getStorageBuilder().setLocation("/");
 
                 // drop table
-                replaceTable(identity, databaseName, tableName, tableBuilder.build(), new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of()));
+                replaceTable(identity, databaseName, tableName, tableBuilder.build(), NO_PRIVILEGES);
                 delegate.dropTable(identity, databaseName, tableName, false);
 
                 // drop data
@@ -610,7 +610,7 @@ public abstract class AbstractTestHiveFileSystem
             tableBuilder.getStorageBuilder().setLocation(location);
 
             // NOTE: this clears the permissions
-            replaceTable(identity, databaseName, tableName, tableBuilder.build(), new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of()));
+            replaceTable(identity, databaseName, tableName, tableBuilder.build(), NO_PRIVILEGES);
         }
 
         private List<String> listAllDataPaths(HiveIdentity identity, String schemaName, String tableName)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
@@ -99,8 +99,8 @@ public abstract class AbstractTestHiveLocal
         metastore.createDatabase(HIVE_IDENTITY,
                 Database.builder()
                         .setDatabaseName(testDbName)
-                        .setOwnerName("public")
-                        .setOwnerType(PrincipalType.ROLE)
+                        .setOwnerName(Optional.of("public"))
+                        .setOwnerType(Optional.of(PrincipalType.ROLE))
                         .build());
 
         HiveConfig hiveConfig = new HiveConfig()
@@ -242,7 +242,7 @@ public abstract class AbstractTestHiveLocal
             Table.Builder tableBuilder = Table.builder()
                     .setDatabaseName(schemaName)
                     .setTableName(tableName)
-                    .setOwner(tableOwner)
+                    .setOwner(Optional.of(tableOwner))
                     .setTableType(TableType.EXTERNAL_TABLE.name())
                     .setParameters(ImmutableMap.of(
                             PRESTO_VERSION_NAME, TEST_SERVER_VERSION,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveBenchmarkQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveBenchmarkQueryRunner.java
@@ -27,6 +27,7 @@ import io.trino.testing.LocalQueryRunner;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -72,8 +73,8 @@ public final class HiveBenchmarkQueryRunner
         metastore.createDatabase(identity,
                 Database.builder()
                         .setDatabaseName("tpch")
-                        .setOwnerName("public")
-                        .setOwnerType(PrincipalType.ROLE)
+                        .setOwnerName(Optional.of("public"))
+                        .setOwnerType(Optional.of(PrincipalType.ROLE))
                         .build());
 
         Map<String, String> hiveCatalogConfig = ImmutableMap.<String, String>builder()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/HiveQueryRunner.java
@@ -220,8 +220,8 @@ public final class HiveQueryRunner
     {
         return Database.builder()
                 .setDatabaseName(name)
-                .setOwnerName("public")
-                .setOwnerType(PrincipalType.ROLE)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
                 .build();
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -1253,7 +1253,7 @@ public class TestBackgroundHiveSplitLoader
 
         return tableBuilder
                 .setDatabaseName("test_dbname")
-                .setOwner("testOwner")
+                .setOwner(Optional.of("testOwner"))
                 .setTableName("test_table")
                 .setTableType(TableType.MANAGED_TABLE.toString())
                 .setDataColumns(ImmutableList.of(new Column("col1", HIVE_STRING, Optional.empty())))

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSystemSecurity.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveSystemSecurity.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestHiveSystemSecurity
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.builder()
+                .setHiveProperties(ImmutableMap.of("hive.security", "system"))
+                .setInitialTables(ImmutableList.of())
+                .build();
+    }
+
+    @Test
+    public void testDefinerView()
+    {
+        assertUpdate("CREATE VIEW system_security_definer_view AS SELECT 42 as n");
+        // select from view fails because the view does not have an owner in Hive and there is no system security system to provide the run-as identity.
+        assertQueryFails("SELECT * from system_security_definer_view", "Catalog does not support run-as DEFINER views: hive.tpch.system_security_definer_view");
+        assertUpdate("DROP VIEW system_security_definer_view");
+    }
+
+    @Test
+    public void testInvokerView()
+    {
+        assertUpdate("CREATE VIEW system_security_invoker_view SECURITY INVOKER AS SELECT 42 as n");
+        assertQuery("SELECT * from system_security_invoker_view", "SELECT 42 as n");
+        assertUpdate("DROP VIEW system_security_invoker_view");
+    }
+
+    @Test
+    public void testCreateSchema()
+    {
+        assertUpdate("CREATE SCHEMA system_security_schema");
+        assertThat((String) computeScalar("SHOW CREATE SCHEMA system_security_schema"))
+                .doesNotContain("AUTHORIZATION");
+        assertUpdate("DROP SCHEMA system_security_schema");
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestMetastoreUtil.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestMetastoreUtil.java
@@ -15,7 +15,6 @@ package io.trino.plugin.hive.metastore;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import io.trino.plugin.hive.HiveColumnHandle;
 import io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil;
 import io.trino.spi.predicate.Domain;
@@ -40,6 +39,7 @@ import static io.trino.plugin.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static io.trino.plugin.hive.HiveColumnHandle.bucketColumnHandle;
 import static io.trino.plugin.hive.HiveType.HIVE_STRING;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.computePartitionKeyFilter;
+import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static org.apache.hadoop.hive.serde.serdeConstants.COLUMN_NAME_DELIMITER;
@@ -137,8 +137,7 @@ public class TestMetastoreUtil
     public void testTableRoundTrip()
     {
         Table table = ThriftMetastoreUtil.fromMetastoreApiTable(TEST_TABLE, TEST_SCHEMA);
-        PrincipalPrivileges privileges = new PrincipalPrivileges(ImmutableMultimap.of(), ImmutableMultimap.of());
-        org.apache.hadoop.hive.metastore.api.Table metastoreApiTable = ThriftMetastoreUtil.toMetastoreApiTable(table, privileges);
+        org.apache.hadoop.hive.metastore.api.Table metastoreApiTable = ThriftMetastoreUtil.toMetastoreApiTable(table, NO_PRIVILEGES);
         assertEquals(metastoreApiTable, TEST_TABLE);
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestRecordingHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestRecordingHiveMetastore.java
@@ -66,8 +66,8 @@ public class TestRecordingHiveMetastore
     private static final Database DATABASE = new Database(
             "database",
             Optional.of("location"),
-            "owner",
-            USER,
+            Optional.of("owner"),
+            Optional.of(USER),
             Optional.of("comment"),
             ImmutableMap.of("param", "value"));
     private static final Column TABLE_COLUMN = new Column(
@@ -83,7 +83,7 @@ public class TestRecordingHiveMetastore
     private static final Table TABLE = new Table(
             "database",
             "table",
-            "owner",
+            Optional.of("owner"),
             "table_type",
             TABLE_STORAGE,
             ImmutableList.of(TABLE_COLUMN),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestSemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/TestSemiTransactionalHiveMetastore.java
@@ -136,7 +136,7 @@ public class TestSemiTransactionalHiveMetastore
                 return Optional.of(new Table(
                         "database",
                         tableName,
-                        "owner",
+                        Optional.of("owner"),
                         "table_type",
                         TABLE_STORAGE,
                         ImmutableList.of(TABLE_COLUMN),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/alluxio/TestProtoUtils.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/alluxio/TestProtoUtils.java
@@ -84,7 +84,7 @@ public class TestProtoUtils
         Column c = t.getColumn(TestingAlluxioMetastoreObjects.COLUMN_NAME).get();
         assertEquals(table.getDbName(), t.getDatabaseName());
         assertEquals(table.getTableName(), t.getTableName());
-        assertEquals(table.getOwner(), t.getOwner());
+        assertEquals(table.getOwner(), t.getOwner().orElse(null));
         assertEquals(table.getType().toString(), t.getTableType());
         assertEquals(0, t.getDataColumns().size());
         assertEquals(1, t.getPartitionColumns().size());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueInputConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueInputConverter.java
@@ -58,7 +58,7 @@ public class TestGlueInputConverter
         TableInput tblInput = GlueInputConverter.convertTable(testTbl);
 
         assertEquals(tblInput.getName(), testTbl.getTableName());
-        assertEquals(tblInput.getOwner(), testTbl.getOwner());
+        assertEquals(tblInput.getOwner(), testTbl.getOwner().orElse(null));
         assertEquals(tblInput.getTableType(), testTbl.getTableType());
         assertEquals(tblInput.getParameters(), testTbl.getParameters());
         assertColumnList(tblInput.getStorageDescriptor().getColumns(), testTbl.getDataColumns());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueToTrinoConverter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestGlueToTrinoConverter.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 import static com.amazonaws.util.CollectionUtils.isNullOrEmpty;
 import static io.trino.plugin.hive.HiveType.HIVE_STRING;
@@ -76,8 +77,8 @@ public class TestGlueToTrinoConverter
         assertEquals(trinoDatabase.getLocation().get(), testDatabase.getLocationUri());
         assertEquals(trinoDatabase.getComment().get(), testDatabase.getDescription());
         assertEquals(trinoDatabase.getParameters(), testDatabase.getParameters());
-        assertEquals(trinoDatabase.getOwnerName(), PUBLIC_OWNER);
-        assertEquals(trinoDatabase.getOwnerType(), PrincipalType.ROLE);
+        assertEquals(trinoDatabase.getOwnerName(), Optional.of(PUBLIC_OWNER));
+        assertEquals(trinoDatabase.getOwnerType(), Optional.of(PrincipalType.ROLE));
     }
 
     @Test
@@ -87,7 +88,7 @@ public class TestGlueToTrinoConverter
         assertEquals(trinoTable.getTableName(), testTable.getName());
         assertEquals(trinoTable.getDatabaseName(), testDatabase.getName());
         assertEquals(trinoTable.getTableType(), testTable.getTableType());
-        assertEquals(trinoTable.getOwner(), testTable.getOwner());
+        assertEquals(trinoTable.getOwner().orElse(null), testTable.getOwner());
         assertEquals(trinoTable.getParameters(), testTable.getParameters());
         assertColumnList(trinoTable.getDataColumns(), testTable.getStorageDescriptor().getColumns());
         assertColumnList(trinoTable.getPartitionColumns(), testTable.getPartitionKeys());
@@ -108,7 +109,7 @@ public class TestGlueToTrinoConverter
         assertEquals(trinoTable.getTableName(), glueTable.getName());
         assertEquals(trinoTable.getDatabaseName(), testDatabase.getName());
         assertEquals(trinoTable.getTableType(), glueTable.getTableType());
-        assertEquals(trinoTable.getOwner(), glueTable.getOwner());
+        assertEquals(trinoTable.getOwner().orElse(null), glueTable.getOwner());
         assertEquals(trinoTable.getParameters(), glueTable.getParameters());
         assertEquals(trinoTable.getDataColumns().size(), 1);
         assertEquals(trinoTable.getDataColumns().get(0).getType(), HIVE_STRING);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestingMetastoreObjects.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/glue/TestingMetastoreObjects.java
@@ -115,8 +115,9 @@ public final class TestingMetastoreObjects
                 .setComment(Optional.of("database desc"))
                 .setLocation(Optional.of("/db"))
                 .setParameters(ImmutableMap.of())
-                .setOwnerName("PUBLIC")
-                .setOwnerType(PrincipalType.ROLE).build();
+                .setOwnerName(Optional.of("PUBLIC"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
+                .build();
     }
 
     public static io.trino.plugin.hive.metastore.Table getPrestoTestTable(String dbName)
@@ -124,7 +125,7 @@ public final class TestingMetastoreObjects
         return io.trino.plugin.hive.metastore.Table.builder()
                 .setDatabaseName(dbName)
                 .setTableName("test-tbl" + generateRandom())
-                .setOwner("owner")
+                .setOwner(Optional.of("owner"))
                 .setParameters(ImmutableMap.of())
                 .setTableType(TableType.EXTERNAL_TABLE.name())
                 .setDataColumns(ImmutableList.of(getPrestoTestColumn()))

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestConnectorPushdownRulesWithHive.java
@@ -120,8 +120,8 @@ public class TestConnectorPushdownRulesWithHive
                         .setMetastoreUser("test"));
         Database database = Database.builder()
                 .setDatabaseName(SCHEMA_NAME)
-                .setOwnerName("public")
-                .setOwnerType(PrincipalType.ROLE)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
                 .build();
 
         metastore.createDatabase(new HiveIdentity(SESSION), database);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHivePlans.java
@@ -43,6 +43,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -92,8 +93,8 @@ public class TestHivePlans
                         .setMetastoreUser("test"));
         Database database = Database.builder()
                 .setDatabaseName(SCHEMA_NAME)
-                .setOwnerName("public")
-                .setOwnerType(PrincipalType.ROLE)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
                 .build();
 
         metastore.createDatabase(new HiveIdentity(HIVE_SESSION.toConnectorSession()), database);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/optimizer/TestHiveProjectionPushdownIntoTableScan.java
@@ -96,8 +96,8 @@ public class TestHiveProjectionPushdownIntoTableScan
                         .setMetastoreUser("test"));
         Database database = Database.builder()
                 .setDatabaseName(SCHEMA_NAME)
-                .setOwnerName("public")
-                .setOwnerType(PrincipalType.ROLE)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
                 .build();
 
         metastore.createDatabase(new HiveIdentity(HIVE_SESSION.toConnectorSession()), database);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/file/FileMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/file/FileMetastoreTableOperations.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
+import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 
 @NotThreadSafe
 public class FileMetastoreTableOperations
@@ -79,7 +80,8 @@ public class FileMetastoreTableOperations
             throw e;
         }
 
-        PrincipalPrivileges privileges = buildInitialPrivilegeSet(table.getOwner());
+        // todo privileges should not be replaced for an alter
+        PrincipalPrivileges privileges = owner.isEmpty() && table.getOwner().isPresent() ? NO_PRIVILEGES : buildInitialPrivilegeSet(table.getOwner().get());
         HiveIdentity identity = new HiveIdentity(session);
         metastore.replaceTable(identity, database, tableName, table, privileges);
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/catalog/hms/HiveMetastoreTableOperations.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.trino.plugin.hive.metastore.MetastoreUtil.buildInitialPrivilegeSet;
+import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.fromMetastoreApiTable;
 import static java.util.Objects.requireNonNull;
 
@@ -95,7 +96,8 @@ public class HiveMetastoreTableOperations
                 throw e;
             }
 
-            PrincipalPrivileges privileges = buildInitialPrivilegeSet(table.getOwner());
+            // todo privileges should not be replaced for an alter
+            PrincipalPrivileges privileges = owner.isEmpty() && table.getOwner().isPresent() ? NO_PRIVILEGES : buildInitialPrivilegeSet(table.getOwner().get());
             metastore.replaceTable(identity, database, tableName, table, privileges);
         }
         finally {

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestMetadataQueryOptimization.java
@@ -64,8 +64,8 @@ public class TestMetadataQueryOptimization
 
         Database database = Database.builder()
                 .setDatabaseName(SCHEMA_NAME)
-                .setOwnerName("public")
-                .setOwnerType(PrincipalType.ROLE)
+                .setOwnerName(Optional.of("public"))
+                .setOwnerType(Optional.of(PrincipalType.ROLE))
                 .build();
         metastore.createDatabase(new HiveIdentity(session.toConnectorSession()), database);
 

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestEventListenerBasic.java
@@ -139,7 +139,7 @@ public class TestEventListenerBasic
                                     Optional.empty(),
                                     ImmutableList.of(new Column("test_column", BIGINT.getTypeId())),
                                     Optional.empty(),
-                                    "alice",
+                                    Optional.of("alice"),
                                     ImmutableMap.of());
                             SchemaTableName materializedViewName = new SchemaTableName("default", "test_materialized_view");
                             return ImmutableMap.of(materializedViewName, definition);

--- a/testing/trino-tests/src/test/java/io/trino/execution/TestRefreshMaterializedView.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestRefreshMaterializedView.java
@@ -102,7 +102,7 @@ public class TestRefreshMaterializedView
                                                 Optional.of("default"),
                                                 ImmutableList.of(new ConnectorMaterializedViewDefinition.Column("nationkey", BIGINT.getTypeId())),
                                                 Optional.empty(),
-                                                "alice",
+                                                Optional.of("alice"),
                                                 ImmutableMap.of())))
                                 .withDelegateMaterializedViewRefreshToConnector((connectorSession, schemaTableName) -> true)
                                 .withRefreshMaterializedView(((connectorSession, schemaTableName) -> {

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestMockConnector.java
@@ -70,7 +70,7 @@ public class TestMockConnector
                                                 Optional.of("default"),
                                                 ImmutableList.of(new Column("nationkey", BIGINT.getTypeId())),
                                                 Optional.empty(),
-                                                "alice",
+                                                Optional.of("alice"),
                                                 ImmutableMap.of())))
                                 .withData(schemaTableName -> {
                                     if (schemaTableName.equals(new SchemaTableName("default", "nation"))) {


### PR DESCRIPTION
When using system security, do not set the owner of tables or databases, and do not set permissions, because the user and roles of system security many not map to Hive uses and roles.