### PR TITLE
Replace deprecated iceberg Rollback.toSnapshotId usage

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RollbackToSnapshotProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RollbackToSnapshotProcedure.java
@@ -65,6 +65,6 @@ public class RollbackToSnapshotProcedure
     {
         SchemaTableName schemaTableName = new SchemaTableName(schema, table);
         Table icebergTable = catalogFactory.create().loadTable(clientSession, schemaTableName);
-        icebergTable.rollback().toSnapshotId(snapshotId).commit();
+        icebergTable.manageSnapshots().setCurrentSnapshot(snapshotId).commit();
     }
 }


### PR DESCRIPTION
As title, replace deprecated Rollback.toSnapshotId(long) with ManageSnapshots.setCurrentSnapshot(long) in iceberg.