### PR TITLE
Make event-listener SPI objects fully jackson serializable

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnDetail.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnDetail.java
@@ -13,12 +13,16 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class ColumnDetail
 {
     private final String catalog;
@@ -26,6 +30,7 @@ public class ColumnDetail
     private final String table;
     private final String columnName;
 
+    @JsonCreator
     public ColumnDetail(String catalog, String schema, String table, String columnName)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/ColumnInfo.java
@@ -13,15 +13,20 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class ColumnInfo
 {
     private final String column;
     private final List<String> masks;
 
+    @JsonCreator
     public ColumnInfo(String column, List<String> masks)
     {
         this.column = column;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/OutputColumnMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/OutputColumnMetadata.java
@@ -14,12 +14,16 @@
 package io.trino.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class OutputColumnMetadata
 {
     private final String columnName;
@@ -34,16 +38,19 @@ public class OutputColumnMetadata
         this.sourceColumns = requireNonNull(sourceColumns, "sourceColumns is null");
     }
 
+    @JsonProperty
     public String getColumnName()
     {
         return columnName;
     }
 
+    @JsonProperty
     public String getColumnType()
     {
         return columnType;
     }
 
+    @JsonProperty
     public Set<ColumnDetail> getSourceColumns()
     {
         return sourceColumns;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryCompletedEvent.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryCompletedEvent.java
@@ -13,6 +13,8 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.TrinoWarning;
 
 import java.time.Instant;
@@ -22,6 +24,9 @@ import java.util.StringJoiner;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class QueryCompletedEvent
 {
     private final QueryMetadata metadata;
@@ -35,6 +40,7 @@ public class QueryCompletedEvent
     private final Instant executionStartTime;
     private final Instant endTime;
 
+    @JsonCreator
     public QueryCompletedEvent(
             QueryMetadata metadata,
             QueryStatistics statistics,
@@ -57,46 +63,55 @@ public class QueryCompletedEvent
         this.endTime = requireNonNull(endTime, "endTime is null");
     }
 
+    @JsonProperty
     public QueryMetadata getMetadata()
     {
         return metadata;
     }
 
+    @JsonProperty
     public QueryStatistics getStatistics()
     {
         return statistics;
     }
 
+    @JsonProperty
     public QueryContext getContext()
     {
         return context;
     }
 
+    @JsonProperty
     public QueryIOMetadata getIoMetadata()
     {
         return ioMetadata;
     }
 
+    @JsonProperty
     public Optional<QueryFailureInfo> getFailureInfo()
     {
         return failureInfo;
     }
 
+    @JsonProperty
     public List<TrinoWarning> getWarnings()
     {
         return warnings;
     }
 
+    @JsonProperty
     public Instant getCreateTime()
     {
         return createTime;
     }
 
+    @JsonProperty
     public Instant getExecutionStartTime()
     {
         return executionStartTime;
     }
 
+    @JsonProperty
     public Instant getEndTime()
     {
         return endTime;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryContext.java
@@ -13,6 +13,7 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.resourcegroups.QueryType;
 import io.trino.spi.resourcegroups.ResourceGroupId;
@@ -24,6 +25,9 @@ import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class QueryContext
 {
     private final String user;
@@ -51,6 +55,7 @@ public class QueryContext
 
     private final Optional<QueryType> queryType;
 
+    @JsonCreator
     public QueryContext(
             String user,
             Optional<String> principal,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryCreatedEvent.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryCreatedEvent.java
@@ -13,11 +13,17 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.Instant;
 import java.util.StringJoiner;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class QueryCreatedEvent
 {
     private final Instant createTime;
@@ -25,6 +31,7 @@ public class QueryCreatedEvent
     private final QueryContext context;
     private final QueryMetadata metadata;
 
+    @JsonCreator
     public QueryCreatedEvent(Instant createTime, QueryContext context, QueryMetadata metadata)
     {
         this.createTime = requireNonNull(createTime, "createTime is null");
@@ -32,16 +39,19 @@ public class QueryCreatedEvent
         this.metadata = requireNonNull(metadata, "metadata is null");
     }
 
+    @JsonProperty
     public Instant getCreateTime()
     {
         return createTime;
     }
 
+    @JsonProperty
     public QueryContext getContext()
     {
         return context;
     }
 
+    @JsonProperty
     public QueryMetadata getMetadata()
     {
         return metadata;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryFailureInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryFailureInfo.java
@@ -13,12 +13,17 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.trino.spi.ErrorCode;
 
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class QueryFailureInfo
 {
     private final ErrorCode errorCode;
@@ -28,6 +33,7 @@ public class QueryFailureInfo
     private final Optional<String> failureHost;
     private final String failuresJson;
 
+    @JsonCreator
     public QueryFailureInfo(
             ErrorCode errorCode,
             Optional<String> failureType,
@@ -44,31 +50,37 @@ public class QueryFailureInfo
         this.failuresJson = requireNonNull(failuresJson, "failuresJson is null");
     }
 
+    @JsonProperty
     public ErrorCode getErrorCode()
     {
         return errorCode;
     }
 
+    @JsonProperty
     public Optional<String> getFailureType()
     {
         return failureType;
     }
 
+    @JsonProperty
     public Optional<String> getFailureMessage()
     {
         return failureMessage;
     }
 
+    @JsonProperty
     public Optional<String> getFailureTask()
     {
         return failureTask;
     }
 
+    @JsonProperty
     public Optional<String> getFailureHost()
     {
         return failureHost;
     }
 
+    @JsonProperty
     public String getFailuresJson()
     {
         return failuresJson;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryIOMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryIOMetadata.java
@@ -13,27 +13,36 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class QueryIOMetadata
 {
     private final List<QueryInputMetadata> inputs;
     private final Optional<QueryOutputMetadata> output;
 
+    @JsonCreator
     public QueryIOMetadata(List<QueryInputMetadata> inputs, Optional<QueryOutputMetadata> output)
     {
         this.inputs = requireNonNull(inputs, "inputs is null");
         this.output = requireNonNull(output, "output is null");
     }
 
+    @JsonProperty
     public List<QueryInputMetadata> getInputs()
     {
         return inputs;
     }
 
+    @JsonProperty
     public Optional<QueryOutputMetadata> getOutput()
     {
         return output;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryInputMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryInputMetadata.java
@@ -13,6 +13,7 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -21,6 +22,9 @@ import java.util.OptionalLong;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class QueryInputMetadata
 {
     private final String catalogName;
@@ -31,6 +35,7 @@ public class QueryInputMetadata
     private final OptionalLong physicalInputBytes;
     private final OptionalLong physicalInputRows;
 
+    @JsonCreator
     public QueryInputMetadata(String catalogName,
             String schema,
             String table,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryMetadata.java
@@ -13,6 +13,7 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.net.URI;
@@ -21,6 +22,9 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class QueryMetadata
 {
     private final String queryId;
@@ -40,6 +44,7 @@ public class QueryMetadata
 
     private final Optional<String> payload;
 
+    @JsonCreator
     public QueryMetadata(
             String queryId,
             Optional<String> transactionId,

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryOutputMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryOutputMetadata.java
@@ -13,6 +13,7 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -20,6 +21,9 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class QueryOutputMetadata
 {
     private final String catalogName;
@@ -30,6 +34,7 @@ public class QueryOutputMetadata
     private final Optional<String> connectorOutputMetadata;
     private final Optional<Boolean> jsonLengthLimitExceeded;
 
+    @JsonCreator
     public QueryOutputMetadata(String catalogName, String schema, String table, Optional<List<OutputColumnMetadata>> columns, Optional<String> connectorOutputMetadata, Optional<Boolean> jsonLengthLimitExceeded)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/QueryStatistics.java
@@ -13,12 +13,18 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class QueryStatistics
 {
     private final Duration cpuTime;
@@ -67,6 +73,7 @@ public class QueryStatistics
      */
     private final Optional<String> planNodeStatsAndCosts;
 
+    @JsonCreator
     public QueryStatistics(
             Duration cpuTime,
             Duration wallTime,
@@ -131,151 +138,181 @@ public class QueryStatistics
         this.planNodeStatsAndCosts = requireNonNull(planNodeStatsAndCosts, "planNodeStatsAndCosts is null");
     }
 
+    @JsonProperty
     public Duration getCpuTime()
     {
         return cpuTime;
     }
 
+    @JsonProperty
     public Duration getWallTime()
     {
         return wallTime;
     }
 
+    @JsonProperty
     public Duration getQueuedTime()
     {
         return queuedTime;
     }
 
+    @JsonProperty
     public Optional<Duration> getScheduledTime()
     {
         return scheduledTime;
     }
 
+    @JsonProperty
     public Optional<Duration> getResourceWaitingTime()
     {
         return waitingTime;
     }
 
+    @JsonProperty
     public Optional<Duration> getAnalysisTime()
     {
         return analysisTime;
     }
 
+    @JsonProperty
     public Optional<Duration> getPlanningTime()
     {
         return planningTime;
     }
 
+    @JsonProperty
     public Optional<Duration> getExecutionTime()
     {
         return executionTime;
     }
 
+    @JsonProperty
     public long getPeakUserMemoryBytes()
     {
         return peakUserMemoryBytes;
     }
 
+    @JsonProperty
     public long getPeakTotalNonRevocableMemoryBytes()
     {
         return peakTotalNonRevocableMemoryBytes;
     }
 
+    @JsonProperty
     public long getPeakTaskUserMemory()
     {
         return peakTaskUserMemory;
     }
 
+    @JsonProperty
     public long getPeakTaskTotalMemory()
     {
         return peakTaskTotalMemory;
     }
 
+    @JsonProperty
     public long getPhysicalInputBytes()
     {
         return physicalInputBytes;
     }
 
+    @JsonProperty
     public long getPhysicalInputRows()
     {
         return physicalInputRows;
     }
 
+    @JsonProperty
     public long getInternalNetworkBytes()
     {
         return internalNetworkBytes;
     }
 
+    @JsonProperty
     public long getInternalNetworkRows()
     {
         return internalNetworkRows;
     }
 
+    @JsonProperty
     public long getTotalBytes()
     {
         return totalBytes;
     }
 
+    @JsonProperty
     public long getTotalRows()
     {
         return totalRows;
     }
 
+    @JsonProperty
     public long getOutputBytes()
     {
         return outputBytes;
     }
 
+    @JsonProperty
     public long getOutputRows()
     {
         return outputRows;
     }
 
+    @JsonProperty
     public long getWrittenBytes()
     {
         return writtenBytes;
     }
 
+    @JsonProperty
     public long getWrittenRows()
     {
         return writtenRows;
     }
 
+    @JsonProperty
     public double getCumulativeMemory()
     {
         return cumulativeMemory;
     }
 
+    @JsonProperty
     public double getCumulativeSystemMemory()
     {
         return cumulativeSystemMemory;
     }
 
+    @JsonProperty
     public List<StageGcStatistics> getStageGcStatistics()
     {
         return stageGcStatistics;
     }
 
+    @JsonProperty
     public int getCompletedSplits()
     {
         return completedSplits;
     }
 
+    @JsonProperty
     public boolean isComplete()
     {
         return complete;
     }
 
+    @JsonProperty
     public List<StageCpuDistribution> getCpuTimeDistribution()
     {
         return cpuTimeDistribution;
     }
 
+    @JsonProperty
     public List<String> getOperatorSummaries()
     {
         return operatorSummaries;
     }
 
+    @JsonProperty
     public Optional<String> getPlanNodeStatsAndCosts()
     {
         return planNodeStatsAndCosts;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/RoutineInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/RoutineInfo.java
@@ -18,6 +18,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class RoutineInfo
 {
     private final String routine;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitCompletedEvent.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitCompletedEvent.java
@@ -13,12 +13,18 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.Instant;
 import java.util.Optional;
 import java.util.StringJoiner;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class SplitCompletedEvent
 {
     private final String queryId;
@@ -35,6 +41,7 @@ public class SplitCompletedEvent
 
     private final String payload;
 
+    @JsonCreator
     public SplitCompletedEvent(
             String queryId,
             String stageId,
@@ -59,51 +66,61 @@ public class SplitCompletedEvent
         this.payload = requireNonNull(payload, "payload is null");
     }
 
+    @JsonProperty
     public String getQueryId()
     {
         return queryId;
     }
 
+    @JsonProperty
     public String getStageId()
     {
         return stageId;
     }
 
+    @JsonProperty
     public String getTaskId()
     {
         return taskId;
     }
 
+    @JsonProperty
     public Instant getCreateTime()
     {
         return createTime;
     }
 
+    @JsonProperty
     public Optional<Instant> getStartTime()
     {
         return startTime;
     }
 
+    @JsonProperty
     public Optional<Instant> getEndTime()
     {
         return endTime;
     }
 
+    @JsonProperty
     public SplitStatistics getStatistics()
     {
         return statistics;
     }
 
+    @JsonProperty
     public Optional<SplitFailureInfo> getFailureInfo()
     {
         return failureInfo;
     }
 
+    @JsonProperty
     public String getPayload()
     {
         return payload;
     }
 
+    @JsonProperty
     public Optional<String> getCatalogName()
     {
         return catalogName;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitFailureInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitFailureInfo.java
@@ -13,24 +13,33 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class SplitFailureInfo
 {
     private final String failureType;
     private final String failureMessage;
 
+    @JsonCreator
     public SplitFailureInfo(String failureType, String failureMessage)
     {
         this.failureType = requireNonNull(failureType, "failureType is null");
         this.failureMessage = requireNonNull(failureMessage, "failureMessage is null");
     }
 
+    @JsonProperty
     public String getFailureType()
     {
         return failureType;
     }
 
+    @JsonProperty
     public String getFailureMessage()
     {
         return failureMessage;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/SplitStatistics.java
@@ -13,11 +13,17 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.Duration;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class SplitStatistics
 {
     private final Duration cpuTime;
@@ -31,6 +37,7 @@ public class SplitStatistics
     private final Optional<Duration> timeToFirstByte;
     private final Optional<Duration> timeToLastByte;
 
+    @JsonCreator
     public SplitStatistics(
             Duration cpuTime,
             Duration wallTime,
@@ -51,42 +58,50 @@ public class SplitStatistics
         this.timeToLastByte = requireNonNull(timeToLastByte, "timeToLastByte is null");
     }
 
+    @JsonProperty
     public Duration getCpuTime()
     {
         return cpuTime;
     }
 
+    @JsonProperty
     public Duration getWallTime()
     {
         return wallTime;
     }
 
+    @JsonProperty
     public Duration getQueuedTime()
     {
         return queuedTime;
     }
 
+    @JsonProperty
     public Duration getCompletedReadTime()
     {
         return completedReadTime;
     }
 
+    @JsonProperty
     public long getCompletedPositions()
     {
         return completedPositions;
     }
 
+    @JsonProperty
     public long getCompletedDataSizeBytes()
     {
         return completedDataSizeBytes;
     }
 
+    @JsonProperty
     @Deprecated
     public Optional<Duration> getTimeToFirstByte()
     {
         return timeToFirstByte;
     }
 
+    @JsonProperty
     @Deprecated
     public Optional<Duration> getTimeToLastByte()
     {

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/StageCpuDistribution.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/StageCpuDistribution.java
@@ -16,6 +16,9 @@ package io.trino.spi.eventlistener;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class StageCpuDistribution
 {
     private final int stageId;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/StageGcStatistics.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/StageGcStatistics.java
@@ -16,6 +16,9 @@ package io.trino.spi.eventlistener;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class StageGcStatistics
 {
     private final int stageId;

--- a/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableInfo.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/eventlistener/TableInfo.java
@@ -13,12 +13,16 @@
  */
 package io.trino.spi.eventlistener;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * This class is JSON serializable for convenience and serialization compatibility is not guaranteed across versions.
+ */
 public class TableInfo
 {
     private final String catalog;
@@ -30,6 +34,7 @@ public class TableInfo
     private final List<ColumnInfo> columns;
     private final boolean directlyReferenced;
 
+    @JsonCreator
     public TableInfo(String catalog, String schema, String table, String authorization, List<String> filters, List<ColumnInfo> columns, boolean directlyReferenced)
     {
         this.catalog = requireNonNull(catalog, "catalog is null");


### PR DESCRIPTION
This is inconsistently implemented today, so let's at least be consistent. We now add the proper annotations to also serialize the remaining objects for convenience, but the format will not be counted on to be consistent for future versions.