### PR TITLE
Add xml-related functions for parsing XML data using XPath expressions

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/FunctionRegistry.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/FunctionRegistry.java
@@ -162,6 +162,7 @@ import io.trino.operator.scalar.VarbinaryFunctions;
 import io.trino.operator.scalar.VersionFunction;
 import io.trino.operator.scalar.WilsonInterval;
 import io.trino.operator.scalar.WordStemFunction;
+import io.trino.operator.scalar.XPathFunctions;
 import io.trino.operator.scalar.time.LocalTimeFunction;
 import io.trino.operator.scalar.time.TimeFunctions;
 import io.trino.operator.scalar.time.TimeOperators;
@@ -477,6 +478,7 @@ public class FunctionRegistry
                 .scalars(SequenceFunction.class)
                 .scalars(SessionFunctions.class)
                 .scalars(StringFunctions.class)
+                .scalars(XPathFunctions.class)
                 .scalars(WordStemFunction.class)
                 .scalar(SplitToMapFunction.class)
                 .scalar(SplitToMultimapFunction.class)

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/XPathFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/XPathFunctions.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.operator.scalar;
+
+import io.airlift.slice.Slice;
+import io.trino.spi.block.Block;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.function.Description;
+import io.trino.spi.function.LiteralParameters;
+import io.trino.spi.function.ScalarFunction;
+import io.trino.spi.function.SqlNullable;
+import io.trino.spi.function.SqlType;
+import io.trino.spi.type.StandardTypes;
+import org.w3c.dom.NodeList;
+
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+/**
+ * implementation of xml string operation function, migrate from hive function
+ * https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/udf/xml/
+ */
+public class XPathFunctions
+{
+    private static final XPathUtils xpathUtil = XPathUtils.getInstance();
+
+    private XPathFunctions() {}
+
+    @SqlNullable
+    @Description("Returns a string array of values within xml nodes that match the xpath expression")
+    @ScalarFunction("xpath")
+    @LiteralParameters({"x", "y"})
+    @SqlType("array(varchar(x))")
+    public static Block xpath(@SqlType("varchar(x)") Slice xml, @SqlType("varchar(y)") Slice path)
+    {
+        BlockBuilder parts = VARCHAR.createBlockBuilder(null, 1, xml.length());
+        NodeList nodeList = xpathUtil.evalNodeList(xml.toStringUtf8(), path.toStringUtf8());
+
+        if (nodeList == null || nodeList.getLength() == 0) {
+            return parts.build();
+        }
+
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            String value = nodeList.item(i).getNodeValue();
+            if (value != null) {
+                VARCHAR.writeSlice(parts, utf8Slice(value));
+            }
+        }
+        return parts.build();
+    }
+
+    @SqlNullable
+    @Description("Evaluates a boolean xpath expression")
+    @ScalarFunction("xpath_boolean")
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.BOOLEAN)
+    public static Boolean xpathBoolean(@SqlType("varchar(x)") Slice xml, @SqlType("varchar(y)") Slice path)
+    {
+        return xpathUtil.evalBoolean(xml.toStringUtf8(), path.toStringUtf8());
+    }
+
+    @SqlNullable
+    @Description("Returns a double value that matches the xpath expression")
+    @ScalarFunction(value = "xpath_double", alias = {"xpath_number", "xpath_float"})
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.DOUBLE)
+    public static Double xpathDouble(@SqlType("varchar(x)") Slice xml, @SqlType("varchar(y)") Slice path)
+    {
+        return xpathUtil.evalNumber(xml.toStringUtf8(), path.toStringUtf8());
+    }
+
+    @SqlNullable
+    @Description("Returns a long value that matches the xpath expression")
+    @ScalarFunction(value = "xpath_long", alias = "xpath_int")
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.BIGINT)
+    public static Long xpathLong(@SqlType("varchar(x)") Slice xml, @SqlType("varchar(y)") Slice path)
+    {
+        Double result = xpathUtil.evalNumber(xml.toStringUtf8(), path.toStringUtf8());
+        return result == null ? null : result.longValue();
+    }
+
+    @SqlNullable
+    @Description("Returns a string value that matches the xpath expression")
+    @ScalarFunction(value = "xpath_string", alias = "xpath_str")
+    @LiteralParameters({"x", "y"})
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice xpathString(@SqlType("varchar(x)") Slice xml, @SqlType("varchar(y)") Slice path)
+    {
+        String result = xpathUtil.evalString(xml.toStringUtf8(), path.toStringUtf8());
+        return result == null ? null : utf8Slice(result);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/scalar/XPathUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/XPathUtils.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.operator.scalar;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import java.io.IOException;
+import java.io.Reader;
+
+/*
+ * Utility class for all XPath UDFs. Each UDF instance should keep an instance of this class.
+ */
+public class XPathUtils
+{
+    public static final String SAX_FEATURE_PREFIX = "http://xml.org/sax/features/";
+    public static final String EXTERNAL_GENERAL_ENTITIES_FEATURE = "external-general-entities";
+    public static final String EXTERNAL_PARAMETER_ENTITIES_FEATURE = "external-parameter-entities";
+    private final XPath xpath = XPathFactory.newInstance().newXPath();
+
+    private static final Object mutex = new Object();
+    private static volatile XPathUtils instance;
+    private XPathExpression expression;
+    private String oldPath;
+
+    private static final ThreadLocal<DocumentBuilder> docBuilderIns = ThreadLocal.withInitial(() -> {
+        try {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setFeature(SAX_FEATURE_PREFIX + EXTERNAL_GENERAL_ENTITIES_FEATURE, false);
+            dbf.setFeature(SAX_FEATURE_PREFIX + EXTERNAL_PARAMETER_ENTITIES_FEATURE, false);
+            return dbf.newDocumentBuilder();
+        }
+        catch (ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    });
+
+    public static XPathUtils getInstance()
+    {
+        XPathUtils result = instance;
+        if (result == null) {
+            synchronized (mutex) {
+                result = instance;
+                if (result == null) {
+                    instance = new XPathUtils();
+                    result = instance;
+                }
+            }
+            return result;
+        }
+        return instance;
+    }
+
+    public Object eval(String xml, String path, QName qname)
+    {
+        if (xml == null || path == null || qname == null) {
+            return null;
+        }
+
+        if (xml.length() == 0 || path.length() == 0) {
+            return null;
+        }
+
+        if (!path.equals(oldPath)) {
+            try {
+                expression = xpath.compile(path);
+            }
+            catch (XPathExpressionException e) {
+                expression = null;
+            }
+            oldPath = path;
+        }
+
+        if (expression == null) {
+            return null;
+        }
+
+        ReusableStringReader reader = new ReusableStringReader();
+        InputSource inputSource = new InputSource(reader);
+        reader.set(xml);
+        try {
+            return expression.evaluate(docBuilderIns.get().parse(inputSource), qname);
+        }
+        catch (Exception e) {
+            return null;
+        }
+    }
+
+    public Boolean evalBoolean(String xml, String path)
+    {
+        return (Boolean) eval(xml, path, XPathConstants.BOOLEAN);
+    }
+
+    public String evalString(String xml, String path)
+    {
+        return (String) eval(xml, path, XPathConstants.STRING);
+    }
+
+    public Double evalNumber(String xml, String path)
+    {
+        return (Double) eval(xml, path, XPathConstants.NUMBER);
+    }
+
+    public Node evalNode(String xml, String path)
+    {
+        return (Node) eval(xml, path, XPathConstants.NODE);
+    }
+
+    public NodeList evalNodeList(String xml, String path)
+    {
+        return (NodeList) eval(xml, path, XPathConstants.NODESET);
+    }
+
+    public static class ReusableStringReader
+            extends Reader
+    {
+        private String str;
+        private int length = -1;
+        private int next;
+        private int mark;
+
+        public ReusableStringReader()
+        {
+        }
+
+        public void set(String str)
+        {
+            this.str = str;
+            this.length = str.length();
+            this.mark = 0;
+            this.next = 0;
+        }
+
+        /**
+         * Check to make sure that the stream has not been closed
+         */
+        private void ensureOpen()
+                throws IOException
+        {
+            if (str == null) {
+                throw new IOException("Stream closed");
+            }
+        }
+
+        @Override
+        public int read()
+                throws IOException
+        {
+            ensureOpen();
+            if (next >= length) {
+                return -1;
+            }
+            return str.charAt(next++);
+        }
+
+        @Override
+        public int read(char[] cbuf, int off, int len)
+                throws IOException
+        {
+            ensureOpen();
+            if ((off < 0) || (off > cbuf.length) || (len < 0)
+                    || ((off + len) > cbuf.length) || ((off + len) < 0)) {
+                throw new IndexOutOfBoundsException();
+            }
+            else if (len == 0) {
+                return 0;
+            }
+            if (next >= length) {
+                return -1;
+            }
+            int n = Math.min(length - next, len);
+            str.getChars(next, next + n, cbuf, off);
+            next += n;
+            return n;
+        }
+
+        @Override
+        public long skip(long ns)
+                throws IOException
+        {
+            ensureOpen();
+            if (next >= length) {
+                return 0;
+            }
+            // Bound skip by beginning and end of the source
+            long n = Math.min(length - next, ns);
+            n = Math.max(-next, n);
+            next += n;
+            return n;
+        }
+
+        @Override
+        public boolean ready()
+                throws IOException
+        {
+            ensureOpen();
+            return true;
+        }
+
+        @Override
+        public boolean markSupported()
+        {
+            return true;
+        }
+
+        @Override
+        public void mark(int readAheadLimit)
+                throws IOException
+        {
+            if (readAheadLimit < 0) {
+                throw new IllegalArgumentException("Read-ahead limit < 0");
+            }
+            ensureOpen();
+            mark = next;
+        }
+
+        @Override
+        public void reset()
+                throws IOException
+        {
+            ensureOpen();
+            next = mark;
+        }
+
+        @Override
+        public void close()
+        {
+            str = null;
+        }
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestXPathFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestXPathFunctions.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.trino.operator.scalar;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.type.ArrayType;
+import org.testng.annotations.Test;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
+import static java.lang.Double.NaN;
+
+public class TestXPathFunctions
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testXPath()
+    {
+        assertFunction("xpath('<a><b>b1</b><b>b2</b></a>', '//b')", new ArrayType(createVarcharType(25)), ImmutableList.of());
+        assertFunction("xpath('<a><b>b1</b><b>b2</b></a>', '//b')", new ArrayType(createVarcharType(25)), ImmutableList.of());
+        assertFunction("xpath('<a><b>b1</b><b>b2</b></a>','a/*/text()')", new ArrayType(createVarcharType(25)), ImmutableList.of("b1", "b2"));
+        assertFunction("xpath('<a><b class=\"bb\">b1</b><b>b2</b><b>b3</b><c class=\"bb\">c1</c><c>c2</c></a>', 'a/*[@class=\"bb\"]/text()')",
+                new ArrayType(createVarcharType(74)), ImmutableList.of("b1", "c1"));
+
+        // test illegal xml string
+
+        // test non-ascii characters
+        assertFunction("xpath('<a><b>中文</b></a>', '/a/b/text()')", new ArrayType(createVarcharType(16)), ImmutableList.of("中文"));
+        assertFunction("xpath('<a><b>\\xe4\\xb8\\xad\\xe6\\x96\\x87</b></a>', '/a/b/text()')", new ArrayType(createVarcharType(38)),
+                ImmutableList.of("\\xe4\\xb8\\xad\\xe6\\x96\\x87"));
+    }
+
+    @Test
+    public void testXPathWithNull()
+    {
+        assertFunction("xpath('<a><b>b1</b><b>b2</b></a>',null)", new ArrayType(createVarcharType(25)), null);
+        assertFunction("xpath(null,null)", new ArrayType(createVarcharType(0)), null);
+        assertFunction("xpath_boolean(null, 'a/c')", BOOLEAN, null);
+        assertFunction("xpath_boolean(null, null)", BOOLEAN, null);
+        assertFunction("xpath_long(null, 'a/c')", BIGINT, null);
+        assertFunction("xpath_long(null, null)", BIGINT, null);
+        assertFunction("xpath_double(null, '//a')", DOUBLE, null);
+        assertFunction("xpath_double(null, null)", DOUBLE, null);
+        assertFunction("xpath_string(null, 'a/b')", VARCHAR, null);
+        assertFunction("xpath_string(null, null)", VARCHAR, null);
+    }
+
+    @Test
+    public void testXpathWithIllegal()
+    {
+        assertFunction("xpath('/a', '/')", new ArrayType(createVarcharType(2)), ImmutableList.of());
+        assertFunction("xpath('<a>hello<b>world</b>', '/')", new ArrayType(createVarcharType(20)), ImmutableList.of());
+        assertFunction("xpath_boolean('/a', '/')", BOOLEAN, null);
+        assertFunction("xpath_boolean('<a>hello<b>world</b>', '/')", BOOLEAN, null);
+        assertFunction("xpath_long('/a', '/')", BIGINT, null);
+        assertFunction("xpath_long('<a>hello<b>world</b>', '/')", BIGINT, null);
+        assertFunction("xpath_double('/a', '/')", DOUBLE, null);
+        assertFunction("xpath_double('<a>hello<b>world</b>', '/')", DOUBLE, null);
+        assertFunction("xpath_string('/a', '/')", VARCHAR, null);
+        assertFunction("xpath_string('<a>hello<b>world</b>', '/')", VARCHAR, null);
+    }
+
+    @Test
+    public void testXPathBoolean()
+    {
+        assertFunction("xpath_boolean('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>', 'a/text()')", BOOLEAN, false);
+        assertFunction("xpath_boolean('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>', 'a/b')", BOOLEAN, true);
+        assertFunction("xpath_boolean('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>', '/a')", BOOLEAN, true);
+    }
+
+    @Test
+    public void testXPathLong()
+    {
+        assertFunction("xpath_long('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>', 'count(//b)')", BIGINT, 3L);
+        assertFunction("xpath_long('<a><b>12</b><b>23</b><b>34</b><c>c1</c><c>c2</c></a>', 'sum(//b/text())')", BIGINT, 69L);
+        assertFunction("xpath_long('<a><b>12</b><b>23</b><b>-34</b><c>c1</c><c>c2</c></a>', 'sum(//b/text())')", BIGINT, 1L);
+        assertFunction("xpath_long('<a><b>120000000001</b><b>230000000000000000001</b><b>34</b><c>c1</c><c>c2</c></a>', 'sum(//b/text())')",
+                BIGINT, 9223372036854775807L);
+
+        assertFunction("xpath_long('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>', 'a/text()')", BIGINT, 0L);
+        assertFunction("xpath_long('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>', 'a/b')", BIGINT, 0L);
+        assertFunction("xpath_long('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>', '/a')", BIGINT, 0L);
+    }
+
+    @Test
+    public void testXPathDouble()
+    {
+        assertFunction("xpath_double('<a>b</a>', 'a = 10')", DOUBLE, 0.0);
+        assertFunction("xpath_double('<a>this is not a number</a>', 'a')", DOUBLE, NaN);
+        assertFunction("xpath_double('<a><b>2000000000</b><c>40000000000</c></a>', 'a/b * a/c')", DOUBLE, 8.0E19);
+        assertFunction("xpath_double('<a><b>2000000000.123456789</b><c>40000000000.98765432001</c></a>', 'a/b * a/c')", DOUBLE, 8.000000000691357E19);
+        assertFunction("xpath_double('<a><b>20000</b><c>400000</c></a>', null)", DOUBLE, null);
+    }
+
+    @Test
+    public void testXPathString()
+    {
+        assertFunction("xpath_string('<a><b>bb</b><c>cc</c></a>', 'a/b')", VARCHAR, "bb");
+        assertFunction("xpath_string('<a><b>bb</b><c>cc</c></a>', 'a')", VARCHAR, "bbcc");
+        assertFunction("xpath_string('<a><b>bb</b><c>cc</c></a>', 'a/d')", VARCHAR, "");
+        assertFunction("xpath_string('<a><b>b1</b><b>b2</b></a>', '//b')", VARCHAR, "b1");
+        assertFunction("xpath_string('<a><b>b1</b><b id=\"b_2\">b2</b></a>', 'a/b[@id=\"b_2\"]')", VARCHAR, "b2");
+        assertFunction("xpath_string('<a><b>b1</b><b id=\"b_2\">b2</b></a>', null)", VARCHAR, null);
+        assertFunction("xpath_string('<a><b>b1</b><b id=\"b_2\">b2</b></a>', '/a/b[@id=\"b_2\"]')", VARCHAR, "b2");
+    }
+}

--- a/docs/src/main/sphinx/functions.rst
+++ b/docs/src/main/sphinx/functions.rst
@@ -46,5 +46,6 @@ and the :doc:`SQL statement and syntax reference</sql>`.
     URL                 <functions/url>
     UUID                <functions/uuid>
     Window              <functions/window>
+    XML                 <functions/xml>
     functions/list
     functions/list-by-topic

--- a/docs/src/main/sphinx/functions/xml.rst
+++ b/docs/src/main/sphinx/functions/xml.rst
@@ -1,0 +1,63 @@
+===============================
+XML of functions and operators
+===============================
+
+These functions and operators are used for parsing XML data using XPath expressions.
+They are migrated from `Hive xpath and related functions<https://cwiki.apache.org/confluence/display/Hive/LanguageManual+XPathUDF>`_
+
+.. function:: xpath(xml_string, xpath_expression_string) -> array
+    :noindex:
+
+    Returns array of strings  If the expression results in a non-text value (e.g., another xml node)
+    the function will return an empty array. There are 2 primary uses for this function:
+    to get a list of node text values or to get a list of attribute values.::
+
+        SELECT xpath('<a><b>b1</b><b>b2</b></a>','a/*'); -- []
+        SELECT xpath('<a><b>b1</b><b>b2</b></a>','a/*/text()'); -- [b1, b2]
+
+        SELECT xpath('<a><b id="foo">b1</b><b id="bar">b2</b></a>','//@id'); -- [foo, bar]
+        SELECT xpath ('<a><b class="bb">b1</b><b>b2</b><b>b3</b><c class="bb">c1</c><c>c2</c></a>', 'a/*[@class="bb"]/text()'); -- [b1, c1]
+
+.. function:: xpath_string(xml_string, xpath_expression_string) -> varchar
+    :noindex::
+
+    Returns the text of the first matching node.::
+
+        SELECT xpath_string('<a><b>bb</b><c>cc</c></a>', 'a/b'); -- bb
+        SELECT xpath_string('<a><b>bb</b><c>cc</c></a>', 'a'); -- bbcc
+        SELECT xpath_string('<a><b>bb</b><c>cc</c></a>', 'a/d'); --
+        SELECT xpath_string('<a><b>b1</b><b>b2</b></a>', '//b'); -- b1
+        SELECT xpath_string ('<a><b>b1</b><b>b2</b></a>', 'a/b[2]'); -- b2
+        SELECT xpath_string ('<a><b>b1</b><b id="b_2">b2</b></a>', 'a/b[@id="b_2"]'); -- b2
+
+.. function:: xpath_boolean(xml_string, xpath_expression_string) -> boolean
+    :noindex::
+
+    Returns true if the XPath expression evaluates to true, or if a matching node is found.::
+
+        SELECT xpath_boolean('<a><b>b</b></a>', 'a/b'); -- true
+        SELECT xpath_boolean('<a><b>b</b></a>', 'a/c'); -- false
+        SELECT xpath_boolean ('<a><b>b</b></a>', 'a/b = "b"'); -- true
+
+.. function:: xpath_long(xml_string, xpath_expression_string) -> boolean
+    :noindex::
+
+     Returns an integer numeric value, or the value zero if no match is found, or a match is found but the value
+     is non-numeric. Mathematical operations are supported. In cases where the value overflows the return type,
+     then the maximum value for the type is returned..::
+
+        SELECT xpath_long('<a>b</a>', 'a = 10'); -- 0
+        SELECT xpath_long('<a>this is not a number</a>', 'a'); -- 0
+        SELECT xpath_long('<a><b class="odd">1</b><b class="even">2</b><b class="odd">4</b><c>8</c></a>', 'sum(a/*)'); -- 15
+        SELECT xpath_long('<a><b class="odd">1</b><b class="even">2</b><b class="odd">4</b><c>8</c></a>', 'sum(a/b)'); -- 7
+
+.. function:: xpath_double(xml_string, xpath_expression_string) -> boolean
+    :noindex::
+
+     Returns a float numeric value, or the value zero if no match is found, or the value of NaN if a match is found but the value
+     is non-numeric. Mathematical operations are supported. In cases where the value overflows the return type,
+     then the maximum value for the type is returned..::
+
+        SELECT xpath_double ('<a>b</a>', 'a = 10'); -- 0.0
+        SELECT xpath_double ('<a>this is not a number</a>', 'a'); -- NaN
+        SELECT xpath_double ('<a><b>2000000000</b><c>40000000000</c></a>', 'a/b * a/c'); -- 8.0E19

--- a/docs/src/main/sphinx/functions/xml.rst
+++ b/docs/src/main/sphinx/functions/xml.rst
@@ -3,25 +3,23 @@ XML of functions and operators
 ===============================
 
 These functions and operators are used for parsing XML data using XPath expressions.
-They are migrated from `Hive xpath and related functions<https://cwiki.apache.org/confluence/display/Hive/LanguageManual+XPathUDF>`_
+They are migrated from `Hive xpath and related functions <https://cwiki.apache.org/confluence/display/Hive/LanguageManual+XPathUDF>`_
 
 .. function:: xpath(xml_string, xpath_expression_string) -> array
-    :noindex:
-
+    
     Returns array of strings  If the expression results in a non-text value (e.g., another xml node)
     the function will return an empty array. There are 2 primary uses for this function:
-    to get a list of node text values or to get a list of attribute values.::
+    to get a list of node text values or to get a list of attribute values::
 
         SELECT xpath('<a><b>b1</b><b>b2</b></a>','a/*'); -- []
         SELECT xpath('<a><b>b1</b><b>b2</b></a>','a/*/text()'); -- [b1, b2]
-
         SELECT xpath('<a><b id="foo">b1</b><b id="bar">b2</b></a>','//@id'); -- [foo, bar]
         SELECT xpath ('<a><b class="bb">b1</b><b>b2</b><b>b3</b><c class="bb">c1</c><c>c2</c></a>', 'a/*[@class="bb"]/text()'); -- [b1, c1]
 
 .. function:: xpath_string(xml_string, xpath_expression_string) -> varchar
-    :noindex::
+    
 
-    Returns the text of the first matching node.::
+    Returns the text of the first matching node::
 
         SELECT xpath_string('<a><b>bb</b><c>cc</c></a>', 'a/b'); -- bb
         SELECT xpath_string('<a><b>bb</b><c>cc</c></a>', 'a'); -- bbcc
@@ -31,20 +29,19 @@ They are migrated from `Hive xpath and related functions<https://cwiki.apache.or
         SELECT xpath_string ('<a><b>b1</b><b id="b_2">b2</b></a>', 'a/b[@id="b_2"]'); -- b2
 
 .. function:: xpath_boolean(xml_string, xpath_expression_string) -> boolean
-    :noindex::
-
-    Returns true if the XPath expression evaluates to true, or if a matching node is found.::
+    
+    Returns true if the XPath expression evaluates to true, or if a matching node is found::
 
         SELECT xpath_boolean('<a><b>b</b></a>', 'a/b'); -- true
         SELECT xpath_boolean('<a><b>b</b></a>', 'a/c'); -- false
         SELECT xpath_boolean ('<a><b>b</b></a>', 'a/b = "b"'); -- true
 
 .. function:: xpath_long(xml_string, xpath_expression_string) -> boolean
-    :noindex::
+    
 
-     Returns an integer numeric value, or the value zero if no match is found, or a match is found but the value
-     is non-numeric. Mathematical operations are supported. In cases where the value overflows the return type,
-     then the maximum value for the type is returned..::
+    Returns an integer numeric value, or the value zero if no match is found, or a match is found but the value
+    is non-numeric. Mathematical operations are supported. In cases where the value overflows the return type,
+    then the maximum value for the type is returned::
 
         SELECT xpath_long('<a>b</a>', 'a = 10'); -- 0
         SELECT xpath_long('<a>this is not a number</a>', 'a'); -- 0
@@ -52,11 +49,10 @@ They are migrated from `Hive xpath and related functions<https://cwiki.apache.or
         SELECT xpath_long('<a><b class="odd">1</b><b class="even">2</b><b class="odd">4</b><c>8</c></a>', 'sum(a/b)'); -- 7
 
 .. function:: xpath_double(xml_string, xpath_expression_string) -> boolean
-    :noindex::
 
-     Returns a float numeric value, or the value zero if no match is found, or the value of NaN if a match is found but the value
-     is non-numeric. Mathematical operations are supported. In cases where the value overflows the return type,
-     then the maximum value for the type is returned..::
+    Returns a float numeric value, or the value zero if no match is found, or the value of NaN if a match is found but the value
+    is non-numeric. Mathematical operations are supported. In cases where the value overflows the return type,
+    then the maximum value for the type is returned::
 
         SELECT xpath_double ('<a>b</a>', 'a = 10'); -- 0.0
         SELECT xpath_double ('<a>this is not a number</a>', 'a'); -- NaN


### PR DESCRIPTION
These functions are migrated from [Hive UDF XPath functions](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+XPathUDF)