### PR TITLE
Fix exception handling for Hive OPTIMIZE table procedure

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2138,6 +2138,7 @@ public class HiveMetadata
                     firstScannedPath = Optional.of(scannedPath);
                 }
                 retry().run("delete " + scannedPath, () -> fs.delete(scannedPath, false));
+                someDeleted = true;
                 remainingFilesToDelete.remove(scannedPath);
             }
         }


### PR DESCRIPTION
This is a fix after https://github.com/trinodb/trino/pull/9665/commits/57e48d2e78f35da01b6e1bd5a657dc79c2672ce5

Currently `someDeleted` flag is always false.