### PR TITLE
Report input positions distribution in EXPLAIN ANALYZE VERBOSE

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -50,6 +50,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.operator.BlockedReason.WAITING_FOR_MEMORY;
+import static io.trino.operator.OperatorContext.getOperatorMetrics;
 import static io.trino.operator.PageUtils.recordMaterializedBytes;
 import static io.trino.operator.WorkProcessor.ProcessState.Type.BLOCKED;
 import static io.trino.operator.WorkProcessor.ProcessState.Type.FINISHED;
@@ -342,7 +343,7 @@ public class WorkProcessorPipelineSourceOperator
                         context.outputPositions.get(),
 
                         context.dynamicFilterSplitsProcessed.get(),
-                        context.metrics.get(),
+                        getOperatorMetrics(context.metrics.get(), context.inputPositions.get()),
                         context.connectorMetrics.get(),
 
                         DataSize.ofBytes(0),

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -332,7 +332,7 @@ public class WorkProcessorPipelineSourceOperator
 
                         succinctBytes(context.inputDataSize.get()),
                         context.inputPositions.get(),
-                        context.inputPositions.get() * context.inputPositions.get(),
+                        (double) context.inputPositions.get() * context.inputPositions.get(),
 
                         context.operatorTiming.getCalls(),
                         new Duration(context.operatorTiming.getWallNanos(), NANOSECONDS),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/BasicOperatorStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/BasicOperatorStats.java
@@ -13,17 +13,30 @@
  */
 package io.trino.sql.planner.planprinter;
 
-class OperatorInputStats
+import io.trino.spi.metrics.Metrics;
+
+import static java.util.Objects.requireNonNull;
+
+class BasicOperatorStats
 {
     private final long totalDrivers;
     private final long inputPositions;
     private final double sumSquaredInputPositions;
+    private final Metrics metrics;
+    private final Metrics connectorMetrics;
 
-    public OperatorInputStats(long totalDrivers, long inputPositions, double sumSquaredInputPositions)
+    public BasicOperatorStats(
+            long totalDrivers,
+            long inputPositions,
+            double sumSquaredInputPositions,
+            Metrics metrics,
+            Metrics connectorMetrics)
     {
         this.totalDrivers = totalDrivers;
         this.inputPositions = inputPositions;
         this.sumSquaredInputPositions = sumSquaredInputPositions;
+        this.metrics = requireNonNull(metrics, "metrics is null");
+        this.connectorMetrics = requireNonNull(connectorMetrics, "connectorMetrics is null");
     }
 
     public long getTotalDrivers()
@@ -41,11 +54,23 @@ class OperatorInputStats
         return sumSquaredInputPositions;
     }
 
-    public static OperatorInputStats merge(OperatorInputStats first, OperatorInputStats second)
+    public Metrics getMetrics()
     {
-        return new OperatorInputStats(
+        return metrics;
+    }
+
+    public Metrics getConnectorMetrics()
+    {
+        return connectorMetrics;
+    }
+
+    public static BasicOperatorStats merge(BasicOperatorStats first, BasicOperatorStats second)
+    {
+        return new BasicOperatorStats(
                 first.totalDrivers + second.totalDrivers,
                 first.inputPositions + second.inputPositions,
-                first.sumSquaredInputPositions + second.sumSquaredInputPositions);
+                first.sumSquaredInputPositions + second.sumSquaredInputPositions,
+                first.metrics.mergeWith(second.metrics),
+                first.connectorMetrics.mergeWith(second.connectorMetrics));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/HashCollisionPlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/HashCollisionPlanNodeStats.java
@@ -15,7 +15,6 @@ package io.trino.sql.planner.planprinter;
 
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import java.util.Map;
@@ -39,9 +38,8 @@ public class HashCollisionPlanNodeStats
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
             DataSize planNodeSpilledDataSize,
-            Map<String, OperatorInputStats> operatorInputStats,
-            Map<String, OperatorHashCollisionsStats> operatorHashCollisionsStats,
-            Metrics metrics)
+            Map<String, BasicOperatorStats> operatorStats,
+            Map<String, OperatorHashCollisionsStats> operatorHashCollisionsStats)
     {
         super(
                 planNodeId,
@@ -52,9 +50,7 @@ public class HashCollisionPlanNodeStats
                 planNodeOutputPositions,
                 planNodeOutputDataSize,
                 planNodeSpilledDataSize,
-                operatorInputStats,
-                metrics,
-                Metrics.EMPTY);
+                operatorStats);
         this.operatorHashCollisionsStats = requireNonNull(operatorHashCollisionsStats, "operatorHashCollisionsStats is null");
     }
 
@@ -107,8 +103,7 @@ public class HashCollisionPlanNodeStats
                 merged.getPlanNodeOutputPositions(),
                 merged.getPlanNodeOutputDataSize(),
                 merged.getPlanNodeSpilledDataSize(),
-                merged.operatorInputStats,
-                operatorHashCollisionsStats,
-                merged.getMetrics());
+                merged.operatorStats,
+                operatorHashCollisionsStats);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
@@ -23,13 +23,13 @@ import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.util.MoreMaps.mergeMaps;
 import static java.lang.Double.max;
 import static java.lang.Math.sqrt;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.stream.Collectors.toMap;
 
 public class PlanNodeStats
         implements Mergeable<PlanNodeStats>
@@ -142,7 +142,7 @@ public class PlanNodeStats
     public Map<String, Double> getOperatorInputPositionsAverages()
     {
         return operatorInputStats.entrySet().stream()
-                .collect(toMap(
+                .collect(toImmutableMap(
                         Map.Entry::getKey,
                         entry -> (double) entry.getValue().getInputPositions() / operatorInputStats.get(entry.getKey()).getTotalDrivers()));
     }
@@ -150,7 +150,7 @@ public class PlanNodeStats
     public Map<String, Double> getOperatorInputPositionsStdDevs()
     {
         return operatorInputStats.entrySet().stream()
-                .collect(toMap(
+                .collect(toImmutableMap(
                         Map.Entry::getKey,
                         entry -> computedStdDev(
                                 entry.getValue().getSumSquaredInputPositions(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/PlanNodeStats.java
@@ -13,10 +13,10 @@
  */
 package io.trino.sql.planner.planprinter;
 
+import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import io.trino.spi.Mergeable;
-import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import java.util.Map;
@@ -43,10 +43,8 @@ public class PlanNodeStats
     private final long planNodeOutputPositions;
     private final DataSize planNodeOutputDataSize;
     private final DataSize planNodeSpilledDataSize;
-    private final Metrics metrics;
-    private final Metrics connectorMetrics;
 
-    protected final Map<String, OperatorInputStats> operatorInputStats;
+    protected final Map<String, BasicOperatorStats> operatorStats;
 
     PlanNodeStats(
             PlanNodeId planNodeId,
@@ -57,9 +55,7 @@ public class PlanNodeStats
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
             DataSize planNodeSpilledDataSize,
-            Map<String, OperatorInputStats> operatorInputStats,
-            Metrics metrics,
-            Metrics connectorMetrics)
+            Map<String, BasicOperatorStats> operatorStats)
     {
         this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
 
@@ -70,10 +66,7 @@ public class PlanNodeStats
         this.planNodeOutputPositions = planNodeOutputPositions;
         this.planNodeOutputDataSize = planNodeOutputDataSize;
         this.planNodeSpilledDataSize = requireNonNull(planNodeSpilledDataSize, "planNodeSpilledDataSize is null");
-
-        this.operatorInputStats = requireNonNull(operatorInputStats, "operatorInputStats is null");
-        this.metrics = requireNonNull(metrics, "metrics is null");
-        this.connectorMetrics = requireNonNull(connectorMetrics, "connectorMetrics is null");
+        this.operatorStats = ImmutableMap.copyOf(requireNonNull(operatorStats, "operatorStats is null"));
     }
 
     private static double computedStdDev(double sumSquared, double sum, long n)
@@ -101,7 +94,7 @@ public class PlanNodeStats
 
     public Set<String> getOperatorTypes()
     {
-        return operatorInputStats.keySet();
+        return operatorStats.keySet();
     }
 
     public long getPlanNodeInputPositions()
@@ -129,33 +122,28 @@ public class PlanNodeStats
         return planNodeSpilledDataSize;
     }
 
-    public Metrics getMetrics()
-    {
-        return metrics;
-    }
-
-    public Metrics getConnectorMetrics()
-    {
-        return connectorMetrics;
-    }
-
     public Map<String, Double> getOperatorInputPositionsAverages()
     {
-        return operatorInputStats.entrySet().stream()
+        return operatorStats.entrySet().stream()
                 .collect(toImmutableMap(
                         Map.Entry::getKey,
-                        entry -> (double) entry.getValue().getInputPositions() / operatorInputStats.get(entry.getKey()).getTotalDrivers()));
+                        entry -> (double) entry.getValue().getInputPositions() / operatorStats.get(entry.getKey()).getTotalDrivers()));
     }
 
     public Map<String, Double> getOperatorInputPositionsStdDevs()
     {
-        return operatorInputStats.entrySet().stream()
+        return operatorStats.entrySet().stream()
                 .collect(toImmutableMap(
                         Map.Entry::getKey,
                         entry -> computedStdDev(
                                 entry.getValue().getSumSquaredInputPositions(),
                                 entry.getValue().getInputPositions(),
                                 entry.getValue().getTotalDrivers())));
+    }
+
+    public Map<String, BasicOperatorStats> getOperatorStats()
+    {
+        return operatorStats;
     }
 
     @Override
@@ -168,7 +156,7 @@ public class PlanNodeStats
         long planNodeOutputPositions = this.planNodeOutputPositions + other.planNodeOutputPositions;
         DataSize planNodeOutputDataSize = succinctBytes(this.planNodeOutputDataSize.toBytes() + other.planNodeOutputDataSize.toBytes());
 
-        Map<String, OperatorInputStats> operatorInputStats = mergeMaps(this.operatorInputStats, other.operatorInputStats, OperatorInputStats::merge);
+        Map<String, BasicOperatorStats> operatorStats = mergeMaps(this.operatorStats, other.operatorStats, BasicOperatorStats::merge);
 
         return new PlanNodeStats(
                 planNodeId,
@@ -177,8 +165,6 @@ public class PlanNodeStats
                 planNodeInputPositions, planNodeInputDataSize,
                 planNodeOutputPositions, planNodeOutputDataSize,
                 succinctBytes(this.planNodeSpilledDataSize.toBytes() + other.planNodeSpilledDataSize.toBytes()),
-                operatorInputStats,
-                this.metrics.mergeWith(other.metrics),
-                this.connectorMetrics.mergeWith(other.connectorMetrics));
+                operatorStats);
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
@@ -171,8 +171,11 @@ public class TextRenderer
             double inputAverage = inputAverages.get(operator);
 
             output.append(translatedOperatorType);
-            output.append(format(Locale.US, "Input avg.: %s rows, Input std.dev.: %s%%\n",
-                    formatDouble(inputAverage), formatDouble(100.0d * inputStdDevs.get(operator) / inputAverage)));
+            output.append(format(
+                    Locale.US,
+                    "Input avg.: %s rows, Input std.dev.: %s%%\n",
+                    formatDouble(inputAverage),
+                    formatDouble(100.0d * inputStdDevs.get(operator) / inputAverage)));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/TextRenderer.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
@@ -138,8 +139,8 @@ public class TextRenderer
         }
         output.append("\n");
 
-        printMetrics(output, "connector metrics:", nodeStats.getConnectorMetrics());
-        printMetrics(output, "metrics:", nodeStats.getMetrics());
+        printMetrics(output, "connector metrics:", BasicOperatorStats::getConnectorMetrics, nodeStats);
+        printMetrics(output, "metrics:", BasicOperatorStats::getMetrics, nodeStats);
         printDistributions(output, nodeStats);
         printCollisions(output, nodeStats);
 
@@ -150,14 +151,24 @@ public class TextRenderer
         return output.toString();
     }
 
-    private void printMetrics(StringBuilder output, String label, Metrics metrics)
+    private void printMetrics(StringBuilder output, String label, Function<BasicOperatorStats, Metrics> metricsGetter, PlanNodeStats stats)
     {
-        if (!verbose || metrics.getMetrics().isEmpty()) {
+        if (!verbose) {
             return;
         }
-        output.append(label).append("\n");
-        Map<String, Metric<?>> sortedMap = new TreeMap<>(metrics.getMetrics());
-        sortedMap.forEach((name, metric) -> output.append(format("  '%s' = %s\n", name, metric)));
+
+        Map<String, String> translatedOperatorTypes = translateOperatorTypes(stats.getOperatorTypes());
+        for (String operator : translatedOperatorTypes.keySet()) {
+            String translatedOperatorType = translatedOperatorTypes.get(operator);
+            Metrics metrics = metricsGetter.apply(stats.getOperatorStats().get(operator));
+            if (metrics.getMetrics().isEmpty()) {
+                continue;
+            }
+
+            output.append(translatedOperatorType + label).append("\n");
+            Map<String, Metric<?>> sortedMap = new TreeMap<>(metrics.getMetrics());
+            sortedMap.forEach((name, metric) -> output.append(format("  '%s' = %s\n", name, metric)));
+        }
     }
 
     private void printDistributions(StringBuilder output, PlanNodeStats stats)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/WindowPlanNodeStats.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/planprinter/WindowPlanNodeStats.java
@@ -15,7 +15,6 @@ package io.trino.sql.planner.planprinter;
 
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
-import io.trino.spi.metrics.Metrics;
 import io.trino.sql.planner.plan.PlanNodeId;
 
 import java.util.Map;
@@ -34,9 +33,8 @@ public class WindowPlanNodeStats
             long planNodeOutputPositions,
             DataSize planNodeOutputDataSize,
             DataSize planNodeSpilledDataSize,
-            Map<String, OperatorInputStats> operatorInputStats,
-            WindowOperatorStats windowOperatorStats,
-            Metrics metrics)
+            Map<String, BasicOperatorStats> operatorStats,
+            WindowOperatorStats windowOperatorStats)
     {
         super(
                 planNodeId,
@@ -47,9 +45,7 @@ public class WindowPlanNodeStats
                 planNodeOutputPositions,
                 planNodeOutputDataSize,
                 planNodeSpilledDataSize,
-                operatorInputStats,
-                metrics,
-                Metrics.EMPTY);
+                operatorStats);
         this.windowOperatorStats = windowOperatorStats;
     }
 
@@ -72,8 +68,7 @@ public class WindowPlanNodeStats
                 merged.getPlanNodeOutputPositions(),
                 merged.getPlanNodeOutputDataSize(),
                 merged.getPlanNodeSpilledDataSize(),
-                merged.operatorInputStats,
-                windowOperatorStats,
-                merged.getMetrics());
+                merged.operatorStats,
+                windowOperatorStats);
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorOperatorAdapter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorOperatorAdapter.java
@@ -64,11 +64,15 @@ public class TestWorkProcessorOperatorAdapter
 
         operator.getOutput();
         assertThat(operator.isFinished()).isFalse();
-        assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics()).isEqualTo(ImmutableMap.of("testOperatorMetric", new LongCount(1)));
+        assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics())
+                .hasSize(2)
+                .containsEntry("testOperatorMetric", new LongCount(1));
 
         operator.getOutput();
         assertThat(operator.isFinished()).isTrue();
-        assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics()).isEqualTo(ImmutableMap.of("testOperatorMetric", new LongCount(2)));
+        assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics())
+                .hasSize(2)
+                .containsEntry("testOperatorMetric", new LongCount(2));
     }
 
     private static class TestWorkProcessorOperatorFactory

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -440,7 +440,6 @@ public class TestWorkProcessorPipelineSourceOperator
         @Override
         public Metrics getMetrics()
         {
-            System.err.println("closed: " + closed);
             return new Metrics(ImmutableMap.of(
                     "testSourceMetric", new LongCount(1),
                     "testSourceClosed", new LongCount(closed ? 1 : 0)));

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -51,6 +51,7 @@ import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.TestingSplit.createLocalSplit;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -203,14 +204,17 @@ public class TestWorkProcessorPipelineSourceOperator
         assertEquals(operatorStats.get(2).getOutputPositions(), 5);
         assertEquals(operatorStats.get(2).getOutputDataSize().toBytes(), 45);
 
-        assertEquals(operatorStats.get(1).getMetrics().getMetrics(), ImmutableMap.of("testOperatorMetric", new LongCount(1)));
+        assertThat(operatorStats.get(1).getMetrics().getMetrics())
+                .hasSize(2)
+                .containsEntry("testOperatorMetric", new LongCount(1));
 
         // assert source operator stats are correct
         OperatorStats sourceOperatorStats = operatorStats.get(0);
 
-        assertEquals(sourceOperatorStats.getMetrics().getMetrics(), ImmutableMap.of(
-                "testSourceMetric", new LongCount(1),
-                "testSourceClosed", new LongCount(1)));
+        assertThat(sourceOperatorStats.getMetrics().getMetrics())
+                .hasSize(3)
+                .containsEntry("testSourceMetric", new LongCount(1))
+                .containsEntry("testSourceClosed", new LongCount(1));
         assertEquals(sourceOperatorStats.getConnectorMetrics().getMetrics(), ImmutableMap.of(
                 "testSourceConnectorMetric", new LongCount(2),
                 "testSourceConnectorClosed", new LongCount(1)));
@@ -243,13 +247,16 @@ public class TestWorkProcessorPipelineSourceOperator
 
         // assert pipeline metrics
         List<OperatorStats> operatorSummaries = pipelineStats.getOperatorSummaries();
-        assertEquals(operatorSummaries.get(0).getMetrics().getMetrics(), ImmutableMap.of(
-                "testSourceMetric", new LongCount(1),
-                "testSourceClosed", new LongCount(1)));
+        assertThat(operatorSummaries.get(0).getMetrics().getMetrics())
+                .hasSize(3)
+                .containsEntry("testSourceMetric", new LongCount(1))
+                .containsEntry("testSourceClosed", new LongCount(1));
         assertEquals(operatorSummaries.get(0).getConnectorMetrics().getMetrics(), ImmutableMap.of(
                 "testSourceConnectorMetric", new LongCount(2),
                 "testSourceConnectorClosed", new LongCount(1)));
-        assertEquals(operatorSummaries.get(1).getMetrics().getMetrics(), ImmutableMap.of("testOperatorMetric", new LongCount(1)));
+        assertThat(operatorSummaries.get(1).getMetrics().getMetrics())
+                .hasSize(2)
+                .containsEntry("testOperatorMetric", new LongCount(1));
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorSourceOperatorAdapter.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorSourceOperatorAdapter.java
@@ -70,12 +70,16 @@ public class TestWorkProcessorSourceOperatorAdapter
 
         operator.getOutput();
         assertThat(operator.isFinished()).isFalse();
-        assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics()).isEqualTo(ImmutableMap.of("testOperatorMetric", new LongCount(1)));
+        assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics())
+                .hasSize(2)
+                .containsEntry("testOperatorMetric", new LongCount(1));
         assertThat(getOnlyElement(context.getNestedOperatorStats()).getConnectorMetrics().getMetrics()).isEqualTo(ImmutableMap.of("testConnectorMetric", new LongCount(2)));
 
         operator.getOutput();
         assertThat(operator.isFinished()).isTrue();
-        assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics()).isEqualTo(ImmutableMap.of("testOperatorMetric", new LongCount(2)));
+        assertThat(getOnlyElement(context.getNestedOperatorStats()).getMetrics().getMetrics())
+                .hasSize(2)
+                .containsEntry("testOperatorMetric", new LongCount(2));
         assertThat(getOnlyElement(context.getNestedOperatorStats()).getConnectorMetrics().getMetrics()).isEqualTo(ImmutableMap.of("testConnectorMetric", new LongCount(3)));
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
@@ -58,9 +58,76 @@ public class TDigestHistogram
     }
 
     @Override
+    @JsonProperty
     public long getTotal()
     {
         return (long) digest.getCount();
+    }
+
+    @JsonProperty
+    public synchronized double getMin()
+    {
+        return digest.getMin();
+    }
+
+    @JsonProperty
+    public synchronized double getMax()
+    {
+        return digest.getMax();
+    }
+
+    @JsonProperty
+    public synchronized double getP01()
+    {
+        return digest.valueAt(0.01);
+    }
+
+    @JsonProperty
+    public synchronized double getP05()
+    {
+        return digest.valueAt(0.05);
+    }
+
+    @JsonProperty
+    public synchronized double getP10()
+    {
+        return digest.valueAt(0.10);
+    }
+
+    @JsonProperty
+    public synchronized double getP25()
+    {
+        return digest.valueAt(0.25);
+    }
+
+    @JsonProperty
+    public synchronized double getP50()
+    {
+        return digest.valueAt(0.50);
+    }
+
+    @JsonProperty
+    public synchronized double getP75()
+    {
+        return digest.valueAt(0.75);
+    }
+
+    @JsonProperty
+    public synchronized double getP90()
+    {
+        return digest.valueAt(0.90);
+    }
+
+    @JsonProperty
+    public synchronized double getP95()
+    {
+        return digest.valueAt(0.95);
+    }
+
+    @JsonProperty
+    public synchronized double getP99()
+    {
+        return digest.valueAt(0.99);
     }
 
     @Override

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/TDigestHistogram.java
@@ -24,6 +24,7 @@ import io.airlift.stats.TDigest;
 import io.trino.spi.metrics.Distribution;
 
 import java.util.Base64;
+import java.util.Locale;
 
 import static com.google.common.base.MoreObjects.ToStringHelper;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -139,11 +140,25 @@ public class TDigestHistogram
     @Override
     public String toString()
     {
-        ToStringHelper helper = toStringHelper(this).add("count", digest.getCount());
-        for (int q = 0; q <= 100; q += 10) {
-            helper.add(format("p%d", q), getPercentile(q));
-        }
+        ToStringHelper helper = toStringHelper("")
+                .add("count", formatDouble(digest.getCount()))
+                .add("p01", formatDouble(getP01()))
+                .add("p05", formatDouble(getP05()))
+                .add("p10", formatDouble(getP10()))
+                .add("p25", formatDouble(getP25()))
+                .add("p50", formatDouble(getP50()))
+                .add("p75", formatDouble(getP75()))
+                .add("p90", formatDouble(getP90()))
+                .add("p95", formatDouble(getP95()))
+                .add("p99", formatDouble(getP99()))
+                .add("min", formatDouble(getMin()))
+                .add("max", formatDouble(getMax()));
         return helper.toString();
+    }
+
+    private static String formatDouble(double value)
+    {
+        return format(Locale.US, "%.2f", value);
     }
 
     public static class TDigestToBase64Converter

--- a/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/metrics/TestMetrics.java
+++ b/lib/trino-plugin-toolkit/src/test/java/io/trino/plugin/base/metrics/TestMetrics.java
@@ -61,7 +61,8 @@ public class TestMetrics
         assertThat(merged.getTotal()).isEqualTo(3L);
         assertThat(merged.getPercentile(0)).isEqualTo(5.0);
         assertThat(merged.getPercentile(100)).isEqualTo(10.0);
-        assertThat(merged.toString()).matches("TDigestHistogram\\{count=3.0, p0=5\\.0, p10=5\\.0, .*, p90=10\\.0, p100=10\\.0\\}");
+        assertThat(merged.toString())
+                .matches("\\{count=3\\.00, p01=5\\.00, p05=5\\.00, p10=5\\.00, p25=5\\.00, p50=7\\.50, p75=10\\.00, p90=10\\.00, p95=10\\.00, p99=10\\.00, min=5\\.00, max=10\\.00\\}");
     }
 
     @Test

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedEngineOnlyQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestDistributedEngineOnlyQueries.java
@@ -224,6 +224,14 @@ public class TestDistributedEngineOnlyQueries
     }
 
     @Test
+    public void testExplainAnalyzeVerbose()
+    {
+        assertExplainAnalyze(
+                "EXPLAIN ANALYZE VERBOSE SELECT * FROM nation a",
+                "'Input distribution' = \\{count=.*, p01=.*, p05=.*, p10=.*, p25=.*, p50=.*, p75=.*, p90=.*, p95=.*, p99=.*, min=.*, max=.*}");
+    }
+
+    @Test
     public void testInsertWithCoercion()
     {
         String tableName = "test_insert_with_coercion_" + randomTableSuffix();


### PR DESCRIPTION
Example output
```
 └─ TableScan[hive:tpch_sf10_orc:lineitem_part, grouped = false]
        Layout: []
        Estimates: {rows: 32639679 (0B), cpu: 0, memory: 0B, network: 0B}
        CPU: 3.62s (88.81%), Scheduled: 13.36m (99.94%), Output: 34156833 rows (0B)
        metrics:
          'Input distribution' = TDigestHistogram{count=1430.00, p01=3102.00, p05=14835.88, p10=24473.31, p25=24781.22, p50=24913.10, p75=25033.02, p90=25128.67, p95=25
        Input avg.: 23885.90 rows, Input std.dev.: 16.87%
        shipdate:date:PARTITION_KEY
            :: [[1995-01-02, 1998-12-01]]

 └─ InnerJoin[("nationkey" = "nationkey_0")][$hashvalue, $hashvalue_7]
    │   Layout: []
    │   Reorder joins cost : {rows: 100000 (0B), cpu: 1.72M, memory: 225B, network: 225B}
    │   Estimates: {rows: 100000 (0B), cpu: 5.15M, memory: 450B, network: 450B}
    │   CPU: 97.00ms (61.78%), Scheduled: 346.00ms (51.87%), Output: 100000 rows (0B)
    │   Left (probe) metrics:
    │     'Input distribution' = TDigestHistogram{count=1.00, p01=100000.00, p05=100000.00, p10=100000.00, p25=100000.00, p50=100000.00, p75=100000.00, p90=100000.00, p
    │   Right (build) metrics:
    │     'Input distribution' = TDigestHistogram{count=16.00, p01=0.00, p05=0.00, p10=0.00, p25=0.00, p50=1.00, p75=4.00, p90=4.00, p95=4.00, p99=4.00, min=0.00, max=4
    │   Left (probe) Input avg.: 100000.00 rows, Input std.dev.: 0.00%
    │   Right (build) Input avg.: 1.56 rows, Input std.dev.: 98.55%
    │   Collisions avg.: 0.80 (155.86% est.), Collisions std.dev.: 111.80%
```
cc @martint 