### PR TITLE
Enable Maven cache in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
+          cache: 'maven'
       - name: Maven Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -73,6 +74,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -105,6 +107,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -132,6 +135,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - name: Install Hive Module
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -229,6 +233,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -291,6 +296,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -323,6 +329,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - name: Cleanup node
         # This is required as a virtual environment update 20210219.1 left too little space for MemSQL to work
         run: .github/bin/cleanup-node.sh
@@ -355,6 +362,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
@@ -477,6 +485,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
+          cache: 'maven'
       - name: Maven Checks
         run: |
           $RETRY $MAVEN install -B --strict-checksums -V -T C1 -DskipTests -P ci -am -pl ':trino-docs'
@@ -61,6 +62,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
+          cache: 'maven'
       - name: Maven Install
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"


### PR DESCRIPTION
Enable Maven cache in the CI workflow to speed up steps that compile code. This is equivalent to using `actions/cache`, per [docs](https://github.com/actions/setup-java#caching-packages-dependencies).

More Github docs on the subject: https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows

Some stats I grabbed for last 3 weeks:
```
select count(*) as count, min(started_at) as min_started, max(started_at) as max_started, avg(completed_at-started_at) as avg_duration, min(completed_at-started_at) as min_duration, max(completed_at-started_at) as max_duration from steps where name = 'Maven Install';
 count |       min_started       |       max_started       |  avg_duration  |  min_duration  |  max_duration  
-------+-------------------------+-------------------------+----------------+----------------+----------------
 24710 | 2021-11-09 06:29:37.000 | 2021-11-30 09:53:28.000 | 0 00:04:57.659 | 0 00:00:00.000 | 0 00:31:37.000 
(1 row)
```
The avg above is very rough, I intentionally did not bother with detecting outliers.