### PR TITLE
Verify IcebergMetadata.transaction not overwritten

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -422,6 +422,7 @@ public class IcebergMetadata
     @Override
     public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
     {
+        verify(transaction == null, "transaction already set");
         transaction = newCreateTableTransaction(catalog, tableMetadata, session);
         return new IcebergWritableTableHandle(
                 tableMetadata.getTable().getSchemaName(),
@@ -480,6 +481,7 @@ public class IcebergMetadata
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
         Table icebergTable = catalog.loadTable(session, table.getSchemaTableName());
 
+        verify(transaction == null, "transaction already set");
         transaction = icebergTable.newTransaction();
 
         return new IcebergWritableTableHandle(
@@ -527,6 +529,7 @@ public class IcebergMetadata
 
         appendFiles.commit();
         transaction.commitTransaction();
+        transaction = null;
 
         return Optional.of(new HiveWrittenPartitions(commitTasks.stream()
                 .map(CommitTaskData::getPath)
@@ -899,6 +902,7 @@ public class IcebergMetadata
     {
         IcebergTableHandle table = (IcebergTableHandle) tableHandle;
         Table icebergTable = catalog.loadTable(session, table.getSchemaTableName());
+        verify(transaction == null, "transaction already set");
         transaction = icebergTable.newTransaction();
 
         return new IcebergWritableTableHandle(
@@ -964,6 +968,7 @@ public class IcebergMetadata
         appendFiles.commit();
 
         transaction.commitTransaction();
+        transaction = null;
         return Optional.of(new HiveWrittenPartitions(commitTasks.stream()
                 .map(CommitTaskData::getPath)
                 .collect(toImmutableList())));


### PR DESCRIPTION
It seems possible with some tricky client use to send queries in same
transaction. Guard against such case in `IcebergMetadata` to prevent
data corruption.

References

- https://github.com/trinodb/trino/issues/10096 mentions transaction id
  sharing between JDBC Statement objects
- "Query already begun" failures in `SemiTransactionalHiveMetastore`
  observed in real life (example reference:
  https://trinodb.slack.com/archives/CP1MUNEUX/p1583486329116800).