### PR TITLE
Add scroll functionality to Elasticsearch PassthroughQueryPageSource

### DIFF
--- a/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/PassthroughQueryPageSource.java
+++ b/plugin/trino-elasticsearch/src/main/java/io/trino/plugin/elasticsearch/PassthroughQueryPageSource.java
@@ -13,15 +13,23 @@
  */
 package io.trino.plugin.elasticsearch;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
 import io.airlift.slice.Slices;
 import io.trino.plugin.elasticsearch.client.ElasticsearchClient;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.block.BlockBuilder;
 import io.trino.spi.connector.ConnectorPageSource;
+import org.elasticsearch.common.collect.Tuple;
 
 import java.io.IOException;
+import java.util.List;
 
 import static io.trino.spi.type.VarcharType.VARCHAR;
 import static java.util.Objects.requireNonNull;
@@ -29,8 +37,12 @@ import static java.util.Objects.requireNonNull;
 public class PassthroughQueryPageSource
         implements ConnectorPageSource
 {
+    private static final Logger LOG = Logger.get(PassthroughQueryPageSource.class);
+
+    private SearchHitIterator iterator;
+    private long totalBytes;
     private final long readTimeNanos;
-    private final String result;
+    private final Tuple<String, Boolean> result;
     private boolean done;
 
     public PassthroughQueryPageSource(ElasticsearchClient client, ElasticsearchTableHandle table)
@@ -41,40 +53,55 @@ public class PassthroughQueryPageSource
         long start = System.nanoTime();
         result = client.executeQuery(table.getIndex(), table.getQuery().get());
         readTimeNanos = System.nanoTime() - start;
+
+        if (result.v2()) {
+            this.iterator = new SearchHitIterator(client, result.v1());
+        }
     }
 
     @Override
     public long getCompletedBytes()
     {
-        return result.length();
+        return totalBytes;
     }
 
     @Override
     public long getReadTimeNanos()
     {
-        return readTimeNanos;
+        return readTimeNanos + (iterator != null ? iterator.getReadTimeNanos() : 0);
     }
 
     @Override
     public boolean isFinished()
     {
-        return done;
+        return (iterator != null && !iterator.hasNext()) || done;
     }
 
     @Override
     public Page getNextPage()
     {
-        if (done) {
-            return null;
+        if (!done) {
+            String hit;
+
+            // Get next result
+            if (iterator != null) {
+                hit = iterator.next();
+            }
+            else {
+                hit = result.v1();
+                done = true;
+            }
+
+            totalBytes += hit.length();
+
+            PageBuilder page = new PageBuilder(1, ImmutableList.of(VARCHAR));
+            page.declarePosition();
+            BlockBuilder column = page.getBlockBuilder(0);
+            VARCHAR.writeSlice(column, Slices.utf8Slice(hit));
+            return page.build();
         }
 
-        done = true;
-
-        PageBuilder page = new PageBuilder(1, ImmutableList.of(VARCHAR));
-        page.declarePosition();
-        BlockBuilder column = page.getBlockBuilder(0);
-        VARCHAR.writeSlice(column, Slices.utf8Slice(result));
-        return page.build();
+        return null;
     }
 
     @Override
@@ -87,5 +114,121 @@ public class PassthroughQueryPageSource
     public void close()
             throws IOException
     {
+        iterator.close();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class ScrollSearchResponse
+    {
+        @JsonProperty("_scroll_id")
+        private String scrollId;
+
+        @JsonProperty("hits")
+        private Hits hits;
+
+        public String getScrollId()
+        {
+            return scrollId;
+        }
+
+        public boolean hasMoreHits()
+        {
+            return hits != null && hits.getHits() != null && !hits.getHits().isEmpty();
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class Hits
+    {
+        @JsonProperty("hits")
+        private List<Object> hits;
+
+        public List<Object> getHits()
+        {
+            return hits;
+        }
+    }
+
+    private static class SearchHitIterator
+            extends AbstractIterator<String>
+    {
+        private final ElasticsearchClient client;
+        private final String first;
+
+        private String scrollId;
+        private Boolean hasMoreHits;
+        private long readTimeNanos;
+        String response;
+        ObjectMapper objectMapper;
+
+        public SearchHitIterator(ElasticsearchClient client, String first)
+        {
+            this.client = client;
+            this.first = first;
+            this.objectMapper = new ObjectMapper();
+        }
+
+        public long getReadTimeNanos()
+        {
+            return readTimeNanos;
+        }
+
+        @Override
+        protected String computeNext()
+        {
+            long start = System.nanoTime();
+
+            if (scrollId == null) {
+                response = first;
+            }
+            else {
+                response = client.executeScrollQuery(scrollId);
+            }
+
+            readTimeNanos += System.nanoTime() - start;
+            reset(response);
+
+            if (!hasMoreHits || scrollId == null) {
+                return endOfData();
+            }
+
+            return response;
+        }
+
+        private void reset(String response)
+        {
+            ScrollSearchResponse scrollSearchResponse = extractSearchResponse(response);
+            if (scrollSearchResponse != null) {
+                scrollId = scrollSearchResponse.getScrollId();
+                hasMoreHits = scrollSearchResponse.hasMoreHits();
+            }
+        }
+
+        private ScrollSearchResponse extractSearchResponse(String response)
+        {
+            try {
+                ScrollSearchResponse scrollSearchResponse = objectMapper.readValue(response, ScrollSearchResponse.class);
+                if (scrollSearchResponse != null) {
+                    return scrollSearchResponse;
+                }
+            }
+            catch (JsonProcessingException e) {
+                LOG.warn(e, "No Scroll_id returned from elasticSearch");
+            }
+
+            return null;
+        }
+
+        public void close()
+        {
+            if (scrollId != null) {
+                try {
+                    client.clearScroll(scrollId);
+                }
+                catch (Exception e) {
+                    LOG.debug(e, "Error clearing scroll");
+                }
+            }
+        }
     }
 }

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/BaseElasticsearchConnectorTest.java
@@ -1693,7 +1693,45 @@ public abstract class BaseElasticsearchConnectorTest
     }
 
     @Test
-    public void testPassthroughQuery()
+    public void testPassthroughQueryWithSize()
+    {
+        @Language("JSON")
+        String query = "{\n " +
+                " \"size\":5000\n" +
+                "}";
+
+        assertQuery(format("SELECT count(*) " +
+                        " FROM \"orders$query:%s\"", BaseEncoding.base32().encode(query.getBytes(UTF_8))), "VALUES (3)");
+
+        assertQueryFails(
+                "SELECT * FROM \"orders$query:invalid-base32-encoding\"",
+                "Elasticsearch query for 'orders' is not base32-encoded correctly");
+        assertQueryFails(
+                format("SELECT * FROM \"orders$query:%s\"", BaseEncoding.base32().encode("invalid json".getBytes(UTF_8))),
+                "Elasticsearch query for 'orders' is not valid JSON");
+    }
+
+    @Test
+    public void testPassthroughQueryWithoutSize()
+    {
+        @Language("JSON")
+        String query = "{\n " +
+                " \"query\": {\"match_all\": {}}" +
+                "}";
+
+        assertQuery(format("SELECT count(*) " +
+                " FROM \"orders$query:%s\"", BaseEncoding.base32().encode(query.getBytes(UTF_8))), "VALUES (15)");
+
+        assertQueryFails(
+                "SELECT * FROM \"orders$query:invalid-base32-encoding\"",
+                "Elasticsearch query for 'orders' is not base32-encoded correctly");
+        assertQueryFails(
+                format("SELECT * FROM \"orders$query:%s\"", BaseEncoding.base32().encode("invalid json".getBytes(UTF_8))),
+                "Elasticsearch query for 'orders' is not valid JSON");
+    }
+
+    @Test
+    public void testPassthroughQueryAgg()
     {
         @Language("JSON")
         String query = "{\n" +


### PR DESCRIPTION
- Scroll is handled like in ScanQueryPageSource, first query gets the scroll_id and iterates the results until there are no more hits.
- Aggregate query will never perform a scroll and will only run once.
- The scroll size is handled like this:
  * If there is a size property in the query, this is the scroll size.
  * If there is no size property in the query, the scroll size will be the default scroll size parameter defined in Trino's defaults.
- Add tests to check queries with and without size parameter.
- Add Agg suffix to existing test name for passThroughQuery.