### PR TITLE
Report input positions distribution in EXPLAIN ANALYZE VERBOSE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
+++ b/core/trino-main/src/main/java/io/trino/dispatcher/DispatchManager.java
@@ -300,6 +300,11 @@ public class DispatchManager
         return queryTracker.getQuery(queryId).getBasicQueryInfo();
     }
 
+    public Optional<QueryInfo> getPrunedFullQueryInfo(QueryId queryId)
+    {
+        return getFullQueryInfo(queryId).map(QueryInfo::pruneIntermediateStats);
+    }
+
     public Optional<QueryInfo> getFullQueryInfo(QueryId queryId)
     {
         return queryTracker.tryGetQuery(queryId).map(DispatchQuery::getFullQueryInfo);

--- a/core/trino-main/src/main/java/io/trino/execution/QueryInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryInfo.java
@@ -393,4 +393,41 @@ public class QueryInfo
     {
         return completeInfo;
     }
+
+    public QueryInfo pruneIntermediateStats()
+    {
+        return new QueryInfo(
+                queryId,
+                session,
+                state,
+                memoryPool,
+                scheduled,
+                self,
+                fieldNames,
+                query,
+                preparedQuery,
+                queryStats.pruneIntermediateStats(),
+                setCatalog,
+                setSchema,
+                setPath,
+                setSessionProperties,
+                resetSessionProperties,
+                setRoles,
+                addedPreparedStatements,
+                deallocatedPreparedStatements,
+                startedTransactionId,
+                clearTransactionId,
+                updateType,
+                outputStage.map(StageInfo::pruneIntermediateStats),
+                failureInfo,
+                errorCode,
+                warnings,
+                inputs,
+                output,
+                referencedTables,
+                routines,
+                completeInfo,
+                resourceGroupId,
+                queryType);
+    }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/QueryStats.java
@@ -32,6 +32,7 @@ import java.util.OptionalDouble;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.server.DynamicFilterService.DynamicFiltersStats;
 import static java.lang.Math.min;
@@ -613,5 +614,65 @@ public class QueryStats
         return succinctBytes(operatorSummaries.stream()
                 .mapToLong(stats -> stats.getSpilledDataSize().toBytes())
                 .sum());
+    }
+
+    public QueryStats pruneIntermediateStats()
+    {
+        return new QueryStats(
+                createTime,
+                executionStartTime,
+                lastHeartbeat,
+                endTime,
+                elapsedTime,
+                queuedTime,
+                resourceWaitingTime,
+                dispatchingTime,
+                executionTime,
+                analysisTime,
+                planningTime,
+                finishingTime,
+                totalTasks,
+                runningTasks,
+                completedTasks,
+                totalDrivers,
+                queuedDrivers,
+                runningDrivers,
+                blockedDrivers,
+                completedDrivers,
+                cumulativeUserMemory,
+                cumulativeSystemMemory,
+                userMemoryReservation,
+                revocableMemoryReservation,
+                totalMemoryReservation,
+                peakUserMemoryReservation,
+                peakRevocableMemoryReservation,
+                peakNonRevocableMemoryReservation,
+                peakTotalMemoryReservation,
+                peakTaskUserMemory,
+                peakTaskRevocableMemory,
+                peakTaskTotalMemory,
+                scheduled,
+                totalScheduledTime,
+                totalCpuTime,
+                totalBlockedTime,
+                fullyBlocked,
+                blockedReasons,
+                physicalInputDataSize,
+                physicalInputPositions,
+                physicalInputReadTime,
+                internalNetworkInputDataSize,
+                internalNetworkInputPositions,
+                rawInputDataSize,
+                rawInputPositions,
+                processedInputDataSize,
+                processedInputPositions,
+                outputDataSize,
+                outputPositions,
+                physicalWrittenDataSize,
+                stageGcStatistics,
+                dynamicFiltersStats,
+                operatorSummaries.stream()
+                        .map(OperatorStats::pruneIntermediateStats)
+                        .collect(toImmutableList()));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/execution/StageInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageInfo.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -132,6 +133,37 @@ public class StageInfo
     public boolean isFinalStageInfo()
     {
         return state.isDone() && tasks.stream().allMatch(taskInfo -> taskInfo.getTaskStatus().getState().isDone());
+    }
+
+    public StageInfo(StageInfo other)
+    {
+        this.stageId = other.stageId;
+        this.state = other.state;
+        this.plan = other.plan;
+        this.types = other.types;
+        this.stageStats = other.stageStats;
+        this.tasks = other.tasks;
+        this.subStages = other.subStages;
+        this.failureCause = other.failureCause;
+        this.tables = other.tables;
+    }
+
+    public StageInfo pruneIntermediateStats()
+    {
+        return new StageInfo(
+                stageId,
+                state,
+                plan,
+                types,
+                stageStats.pruneIntermediateStats(),
+                tasks.stream()
+                        .map(TaskInfo::pruneIntermediateStats)
+                        .collect(toImmutableList()),
+                subStages.stream()
+                        .map(StageInfo::pruneIntermediateStats)
+                        .collect(toImmutableList()),
+                tables,
+                failureCause);
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/execution/StageStats.java
+++ b/core/trino-main/src/main/java/io/trino/execution/StageStats.java
@@ -32,6 +32,7 @@ import java.util.OptionalDouble;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.execution.StageState.FLUSHING;
 import static io.trino.execution.StageState.RUNNING;
 import static java.lang.Math.min;
@@ -429,6 +430,50 @@ public class StageStats
     public List<OperatorStats> getOperatorSummaries()
     {
         return operatorSummaries;
+    }
+
+    public StageStats pruneIntermediateStats()
+    {
+        return new StageStats(
+                schedulingComplete,
+                getSplitDistribution,
+                totalTasks,
+                runningTasks,
+                completedTasks,
+                totalDrivers,
+                queuedDrivers,
+                runningDrivers,
+                blockedDrivers,
+                completedDrivers,
+                cumulativeUserMemory,
+                cumulativeSystemMemory,
+                userMemoryReservation,
+                revocableMemoryReservation,
+                totalMemoryReservation,
+                peakUserMemoryReservation,
+                peakRevocableMemoryReservation,
+                totalScheduledTime,
+                totalCpuTime,
+                totalBlockedTime,
+                fullyBlocked,
+                blockedReasons,
+                physicalInputDataSize,
+                physicalInputPositions,
+                physicalInputReadTime,
+                internalNetworkInputDataSize,
+                internalNetworkInputPositions,
+                rawInputDataSize,
+                rawInputPositions,
+                processedInputDataSize,
+                processedInputPositions,
+                bufferedDataSize,
+                outputDataSize,
+                outputPositions,
+                physicalWrittenDataSize,
+                gcInfo,
+                operatorSummaries.stream()
+                        .map(OperatorStats::pruneIntermediateStats)
+                        .collect(toImmutableList()));
     }
 
     public BasicStageStats toBasicStageStats(StageState stageState)

--- a/core/trino-main/src/main/java/io/trino/execution/TaskInfo.java
+++ b/core/trino-main/src/main/java/io/trino/execution/TaskInfo.java
@@ -97,6 +97,11 @@ public class TaskInfo
         return needsPlan;
     }
 
+    public TaskInfo pruneIntermediateStats()
+    {
+        return new TaskInfo(taskStatus, lastHeartbeat, outputBuffers.summarize(), noMoreSplits, stats.pruneIntermediateStats(), needsPlan);
+    }
+
     public TaskInfo summarize()
     {
         if (taskStatus.getState().isDone()) {

--- a/core/trino-main/src/main/java/io/trino/operator/Distribution.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Distribution.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.airlift.stats.TDigest;
+import io.trino.plugin.base.metrics.TDigestHistogram;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class Distribution
+{
+    @Nullable
+    @JsonSerialize(converter = TDigestHistogram.TDigestToBase64Converter.class)
+    @JsonDeserialize(converter = TDigestHistogram.Base64ToTDigestConverter.class)
+    private final TDigest digest;
+    private final double count;
+    private final double min;
+    private final double max;
+    private final double p01;
+    private final double p05;
+    private final double p10;
+    private final double p25;
+    private final double p50;
+    private final double p75;
+    private final double p90;
+    private final double p95;
+    private final double p99;
+
+    public static Distribution ofCount(long count)
+    {
+        TDigest digest = new TDigest();
+        digest.add(count);
+        return new Distribution(digest);
+    }
+
+    @JsonCreator
+    public Distribution(
+            @Nullable TDigest digest,
+            double count,
+            double min,
+            double max,
+            double p01,
+            double p05,
+            double p10,
+            double p25,
+            double p50,
+            double p75,
+            double p90,
+            double p95,
+            double p99)
+    {
+        this.digest = digest;
+        this.count = count;
+        this.min = min;
+        this.max = max;
+        this.p01 = p01;
+        this.p05 = p05;
+        this.p10 = p10;
+        this.p25 = p25;
+        this.p50 = p50;
+        this.p75 = p75;
+        this.p90 = p90;
+        this.p95 = p95;
+        this.p99 = p99;
+    }
+
+    private Distribution(TDigest digest)
+    {
+        this.digest = requireNonNull(digest, "digest is null");
+        this.count = digest.getCount();
+        this.min = digest.getMin();
+        this.max = digest.getMax();
+        this.p01 = digest.valueAt(0.01);
+        this.p05 = digest.valueAt(0.05);
+        this.p10 = digest.valueAt(0.10);
+        this.p25 = digest.valueAt(0.25);
+        this.p50 = digest.valueAt(0.5);
+        this.p75 = digest.valueAt(0.75);
+        this.p90 = digest.valueAt(0.90);
+        this.p95 = digest.valueAt(0.95);
+        this.p99 = digest.valueAt(0.99);
+    }
+
+    public Distribution mergeWith(Distribution distribution)
+    {
+        requireNonNull(digest, "digest is null");
+        requireNonNull(distribution.getDigest(), "distribution.getDigest() is null");
+
+        TDigest result = TDigest.copyOf(digest);
+        result.mergeWith(distribution.getDigest());
+        return new Distribution(result);
+    }
+
+    public Distribution pruneDigest()
+    {
+        if (digest == null) {
+            return this;
+        }
+        return new Distribution(
+                null,
+                count,
+                min,
+                max,
+                p01,
+                p05,
+                p10,
+                p25,
+                p50,
+                p75,
+                p90,
+                p95,
+                p99);
+    }
+
+    @Nullable
+    @JsonProperty
+    public TDigest getDigest()
+    {
+        if (digest == null) {
+            return null;
+        }
+
+        return TDigest.copyOf(digest);
+    }
+
+    @JsonProperty
+    public synchronized double getCount()
+    {
+        return count;
+    }
+
+    @JsonProperty
+    public synchronized double getMin()
+    {
+        return min;
+    }
+
+    @JsonProperty
+    public synchronized double getMax()
+    {
+        return max;
+    }
+
+    @JsonProperty
+    public synchronized double getP01()
+    {
+        return p01;
+    }
+
+    @JsonProperty
+    public synchronized double getP05()
+    {
+        return p05;
+    }
+
+    @JsonProperty
+    public synchronized double getP10()
+    {
+        return p10;
+    }
+
+    @JsonProperty
+    public synchronized double getP25()
+    {
+        return p25;
+    }
+
+    @JsonProperty
+    public synchronized double getP50()
+    {
+        return p50;
+    }
+
+    @JsonProperty
+    public synchronized double getP75()
+    {
+        return p75;
+    }
+
+    @JsonProperty
+    public synchronized double getP90()
+    {
+        return p90;
+    }
+
+    @JsonProperty
+    public synchronized double getP95()
+    {
+        return p95;
+    }
+
+    @JsonProperty
+    public synchronized double getP99()
+    {
+        return p99;
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/operator/Distribution.java
+++ b/core/trino-main/src/main/java/io/trino/operator/Distribution.java
@@ -17,11 +17,14 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.stats.TDigest;
 import io.trino.plugin.base.metrics.TDigestHistogram;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
@@ -212,5 +215,20 @@ public class Distribution
     public synchronized double getP99()
     {
         return p99;
+    }
+
+    public Map<Double, Double> getPercentiles()
+    {
+        return ImmutableMap.<Double, Double>builder()
+                .put(0.01, p01)
+                .put(0.05, p05)
+                .put(0.10, p10)
+                .put(0.25, p25)
+                .put(0.50, p50)
+                .put(0.75, p75)
+                .put(0.90, p90)
+                .put(0.95, p95)
+                .put(0.99, p99)
+                .build();
     }
 }

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -553,6 +553,7 @@ public class OperatorContext
                 DataSize.ofBytes(physicalInputDataSize.getTotalCount() + internalNetworkInputDataSize.getTotalCount()),
                 DataSize.ofBytes(inputDataSize.getTotalCount()),
                 inputPositionsCount,
+                Distribution.ofCount(inputPositionsCount),
                 (double) inputPositionsCount * inputPositionsCount,
 
                 getOutputTiming.getCalls(),

--- a/core/trino-main/src/main/java/io/trino/operator/PipelineStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PipelineStats.java
@@ -447,6 +447,50 @@ public class PipelineStats
         return drivers;
     }
 
+    public PipelineStats pruneIntermediateStats()
+    {
+        return new PipelineStats(
+                pipelineId,
+                firstStartTime,
+                lastStartTime,
+                lastEndTime,
+                inputPipeline,
+                outputPipeline,
+                totalDrivers,
+                queuedDrivers,
+                queuedPartitionedDrivers,
+                queuedPartitionedSplitsWeight,
+                runningDrivers,
+                runningPartitionedDrivers,
+                runningPartitionedSplitsWeight,
+                blockedDrivers,
+                completedDrivers,
+                userMemoryReservation,
+                revocableMemoryReservation,
+                systemMemoryReservation,
+                queuedTime,
+                elapsedTime,
+                totalScheduledTime,
+                totalCpuTime,
+                totalBlockedTime,
+                fullyBlocked,
+                blockedReasons,
+                physicalInputDataSize,
+                physicalInputPositions,
+                physicalInputReadTime,
+                internalNetworkInputDataSize,
+                internalNetworkInputPositions,
+                rawInputDataSize,
+                rawInputPositions,
+                processedInputDataSize,
+                processedInputPositions,
+                outputDataSize,
+                outputPositions,
+                physicalWrittenDataSize,
+                pruneIntermediateOperatorStats(operatorSummaries),
+                drivers);
+    }
+
     public PipelineStats summarize()
     {
         return new PipelineStats(
@@ -489,6 +533,16 @@ public class PipelineStats
                 physicalWrittenDataSize,
                 summarizeOperatorStats(operatorSummaries),
                 ImmutableList.of());
+    }
+
+    private static List<OperatorStats> pruneIntermediateOperatorStats(List<OperatorStats> operatorSummaries)
+    {
+        // Use an exact size ImmutableList builder to avoid a redundant copy in the PipelineStats constructor
+        ImmutableList.Builder<OperatorStats> results = ImmutableList.builderWithExpectedSize(operatorSummaries.size());
+        for (OperatorStats operatorStats : operatorSummaries) {
+            results.add(operatorStats.pruneIntermediateStats());
+        }
+        return results.build();
     }
 
     private static List<OperatorStats> summarizeOperatorStats(List<OperatorStats> operatorSummaries)

--- a/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskStats.java
@@ -508,6 +508,52 @@ public class TaskStats
         return fullGcTime;
     }
 
+    public TaskStats pruneIntermediateStats()
+    {
+        return new TaskStats(
+                createTime,
+                firstStartTime,
+                lastStartTime,
+                lastEndTime,
+                endTime,
+                elapsedTime,
+                queuedTime,
+                totalDrivers,
+                queuedDrivers,
+                queuedPartitionedDrivers,
+                queuedPartitionedSplitsWeight,
+                runningDrivers,
+                runningPartitionedDrivers,
+                runningPartitionedSplitsWeight,
+                blockedDrivers,
+                completedDrivers,
+                cumulativeUserMemory,
+                cumulativeSystemMemory,
+                userMemoryReservation,
+                revocableMemoryReservation,
+                systemMemoryReservation,
+                totalScheduledTime,
+                totalCpuTime,
+                totalBlockedTime,
+                fullyBlocked,
+                blockedReasons,
+                physicalInputDataSize,
+                physicalInputPositions,
+                physicalInputReadTime,
+                internalNetworkInputDataSize,
+                internalNetworkInputPositions,
+                rawInputDataSize,
+                rawInputPositions,
+                processedInputDataSize,
+                processedInputPositions,
+                outputDataSize,
+                outputPositions,
+                physicalWrittenDataSize,
+                fullGcCount,
+                fullGcTime,
+                pruneIntermediatePipelineStats(pipelines));
+    }
+
     public TaskStats summarize()
     {
         return new TaskStats(
@@ -598,6 +644,16 @@ public class TaskStats
                 fullGcCount,
                 fullGcTime,
                 summarizePipelineStats(pipelines));
+    }
+
+    private static List<PipelineStats> pruneIntermediatePipelineStats(List<PipelineStats> pipelines)
+    {
+        // Use an exact size ImmutableList builder to avoid a redundant copy in the TaskStats constructor
+        ImmutableList.Builder<PipelineStats> results = ImmutableList.builderWithExpectedSize(pipelines.size());
+        for (PipelineStats pipeline : pipelines) {
+            results.add(pipeline.pruneIntermediateStats());
+        }
+        return results.build();
     }
 
     private static List<PipelineStats> summarizePipelineStats(List<PipelineStats> pipelines)

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -332,6 +332,7 @@ public class WorkProcessorPipelineSourceOperator
 
                         succinctBytes(context.inputDataSize.get()),
                         context.inputPositions.get(),
+                        Distribution.ofCount(context.inputPositions.get()),
                         (double) context.inputPositions.get() * context.inputPositions.get(),
 
                         context.operatorTiming.getCalls(),

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -332,7 +332,7 @@ public class WorkProcessorPipelineSourceOperator
 
                         succinctBytes(context.inputDataSize.get()),
                         context.inputPositions.get(),
-                        context.inputPositions.get() * context.inputPositions.get(),
+                        (double) context.inputPositions.get() * context.inputPositions.get(),
 
                         context.operatorTiming.getCalls(),
                         new Duration(context.operatorTiming.getWallNanos(), NANOSECONDS),

--- a/core/trino-main/src/main/java/io/trino/server/QueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/QueryResource.java
@@ -95,7 +95,7 @@ public class QueryResource
     {
         requireNonNull(queryId, "queryId is null");
 
-        Optional<QueryInfo> queryInfo = dispatchManager.getFullQueryInfo(queryId);
+        Optional<QueryInfo> queryInfo = dispatchManager.getPrunedFullQueryInfo(queryId);
         if (queryInfo.isEmpty()) {
             return Response.status(Status.GONE).build();
         }

--- a/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/UiQueryResource.java
@@ -94,7 +94,7 @@ public class UiQueryResource
     {
         requireNonNull(queryId, "queryId is null");
 
-        Optional<QueryInfo> queryInfo = dispatchManager.getFullQueryInfo(queryId);
+        Optional<QueryInfo> queryInfo = dispatchManager.getPrunedFullQueryInfo(queryId);
         if (queryInfo.isPresent()) {
             try {
                 checkCanViewQueryOwnedBy(sessionContextFactory.extractAuthorizedIdentity(servletRequest, httpHeaders, alternateHeaderName), queryInfo.get().getSession().toIdentity(), accessControl);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/OperatorInputStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/OperatorInputStats.java
@@ -13,17 +13,27 @@
  */
 package io.trino.sql.planner.planprinter;
 
+import io.trino.operator.Distribution;
+
+import static java.util.Objects.requireNonNull;
+
 class OperatorInputStats
 {
     private final long totalDrivers;
     private final long inputPositions;
     private final double sumSquaredInputPositions;
+    private final Distribution inputPositionsDistribution;
 
-    public OperatorInputStats(long totalDrivers, long inputPositions, double sumSquaredInputPositions)
+    public OperatorInputStats(
+            long totalDrivers,
+            long inputPositions,
+            double sumSquaredInputPositions,
+            Distribution inputPositionsDistribution)
     {
         this.totalDrivers = totalDrivers;
         this.inputPositions = inputPositions;
         this.sumSquaredInputPositions = sumSquaredInputPositions;
+        this.inputPositionsDistribution = requireNonNull(inputPositionsDistribution, "inputPositionsDistribution is null");
     }
 
     public long getTotalDrivers()
@@ -41,11 +51,17 @@ class OperatorInputStats
         return sumSquaredInputPositions;
     }
 
+    public Distribution getInputPositionsDistribution()
+    {
+        return inputPositionsDistribution;
+    }
+
     public static OperatorInputStats merge(OperatorInputStats first, OperatorInputStats second)
     {
         return new OperatorInputStats(
                 first.totalDrivers + second.totalDrivers,
                 first.inputPositions + second.inputPositions,
-                first.sumSquaredInputPositions + second.sumSquaredInputPositions);
+                first.sumSquaredInputPositions + second.sumSquaredInputPositions,
+                first.inputPositionsDistribution.mergeWith(second.inputPositionsDistribution));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
@@ -23,13 +23,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.util.MoreMaps.mergeMaps;
 import static java.lang.Double.max;
 import static java.lang.Math.sqrt;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.stream.Collectors.toMap;
 
 public class PlanNodeStats
         implements Mergeable<PlanNodeStats>
@@ -142,7 +142,7 @@ public class PlanNodeStats
     public Map<String, Double> getOperatorInputPositionsAverages()
     {
         return operatorInputStats.entrySet().stream()
-                .collect(toMap(
+                .collect(toImmutableMap(
                         Map.Entry::getKey,
                         entry -> (double) entry.getValue().getInputPositions() / operatorInputStats.get(entry.getKey()).getTotalDrivers()));
     }
@@ -150,7 +150,7 @@ public class PlanNodeStats
     public Map<String, Double> getOperatorInputPositionsStdDevs()
     {
         return operatorInputStats.entrySet().stream()
-                .collect(toMap(
+                .collect(toImmutableMap(
                         Map.Entry::getKey,
                         entry -> computedStdDev(
                                 entry.getValue().getSumSquaredInputPositions(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.planprinter;
 
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.operator.Distribution;
 import io.trino.spi.Mergeable;
 import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
@@ -156,6 +157,14 @@ public class PlanNodeStats
                                 entry.getValue().getSumSquaredInputPositions(),
                                 entry.getValue().getInputPositions(),
                                 entry.getValue().getTotalDrivers())));
+    }
+
+    public Map<String, Distribution> getOperatorInputPositionsDistribution()
+    {
+        return operatorInputStats.entrySet().stream()
+                .collect(toImmutableMap(
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().getInputPositionsDistribution()));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStatsSummarizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStatsSummarizer.java
@@ -121,7 +121,8 @@ public final class PlanNodeStatsSummarizer
                                 new OperatorInputStats(
                                         operatorStats.getTotalDrivers(),
                                         operatorStats.getInputPositions(),
-                                        operatorStats.getSumSquaredInputPositions())),
+                                        operatorStats.getSumSquaredInputPositions(),
+                                        operatorStats.getInputPositionsDistribution())),
                         (map1, map2) -> mergeMaps(map1, map2, OperatorInputStats::merge));
 
                 metrics.merge(planNodeId, operatorStats.getMetrics(), Metrics::mergeWith);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
@@ -18,6 +18,7 @@ import io.airlift.units.DataSize;
 import io.trino.cost.PlanCostEstimate;
 import io.trino.cost.PlanNodeStatsAndCostSummary;
 import io.trino.cost.PlanNodeStatsEstimate;
+import io.trino.operator.Distribution;
 import io.trino.spi.metrics.Metric;
 import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.Symbol;
@@ -176,6 +177,17 @@ public class TextRenderer
                     "Input avg.: %s rows, Input std.dev.: %s%%\n",
                     formatDouble(inputAverage),
                     formatDouble(100.0d * inputStdDevs.get(operator) / inputAverage)));
+
+            if (verbose) {
+                Distribution inputDistribution = stats.getOperatorInputPositionsDistribution().get(operator);
+                output.append("Input distribution: ")
+                        .append(inputDistribution.getPercentiles().entrySet().stream()
+                                .map(entry -> "p" + String.format("%02d", (int) (entry.getKey() * 100)) + ":" + formatDouble(entry.getValue()))
+                                .collect(joining(", ")) + ", ")
+                        .append("min:" + inputDistribution.getMin() + ", ")
+                        .append("max:" + inputDistribution.getMax() + ", ")
+                        .append("count: " + inputDistribution.getCount() + "\n");
+            }
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
@@ -171,8 +171,11 @@ public class TextRenderer
             double inputAverage = inputAverages.get(operator);
 
             output.append(translatedOperatorType);
-            output.append(format(Locale.US, "Input avg.: %s rows, Input std.dev.: %s%%\n",
-                    formatDouble(inputAverage), formatDouble(100.0d * inputStdDevs.get(operator) / inputAverage)));
+            output.append(format(
+                    Locale.US,
+                    "Input avg.: %s rows, Input std.dev.: %s%%\n",
+                    formatDouble(inputAverage),
+                    formatDouble(100.0d * inputStdDevs.get(operator) / inputAverage)));
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestQueryStats.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import io.airlift.json.JsonCodec;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import io.trino.operator.Distribution;
 import io.trino.operator.FilterAndProjectOperator;
 import io.trino.operator.OperatorStats;
 import io.trino.operator.TableWriterOperator;
@@ -56,6 +57,7 @@ public class TestQueryStats
                     succinctBytes(18L),
                     succinctBytes(19L),
                     110L,
+                    Distribution.ofCount(110L),
                     111.0,
                     112L,
                     new Duration(113, NANOSECONDS),
@@ -97,6 +99,7 @@ public class TestQueryStats
                     succinctBytes(28L),
                     succinctBytes(29L),
                     210L,
+                    Distribution.ofCount(211L),
                     211.0,
                     212L,
                     new Duration(213, NANOSECONDS),
@@ -138,6 +141,7 @@ public class TestQueryStats
                     succinctBytes(38L),
                     succinctBytes(39L),
                     310L,
+                    Distribution.ofCount(311L),
                     311.0,
                     312L,
                     new Duration(313, NANOSECONDS),

--- a/core/trino-main/src/test/java/io/trino/operator/TestOperatorStats.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestOperatorStats.java
@@ -55,6 +55,7 @@ public class TestOperatorStats
             DataSize.ofBytes(5),
             DataSize.ofBytes(6),
             7,
+            Distribution.ofCount(911),
             8d,
 
             9,
@@ -104,6 +105,7 @@ public class TestOperatorStats
             DataSize.ofBytes(5),
             DataSize.ofBytes(6),
             7,
+            Distribution.ofCount(811),
             8d,
 
             9,
@@ -162,6 +164,7 @@ public class TestOperatorStats
         assertEquals(actual.getRawInputDataSize(), DataSize.ofBytes(5));
         assertEquals(actual.getInputDataSize(), DataSize.ofBytes(6));
         assertEquals(actual.getInputPositions(), 7);
+        assertEquals(actual.getInputPositionsDistribution().getCount(), 1.0);
         assertEquals(actual.getSumSquaredInputPositions(), 8.0);
 
         assertEquals(actual.getGetOutputCalls(), 9);
@@ -214,6 +217,7 @@ public class TestOperatorStats
         assertEquals(actual.getRawInputDataSize(), DataSize.ofBytes(3 * 5));
         assertEquals(actual.getInputDataSize(), DataSize.ofBytes(3 * 6));
         assertEquals(actual.getInputPositions(), 3 * 7);
+        assertEquals(actual.getInputPositionsDistribution().getCount(), 3.0);
         assertEquals(actual.getSumSquaredInputPositions(), 3 * 8.0);
 
         assertEquals(actual.getGetOutputCalls(), 3 * 9);
@@ -264,6 +268,7 @@ public class TestOperatorStats
         assertEquals(actual.getRawInputDataSize(), DataSize.ofBytes(3 * 5));
         assertEquals(actual.getInputDataSize(), DataSize.ofBytes(3 * 6));
         assertEquals(actual.getInputPositions(), 3 * 7);
+        assertEquals(actual.getInputPositionsDistribution().getCount(), 3.0);
         assertEquals(actual.getSumSquaredInputPositions(), 3 * 8.0);
 
         assertEquals(actual.getGetOutputCalls(), 3 * 9);

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedEngineOnlyQueries.java
@@ -224,6 +224,14 @@ public class TestDistributedEngineOnlyQueries
     }
 
     @Test
+    public void testExplainAnalyzeVerbose()
+    {
+        assertExplainAnalyze(
+                "EXPLAIN ANALYZE VERBOSE SELECT * FROM nation a",
+                "Input distribution: p01:.*, p05:.*, p10:.*, p25:.*, p50:.*, p75:.*, p90:.*, p95:.*, p99:.*, min:.*, max:.*, count:.*");
+    }
+
+    @Test
     public void testInsertWithCoercion()
     {
         String tableName = "test_insert_with_coercion_" + randomTableSuffix();


### PR DESCRIPTION
```
               Layout: [count_0:bigint]
               CPU: 47.00ms (0.76%), Scheduled: 78.00ms (0.01%), Output: 1430 rows (12.57kB)
               Input avg.: 89.38 rows, Input std.dev.: 331.63%
               Input distribution: p01:1.00, p05:1.00, p10:2.00, p25:4.00, p50:5.00, p75:10.00, p90:122.00, p95:1232.00, p99:1232.00, min:1.0, max:1232.0, count: 16.0
```

Based on: https://github.com/trinodb/trino/pull/10107