### PR TITLE
Implement adaptive remote task request size

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -144,6 +144,10 @@ public final class SystemSessionProperties
     public static final String TIME_ZONE_ID = "time_zone_id";
     public static final String LEGACY_CATALOG_ROLES = "legacy_catalog_roles";
     public static final String INCREMENTAL_HASH_ARRAY_LOAD_FACTOR_ENABLED = "incremental_hash_array_load_factor_enabled";
+    public static final String ENABLE_ADAPTIVE_REMOTE_TASK_REQUEST_SIZE = "enable_adaptive_remote_task_request_size";
+    public static final String MAX_REMOTE_TASK_REQUEST_SIZE = "max_remote_task_request_size";
+    public static final String REMOTE_TASK_REQUEST_SIZE_HEADROOM = "remote_task_request_size_headroom";
+    public static final String REMOTE_TASK_GUARANTEED_SPLITS_PER_REQUEST = "remote_task_guaranteed_splits_per_request";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -666,6 +670,26 @@ public final class SystemSessionProperties
                         INCREMENTAL_HASH_ARRAY_LOAD_FACTOR_ENABLED,
                         "Use smaller load factor for small hash arrays in order to improve performance",
                         featuresConfig.isIncrementalHashArrayLoadFactorEnabled(),
+                        false),
+                booleanProperty(
+                        ENABLE_ADAPTIVE_REMOTE_TASK_REQUEST_SIZE,
+                        "Experimental: Enable adaptive adjustment for size of remote task update request",
+                        queryManagerConfig.isEnabledAdaptiveTaskRequestSize(),
+                        false),
+                dataSizeProperty(
+                        MAX_REMOTE_TASK_REQUEST_SIZE,
+                        "Experimental: Max size of remote task update request",
+                        queryManagerConfig.getMaxRemoteTaskRequestSize(),
+                        false),
+                dataSizeProperty(
+                        REMOTE_TASK_REQUEST_SIZE_HEADROOM,
+                        "Experimental: Headroom for size of remote task update request",
+                        queryManagerConfig.getRemoteTaskRequestSizeHeadroom(),
+                        false),
+                integerProperty(
+                        REMOTE_TASK_GUARANTEED_SPLITS_PER_REQUEST,
+                        "Guaranteed splits per remote task request",
+                        queryManagerConfig.getRemoteTaskGuaranteedSplitPerTask(),
                         false));
     }
 
@@ -1183,5 +1207,25 @@ public final class SystemSessionProperties
     public static boolean isIncrementalHashArrayLoadFactorEnabled(Session session)
     {
         return session.getSystemProperty(INCREMENTAL_HASH_ARRAY_LOAD_FACTOR_ENABLED, Boolean.class);
+    }
+
+    public static boolean isEnableAdaptiveTaskRequestSize(Session session)
+    {
+        return session.getSystemProperty(ENABLE_ADAPTIVE_REMOTE_TASK_REQUEST_SIZE, Boolean.class);
+    }
+
+    public static DataSize getMaxRemoteTaskRequestSize(Session session)
+    {
+        return session.getSystemProperty(MAX_REMOTE_TASK_REQUEST_SIZE, DataSize.class);
+    }
+
+    public static DataSize getRemoteTaskRequestSizeHeadroom(Session session)
+    {
+        return session.getSystemProperty(REMOTE_TASK_REQUEST_SIZE_HEADROOM, DataSize.class);
+    }
+
+    public static int getRemoteTaskGuaranteedSplitsPerRequest(Session session)
+    {
+        return session.getSystemProperty(REMOTE_TASK_GUARANTEED_SPLITS_PER_REQUEST, Integer.class);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryManagerConfig.java
@@ -58,6 +58,11 @@ public class QueryManagerConfig
     private Duration remoteTaskMaxErrorDuration = new Duration(5, TimeUnit.MINUTES);
     private int remoteTaskMaxCallbackThreads = 1000;
 
+    private boolean enabledAdaptiveTaskRequestSize;
+    private DataSize maxRemoteTaskRequestSize = DataSize.of(8, DataSize.Unit.MEGABYTE);
+    private DataSize remoteTaskRequestSizeHeadroom = DataSize.of(2, DataSize.Unit.MEGABYTE);
+    private int remoteTaskGuaranteedSplitPerTask = 3;
+
     private String queryExecutionPolicy = "all-at-once";
     private Duration queryMaxRunTime = new Duration(100, TimeUnit.DAYS);
     private Duration queryMaxExecutionTime = new Duration(100, TimeUnit.DAYS);
@@ -335,6 +340,57 @@ public class QueryManagerConfig
     public QueryManagerConfig setRemoteTaskMaxCallbackThreads(int remoteTaskMaxCallbackThreads)
     {
         this.remoteTaskMaxCallbackThreads = remoteTaskMaxCallbackThreads;
+        return this;
+    }
+
+    public boolean isEnabledAdaptiveTaskRequestSize()
+    {
+        return enabledAdaptiveTaskRequestSize;
+    }
+
+    @Config("query.remote-task.enable-adaptive-request-size")
+    public QueryManagerConfig setEnabledAdaptiveTaskRequestSize(boolean enabledAdaptiveTaskRequestSize)
+    {
+        this.enabledAdaptiveTaskRequestSize = enabledAdaptiveTaskRequestSize;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getMaxRemoteTaskRequestSize()
+    {
+        return maxRemoteTaskRequestSize;
+    }
+
+    @Config("query.remote-task.max-request-size")
+    public QueryManagerConfig setMaxRemoteTaskRequestSize(DataSize maxRemoteTaskRequestSize)
+    {
+        this.maxRemoteTaskRequestSize = maxRemoteTaskRequestSize;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getRemoteTaskRequestSizeHeadroom()
+    {
+        return remoteTaskRequestSizeHeadroom;
+    }
+
+    @Config("query.remote-task.request-size-headroom")
+    public QueryManagerConfig setRemoteTaskRequestSizeHeadroom(DataSize remoteTaskRequestSizeHeadroom)
+    {
+        this.remoteTaskRequestSizeHeadroom = remoteTaskRequestSizeHeadroom;
+        return this;
+    }
+
+    @Min(1)
+    public int getRemoteTaskGuaranteedSplitPerTask()
+    {
+        return remoteTaskGuaranteedSplitPerTask;
+    }
+
+    @Config("query.remote-task.guaranteed-splits-per-task")
+    public QueryManagerConfig setRemoteTaskGuaranteedSplitPerTask(int remoteTaskGuaranteedSplitPerTask)
+    {
+        this.remoteTaskGuaranteedSplitPerTask = remoteTaskGuaranteedSplitPerTask;
         return this;
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryManagerConfig.java
@@ -57,7 +57,11 @@ public class TestQueryManagerConfig
                 .setQueryMaxCpuTime(new Duration(1_000_000_000, DAYS))
                 .setQueryMaxScanPhysicalBytes(null)
                 .setRequiredWorkers(1)
-                .setRequiredWorkersMaxWait(new Duration(5, MINUTES)));
+                .setRequiredWorkersMaxWait(new Duration(5, MINUTES))
+                .setEnabledAdaptiveTaskRequestSize(false)
+                .setMaxRemoteTaskRequestSize(DataSize.of(8, DataSize.Unit.MEGABYTE))
+                .setRemoteTaskRequestSizeHeadroom(DataSize.of(2, DataSize.Unit.MEGABYTE))
+                .setRemoteTaskGuaranteedSplitPerTask(3));
     }
 
     @Test
@@ -87,6 +91,10 @@ public class TestQueryManagerConfig
                 .put("query.max-scan-physical-bytes", "1kB")
                 .put("query-manager.required-workers", "333")
                 .put("query-manager.required-workers-max-wait", "33m")
+                .put("query.remote-task.enable-adaptive-request-size", "true")
+                .put("query.remote-task.max-request-size", "10MB")
+                .put("query.remote-task.request-size-headroom", "1MB")
+                .put("query.remote-task.guaranteed-splits-per-task", "5")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -112,7 +120,11 @@ public class TestQueryManagerConfig
                 .setQueryMaxCpuTime(new Duration(2, DAYS))
                 .setQueryMaxScanPhysicalBytes(DataSize.of(1, KILOBYTE))
                 .setRequiredWorkers(333)
-                .setRequiredWorkersMaxWait(new Duration(33, MINUTES));
+                .setRequiredWorkersMaxWait(new Duration(33, MINUTES))
+                .setEnabledAdaptiveTaskRequestSize(true)
+                .setMaxRemoteTaskRequestSize(DataSize.of(10, DataSize.Unit.MEGABYTE))
+                .setRemoteTaskRequestSizeHeadroom(DataSize.of(1, DataSize.Unit.MEGABYTE))
+                .setRemoteTaskGuaranteedSplitPerTask(5);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Currently HttpRemotTask will send all pending splits in one taskUpdateRequest, sometimes causing large request for each task in coordinator.

This change will enable the ability to split large taskUpdateRequest into several smaller batch dynamically to send.

Introduced 4 parameters regarding to this feature:

`query.remote-task.enable-adaptive-request-size`
* session: enable_adaptive_remote_task_request_size
* to control the enable/disable of the feature

`query.remote-task.max-request-size` 
* session: max_remote_task_request_size
* the max size of taskUpdateRequest

`query.remote-task.request-size-headroom`
* session: remote_task_request_size_headroom
* the expected mean value of the taskUpdateRequest will be between _(max_remote_task_request_size - remote_task_request_size_headroom)_ and _(max_remote_task_request_size)_

`query.remote-task.guaranteed-splits-per-task` 
* session: remote_task_guaranteed_splits_per_request
* guaranteed splits that will be sent in taskUpdateRequest for each task to prevent deadlock, regardless of max_remote_task_request_size