### PR TITLE
Describe support of CHAR/VARCHAR predicate pushdown

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -143,6 +143,8 @@ The connector supports pushdown for a number of operations:
 * :func:`min`
 * :func:`sum`
 
+.. include:: no-pushdown-text-type.fragment
+
 .. _clickhouse-sql-support:
 
 SQL support

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -91,6 +91,8 @@ The connector supports pushdown for a number of operations:
 * :ref:`limit-pushdown`
 * :ref:`topn-pushdown`
 
+.. include:: no-pushdown-text-type.fragment
+
 .. _singlestore-sql-support:
 
 SQL support

--- a/docs/src/main/sphinx/connector/mysql.rst
+++ b/docs/src/main/sphinx/connector/mysql.rst
@@ -278,6 +278,8 @@ The connector supports pushdown for a number of operations:
 * :func:`var_pop`
 * :func:`var_samp`
 
+.. include:: no-pushdown-text-type.fragment
+
 .. _mysql-sql-support:
 
 SQL support

--- a/docs/src/main/sphinx/connector/no-inequality-pushdown-text-type.fragment
+++ b/docs/src/main/sphinx/connector/no-inequality-pushdown-text-type.fragment
@@ -1,0 +1,18 @@
+Predicate pushdown support
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The connector does not support pushdown of inequality predicates, such as
+``!=``, ``>``, or ``BETWEEN``, on columns with
+:ref:`character string types <string-data-types>` like ``CHAR`` or ``VARCHAR``.
+Equality predicates, such as ``IN`` or ``=``, on columns with textual types are
+pushed down. This ensures correctness of results since the remote data source
+may sort strings differently than Trino.
+
+In the following example, the predicate of the first query is not pushed down
+since ``name`` is a column of type ``VARCHAR`` and ``>`` is an inequality
+predicate. The second query is pushed down.
+
+.. code-block:: sql
+
+    SELECT * FROM nation WHERE name > 'CANADA';
+    SELECT * FROM nation WHERE name = 'CANADA';

--- a/docs/src/main/sphinx/connector/no-pushdown-text-type.fragment
+++ b/docs/src/main/sphinx/connector/no-pushdown-text-type.fragment
@@ -1,0 +1,15 @@
+Predicate pushdown support
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The connector does not support pushdown of any predicates on columns with
+:ref:`textual types <string-data-types>` like ``CHAR`` or ``VARCHAR``.
+This ensures correctness of results since the data source may compare strings
+case-insensitively.
+
+In the following example, the predicate is not pushed down for either query
+since ``name`` is a column of type ``VARCHAR``:
+
+.. code-block:: sql
+
+    SELECT * FROM nation WHERE name > 'CANADA';
+    SELECT * FROM nation WHERE name = 'CANADA';

--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -173,3 +173,5 @@ The connector supports pushdown for a number of operations:
 * :func:`corr`
 * :func:`regr_intercept`
 * :func:`regr_slope`
+
+.. include:: no-inequality-pushdown-text-type.fragment

--- a/docs/src/main/sphinx/connector/sqlserver.rst
+++ b/docs/src/main/sphinx/connector/sqlserver.rst
@@ -161,6 +161,8 @@ The connector supports pushdown for a number of operations:
 * :func:`var_pop`
 * :func:`var_samp`
 
+.. include:: no-pushdown-text-type.fragment
+
 Data compression
 ----------------
 

--- a/docs/src/main/sphinx/language/types.rst
+++ b/docs/src/main/sphinx/language/types.rst
@@ -10,6 +10,8 @@ Additional types can be provided by plugins.
     Connectors are not required to support all types.
     See connector documentation for details on supported types.
 
+.. _boolean-data-types:
+
 Boolean
 -------
 
@@ -17,6 +19,8 @@ Boolean
 ^^^^^^^^^^^
 
 This type captures boolean values ``true`` and ``false``.
+
+.. _integer-data-types:
 
 Integer
 -------
@@ -46,6 +50,8 @@ also available for this type.
 A 64-bit signed two's complement integer with a minimum value of
 ``-2^63`` and a maximum value of ``2^63 - 1``.
 
+.. _floating-point-data-types:
+
 Floating-point
 --------------
 
@@ -65,6 +71,8 @@ IEEE Standard 754 for Binary Floating-Point Arithmetic.
 
 Example literals: ``DOUBLE '10.3'``, ``DOUBLE '1.03e1'``, ``10.3e0``, ``1.03e1``
 
+.. _fixed-precision-data-types:
+
 Fixed-precision
 ---------------
 
@@ -83,6 +91,8 @@ The decimal type takes two literal parameters:
 Example type definitions: ``DECIMAL(10,3)``, ``DECIMAL(20)``
 
 Example literals: ``DECIMAL '10.3'``, ``DECIMAL '1234567890'``, ``1.1``
+
+.. _string-data-types:
 
 String
 ------
@@ -248,6 +258,8 @@ Example: ``INTERVAL '3' MONTH``
 Span of days, hours, minutes, seconds and milliseconds.
 
 Example: ``INTERVAL '2' DAY``
+
+.. _structural-data-types:
 
 Structural
 ----------


### PR DESCRIPTION
Add documentation for limitations around certain connectors pushing down predicates on CHAR/VARCHAR type columns.