### PR TITLE
Make TDigestHistogram immutable

### DIFF
--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
@@ -46,7 +46,7 @@ public class TDigestHistogram
     @JsonProperty
     public TDigest getDigest()
     {
-        return digest;
+        return TDigest.copyOf(digest);
     }
 
     @Override


### PR DESCRIPTION
There are no guarantees that TDigestHistogram
will be used within single threaded context.
Since TDigest is not immutable (e.g. TDigest#mergeWith method),
it needs to be copied before being returned by getDigest
method. Otherwise TDigestHistogram#mergeWith
could concurrently change TDigest state of another
TDigestHistogram instance.