### PR TITLE
Consistently reject empty schema location

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/Database.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/Database.java
@@ -51,7 +51,9 @@ public class Database
             @JsonProperty("parameters") Map<String, String> parameters)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
-        this.location = requireNonNull(location, "location is null");
+        requireNonNull(location, "location is null");
+        checkArgument(location.isEmpty() || !location.get().isEmpty(), "location cannot be an empty string");
+        this.location = location;
         this.ownerName = requireNonNull(ownerName, "ownerName is null");
         this.ownerType = requireNonNull(ownerType, "ownerType is null");
         checkArgument(ownerName.isPresent() == ownerType.isPresent(), "Both ownerName and ownerType must be present or empty");

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveWriteUtils.java
@@ -448,7 +448,7 @@ public final class HiveWriteUtils
     public static Path getTableDefaultLocation(Database database, HdfsContext context, HdfsEnvironment hdfsEnvironment, String schemaName, String tableName)
     {
         Optional<String> location = database.getLocation();
-        if (location.isEmpty() || location.get().isEmpty()) {
+        if (location.isEmpty()) {
             throw new TrinoException(HIVE_DATABASE_LOCATION_ERROR, format("Database '%s' location is not set", schemaName));
         }
 


### PR DESCRIPTION
In all cases except one we don't have special handling for location
being present, but an empty string. Consistently reject such value in
`Database` constructor.