### PR TITLE
Add retries for the getTableDataCompression query in the SqlServerClient 

### DIFF
--- a/plugin/trino-sqlserver/pom.xml
+++ b/plugin/trino-sqlserver/pom.xml
@@ -69,15 +69,13 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jdbi</groupId>
-            <artifactId>jdbi3-core</artifactId>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
         </dependency>
 
         <dependency>
-            <!-- transitive compile, but used in tests -->
-            <groupId>net.jodah</groupId>
-            <artifactId>failsafe</artifactId>
-            <scope>runtime</scope>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
         </dependency>
 
         <dependency>

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -15,10 +15,13 @@ package io.trino.plugin.sqlserver;
 
 import com.google.common.base.Enums;
 import com.google.common.base.Joiner;
+import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.microsoft.sqlserver.jdbc.SQLServerException;
+import io.airlift.log.Logger;
 import io.airlift.slice.Slice;
 import io.trino.plugin.base.expression.AggregateFunctionRewriter;
 import io.trino.plugin.base.expression.AggregateFunctionRule;
@@ -64,6 +67,8 @@ import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.Type;
 import io.trino.spi.type.VarbinaryType;
 import io.trino.spi.type.VarcharType;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
 
@@ -162,6 +167,8 @@ import static java.util.stream.Collectors.joining;
 public class SqlServerClient
         extends BaseJdbcClient
 {
+    private static final Logger log = Logger.get(SqlServerClient.class);
+
     // SqlServer supports 2100 parameters in prepared statement, let's create a space for about 4 big IN predicates
     public static final int SQL_SERVER_MAX_LIST_EXPRESSIONS = 500;
 
@@ -625,7 +632,7 @@ public class SqlServerClient
         }
         try (Connection connection = configureConnectionTransactionIsolation(connectionFactory.openConnection(session));
                 Handle handle = Jdbi.open(connection)) {
-            return getTableDataCompression(handle, tableHandle)
+            return getTableDataCompressionWithRetries(handle, tableHandle)
                     .map(dataCompression -> ImmutableMap.<String, Object>of(DATA_COMPRESSION, dataCompression))
                     .orElseGet(ImmutableMap::of);
         }
@@ -766,6 +773,26 @@ public class SqlServerClient
                 .mapTo(String.class)
                 .findOne()
                 .flatMap(dataCompression -> Enums.getIfPresent(DataCompression.class, dataCompression).toJavaUtil());
+    }
+
+    private static Optional<DataCompression> getTableDataCompressionWithRetries(Handle handle, JdbcTableHandle table)
+    {
+        // DDL operations can take out locks against system tables causing the `getTableDataCompression` query to deadlock
+        final int maxAttemptCount = 3;
+        RetryPolicy<Optional<DataCompression>> retryPolicy = new RetryPolicy<Optional<DataCompression>>()
+                .withMaxAttempts(maxAttemptCount)
+                .handleIf(throwable ->
+                {
+                    final int deadlockErrorCode = 1205;
+                    Throwable rootCause = Throwables.getRootCause(throwable);
+                    return rootCause instanceof SQLServerException &&
+                            ((SQLServerException) (rootCause)).getSQLServerError().getErrorNumber() == deadlockErrorCode;
+                })
+                .onFailedAttempt(event -> log.warn(event.getLastFailure(), "Attempt %d of %d: error when getting table compression info for '%s'", event.getAttemptCount(), maxAttemptCount, table));
+
+        return Failsafe
+                .with(retryPolicy)
+                .get(() -> getTableDataCompression(handle, table));
     }
 
     private enum SnapshotIsolationEnabledCacheKey


### PR DESCRIPTION
This query can deadlock if it is long running and concurrent DDL operations are running. 

This deadlock happens sometimes during this test:
https://github.com/trinodb/trino/blob/master/testing/trino-testing/src/main/java/io/trino/testing/BaseConnectorTest.java#L987

The single test takes 10minutes+ on my machine since it lists each table in sqlserver then runs queries against each table to fetch table metadata and the associated table properties.

I decided to add this retry logic to the SqlServerClient, but if we simply want to fix the flaky test I can do that by breaking out the single flaky assert from `BaseConnectorTest` into a separate test case and overriding its implementation in `BaseSqlServerConnectorTest`.  

