### PR TITLE
Fix/predicate skip nested row type

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestComplexTypesWithNull.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestComplexTypesWithNull.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.sql.query;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for https://github.com/trinodb/trino/issues/9528
+ */
+public class TestComplexTypesWithNull
+{
+    private QueryAssertions assertions;
+
+    @BeforeClass
+    public void init()
+    {
+        assertions = new QueryAssertions();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        assertions.close();
+        assertions = null;
+    }
+
+    @Test
+    public void testRowTypeWithNull()
+    {
+        assertThat(assertions.query(
+                "SELECT r.a, r.b, c FROM " +
+                        "(VALUES ROW(CAST(ROW(1, NULL) AS ROW(a INTEGER, b INTEGER)))) t(r) " +
+                        "JOIN (VALUES 1) u(c) ON c = r.a"))
+                .matches("VALUES (1, CAST(NULL AS INTEGER), 1)");
+    }
+
+    @Test
+    public void testArrayTypeWithNull()
+    {
+        assertThat(assertions.query(
+                "SELECT t.a, t.b, c FROM " +
+                        "UNNEST(ARRAY[CAST(ROW(1, NULL) as ROW(a INTEGER, b INTEGER)) ]) t " +
+                        "JOIN (VALUES 1) u(c) ON c = t.a"))
+                .matches("VALUES (1, CAST(NULL AS INTEGER), 1)");
+    }
+
+    @Test
+    public void testNestedRowTypeWithNull()
+    {
+        assertThat(assertions.query(
+                "SELECT r.a, r[2].b, r[2].c, c FROM " +
+                        "(VALUES ROW(CAST(ROW(1, ROW(1, NULL)) AS ROW(a INTEGER, ROW(b INTEGER, c INTEGER))))) t(r) " +
+                        "JOIN (VALUES 1) u(c) ON c = r.a"))
+                .matches("VALUES (1, 1, CAST(NULL AS INTEGER), 1)");
+    }
+
+    @Test
+    public void testNestedArrayTypeWithNull()
+    {
+        assertThat(assertions.query(
+                "SELECT r.a, r.b, c FROM " +
+                        "(VALUES CAST(ROW(ROW(1, ARRAY[NULL])) AS ROW(ROW(a INTEGER, b ARRAY(INTEGER))))) t(r) " +
+                        "JOIN (VALUES 1) u(c) ON c = r.a"))
+                .matches("VALUES (1, ARRAY[CAST(NULL AS INTEGER)], 1)");
+    }
+}


### PR DESCRIPTION
### What are you trying to accomplish?

Close: https://github.com/trinodb/trino/issues/9528.

### What approach did you choose and why?

The root cause of this issue is because during predication, `ROW` and `ARRAY` (struct type) does accept nested `ROWType`, and if the query is a `JOIN`, the `ComparisonOperatorInvokers` will check all the fields in both sides if there's null value.

The `VALUES` works in this case is because the [predicate-pushdown](https://trino.io/docs/current/optimizer/pushdown.html#predicate-pushdown) didn't executed. 
However, when creating query plan the parentheses value after `VALUES` is actually parser to `ROW()` wrapped value.

Check this example:

```sql
SELECT *
FROM UNNEST(ARRAY[CAST(ROW(null,null,null) as ROW(id INTEGER,shopify_order_id INTEGER,user_id INTEGER))
])  /* failed because there's ROW type nested in ARRAY type */

SELECT *
FROM ( VALUES (null,null,null), (null,null,null)) as vals (id, shopify_order_id, user_id)
) /* almost identical to the first query, just without type definition and no pushdown predicate. */
```
This branch is to fix the issue by use BFS to check if there's `null` value present, skipping predicate for ROW and ARRAY if it contains struct type and there's `null` in a field.

### What should reviewers focus on?

1. Is this the right approach?
2. I use `item instanceof Block` to check if the field is struct type. Is this cover some cases shouldn't be skipped?

### Tophatting 🎩

```sql
trino> SELECT *
    -> FROM (VALUES (1, null)) AS t(a, b)
    -> JOIN (VALUES 1) u(c) ON c = a;
 a |  b   | c 
---+------+---
 1 | NULL | 1 
(1 row)

trino> SELECT *
    -> FROM (VALUES ROW(CAST(ROW(1, NULL) AS ROW(a integer, b integer)))) t(r)
    -> JOIN (VALUES 1) u(c) ON c = r.a;
       r       | c 
---------------+---
 {a=1, b=NULL} | 1 
(1 row)

trino> SELECT *
    -> FROM (VALUES ROW(CAST(ROW(1, NULL) AS ROW(a integer, b integer)))) t(r)
    -> JOIN (VALUES 42) u(c) ON c = r.a;
 r | c 
---+---
(0 rows)

trino> SELECT *
    -> FROM (VALUES ROW(CAST(ROW(42, Row(1, null)) AS ROW(a integer, Row(b integer, c integer))))) t(r)
    -> JOIN (VALUES 42) u(c) ON c = r.a;
           r           | c  
-----------------------+----
 {a=42, {b=1, c=NULL}} | 42 
(1 row)

trino> SELECT * FROM (VALUES cast(ROW(ROW(1, array[null])) AS ROW(row(a integer, b array(integer))))) t(r) JOIN (VALUES 1) u(c) ON c = r.a;
        r        | c 
-----------------+---
 {a=1, b=[NULL]} | 1 
(1 row)


trino> WITH                                                                                                                                                                                                                        
    ->                                                                                                                                                                                                                             
    -> a AS (                                                                                                                                                                                                                      
    -> SELECT *                                                                                                                                                                                                                    
    -> FROM UNNEST(ARRAY[CAST(ROW('2021-01-01 00:00:00+00:00','1',1,'api1','shop1','Test') as ROW(order_created_at TIMESTAMP(6) WITH TIME ZONE,order_id VARCHAR,adjustment_usd DECIMAL(38,9),_api_client_key VARCHAR,_shop_key VARC
HAR,inclusion_status VARCHAR))                                                                                                                                                                                                     
    -> ])                                                                                                                                                                                                                          
    -> )                                                                                                                                                                                                                           
    -> ,                                                                                                                                                                                                                           
    -> b AS (                                                                                                                                                                                                                      
    -> SELECT *                                                                                                                                                                                                                    
    -> FROM UNNEST(ARRAY[CAST(ROW(null,null,null) as ROW(id INTEGER,shopify_order_id INTEGER,user_id INTEGER))                                                                                                                     
    -> ])                                                                                                                                                                                                                          
    -> )                                                                                                                                                                                                                           
    -> ,                                                                                                                                                                                                                           
    -> c AS (                                                                                                                                                                                                                      
    -> SELECT *                                                                                                                                                                                                                    
    -> FROM UNNEST(ARRAY[CAST(ROW(null,null,null) as ROW(user_id INTEGER,order_id INTEGER,cart_uuid VARCHAR))                                                                                                                      
    -> ])                                                                                                                                                                                                                          
    -> )                                                                                                                                                                                                                           
    -> ,                                                                                                                                                                                                                           
    -> d AS (                                                                                                                                                                                                                      
    -> SELECT *                                                                                                                                                                                                                    
    -> FROM UNNEST(ARRAY[CAST(ROW('shop1','1') as ROW(_shop_key VARCHAR,shop_id VARCHAR))                                                                                                                                          
    -> ])                                                                                                                                                                                                                          
    -> )                                                                                                                                                                                                                           
    -> ,                                                                                                                                                                                                                           
    -> e AS (
    -> SELECT *
    -> FROM UNNEST(ARRAY[CAST(ROW('api1','1234') as ROW(_api_client_key VARCHAR,api_client_id VARCHAR))
    -> ])
    -> )
    -> ,
    -> final_table AS (
    -> 
    -> SELECT
    ->   d._shop_key,
    ->   CAST(d.shop_id AS BIGINT) AS shop_id,
    ->   checkouts.user_id AS user_id,
    ->   CAST(a.order_id AS BIGINT) AS shopify_order_id,
    ->   a.order_created_at AS order_created_at,
    ->   DATE(a.order_created_at) AS order_created_date,
    ->   CASE
    ->     WHEN checkouts.order_id IS NULL THEN NULL
    ->     WHEN checkouts.cart_uuid IS NULL THEN 'buy_now'
    ->     ELSE 'cart'
    ->    END AS is_buy_now_or_cart,
    ->    checkouts.order_id AS arrive_order_id,
    ->   SUM(a.adjustment_usd) AS gmv_usd_total
    -> FROM a AS a
    -> JOIN d AS d
    ->   ON d._shop_key =  a._shop_key
    ->   AND inclusion_status = 'Test'
    -> JOIN e AS e
    ->   ON e._api_client_key = a._api_client_key
    ->   AND api_client_id = '1234'
    -> LEFT JOIN b AS orders
    ->   ON CAST(a.order_id AS BIGINT) = orders.shopify_order_id
    -> LEFT JOIN c AS checkouts
    ->   ON checkouts.order_id = orders.id
    -> GROUP BY 1,2,3,4,5,6,7,8
    ->                                                                                                                                                                                                                             
    -> )
    -> SELECT * 
    -> FROM final_table;
 _shop_key | shop_id | user_id | shopify_order_id |        order_created_at        | order_created_date | is_buy_now_or_cart | arrive_order_id | gmv_usd_total 
-----------+---------+---------+------------------+--------------------------------+--------------------+--------------------+-----------------+---------------
 shop1     |       1 |    NULL |                1 | 2021-01-01 00:00:00.000000 UTC | 2021-01-01         | NULL               |            NULL |   1.000000000
```
