### PR TITLE
Fix DynamicFilter probe timeout

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -92,6 +92,7 @@ import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.common.io.Resources.getResource;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.concurrent.MoreFutures.unmodifiableFuture;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
@@ -390,14 +391,14 @@ public class TestBackgroundHiveSplitLoader
                     @Override
                     public CompletableFuture<?> isBlocked()
                     {
-                        return CompletableFuture.runAsync(() -> {
+                        return unmodifiableFuture(CompletableFuture.runAsync(() -> {
                             try {
                                 TimeUnit.HOURS.sleep(1);
                             }
                             catch (InterruptedException e) {
                                 throw new IllegalStateException(e);
                             }
-                        });
+                        }));
                     }
 
                     @Override


### PR DESCRIPTION
as the DynamicFilter returns `unmodifiableFuture`, the `orTimeout` doesn't get propagated to the listenable future. 
By using `thenApply(Function.identity()) `, the timeout is set on another completable future... 
The problem is easily reproduced by casting to `unmodifiableFuture` the returned future from the `testIncompleteDynamicFilterTimeout`, as added here.