### PR TITLE
Add sql server lock timeout for sqlserver tests

### DIFF
--- a/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
+++ b/plugin/trino-sqlserver/src/test/java/io/trino/plugin/sqlserver/TestingSqlServer.java
@@ -93,7 +93,10 @@ public final class TestingSqlServer
         databaseName = initializedState.databaseName;
         cleanup = initializedState.cleanup;
 
-        container.withUrlParam("database", databaseName);
+        container.withUrlParam("database", databaseName)
+                // Instead of having a statement block forever (the default)
+                // Throws SQLServerException with SQLServerError code 1222  "Lock request time out period exceeded"
+                .withUrlParam("lockTimeout", Integer.toString(60 * 1000));
     }
 
     private static InitializedState createContainer(String version, BiConsumer<SqlExecutor, String> databaseSetUp)


### PR DESCRIPTION
As discussed here: https://github.com/trinodb/trino/pull/10034#discussion_r755723599

Breaking this config change out into a separate PR and stress testing it