### PR TITLE
Refactor BigQuery to allow non-static credential suppliers

### DIFF
--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -13,7 +13,6 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.cloud.BaseServiceException;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
 import com.google.cloud.bigquery.Dataset;
@@ -35,7 +34,6 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.log.Logger;
 import io.airlift.units.Duration;
 import io.trino.spi.TrinoException;
-import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.TableNotFoundException;
 
 import java.util.Collections;
@@ -44,8 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 
 import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
@@ -55,12 +51,9 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Streams.stream;
 import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_AMBIGUOUS_OBJECT_NAME;
-import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_VIEW_DESTINATION_TABLE_CREATION_FAILED;
-import static io.trino.plugin.bigquery.BigQueryUtil.convertToBigQueryException;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
-import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.joining;
 
@@ -69,18 +62,16 @@ public class BigQueryClient
     private static final Logger log = Logger.get(BigQueryClient.class);
 
     private final BigQuery bigQuery;
-    private final Optional<String> viewMaterializationProject;
-    private final Optional<String> viewMaterializationDataset;
+    private final ViewMaterializationCache materializationCache;
     private final boolean caseInsensitiveNameMatching;
     private final Cache<String, Optional<RemoteDatabaseObject>> remoteDatasets;
     private final Cache<TableId, Optional<RemoteDatabaseObject>> remoteTables;
-    private final Cache<String, TableInfo> destinationTableCache;
 
-    public BigQueryClient(BigQuery bigQuery, BigQueryConfig config)
+    public BigQueryClient(BigQuery bigQuery, BigQueryConfig config, ViewMaterializationCache materializationCache)
     {
         this.bigQuery = requireNonNull(bigQuery, "bigQuery is null");
-        this.viewMaterializationProject = requireNonNull(config, "config is null").getViewMaterializationProject();
-        this.viewMaterializationDataset = config.getViewMaterializationDataset();
+        this.materializationCache = requireNonNull(materializationCache, "materializationCache is null");
+
         Duration caseInsensitiveNameMatchingCacheTtl = requireNonNull(config.getCaseInsensitiveNameMatchingCacheTtl(), "caseInsensitiveNameMatchingCacheTtl is null");
 
         this.caseInsensitiveNameMatching = config.isCaseInsensitiveNameMatching();
@@ -88,10 +79,6 @@ public class BigQueryClient
                 .expireAfterWrite(caseInsensitiveNameMatchingCacheTtl.toMillis(), MILLISECONDS);
         this.remoteDatasets = remoteNamesCacheBuilder.build();
         this.remoteTables = remoteNamesCacheBuilder.build();
-        this.destinationTableCache = CacheBuilder.newBuilder()
-                .expireAfterWrite(config.getViewsCacheTtl().toMillis(), MILLISECONDS)
-                .maximumSize(1000)
-                .build();
     }
 
     public Optional<RemoteDatabaseObject> toRemoteDataset(String projectId, String datasetName)
@@ -192,13 +179,7 @@ public class BigQueryClient
     {
         String query = selectSql(remoteTableId, requiredColumns);
         log.debug("query is %s", query);
-        try {
-            return destinationTableCache.get(query,
-                    new DestinationTableBuilder(this, viewExpiration, query, remoteTableId.getTableId()));
-        }
-        catch (ExecutionException e) {
-            throw new TrinoException(BIGQUERY_VIEW_DESTINATION_TABLE_CREATION_FAILED, "Error creating destination table", e);
-        }
+        return materializationCache.getCachedTable(this, query, viewExpiration, remoteTableId);
     }
 
     public String getProjectId()
@@ -220,16 +201,7 @@ public class BigQueryClient
                 .collect(toImmutableList());
     }
 
-    private TableId createDestinationTable(TableId remoteTableId)
-    {
-        String project = viewMaterializationProject.orElse(remoteTableId.getProject());
-        String dataset = viewMaterializationDataset.orElse(remoteTableId.getDataset());
-
-        String name = format("_pbc_%s", randomUUID().toString().toLowerCase(ENGLISH).replace("-", ""));
-        return TableId.of(project, dataset, name);
-    }
-
-    private Table update(TableInfo table)
+    Table update(TableInfo table)
     {
         return bigQuery.update(table);
     }
@@ -254,7 +226,7 @@ public class BigQueryClient
         bigQuery.delete(tableId);
     }
 
-    private Job create(JobInfo jobInfo)
+    Job create(JobInfo jobInfo)
     {
         return bigQuery.create(jobInfo);
     }
@@ -349,65 +321,6 @@ public class BigQueryClient
         public boolean isAmbiguous()
         {
             return remoteNames.size() > 1;
-        }
-    }
-
-    private static class DestinationTableBuilder
-            implements Callable<TableInfo>
-    {
-        private final BigQueryClient bigQueryClient;
-        private final Duration viewExpiration;
-        private final String query;
-        private final TableId remoteTable;
-
-        DestinationTableBuilder(BigQueryClient bigQueryClient, Duration viewExpiration, String query, TableId remoteTable)
-        {
-            this.bigQueryClient = requireNonNull(bigQueryClient, "bigQueryClient is null");
-            this.viewExpiration = requireNonNull(viewExpiration, "viewExpiration is null");
-            this.query = requireNonNull(query, "query is null");
-            this.remoteTable = requireNonNull(remoteTable, "remoteTable is null");
-        }
-
-        @Override
-        public TableInfo call()
-        {
-            return createTableFromQuery();
-        }
-
-        private TableInfo createTableFromQuery()
-        {
-            TableId destinationTable = bigQueryClient.createDestinationTable(remoteTable);
-            log.debug("destinationTable is %s", destinationTable);
-            JobInfo jobInfo = JobInfo.of(
-                    QueryJobConfiguration
-                            .newBuilder(query)
-                            .setDestinationTable(destinationTable)
-                            .build());
-            log.debug("running query %s", jobInfo);
-            Job job = waitForJob(bigQueryClient.create(jobInfo));
-            log.debug("job has finished. %s", job);
-            if (job.getStatus().getError() != null) {
-                throw convertToBigQueryException(job.getStatus().getError());
-            }
-            // add expiration time to the table
-            TableInfo createdTable = bigQueryClient.getTable(destinationTable)
-                    .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(destinationTable.getDataset(), destinationTable.getTable())));
-            long expirationTimeMillis = createdTable.getCreationTime() + viewExpiration.toMillis();
-            Table updatedTable = bigQueryClient.update(createdTable.toBuilder()
-                    .setExpirationTime(expirationTimeMillis)
-                    .build());
-            return updatedTable;
-        }
-
-        private Job waitForJob(Job job)
-        {
-            try {
-                return job.waitFor();
-            }
-            catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new BigQueryException(BaseServiceException.UNKNOWN_CODE, format("Job %s has been interrupted", job.getJobId()), e);
-            }
         }
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClient.java
@@ -78,8 +78,8 @@ public class BigQueryClient
 
     public BigQueryClient(BigQuery bigQuery, BigQueryConfig config)
     {
-        this.bigQuery = bigQuery;
-        this.viewMaterializationProject = config.getViewMaterializationProject();
+        this.bigQuery = requireNonNull(bigQuery, "bigQuery is null");
+        this.viewMaterializationProject = requireNonNull(config, "config is null").getViewMaterializationProject();
         this.viewMaterializationDataset = config.getViewMaterializationDataset();
         Duration caseInsensitiveNameMatchingCacheTtl = requireNonNull(config.getCaseInsensitiveNameMatchingCacheTtl(), "caseInsensitiveNameMatchingCacheTtl is null");
 

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.api.gax.rpc.HeaderProvider;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.trino.spi.connector.ConnectorSession;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class BigQueryClientFactory
+{
+    private final IdentityCacheMapping identityCacheMapping;
+    private final BigQueryCredentialsSupplier credentialsSupplier;
+    private final BigQueryConfig bigQueryConfig;
+    private final HeaderProvider headerProvider;
+    private final Cache<IdentityCacheMapping.IdentityCacheKey, BigQueryClient> clientCache;
+
+    @Inject
+    public BigQueryClientFactory(IdentityCacheMapping identityCacheMapping, BigQueryCredentialsSupplier credentialsSupplier, BigQueryConfig bigQueryConfig, HeaderProvider headerProvider)
+    {
+        this.identityCacheMapping = requireNonNull(identityCacheMapping, "identityCacheMaping is null");
+        this.credentialsSupplier = requireNonNull(credentialsSupplier, "credentialsSupplier is null");
+        this.bigQueryConfig = requireNonNull(bigQueryConfig, "bigQueryConfig is null");
+        this.headerProvider = requireNonNull(headerProvider, "headerProvider is null");
+
+        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder()
+                .expireAfterWrite(bigQueryConfig.getServiceCacheTtl().toMillis(), MILLISECONDS);
+
+        clientCache = cacheBuilder.build();
+    }
+
+    public BigQueryClient create(ConnectorSession session)
+    {
+        IdentityCacheMapping.IdentityCacheKey cacheKey = identityCacheMapping.getRemoteUserCacheKey(session);
+
+        try {
+            return clientCache.get(cacheKey, () -> createBigQueryClient(session));
+        }
+        catch (ExecutionException e) {
+            return createBigQueryClient(session);
+        }
+    }
+
+    protected BigQueryClient createBigQueryClient(ConnectorSession session)
+    {
+        return new BigQueryClient(createBigQuery(session), bigQueryConfig);
+    }
+
+    protected BigQuery createBigQuery(ConnectorSession session)
+    {
+        Optional<Credentials> credentials = credentialsSupplier.getCredentials(session);
+        String billingProjectId = calculateBillingProjectId(bigQueryConfig.getParentProjectId(), credentials);
+        BigQueryOptions.Builder options = BigQueryOptions.newBuilder()
+                .setHeaderProvider(headerProvider)
+                .setProjectId(billingProjectId);
+        credentials.ifPresent(options::setCredentials);
+        return options.build().getService();
+    }
+
+    // Note that at this point the config has been validated, which means that option 2 or option 3 will always be valid
+    static String calculateBillingProjectId(Optional<String> configParentProjectId, Optional<Credentials> credentials)
+    {
+        // 1. Get from configuration
+        return configParentProjectId
+                // 2. Get from the provided credentials, but only ServiceAccountCredentials contains the project id.
+                // All other credentials types (User, AppEngine, GCE, CloudShell, etc.) take it from the environment
+                .orElseGet(() -> credentials
+                        .filter(ServiceAccountCredentials.class::isInstance)
+                        .map(ServiceAccountCredentials.class::cast)
+                        .map(ServiceAccountCredentials::getProjectId)
+                        // 3. No configuration was provided, so get the default from the environment
+                        .orElseGet(BigQueryOptions::getDefaultProjectId));
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryClientFactory.java
@@ -35,15 +35,22 @@ public class BigQueryClientFactory
     private final IdentityCacheMapping identityCacheMapping;
     private final BigQueryCredentialsSupplier credentialsSupplier;
     private final BigQueryConfig bigQueryConfig;
+    private final ViewMaterializationCache materializationCache;
     private final HeaderProvider headerProvider;
     private final Cache<IdentityCacheMapping.IdentityCacheKey, BigQueryClient> clientCache;
 
     @Inject
-    public BigQueryClientFactory(IdentityCacheMapping identityCacheMapping, BigQueryCredentialsSupplier credentialsSupplier, BigQueryConfig bigQueryConfig, HeaderProvider headerProvider)
+    public BigQueryClientFactory(
+            IdentityCacheMapping identityCacheMapping,
+            BigQueryCredentialsSupplier credentialsSupplier,
+            BigQueryConfig bigQueryConfig,
+            ViewMaterializationCache materializationCache,
+            HeaderProvider headerProvider)
     {
         this.identityCacheMapping = requireNonNull(identityCacheMapping, "identityCacheMaping is null");
         this.credentialsSupplier = requireNonNull(credentialsSupplier, "credentialsSupplier is null");
         this.bigQueryConfig = requireNonNull(bigQueryConfig, "bigQueryConfig is null");
+        this.materializationCache = requireNonNull(materializationCache, "materializationCache is null");
         this.headerProvider = requireNonNull(headerProvider, "headerProvider is null");
 
         CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder()
@@ -66,7 +73,7 @@ public class BigQueryClientFactory
 
     protected BigQueryClient createBigQueryClient(ConnectorSession session)
     {
-        return new BigQueryClient(createBigQuery(session), bigQueryConfig);
+        return new BigQueryClient(createBigQuery(session), bigQueryConfig, materializationCache);
     }
 
     protected BigQuery createBigQuery(ConnectorSession session)

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConfig.java
@@ -16,6 +16,7 @@ package io.trino.plugin.bigquery;
 import com.google.auth.oauth2.GoogleCredentials;
 import io.airlift.configuration.Config;
 import io.airlift.configuration.ConfigDescription;
+import io.airlift.configuration.ConfigHidden;
 import io.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.configuration.validation.FileExists;
 import io.airlift.units.Duration;
@@ -49,6 +50,7 @@ public class BigQueryConfig
     private boolean caseInsensitiveNameMatching;
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
     private Duration viewsCacheTtl = new Duration(15, MINUTES);
+    private Duration serviceCacheTtl = new Duration(3, MINUTES);
 
     @AssertTrue(message = "Exactly one of 'bigquery.credentials-key' or 'bigquery.credentials-file' must be specified, or the default GoogleCredentials could be created")
     public boolean isCredentialsConfigurationValid()
@@ -233,6 +235,22 @@ public class BigQueryConfig
     public BigQueryConfig setViewsCacheTtl(Duration viewsCacheTtl)
     {
         this.viewsCacheTtl = viewsCacheTtl;
+        return this;
+    }
+
+    @NotNull
+    @MinDuration("0m")
+    public Duration getServiceCacheTtl()
+    {
+        return serviceCacheTtl;
+    }
+
+    @ConfigHidden
+    @Config("bigquery.service-cache-ttl")
+    @ConfigDescription("Duration for which BigQuery client service instances are cached")
+    public BigQueryConfig setServiceCacheTtl(Duration serviceCacheTtl)
+    {
+        this.serviceCacheTtl = serviceCacheTtl;
         return this;
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
@@ -59,6 +59,7 @@ public class BigQueryConnectorModule
         binder.bind(BigQueryMetadata.class).in(Scopes.SINGLETON);
         binder.bind(BigQuerySplitManager.class).in(Scopes.SINGLETON);
         binder.bind(BigQueryPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(ViewMaterializationCache.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(BigQueryConfig.class);
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryConnectorModule.java
@@ -15,9 +15,6 @@ package io.trino.plugin.bigquery;
 
 import com.google.api.gax.rpc.FixedHeaderProvider;
 import com.google.api.gax.rpc.HeaderProvider;
-import com.google.auth.Credentials;
-import com.google.auth.oauth2.ServiceAccountCredentials;
-import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
@@ -25,8 +22,7 @@ import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import io.trino.spi.NodeManager;
 
-import java.util.Optional;
-
+import static com.google.inject.multibindings.OptionalBinder.newOptionalBinder;
 import static io.airlift.configuration.ConfigBinder.configBinder;
 
 public class BigQueryConnectorModule
@@ -44,48 +40,25 @@ public class BigQueryConnectorModule
     {
         // BigQuery related
         binder.bind(BigQueryReadClientFactory.class).in(Scopes.SINGLETON);
+        binder.bind(BigQueryClientFactory.class).in(Scopes.SINGLETON);
+
+        // SingletonIdentityCacheMapping is safe to use with StaticBigQueryCredentialsSupplier
+        // as credentials do not depend on actual connector session.
+        newOptionalBinder(binder, IdentityCacheMapping.class)
+                .setDefault()
+                .to(IdentityCacheMapping.SingletonIdentityCacheMapping.class)
+                .in(Scopes.SINGLETON);
+
+        newOptionalBinder(binder, BigQueryCredentialsSupplier.class)
+                .setDefault()
+                .to(StaticBigQueryCredentialsSupplier.class)
+                .in(Scopes.SINGLETON);
 
         // Connector implementation
         binder.bind(BigQueryConnector.class).in(Scopes.SINGLETON);
-
         binder.bind(BigQueryMetadata.class).in(Scopes.SINGLETON);
         binder.bind(BigQuerySplitManager.class).in(Scopes.SINGLETON);
         binder.bind(BigQueryPageSourceProvider.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(BigQueryConfig.class);
-    }
-
-    @Provides
-    @Singleton
-    public BigQueryCredentialsSupplier provideBigQueryCredentialsSupplier(BigQueryConfig config)
-    {
-        return new BigQueryCredentialsSupplier(config.getCredentialsKey(), config.getCredentialsFile());
-    }
-
-    @Provides
-    @Singleton
-    public BigQueryClient provideBigQueryClient(BigQueryConfig config, HeaderProvider headerProvider, BigQueryCredentialsSupplier bigQueryCredentialsSupplier)
-    {
-        String billingProjectId = calculateBillingProjectId(config.getParentProjectId(), bigQueryCredentialsSupplier.getCredentials());
-        BigQueryOptions.Builder options = BigQueryOptions.newBuilder()
-                .setHeaderProvider(headerProvider)
-                .setProjectId(billingProjectId);
-        // set credentials of provided
-        bigQueryCredentialsSupplier.getCredentials().ifPresent(options::setCredentials);
-        return new BigQueryClient(options.build().getService(), config);
-    }
-
-    // Note that at this point the config has been validated, which means that option 2 or option 3 will always be valid
-    public static String calculateBillingProjectId(Optional<String> configParentProjectId, Optional<Credentials> credentials)
-    {
-        // 1. Get from configuration
-        return configParentProjectId
-                // 2. Get from the provided credentials, but only ServiceAccountCredentials contains the project id.
-                // All other credentials types (User, AppEngine, GCE, CloudShell, etc.) take it from the environment
-                .orElseGet(() -> credentials
-                        .filter(ServiceAccountCredentials.class::isInstance)
-                        .map(ServiceAccountCredentials.class::cast)
-                        .map(ServiceAccountCredentials::getProjectId)
-                        // 3. No configuration was provided, so get the default from the environment
-                        .orElseGet(BigQueryOptions::getDefaultProjectId));
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryCredentialsSupplier.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryCredentialsSupplier.java
@@ -13,56 +13,12 @@
  */
 package io.trino.plugin.bigquery;
 
-import com.google.api.client.util.Base64;
 import com.google.auth.Credentials;
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
+import io.trino.spi.connector.ConnectorSession;
 
-import java.io.ByteArrayInputStream;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Optional;
 
-import static java.util.Objects.requireNonNull;
-
-public class BigQueryCredentialsSupplier
+public interface BigQueryCredentialsSupplier
 {
-    private final Supplier<Optional<Credentials>> credentialsCreator;
-
-    public BigQueryCredentialsSupplier(Optional<String> credentialsKey, Optional<String> credentialsFile)
-    {
-        requireNonNull(credentialsKey, "credentialsKey is null");
-        requireNonNull(credentialsFile, "credentialsFile is null");
-        // lazy creation, cache once it's created
-        this.credentialsCreator = Suppliers.memoize(() ->
-            credentialsKey.map(BigQueryCredentialsSupplier::createCredentialsFromKey)
-                    .or(() -> credentialsFile.map(BigQueryCredentialsSupplier::createCredentialsFromFile)));
-    }
-
-    private static Credentials createCredentialsFromKey(String key)
-    {
-        try {
-            return GoogleCredentials.fromStream(new ByteArrayInputStream(Base64.decodeBase64(key)));
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException("Failed to create Credentials from key", e);
-        }
-    }
-
-    private static Credentials createCredentialsFromFile(String file)
-    {
-        try {
-            return GoogleCredentials.fromStream(new FileInputStream(file));
-        }
-        catch (IOException e) {
-            throw new UncheckedIOException("Failed to create Credentials from file", e);
-        }
-    }
-
-    public Optional<Credentials> getCredentials()
-    {
-        return credentialsCreator.get();
-    }
+    Optional<Credentials> getCredentials(ConnectorSession session);
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryMetadata.java
@@ -69,6 +69,7 @@ import java.util.stream.Stream;
 import static com.google.cloud.bigquery.TableDefinition.Type.TABLE;
 import static com.google.cloud.bigquery.TableDefinition.Type.VIEW;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_LISTING_DATASET_ERROR;
@@ -87,34 +88,45 @@ public class BigQueryMetadata
     static final String INFORMATION_SCHEMA = "information_schema";
     private static final String VIEW_DEFINITION_SYSTEM_TABLE_SUFFIX = "$view_definition";
 
-    private final BigQueryClient bigQueryClient;
-    private final String projectId;
+    private final BigQueryClientFactory bigQueryClientFactory;
+    private final Optional<String> configProjectId;
 
     @Inject
-    public BigQueryMetadata(BigQueryClient bigQueryClient, BigQueryConfig config)
+    public BigQueryMetadata(BigQueryClientFactory bigQueryClientFactory, BigQueryConfig config)
     {
-        this.bigQueryClient = requireNonNull(bigQueryClient, "bigQueryClient is null");
-        this.projectId = requireNonNull(config, "config is null").getProjectId().orElse(bigQueryClient.getProjectId());
+        this.bigQueryClientFactory = requireNonNull(bigQueryClientFactory, "bigQueryClientFactory is null");
+        this.configProjectId = requireNonNull(config, "config is null").getProjectId();
+    }
+
+    protected String getProjectId(BigQueryClient client)
+    {
+        String projectId = configProjectId.orElse(client.getProjectId());
+        checkState(projectId.toLowerCase(ENGLISH).equals(projectId), "projectId must be lowercase but it's " + projectId);
+        return projectId;
     }
 
     @Override
     public List<String> listSchemaNames(ConnectorSession session)
     {
         log.debug("listSchemaNames(session=%s)", session);
-        return listRemoteSchemaNames().stream()
+        return listRemoteSchemaNames(session).stream()
                 .map(schema -> schema.toLowerCase(ENGLISH))
                 .collect(toImmutableList());
     }
 
-    private List<String> listRemoteSchemaNames()
+    private List<String> listRemoteSchemaNames(ConnectorSession session)
     {
-        Stream<String> remoteSchemaNames = Streams.stream(bigQueryClient.listDatasets(projectId))
+        BigQueryClient client = bigQueryClientFactory.create(session);
+        String projectId = getProjectId(client);
+
+        Stream<String> remoteSchemaNames = Streams.stream(client.listDatasets(projectId))
                 .map(dataset -> dataset.getDatasetId().getDataset())
                 .filter(schemaName -> !schemaName.equalsIgnoreCase(INFORMATION_SCHEMA))
                 .distinct();
 
         // filter out all the ambiguous schemas to prevent failures if anyone tries to access the listed schemas
-        return remoteSchemaNames.map(remoteSchema -> bigQueryClient.toRemoteDataset(projectId, remoteSchema.toLowerCase(ENGLISH)))
+
+        return remoteSchemaNames.map(remoteSchema -> client.toRemoteDataset(projectId, remoteSchema.toLowerCase(ENGLISH)))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .filter(dataset -> !dataset.isAmbiguous())
@@ -125,24 +137,31 @@ public class BigQueryMetadata
     @Override
     public boolean schemaExists(ConnectorSession session, String schemaName)
     {
+        BigQueryClient client = bigQueryClientFactory.create(session);
+
         // Overridden to make sure an error message is returned in case of an ambiguous schema name
         log.debug("schemaExists(session=%s)", session);
-        return bigQueryClient.toRemoteDataset(projectId, schemaName)
+        String projectId = getProjectId(client);
+        return client.toRemoteDataset(projectId, schemaName)
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
-                .filter(remoteSchema -> bigQueryClient.getDataset(DatasetId.of(projectId, remoteSchema)) != null)
+                .filter(remoteSchema -> client.getDataset(DatasetId.of(projectId, remoteSchema)) != null)
                 .isPresent();
     }
 
     @Override
     public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
     {
+        BigQueryClient client = bigQueryClientFactory.create(session);
+
         log.debug("listTables(session=%s, schemaName=%s)", session, schemaName);
         if (schemaName.isPresent() && schemaName.get().equalsIgnoreCase(INFORMATION_SCHEMA)) {
             return ImmutableList.of();
         }
 
+        String projectId = getProjectId(client);
+
         // filter ambiguous schemas
-        Optional<String> remoteSchema = schemaName.flatMap(schema -> bigQueryClient.toRemoteDataset(projectId, schema)
+        Optional<String> remoteSchema = schemaName.flatMap(schema -> client.toRemoteDataset(projectId, schema)
                 .filter(dataset -> !dataset.isAmbiguous())
                 .map(RemoteDatabaseObject::getOnlyRemoteName));
         if (remoteSchema.isPresent() && remoteSchema.get().equalsIgnoreCase(INFORMATION_SCHEMA)) {
@@ -150,15 +169,15 @@ public class BigQueryMetadata
         }
 
         Set<String> remoteSchemaNames = remoteSchema.map(ImmutableSet::of)
-                .orElseGet(() -> ImmutableSet.copyOf(listRemoteSchemaNames()));
+                .orElseGet(() -> ImmutableSet.copyOf(listRemoteSchemaNames(session)));
 
         ImmutableList.Builder<SchemaTableName> tableNames = ImmutableList.builder();
         for (String remoteSchemaName : remoteSchemaNames) {
             try {
-                Iterable<Table> tables = bigQueryClient.listTables(DatasetId.of(projectId, remoteSchemaName), TABLE, VIEW);
+                Iterable<Table> tables = client.listTables(DatasetId.of(projectId, remoteSchemaName), TABLE, VIEW);
                 for (Table table : tables) {
                     // filter ambiguous tables
-                    bigQueryClient.toRemoteTable(projectId, remoteSchemaName, table.getTableId().getTable().toLowerCase(ENGLISH), tables)
+                    client.toRemoteTable(projectId, remoteSchemaName, table.getTableId().getTable().toLowerCase(ENGLISH), tables)
                             .filter(RemoteDatabaseObject::isAmbiguous)
                             .ifPresentOrElse(
                                     remoteTable -> log.debug("Filtered out [%s.%s] from list of tables due to ambiguous name", remoteSchemaName, table.getTableId().getTable()),
@@ -181,14 +200,16 @@ public class BigQueryMetadata
     @Override
     public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName schemaTableName)
     {
+        BigQueryClient client = bigQueryClientFactory.create(session);
+        String projectId = getProjectId(client);
         log.debug("getTableHandle(session=%s, schemaTableName=%s)", session, schemaTableName);
-        String remoteSchemaName = bigQueryClient.toRemoteDataset(projectId, schemaTableName.getSchemaName())
+        String remoteSchemaName = client.toRemoteDataset(projectId, schemaTableName.getSchemaName())
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElse(schemaTableName.getSchemaName());
-        String remoteTableName = bigQueryClient.toRemoteTable(projectId, remoteSchemaName, schemaTableName.getTableName())
+        String remoteTableName = client.toRemoteTable(projectId, remoteSchemaName, schemaTableName.getTableName())
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElse(schemaTableName.getTableName());
-        Optional<TableInfo> tableInfo = bigQueryClient.getTable(TableId.of(projectId, remoteSchemaName, remoteTableName));
+        Optional<TableInfo> tableInfo = client.getTable(TableId.of(projectId, remoteSchemaName, remoteTableName));
         if (tableInfo.isEmpty()) {
             log.debug("Table [%s.%s] was not found", schemaTableName.getSchemaName(), schemaTableName.getTableName());
             return null;
@@ -197,15 +218,17 @@ public class BigQueryMetadata
         return new BigQueryTableHandle(schemaTableName, new RemoteTableName(tableInfo.get().getTableId()), tableInfo.get());
     }
 
-    private ConnectorTableHandle getTableHandleIgnoringConflicts(SchemaTableName schemaTableName)
+    private ConnectorTableHandle getTableHandleIgnoringConflicts(ConnectorSession session, SchemaTableName schemaTableName)
     {
-        String remoteSchemaName = bigQueryClient.toRemoteDataset(projectId, schemaTableName.getSchemaName())
+        BigQueryClient client = bigQueryClientFactory.create(session);
+        String projectId = getProjectId(client);
+        String remoteSchemaName = client.toRemoteDataset(projectId, schemaTableName.getSchemaName())
                 .map(RemoteDatabaseObject::getAnyRemoteName)
                 .orElse(schemaTableName.getSchemaName());
-        String remoteTableName = bigQueryClient.toRemoteTable(projectId, remoteSchemaName, schemaTableName.getTableName())
+        String remoteTableName = client.toRemoteTable(projectId, remoteSchemaName, schemaTableName.getTableName())
                 .map(RemoteDatabaseObject::getAnyRemoteName)
                 .orElse(schemaTableName.getTableName());
-        Optional<TableInfo> tableInfo = bigQueryClient.getTable(TableId.of(projectId, remoteSchemaName, remoteTableName));
+        Optional<TableInfo> tableInfo = client.getTable(TableId.of(projectId, remoteSchemaName, remoteTableName));
         if (tableInfo.isEmpty()) {
             log.debug("Table [%s.%s] was not found", schemaTableName.getSchemaName(), schemaTableName.getTableName());
             return null;
@@ -217,11 +240,12 @@ public class BigQueryMetadata
     @Override
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
+        BigQueryClient client = bigQueryClientFactory.create(session);
         log.debug("getTableMetadata(session=%s, tableHandle=%s)", session, tableHandle);
         BigQueryTableHandle handle = ((BigQueryTableHandle) tableHandle);
 
         ImmutableList.Builder<ColumnMetadata> columnMetadata = ImmutableList.builder();
-        for (BigQueryColumnHandle column : bigQueryClient.getColumns(handle)) {
+        for (BigQueryColumnHandle column : client.getColumns(handle)) {
             columnMetadata.add(column.getColumnMetadata());
         }
         return new ConnectorTableMetadata(handle.getSchemaTableName(), columnMetadata.build());
@@ -231,20 +255,22 @@ public class BigQueryMetadata
     public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
         if (isViewDefinitionSystemTable(tableName)) {
-            return getViewDefinitionSystemTable(tableName, getViewDefinitionSourceTableName(tableName));
+            return getViewDefinitionSystemTable(session, tableName, getViewDefinitionSourceTableName(tableName));
         }
         return Optional.empty();
     }
 
-    private Optional<SystemTable> getViewDefinitionSystemTable(SchemaTableName viewDefinitionTableName, SchemaTableName sourceTableName)
+    private Optional<SystemTable> getViewDefinitionSystemTable(ConnectorSession session, SchemaTableName viewDefinitionTableName, SchemaTableName sourceTableName)
     {
-        String remoteSchemaName = bigQueryClient.toRemoteDataset(projectId, sourceTableName.getSchemaName())
+        BigQueryClient client = bigQueryClientFactory.create(session);
+        String projectId = getProjectId(client);
+        String remoteSchemaName = client.toRemoteDataset(projectId, sourceTableName.getSchemaName())
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElseThrow(() -> new TableNotFoundException(viewDefinitionTableName));
-        String remoteTableName = bigQueryClient.toRemoteTable(projectId, remoteSchemaName, sourceTableName.getTableName())
+        String remoteTableName = client.toRemoteTable(projectId, remoteSchemaName, sourceTableName.getTableName())
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElseThrow(() -> new TableNotFoundException(viewDefinitionTableName));
-        TableInfo tableInfo = bigQueryClient.getTable(TableId.of(projectId, remoteSchemaName, remoteTableName))
+        TableInfo tableInfo = client.getTable(TableId.of(projectId, remoteSchemaName, remoteTableName))
                 .orElseThrow(() -> new TableNotFoundException(viewDefinitionTableName));
         if (!(tableInfo.getDefinition() instanceof ViewDefinition)) {
             throw new TableNotFoundException(viewDefinitionTableName);
@@ -263,8 +289,9 @@ public class BigQueryMetadata
     @Override
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
+        BigQueryClient client = bigQueryClientFactory.create(session);
         log.debug("getColumnHandles(session=%s, tableHandle=%s)", session, tableHandle);
-        return bigQueryClient.getColumns((BigQueryTableHandle) tableHandle).stream()
+        return client.getColumns((BigQueryTableHandle) tableHandle).stream()
                 .collect(toImmutableMap(columnHandle -> columnHandle.getColumnMetadata().getName(), identity()));
     }
 
@@ -288,7 +315,7 @@ public class BigQueryMetadata
                 .orElseGet(() -> listTables(session, prefix.getSchema()));
         for (SchemaTableName tableName : tables) {
             try {
-                Optional.ofNullable(getTableHandleIgnoringConflicts(tableName))
+                Optional.ofNullable(getTableHandleIgnoringConflicts(session, tableName))
                         .ifPresent(tableHandle -> columns.put(tableName, getTableMetadata(session, tableHandle).getColumns()));
             }
             catch (TableNotFoundException e) {
@@ -314,25 +341,27 @@ public class BigQueryMetadata
     @Override
     public void createSchema(ConnectorSession session, String schemaName, Map<String, Object> properties, TrinoPrincipal owner)
     {
+        BigQueryClient client = bigQueryClientFactory.create(session);
         checkArgument(properties.isEmpty(), "Can't have properties for schema creation");
         DatasetInfo datasetInfo = DatasetInfo.newBuilder(schemaName).build();
-        bigQueryClient.createSchema(datasetInfo);
+        client.createSchema(datasetInfo);
     }
 
     @Override
     public void dropSchema(ConnectorSession session, String schemaName)
     {
-        String remoteSchemaName = bigQueryClient.toRemoteDataset(projectId, schemaName)
+        BigQueryClient client = bigQueryClientFactory.create(session);
+        String remoteSchemaName = client.toRemoteDataset(getProjectId(client), schemaName)
                 .map(RemoteDatabaseObject::getOnlyRemoteName)
                 .orElseThrow(() -> new SchemaNotFoundException(schemaName));
-        bigQueryClient.dropSchema(DatasetId.of(remoteSchemaName));
+        client.dropSchema(DatasetId.of(remoteSchemaName));
     }
 
     @Override
     public void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, boolean ignoreExisting)
     {
         try {
-            createTable(tableMetadata);
+            createTable(session, tableMetadata);
         }
         catch (BigQueryException e) {
             if (ignoreExisting && e.getCode() == 409) {
@@ -342,7 +371,7 @@ public class BigQueryMetadata
         }
     }
 
-    private void createTable(ConnectorTableMetadata tableMetadata)
+    private void createTable(ConnectorSession session, ConnectorTableMetadata tableMetadata)
     {
         SchemaTableName schemaTableName = tableMetadata.getTable();
         String schemaName = schemaTableName.getSchemaName();
@@ -355,15 +384,16 @@ public class BigQueryMetadata
         TableDefinition tableDefinition = StandardTableDefinition.of(Schema.of(fields));
         TableInfo tableInfo = TableInfo.newBuilder(tableId, tableDefinition).build();
 
-        bigQueryClient.createTable(tableInfo);
+        bigQueryClientFactory.create(session).createTable(tableInfo);
     }
 
     @Override
     public void dropTable(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
+        BigQueryClient client = bigQueryClientFactory.create(session);
         BigQueryTableHandle bigQueryTable = (BigQueryTableHandle) tableHandle;
         TableId tableId = bigQueryTable.getRemoteTableName().toTableId();
-        bigQueryClient.dropTable(tableId);
+        client.dropTable(tableId);
     }
 
     @Override

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSourceProvider.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryPageSourceProvider.java
@@ -71,6 +71,6 @@ public class BigQueryPageSourceProvider
                 .map(BigQueryColumnHandle.class::cast)
                 .collect(toImmutableList());
 
-        return new BigQueryResultPageSource(bigQueryReadClientFactory, maxReadRowsRetries, bigQuerySplit, bigQueryColumnHandles);
+        return new BigQueryResultPageSource(bigQueryReadClientFactory.create(session), maxReadRowsRetries, bigQuerySplit, bigQueryColumnHandles);
     }
 }

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryResultPageSource.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQueryResultPageSource.java
@@ -91,12 +91,12 @@ public class BigQueryResultPageSource
     private final Iterator<ReadRowsResponse> responses;
 
     public BigQueryResultPageSource(
-            BigQueryReadClientFactory bigQueryReadClientFactory,
+            BigQueryReadClient bigQueryReadClient,
             int maxReadRowsRetries,
             BigQuerySplit split,
             List<BigQueryColumnHandle> columns)
     {
-        this.bigQueryReadClient = requireNonNull(bigQueryReadClientFactory, "bigQueryReadClientFactory is null").createBigQueryReadClient();
+        this.bigQueryReadClient = requireNonNull(bigQueryReadClient, "bigQueryReadClient is null");
         this.split = requireNonNull(split, "split is null");
         this.readBytes = new AtomicLong();
         requireNonNull(columns, "columns is null");

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/BigQuerySplitManager.java
@@ -55,7 +55,7 @@ public class BigQuerySplitManager
 {
     private static final Logger log = Logger.get(BigQuerySplitManager.class);
 
-    private final BigQueryClient bigQueryClient;
+    private final BigQueryClientFactory bigQueryClientFactory;
     private final BigQueryReadClientFactory bigQueryReadClientFactory;
     private final OptionalInt parallelism;
     private final boolean viewEnabled;
@@ -65,13 +65,13 @@ public class BigQuerySplitManager
     @Inject
     public BigQuerySplitManager(
             BigQueryConfig config,
-            BigQueryClient bigQueryClient,
+            BigQueryClientFactory bigQueryClientFactory,
             BigQueryReadClientFactory bigQueryReadClientFactory,
             NodeManager nodeManager)
     {
         requireNonNull(config, "config cannot be null");
 
-        this.bigQueryClient = requireNonNull(bigQueryClient, "bigQueryClient cannot be null");
+        this.bigQueryClientFactory = requireNonNull(bigQueryClientFactory, "bigQueryClientFactory cannot be null");
         this.bigQueryReadClientFactory = requireNonNull(bigQueryReadClientFactory, "bigQueryReadClientFactory cannot be null");
         this.parallelism = config.getParallelism();
         this.viewEnabled = config.isViewsEnabled();
@@ -95,8 +95,8 @@ public class BigQuerySplitManager
         TupleDomain<ColumnHandle> constraint = bigQueryTableHandle.getConstraint();
         Optional<String> filter = BigQueryFilterQueryBuilder.buildFilter(constraint);
         List<BigQuerySplit> splits = emptyProjectionIsRequired(bigQueryTableHandle.getProjectedColumns()) ?
-                createEmptyProjection(remoteTableId, actualParallelism, filter) :
-                readFromBigQuery(remoteTableId, bigQueryTableHandle.getProjectedColumns(), actualParallelism, filter);
+                createEmptyProjection(session, remoteTableId, actualParallelism, filter) :
+                readFromBigQuery(session, remoteTableId, bigQueryTableHandle.getProjectedColumns(), actualParallelism, filter);
         return new FixedSplitSource(splits);
     }
 
@@ -105,7 +105,7 @@ public class BigQuerySplitManager
         return projectedColumns.isPresent() && projectedColumns.get().isEmpty();
     }
 
-    private List<BigQuerySplit> readFromBigQuery(TableId remoteTableId, Optional<List<ColumnHandle>> projectedColumns, int actualParallelism, Optional<String> filter)
+    private List<BigQuerySplit> readFromBigQuery(ConnectorSession session, TableId remoteTableId, Optional<List<ColumnHandle>> projectedColumns, int actualParallelism, Optional<String> filter)
     {
         log.debug("readFromBigQuery(tableId=%s, projectedColumns=%s, actualParallelism=%s, filter=[%s])", remoteTableId, projectedColumns, actualParallelism, filter);
         List<ColumnHandle> columns = projectedColumns.orElse(ImmutableList.of());
@@ -113,35 +113,36 @@ public class BigQuerySplitManager
                 .map(column -> ((BigQueryColumnHandle) column).getName())
                 .collect(toImmutableList());
 
-        ReadSession readSession = new ReadSessionCreator(bigQueryClient, bigQueryReadClientFactory, viewEnabled, viewExpiration)
-                .create(remoteTableId, projectedColumnsNames, filter, actualParallelism);
+        ReadSession readSession = new ReadSessionCreator(bigQueryClientFactory, bigQueryReadClientFactory, viewEnabled, viewExpiration)
+                .create(session, remoteTableId, projectedColumnsNames, filter, actualParallelism);
 
         return readSession.getStreamsList().stream()
                 .map(stream -> BigQuerySplit.forStream(stream.getName(), readSession.getAvroSchema().getSchema(), columns))
                 .collect(toImmutableList());
     }
 
-    private List<BigQuerySplit> createEmptyProjection(TableId remoteTableId, int actualParallelism, Optional<String> filter)
+    private List<BigQuerySplit> createEmptyProjection(ConnectorSession session, TableId remoteTableId, int actualParallelism, Optional<String> filter)
     {
+        BigQueryClient client = bigQueryClientFactory.create(session);
         log.debug("createEmptyProjection(tableId=%s, actualParallelism=%s, filter=[%s])", remoteTableId, actualParallelism, filter);
         try {
             long numberOfRows;
             if (filter.isPresent()) {
                 // count the rows based on the filter
-                String sql = bigQueryClient.selectSql(remoteTableId, "COUNT(*)");
-                TableResult result = bigQueryClient.query(sql);
+                String sql = client.selectSql(remoteTableId, "COUNT(*)");
+                TableResult result = client.query(sql);
                 numberOfRows = result.iterateAll().iterator().next().get(0).getLongValue();
             }
             else {
                 // no filters, so we can take the value from the table info when the object is TABLE
-                TableInfo tableInfo = bigQueryClient.getTable(remoteTableId)
+                TableInfo tableInfo = client.getTable(remoteTableId)
                         .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(remoteTableId.getDataset(), remoteTableId.getTable())));
                 if (tableInfo.getDefinition().getType() == TABLE) {
                     numberOfRows = tableInfo.getNumRows().longValue();
                 }
                 else if (tableInfo.getDefinition().getType() == VIEW) {
-                    String sql = bigQueryClient.selectSql(remoteTableId, "COUNT(*)");
-                    TableResult result = bigQueryClient.query(sql);
+                    String sql = client.selectSql(remoteTableId, "COUNT(*)");
+                    TableResult result = client.query(sql);
                     numberOfRows = result.iterateAll().iterator().next().get(0).getLongValue();
                 }
                 else {

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/IdentityCacheMapping.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/IdentityCacheMapping.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import io.trino.spi.connector.ConnectorSession;
+
+public interface IdentityCacheMapping
+{
+    IdentityCacheKey getRemoteUserCacheKey(ConnectorSession session);
+
+    /**
+     * This will be used as cache key for creating BigQuery service. If {@link ConnectorSession} content can influence
+     * service creation we should chavereate {@link IdentityCacheKey} instance so
+     * we could cache proper service for given {@link ConnectorSession}.
+     */
+    abstract class IdentityCacheKey
+    {
+        @Override
+        public abstract int hashCode();
+
+        @Override
+        public abstract boolean equals(Object obj);
+    }
+
+    final class SingletonIdentityCacheMapping
+            implements IdentityCacheMapping
+    {
+        @Override
+        public IdentityCacheKey getRemoteUserCacheKey(ConnectorSession session)
+        {
+            return SingletonIdentityCacheKey.INSTANCE;
+        }
+
+        private static final class SingletonIdentityCacheKey
+                extends IdentityCacheKey
+        {
+            private static final SingletonIdentityCacheKey INSTANCE = new SingletonIdentityCacheKey();
+
+            @Override
+            public int hashCode()
+            {
+                return getClass().hashCode();
+            }
+
+            @Override
+            public boolean equals(Object obj)
+            {
+                return obj instanceof SingletonIdentityCacheKey;
+            }
+        }
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/StaticBigQueryCredentialsSupplier.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/StaticBigQueryCredentialsSupplier.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.api.client.util.Base64;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import io.trino.spi.connector.ConnectorSession;
+
+import javax.inject.Inject;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class StaticBigQueryCredentialsSupplier
+        implements BigQueryCredentialsSupplier
+{
+    private final Supplier<Optional<Credentials>> credentialsCreator;
+
+    @Inject
+    public StaticBigQueryCredentialsSupplier(BigQueryConfig config)
+    {
+        requireNonNull(config, "config is null");
+        // lazy creation, cache once it's created
+        Optional<Credentials> credentialsKey = config.getCredentialsKey()
+                .map(StaticBigQueryCredentialsSupplier::createCredentialsFromKey);
+
+        Optional<Credentials> credentialsFile = config.getCredentialsFile()
+                .map(StaticBigQueryCredentialsSupplier::createCredentialsFromFile);
+
+        this.credentialsCreator = Suppliers.memoize(() -> credentialsKey.or(() -> credentialsFile));
+    }
+
+    @Override
+    public Optional<Credentials> getCredentials(ConnectorSession session)
+    {
+        return credentialsCreator.get();
+    }
+
+    private static Credentials createCredentialsFromKey(String key)
+    {
+        try {
+            return GoogleCredentials.fromStream(new ByteArrayInputStream(Base64.decodeBase64(key)));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to create Credentials from key", e);
+        }
+    }
+
+    private static Credentials createCredentialsFromFile(String file)
+    {
+        try {
+            return GoogleCredentials.fromStream(new FileInputStream(file));
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException("Failed to create Credentials from file", e);
+        }
+    }
+}

--- a/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
+++ b/plugin/trino-bigquery/src/main/java/io/trino/plugin/bigquery/ViewMaterializationCache.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.bigquery;
+
+import com.google.cloud.BaseServiceException;
+import com.google.cloud.bigquery.BigQueryException;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Table;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.airlift.log.Logger;
+import io.airlift.units.Duration;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.TableNotFoundException;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+import static io.trino.plugin.bigquery.BigQueryErrorCode.BIGQUERY_VIEW_DESTINATION_TABLE_CREATION_FAILED;
+import static io.trino.plugin.bigquery.BigQueryUtil.convertToBigQueryException;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static java.util.UUID.randomUUID;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class ViewMaterializationCache
+{
+    private static final Logger log = Logger.get(ViewMaterializationCache.class);
+
+    private final Cache<String, TableInfo> destinationTableCache;
+    private final Optional<String> viewMaterializationProject;
+    private final Optional<String> viewMaterializationDataset;
+
+    @Inject
+    public ViewMaterializationCache(BigQueryConfig config)
+    {
+        requireNonNull(config, "config is null");
+        this.destinationTableCache = CacheBuilder.newBuilder()
+                .expireAfterWrite(config.getViewsCacheTtl().toMillis(), MILLISECONDS)
+                .maximumSize(1000)
+                .build();
+        this.viewMaterializationProject = config.getViewMaterializationProject();
+        this.viewMaterializationDataset = config.getViewMaterializationDataset();
+    }
+
+    public TableInfo getCachedTable(BigQueryClient client, String query, Duration viewExpiration, TableInfo remoteTableId)
+    {
+        try {
+            return destinationTableCache.get(query, new DestinationTableBuilder(client, viewExpiration, query, createDestinationTable(remoteTableId.getTableId())));
+        }
+        catch (ExecutionException e) {
+            throw new TrinoException(BIGQUERY_VIEW_DESTINATION_TABLE_CREATION_FAILED, "Error creating destination table", e);
+        }
+    }
+
+    private TableId createDestinationTable(TableId remoteTableId)
+    {
+        String project = viewMaterializationProject.orElse(remoteTableId.getProject());
+        String dataset = viewMaterializationDataset.orElse(remoteTableId.getDataset());
+
+        String name = format("_pbc_%s", randomUUID().toString().toLowerCase(ENGLISH).replace("-", ""));
+        return TableId.of(project, dataset, name);
+    }
+
+    private static class DestinationTableBuilder
+            implements Callable<TableInfo>
+    {
+        private final BigQueryClient bigQueryClient;
+        private final Duration viewExpiration;
+        private final String query;
+        private final TableId destinationTable;
+
+        DestinationTableBuilder(BigQueryClient bigQueryClient, Duration viewExpiration, String query, TableId destinationTable)
+        {
+            this.bigQueryClient = requireNonNull(bigQueryClient, "bigQueryClient is null");
+            this.viewExpiration = requireNonNull(viewExpiration, "viewExpiration is null");
+            this.query = requireNonNull(query, "query is null");
+            this.destinationTable = requireNonNull(destinationTable, "destinationTable is null");
+        }
+
+        @Override
+        public TableInfo call()
+        {
+            return createTableFromQuery();
+        }
+
+        private TableInfo createTableFromQuery()
+        {
+            log.debug("destinationTable is %s", destinationTable);
+            JobInfo jobInfo = JobInfo.of(
+                    QueryJobConfiguration
+                            .newBuilder(query)
+                            .setDestinationTable(destinationTable)
+                            .build());
+            log.debug("running query %s", jobInfo);
+            Job job = waitForJob(bigQueryClient.create(jobInfo));
+            log.debug("job has finished. %s", job);
+            if (job.getStatus().getError() != null) {
+                throw convertToBigQueryException(job.getStatus().getError());
+            }
+            // add expiration time to the table
+            TableInfo createdTable = bigQueryClient.getTable(destinationTable)
+                    .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(destinationTable.getDataset(), destinationTable.getTable())));
+            long expirationTimeMillis = createdTable.getCreationTime() + viewExpiration.toMillis();
+            Table updatedTable = bigQueryClient.update(createdTable.toBuilder()
+                    .setExpirationTime(expirationTimeMillis)
+                    .build());
+            return updatedTable;
+        }
+
+        private Job waitForJob(Job job)
+        {
+            try {
+                return job.waitFor();
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new BigQueryException(BaseServiceException.UNKNOWN_CODE, format("Job %s has been interrupted", job.getJobId()), e);
+            }
+        }
+    }
+}

--- a/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryClientFactory.java
+++ b/plugin/trino-bigquery/src/test/java/io/trino/plugin/bigquery/TestBigQueryClientFactory.java
@@ -22,12 +22,12 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestBigQueryConnectorModule
+public class TestBigQueryClientFactory
 {
     @Test
     public void testConfigurationOnly()
     {
-        String projectId = BigQueryConnectorModule.calculateBillingProjectId(Optional.of("pid"), Optional.empty());
+        String projectId = BigQueryClientFactory.calculateBillingProjectId(Optional.of("pid"), Optional.empty());
         assertThat(projectId).isEqualTo("pid");
     }
 
@@ -35,7 +35,7 @@ public class TestBigQueryConnectorModule
     public void testCredentialsOnly()
             throws Exception
     {
-        String projectId = BigQueryConnectorModule.calculateBillingProjectId(Optional.empty(), credentials());
+        String projectId = BigQueryClientFactory.calculateBillingProjectId(Optional.empty(), credentials());
         assertThat(projectId).isEqualTo("presto-bq-credentials-test");
     }
 
@@ -43,7 +43,7 @@ public class TestBigQueryConnectorModule
     public void testBothConfigurationAndCredentials()
             throws Exception
     {
-        String projectId = BigQueryConnectorModule.calculateBillingProjectId(Optional.of("pid"), credentials());
+        String projectId = BigQueryClientFactory.calculateBillingProjectId(Optional.of("pid"), credentials());
         assertThat(projectId).isEqualTo("pid");
     }
 


### PR DESCRIPTION
Prior to this change `BigQueryClient` was created on connector initialization
and now it's possible to configure it dynamically using `ConnectorSession`.

Additionaly cache `BigQueryClient` using identity key derived from `ConnectorSession`