### PR TITLE
Explain circular dependency between analyzer and tasks

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/AddColumnTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/AddColumnTask.java
@@ -28,7 +28,8 @@ import io.trino.spi.type.TypeNotFoundException;
 import io.trino.sql.tree.AddColumn;
 import io.trino.sql.tree.ColumnDefinition;
 import io.trino.sql.tree.Expression;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
@@ -49,10 +50,21 @@ import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.toTypeSignature;
 import static io.trino.type.UnknownType.UNKNOWN;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class AddColumnTask
         implements DataDefinitionTask<AddColumn>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public AddColumnTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -62,9 +74,6 @@ public class AddColumnTask
     @Override
     public ListenableFuture<Void> execute(
             AddColumn statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/CallTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CallTask.java
@@ -39,6 +39,8 @@ import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Parameter;
 import io.trino.transaction.TransactionManager;
 
+import javax.inject.Inject;
+
 import java.lang.invoke.MethodType;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -63,10 +65,23 @@ import static io.trino.sql.ParameterUtils.parameterExtractor;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static io.trino.sql.planner.ExpressionInterpreter.evaluateConstantExpression;
 import static java.util.Arrays.asList;
+import static java.util.Objects.requireNonNull;
 
 public class CallTask
         implements DataDefinitionTask<Call>
 {
+    private final TransactionManager transactionManager;
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public CallTask(TransactionManager transactionManager, Metadata metadata, AccessControl accessControl)
+    {
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -76,9 +91,6 @@ public class CallTask
     @Override
     public ListenableFuture<Void> execute(
             Call call,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CommentTask.java
@@ -24,7 +24,8 @@ import io.trino.spi.connector.ColumnHandle;
 import io.trino.sql.tree.Comment;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.QualifiedName;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
@@ -37,10 +38,21 @@ import static io.trino.spi.StandardErrorCode.MISSING_TABLE;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class CommentTask
         implements DataDefinitionTask<Comment>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public CommentTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -50,9 +62,6 @@ public class CommentTask
     @Override
     public ListenableFuture<Void> execute(
             Comment statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/CommitTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CommitTask.java
@@ -16,21 +16,30 @@ package io.trino.execution;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
-import io.trino.metadata.Metadata;
-import io.trino.security.AccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.sql.tree.Commit;
 import io.trino.sql.tree.Expression;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
 
+import javax.inject.Inject;
+
 import java.util.List;
 
 import static io.trino.spi.StandardErrorCode.NOT_IN_TRANSACTION;
+import static java.util.Objects.requireNonNull;
 
 public class CommitTask
         implements DataDefinitionTask<Commit>
 {
+    private final TransactionManager transactionManager;
+
+    @Inject
+    public CommitTask(TransactionManager transactionManager)
+    {
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+    }
+
     @Override
     public String getName()
     {
@@ -40,9 +49,6 @@ public class CommitTask
     @Override
     public ListenableFuture<Void> execute(
             Commit statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
@@ -31,7 +31,6 @@ import io.trino.sql.tree.CreateMaterializedView;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.NodeRef;
 import io.trino.sql.tree.Parameter;
-import io.trino.transaction.TransactionManager;
 
 import javax.inject.Inject;
 
@@ -51,13 +50,17 @@ import static java.util.Objects.requireNonNull;
 public class CreateMaterializedViewTask
         implements DataDefinitionTask<CreateMaterializedView>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
     private final SqlParser sqlParser;
     private final GroupProvider groupProvider;
     private final StatsCalculator statsCalculator;
 
     @Inject
-    public CreateMaterializedViewTask(SqlParser sqlParser, GroupProvider groupProvider, StatsCalculator statsCalculator)
+    public CreateMaterializedViewTask(Metadata metadata, AccessControl accessControl, SqlParser sqlParser, GroupProvider groupProvider, StatsCalculator statsCalculator)
     {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
@@ -72,9 +75,6 @@ public class CreateMaterializedViewTask
     @Override
     public ListenableFuture<Void> execute(
             CreateMaterializedView statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateMaterializedViewTask.java
@@ -70,12 +70,6 @@ public class CreateMaterializedViewTask
     }
 
     @Override
-    public String explain(CreateMaterializedView statement, List<Expression> parameters)
-    {
-        return "CREATE MATERIALIZED VIEW " + statement.getName();
-    }
-
-    @Override
     public ListenableFuture<Void> execute(
             CreateMaterializedView statement,
             TransactionManager transactionManager,

--- a/core/trino-main/src/main/java/io/trino/execution/CreateRoleTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateRoleTask.java
@@ -22,7 +22,8 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.sql.tree.CreateRole;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Identifier;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,10 +35,21 @@ import static io.trino.metadata.MetadataUtil.processRoleCommandCatalog;
 import static io.trino.spi.StandardErrorCode.ROLE_ALREADY_EXISTS;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class CreateRoleTask
         implements DataDefinitionTask<CreateRole>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public CreateRoleTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -47,9 +59,6 @@ public class CreateRoleTask
     @Override
     public ListenableFuture<Void> execute(
             CreateRole statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/CreateSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateSchemaTask.java
@@ -26,7 +26,8 @@ import io.trino.spi.security.PrincipalType;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.sql.tree.CreateSchema;
 import io.trino.sql.tree.Expression;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
@@ -42,10 +43,21 @@ import static io.trino.spi.StandardErrorCode.SCHEMA_ALREADY_EXISTS;
 import static io.trino.sql.NodeUtils.mapFromProperties;
 import static io.trino.sql.ParameterUtils.parameterExtractor;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class CreateSchemaTask
         implements DataDefinitionTask<CreateSchema>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public CreateSchemaTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -55,9 +67,6 @@ public class CreateSchemaTask
     @Override
     public ListenableFuture<Void> execute(
             CreateSchema statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/CreateSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateSchemaTask.java
@@ -53,12 +53,6 @@ public class CreateSchemaTask
     }
 
     @Override
-    public String explain(CreateSchema statement, List<Expression> parameters)
-    {
-        return "CREATE SCHEMA " + statement.getSchemaName();
-    }
-
-    @Override
     public ListenableFuture<Void> execute(
             CreateSchema statement,
             TransactionManager transactionManager,

--- a/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateTableTask.java
@@ -99,12 +99,6 @@ public class CreateTableTask
     }
 
     @Override
-    public String explain(CreateTable statement, List<Expression> parameters)
-    {
-        return "CREATE TABLE " + statement.getName();
-    }
-
-    @Override
     public ListenableFuture<Void> execute(
             CreateTable statement,
             TransactionManager transactionManager,

--- a/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
@@ -29,7 +29,6 @@ import io.trino.sql.analyzer.Analyzer;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.CreateView;
 import io.trino.sql.tree.Expression;
-import io.trino.transaction.TransactionManager;
 
 import javax.inject.Inject;
 
@@ -47,13 +46,17 @@ import static java.util.Objects.requireNonNull;
 public class CreateViewTask
         implements DataDefinitionTask<CreateView>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
     private final SqlParser sqlParser;
     private final GroupProvider groupProvider;
     private final StatsCalculator statsCalculator;
 
     @Inject
-    public CreateViewTask(SqlParser sqlParser, GroupProvider groupProvider, StatsCalculator statsCalculator)
+    public CreateViewTask(Metadata metadata, AccessControl accessControl, SqlParser sqlParser, GroupProvider groupProvider, StatsCalculator statsCalculator)
     {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
         this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
@@ -68,9 +71,6 @@ public class CreateViewTask
     @Override
     public ListenableFuture<Void> execute(
             CreateView statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
@@ -15,17 +15,15 @@ package io.trino.execution;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.Session;
-import io.trino.cost.StatsCalculator;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.ViewColumn;
 import io.trino.metadata.ViewDefinition;
 import io.trino.security.AccessControl;
-import io.trino.spi.security.GroupProvider;
 import io.trino.spi.security.Identity;
 import io.trino.sql.analyzer.Analysis;
-import io.trino.sql.analyzer.Analyzer;
+import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.CreateView;
 import io.trino.sql.tree.Expression;
@@ -49,17 +47,15 @@ public class CreateViewTask
     private final Metadata metadata;
     private final AccessControl accessControl;
     private final SqlParser sqlParser;
-    private final GroupProvider groupProvider;
-    private final StatsCalculator statsCalculator;
+    private final AnalyzerFactory analyzerFactory;
 
     @Inject
-    public CreateViewTask(Metadata metadata, AccessControl accessControl, SqlParser sqlParser, GroupProvider groupProvider, StatsCalculator statsCalculator)
+    public CreateViewTask(Metadata metadata, AccessControl accessControl, SqlParser sqlParser, AnalyzerFactory analyzerFactory)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
-        this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
-        this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
+        this.analyzerFactory = requireNonNull(analyzerFactory, "analyzerFactory is null");
     }
 
     @Override
@@ -82,7 +78,7 @@ public class CreateViewTask
 
         String sql = getFormattedSql(statement.getQuery(), sqlParser);
 
-        Analysis analysis = new Analyzer(session, metadata, sqlParser, groupProvider, accessControl, Optional.empty(), parameters, parameterExtractor(statement, parameters), stateMachine.getWarningCollector(), statsCalculator)
+        Analysis analysis = analyzerFactory.createAnalyzer(session, parameters, parameterExtractor(statement, parameters), stateMachine.getWarningCollector())
                 .analyze(statement);
 
         List<ViewColumn> columns = analysis.getOutputDescriptor(statement.getQuery())

--- a/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/CreateViewTask.java
@@ -66,12 +66,6 @@ public class CreateViewTask
     }
 
     @Override
-    public String explain(CreateView statement, List<Expression> parameters)
-    {
-        return "CREATE VIEW " + statement.getName();
-    }
-
-    @Override
     public ListenableFuture<Void> execute(
             CreateView statement,
             TransactionManager transactionManager,

--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionExecution.java
@@ -23,15 +23,12 @@ import io.trino.execution.QueryPreparer.PreparedQuery;
 import io.trino.execution.StateMachine.StateChangeListener;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.memory.VersionedMemoryPoolId;
-import io.trino.metadata.Metadata;
-import io.trino.security.AccessControl;
 import io.trino.server.BasicQueryInfo;
 import io.trino.server.protocol.Slug;
 import io.trino.spi.QueryId;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Statement;
-import io.trino.transaction.TransactionManager;
 import org.joda.time.DateTime;
 
 import javax.annotation.Nullable;
@@ -54,9 +51,6 @@ public class DataDefinitionExecution<T extends Statement>
     private final DataDefinitionTask<T> task;
     private final T statement;
     private final Slug slug;
-    private final TransactionManager transactionManager;
-    private final Metadata metadata;
-    private final AccessControl accessControl;
     private final QueryStateMachine stateMachine;
     private final List<Expression> parameters;
     private final WarningCollector warningCollector;
@@ -65,9 +59,6 @@ public class DataDefinitionExecution<T extends Statement>
             DataDefinitionTask<T> task,
             T statement,
             Slug slug,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)
@@ -75,9 +66,6 @@ public class DataDefinitionExecution<T extends Statement>
         this.task = requireNonNull(task, "task is null");
         this.statement = requireNonNull(statement, "statement is null");
         this.slug = requireNonNull(slug, "slug is null");
-        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
-        this.metadata = requireNonNull(metadata, "metadata is null");
-        this.accessControl = requireNonNull(accessControl, "accessControl is null");
         this.stateMachine = requireNonNull(stateMachine, "stateMachine is null");
         this.parameters = parameters;
         this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
@@ -167,7 +155,7 @@ public class DataDefinitionExecution<T extends Statement>
                 return;
             }
 
-            ListenableFuture<Void> future = task.execute(statement, transactionManager, metadata, accessControl, stateMachine, parameters, warningCollector);
+            ListenableFuture<Void> future = task.execute(statement, stateMachine, parameters, warningCollector);
             Futures.addCallback(future, new FutureCallback<>()
             {
                 @Override
@@ -293,21 +281,11 @@ public class DataDefinitionExecution<T extends Statement>
     public static class DataDefinitionExecutionFactory
             implements QueryExecutionFactory<DataDefinitionExecution<?>>
     {
-        private final TransactionManager transactionManager;
-        private final Metadata metadata;
-        private final AccessControl accessControl;
         private final Map<Class<? extends Statement>, DataDefinitionTask<?>> tasks;
 
         @Inject
-        public DataDefinitionExecutionFactory(
-                TransactionManager transactionManager,
-                Metadata metadata,
-                AccessControl accessControl,
-                Map<Class<? extends Statement>, DataDefinitionTask<?>> tasks)
+        public DataDefinitionExecutionFactory(Map<Class<? extends Statement>, DataDefinitionTask<?>> tasks)
         {
-            this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
-            this.metadata = requireNonNull(metadata, "metadata is null");
-            this.accessControl = requireNonNull(accessControl, "accessControl is null");
             this.tasks = requireNonNull(tasks, "tasks is null");
         }
 
@@ -333,7 +311,7 @@ public class DataDefinitionExecution<T extends Statement>
             checkArgument(task != null, "no task for statement: %s", statement.getClass().getSimpleName());
 
             stateMachine.setUpdateType(task.getName());
-            return new DataDefinitionExecution<>(task, statement, slug, transactionManager, metadata, accessControl, stateMachine, parameters, warningCollector);
+            return new DataDefinitionExecution<>(task, statement, slug, stateMachine, parameters, warningCollector);
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionTask.java
@@ -15,11 +15,8 @@ package io.trino.execution;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.execution.warnings.WarningCollector;
-import io.trino.metadata.Metadata;
-import io.trino.security.AccessControl;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Statement;
-import io.trino.transaction.TransactionManager;
 
 import java.util.List;
 
@@ -29,9 +26,6 @@ public interface DataDefinitionTask<T extends Statement>
 
     ListenableFuture<Void> execute(
             T statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector);

--- a/core/trino-main/src/main/java/io/trino/execution/DataDefinitionTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DataDefinitionTask.java
@@ -17,7 +17,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
 import io.trino.security.AccessControl;
-import io.trino.sql.SqlFormatter;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Statement;
 import io.trino.transaction.TransactionManager;
@@ -37,18 +36,8 @@ public interface DataDefinitionTask<T extends Statement>
             List<Expression> parameters,
             WarningCollector warningCollector);
 
-    default String explain(T statement, List<Expression> parameters)
+    interface ExplainDataDefinition<T extends Statement>
     {
-        StringBuilder builder = new StringBuilder();
-
-        builder.append(SqlFormatter.formatSql(statement));
-
-        if (!parameters.isEmpty()) {
-            builder.append("\n")
-                    .append("Parameters: ")
-                    .append(parameters);
-        }
-
-        return builder.toString();
+        String explain(T statement, List<Expression> parameters);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/DeallocateTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DeallocateTask.java
@@ -15,11 +15,8 @@ package io.trino.execution;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.execution.warnings.WarningCollector;
-import io.trino.metadata.Metadata;
-import io.trino.security.AccessControl;
 import io.trino.sql.tree.Deallocate;
 import io.trino.sql.tree.Expression;
-import io.trino.transaction.TransactionManager;
 
 import java.util.List;
 
@@ -37,9 +34,6 @@ public class DeallocateTask
     @Override
     public ListenableFuture<Void> execute(
             Deallocate statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/DropColumnTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropColumnTask.java
@@ -23,7 +23,8 @@ import io.trino.security.AccessControl;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.sql.tree.DropColumn;
 import io.trino.sql.tree.Expression;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,10 +36,21 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class DropColumnTask
         implements DataDefinitionTask<DropColumn>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public DropColumnTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -48,9 +60,6 @@ public class DropColumnTask
     @Override
     public ListenableFuture<Void> execute(
             DropColumn statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/DropMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropMaterializedViewTask.java
@@ -22,7 +22,8 @@ import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.sql.tree.DropMaterializedView;
 import io.trino.sql.tree.Expression;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,10 +32,21 @@ import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class DropMaterializedViewTask
         implements DataDefinitionTask<DropMaterializedView>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public DropMaterializedViewTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -44,9 +56,6 @@ public class DropMaterializedViewTask
     @Override
     public ListenableFuture<Void> execute(
             DropMaterializedView statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/DropRoleTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropRoleTask.java
@@ -21,7 +21,8 @@ import io.trino.security.AccessControl;
 import io.trino.sql.tree.DropRole;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Identifier;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -30,10 +31,21 @@ import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.checkRoleExists;
 import static io.trino.metadata.MetadataUtil.processRoleCommandCatalog;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class DropRoleTask
         implements DataDefinitionTask<DropRole>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public DropRoleTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -43,9 +55,6 @@ public class DropRoleTask
     @Override
     public ListenableFuture<Void> execute(
             DropRole statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
@@ -23,7 +23,8 @@ import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.sql.tree.DropSchema;
 import io.trino.sql.tree.Expression;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,10 +35,21 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_EMPTY;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class DropSchemaTask
         implements DataDefinitionTask<DropSchema>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public DropSchemaTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -47,9 +59,6 @@ public class DropSchemaTask
     @Override
     public ListenableFuture<Void> execute(
             DropSchema statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropSchemaTask.java
@@ -45,12 +45,6 @@ public class DropSchemaTask
     }
 
     @Override
-    public String explain(DropSchema statement, List<Expression> parameters)
-    {
-        return "DROP SCHEMA " + statement.getSchemaName();
-    }
-
-    @Override
     public ListenableFuture<Void> execute(
             DropSchema statement,
             TransactionManager transactionManager,

--- a/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropTableTask.java
@@ -22,7 +22,8 @@ import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.sql.tree.DropTable;
 import io.trino.sql.tree.Expression;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,10 +32,21 @@ import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class DropTableTask
         implements DataDefinitionTask<DropTable>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public DropTableTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -44,9 +56,6 @@ public class DropTableTask
     @Override
     public ListenableFuture<Void> execute(
             DropTable statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/DropViewTask.java
@@ -22,7 +22,8 @@ import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.sql.tree.DropView;
 import io.trino.sql.tree.Expression;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,10 +32,21 @@ import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class DropViewTask
         implements DataDefinitionTask<DropView>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public DropViewTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -44,9 +56,6 @@ public class DropViewTask
     @Override
     public ListenableFuture<Void> execute(
             DropView statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/GrantRolesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/GrantRolesTask.java
@@ -23,7 +23,8 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.GrantRoles;
 import io.trino.sql.tree.Identifier;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -37,10 +38,21 @@ import static io.trino.metadata.MetadataUtil.checkRoleExists;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.processRoleCommandCatalog;
 import static io.trino.spi.security.PrincipalType.ROLE;
+import static java.util.Objects.requireNonNull;
 
 public class GrantRolesTask
         implements DataDefinitionTask<GrantRoles>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public GrantRolesTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -50,9 +62,6 @@ public class GrantRolesTask
     @Override
     public ListenableFuture<Void> execute(
             GrantRoles statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/GrantTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/GrantTask.java
@@ -25,7 +25,8 @@ import io.trino.spi.security.Privilege;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Grant;
 import io.trino.sql.tree.GrantOnType;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -41,10 +42,21 @@ import static io.trino.spi.StandardErrorCode.INVALID_PRIVILEGE;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class GrantTask
         implements DataDefinitionTask<Grant>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public GrantTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -54,23 +66,20 @@ public class GrantTask
     @Override
     public ListenableFuture<Void> execute(
             Grant statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)
     {
         if (statement.getType().filter(GrantOnType.SCHEMA::equals).isPresent()) {
-            executeGrantOnSchema(stateMachine.getSession(), statement, metadata, accessControl);
+            executeGrantOnSchema(stateMachine.getSession(), statement);
         }
         else {
-            executeGrantOnTable(stateMachine.getSession(), statement, metadata, accessControl);
+            executeGrantOnTable(stateMachine.getSession(), statement);
         }
         return immediateVoidFuture();
     }
 
-    private void executeGrantOnSchema(Session session, Grant statement, Metadata metadata, AccessControl accessControl)
+    private void executeGrantOnSchema(Session session, Grant statement)
     {
         CatalogSchemaName schemaName = createCatalogSchemaName(session, statement, Optional.of(statement.getName()));
 
@@ -86,7 +95,7 @@ public class GrantTask
         metadata.grantSchemaPrivileges(session, schemaName, privileges, createPrincipal(statement.getGrantee()), statement.isWithGrantOption());
     }
 
-    private void executeGrantOnTable(Session session, Grant statement, Metadata metadata, AccessControl accessControl)
+    private void executeGrantOnTable(Session session, Grant statement)
     {
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);

--- a/core/trino-main/src/main/java/io/trino/execution/PrepareTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/PrepareTask.java
@@ -15,8 +15,6 @@ package io.trino.execution;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.execution.warnings.WarningCollector;
-import io.trino.metadata.Metadata;
-import io.trino.security.AccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.Deallocate;
@@ -24,7 +22,6 @@ import io.trino.sql.tree.Execute;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Prepare;
 import io.trino.sql.tree.Statement;
-import io.trino.transaction.TransactionManager;
 
 import javax.inject.Inject;
 
@@ -56,9 +53,6 @@ public class PrepareTask
     @Override
     public ListenableFuture<Void> execute(
             Prepare prepare,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/PrepareTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/PrepareTask.java
@@ -54,12 +54,6 @@ public class PrepareTask
     }
 
     @Override
-    public String explain(Prepare statement, List<Expression> parameters)
-    {
-        return "PREPARE " + statement.getName();
-    }
-
-    @Override
     public ListenableFuture<Void> execute(
             Prepare prepare,
             TransactionManager transactionManager,

--- a/core/trino-main/src/main/java/io/trino/execution/RenameColumnTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameColumnTask.java
@@ -23,7 +23,8 @@ import io.trino.security.AccessControl;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameColumn;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
@@ -37,10 +38,21 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class RenameColumnTask
         implements DataDefinitionTask<RenameColumn>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public RenameColumnTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -50,9 +62,6 @@ public class RenameColumnTask
     @Override
     public ListenableFuture<Void> execute(
             RenameColumn statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameMaterializedViewTask.java
@@ -22,7 +22,8 @@ import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameMaterializedView;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,10 +35,21 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class RenameMaterializedViewTask
         implements DataDefinitionTask<RenameMaterializedView>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public RenameMaterializedViewTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -47,9 +59,6 @@ public class RenameMaterializedViewTask
     @Override
     public ListenableFuture<Void> execute(
             RenameMaterializedView statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/RenameSchemaTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameSchemaTask.java
@@ -21,7 +21,8 @@ import io.trino.security.AccessControl;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameSchema;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -31,10 +32,21 @@ import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
 import static io.trino.spi.StandardErrorCode.SCHEMA_ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class RenameSchemaTask
         implements DataDefinitionTask<RenameSchema>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public RenameSchemaTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -44,9 +56,6 @@ public class RenameSchemaTask
     @Override
     public ListenableFuture<Void> execute(
             RenameSchema statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameTableTask.java
@@ -22,7 +22,8 @@ import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameTable;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,10 +35,21 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class RenameTableTask
         implements DataDefinitionTask<RenameTable>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public RenameTableTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -47,9 +59,6 @@ public class RenameTableTask
     @Override
     public ListenableFuture<Void> execute(
             RenameTable statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RenameViewTask.java
@@ -22,7 +22,8 @@ import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.RenameView;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,10 +35,21 @@ import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_ALREADY_EXISTS;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class RenameViewTask
         implements DataDefinitionTask<RenameView>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public RenameViewTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -47,9 +59,6 @@ public class RenameViewTask
     @Override
     public ListenableFuture<Void> execute(
             RenameView statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/ResetSessionTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/ResetSessionTask.java
@@ -17,10 +17,10 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.connector.CatalogName;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
-import io.trino.security.AccessControl;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.ResetSession;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 
@@ -28,10 +28,19 @@ import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.spi.StandardErrorCode.CATALOG_NOT_FOUND;
 import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class ResetSessionTask
         implements DataDefinitionTask<ResetSession>
 {
+    private final Metadata metadata;
+
+    @Inject
+    public ResetSessionTask(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
     @Override
     public String getName()
     {
@@ -41,9 +50,6 @@ public class ResetSessionTask
     @Override
     public ListenableFuture<Void> execute(
             ResetSession statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/RevokeRolesTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RevokeRolesTask.java
@@ -23,7 +23,8 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.RevokeRoles;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -37,10 +38,21 @@ import static io.trino.metadata.MetadataUtil.checkRoleExists;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.processRoleCommandCatalog;
 import static io.trino.spi.security.PrincipalType.ROLE;
+import static java.util.Objects.requireNonNull;
 
 public class RevokeRolesTask
         implements DataDefinitionTask<RevokeRoles>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public RevokeRolesTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -50,9 +62,6 @@ public class RevokeRolesTask
     @Override
     public ListenableFuture<Void> execute(
             RevokeRoles statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/RollbackTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/RollbackTask.java
@@ -16,22 +16,31 @@ package io.trino.execution;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
-import io.trino.metadata.Metadata;
-import io.trino.security.AccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Rollback;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
 
+import javax.inject.Inject;
+
 import java.util.List;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.spi.StandardErrorCode.NOT_IN_TRANSACTION;
+import static java.util.Objects.requireNonNull;
 
 public class RollbackTask
         implements DataDefinitionTask<Rollback>
 {
+    private final TransactionManager transactionManager;
+
+    @Inject
+    public RollbackTask(TransactionManager transactionManager)
+    {
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+    }
+
     @Override
     public String getName()
     {
@@ -41,9 +50,6 @@ public class RollbackTask
     @Override
     public ListenableFuture<Void> execute(
             Rollback statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/SetPathTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetPathTask.java
@@ -18,13 +18,13 @@ import io.trino.Session;
 import io.trino.client.ClientCapabilities;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
-import io.trino.security.AccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.sql.SqlPath;
 import io.trino.sql.SqlPathElement;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.SetPath;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -35,10 +35,19 @@ import static io.trino.spi.StandardErrorCode.MISSING_CATALOG_NAME;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class SetPathTask
         implements DataDefinitionTask<SetPath>
 {
+    private final Metadata metadata;
+
+    @Inject
+    public SetPathTask(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
     @Override
     public String getName()
     {
@@ -48,9 +57,6 @@ public class SetPathTask
     @Override
     public ListenableFuture<Void> execute(
             SetPath statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/SetRoleTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetRoleTask.java
@@ -25,7 +25,8 @@ import io.trino.spi.security.TrinoPrincipal;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Identifier;
 import io.trino.sql.tree.SetRole;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -38,10 +39,21 @@ import static io.trino.spi.security.AccessDeniedException.denySetRole;
 import static io.trino.spi.security.PrincipalType.USER;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class SetRoleTask
         implements DataDefinitionTask<SetRole>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public SetRoleTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -51,9 +63,6 @@ public class SetRoleTask
     @Override
     public ListenableFuture<Void> execute(
             SetRole statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/SetSchemaAuthorizationTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetSchemaAuthorizationTask.java
@@ -22,7 +22,8 @@ import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.SetSchemaAuthorization;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -33,10 +34,21 @@ import static io.trino.metadata.MetadataUtil.createCatalogSchemaName;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.spi.StandardErrorCode.SCHEMA_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class SetSchemaAuthorizationTask
         implements DataDefinitionTask<SetSchemaAuthorization>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public SetSchemaAuthorizationTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -46,9 +58,6 @@ public class SetSchemaAuthorizationTask
     @Override
     public ListenableFuture<Void> execute(
             SetSchemaAuthorization statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/SetSessionTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetSessionTask.java
@@ -26,7 +26,8 @@ import io.trino.spi.type.Type;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.QualifiedName;
 import io.trino.sql.tree.SetSession;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 
@@ -38,10 +39,21 @@ import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static io.trino.sql.ParameterUtils.parameterExtractor;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public class SetSessionTask
         implements DataDefinitionTask<SetSession>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public SetSessionTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -51,9 +63,6 @@ public class SetSessionTask
     @Override
     public ListenableFuture<Void> execute(
             SetSession statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/SetTableAuthorizationTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetTableAuthorizationTask.java
@@ -22,7 +22,8 @@ import io.trino.security.AccessControl;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.SetTableAuthorization;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,10 +35,21 @@ import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class SetTableAuthorizationTask
         implements DataDefinitionTask<SetTableAuthorization>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public SetTableAuthorizationTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -47,9 +59,6 @@ public class SetTableAuthorizationTask
     @Override
     public ListenableFuture<Void> execute(
             SetTableAuthorization statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/SetViewAuthorizationTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetViewAuthorizationTask.java
@@ -22,7 +22,8 @@ import io.trino.security.AccessControl;
 import io.trino.spi.security.TrinoPrincipal;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.SetViewAuthorization;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,10 +35,21 @@ import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class SetViewAuthorizationTask
         implements DataDefinitionTask<SetViewAuthorization>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public SetViewAuthorizationTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -47,9 +59,6 @@ public class SetViewAuthorizationTask
     @Override
     public ListenableFuture<Void> execute(
             SetViewAuthorization statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/StartTransactionTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StartTransactionTask.java
@@ -16,8 +16,6 @@ package io.trino.execution;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
-import io.trino.metadata.Metadata;
-import io.trino.security.AccessControl;
 import io.trino.spi.StandardErrorCode;
 import io.trino.spi.TrinoException;
 import io.trino.spi.transaction.IsolationLevel;
@@ -28,16 +26,27 @@ import io.trino.sql.tree.TransactionAccessMode;
 import io.trino.transaction.TransactionId;
 import io.trino.transaction.TransactionManager;
 
+import javax.inject.Inject;
+
 import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.spi.StandardErrorCode.SYNTAX_ERROR;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class StartTransactionTask
         implements DataDefinitionTask<StartTransaction>
 {
+    private final TransactionManager transactionManager;
+
+    @Inject
+    public StartTransactionTask(TransactionManager transactionManager)
+    {
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+    }
+
     @Override
     public String getName()
     {
@@ -47,9 +56,6 @@ public class StartTransactionTask
     @Override
     public ListenableFuture<Void> execute(
             StartTransaction statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TruncateTableTask.java
@@ -22,7 +22,8 @@ import io.trino.metadata.TableHandle;
 import io.trino.security.AccessControl;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.TruncateTable;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,10 +33,21 @@ import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
+import static java.util.Objects.requireNonNull;
 
 public class TruncateTableTask
         implements DataDefinitionTask<TruncateTable>
 {
+    private final Metadata metadata;
+    private final AccessControl accessControl;
+
+    @Inject
+    public TruncateTableTask(Metadata metadata, AccessControl accessControl)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+    }
+
     @Override
     public String getName()
     {
@@ -45,9 +57,6 @@ public class TruncateTableTask
     @Override
     public ListenableFuture<Void> execute(
             TruncateTable statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/execution/UseTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/UseTask.java
@@ -17,12 +17,12 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
-import io.trino.security.AccessControl;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.CatalogSchemaName;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.Use;
-import io.trino.transaction.TransactionManager;
+
+import javax.inject.Inject;
 
 import java.util.List;
 
@@ -31,10 +31,19 @@ import static io.trino.spi.StandardErrorCode.MISSING_CATALOG_NAME;
 import static io.trino.spi.StandardErrorCode.NOT_FOUND;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
 import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
 
 public class UseTask
         implements DataDefinitionTask<Use>
 {
+    private final Metadata metadata;
+
+    @Inject
+    public UseTask(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
     @Override
     public String getName()
     {
@@ -44,9 +53,6 @@ public class UseTask
     @Override
     public ListenableFuture<Void> execute(
             Use statement,
-            TransactionManager transactionManager,
-            Metadata metadata,
-            AccessControl accessControl,
             QueryStateMachine stateMachine,
             List<Expression> parameters,
             WarningCollector warningCollector)

--- a/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
+++ b/core/trino-main/src/main/java/io/trino/server/testing/TestingTrinoServer.java
@@ -75,6 +75,7 @@ import io.trino.spi.security.GroupProvider;
 import io.trino.spi.security.SystemAccessControl;
 import io.trino.split.PageSourceManager;
 import io.trino.split.SplitManager;
+import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.sql.planner.Plan;
 import io.trino.testing.ProcedureTester;
@@ -140,6 +141,7 @@ public class TestingTrinoServer
     private final CatalogManager catalogManager;
     private final TransactionManager transactionManager;
     private final Metadata metadata;
+    private final AnalyzerFactory analyzerFactory;
     private final StatsCalculator statsCalculator;
     private final TestingAccessControlManager accessControl;
     private final TestingGroupProvider groupProvider;
@@ -293,6 +295,7 @@ public class TestingTrinoServer
         splitManager = injector.getInstance(SplitManager.class);
         pageSourceManager = injector.getInstance(PageSourceManager.class);
         if (coordinator) {
+            analyzerFactory = injector.getInstance(AnalyzerFactory.class);
             dispatchManager = injector.getInstance(DispatchManager.class);
             queryManager = (SqlQueryManager) injector.getInstance(QueryManager.class);
             resourceGroupManager = Optional.of((InternalResourceGroupManager<?>) injector.getInstance(InternalResourceGroupManager.class));
@@ -303,6 +306,7 @@ public class TestingTrinoServer
             injector.getInstance(CertificateAuthenticatorManager.class).useDefaultAuthenticator();
         }
         else {
+            analyzerFactory = null;
             dispatchManager = null;
             queryManager = null;
             resourceGroupManager = Optional.empty();
@@ -435,6 +439,11 @@ public class TestingTrinoServer
     public Metadata getMetadata()
     {
         return metadata;
+    }
+
+    public AnalyzerFactory getAnalyzerFactory()
+    {
+        return analyzerFactory;
     }
 
     public StatsCalculator getStatsCalculator()

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/AnalyzerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/AnalyzerFactory.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.analyzer;
+
+import io.trino.Session;
+import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.Metadata;
+import io.trino.security.AccessControl;
+import io.trino.spi.security.GroupProvider;
+import io.trino.sql.parser.SqlParser;
+import io.trino.sql.rewrite.StatementRewrite;
+import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.NodeRef;
+import io.trino.sql.tree.Parameter;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class AnalyzerFactory
+{
+    private final Metadata metadata;
+    private final SqlParser sqlParser;
+    private final AccessControl accessControl;
+    private final GroupProvider groupProvider;
+    private final StatementRewrite statementRewrite;
+
+    @Inject
+    public AnalyzerFactory(
+            Metadata metadata,
+            SqlParser sqlParser,
+            AccessControl accessControl,
+            GroupProvider groupProvider,
+            StatementRewrite statementRewrite)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
+        this.statementRewrite = requireNonNull(statementRewrite, "statementRewrite is null");
+    }
+
+    public Analyzer createAnalyzer(
+            Session session,
+            List<Expression> parameters,
+            Map<NodeRef<Parameter>, Expression> parameterLookup,
+            WarningCollector warningCollector)
+    {
+        return new Analyzer(
+                session,
+                metadata,
+                sqlParser,
+                this,
+                groupProvider,
+                accessControl,
+                parameters,
+                parameterLookup,
+                warningCollector,
+                statementRewrite);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/QueryExplainerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/QueryExplainerFactory.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.analyzer;
+
+import io.trino.cost.CostCalculator;
+import io.trino.cost.StatsCalculator;
+import io.trino.metadata.Metadata;
+import io.trino.spi.type.TypeOperators;
+import io.trino.sql.parser.SqlParser;
+import io.trino.sql.planner.PlanFragmenter;
+import io.trino.sql.planner.PlanOptimizersFactory;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueryExplainerFactory
+{
+    private final PlanOptimizersFactory planOptimizersFactory;
+    private final PlanFragmenter planFragmenter;
+    private final Metadata metadata;
+    private final TypeOperators typeOperators;
+    private final SqlParser sqlParser;
+    private final StatsCalculator statsCalculator;
+    private final CostCalculator costCalculator;
+
+    @Inject
+    public QueryExplainerFactory(
+            PlanOptimizersFactory planOptimizersFactory,
+            PlanFragmenter planFragmenter,
+            Metadata metadata,
+            TypeOperators typeOperators,
+            SqlParser sqlParser,
+            StatsCalculator statsCalculator,
+            CostCalculator costCalculator)
+    {
+        this.planOptimizersFactory = requireNonNull(planOptimizersFactory, "planOptimizersFactory is null");
+        this.planFragmenter = requireNonNull(planFragmenter, "planFragmenter is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.typeOperators = requireNonNull(typeOperators, "typeOperators is null");
+        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
+        this.costCalculator = requireNonNull(costCalculator, "costCalculator is null");
+    }
+
+    public QueryExplainer createQueryExplainer(AnalyzerFactory analyzerFactory)
+    {
+        return new QueryExplainer(
+                planOptimizersFactory,
+                planFragmenter,
+                metadata,
+                typeOperators,
+                sqlParser,
+                analyzerFactory,
+                statsCalculator,
+                costCalculator);
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizersFactory.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizersFactory.java
@@ -13,6 +13,7 @@
  */
 package io.trino.sql.planner;
 
+import com.google.common.collect.ImmutableMap;
 import io.trino.sql.planner.iterative.RuleStats;
 import io.trino.sql.planner.optimizations.OptimizerStats;
 import io.trino.sql.planner.optimizations.PlanOptimizer;
@@ -24,7 +25,13 @@ public interface PlanOptimizersFactory
 {
     List<PlanOptimizer> get();
 
-    Map<Class<?>, OptimizerStats> getOptimizerStats();
+    default Map<Class<?>, OptimizerStats> getOptimizerStats()
+    {
+        return ImmutableMap.of();
+    }
 
-    Map<Class<?>, RuleStats> getRuleStats();
+    default Map<Class<?>, RuleStats> getRuleStats()
+    {
+        return ImmutableMap.of();
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/DescribeOutputRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/DescribeOutputRewrite.java
@@ -15,17 +15,13 @@ package io.trino.sql.rewrite;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.Session;
-import io.trino.cost.StatsCalculator;
 import io.trino.execution.warnings.WarningCollector;
-import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
-import io.trino.security.AccessControl;
-import io.trino.spi.security.GroupProvider;
 import io.trino.spi.type.FixedWidthType;
 import io.trino.sql.analyzer.Analysis;
 import io.trino.sql.analyzer.Analyzer;
+import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.analyzer.Field;
-import io.trino.sql.analyzer.QueryExplainer;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.AstVisitor;
 import io.trino.sql.tree.BooleanLiteral;
@@ -40,6 +36,8 @@ import io.trino.sql.tree.Parameter;
 import io.trino.sql.tree.Row;
 import io.trino.sql.tree.Statement;
 import io.trino.sql.tree.StringLiteral;
+
+import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
@@ -57,24 +55,27 @@ import static io.trino.sql.analyzer.QueryType.DESCRIBE;
 import static io.trino.type.TypeUtils.getDisplayLabel;
 import static java.util.Objects.requireNonNull;
 
-final class DescribeOutputRewrite
+public final class DescribeOutputRewrite
         implements StatementRewrite.Rewrite
 {
+    private final SqlParser parser;
+
+    @Inject
+    public DescribeOutputRewrite(SqlParser parser)
+    {
+        this.parser = requireNonNull(parser, "parser is null");
+    }
+
     @Override
     public Statement rewrite(
+            AnalyzerFactory analyzerFactory,
             Session session,
-            Metadata metadata,
-            SqlParser parser,
-            Optional<QueryExplainer> queryExplainer,
             Statement node,
             List<Expression> parameters,
             Map<NodeRef<Parameter>, Expression> parameterLookup,
-            GroupProvider groupProvider,
-            AccessControl accessControl,
-            WarningCollector warningCollector,
-            StatsCalculator statsCalculator)
+            WarningCollector warningCollector)
     {
-        return (Statement) new Visitor(session, parser, metadata, queryExplainer, parameters, parameterLookup, groupProvider, accessControl, warningCollector, statsCalculator).process(node, null);
+        return (Statement) new Visitor(session, parser, analyzerFactory, parameters, parameterLookup, warningCollector).process(node, null);
     }
 
     private static final class Visitor
@@ -82,37 +83,25 @@ final class DescribeOutputRewrite
     {
         private final Session session;
         private final SqlParser parser;
-        private final Metadata metadata;
-        private final Optional<QueryExplainer> queryExplainer;
+        private final AnalyzerFactory analyzerFactory;
         private final List<Expression> parameters;
         private final Map<NodeRef<Parameter>, Expression> parameterLookup;
-        private final GroupProvider groupProvider;
-        private final AccessControl accessControl;
         private final WarningCollector warningCollector;
-        private final StatsCalculator statsCalculator;
 
         public Visitor(
                 Session session,
                 SqlParser parser,
-                Metadata metadata,
-                Optional<QueryExplainer> queryExplainer,
+                AnalyzerFactory analyzerFactory,
                 List<Expression> parameters,
                 Map<NodeRef<Parameter>, Expression> parameterLookup,
-                GroupProvider groupProvider,
-                AccessControl accessControl,
-                WarningCollector warningCollector,
-                StatsCalculator statsCalculator)
+                WarningCollector warningCollector)
         {
             this.session = requireNonNull(session, "session is null");
-            this.parser = parser;
-            this.metadata = metadata;
-            this.queryExplainer = queryExplainer;
+            this.parser = requireNonNull(parser, "parser is null");
+            this.analyzerFactory = analyzerFactory;
             this.parameters = parameters;
             this.parameterLookup = parameterLookup;
-            this.groupProvider = requireNonNull(groupProvider, "groupProvider is null");
-            this.accessControl = accessControl;
             this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
-            this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
         }
 
         @Override
@@ -121,7 +110,7 @@ final class DescribeOutputRewrite
             String sqlString = session.getPreparedStatement(node.getName().getValue());
             Statement statement = parser.createStatement(sqlString, createParsingOptions(session));
 
-            Analyzer analyzer = new Analyzer(session, metadata, parser, groupProvider, accessControl, queryExplainer, parameters, parameterLookup, warningCollector, statsCalculator);
+            Analyzer analyzer = analyzerFactory.createAnalyzer(session, parameters, parameterLookup, warningCollector);
             Analysis analysis = analyzer.analyze(statement, DESCRIBE);
 
             Optional<Node> limit = Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowStatsRewrite.java
+++ b/core/trino-main/src/main/java/io/trino/sql/rewrite/ShowStatsRewrite.java
@@ -20,11 +20,8 @@ import io.trino.cost.PlanNodeStatsEstimate;
 import io.trino.cost.StatsCalculator;
 import io.trino.cost.SymbolStatsEstimate;
 import io.trino.execution.warnings.WarningCollector;
-import io.trino.metadata.Metadata;
 import io.trino.operator.scalar.timestamp.TimestampToVarcharCast;
 import io.trino.operator.scalar.timestamptz.TimestampWithTimeZoneToVarcharCast;
-import io.trino.security.AccessControl;
-import io.trino.spi.security.GroupProvider;
 import io.trino.spi.type.BigintType;
 import io.trino.spi.type.DecimalType;
 import io.trino.spi.type.IntegerType;
@@ -35,8 +32,9 @@ import io.trino.spi.type.TimestampWithTimeZoneType;
 import io.trino.spi.type.TinyintType;
 import io.trino.spi.type.Type;
 import io.trino.sql.QueryUtil;
+import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.analyzer.QueryExplainer;
-import io.trino.sql.parser.SqlParser;
+import io.trino.sql.analyzer.QueryExplainerFactory;
 import io.trino.sql.planner.Plan;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.OutputNode;
@@ -59,12 +57,12 @@ import io.trino.sql.tree.Table;
 import io.trino.sql.tree.TableSubquery;
 import io.trino.sql.tree.Values;
 
+import javax.inject.Inject;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -89,21 +87,26 @@ public class ShowStatsRewrite
     private static final Expression NULL_DOUBLE = new Cast(new NullLiteral(), toSqlType(DOUBLE));
     private static final Expression NULL_VARCHAR = new Cast(new NullLiteral(), toSqlType(VARCHAR));
 
+    private final QueryExplainerFactory queryExplainerFactory;
+    private final StatsCalculator statsCalculator;
+
+    @Inject
+    public ShowStatsRewrite(QueryExplainerFactory queryExplainerFactory, StatsCalculator statsCalculator)
+    {
+        this.queryExplainerFactory = requireNonNull(queryExplainerFactory, "queryExplainerFactory is null");
+        this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator is null");
+    }
+
     @Override
     public Statement rewrite(
+            AnalyzerFactory analyzerFactory,
             Session session,
-            Metadata metadata,
-            SqlParser parser,
-            Optional<QueryExplainer> queryExplainer,
             Statement node,
             List<Expression> parameters,
             Map<NodeRef<Parameter>, Expression> parameterLookup,
-            GroupProvider groupProvider,
-            AccessControl accessControl,
-            WarningCollector warningCollector,
-            StatsCalculator statsCalculator)
+            WarningCollector warningCollector)
     {
-        return (Statement) new Visitor(session, parameters, queryExplainer, warningCollector, statsCalculator).process(node, null);
+        return (Statement) new Visitor(session, parameters, queryExplainerFactory.createQueryExplainer(analyzerFactory), warningCollector, statsCalculator).process(node, null);
     }
 
     private static class Visitor
@@ -111,11 +114,11 @@ public class ShowStatsRewrite
     {
         private final Session session;
         private final List<Expression> parameters;
-        private final Optional<QueryExplainer> queryExplainer;
+        private final QueryExplainer queryExplainer;
         private final WarningCollector warningCollector;
         private final StatsCalculator statsCalculator;
 
-        private Visitor(Session session, List<Expression> parameters, Optional<QueryExplainer> queryExplainer, WarningCollector warningCollector, StatsCalculator statsCalculator)
+        private Visitor(Session session, List<Expression> parameters, QueryExplainer queryExplainer, WarningCollector warningCollector, StatsCalculator statsCalculator)
         {
             this.session = requireNonNull(session, "session is null");
             this.parameters = requireNonNull(parameters, "parameters is null");
@@ -127,10 +130,8 @@ public class ShowStatsRewrite
         @Override
         protected Node visitShowStats(ShowStats node, Void context)
         {
-            checkState(queryExplainer.isPresent(), "Query explainer must be provided for SHOW STATS SELECT");
-
             Query query = getRelation(node);
-            Plan plan = queryExplainer.get().getLogicalPlan(session, query, parameters, warningCollector);
+            Plan plan = queryExplainer.getLogicalPlan(session, query, parameters, warningCollector);
             CachingStatsProvider cachingStatsProvider = new CachingStatsProvider(statsCalculator, session, plan.getTypes());
             PlanNodeStatsEstimate stats = cachingStatsProvider.getStats(plan.getRoot());
             return rewriteShowStats(plan, stats);

--- a/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
+++ b/core/trino-main/src/main/java/io/trino/testing/QueryRunner.java
@@ -22,6 +22,7 @@ import io.trino.metadata.SqlFunction;
 import io.trino.spi.Plugin;
 import io.trino.split.PageSourceManager;
 import io.trino.split.SplitManager;
+import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.sql.planner.Plan;
 import io.trino.transaction.TransactionManager;
@@ -45,6 +46,8 @@ public interface QueryRunner
     TransactionManager getTransactionManager();
 
     Metadata getMetadata();
+
+    AnalyzerFactory getAnalyzerFactory();
 
     SplitManager getSplitManager();
 

--- a/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
+++ b/core/trino-main/src/main/java/io/trino/util/StatementUtils.java
@@ -13,7 +13,48 @@
  */
 package io.trino.util;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableList;
+import io.trino.execution.AddColumnTask;
+import io.trino.execution.CallTask;
+import io.trino.execution.CommentTask;
+import io.trino.execution.CommitTask;
+import io.trino.execution.CreateMaterializedViewTask;
+import io.trino.execution.CreateRoleTask;
+import io.trino.execution.CreateSchemaTask;
+import io.trino.execution.CreateTableTask;
+import io.trino.execution.CreateViewTask;
+import io.trino.execution.DataDefinitionTask;
+import io.trino.execution.DeallocateTask;
+import io.trino.execution.DropColumnTask;
+import io.trino.execution.DropMaterializedViewTask;
+import io.trino.execution.DropRoleTask;
+import io.trino.execution.DropSchemaTask;
+import io.trino.execution.DropTableTask;
+import io.trino.execution.DropViewTask;
+import io.trino.execution.GrantRolesTask;
+import io.trino.execution.GrantTask;
+import io.trino.execution.PrepareTask;
+import io.trino.execution.RenameColumnTask;
+import io.trino.execution.RenameMaterializedViewTask;
+import io.trino.execution.RenameSchemaTask;
+import io.trino.execution.RenameTableTask;
+import io.trino.execution.RenameViewTask;
+import io.trino.execution.ResetSessionTask;
+import io.trino.execution.RevokeRolesTask;
+import io.trino.execution.RevokeTask;
+import io.trino.execution.RollbackTask;
+import io.trino.execution.SetPathTask;
+import io.trino.execution.SetPropertiesTask;
+import io.trino.execution.SetRoleTask;
+import io.trino.execution.SetSchemaAuthorizationTask;
+import io.trino.execution.SetSessionTask;
+import io.trino.execution.SetTableAuthorizationTask;
+import io.trino.execution.SetTimeZoneTask;
+import io.trino.execution.SetViewAuthorizationTask;
+import io.trino.execution.StartTransactionTask;
+import io.trino.execution.TruncateTableTask;
+import io.trino.execution.UseTask;
 import io.trino.spi.resourcegroups.QueryType;
 import io.trino.sql.tree.AddColumn;
 import io.trino.sql.tree.Analyze;
@@ -79,11 +120,15 @@ import io.trino.sql.tree.TruncateTable;
 import io.trino.sql.tree.Update;
 import io.trino.sql.tree.Use;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.spi.resourcegroups.QueryType.ALTER_TABLE_EXECUTE;
 import static io.trino.spi.resourcegroups.QueryType.ANALYZE;
@@ -94,86 +139,92 @@ import static io.trino.spi.resourcegroups.QueryType.EXPLAIN;
 import static io.trino.spi.resourcegroups.QueryType.INSERT;
 import static io.trino.spi.resourcegroups.QueryType.SELECT;
 import static io.trino.spi.resourcegroups.QueryType.UPDATE;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
 
 public final class StatementUtils
 {
     private StatementUtils() {}
 
-    private static final Map<Class<? extends Statement>, QueryType> STATEMENT_QUERY_TYPES = ImmutableMap.<Class<? extends Statement>, QueryType>builder()
+    private static final Map<Class<? extends Statement>, StatementTypeInfo<? extends Statement>> STATEMENT_QUERY_TYPES = ImmutableList.<StatementTypeInfo<?>>builder()
             // SELECT
-            .put(Query.class, SELECT)
+            .add(basicStatement(Query.class, SELECT))
             // EXPLAIN
-            .put(Explain.class, EXPLAIN)
+            .add(basicStatement(Explain.class, EXPLAIN))
             // DESCRIBE
-            .put(DescribeInput.class, DESCRIBE)
-            .put(DescribeOutput.class, DESCRIBE)
-            .put(ShowCatalogs.class, DESCRIBE)
-            .put(ShowColumns.class, DESCRIBE)
-            .put(ShowCreate.class, DESCRIBE)
-            .put(ShowFunctions.class, DESCRIBE)
-            .put(ShowGrants.class, DESCRIBE)
-            .put(ShowRoleGrants.class, DESCRIBE)
-            .put(ShowRoles.class, DESCRIBE)
-            .put(ShowSchemas.class, DESCRIBE)
-            .put(ShowSession.class, DESCRIBE)
-            .put(ShowStats.class, DESCRIBE)
-            .put(ShowTables.class, DESCRIBE)
+            .add(basicStatement(DescribeInput.class, DESCRIBE))
+            .add(basicStatement(DescribeOutput.class, DESCRIBE))
+            .add(basicStatement(ShowCatalogs.class, DESCRIBE))
+            .add(basicStatement(ShowColumns.class, DESCRIBE))
+            .add(basicStatement(ShowCreate.class, DESCRIBE))
+            .add(basicStatement(ShowFunctions.class, DESCRIBE))
+            .add(basicStatement(ShowGrants.class, DESCRIBE))
+            .add(basicStatement(ShowRoleGrants.class, DESCRIBE))
+            .add(basicStatement(ShowRoles.class, DESCRIBE))
+            .add(basicStatement(ShowSchemas.class, DESCRIBE))
+            .add(basicStatement(ShowSession.class, DESCRIBE))
+            .add(basicStatement(ShowStats.class, DESCRIBE))
+            .add(basicStatement(ShowTables.class, DESCRIBE))
+            // Table Procedure
+            .add(basicStatement(TableExecute.class, ALTER_TABLE_EXECUTE))
             // DML
-            .put(CreateTableAsSelect.class, INSERT)
-            .put(RefreshMaterializedView.class, INSERT)
-            .put(Insert.class, INSERT)
-            .put(Update.class, UPDATE)
-            .put(Delete.class, DELETE)
-            .put(Analyze.class, ANALYZE)
+            .add(basicStatement(CreateTableAsSelect.class, INSERT))
+            .add(basicStatement(RefreshMaterializedView.class, INSERT))
+            .add(basicStatement(Insert.class, INSERT))
+            .add(basicStatement(Update.class, UPDATE))
+            .add(basicStatement(Delete.class, DELETE))
+            .add(basicStatement(Analyze.class, ANALYZE))
             // DDL
-            .put(AddColumn.class, DATA_DEFINITION)
-            .put(Call.class, DATA_DEFINITION)
-            .put(Comment.class, DATA_DEFINITION)
-            .put(Commit.class, DATA_DEFINITION)
-            .put(CreateMaterializedView.class, DATA_DEFINITION)
-            .put(CreateRole.class, DATA_DEFINITION)
-            .put(CreateSchema.class, DATA_DEFINITION)
-            .put(CreateTable.class, DATA_DEFINITION)
-            .put(CreateView.class, DATA_DEFINITION)
-            .put(Deallocate.class, DATA_DEFINITION)
-            .put(DropColumn.class, DATA_DEFINITION)
-            .put(DropMaterializedView.class, DATA_DEFINITION)
-            .put(DropRole.class, DATA_DEFINITION)
-            .put(DropSchema.class, DATA_DEFINITION)
-            .put(DropTable.class, DATA_DEFINITION)
-            .put(DropView.class, DATA_DEFINITION)
-            .put(TruncateTable.class, DATA_DEFINITION)
-            .put(Grant.class, DATA_DEFINITION)
-            .put(GrantRoles.class, DATA_DEFINITION)
-            .put(Prepare.class, DATA_DEFINITION)
-            .put(RenameColumn.class, DATA_DEFINITION)
-            .put(RenameMaterializedView.class, DATA_DEFINITION)
-            .put(RenameSchema.class, DATA_DEFINITION)
-            .put(RenameTable.class, DATA_DEFINITION)
-            .put(RenameView.class, DATA_DEFINITION)
-            .put(ResetSession.class, DATA_DEFINITION)
-            .put(Revoke.class, DATA_DEFINITION)
-            .put(RevokeRoles.class, DATA_DEFINITION)
-            .put(Rollback.class, DATA_DEFINITION)
-            .put(SetPath.class, DATA_DEFINITION)
-            .put(SetRole.class, DATA_DEFINITION)
-            .put(SetSchemaAuthorization.class, DATA_DEFINITION)
-            .put(SetSession.class, DATA_DEFINITION)
-            .put(SetProperties.class, DATA_DEFINITION)
-            .put(SetTableAuthorization.class, DATA_DEFINITION)
-            .put(SetTimeZone.class, DATA_DEFINITION)
-            .put(SetViewAuthorization.class, DATA_DEFINITION)
-            .put(StartTransaction.class, DATA_DEFINITION)
-            .put(TableExecute.class, ALTER_TABLE_EXECUTE)
-            .put(Use.class, DATA_DEFINITION)
-            .build();
+            .add(dataDefinitionStatement(AddColumn.class, AddColumnTask.class))
+            .add(dataDefinitionStatement(Call.class, CallTask.class))
+            .add(dataDefinitionStatement(Comment.class, CommentTask.class))
+            .add(dataDefinitionStatement(Commit.class, CommitTask.class))
+            .add(dataDefinitionStatement(CreateMaterializedView.class, CreateMaterializedViewTask.class))
+            .add(dataDefinitionStatement(CreateRole.class, CreateRoleTask.class))
+            .add(dataDefinitionStatement(CreateSchema.class, CreateSchemaTask.class))
+            .add(dataDefinitionStatement(CreateTable.class, CreateTableTask.class))
+            .add(dataDefinitionStatement(CreateView.class, CreateViewTask.class))
+            .add(dataDefinitionStatement(Deallocate.class, DeallocateTask.class))
+            .add(dataDefinitionStatement(DropColumn.class, DropColumnTask.class))
+            .add(dataDefinitionStatement(DropMaterializedView.class, DropMaterializedViewTask.class))
+            .add(dataDefinitionStatement(DropRole.class, DropRoleTask.class))
+            .add(dataDefinitionStatement(DropSchema.class, DropSchemaTask.class))
+            .add(dataDefinitionStatement(DropTable.class, DropTableTask.class))
+            .add(dataDefinitionStatement(DropView.class, DropViewTask.class))
+            .add(dataDefinitionStatement(TruncateTable.class, TruncateTableTask.class))
+            .add(dataDefinitionStatement(Grant.class, GrantTask.class))
+            .add(dataDefinitionStatement(GrantRoles.class, GrantRolesTask.class))
+            .add(dataDefinitionStatement(Prepare.class, PrepareTask.class))
+            .add(dataDefinitionStatement(RenameColumn.class, RenameColumnTask.class))
+            .add(dataDefinitionStatement(RenameMaterializedView.class, RenameMaterializedViewTask.class))
+            .add(dataDefinitionStatement(RenameSchema.class, RenameSchemaTask.class))
+            .add(dataDefinitionStatement(RenameTable.class, RenameTableTask.class))
+            .add(dataDefinitionStatement(RenameView.class, RenameViewTask.class))
+            .add(dataDefinitionStatement(ResetSession.class, ResetSessionTask.class))
+            .add(dataDefinitionStatement(Revoke.class, RevokeTask.class))
+            .add(dataDefinitionStatement(RevokeRoles.class, RevokeRolesTask.class))
+            .add(dataDefinitionStatement(Rollback.class, RollbackTask.class))
+            .add(dataDefinitionStatement(SetPath.class, SetPathTask.class))
+            .add(dataDefinitionStatement(SetRole.class, SetRoleTask.class))
+            .add(dataDefinitionStatement(SetSchemaAuthorization.class, SetSchemaAuthorizationTask.class))
+            .add(dataDefinitionStatement(SetSession.class, SetSessionTask.class))
+            .add(dataDefinitionStatement(SetProperties.class, SetPropertiesTask.class))
+            .add(dataDefinitionStatement(SetTableAuthorization.class, SetTableAuthorizationTask.class))
+            .add(dataDefinitionStatement(SetTimeZone.class, SetTimeZoneTask.class))
+            .add(dataDefinitionStatement(SetViewAuthorization.class, SetViewAuthorizationTask.class))
+            .add(dataDefinitionStatement(StartTransaction.class, StartTransactionTask.class))
+            .add(dataDefinitionStatement(Use.class, UseTask.class))
+            .build().stream()
+            .collect(toImmutableMap(StatementTypeInfo::getStatementType, identity()));
 
     public static Optional<QueryType> getQueryType(Statement statement)
     {
         if (statement instanceof ExplainAnalyze) {
             return getQueryType(((ExplainAnalyze) statement).getStatement());
         }
-        return Optional.ofNullable(STATEMENT_QUERY_TYPES.get(statement.getClass()));
+        return Optional.ofNullable(STATEMENT_QUERY_TYPES.get(statement.getClass()))
+                .map(StatementTypeInfo::getQueryType);
     }
 
     public static Set<Class<? extends Statement>> getNonDataDefinitionStatements()
@@ -183,18 +234,83 @@ public final class StatementUtils
         return Stream.concat(
                 Stream.of(ExplainAnalyze.class),
                 STATEMENT_QUERY_TYPES.entrySet().stream()
-                        .filter(entry -> entry.getValue() != DATA_DEFINITION)
+                        .filter(entry -> entry.getValue().getQueryType() != DATA_DEFINITION)
                         .map(Map.Entry::getKey))
                 .collect(toImmutableSet());
     }
 
     public static boolean isDataDefinitionStatement(Class<? extends Statement> statement)
     {
-        return STATEMENT_QUERY_TYPES.get(statement) == DATA_DEFINITION;
+        StatementTypeInfo<? extends Statement> info = STATEMENT_QUERY_TYPES.get(statement);
+        return info != null && info.getQueryType() == DATA_DEFINITION;
     }
 
     public static boolean isTransactionControlStatement(Statement statement)
     {
         return statement instanceof StartTransaction || statement instanceof Commit || statement instanceof Rollback;
+    }
+
+    private static <T extends Statement> StatementTypeInfo<T> basicStatement(Class<T> statementType, QueryType queryType)
+    {
+        return new StatementTypeInfo<>(statementType, queryType, Optional.empty());
+    }
+
+    private static <T extends Statement> StatementTypeInfo<T> dataDefinitionStatement(Class<T> statementType, Class<? extends DataDefinitionTask<T>> taskType)
+    {
+        requireNonNull(taskType, "taskType is null");
+        verifyTaskInterfaceType(statementType, taskType, DataDefinitionTask.class);
+        return new StatementTypeInfo<>(statementType, DATA_DEFINITION, Optional.of(taskType));
+    }
+
+    private static <T extends Statement> void verifyTaskInterfaceType(Class<T> statementType, Class<?> taskType, Class<?> expectedInterfaceType)
+    {
+        for (Type genericInterface : taskType.getGenericInterfaces()) {
+            if (genericInterface instanceof ParameterizedType) {
+                ParameterizedType parameterizedInterface = (ParameterizedType) genericInterface;
+                if (parameterizedInterface.getRawType().equals(expectedInterfaceType)) {
+                    Type actualStatementType = parameterizedInterface.getActualTypeArguments()[0];
+                    checkArgument(actualStatementType.equals(statementType), format("Expected %s statement type to be %s", statementType.getSimpleName(), taskType.getSimpleName()));
+                    return;
+                }
+            }
+        }
+        throw new VerifyException(format("%s does not implement %s", taskType.getSimpleName(), DataDefinitionTask.class.getName()));
+    }
+
+    private static class StatementTypeInfo<T extends Statement>
+    {
+        private final Class<T> statementType;
+        private final QueryType queryType;
+        private final Optional<Class<? extends DataDefinitionTask<T>>> taskType;
+
+        private StatementTypeInfo(Class<T> statementType,
+                QueryType queryType,
+                Optional<Class<? extends DataDefinitionTask<T>>> taskType)
+        {
+            this.statementType = requireNonNull(statementType, "statementType is null");
+            this.queryType = requireNonNull(queryType, "queryType is null");
+            this.taskType = requireNonNull(taskType, "taskType is null");
+            if (queryType == DATA_DEFINITION) {
+                checkArgument(taskType.isPresent(), "taskType is required for " + DATA_DEFINITION);
+            }
+            else {
+                checkArgument(taskType.isEmpty(), "taskType is not allowed for " + queryType);
+            }
+        }
+
+        public Class<T> getStatementType()
+        {
+            return statementType;
+        }
+
+        public QueryType getQueryType()
+        {
+            return queryType;
+        }
+
+        public Class<? extends DataDefinitionTask<T>> getTaskType()
+        {
+            return taskType.orElseThrow(() -> new IllegalStateException(queryType + " does not have a task type"));
+        }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCallTask.java
@@ -130,12 +130,9 @@ public class TestCallTask
                         methodHandle));
         AccessControl accessControl = accessControlProvider.apply(transactionManager);
 
-        new CallTask()
+        new CallTask(transactionManager, metadata, accessControl)
                 .execute(
                         new Call(QualifiedName.of("testing_procedure"), ImmutableList.of()),
-                        transactionManager,
-                        metadata,
-                        accessControl,
                         stateMachine(transactionManager, metadata, accessControl),
                         ImmutableList.of(),
                         WarningCollector.NOOP);

--- a/core/trino-main/src/test/java/io/trino/execution/TestCommitTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCommitTask.java
@@ -21,7 +21,6 @@ import io.trino.metadata.Metadata;
 import io.trino.plugin.base.security.DefaultSystemAccessControl;
 import io.trino.security.AccessControlConfig;
 import io.trino.security.AccessControlManager;
-import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.tree.Commit;
 import io.trino.transaction.TransactionId;
@@ -74,7 +73,7 @@ public class TestCommitTask
         assertTrue(stateMachine.getSession().getTransactionId().isPresent());
         assertEquals(transactionManager.getAllTransactionInfos().size(), 1);
 
-        getFutureValue(new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList(), WarningCollector.NOOP));
+        getFutureValue(new CommitTask(transactionManager).execute(new Commit(), stateMachine, emptyList(), WarningCollector.NOOP));
         assertTrue(stateMachine.getQueryInfo(Optional.empty()).isClearTransactionId());
         assertFalse(stateMachine.getQueryInfo(Optional.empty()).getStartedTransactionId().isPresent());
 
@@ -91,7 +90,7 @@ public class TestCommitTask
         QueryStateMachine stateMachine = createQueryStateMachine("COMMIT", session, transactionManager);
 
         assertTrinoExceptionThrownBy(
-                () -> getFutureValue(new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList(), WarningCollector.NOOP)))
+                () -> getFutureValue(new CommitTask(transactionManager).execute(new Commit(), stateMachine, emptyList(), WarningCollector.NOOP)))
                 .hasErrorCode(NOT_IN_TRANSACTION);
 
         assertFalse(stateMachine.getQueryInfo(Optional.empty()).isClearTransactionId());
@@ -110,7 +109,7 @@ public class TestCommitTask
                 .build();
         QueryStateMachine stateMachine = createQueryStateMachine("COMMIT", session, transactionManager);
 
-        Future<?> future = new CommitTask().execute(new Commit(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList(), WarningCollector.NOOP);
+        Future<?> future = new CommitTask(transactionManager).execute(new Commit(), stateMachine, emptyList(), WarningCollector.NOOP);
         assertTrinoExceptionThrownBy(() -> getFutureValue(future))
                 .hasErrorCode(UNKNOWN_TRANSACTION);
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateMaterializedViewTask.java
@@ -143,8 +143,8 @@ public class TestCreateMaterializedViewTask
                 ImmutableList.of(),
                 Optional.empty());
 
-        getFutureValue(new CreateMaterializedViewTask(parser, new TestingGroupProvider(), statsCalculator)
-                .execute(statement, transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP));
+        getFutureValue(new CreateMaterializedViewTask(metadata, new AllowAllAccessControl(), parser, new TestingGroupProvider(), statsCalculator)
+                .execute(statement, queryStateMachine, ImmutableList.of(), WarningCollector.NOOP));
         assertEquals(metadata.getCreateMaterializedViewCallCount(), 1);
     }
 
@@ -160,8 +160,8 @@ public class TestCreateMaterializedViewTask
                 ImmutableList.of(),
                 Optional.empty());
 
-        assertTrinoExceptionThrownBy(() -> getFutureValue(new CreateMaterializedViewTask(parser, new TestingGroupProvider(), statsCalculator)
-                .execute(statement, transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP)))
+        assertTrinoExceptionThrownBy(() -> getFutureValue(new CreateMaterializedViewTask(metadata, new AllowAllAccessControl(), parser, new TestingGroupProvider(), statsCalculator)
+                .execute(statement, queryStateMachine, ImmutableList.of(), WarningCollector.NOOP)))
                 .hasErrorCode(ALREADY_EXISTS)
                 .hasMessage("Materialized view already exists");
 
@@ -180,8 +180,8 @@ public class TestCreateMaterializedViewTask
                 ImmutableList.of(new Property(new Identifier("baz"), new StringLiteral("abc"))),
                 Optional.empty());
 
-        assertTrinoExceptionThrownBy(() -> getFutureValue(new CreateMaterializedViewTask(parser, new TestingGroupProvider(), statsCalculator)
-                .execute(statement, transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP)))
+        assertTrinoExceptionThrownBy(() -> getFutureValue(new CreateMaterializedViewTask(metadata, new AllowAllAccessControl(), parser, new TestingGroupProvider(), statsCalculator)
+                .execute(statement, queryStateMachine, ImmutableList.of(), WarningCollector.NOOP)))
                 .hasErrorCode(INVALID_MATERIALIZED_VIEW_PROPERTY)
                 .hasMessage("Catalog 'catalog' does not support materialized view property 'baz'");
 
@@ -203,8 +203,8 @@ public class TestCreateMaterializedViewTask
         accessControl.loadSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
         accessControl.deny(privilege("test_mv", CREATE_MATERIALIZED_VIEW));
 
-        assertThatThrownBy(() -> getFutureValue(new CreateMaterializedViewTask(parser, new TestingGroupProvider(), statsCalculator)
-                .execute(statement, transactionManager, metadata, accessControl, queryStateMachine, ImmutableList.of(), WarningCollector.NOOP)))
+        assertThatThrownBy(() -> getFutureValue(new CreateMaterializedViewTask(metadata, accessControl, parser, new TestingGroupProvider(), statsCalculator)
+                .execute(statement, queryStateMachine, ImmutableList.of(), WarningCollector.NOOP)))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessageContaining("Cannot create materialized view catalog.schema.test_mv");
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestCreateTableTask.java
@@ -145,7 +145,7 @@ public class TestCreateTableTask
                 ImmutableList.of(),
                 Optional.empty());
 
-        getFutureValue(new CreateTableTask(new FeaturesConfig()).internalExecute(statement, metadata, new AllowAllAccessControl(), testSession, emptyList(), output -> {}));
+        getFutureValue(new CreateTableTask(metadata, new AllowAllAccessControl(), new FeaturesConfig()).internalExecute(statement, testSession, emptyList(), output -> {}));
         assertEquals(metadata.getCreateTableCallCount(), 1);
     }
 
@@ -158,7 +158,7 @@ public class TestCreateTableTask
                 ImmutableList.of(),
                 Optional.empty());
 
-        assertTrinoExceptionThrownBy(() -> getFutureValue(new CreateTableTask(new FeaturesConfig()).internalExecute(statement, metadata, new AllowAllAccessControl(), testSession, emptyList(), output -> {})))
+        assertTrinoExceptionThrownBy(() -> getFutureValue(new CreateTableTask(metadata, new AllowAllAccessControl(), new FeaturesConfig()).internalExecute(statement, testSession, emptyList(), output -> {})))
                 .hasErrorCode(ALREADY_EXISTS)
                 .hasMessage("Table already exists");
 
@@ -174,7 +174,7 @@ public class TestCreateTableTask
                 ImmutableList.of(new Property(new Identifier("foo"), new StringLiteral("bar"))),
                 Optional.empty());
 
-        assertTrinoExceptionThrownBy(() -> getFutureValue(new CreateTableTask(new FeaturesConfig()).internalExecute(statement, metadata, new AllowAllAccessControl(), testSession, emptyList(), output -> {})))
+        assertTrinoExceptionThrownBy(() -> getFutureValue(new CreateTableTask(metadata, new AllowAllAccessControl(), new FeaturesConfig()).internalExecute(statement, testSession, emptyList(), output -> {})))
                 .hasErrorCode(INVALID_TABLE_PROPERTY)
                 .hasMessage("Catalog 'catalog' does not support table property 'foo'");
 
@@ -191,7 +191,7 @@ public class TestCreateTableTask
                 new ColumnDefinition(identifier("c"), toSqlType(VARBINARY), false, emptyList(), Optional.empty()));
         CreateTable statement = new CreateTable(QualifiedName.of("test_table"), inputColumns, true, ImmutableList.of(), Optional.empty());
 
-        getFutureValue(new CreateTableTask(new FeaturesConfig()).internalExecute(statement, metadata, new AllowAllAccessControl(), testSession, emptyList(), output -> {}));
+        getFutureValue(new CreateTableTask(metadata, new AllowAllAccessControl(), new FeaturesConfig()).internalExecute(statement, testSession, emptyList(), output -> {}));
         assertEquals(metadata.getCreateTableCallCount(), 1);
         List<ColumnMetadata> columns = metadata.getReceivedTableMetadata().get(0).getColumns();
         assertEquals(columns.size(), 3);
@@ -224,7 +224,7 @@ public class TestCreateTableTask
                 Optional.empty());
 
         assertTrinoExceptionThrownBy(() ->
-                getFutureValue(new CreateTableTask(new FeaturesConfig()).internalExecute(statement, metadata, new AllowAllAccessControl(), testSession, emptyList(), output -> {})))
+                getFutureValue(new CreateTableTask(metadata, new AllowAllAccessControl(), new FeaturesConfig()).internalExecute(statement, testSession, emptyList(), output -> {})))
                 .hasErrorCode(NOT_SUPPORTED)
                 .hasMessage("Catalog 'catalog' does not support non-null column for column name 'b'");
     }
@@ -234,7 +234,7 @@ public class TestCreateTableTask
     {
         CreateTable statement = getCreatleLikeStatement(false);
 
-        getFutureValue(new CreateTableTask(new FeaturesConfig()).internalExecute(statement, metadata, new AllowAllAccessControl(), testSession, List.of(), output -> {}));
+        getFutureValue(new CreateTableTask(metadata, new AllowAllAccessControl(), new FeaturesConfig()).internalExecute(statement, testSession, List.of(), output -> {}));
         assertEquals(metadata.getCreateTableCallCount(), 1);
 
         assertThat(metadata.getReceivedTableMetadata().get(0).getColumns())
@@ -247,7 +247,7 @@ public class TestCreateTableTask
     {
         CreateTable statement = getCreatleLikeStatement(true);
 
-        getFutureValue(new CreateTableTask(new FeaturesConfig()).internalExecute(statement, metadata, new AllowAllAccessControl(), testSession, List.of(), output -> {}));
+        getFutureValue(new CreateTableTask(metadata, new AllowAllAccessControl(), new FeaturesConfig()).internalExecute(statement, testSession, List.of(), output -> {}));
         assertEquals(metadata.getCreateTableCallCount(), 1);
 
         assertThat(metadata.getReceivedTableMetadata().get(0).getColumns())
@@ -264,7 +264,7 @@ public class TestCreateTableTask
         TestingAccessControlManager accessControl = new TestingAccessControlManager(transactionManager, new EventListenerManager(new EventListenerConfig()));
         accessControl.deny(privilege("parent_table", SELECT_COLUMN));
 
-        assertThatThrownBy(() -> getFutureValue(new CreateTableTask(new FeaturesConfig()).internalExecute(statement, metadata, accessControl, testSession, List.of(), output -> {})))
+        assertThatThrownBy(() -> getFutureValue(new CreateTableTask(metadata, accessControl, new FeaturesConfig()).internalExecute(statement, testSession, List.of(), output -> {})))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessageContaining("Cannot reference columns of table");
     }
@@ -277,7 +277,7 @@ public class TestCreateTableTask
         TestingAccessControlManager accessControl = new TestingAccessControlManager(transactionManager, new EventListenerManager(new EventListenerConfig()));
         accessControl.deny(privilege("parent_table", SHOW_CREATE_TABLE));
 
-        assertThatThrownBy(() -> getFutureValue(new CreateTableTask(new FeaturesConfig()).internalExecute(statement, metadata, accessControl, testSession, List.of(), output -> {})))
+        assertThatThrownBy(() -> getFutureValue(new CreateTableTask(metadata, accessControl, new FeaturesConfig()).internalExecute(statement, testSession, List.of(), output -> {})))
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessageContaining("Cannot reference properties of table");
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestDeallocateTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDeallocateTask.java
@@ -21,7 +21,6 @@ import io.trino.plugin.base.security.AllowAllSystemAccessControl;
 import io.trino.plugin.base.security.DefaultSystemAccessControl;
 import io.trino.security.AccessControlConfig;
 import io.trino.security.AccessControlManager;
-import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.tree.Deallocate;
 import io.trino.sql.tree.Identifier;
@@ -96,7 +95,7 @@ public class TestDeallocateTask
                 WarningCollector.NOOP,
                 Optional.empty());
         Deallocate deallocate = new Deallocate(new Identifier(statementName));
-        new DeallocateTask().execute(deallocate, transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList(), WarningCollector.NOOP);
+        new DeallocateTask().execute(deallocate, stateMachine, emptyList(), WarningCollector.NOOP);
         return stateMachine.getDeallocatedPreparedStatements();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropMaterializedViewTask.java
@@ -105,6 +105,7 @@ public class TestDropMaterializedViewTask
 
     private ListenableFuture<Void> executeDropMaterializedView(QualifiedName viewName, boolean exists)
     {
-        return new DropMaterializedViewTask().execute(new DropMaterializedView(viewName, exists), transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+        return new DropMaterializedViewTask(metadata, new AllowAllAccessControl())
+                .execute(new DropMaterializedView(viewName, exists), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropTableTask.java
@@ -105,6 +105,6 @@ public class TestDropTableTask
 
     private ListenableFuture<Void> executeDropTable(QualifiedName tableName, boolean exists)
     {
-        return new DropTableTask().execute(new DropTable(tableName, exists), transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+        return new DropTableTask(metadata, new AllowAllAccessControl()).execute(new DropTable(tableName, exists), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestDropViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestDropViewTask.java
@@ -105,6 +105,6 @@ public class TestDropViewTask
 
     private ListenableFuture<Void> executeDropView(QualifiedName viewName, boolean exists)
     {
-        return new DropViewTask().execute(new DropView(viewName, exists), transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+        return new DropViewTask(metadata, new AllowAllAccessControl()).execute(new DropView(viewName, exists), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestPrepareTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestPrepareTask.java
@@ -21,7 +21,6 @@ import io.trino.plugin.base.security.AllowAllSystemAccessControl;
 import io.trino.plugin.base.security.DefaultSystemAccessControl;
 import io.trino.security.AccessControlConfig;
 import io.trino.security.AccessControlManager;
-import io.trino.security.AllowAllAccessControl;
 import io.trino.spi.resourcegroups.ResourceGroupId;
 import io.trino.sql.parser.SqlParser;
 import io.trino.sql.tree.AllColumns;
@@ -119,7 +118,7 @@ public class TestPrepareTask
                 WarningCollector.NOOP,
                 Optional.empty());
         Prepare prepare = new Prepare(identifier(statementName), statement);
-        new PrepareTask(new SqlParser()).execute(prepare, transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList(), WarningCollector.NOOP);
+        new PrepareTask(new SqlParser()).execute(prepare, stateMachine, emptyList(), WarningCollector.NOOP);
         return stateMachine.getAddedPreparedStatements();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameMaterializedViewTask.java
@@ -140,6 +140,7 @@ public class TestRenameMaterializedViewTask
 
     private ListenableFuture<Void> executeRenameMaterializedView(QualifiedName source, QualifiedName target, boolean exists)
     {
-        return new RenameMaterializedViewTask().execute(new RenameMaterializedView(source, target, exists), transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+        return new RenameMaterializedViewTask(metadata, new AllowAllAccessControl())
+                .execute(new RenameMaterializedView(source, target, exists), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameTableTask.java
@@ -106,6 +106,7 @@ public class TestRenameTableTask
 
     private ListenableFuture<Void> executeRenameTable(QualifiedName source, QualifiedName target, boolean exists)
     {
-        return new RenameTableTask().execute(new RenameTable(source, target, exists), transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+        return new RenameTableTask(metadata, new AllowAllAccessControl())
+                .execute(new RenameTable(source, target, exists), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRenameViewTask.java
@@ -77,6 +77,7 @@ public class TestRenameViewTask
 
     private ListenableFuture<Void> executeRenameView(QualifiedName source, QualifiedName target)
     {
-        return new RenameViewTask().execute(new RenameView(source, target), transactionManager, metadata, new AllowAllAccessControl(), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
+        return new RenameViewTask(metadata, new AllowAllAccessControl())
+                .execute(new RenameView(source, target), queryStateMachine, ImmutableList.of(), WarningCollector.NOOP);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestResetSessionTask.java
@@ -106,11 +106,8 @@ public class TestResetSessionTask
                 WarningCollector.NOOP,
                 Optional.empty());
 
-        getFutureValue(new ResetSessionTask().execute(
+        getFutureValue(new ResetSessionTask(metadata).execute(
                 new ResetSession(QualifiedName.of(CATALOG_NAME, "baz")),
-                transactionManager,
-                metadata,
-                accessControl,
                 stateMachine,
                 emptyList(),
                 WarningCollector.NOOP));

--- a/core/trino-main/src/test/java/io/trino/execution/TestRollbackTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestRollbackTask.java
@@ -69,7 +69,7 @@ public class TestRollbackTask
         assertTrue(stateMachine.getSession().getTransactionId().isPresent());
         assertEquals(transactionManager.getAllTransactionInfos().size(), 1);
 
-        getFutureValue(new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList(), WarningCollector.NOOP));
+        getFutureValue(new RollbackTask(transactionManager).execute(new Rollback(), stateMachine, emptyList(), WarningCollector.NOOP));
         assertTrue(stateMachine.getQueryInfo(Optional.empty()).isClearTransactionId());
         assertFalse(stateMachine.getQueryInfo(Optional.empty()).getStartedTransactionId().isPresent());
 
@@ -86,7 +86,7 @@ public class TestRollbackTask
         QueryStateMachine stateMachine = createQueryStateMachine("ROLLBACK", session, transactionManager);
 
         assertTrinoExceptionThrownBy(
-                () -> getFutureValue((Future<?>) new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList(), WarningCollector.NOOP)))
+                () -> getFutureValue((Future<?>) new RollbackTask(transactionManager).execute(new Rollback(), stateMachine, emptyList(), WarningCollector.NOOP)))
                 .hasErrorCode(NOT_IN_TRANSACTION);
 
         assertFalse(stateMachine.getQueryInfo(Optional.empty()).isClearTransactionId());
@@ -105,7 +105,7 @@ public class TestRollbackTask
                 .build();
         QueryStateMachine stateMachine = createQueryStateMachine("ROLLBACK", session, transactionManager);
 
-        getFutureValue(new RollbackTask().execute(new Rollback(), transactionManager, metadata, new AllowAllAccessControl(), stateMachine, emptyList(), WarningCollector.NOOP));
+        getFutureValue(new RollbackTask(transactionManager).execute(new Rollback(), stateMachine, emptyList(), WarningCollector.NOOP));
         assertTrue(stateMachine.getQueryInfo(Optional.empty()).isClearTransactionId()); // Still issue clear signal
         assertFalse(stateMachine.getQueryInfo(Optional.empty()).getStartedTransactionId().isPresent());
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetPathTask.java
@@ -112,11 +112,8 @@ public class TestSetPathTask
 
     private void executeSetPathTask(PathSpecification pathSpecification, QueryStateMachine stateMachine)
     {
-        getFutureValue(new SetPathTask().execute(
+        getFutureValue(new SetPathTask(metadata).execute(
                 new SetPath(pathSpecification),
-                transactionManager,
-                metadata,
-                accessControl,
                 stateMachine,
                 emptyList(),
                 WarningCollector.NOOP));

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetRoleTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetRoleTask.java
@@ -204,7 +204,7 @@ public class TestSetRoleTask
                 metadata,
                 WarningCollector.NOOP,
                 Optional.empty());
-        new SetRoleTask().execute(setRole, transactionManager, metadata, accessControl, stateMachine, ImmutableList.of(), WarningCollector.NOOP);
+        new SetRoleTask(metadata, accessControl).execute(setRole, stateMachine, ImmutableList.of(), WarningCollector.NOOP);
         return stateMachine;
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetSessionTask.java
@@ -198,7 +198,7 @@ public class TestSetSessionTask
                 metadata,
                 WarningCollector.NOOP,
                 Optional.empty());
-        getFutureValue(new SetSessionTask().execute(new SetSession(qualifiedPropName, expression), transactionManager, metadata, accessControl, stateMachine, parameters, WarningCollector.NOOP));
+        getFutureValue(new SetSessionTask(metadata, accessControl).execute(new SetSession(qualifiedPropName, expression), stateMachine, parameters, WarningCollector.NOOP));
 
         Map<String, String> sessionProperties = stateMachine.getSetSessionProperties();
         assertEquals(sessionProperties, ImmutableMap.of(qualifiedPropName.toString(), expectedValue));

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
@@ -259,8 +259,8 @@ public class TestSetTimeZoneTask
                 localQueryRunner.getMetadata(),
                 localQueryRunner.getAccessControl(),
                 localQueryRunner.getSqlParser(),
-                localQueryRunner.getGroupProvider(),
-                localQueryRunner.getStatsCalculator());
+                localQueryRunner.getAnalyzerFactory(),
+                localQueryRunner.getGroupProvider());
         getFutureValue(task.execute(setTimeZone, stateMachine, emptyList(), WarningCollector.NOOP));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestSetTimeZoneTask.java
@@ -255,14 +255,12 @@ public class TestSetTimeZoneTask
 
     private void executeSetTimeZone(SetTimeZone setTimeZone, QueryStateMachine stateMachine)
     {
-        getFutureValue(new SetTimeZoneTask(localQueryRunner.getSqlParser(), localQueryRunner.getGroupProvider(), localQueryRunner.getStatsCalculator())
-                .execute(
-                        setTimeZone,
-                        localQueryRunner.getTransactionManager(),
-                        localQueryRunner.getMetadata(),
-                        localQueryRunner.getAccessControl(),
-                        stateMachine,
-                        emptyList(),
-                        WarningCollector.NOOP));
+        SetTimeZoneTask task = new SetTimeZoneTask(
+                localQueryRunner.getMetadata(),
+                localQueryRunner.getAccessControl(),
+                localQueryRunner.getSqlParser(),
+                localQueryRunner.getGroupProvider(),
+                localQueryRunner.getStatsCalculator());
+        getFutureValue(task.execute(setTimeZone, stateMachine, emptyList(), WarningCollector.NOOP));
     }
 }

--- a/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
+++ b/plugin/trino-thrift/src/test/java/io/trino/plugin/thrift/integration/ThriftQueryRunner.java
@@ -38,6 +38,7 @@ import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.Plugin;
 import io.trino.split.PageSourceManager;
 import io.trino.split.SplitManager;
+import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.testing.DistributedQueryRunner;
 import io.trino.testing.MaterializedResult;
@@ -208,6 +209,12 @@ public final class ThriftQueryRunner
         public Metadata getMetadata()
         {
             return source.getMetadata();
+        }
+
+        @Override
+        public AnalyzerFactory getAnalyzerFactory()
+        {
+            return source.getAnalyzerFactory();
         }
 
         @Override

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueryFramework.java
@@ -14,7 +14,6 @@
 package io.trino.testing;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.MoreCollectors;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.airlift.units.Duration;
@@ -487,8 +486,7 @@ public abstract class AbstractTestQueryFramework
                 queryRunner.getAccessControl(),
                 sqlParser,
                 queryRunner.getStatsCalculator(),
-                costCalculator,
-                ImmutableMap.of());
+                costCalculator);
     }
 
     protected static void skipTestUnless(boolean requirement)

--- a/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/DistributedQueryRunner.java
@@ -41,6 +41,7 @@ import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.security.SystemAccessControl;
 import io.trino.split.PageSourceManager;
 import io.trino.split.SplitManager;
+import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.sql.planner.Plan;
 import io.trino.transaction.TransactionManager;
@@ -321,6 +322,12 @@ public class DistributedQueryRunner
     public Metadata getMetadata()
     {
         return coordinator.getMetadata();
+    }
+
+    @Override
+    public AnalyzerFactory getAnalyzerFactory()
+    {
+        return coordinator.getAnalyzerFactory();
     }
 
     @Override

--- a/testing/trino-testing/src/main/java/io/trino/testing/StandaloneQueryRunner.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/StandaloneQueryRunner.java
@@ -26,6 +26,7 @@ import io.trino.server.testing.TestingTrinoServer;
 import io.trino.spi.Plugin;
 import io.trino.split.PageSourceManager;
 import io.trino.split.SplitManager;
+import io.trino.sql.analyzer.AnalyzerFactory;
 import io.trino.sql.planner.NodePartitioningManager;
 import io.trino.transaction.TransactionManager;
 import org.intellij.lang.annotations.Language;
@@ -120,6 +121,12 @@ public final class StandaloneQueryRunner
     public Metadata getMetadata()
     {
         return server.getMetadata();
+    }
+
+    @Override
+    public AnalyzerFactory getAnalyzerFactory()
+    {
+        return server.getAnalyzerFactory();
     }
 
     @Override


### PR DESCRIPTION
There is a circular dependency between the analyzer and tasks that makes adding new helper services into analyzer.  The dependency is a bit hidden in the code, but exists as follows:
```java
Analyser -> StatementRewrite -> ExplainRewrite -> QueryExplainer -> DataDefinitionTask -> several tasks -> Analyser
```