### PR TITLE
Correct anchors for pushdown and type mapping

### DIFF
--- a/docs/src/main/sphinx/connector/clickhouse.rst
+++ b/docs/src/main/sphinx/connector/clickhouse.rst
@@ -128,6 +128,8 @@ Type mapping
 
 .. include:: jdbc-type-mapping.fragment
 
+.. _clickhouse-pushdown:
+
 Pushdown
 --------
 

--- a/docs/src/main/sphinx/connector/memsql.rst
+++ b/docs/src/main/sphinx/connector/memsql.rst
@@ -73,14 +73,14 @@ Finally, you can access the ``clicks`` table in the ``web`` database::
 If you used a different name for your catalog properties file, use
 that catalog name instead of ``memsql`` in the above examples.
 
-.. _memsql-type-mapping:
+.. _singlestore-type-mapping:
 
 Type mapping
 ------------
 
 .. include:: jdbc-type-mapping.fragment
 
-.. _memsql-pushdown:
+.. _singlestore-pushdown:
 
 Pushdown
 --------


### PR DESCRIPTION
Correct missing & outdated anchors for pushdown and type mapping in SingleStore and Clickhouse connector docs