### PR TITLE
Refactor QueryBuilder usage and implement *char join pushdown in PostgreSQL

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -377,7 +377,7 @@ public abstract class BaseJdbcClient
             throws SQLException
     {
         PreparedQuery preparedQuery = prepareQuery(session, connection, table, Optional.empty(), columns, ImmutableMap.of(), Optional.of(split));
-        return new QueryBuilder(this).prepareStatement(session, connection, preparedQuery);
+        return new QueryBuilder(this).prepareStatement(this, session, connection, preparedQuery);
     }
 
     protected PreparedQuery prepareQuery(
@@ -390,6 +390,7 @@ public abstract class BaseJdbcClient
             Optional<JdbcSplit> split)
     {
         return applyQueryTransformations(table, new QueryBuilder(this).prepareQuery(
+                this,
                 session,
                 connection,
                 table.getRelationHandle(),
@@ -419,6 +420,7 @@ public abstract class BaseJdbcClient
 
         QueryBuilder queryBuilder = new QueryBuilder(this);
         return Optional.of(queryBuilder.prepareJoinQuery(
+                this,
                 session,
                 joinType,
                 leftSource,
@@ -971,8 +973,8 @@ public abstract class BaseJdbcClient
         try (Connection connection = connectionFactory.openConnection(session)) {
             verify(connection.getAutoCommit());
             QueryBuilder queryBuilder = new QueryBuilder(this);
-            PreparedQuery preparedQuery = queryBuilder.prepareDelete(session, connection, handle.getRequiredNamedRelation(), handle.getConstraint());
-            try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(session, connection, preparedQuery)) {
+            PreparedQuery preparedQuery = queryBuilder.prepareDelete(this, session, connection, handle.getRequiredNamedRelation(), handle.getConstraint());
+            try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(this, session, connection, preparedQuery)) {
                 return OptionalLong.of(preparedStatement.executeUpdate());
             }
         }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -394,7 +394,7 @@ public abstract class BaseJdbcClient
             Map<String, String> columnExpressions,
             Optional<JdbcSplit> split)
     {
-        return applyQueryTransformations(table, queryBuilder.prepareQuery(
+        return applyQueryTransformations(table, queryBuilder.prepareSelectQuery(
                 this,
                 session,
                 connection,
@@ -976,7 +976,7 @@ public abstract class BaseJdbcClient
         checkArgument(handle.getSortOrder().isEmpty(), "Unable to delete when sort order is set: %s", handle);
         try (Connection connection = connectionFactory.openConnection(session)) {
             verify(connection.getAutoCommit());
-            PreparedQuery preparedQuery = queryBuilder.prepareDelete(this, session, connection, handle.getRequiredNamedRelation(), handle.getConstraint());
+            PreparedQuery preparedQuery = queryBuilder.prepareDeleteQuery(this, session, connection, handle.getRequiredNamedRelation(), handle.getConstraint());
             try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(this, session, connection, preparedQuery)) {
                 return OptionalLong.of(preparedStatement.executeUpdate());
             }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -423,15 +423,21 @@ public abstract class BaseJdbcClient
             }
         }
 
-        return Optional.of(queryBuilder.prepareJoinQuery(
-                this,
-                session,
-                joinType,
-                leftSource,
-                rightSource,
-                joinConditions,
-                leftAssignments,
-                rightAssignments));
+        try (Connection connection = this.connectionFactory.openConnection(session)) {
+            return Optional.of(queryBuilder.prepareJoinQuery(
+                    this,
+                    session,
+                    connection,
+                    joinType,
+                    leftSource,
+                    rightSource,
+                    joinConditions,
+                    leftAssignments,
+                    rightAssignments));
+        }
+        catch (SQLException e) {
+            throw new TrinoException(JDBC_ERROR, e);
+        }
     }
 
     protected boolean isSupportedJoinCondition(JdbcJoinCondition joinCondition)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -418,7 +418,7 @@ public abstract class BaseJdbcClient
             JoinStatistics statistics)
     {
         for (JdbcJoinCondition joinCondition : joinConditions) {
-            if (!isSupportedJoinCondition(joinCondition)) {
+            if (!isSupportedJoinCondition(session, joinCondition)) {
                 return Optional.empty();
             }
         }
@@ -440,7 +440,7 @@ public abstract class BaseJdbcClient
         }
     }
 
-    protected boolean isSupportedJoinCondition(JdbcJoinCondition joinCondition)
+    protected boolean isSupportedJoinCondition(ConnectorSession session, JdbcJoinCondition joinCondition)
     {
         return false;
     }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -54,7 +54,7 @@ public class DefaultQueryBuilder
     private static final String ALWAYS_FALSE = "1=0";
 
     @Override
-    public PreparedQuery prepareQuery(
+    public PreparedQuery prepareSelectQuery(
             JdbcClient client,
             ConnectorSession session,
             Connection connection,
@@ -156,7 +156,7 @@ public class DefaultQueryBuilder
     }
 
     @Override
-    public PreparedQuery prepareDelete(
+    public PreparedQuery prepareDeleteQuery(
             JdbcClient client,
             ConnectorSession session,
             Connection connection,

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.jdbc;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableList;
+import io.airlift.log.Logger;
+import io.airlift.slice.Slice;
+import io.trino.spi.connector.ColumnHandle;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.JoinType;
+import io.trino.spi.predicate.Domain;
+import io.trino.spi.predicate.Range;
+import io.trino.spi.predicate.TupleDomain;
+import io.trino.spi.predicate.ValueSet;
+import io.trino.spi.type.Type;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.lang.String.format;
+import static java.util.Collections.nCopies;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+public class DefaultQueryBuilder
+{
+    private static final Logger log = Logger.get(DefaultQueryBuilder.class);
+
+    // not all databases support booleans, so use 1=1 and 1=0 instead
+    private static final String ALWAYS_TRUE = "1=1";
+    private static final String ALWAYS_FALSE = "1=0";
+
+    private final JdbcClient client;
+
+    public DefaultQueryBuilder(JdbcClient client)
+    {
+        this.client = requireNonNull(client, "client is null");
+    }
+
+    public PreparedQuery prepareQuery(
+            JdbcClient client,
+            ConnectorSession session,
+            Connection connection,
+            JdbcRelationHandle baseRelation,
+            Optional<List<List<JdbcColumnHandle>>> groupingSets,
+            List<JdbcColumnHandle> columns,
+            Map<String, String> columnExpressions,
+            TupleDomain<ColumnHandle> tupleDomain,
+            Optional<String> additionalPredicate)
+    {
+        if (!tupleDomain.isNone()) {
+            Map<ColumnHandle, Domain> domains = tupleDomain.getDomains().orElseThrow();
+            columns.stream()
+                    .filter(domains::containsKey)
+                    .filter(column -> columnExpressions.containsKey(column.getColumnName()))
+                    .findFirst()
+                    .ifPresent(column -> { throw new IllegalArgumentException(format("Column %s has an expression and a constraint attached at the same time", column)); });
+        }
+
+        ImmutableList.Builder<QueryParameter> accumulator = ImmutableList.builder();
+
+        String sql = "SELECT " + getProjection(columns, columnExpressions);
+        sql += getFrom(baseRelation, accumulator::add);
+
+        List<String> clauses = toConjuncts(session, connection, tupleDomain, accumulator::add);
+        if (additionalPredicate.isPresent()) {
+            clauses = ImmutableList.<String>builder()
+                    .addAll(clauses)
+                    .add(additionalPredicate.get())
+                    .build();
+        }
+        if (!clauses.isEmpty()) {
+            sql += " WHERE " + Joiner.on(" AND ").join(clauses);
+        }
+
+        sql += getGroupBy(groupingSets);
+
+        return new PreparedQuery(sql, accumulator.build());
+    }
+
+    public PreparedQuery prepareJoinQuery(
+            JdbcClient client,
+            ConnectorSession session,
+            JoinType joinType,
+            PreparedQuery leftSource,
+            PreparedQuery rightSource,
+            List<JdbcJoinCondition> joinConditions,
+            Map<JdbcColumnHandle, String> leftAssignments,
+            Map<JdbcColumnHandle, String> rightAssignments)
+    {
+        // Verify assignments are present. This is safe assumption as join conditions are not pruned, and simplifies the code here.
+        verify(!leftAssignments.isEmpty(), "leftAssignments is empty");
+        verify(!rightAssignments.isEmpty(), "rightAssignments is empty");
+        // Joins wih no conditions are not pushed down, so it is a same assumption and simplifies the code here
+        verify(!joinConditions.isEmpty(), "joinConditions is empty");
+
+        String query = format(
+                "SELECT %s, %s FROM (%s) l %s (%s) r ON %s",
+                formatAssignments("l", leftAssignments),
+                formatAssignments("r", rightAssignments),
+                leftSource.getQuery(),
+                formatJoinType(joinType),
+                rightSource.getQuery(),
+                joinConditions.stream()
+                        .map(condition -> format(
+                                "l.%s %s r.%s",
+                                client.quoted(condition.getLeftColumn().getColumnName()),
+                                condition.getOperator().getValue(),
+                                client.quoted(condition.getRightColumn().getColumnName())))
+                        .collect(joining(" AND ")));
+        List<QueryParameter> parameters = ImmutableList.<QueryParameter>builder()
+                .addAll(leftSource.getParameters())
+                .addAll(rightSource.getParameters())
+                .build();
+        return new PreparedQuery(query, parameters);
+    }
+
+    protected String formatAssignments(String relationAlias, Map<JdbcColumnHandle, String> assignments)
+    {
+        return assignments.entrySet().stream()
+                .map(entry -> format("%s.%s AS %s", relationAlias, client.quoted(entry.getKey().getColumnName()), client.quoted(entry.getValue())))
+                .collect(joining(", "));
+    }
+
+    protected static String formatJoinType(JoinType joinType)
+    {
+        switch (joinType) {
+            case INNER:
+                return "INNER JOIN";
+            case LEFT_OUTER:
+                return "LEFT JOIN";
+            case RIGHT_OUTER:
+                return "RIGHT JOIN";
+            case FULL_OUTER:
+                return "FULL JOIN";
+        }
+        throw new IllegalStateException("Unsupported join type: " + joinType);
+    }
+
+    public PreparedQuery prepareDelete(
+            JdbcClient client,
+            ConnectorSession session,
+            Connection connection,
+            JdbcNamedRelationHandle baseRelation,
+            TupleDomain<ColumnHandle> tupleDomain)
+    {
+        String sql = "DELETE FROM " + getRelation(baseRelation.getRemoteTableName());
+
+        ImmutableList.Builder<QueryParameter> accumulator = ImmutableList.builder();
+
+        List<String> clauses = toConjuncts(session, connection, tupleDomain, accumulator::add);
+        if (!clauses.isEmpty()) {
+            sql += " WHERE " + Joiner.on(" AND ").join(clauses);
+        }
+        return new PreparedQuery(sql, accumulator.build());
+    }
+
+    public PreparedStatement prepareStatement(
+            JdbcClient client,
+            ConnectorSession session,
+            Connection connection,
+            PreparedQuery preparedQuery)
+            throws SQLException
+    {
+        log.debug("Preparing query: %s", preparedQuery.getQuery());
+        PreparedStatement statement = client.getPreparedStatement(connection, preparedQuery.getQuery());
+
+        List<QueryParameter> parameters = preparedQuery.getParameters();
+        for (int i = 0; i < parameters.size(); i++) {
+            QueryParameter parameter = parameters.get(i);
+            int parameterIndex = i + 1;
+            WriteFunction writeFunction = getWriteFunction(session, connection, parameter.getJdbcType(), parameter.getType());
+            Class<?> javaType = writeFunction.getJavaType();
+            Object value = parameter.getValue()
+                    // The value must be present, since DefaultQueryBuilder never creates null parameters. Values coming from Domain's ValueSet are non-null, and
+                    // nullable domains are handled explicitly, with SQL syntax.
+                    .orElseThrow(() -> new VerifyException("Value is missing"));
+            if (javaType == boolean.class) {
+                ((BooleanWriteFunction) writeFunction).set(statement, parameterIndex, (boolean) value);
+            }
+            else if (javaType == long.class) {
+                ((LongWriteFunction) writeFunction).set(statement, parameterIndex, (long) value);
+            }
+            else if (javaType == double.class) {
+                ((DoubleWriteFunction) writeFunction).set(statement, parameterIndex, (double) value);
+            }
+            else if (javaType == Slice.class) {
+                ((SliceWriteFunction) writeFunction).set(statement, parameterIndex, (Slice) value);
+            }
+            else {
+                ((ObjectWriteFunction) writeFunction).set(statement, parameterIndex, value);
+            }
+        }
+
+        return statement;
+    }
+
+    protected String getRelation(RemoteTableName remoteTableName)
+    {
+        return client.quoted(remoteTableName);
+    }
+
+    protected String getProjection(List<JdbcColumnHandle> columns, Map<String, String> columnExpressions)
+    {
+        if (columns.isEmpty()) {
+            return "1 x";
+        }
+        return columns.stream()
+                .map(jdbcColumnHandle -> {
+                    String columnAlias = client.quoted(jdbcColumnHandle.getColumnName());
+                    String expression = columnExpressions.get(jdbcColumnHandle.getColumnName());
+                    if (expression == null) {
+                        return columnAlias;
+                    }
+                    return format("%s AS %s", expression, columnAlias);
+                })
+                .collect(joining(", "));
+    }
+
+    private String getFrom(JdbcRelationHandle baseRelation, Consumer<QueryParameter> accumulator)
+    {
+        if (baseRelation instanceof JdbcNamedRelationHandle) {
+            return " FROM " + getRelation(((JdbcNamedRelationHandle) baseRelation).getRemoteTableName());
+        }
+        if (baseRelation instanceof JdbcQueryRelationHandle) {
+            PreparedQuery preparedQuery = ((JdbcQueryRelationHandle) baseRelation).getPreparedQuery();
+            preparedQuery.getParameters().forEach(accumulator);
+            return " FROM (" + preparedQuery.getQuery() + ") o";
+        }
+        throw new IllegalArgumentException("Unsupported relation: " + baseRelation);
+    }
+
+    private static Domain pushDownDomain(JdbcClient client, ConnectorSession session, Connection connection, JdbcColumnHandle column, Domain domain)
+    {
+        return client.toColumnMapping(session, connection, column.getJdbcTypeHandle())
+                .orElseThrow(() -> new IllegalStateException(format("Unsupported type %s with handle %s", column.getColumnType(), column.getJdbcTypeHandle())))
+                .getPredicatePushdownController().apply(session, domain).getPushedDown();
+    }
+
+    private List<String> toConjuncts(
+            ConnectorSession session,
+            Connection connection,
+            TupleDomain<ColumnHandle> tupleDomain,
+            Consumer<QueryParameter> accumulator)
+    {
+        if (tupleDomain.isNone()) {
+            return ImmutableList.of(ALWAYS_FALSE);
+        }
+        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        for (Map.Entry<ColumnHandle, Domain> entry : tupleDomain.getDomains().get().entrySet()) {
+            JdbcColumnHandle column = ((JdbcColumnHandle) entry.getKey());
+            Domain domain = pushDownDomain(client, session, connection, column, entry.getValue());
+            builder.add(toPredicate(session, connection, column, domain, accumulator));
+        }
+        return builder.build();
+    }
+
+    private String toPredicate(ConnectorSession session, Connection connection, JdbcColumnHandle column, Domain domain, Consumer<QueryParameter> accumulator)
+    {
+        if (domain.getValues().isNone()) {
+            return domain.isNullAllowed() ? client.quoted(column.getColumnName()) + " IS NULL" : ALWAYS_FALSE;
+        }
+
+        if (domain.getValues().isAll()) {
+            return domain.isNullAllowed() ? ALWAYS_TRUE : client.quoted(column.getColumnName()) + " IS NOT NULL";
+        }
+
+        String predicate = toPredicate(session, connection, column, domain.getValues(), accumulator);
+        if (!domain.isNullAllowed()) {
+            return predicate;
+        }
+        return format("(%s OR %s IS NULL)", predicate, client.quoted(column.getColumnName()));
+    }
+
+    private String toPredicate(ConnectorSession session, Connection connection, JdbcColumnHandle column, ValueSet valueSet, Consumer<QueryParameter> accumulator)
+    {
+        checkArgument(!valueSet.isNone(), "none values should be handled earlier");
+
+        if (!valueSet.isDiscreteSet()) {
+            ValueSet complement = valueSet.complement();
+            if (complement.isDiscreteSet()) {
+                return format("NOT (%s)", toPredicate(session, connection, column, complement, accumulator));
+            }
+        }
+
+        JdbcTypeHandle jdbcType = column.getJdbcTypeHandle();
+        Type type = column.getColumnType();
+        WriteFunction writeFunction = getWriteFunction(session, connection, jdbcType, type);
+
+        List<String> disjuncts = new ArrayList<>();
+        List<Object> singleValues = new ArrayList<>();
+        for (Range range : valueSet.getRanges().getOrderedRanges()) {
+            checkState(!range.isAll()); // Already checked
+            if (range.isSingleValue()) {
+                singleValues.add(range.getSingleValue());
+            }
+            else {
+                List<String> rangeConjuncts = new ArrayList<>();
+                if (!range.isLowUnbounded()) {
+                    rangeConjuncts.add(toPredicate(column, jdbcType, type, writeFunction, range.isLowInclusive() ? ">=" : ">", range.getLowBoundedValue(), accumulator));
+                }
+                if (!range.isHighUnbounded()) {
+                    rangeConjuncts.add(toPredicate(column, jdbcType, type, writeFunction, range.isHighInclusive() ? "<=" : "<", range.getHighBoundedValue(), accumulator));
+                }
+                // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
+                checkState(!rangeConjuncts.isEmpty());
+                if (rangeConjuncts.size() == 1) {
+                    disjuncts.add(getOnlyElement(rangeConjuncts));
+                }
+                else {
+                    disjuncts.add("(" + Joiner.on(" AND ").join(rangeConjuncts) + ")");
+                }
+            }
+        }
+
+        // Add back all of the possible single values either as an equality or an IN predicate
+        if (singleValues.size() == 1) {
+            disjuncts.add(toPredicate(column, jdbcType, type, writeFunction, "=", getOnlyElement(singleValues), accumulator));
+        }
+        else if (singleValues.size() > 1) {
+            for (Object value : singleValues) {
+                accumulator.accept(new QueryParameter(jdbcType, type, Optional.of(value)));
+            }
+            String values = Joiner.on(",").join(nCopies(singleValues.size(), writeFunction.getBindExpression()));
+            disjuncts.add(client.quoted(column.getColumnName()) + " IN (" + values + ")");
+        }
+
+        checkState(!disjuncts.isEmpty());
+        if (disjuncts.size() == 1) {
+            return getOnlyElement(disjuncts);
+        }
+        return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
+    }
+
+    private String toPredicate(JdbcColumnHandle column, JdbcTypeHandle jdbcType, Type type, WriteFunction writeFunction, String operator, Object value, Consumer<QueryParameter> accumulator)
+    {
+        accumulator.accept(new QueryParameter(jdbcType, type, Optional.of(value)));
+        return format("%s %s %s", client.quoted(column.getColumnName()), operator, writeFunction.getBindExpression());
+    }
+
+    private WriteFunction getWriteFunction(ConnectorSession session, Connection connection, JdbcTypeHandle jdbcType, Type type)
+    {
+        WriteFunction writeFunction = client.toColumnMapping(session, connection, jdbcType)
+                .orElseThrow(() -> new VerifyException(format("Unsupported type %s with handle %s", type, jdbcType)))
+                .getWriteFunction();
+        verify(writeFunction.getJavaType() == type.getJavaType(), "Java type mismatch: %s, %s", writeFunction, type);
+        return writeFunction;
+    }
+
+    private String getGroupBy(Optional<List<List<JdbcColumnHandle>>> groupingSets)
+    {
+        if (groupingSets.isEmpty()) {
+            return "";
+        }
+
+        verify(!groupingSets.get().isEmpty());
+        if (groupingSets.get().size() == 1) {
+            List<JdbcColumnHandle> groupingSet = getOnlyElement(groupingSets.get());
+            if (groupingSet.isEmpty()) {
+                // global aggregation
+                return "";
+            }
+            return " GROUP BY " + groupingSet.stream()
+                    .map(JdbcColumnHandle::getColumnName)
+                    .map(client::quoted)
+                    .collect(joining(", "));
+        }
+        return " GROUP BY GROUPING SETS " +
+                groupingSets.get().stream()
+                        .map(groupingSet -> groupingSet.stream()
+                                .map(JdbcColumnHandle::getColumnName)
+                                .map(client::quoted)
+                                .collect(joining(", ", "(", ")")))
+                        .collect(joining(", ", "(", ")"));
+    }
+}

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -120,17 +120,22 @@ public class DefaultQueryBuilder
                 formatJoinType(joinType),
                 rightSource.getQuery(),
                 joinConditions.stream()
-                        .map(condition -> format(
-                                "l.%s %s r.%s",
-                                client.quoted(condition.getLeftColumn().getColumnName()),
-                                condition.getOperator().getValue(),
-                                client.quoted(condition.getRightColumn().getColumnName())))
+                        .map(condition -> formatJoinCondition(client, condition))
                         .collect(joining(" AND ")));
         List<QueryParameter> parameters = ImmutableList.<QueryParameter>builder()
                 .addAll(leftSource.getParameters())
                 .addAll(rightSource.getParameters())
                 .build();
         return new PreparedQuery(query, parameters);
+    }
+
+    protected String formatJoinCondition(JdbcClient client, JdbcJoinCondition condition)
+    {
+        return format(
+                "l.%s %s r.%s",
+                client.quoted(condition.getLeftColumn().getColumnName()),
+                condition.getOperator().getValue(),
+                client.quoted(condition.getRightColumn().getColumnName()));
     }
 
     protected String formatAssignments(JdbcClient client, String relationAlias, Map<JdbcColumnHandle, String> assignments)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -200,10 +200,15 @@ public class DefaultQueryBuilder
         return format(
                 "%s.%s %s %s.%s",
                 leftRelationAlias,
-                client.quoted(condition.getLeftColumn().getColumnName()),
+                buildJoinColumn(client, condition.getLeftColumn()),
                 condition.getOperator().getValue(),
                 rightRelationAlias,
-                client.quoted(condition.getRightColumn().getColumnName()));
+                buildJoinColumn(client, condition.getRightColumn()));
+    }
+
+    protected String buildJoinColumn(JdbcClient client, JdbcColumnHandle columnHandle)
+    {
+        return client.quoted(columnHandle.getColumnName());
     }
 
     protected String formatAssignments(JdbcClient client, String relationAlias, Map<JdbcColumnHandle, String> assignments)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -336,10 +336,10 @@ public class DefaultQueryBuilder
             else {
                 List<String> rangeConjuncts = new ArrayList<>();
                 if (!range.isLowUnbounded()) {
-                    rangeConjuncts.add(toPredicate(client, column, jdbcType, type, writeFunction, range.isLowInclusive() ? ">=" : ">", range.getLowBoundedValue(), accumulator));
+                    rangeConjuncts.add(toPredicate(client, session, column, jdbcType, type, writeFunction, range.isLowInclusive() ? ">=" : ">", range.getLowBoundedValue(), accumulator));
                 }
                 if (!range.isHighUnbounded()) {
-                    rangeConjuncts.add(toPredicate(client, column, jdbcType, type, writeFunction, range.isHighInclusive() ? "<=" : "<", range.getHighBoundedValue(), accumulator));
+                    rangeConjuncts.add(toPredicate(client, session, column, jdbcType, type, writeFunction, range.isHighInclusive() ? "<=" : "<", range.getHighBoundedValue(), accumulator));
                 }
                 // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
                 checkState(!rangeConjuncts.isEmpty());
@@ -354,7 +354,7 @@ public class DefaultQueryBuilder
 
         // Add back all of the possible single values either as an equality or an IN predicate
         if (singleValues.size() == 1) {
-            disjuncts.add(toPredicate(client, column, jdbcType, type, writeFunction, "=", getOnlyElement(singleValues), accumulator));
+            disjuncts.add(toPredicate(client, session, column, jdbcType, type, writeFunction, "=", getOnlyElement(singleValues), accumulator));
         }
         else if (singleValues.size() > 1) {
             for (Object value : singleValues) {
@@ -371,7 +371,7 @@ public class DefaultQueryBuilder
         return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
     }
 
-    protected String toPredicate(JdbcClient client, JdbcColumnHandle column, JdbcTypeHandle jdbcType, Type type, WriteFunction writeFunction, String operator, Object value, Consumer<QueryParameter> accumulator)
+    protected String toPredicate(JdbcClient client, ConnectorSession session, JdbcColumnHandle column, JdbcTypeHandle jdbcType, Type type, WriteFunction writeFunction, String operator, Object value, Consumer<QueryParameter> accumulator)
     {
         accumulator.accept(new QueryParameter(jdbcType, type, Optional.of(value)));
         return format("%s %s %s", client.quoted(column.getColumnName()), operator, writeFunction.getBindExpression());

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -99,6 +99,7 @@ public class DefaultQueryBuilder
     public PreparedQuery prepareJoinQuery(
             JdbcClient client,
             ConnectorSession session,
+            Connection connection,
             JoinType joinType,
             PreparedQuery leftSource,
             PreparedQuery rightSource,

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultQueryBuilder.java
@@ -135,39 +135,6 @@ public class DefaultQueryBuilder
         return new PreparedQuery(query, parameters);
     }
 
-    protected String formatJoinCondition(JdbcClient client, String leftRelationAlias, String rightRelationAlias, JdbcJoinCondition condition)
-    {
-        return format(
-                "%s.%s %s %s.%s",
-                leftRelationAlias,
-                client.quoted(condition.getLeftColumn().getColumnName()),
-                condition.getOperator().getValue(),
-                rightRelationAlias,
-                client.quoted(condition.getRightColumn().getColumnName()));
-    }
-
-    protected String formatAssignments(JdbcClient client, String relationAlias, Map<JdbcColumnHandle, String> assignments)
-    {
-        return assignments.entrySet().stream()
-                .map(entry -> format("%s.%s AS %s", relationAlias, client.quoted(entry.getKey().getColumnName()), client.quoted(entry.getValue())))
-                .collect(joining(", "));
-    }
-
-    protected String formatJoinType(JoinType joinType)
-    {
-        switch (joinType) {
-            case INNER:
-                return "INNER JOIN";
-            case LEFT_OUTER:
-                return "LEFT JOIN";
-            case RIGHT_OUTER:
-                return "RIGHT JOIN";
-            case FULL_OUTER:
-                return "FULL JOIN";
-        }
-        throw new IllegalStateException("Unsupported join type: " + joinType);
-    }
-
     @Override
     public PreparedQuery prepareDeleteQuery(
             JdbcClient client,
@@ -226,6 +193,39 @@ public class DefaultQueryBuilder
         }
 
         return statement;
+    }
+
+    protected String formatJoinCondition(JdbcClient client, String leftRelationAlias, String rightRelationAlias, JdbcJoinCondition condition)
+    {
+        return format(
+                "%s.%s %s %s.%s",
+                leftRelationAlias,
+                client.quoted(condition.getLeftColumn().getColumnName()),
+                condition.getOperator().getValue(),
+                rightRelationAlias,
+                client.quoted(condition.getRightColumn().getColumnName()));
+    }
+
+    protected String formatAssignments(JdbcClient client, String relationAlias, Map<JdbcColumnHandle, String> assignments)
+    {
+        return assignments.entrySet().stream()
+                .map(entry -> format("%s.%s AS %s", relationAlias, client.quoted(entry.getKey().getColumnName()), client.quoted(entry.getValue())))
+                .collect(joining(", "));
+    }
+
+    protected String formatJoinType(JoinType joinType)
+    {
+        switch (joinType) {
+            case INNER:
+                return "INNER JOIN";
+            case LEFT_OUTER:
+                return "LEFT JOIN";
+            case RIGHT_OUTER:
+                return "RIGHT JOIN";
+            case FULL_OUTER:
+                return "FULL JOIN";
+        }
+        throw new IllegalStateException("Unsupported join type: " + joinType);
     }
 
     protected String getRelation(JdbcClient client, RemoteTableName remoteTableName)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcModule.java
@@ -57,6 +57,7 @@ public class JdbcModule
         install(new IdentifierMappingModule());
 
         newOptionalBinder(binder, ConnectorAccessControl.class);
+        newOptionalBinder(binder, QueryBuilder.class).setDefault().to(DefaultQueryBuilder.class).in(Scopes.SINGLETON);
 
         procedureBinder(binder);
         tablePropertiesProviderBinder(binder);
@@ -65,6 +66,7 @@ public class JdbcModule
         newOptionalBinder(binder, ConnectorSplitManager.class).setDefault().to(JdbcSplitManager.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, ConnectorRecordSetProvider.class).setDefault().to(JdbcRecordSetProvider.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, ConnectorPageSinkProvider.class).setDefault().to(JdbcPageSinkProvider.class).in(Scopes.SINGLETON);
+
         binder.bind(JdbcConnector.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(JdbcMetadataConfig.class);
         configBinder(binder).bindConfig(JdbcWriteConfig.class);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
@@ -61,6 +61,7 @@ public class QueryBuilder
     }
 
     public PreparedQuery prepareQuery(
+            JdbcClient client,
             ConnectorSession session,
             Connection connection,
             JdbcRelationHandle baseRelation,
@@ -101,6 +102,7 @@ public class QueryBuilder
     }
 
     public PreparedQuery prepareJoinQuery(
+            JdbcClient client,
             ConnectorSession session,
             JoinType joinType,
             PreparedQuery leftSource,
@@ -159,6 +161,7 @@ public class QueryBuilder
     }
 
     public PreparedQuery prepareDelete(
+            JdbcClient client,
             ConnectorSession session,
             Connection connection,
             JdbcNamedRelationHandle baseRelation,
@@ -176,6 +179,7 @@ public class QueryBuilder
     }
 
     public PreparedStatement prepareStatement(
+            JdbcClient client,
             ConnectorSession session,
             Connection connection,
             PreparedQuery preparedQuery)

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
@@ -13,54 +13,21 @@
  */
 package io.trino.plugin.jdbc;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.VerifyException;
-import com.google.common.collect.ImmutableList;
-import io.airlift.log.Logger;
-import io.airlift.slice.Slice;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.JoinType;
-import io.trino.spi.predicate.Domain;
-import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
-import io.trino.spi.predicate.ValueSet;
-import io.trino.spi.type.Type;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Consumer;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Verify.verify;
-import static com.google.common.collect.Iterables.getOnlyElement;
-import static java.lang.String.format;
-import static java.util.Collections.nCopies;
-import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.joining;
-
-public class QueryBuilder
+public interface QueryBuilder
 {
-    private static final Logger log = Logger.get(QueryBuilder.class);
-
-    // not all databases support booleans, so use 1=1 and 1=0 instead
-    private static final String ALWAYS_TRUE = "1=1";
-    private static final String ALWAYS_FALSE = "1=0";
-
-    private final JdbcClient client;
-
-    public QueryBuilder(JdbcClient client)
-    {
-        this.client = requireNonNull(client, "client is null");
-    }
-
-    public PreparedQuery prepareQuery(
+    PreparedQuery prepareQuery(
             JdbcClient client,
             ConnectorSession session,
             Connection connection,
@@ -69,39 +36,9 @@ public class QueryBuilder
             List<JdbcColumnHandle> columns,
             Map<String, String> columnExpressions,
             TupleDomain<ColumnHandle> tupleDomain,
-            Optional<String> additionalPredicate)
-    {
-        if (!tupleDomain.isNone()) {
-            Map<ColumnHandle, Domain> domains = tupleDomain.getDomains().orElseThrow();
-            columns.stream()
-                    .filter(domains::containsKey)
-                    .filter(column -> columnExpressions.containsKey(column.getColumnName()))
-                    .findFirst()
-                    .ifPresent(column -> { throw new IllegalArgumentException(format("Column %s has an expression and a constraint attached at the same time", column)); });
-        }
+            Optional<String> additionalPredicate);
 
-        ImmutableList.Builder<QueryParameter> accumulator = ImmutableList.builder();
-
-        String sql = "SELECT " + getProjection(columns, columnExpressions);
-        sql += getFrom(baseRelation, accumulator::add);
-
-        List<String> clauses = toConjuncts(session, connection, tupleDomain, accumulator::add);
-        if (additionalPredicate.isPresent()) {
-            clauses = ImmutableList.<String>builder()
-                    .addAll(clauses)
-                    .add(additionalPredicate.get())
-                    .build();
-        }
-        if (!clauses.isEmpty()) {
-            sql += " WHERE " + Joiner.on(" AND ").join(clauses);
-        }
-
-        sql += getGroupBy(groupingSets);
-
-        return new PreparedQuery(sql, accumulator.build());
-    }
-
-    public PreparedQuery prepareJoinQuery(
+    PreparedQuery prepareJoinQuery(
             JdbcClient client,
             ConnectorSession session,
             JoinType joinType,
@@ -109,291 +46,19 @@ public class QueryBuilder
             PreparedQuery rightSource,
             List<JdbcJoinCondition> joinConditions,
             Map<JdbcColumnHandle, String> leftAssignments,
-            Map<JdbcColumnHandle, String> rightAssignments)
-    {
-        // Verify assignments are present. This is safe assumption as join conditions are not pruned, and simplifies the code here.
-        verify(!leftAssignments.isEmpty(), "leftAssignments is empty");
-        verify(!rightAssignments.isEmpty(), "rightAssignments is empty");
-        // Joins wih no conditions are not pushed down, so it is a same assumption and simplifies the code here
-        verify(!joinConditions.isEmpty(), "joinConditions is empty");
+            Map<JdbcColumnHandle, String> rightAssignments);
 
-        String query = format(
-                "SELECT %s, %s FROM (%s) l %s (%s) r ON %s",
-                formatAssignments("l", leftAssignments),
-                formatAssignments("r", rightAssignments),
-                leftSource.getQuery(),
-                formatJoinType(joinType),
-                rightSource.getQuery(),
-                joinConditions.stream()
-                        .map(condition -> format(
-                                "l.%s %s r.%s",
-                                client.quoted(condition.getLeftColumn().getColumnName()),
-                                condition.getOperator().getValue(),
-                                client.quoted(condition.getRightColumn().getColumnName())))
-                        .collect(joining(" AND ")));
-        List<QueryParameter> parameters = ImmutableList.<QueryParameter>builder()
-                .addAll(leftSource.getParameters())
-                .addAll(rightSource.getParameters())
-                .build();
-        return new PreparedQuery(query, parameters);
-    }
-
-    protected String formatAssignments(String relationAlias, Map<JdbcColumnHandle, String> assignments)
-    {
-        return assignments.entrySet().stream()
-                .map(entry -> format("%s.%s AS %s", relationAlias, client.quoted(entry.getKey().getColumnName()), client.quoted(entry.getValue())))
-                .collect(joining(", "));
-    }
-
-    protected static String formatJoinType(JoinType joinType)
-    {
-        switch (joinType) {
-            case INNER:
-                return "INNER JOIN";
-            case LEFT_OUTER:
-                return "LEFT JOIN";
-            case RIGHT_OUTER:
-                return "RIGHT JOIN";
-            case FULL_OUTER:
-                return "FULL JOIN";
-        }
-        throw new IllegalStateException("Unsupported join type: " + joinType);
-    }
-
-    public PreparedQuery prepareDelete(
+    PreparedQuery prepareDelete(
             JdbcClient client,
             ConnectorSession session,
             Connection connection,
             JdbcNamedRelationHandle baseRelation,
-            TupleDomain<ColumnHandle> tupleDomain)
-    {
-        String sql = "DELETE FROM " + getRelation(baseRelation.getRemoteTableName());
+            TupleDomain<ColumnHandle> tupleDomain);
 
-        ImmutableList.Builder<QueryParameter> accumulator = ImmutableList.builder();
-
-        List<String> clauses = toConjuncts(session, connection, tupleDomain, accumulator::add);
-        if (!clauses.isEmpty()) {
-            sql += " WHERE " + Joiner.on(" AND ").join(clauses);
-        }
-        return new PreparedQuery(sql, accumulator.build());
-    }
-
-    public PreparedStatement prepareStatement(
+    PreparedStatement prepareStatement(
             JdbcClient client,
             ConnectorSession session,
             Connection connection,
             PreparedQuery preparedQuery)
-            throws SQLException
-    {
-        log.debug("Preparing query: %s", preparedQuery.getQuery());
-        PreparedStatement statement = client.getPreparedStatement(connection, preparedQuery.getQuery());
-
-        List<QueryParameter> parameters = preparedQuery.getParameters();
-        for (int i = 0; i < parameters.size(); i++) {
-            QueryParameter parameter = parameters.get(i);
-            int parameterIndex = i + 1;
-            WriteFunction writeFunction = getWriteFunction(session, connection, parameter.getJdbcType(), parameter.getType());
-            Class<?> javaType = writeFunction.getJavaType();
-            Object value = parameter.getValue()
-                    // The value must be present, since QueryBuilder never creates null parameters. Values coming from Domain's ValueSet are non-null, and
-                    // nullable domains are handled explicitly, with SQL syntax.
-                    .orElseThrow(() -> new VerifyException("Value is missing"));
-            if (javaType == boolean.class) {
-                ((BooleanWriteFunction) writeFunction).set(statement, parameterIndex, (boolean) value);
-            }
-            else if (javaType == long.class) {
-                ((LongWriteFunction) writeFunction).set(statement, parameterIndex, (long) value);
-            }
-            else if (javaType == double.class) {
-                ((DoubleWriteFunction) writeFunction).set(statement, parameterIndex, (double) value);
-            }
-            else if (javaType == Slice.class) {
-                ((SliceWriteFunction) writeFunction).set(statement, parameterIndex, (Slice) value);
-            }
-            else {
-                ((ObjectWriteFunction) writeFunction).set(statement, parameterIndex, value);
-            }
-        }
-
-        return statement;
-    }
-
-    protected String getRelation(RemoteTableName remoteTableName)
-    {
-        return client.quoted(remoteTableName);
-    }
-
-    protected String getProjection(List<JdbcColumnHandle> columns, Map<String, String> columnExpressions)
-    {
-        if (columns.isEmpty()) {
-            return "1 x";
-        }
-        return columns.stream()
-                .map(jdbcColumnHandle -> {
-                    String columnAlias = client.quoted(jdbcColumnHandle.getColumnName());
-                    String expression = columnExpressions.get(jdbcColumnHandle.getColumnName());
-                    if (expression == null) {
-                        return columnAlias;
-                    }
-                    return format("%s AS %s", expression, columnAlias);
-                })
-                .collect(joining(", "));
-    }
-
-    private String getFrom(JdbcRelationHandle baseRelation, Consumer<QueryParameter> accumulator)
-    {
-        if (baseRelation instanceof JdbcNamedRelationHandle) {
-            return " FROM " + getRelation(((JdbcNamedRelationHandle) baseRelation).getRemoteTableName());
-        }
-        if (baseRelation instanceof JdbcQueryRelationHandle) {
-            PreparedQuery preparedQuery = ((JdbcQueryRelationHandle) baseRelation).getPreparedQuery();
-            preparedQuery.getParameters().forEach(accumulator);
-            return " FROM (" + preparedQuery.getQuery() + ") o";
-        }
-        throw new IllegalArgumentException("Unsupported relation: " + baseRelation);
-    }
-
-    private static Domain pushDownDomain(JdbcClient client, ConnectorSession session, Connection connection, JdbcColumnHandle column, Domain domain)
-    {
-        return client.toColumnMapping(session, connection, column.getJdbcTypeHandle())
-                .orElseThrow(() -> new IllegalStateException(format("Unsupported type %s with handle %s", column.getColumnType(), column.getJdbcTypeHandle())))
-                .getPredicatePushdownController().apply(session, domain).getPushedDown();
-    }
-
-    private List<String> toConjuncts(
-            ConnectorSession session,
-            Connection connection,
-            TupleDomain<ColumnHandle> tupleDomain,
-            Consumer<QueryParameter> accumulator)
-    {
-        if (tupleDomain.isNone()) {
-            return ImmutableList.of(ALWAYS_FALSE);
-        }
-        ImmutableList.Builder<String> builder = ImmutableList.builder();
-        for (Map.Entry<ColumnHandle, Domain> entry : tupleDomain.getDomains().get().entrySet()) {
-            JdbcColumnHandle column = ((JdbcColumnHandle) entry.getKey());
-            Domain domain = pushDownDomain(client, session, connection, column, entry.getValue());
-            builder.add(toPredicate(session, connection, column, domain, accumulator));
-        }
-        return builder.build();
-    }
-
-    private String toPredicate(ConnectorSession session, Connection connection, JdbcColumnHandle column, Domain domain, Consumer<QueryParameter> accumulator)
-    {
-        if (domain.getValues().isNone()) {
-            return domain.isNullAllowed() ? client.quoted(column.getColumnName()) + " IS NULL" : ALWAYS_FALSE;
-        }
-
-        if (domain.getValues().isAll()) {
-            return domain.isNullAllowed() ? ALWAYS_TRUE : client.quoted(column.getColumnName()) + " IS NOT NULL";
-        }
-
-        String predicate = toPredicate(session, connection, column, domain.getValues(), accumulator);
-        if (!domain.isNullAllowed()) {
-            return predicate;
-        }
-        return format("(%s OR %s IS NULL)", predicate, client.quoted(column.getColumnName()));
-    }
-
-    private String toPredicate(ConnectorSession session, Connection connection, JdbcColumnHandle column, ValueSet valueSet, Consumer<QueryParameter> accumulator)
-    {
-        checkArgument(!valueSet.isNone(), "none values should be handled earlier");
-
-        if (!valueSet.isDiscreteSet()) {
-            ValueSet complement = valueSet.complement();
-            if (complement.isDiscreteSet()) {
-                return format("NOT (%s)", toPredicate(session, connection, column, complement, accumulator));
-            }
-        }
-
-        JdbcTypeHandle jdbcType = column.getJdbcTypeHandle();
-        Type type = column.getColumnType();
-        WriteFunction writeFunction = getWriteFunction(session, connection, jdbcType, type);
-
-        List<String> disjuncts = new ArrayList<>();
-        List<Object> singleValues = new ArrayList<>();
-        for (Range range : valueSet.getRanges().getOrderedRanges()) {
-            checkState(!range.isAll()); // Already checked
-            if (range.isSingleValue()) {
-                singleValues.add(range.getSingleValue());
-            }
-            else {
-                List<String> rangeConjuncts = new ArrayList<>();
-                if (!range.isLowUnbounded()) {
-                    rangeConjuncts.add(toPredicate(column, jdbcType, type, writeFunction, range.isLowInclusive() ? ">=" : ">", range.getLowBoundedValue(), accumulator));
-                }
-                if (!range.isHighUnbounded()) {
-                    rangeConjuncts.add(toPredicate(column, jdbcType, type, writeFunction, range.isHighInclusive() ? "<=" : "<", range.getHighBoundedValue(), accumulator));
-                }
-                // If rangeConjuncts is null, then the range was ALL, which should already have been checked for
-                checkState(!rangeConjuncts.isEmpty());
-                if (rangeConjuncts.size() == 1) {
-                    disjuncts.add(getOnlyElement(rangeConjuncts));
-                }
-                else {
-                    disjuncts.add("(" + Joiner.on(" AND ").join(rangeConjuncts) + ")");
-                }
-            }
-        }
-
-        // Add back all of the possible single values either as an equality or an IN predicate
-        if (singleValues.size() == 1) {
-            disjuncts.add(toPredicate(column, jdbcType, type, writeFunction, "=", getOnlyElement(singleValues), accumulator));
-        }
-        else if (singleValues.size() > 1) {
-            for (Object value : singleValues) {
-                accumulator.accept(new QueryParameter(jdbcType, type, Optional.of(value)));
-            }
-            String values = Joiner.on(",").join(nCopies(singleValues.size(), writeFunction.getBindExpression()));
-            disjuncts.add(client.quoted(column.getColumnName()) + " IN (" + values + ")");
-        }
-
-        checkState(!disjuncts.isEmpty());
-        if (disjuncts.size() == 1) {
-            return getOnlyElement(disjuncts);
-        }
-        return "(" + Joiner.on(" OR ").join(disjuncts) + ")";
-    }
-
-    private String toPredicate(JdbcColumnHandle column, JdbcTypeHandle jdbcType, Type type, WriteFunction writeFunction, String operator, Object value, Consumer<QueryParameter> accumulator)
-    {
-        accumulator.accept(new QueryParameter(jdbcType, type, Optional.of(value)));
-        return format("%s %s %s", client.quoted(column.getColumnName()), operator, writeFunction.getBindExpression());
-    }
-
-    private WriteFunction getWriteFunction(ConnectorSession session, Connection connection, JdbcTypeHandle jdbcType, Type type)
-    {
-        WriteFunction writeFunction = client.toColumnMapping(session, connection, jdbcType)
-                .orElseThrow(() -> new VerifyException(format("Unsupported type %s with handle %s", type, jdbcType)))
-                .getWriteFunction();
-        verify(writeFunction.getJavaType() == type.getJavaType(), "Java type mismatch: %s, %s", writeFunction, type);
-        return writeFunction;
-    }
-
-    private String getGroupBy(Optional<List<List<JdbcColumnHandle>>> groupingSets)
-    {
-        if (groupingSets.isEmpty()) {
-            return "";
-        }
-
-        verify(!groupingSets.get().isEmpty());
-        if (groupingSets.get().size() == 1) {
-            List<JdbcColumnHandle> groupingSet = getOnlyElement(groupingSets.get());
-            if (groupingSet.isEmpty()) {
-                // global aggregation
-                return "";
-            }
-            return " GROUP BY " + groupingSet.stream()
-                    .map(JdbcColumnHandle::getColumnName)
-                    .map(client::quoted)
-                    .collect(joining(", "));
-        }
-        return " GROUP BY GROUPING SETS " +
-                groupingSets.get().stream()
-                        .map(groupingSet -> groupingSet.stream()
-                                .map(JdbcColumnHandle::getColumnName)
-                                .map(client::quoted)
-                                .collect(joining(", ", "(", ")")))
-                        .collect(joining(", ", "(", ")"));
-    }
+            throws SQLException;
 }

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
@@ -41,6 +41,7 @@ public interface QueryBuilder
     PreparedQuery prepareJoinQuery(
             JdbcClient client,
             ConnectorSession session,
+            Connection connection,
             JoinType joinType,
             PreparedQuery leftSource,
             PreparedQuery rightSource,

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/QueryBuilder.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 
 public interface QueryBuilder
 {
-    PreparedQuery prepareQuery(
+    PreparedQuery prepareSelectQuery(
             JdbcClient client,
             ConnectorSession session,
             Connection connection,
@@ -48,7 +48,7 @@ public interface QueryBuilder
             Map<JdbcColumnHandle, String> leftAssignments,
             Map<JdbcColumnHandle, String> rightAssignments);
 
-    PreparedQuery prepareDelete(
+    PreparedQuery prepareDeleteQuery(
             JdbcClient client,
             ConnectorSession session,
             Connection connection,

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/BaseJdbcConnectorTest.java
@@ -1243,7 +1243,7 @@ public abstract class BaseJdbcConnectorTest
         }
     }
 
-    private boolean expectJoinPushdown(String operator)
+    protected boolean expectJoinPushdown(String operator)
     {
         if ("IS NOT DISTINCT FROM".equals(operator)) {
             // TODO (https://github.com/trinodb/trino/issues/6967) support join pushdown for IS NOT DISTINCT FROM

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -87,7 +87,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 @Test(singleThreaded = true)
-public class TestJdbcQueryBuilder
+public class TestDefaultJdbcQueryBuilder
 {
     private static final JdbcNamedRelationHandle TEST_TABLE = new JdbcNamedRelationHandle(new SchemaTableName(
             "some_test_schema", "test_table"),
@@ -98,6 +98,8 @@ public class TestJdbcQueryBuilder
 
     private TestingDatabase database;
     private JdbcClient jdbcClient;
+
+    private final QueryBuilder queryBuilder = new DefaultQueryBuilder();
 
     private List<JdbcColumnHandle> columns;
 
@@ -223,7 +225,7 @@ public class TestJdbcQueryBuilder
                 .buildOrThrow());
 
         Connection connection = database.getConnection();
-        QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
+
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
@@ -265,7 +267,7 @@ public class TestJdbcQueryBuilder
                 .buildOrThrow());
 
         Connection connection = database.getConnection();
-        QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
+
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(
                 jdbcClient,
                 SESSION,
@@ -306,7 +308,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
+
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
@@ -340,7 +342,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
+
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
@@ -376,7 +378,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
+
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
@@ -417,7 +419,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
+
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
@@ -458,7 +460,7 @@ public class TestJdbcQueryBuilder
                         false)));
 
         Connection connection = database.getConnection();
-        QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
+
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
@@ -490,7 +492,7 @@ public class TestJdbcQueryBuilder
     {
         Connection connection = database.getConnection();
         Function<String, String> function = sql -> sql + " LIMIT 10";
-        QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
+
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), TupleDomain.all(), Optional.empty());
         preparedQuery = preparedQuery.transformQuery(function);
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
@@ -518,7 +520,7 @@ public class TestJdbcQueryBuilder
                 columns.get(1), Domain.onlyNull(DOUBLE)));
 
         Connection connection = database.getConnection();
-        QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
+
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
@@ -546,7 +548,7 @@ public class TestJdbcQueryBuilder
                         Optional.empty()));
 
         Connection connection = database.getConnection();
-        QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
+
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(
                 jdbcClient,
                 SESSION,
@@ -590,7 +592,7 @@ public class TestJdbcQueryBuilder
                         Optional.empty()));
 
         Connection connection = database.getConnection();
-        QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
+
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(
                 jdbcClient,
                 SESSION,

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -226,7 +226,7 @@ public class TestDefaultJdbcQueryBuilder
 
         Connection connection = database.getConnection();
 
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        PreparedQuery preparedQuery = queryBuilder.prepareSelectQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
@@ -268,7 +268,7 @@ public class TestDefaultJdbcQueryBuilder
 
         Connection connection = database.getConnection();
 
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+        PreparedQuery preparedQuery = queryBuilder.prepareSelectQuery(
                 jdbcClient,
                 SESSION,
                 connection,
@@ -309,7 +309,7 @@ public class TestDefaultJdbcQueryBuilder
 
         Connection connection = database.getConnection();
 
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        PreparedQuery preparedQuery = queryBuilder.prepareSelectQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
@@ -343,7 +343,7 @@ public class TestDefaultJdbcQueryBuilder
 
         Connection connection = database.getConnection();
 
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        PreparedQuery preparedQuery = queryBuilder.prepareSelectQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
@@ -379,7 +379,7 @@ public class TestDefaultJdbcQueryBuilder
 
         Connection connection = database.getConnection();
 
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        PreparedQuery preparedQuery = queryBuilder.prepareSelectQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
@@ -420,7 +420,7 @@ public class TestDefaultJdbcQueryBuilder
 
         Connection connection = database.getConnection();
 
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        PreparedQuery preparedQuery = queryBuilder.prepareSelectQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
@@ -461,7 +461,7 @@ public class TestDefaultJdbcQueryBuilder
 
         Connection connection = database.getConnection();
 
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        PreparedQuery preparedQuery = queryBuilder.prepareSelectQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
@@ -493,7 +493,7 @@ public class TestDefaultJdbcQueryBuilder
         Connection connection = database.getConnection();
         Function<String, String> function = sql -> sql + " LIMIT 10";
 
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), TupleDomain.all(), Optional.empty());
+        PreparedQuery preparedQuery = queryBuilder.prepareSelectQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), TupleDomain.all(), Optional.empty());
         preparedQuery = preparedQuery.transformQuery(function);
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
@@ -521,7 +521,7 @@ public class TestDefaultJdbcQueryBuilder
 
         Connection connection = database.getConnection();
 
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        PreparedQuery preparedQuery = queryBuilder.prepareSelectQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
         try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
@@ -549,7 +549,7 @@ public class TestDefaultJdbcQueryBuilder
 
         Connection connection = database.getConnection();
 
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+        PreparedQuery preparedQuery = queryBuilder.prepareSelectQuery(
                 jdbcClient,
                 SESSION,
                 connection,
@@ -593,7 +593,7 @@ public class TestDefaultJdbcQueryBuilder
 
         Connection connection = database.getConnection();
 
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+        PreparedQuery preparedQuery = queryBuilder.prepareSelectQuery(
                 jdbcClient,
                 SESSION,
                 connection,

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcQueryBuilder.java
@@ -497,6 +497,7 @@ public class TestDefaultJdbcQueryBuilder
         PreparedQuery preparedQuery = queryBuilder.prepareJoinQuery(
                 jdbcClient,
                 SESSION,
+                connection,
                 JoinType.INNER,
                 new PreparedQuery("SELECT * FROM \"test_table\"", List.of()),
                 new PreparedQuery("SELECT * FROM \"test_table\"", List.of()),

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcQueryBuilder.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestJdbcQueryBuilder.java
@@ -224,8 +224,8 @@ public class TestJdbcQueryBuilder
 
         Connection connection = database.getConnection();
         QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(SESSION, connection, preparedQuery)) {
+        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
                     "\"col_6\", \"col_7\", \"col_8\", \"col_9\", \"col_10\", \"col_11\" " +
@@ -267,6 +267,7 @@ public class TestJdbcQueryBuilder
         Connection connection = database.getConnection();
         QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+                jdbcClient,
                 SESSION,
                 connection,
                 TEST_TABLE,
@@ -275,7 +276,7 @@ public class TestJdbcQueryBuilder
                 Map.of(),
                 tupleDomain,
                 Optional.empty());
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(SESSION, connection, preparedQuery)) {
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_3\", \"col_9\" " +
                     "FROM \"test_table\" " +
@@ -306,8 +307,8 @@ public class TestJdbcQueryBuilder
 
         Connection connection = database.getConnection();
         QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(SESSION, connection, preparedQuery)) {
+        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
                     "\"col_6\", \"col_7\", \"col_8\", \"col_9\", \"col_10\", \"col_11\" " +
@@ -340,8 +341,8 @@ public class TestJdbcQueryBuilder
 
         Connection connection = database.getConnection();
         QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(SESSION, connection, preparedQuery)) {
+        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
                     "\"col_6\", \"col_7\", \"col_8\", \"col_9\", \"col_10\", \"col_11\" " +
@@ -376,8 +377,8 @@ public class TestJdbcQueryBuilder
 
         Connection connection = database.getConnection();
         QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(SESSION, connection, preparedQuery)) {
+        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
                     "\"col_6\", \"col_7\", \"col_8\", \"col_9\", \"col_10\", \"col_11\" " +
@@ -417,8 +418,8 @@ public class TestJdbcQueryBuilder
 
         Connection connection = database.getConnection();
         QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(SESSION, connection, preparedQuery)) {
+        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
                     "\"col_6\", \"col_7\", \"col_8\", \"col_9\", \"col_10\", \"col_11\" " +
@@ -458,8 +459,8 @@ public class TestJdbcQueryBuilder
 
         Connection connection = database.getConnection();
         QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(SESSION, connection, preparedQuery)) {
+        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
                     "\"col_6\", \"col_7\", \"col_8\", \"col_9\", \"col_10\", \"col_11\" " +
@@ -490,9 +491,9 @@ public class TestJdbcQueryBuilder
         Connection connection = database.getConnection();
         Function<String, String> function = sql -> sql + " LIMIT 10";
         QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), TupleDomain.all(), Optional.empty());
+        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), TupleDomain.all(), Optional.empty());
         preparedQuery = preparedQuery.transformQuery(function);
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(SESSION, connection, preparedQuery)) {
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
                     "\"col_6\", \"col_7\", \"col_8\", \"col_9\", \"col_10\", \"col_11\" " +
@@ -518,8 +519,8 @@ public class TestJdbcQueryBuilder
 
         Connection connection = database.getConnection();
         QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
-        PreparedQuery preparedQuery = queryBuilder.prepareQuery(SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(SESSION, connection, preparedQuery)) {
+        PreparedQuery preparedQuery = queryBuilder.prepareQuery(jdbcClient, SESSION, connection, TEST_TABLE, Optional.empty(), columns, Map.of(), tupleDomain, Optional.empty());
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_0\", \"col_1\", \"col_2\", \"col_3\", \"col_4\", \"col_5\", " +
                     "\"col_6\", \"col_7\", \"col_8\", \"col_9\", \"col_10\", \"col_11\" " +
@@ -547,6 +548,7 @@ public class TestJdbcQueryBuilder
         Connection connection = database.getConnection();
         QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+                jdbcClient,
                 SESSION,
                 connection,
                 TEST_TABLE,
@@ -555,7 +557,7 @@ public class TestJdbcQueryBuilder
                 Map.of("s", "sum(\"col_0\")"),
                 TupleDomain.all(),
                 Optional.empty());
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(SESSION, connection, preparedQuery)) {
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_2\", sum(\"col_0\") AS \"s\" " +
                     "FROM \"test_table\" " +
@@ -590,6 +592,7 @@ public class TestJdbcQueryBuilder
         Connection connection = database.getConnection();
         QueryBuilder queryBuilder = new QueryBuilder(jdbcClient);
         PreparedQuery preparedQuery = queryBuilder.prepareQuery(
+                jdbcClient,
                 SESSION,
                 connection,
                 TEST_TABLE,
@@ -598,7 +601,7 @@ public class TestJdbcQueryBuilder
                 Map.of("s", "sum(\"col_0\")"),
                 tupleDomain,
                 Optional.empty());
-        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(SESSION, connection, preparedQuery)) {
+        try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(jdbcClient, SESSION, connection, preparedQuery)) {
             assertThat(preparedQuery.getQuery()).isEqualTo("" +
                     "SELECT \"col_2\", sum(\"col_0\") AS \"s\" " +
                     "FROM \"test_table\" " +

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestingH2JdbcClient.java
@@ -86,7 +86,7 @@ class TestingH2JdbcClient
 
     public TestingH2JdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, IdentifierMapping identifierMapping)
     {
-        super(config, "\"", connectionFactory, identifierMapping);
+        super(config, "\"", connectionFactory, new DefaultQueryBuilder(), identifierMapping);
     }
 
     @Override

--- a/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
+++ b/plugin/trino-clickhouse/src/main/java/io/trino/plugin/clickhouse/ClickHouseClient.java
@@ -33,6 +33,7 @@ import io.trino.plugin.jdbc.JdbcExpression;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.LongWriteFunction;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.SliceWriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
@@ -171,10 +172,11 @@ public class ClickHouseClient
     public ClickHouseClient(
             BaseJdbcConfig config,
             ConnectionFactory connectionFactory,
+            QueryBuilder queryBuilder,
             TypeManager typeManager,
             IdentifierMapping identifierMapping)
     {
-        super(config, "\"", connectionFactory, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
         this.uuidType = typeManager.getType(new TypeSignature(StandardTypes.UUID));
         this.ipAddressType = typeManager.getType(new TypeSignature(StandardTypes.IPADDRESS));
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());

--- a/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
+++ b/plugin/trino-druid/src/main/java/io/trino/plugin/druid/DruidJdbcClient.java
@@ -25,6 +25,7 @@ import io.trino.plugin.jdbc.JdbcSplit;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.PreparedQuery;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.WriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
@@ -115,9 +116,9 @@ public class DruidJdbcClient
     public static final String DRUID_SCHEMA = "druid";
 
     @Inject
-    public DruidJdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, IdentifierMapping identifierMapping)
+    public DruidJdbcClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping)
     {
-        super(config, "\"", connectionFactory, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
     }
 
     @Override

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
@@ -604,7 +604,7 @@ public class MemSqlClient
     }
 
     @Override
-    protected boolean isSupportedJoinCondition(JdbcJoinCondition joinCondition)
+    protected boolean isSupportedJoinCondition(ConnectorSession session, JdbcJoinCondition joinCondition)
     {
         if (joinCondition.getOperator() == JoinCondition.Operator.IS_DISTINCT_FROM) {
             // Not supported in MemSQL

--- a/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
+++ b/plugin/trino-memsql/src/main/java/io/trino/plugin/memsql/MemSqlClient.java
@@ -27,6 +27,7 @@ import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.LongWriteFunction;
 import io.trino.plugin.jdbc.PreparedQuery;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.UnsupportedTypeHandling;
 import io.trino.plugin.jdbc.WriteMapping;
@@ -148,9 +149,9 @@ public class MemSqlClient
     private final Type jsonType;
 
     @Inject
-    public MemSqlClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, TypeManager typeManager, IdentifierMapping identifierMapping)
+    public MemSqlClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, TypeManager typeManager, IdentifierMapping identifierMapping)
     {
-        super(config, "`", connectionFactory, identifierMapping);
+        super(config, "`", connectionFactory, queryBuilder, identifierMapping);
         requireNonNull(typeManager, "typeManager is null");
         this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
     }

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -28,6 +28,7 @@ import io.trino.plugin.jdbc.JdbcSortItem;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.PreparedQuery;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.WriteMapping;
 import io.trino.plugin.jdbc.aggregation.ImplementAvgDecimal;
 import io.trino.plugin.jdbc.aggregation.ImplementAvgFloatingPoint;
@@ -157,9 +158,9 @@ public class MySqlClient
     private final AggregateFunctionRewriter<JdbcExpression> aggregateFunctionRewriter;
 
     @Inject
-    public MySqlClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, TypeManager typeManager, IdentifierMapping identifierMapping)
+    public MySqlClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, TypeManager typeManager, IdentifierMapping identifierMapping)
     {
-        super(config, "`", connectionFactory, identifierMapping);
+        super(config, "`", connectionFactory, queryBuilder, identifierMapping);
         this.jsonType = typeManager.getType(new TypeSignature(StandardTypes.JSON));
 
         JdbcTypeHandle bigintTypeHandle = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty());

--- a/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
+++ b/plugin/trino-mysql/src/main/java/io/trino/plugin/mysql/MySqlClient.java
@@ -627,7 +627,7 @@ public class MySqlClient
     }
 
     @Override
-    protected boolean isSupportedJoinCondition(JdbcJoinCondition joinCondition)
+    protected boolean isSupportedJoinCondition(ConnectorSession session, JdbcJoinCondition joinCondition)
     {
         if (joinCondition.getOperator() == JoinCondition.Operator.IS_DISTINCT_FROM) {
             // Not supported in MySQL

--- a/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClient.java
+++ b/plugin/trino-mysql/src/test/java/io/trino/plugin/mysql/TestMySqlClient.java
@@ -15,6 +15,7 @@ package io.trino.plugin.mysql;
 
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
@@ -61,6 +62,7 @@ public class TestMySqlClient
             session -> {
                 throw new UnsupportedOperationException();
             },
+            new DefaultQueryBuilder(),
             TESTING_TYPE_MANAGER,
             new DefaultIdentifierMapping());
 

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -382,7 +382,7 @@ public class OracleClient
     }
 
     @Override
-    protected boolean isSupportedJoinCondition(JdbcJoinCondition joinCondition)
+    protected boolean isSupportedJoinCondition(ConnectorSession session, JdbcJoinCondition joinCondition)
     {
         return joinCondition.getOperator() != JoinCondition.Operator.IS_DISTINCT_FROM;
     }

--- a/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
+++ b/plugin/trino-oracle/src/main/java/io/trino/plugin/oracle/OracleClient.java
@@ -27,6 +27,7 @@ import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
 import io.trino.plugin.jdbc.LongReadFunction;
 import io.trino.plugin.jdbc.LongWriteFunction;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.SliceWriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
@@ -173,9 +174,10 @@ public class OracleClient
             BaseJdbcConfig config,
             OracleConfig oracleConfig,
             ConnectionFactory connectionFactory,
+            QueryBuilder queryBuilder,
             IdentifierMapping identifierMapping)
     {
-        super(config, "\"", connectionFactory, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
 
         requireNonNull(oracleConfig, "oracleConfig is null");
         this.synonymsEnabled = oracleConfig.isSynonymsEnabled();

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -294,7 +294,7 @@ public class PhoenixClient
                 columns,
                 ImmutableMap.of(),
                 split);
-        return new QueryBuilder(this).prepareStatement(session, connection, preparedQuery);
+        return new QueryBuilder(this).prepareStatement(this, session, connection, preparedQuery);
     }
 
     @Override

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -206,12 +206,13 @@ public class PhoenixClient
     private final Configuration configuration;
 
     @Inject
-    public PhoenixClient(PhoenixConfig config, ConnectionFactory connectionFactory, IdentifierMapping identifierMapping)
+    public PhoenixClient(PhoenixConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping)
             throws SQLException
     {
         super(
                 ESCAPE_CHARACTER,
                 connectionFactory,
+                queryBuilder,
                 ImmutableSet.of(),
                 identifierMapping);
         this.configuration = new Configuration(false);
@@ -294,7 +295,7 @@ public class PhoenixClient
                 columns,
                 ImmutableMap.of(),
                 split);
-        return new QueryBuilder(this).prepareStatement(this, session, connection, preparedQuery);
+        return queryBuilder.prepareStatement(this, session, connection, preparedQuery);
     }
 
     @Override

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClientModule.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClientModule.java
@@ -27,6 +27,7 @@ import io.trino.plugin.base.classloader.ForClassLoaderSafe;
 import io.trino.plugin.jdbc.ConfiguringConnectionFactory;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DecimalModule;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.ForLazyConnectionFactory;
@@ -41,6 +42,7 @@ import io.trino.plugin.jdbc.JdbcWriteConfig;
 import io.trino.plugin.jdbc.JdbcWriteSessionProperties;
 import io.trino.plugin.jdbc.LazyConnectionFactory;
 import io.trino.plugin.jdbc.MaxDomainCompactionThreshold;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.StatsCollecting;
 import io.trino.plugin.jdbc.TypeHandlingJdbcConfig;
 import io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties;
@@ -83,6 +85,7 @@ public class PhoenixClientModule
         binder.bind(ConnectorRecordSetProvider.class).to(ClassLoaderSafeConnectorRecordSetProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSinkProvider.class).annotatedWith(ForClassLoaderSafe.class).to(JdbcPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSinkProvider.class).to(ClassLoaderSafeConnectorPageSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(QueryBuilder.class).to(DefaultQueryBuilder.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class));
 
         configBinder(binder).bindConfig(TypeHandlingJdbcConfig.class);

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -294,7 +294,7 @@ public class PhoenixClient
                 columns,
                 ImmutableMap.of(),
                 split);
-        return new QueryBuilder(this).prepareStatement(session, connection, preparedQuery);
+        return new QueryBuilder(this).prepareStatement(this, session, connection, preparedQuery);
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -206,12 +206,13 @@ public class PhoenixClient
     private final Configuration configuration;
 
     @Inject
-    public PhoenixClient(PhoenixConfig config, ConnectionFactory connectionFactory, IdentifierMapping identifierMapping)
+    public PhoenixClient(PhoenixConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping)
             throws SQLException
     {
         super(
                 ESCAPE_CHARACTER,
                 connectionFactory,
+                queryBuilder,
                 ImmutableSet.of(),
                 identifierMapping);
         this.configuration = new Configuration(false);
@@ -294,7 +295,7 @@ public class PhoenixClient
                 columns,
                 ImmutableMap.of(),
                 split);
-        return new QueryBuilder(this).prepareStatement(this, session, connection, preparedQuery);
+        return queryBuilder.prepareStatement(this, session, connection, preparedQuery);
     }
 
     @Override

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
@@ -27,6 +27,7 @@ import io.trino.plugin.base.classloader.ForClassLoaderSafe;
 import io.trino.plugin.jdbc.ConfiguringConnectionFactory;
 import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.DecimalModule;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.ForLazyConnectionFactory;
@@ -41,6 +42,7 @@ import io.trino.plugin.jdbc.JdbcWriteConfig;
 import io.trino.plugin.jdbc.JdbcWriteSessionProperties;
 import io.trino.plugin.jdbc.LazyConnectionFactory;
 import io.trino.plugin.jdbc.MaxDomainCompactionThreshold;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.StatsCollecting;
 import io.trino.plugin.jdbc.TypeHandlingJdbcConfig;
 import io.trino.plugin.jdbc.TypeHandlingJdbcSessionProperties;
@@ -83,6 +85,7 @@ public class PhoenixClientModule
         binder.bind(ConnectorRecordSetProvider.class).to(ClassLoaderSafeConnectorRecordSetProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSinkProvider.class).annotatedWith(ForClassLoaderSafe.class).to(JdbcPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(ConnectorPageSinkProvider.class).to(ClassLoaderSafeConnectorPageSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(QueryBuilder.class).to(DefaultQueryBuilder.class).in(Scopes.SINGLETON);
         newOptionalBinder(binder, Key.get(int.class, MaxDomainCompactionThreshold.class));
 
         configBinder(binder).bindConfig(TypeHandlingJdbcConfig.class);

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/CollationAwareQueryBuilder.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/CollationAwareQueryBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.postgresql;
+
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
+import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.JdbcColumnHandle;
+import io.trino.plugin.jdbc.JdbcJoinCondition;
+import io.trino.spi.type.CharType;
+import io.trino.spi.type.Type;
+import io.trino.spi.type.VarcharType;
+
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+
+public class CollationAwareQueryBuilder
+        extends DefaultQueryBuilder
+{
+    @Override
+    protected String formatJoinCondition(JdbcClient client, String leftRelationAlias, String rightRelationAlias, JdbcJoinCondition condition)
+    {
+        boolean needsCollation = Stream.of(condition.getLeftColumn(), condition.getRightColumn())
+                .map(JdbcColumnHandle::getColumnType)
+                .anyMatch(CollationAwareQueryBuilder::isCharType);
+
+        if (needsCollation) {
+            return format(
+                    "%s.%s COLLATE \"C\" %s %s.%s COLLATE \"C\"",
+                    leftRelationAlias,
+                    buildJoinColumn(client, condition.getLeftColumn()),
+                    condition.getOperator().getValue(),
+                    rightRelationAlias,
+                    buildJoinColumn(client, condition.getRightColumn()));
+        }
+
+        return super.formatJoinCondition(client, leftRelationAlias, rightRelationAlias, condition);
+    }
+
+    private static boolean isCharType(Type type)
+    {
+        return type instanceof CharType || type instanceof VarcharType;
+    }
+}

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -817,7 +817,7 @@ public class PostgreSqlClient
     }
 
     @Override
-    protected boolean isSupportedJoinCondition(JdbcJoinCondition joinCondition)
+    protected boolean isSupportedJoinCondition(ConnectorSession session, JdbcJoinCondition joinCondition)
     {
         boolean isVarchar = Stream.of(joinCondition.getLeftColumn(), joinCondition.getRightColumn())
                 .map(JdbcColumnHandle::getColumnType)
@@ -830,7 +830,7 @@ public class PostgreSqlClient
                 case LESS_THAN_OR_EQUAL:
                 case GREATER_THAN:
                 case GREATER_THAN_OR_EQUAL:
-                    break;
+                    return false;
                 case EQUAL:
                 case NOT_EQUAL:
                 case IS_DISTINCT_FROM:

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -268,10 +268,11 @@ public class PostgreSqlClient
             BaseJdbcConfig config,
             PostgreSqlConfig postgreSqlConfig,
             ConnectionFactory connectionFactory,
+            QueryBuilder queryBuilder,
             TypeManager typeManager,
             IdentifierMapping identifierMapping)
     {
-        super(config, "\"", connectionFactory, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
         this.jsonType = typeManager.getType(new TypeSignature(JSON));
         this.uuidType = typeManager.getType(new TypeSignature(StandardTypes.UUID));
         this.varcharMapType = (MapType) typeManager.getType(mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()));
@@ -802,7 +803,6 @@ public class PostgreSqlClient
         checkArgument(handle.getSortOrder().isEmpty(), "Unable to delete when sort order is set: %s", handle);
         try (Connection connection = connectionFactory.openConnection(session)) {
             verify(connection.getAutoCommit());
-            QueryBuilder queryBuilder = new QueryBuilder(this);
             PreparedQuery preparedQuery = queryBuilder.prepareDelete(this, session, connection, handle.getRequiredNamedRelation(), handle.getConstraint());
             try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(this, session, connection, preparedQuery)) {
                 int affectedRowsCount = preparedStatement.executeUpdate();

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -830,7 +830,7 @@ public class PostgreSqlClient
                 case LESS_THAN_OR_EQUAL:
                 case GREATER_THAN:
                 case GREATER_THAN_OR_EQUAL:
-                    return false;
+                    return isEnableStringPushdownWithCollate(session);
                 case EQUAL:
                 case NOT_EQUAL:
                 case IS_DISTINCT_FROM:

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -803,8 +803,8 @@ public class PostgreSqlClient
         try (Connection connection = connectionFactory.openConnection(session)) {
             verify(connection.getAutoCommit());
             QueryBuilder queryBuilder = new QueryBuilder(this);
-            PreparedQuery preparedQuery = queryBuilder.prepareDelete(session, connection, handle.getRequiredNamedRelation(), handle.getConstraint());
-            try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(session, connection, preparedQuery)) {
+            PreparedQuery preparedQuery = queryBuilder.prepareDelete(this, session, connection, handle.getRequiredNamedRelation(), handle.getConstraint());
+            try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(this, session, connection, preparedQuery)) {
                 int affectedRowsCount = preparedStatement.executeUpdate();
                 // In getPreparedStatement we set autocommit to false so here we need an explicit commit
                 connection.commit();

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -803,7 +803,7 @@ public class PostgreSqlClient
         checkArgument(handle.getSortOrder().isEmpty(), "Unable to delete when sort order is set: %s", handle);
         try (Connection connection = connectionFactory.openConnection(session)) {
             verify(connection.getAutoCommit());
-            PreparedQuery preparedQuery = queryBuilder.prepareDelete(this, session, connection, handle.getRequiredNamedRelation(), handle.getConstraint());
+            PreparedQuery preparedQuery = queryBuilder.prepareDeleteQuery(this, session, connection, handle.getRequiredNamedRelation(), handle.getConstraint());
             try (PreparedStatement preparedStatement = queryBuilder.prepareStatement(this, session, connection, preparedQuery)) {
                 int affectedRowsCount = preparedStatement.executeUpdate();
                 // In getPreparedStatement we set autocommit to false so here we need an explicit commit

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClientModule.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClientModule.java
@@ -24,10 +24,12 @@ import io.trino.plugin.jdbc.DecimalModule;
 import io.trino.plugin.jdbc.DriverConnectionFactory;
 import io.trino.plugin.jdbc.ForBaseJdbc;
 import io.trino.plugin.jdbc.JdbcClient;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteQueryCancellationModule;
 import io.trino.plugin.jdbc.credential.CredentialProvider;
 import org.postgresql.Driver;
 
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 import static io.trino.plugin.jdbc.JdbcModule.bindSessionPropertiesProvider;
 
@@ -40,6 +42,7 @@ public class PostgreSqlClientModule
         binder.bind(JdbcClient.class).annotatedWith(ForBaseJdbc.class).to(PostgreSqlClient.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(PostgreSqlConfig.class);
         bindSessionPropertiesProvider(binder, PostgreSqlSessionProperties.class);
+        newOptionalBinder(binder, QueryBuilder.class).setBinding().to(CollationAwareQueryBuilder.class).in(Scopes.SINGLETON);
         install(new DecimalModule());
         install(new RemoteQueryCancellationModule());
     }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlClient.java
@@ -15,6 +15,7 @@ package io.trino.plugin.postgresql;
 
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
@@ -60,6 +61,7 @@ public class TestPostgreSqlClient
             new BaseJdbcConfig(),
             new PostgreSqlConfig(),
             session -> { throw new UnsupportedOperationException(); },
+            new DefaultQueryBuilder(),
             TESTING_TYPE_MANAGER,
             new DefaultIdentifierMapping());
 

--- a/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
+++ b/plugin/trino-redshift/src/main/java/io/trino/plugin/redshift/RedshiftClient.java
@@ -20,6 +20,7 @@ import io.trino.plugin.jdbc.ConnectionFactory;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
 import io.trino.plugin.jdbc.JdbcTypeHandle;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.WriteMapping;
 import io.trino.plugin.jdbc.mapping.IdentifierMapping;
 import io.trino.spi.TrinoException;
@@ -88,9 +89,9 @@ public class RedshiftClient
         extends BaseJdbcClient
 {
     @Inject
-    public RedshiftClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, IdentifierMapping identifierMapping)
+    public RedshiftClient(BaseJdbcConfig config, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping)
     {
-        super(config, "\"", connectionFactory, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
     }
 
     @Override

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -41,6 +41,7 @@ import io.trino.plugin.jdbc.LongReadFunction;
 import io.trino.plugin.jdbc.LongWriteFunction;
 import io.trino.plugin.jdbc.ObjectReadFunction;
 import io.trino.plugin.jdbc.ObjectWriteFunction;
+import io.trino.plugin.jdbc.QueryBuilder;
 import io.trino.plugin.jdbc.RemoteTableName;
 import io.trino.plugin.jdbc.SliceWriteFunction;
 import io.trino.plugin.jdbc.WriteMapping;
@@ -194,9 +195,9 @@ public class SqlServerClient
     private static final int MAX_SUPPORTED_TEMPORAL_PRECISION = 7;
 
     @Inject
-    public SqlServerClient(BaseJdbcConfig config, SqlServerConfig sqlServerConfig, ConnectionFactory connectionFactory, IdentifierMapping identifierMapping)
+    public SqlServerClient(BaseJdbcConfig config, SqlServerConfig sqlServerConfig, ConnectionFactory connectionFactory, QueryBuilder queryBuilder, IdentifierMapping identifierMapping)
     {
-        super(config, "\"", connectionFactory, identifierMapping);
+        super(config, "\"", connectionFactory, queryBuilder, identifierMapping);
 
         requireNonNull(sqlServerConfig, "sqlServerConfig is null");
         snapshotIsolationDisabled = sqlServerConfig.isSnapshotIsolationDisabled();

--- a/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
+++ b/plugin/trino-sqlserver/src/main/java/io/trino/plugin/sqlserver/SqlServerClient.java
@@ -621,7 +621,7 @@ public class SqlServerClient
     }
 
     @Override
-    protected boolean isSupportedJoinCondition(JdbcJoinCondition joinCondition)
+    protected boolean isSupportedJoinCondition(ConnectorSession session, JdbcJoinCondition joinCondition)
     {
         if (joinCondition.getOperator() == JoinCondition.Operator.IS_DISTINCT_FROM) {
             // Not supported in SQL Server

--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestSqlServerClient.java
@@ -15,6 +15,7 @@ package io.trino.plugin.sqlserver;
 
 import io.trino.plugin.jdbc.BaseJdbcConfig;
 import io.trino.plugin.jdbc.ColumnMapping;
+import io.trino.plugin.jdbc.DefaultQueryBuilder;
 import io.trino.plugin.jdbc.JdbcClient;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcExpression;
@@ -61,6 +62,7 @@ public class TestSqlServerClient
             session -> {
                 throw new UnsupportedOperationException();
             },
+            new DefaultQueryBuilder(),
             new DefaultIdentifierMapping());
 
     @Test


### PR DESCRIPTION
This is a preparatory step to be able to provide correct behavior when pushing down joins for case-(in)sensitive columns in the join condition comparisons