### PR TITLE
Update schema of Iceberg $partitions table

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PartitionTable.java
@@ -27,7 +27,6 @@ import io.trino.spi.connector.SystemTable;
 import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.RowType;
 import io.trino.spi.type.TypeManager;
-import io.trino.spi.type.TypeUtils;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionField;
@@ -48,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.iceberg.IcebergTypes.convertIcebergValueToTrino;
@@ -56,6 +56,7 @@ import static io.trino.plugin.iceberg.IcebergUtil.primitiveFieldTypes;
 import static io.trino.plugin.iceberg.Partition.convertBounds;
 import static io.trino.plugin.iceberg.TypeConverter.toTrinoType;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.TypeUtils.writeNativeValue;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
 
@@ -67,9 +68,11 @@ public class PartitionTable
     private final Optional<Long> snapshotId;
     private final Map<Integer, Type.PrimitiveType> idToTypeMapping;
     private final List<Types.NestedField> nonPartitionPrimitiveColumns;
+    private final Optional<RowType> partitionColumnType;
     private final List<io.trino.spi.type.Type> partitionColumnTypes;
-    private final List<io.trino.spi.type.Type> resultTypes;
+    private final Optional<RowType> dataColumnType;
     private final List<RowType> columnMetricTypes;
+    private final List<io.trino.spi.type.Type> resultTypes;
     private final ConnectorTableMetadata connectorTableMetadata;
 
     public PartitionTable(SchemaTableName tableName, TypeManager typeManager, Table icebergTable, Optional<Long> snapshotId)
@@ -84,11 +87,19 @@ public class PartitionTable
 
         ImmutableList.Builder<ColumnMetadata> columnMetadataBuilder = ImmutableList.builder();
 
-        List<ColumnMetadata> partitionColumnsMetadata = getPartitionColumnsMetadata(partitionFields, icebergTable.schema());
-        this.partitionColumnTypes = partitionColumnsMetadata.stream()
-                .map(ColumnMetadata::getType)
-                .collect(toImmutableList());
-        columnMetadataBuilder.addAll(partitionColumnsMetadata);
+        this.partitionColumnType = getPartitionColumnType(partitionFields, icebergTable.schema());
+        if (partitionColumnType.isPresent()) {
+            columnMetadataBuilder.add(new ColumnMetadata("partition", partitionColumnType.get()));
+            this.partitionColumnTypes = partitionColumnType.get().getFields().stream()
+                    .map(RowType.Field::getType)
+                    .collect(toImmutableList());
+        }
+        else {
+            this.partitionColumnTypes = ImmutableList.of();
+        }
+
+        Stream.of("record_count", "file_count", "total_size")
+                .forEach(metric -> columnMetadataBuilder.add(new ColumnMetadata(metric, BIGINT)));
 
         Set<Integer> identityPartitionIds = getIdentityPartitions(icebergTable.spec()).keySet().stream()
                 .map(PartitionField::sourceId)
@@ -98,13 +109,17 @@ public class PartitionTable
                 .filter(column -> !identityPartitionIds.contains(column.fieldId()) && column.type().isPrimitiveType())
                 .collect(toImmutableList());
 
-        ImmutableList.of("row_count", "file_count", "total_size")
-                .forEach(metric -> columnMetadataBuilder.add(new ColumnMetadata(metric, BIGINT)));
-
-        List<ColumnMetadata> columnMetricsMetadata = getColumnMetadata(nonPartitionPrimitiveColumns);
-        columnMetadataBuilder.addAll(columnMetricsMetadata);
-
-        this.columnMetricTypes = columnMetricsMetadata.stream().map(m -> (RowType) m.getType()).collect(toImmutableList());
+        this.dataColumnType = getMetricsColumnType(this.nonPartitionPrimitiveColumns);
+        if (dataColumnType.isPresent()) {
+            columnMetadataBuilder.add(new ColumnMetadata("data", dataColumnType.get()));
+            this.columnMetricTypes = dataColumnType.get().getFields().stream()
+                    .map(RowType.Field::getType)
+                    .map(RowType.class::cast)
+                    .collect(toImmutableList());
+        }
+        else {
+            this.columnMetricTypes = ImmutableList.of();
+        }
 
         ImmutableList<ColumnMetadata> columnMetadata = columnMetadataBuilder.build();
         this.resultTypes = columnMetadata.stream()
@@ -125,35 +140,45 @@ public class PartitionTable
         return connectorTableMetadata;
     }
 
-    private List<ColumnMetadata> getPartitionColumnsMetadata(List<PartitionField> fields, Schema schema)
+    private Optional<RowType> getPartitionColumnType(List<PartitionField> fields, Schema schema)
     {
-        return fields.stream()
-                .map(field -> new ColumnMetadata(
+        List<RowType.Field> partitionFields = fields.stream()
+                .map(field -> RowType.field(
                         field.name(),
                         toTrinoType(field.transform().getResultType(schema.findType(field.sourceId())), typeManager)))
                 .collect(toImmutableList());
+        if (partitionFields.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(RowType.from(partitionFields));
     }
 
-    private List<ColumnMetadata> getColumnMetadata(List<Types.NestedField> columns)
+    private Optional<RowType> getMetricsColumnType(List<Types.NestedField> columns)
     {
-        return columns.stream().map(column -> new ColumnMetadata(column.name(),
-                RowType.from(ImmutableList.of(
-                        new RowType.Field(Optional.of("min"), toTrinoType(column.type(), typeManager)),
-                        new RowType.Field(Optional.of("max"), toTrinoType(column.type(), typeManager)),
-                        new RowType.Field(Optional.of("null_count"), BIGINT)))))
+        List<RowType.Field> metricColumns = columns.stream()
+                .map(column -> RowType.field(
+                        column.name(),
+                        RowType.from(ImmutableList.of(
+                                new RowType.Field(Optional.of("min"), toTrinoType(column.type(), typeManager)),
+                                new RowType.Field(Optional.of("max"), toTrinoType(column.type(), typeManager)),
+                                new RowType.Field(Optional.of("null_count"), BIGINT)))))
                 .collect(toImmutableList());
+        if (metricColumns.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(RowType.from(metricColumns));
     }
 
     @Override
     public RecordCursor cursor(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
     {
-        // TODO instead of cursor use pageSource method.
         if (snapshotId.isEmpty()) {
             return new InMemoryRecordSet(resultTypes, ImmutableList.of()).cursor();
         }
         TableScan tableScan = icebergTable.newScan()
                 .useSnapshot(snapshotId.get())
                 .includeColumnStats();
+        // TODO make the cursor lazy
         return buildRecordCursor(getPartitions(tableScan), icebergTable.spec().fields());
     }
 
@@ -205,17 +230,24 @@ public class PartitionTable
         List<? extends Class<?>> partitionColumnClass = partitionTypes.stream()
                 .map(type -> type.typeId().javaClass())
                 .collect(toImmutableList());
-        int columnCounts = partitionColumnTypes.size() + 3 + columnMetricTypes.size();
 
         ImmutableList.Builder<List<Object>> records = ImmutableList.builder();
 
         for (Partition partition : partitions.values()) {
-            List<Object> row = new ArrayList<>(columnCounts);
+            List<Object> row = new ArrayList<>();
 
             // add data for partition columns
-            for (int i = 0; i < partitionColumnTypes.size(); i++) {
-                row.add(convertIcebergValueToTrino(partitionTypes.get(i), partition.getValues().get(i, partitionColumnClass.get(i))));
-            }
+            partitionColumnType.ifPresent(partitionColumnType -> {
+                BlockBuilder partitionRowBlockBuilder = partitionColumnType.createBlockBuilder(null, 1);
+                BlockBuilder partitionBlockBuilder = partitionRowBlockBuilder.beginBlockEntry();
+                for (int i = 0; i < partitionColumnTypes.size(); i++) {
+                    io.trino.spi.type.Type trinoType = partitionColumnType.getFields().get(i).getType();
+                    Object value = convertIcebergValueToTrino(partitionTypes.get(i), partition.getValues().get(i, partitionColumnClass.get(i)));
+                    writeNativeValue(trinoType, partitionBlockBuilder, value);
+                }
+                partitionRowBlockBuilder.closeEntry();
+                row.add(partitionColumnType.getObject(partitionRowBlockBuilder, 0));
+            });
 
             // add the top level metrics.
             row.add(partition.getRecordCount());
@@ -223,18 +255,25 @@ public class PartitionTable
             row.add(partition.getSize());
 
             // add column level metrics
-            for (int i = 0; i < columnMetricTypes.size(); i++) {
+            dataColumnType.ifPresent(dataColumnType -> {
                 if (!partition.hasValidColumnMetrics()) {
                     row.add(null);
-                    continue;
+                    return;
                 }
-                Integer fieldId = nonPartitionPrimitiveColumns.get(i).fieldId();
-                Type.PrimitiveType type = idToTypeMapping.get(fieldId);
-                Object min = convertIcebergValueToTrino(type, partition.getMinValues().get(fieldId));
-                Object max = convertIcebergValueToTrino(type, partition.getMaxValues().get(fieldId));
-                Long nullCount = partition.getNullCounts().get(fieldId);
-                row.add(getColumnMetricBlock(columnMetricTypes.get(i), min, max, nullCount));
-            }
+                BlockBuilder dataRowBlockBuilder = dataColumnType.createBlockBuilder(null, 1);
+                BlockBuilder dataBlockBuilder = dataRowBlockBuilder.beginBlockEntry();
+
+                for (int i = 0; i < columnMetricTypes.size(); i++) {
+                    Integer fieldId = nonPartitionPrimitiveColumns.get(i).fieldId();
+                    Type.PrimitiveType type = idToTypeMapping.get(fieldId);
+                    Object min = convertIcebergValueToTrino(type, partition.getMinValues().get(fieldId));
+                    Object max = convertIcebergValueToTrino(type, partition.getMaxValues().get(fieldId));
+                    Long nullCount = partition.getNullCounts().get(fieldId);
+                    columnMetricTypes.get(i).writeObject(dataBlockBuilder, getColumnMetricBlock(columnMetricTypes.get(i), min, max, nullCount));
+                }
+                dataRowBlockBuilder.closeEntry();
+                row.add(dataColumnType.getObject(dataRowBlockBuilder, 0));
+            });
 
             records.add(row);
         }
@@ -258,9 +297,9 @@ public class PartitionTable
         BlockBuilder rowBlockBuilder = columnMetricType.createBlockBuilder(null, 1);
         BlockBuilder builder = rowBlockBuilder.beginBlockEntry();
         List<RowType.Field> fields = columnMetricType.getFields();
-        TypeUtils.writeNativeValue(fields.get(0).getType(), builder, min);
-        TypeUtils.writeNativeValue(fields.get(1).getType(), builder, max);
-        TypeUtils.writeNativeValue(fields.get(2).getType(), builder, nullCount);
+        writeNativeValue(fields.get(0).getType(), builder, min);
+        writeNativeValue(fields.get(1).getType(), builder, max);
+        writeNativeValue(fields.get(2).getType(), builder, nullCount);
 
         rowBlockBuilder.closeEntry();
         return columnMetricType.getObject(rowBlockBuilder, 0);

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -36,6 +36,7 @@ import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.statistics.ColumnStatistics;
 import io.trino.spi.statistics.TableStatistics;
 import io.trino.testing.BaseConnectorTest;
+import io.trino.testing.DataProviders;
 import io.trino.testing.MaterializedResult;
 import io.trino.testing.MaterializedRow;
 import io.trino.testing.QueryRunner;
@@ -515,11 +516,11 @@ public abstract class BaseIcebergConnectorTest
                 .matches("VALUES " + instant3Utc);
 
         if (partitioned) {
-            assertThat(query(format("SELECT row_count, file_count, _timestamptz FROM \"%s$partitions\"", tableName)))
+            assertThat(query(format("SELECT record_count, file_count, partition._timestamptz FROM \"%s$partitions\"", tableName)))
                     .matches(format("VALUES (BIGINT '1', BIGINT '1', %s), (BIGINT '1', BIGINT '1', %s), (BIGINT '1', BIGINT '1', %s)", instant1Utc, instant2Utc, instant3Utc));
         }
         else {
-            assertThat(query(format("SELECT row_count, file_count, _timestamptz FROM \"%s$partitions\"", tableName)))
+            assertThat(query(format("SELECT record_count, file_count, data._timestamptz FROM \"%s$partitions\"", tableName)))
                     .matches(format(
                             "VALUES (BIGINT '3', BIGINT '3', CAST(ROW(%s, %s, 0) AS row(min timestamp(6) with time zone, max timestamp(6) with time zone, null_count bigint)))",
                             instant1Utc,
@@ -791,45 +792,24 @@ public abstract class BaseIcebergConnectorTest
         String schema = getSession().getSchema().orElseThrow();
         assertThat(query("SELECT column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name = 'test_partitioned_table$partitions' "))
                 .skippingTypesCheck()
-                .matches("VALUES " +
-                        // Generic columns (selected tested below)
-                        " 'row_count', " +
-                        " 'file_count', " +
-                        " 'total_size', " +
-                        // Table columns
-                        " 'a_boolean', " +
-                        " 'an_integer', " +
-                        " 'a_bigint', " +
-                        " 'a_real', " +
-                        " 'a_double', " +
-                        " 'a_short_decimal', " +
-                        " 'a_long_decimal', " +
-                        " 'a_varchar', " +
-                        " 'a_varbinary', " +
-                        " 'a_date', " +
-                        " 'a_time', " +
-                        " 'a_timestamp', " +
-                        " 'a_timestamptz', " +
-                        " 'a_uuid' " +
-                        // Note: non-primitive columns not being returned from $partitions (otherwise they would be tested below)
-                        "");
+                .matches("VALUES 'partition', 'record_count', 'file_count', 'total_size', 'data'");
         assertThat(query("SELECT " +
-                "  row_count," +
+                "  record_count," +
                 "  file_count, " +
-                "  a_boolean, " +
-                "  an_integer, " +
-                "  a_bigint, " +
-                "  a_real, " +
-                "  a_double, " +
-                "  a_short_decimal, " +
-                "  a_long_decimal, " +
-                "  a_varchar, " +
-                "  a_varbinary, " +
-                "  a_date, " +
-                "  a_time, " +
-                "  a_timestamp, " +
-                "  a_timestamptz, " +
-                "  a_uuid " +
+                "  partition.a_boolean, " +
+                "  partition.an_integer, " +
+                "  partition.a_bigint, " +
+                "  partition.a_real, " +
+                "  partition.a_double, " +
+                "  partition.a_short_decimal, " +
+                "  partition.a_long_decimal, " +
+                "  partition.a_varchar, " +
+                "  data.a_varbinary, " + // TODO (https://github.com/trinodb/trino/issues/9755) partition on varbinary
+                "  partition.a_date, " +
+                "  partition.a_time, " +
+                "  partition.a_timestamp, " +
+                "  partition.a_timestamptz, " +
+                "  partition.a_uuid " +
                 // Note: partitioning on non-primitive columns is not allowed in Iceberg
                 " FROM \"test_partitioned_table$partitions\" "))
                 .matches("" +
@@ -1181,7 +1161,7 @@ public abstract class BaseIcebergConnectorTest
             expectedTimestampStats = "'1969-12-31 22:22:22.222000', '2020-02-21 13:12:12.654999'";
         }
 
-        assertQuery("SELECT d_hour, row_count, d.min, d.max, b.min, b.max FROM \"test_hour_transform$partitions\"", expected);
+        assertQuery("SELECT partition.d_hour, record_count, data.d.min, data.d.max, data.b.min, data.b.max FROM \"test_hour_transform$partitions\"", expected);
 
         // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
         assertQuery(
@@ -1220,7 +1200,7 @@ public abstract class BaseIcebergConnectorTest
         assertQuery("SELECT * FROM test_day_transform_date", values);
 
         assertQuery(
-                "SELECT d_day, row_count, d.min, d.max, b.min, b.max FROM \"test_day_transform_date$partitions\"",
+                "SELECT partition.d_day, record_count, data.d.min, data.d.max, data.b.min, data.b.max FROM \"test_day_transform_date$partitions\"",
                 "VALUES " +
                         "(DATE '1969-01-01', 1, DATE '1969-01-01', DATE '1969-01-01', 10, 10), " +
                         "(DATE '1969-12-31', 1, DATE '1969-12-31', DATE '1969-12-31', 11, 11), " +
@@ -1290,7 +1270,7 @@ public abstract class BaseIcebergConnectorTest
             expectedTimestampStats = "'1969-12-25 15:13:12.876000', '2020-02-21 16:12:12.654999'";
         }
 
-        assertQuery("SELECT d_day, row_count, d.min, d.max, b.min, b.max FROM \"test_day_transform_timestamp$partitions\"", expected);
+        assertQuery("SELECT partition.d_day, record_count, data.d.min, data.d.max, data.b.min, data.b.max FROM \"test_day_transform_timestamp$partitions\"", expected);
 
         // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
         assertQuery(
@@ -1332,7 +1312,7 @@ public abstract class BaseIcebergConnectorTest
         assertQuery("SELECT * FROM test_month_transform_date", values);
 
         assertQuery(
-                "SELECT d_month, row_count, d.min, d.max, b.min, b.max FROM \"test_month_transform_date$partitions\"",
+                "SELECT partition.d_month, record_count, data.d.min, data.d.max, data.b.min, data.b.max FROM \"test_month_transform_date$partitions\"",
                 "VALUES " +
                         "(-2, 1, DATE '1969-11-13', DATE '1969-11-13', 1, 1), " +
                         "(-1, 3, DATE '1969-12-01', DATE '1969-12-31', 2, 4), " +
@@ -1401,7 +1381,7 @@ public abstract class BaseIcebergConnectorTest
             expectedTimestampStats = "'1969-11-15 15:13:12.876000', '2020-02-21 16:12:12.654999'";
         }
 
-        assertQuery("SELECT d_month, row_count, d.min, d.max, b.min, b.max FROM \"test_month_transform_timestamp$partitions\"", expected);
+        assertQuery("SELECT partition.d_month, record_count, data.d.min, data.d.max, data.b.min, data.b.max FROM \"test_month_transform_timestamp$partitions\"", expected);
 
         // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
         assertQuery(
@@ -1441,7 +1421,7 @@ public abstract class BaseIcebergConnectorTest
         assertQuery("SELECT * FROM test_year_transform_date", values);
 
         assertQuery(
-                "SELECT d_year, row_count, d.min, d.max, b.min, b.max FROM \"test_year_transform_date$partitions\"",
+                "SELECT partition.d_year, record_count, data.d.min, data.d.max, data.b.min, data.b.max FROM \"test_year_transform_date$partitions\"",
                 "VALUES " +
                         "(-2, 1, DATE '1968-10-13', DATE '1968-10-13', 1, 1), " +
                         "(-1, 2, DATE '1969-01-01', DATE '1969-03-15', 2, 3), " +
@@ -1506,7 +1486,7 @@ public abstract class BaseIcebergConnectorTest
             expectedTimestampStats = "'1968-03-15 15:13:12.876000', '2020-08-21 16:12:12.654999'";
         }
 
-        assertQuery("SELECT d_year, row_count, d.min, d.max, b.min, b.max FROM \"test_year_transform_timestamp$partitions\"", expected);
+        assertQuery("SELECT partition.d_year, record_count, data.d.min, data.d.max, data.b.min, data.b.max FROM \"test_year_transform_timestamp$partitions\"", expected);
 
         // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
         assertQuery(
@@ -1528,7 +1508,7 @@ public abstract class BaseIcebergConnectorTest
     public void testTruncateTextTransform()
     {
         assertUpdate("CREATE TABLE test_truncate_text_transform (d VARCHAR, b BIGINT) WITH (partitioning = ARRAY['truncate(d, 2)'])");
-        String select = "SELECT d_trunc, row_count, d.min AS d_min, d.max AS d_max, b.min AS b_min, b.max AS b_max FROM \"test_truncate_text_transform$partitions\"";
+        String select = "SELECT partition.d_trunc, record_count, data.d.min AS d_min, data.d.max AS d_max, data.b.min AS b_min, data.b.max AS b_max FROM \"test_truncate_text_transform$partitions\"";
 
         assertUpdate("INSERT INTO test_truncate_text_transform VALUES" +
                 "('abcd', 1)," +
@@ -1539,16 +1519,16 @@ public abstract class BaseIcebergConnectorTest
                 "('Greece', 6)," +
                 "('Grozny', 7)", 7);
 
-        assertQuery("SELECT d_trunc FROM \"test_truncate_text_transform$partitions\"", "VALUES 'ab', 'mo', 'Gr'");
+        assertQuery("SELECT partition.d_trunc FROM \"test_truncate_text_transform$partitions\"", "VALUES 'ab', 'mo', 'Gr'");
 
         assertQuery("SELECT b FROM test_truncate_text_transform WHERE substring(d, 1, 2) = 'ab'", "VALUES 1, 2, 3");
-        assertQuery(select + " WHERE d_trunc = 'ab'", "VALUES ('ab', 3, 'ab598', 'abxy', 1, 3)");
+        assertQuery(select + " WHERE partition.d_trunc = 'ab'", "VALUES ('ab', 3, 'ab598', 'abxy', 1, 3)");
 
         assertQuery("SELECT b FROM test_truncate_text_transform WHERE substring(d, 1, 2) = 'mo'", "VALUES 4, 5");
-        assertQuery(select + " WHERE d_trunc = 'mo'", "VALUES ('mo', 2, 'mommy', 'moscow', 4, 5)");
+        assertQuery(select + " WHERE partition.d_trunc = 'mo'", "VALUES ('mo', 2, 'mommy', 'moscow', 4, 5)");
 
         assertQuery("SELECT b FROM test_truncate_text_transform WHERE substring(d, 1, 2) = 'Gr'", "VALUES 6, 7");
-        assertQuery(select + " WHERE d_trunc = 'Gr'", "VALUES ('Gr', 2, 'Greece', 'Grozny', 6, 7)");
+        assertQuery(select + " WHERE partition.d_trunc = 'Gr'", "VALUES ('Gr', 2, 'Greece', 'Grozny', 6, 7)");
 
         // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
         assertQuery(
@@ -1571,7 +1551,7 @@ public abstract class BaseIcebergConnectorTest
     {
         String table = format("test_truncate_%s_transform", dataType);
         assertUpdate(format("CREATE TABLE " + table + " (d %s, b BIGINT) WITH (partitioning = ARRAY['truncate(d, 10)'])", dataType));
-        String select = "SELECT d_trunc, row_count, d.min AS d_min, d.max AS d_max, b.min AS b_min, b.max AS b_max FROM \"" + table + "$partitions\"";
+        String select = "SELECT partition.d_trunc, record_count, data.d.min AS d_min, data.d.max AS d_max, data.b.min AS b_min, data.b.max AS b_max FROM \"" + table + "$partitions\"";
 
         assertUpdate("INSERT INTO " + table + " VALUES" +
                 "(0, 1)," +
@@ -1590,25 +1570,25 @@ public abstract class BaseIcebergConnectorTest
                 "(-123, 14)," +
                 "(-130, 15)", 15);
 
-        assertQuery("SELECT d_trunc FROM \"" + table + "$partitions\"", "VALUES 0, 10, 120, -10, -20, -130");
+        assertQuery("SELECT partition.d_trunc FROM \"" + table + "$partitions\"", "VALUES 0, 10, 120, -10, -20, -130");
 
         assertQuery("SELECT b FROM " + table + " WHERE d IN (0, 1, 5, 9)", "VALUES 1, 2, 3, 4");
-        assertQuery(select + " WHERE d_trunc = 0", "VALUES (0, 4, 0, 9, 1, 4)");
+        assertQuery(select + " WHERE partition.d_trunc = 0", "VALUES (0, 4, 0, 9, 1, 4)");
 
         assertQuery("SELECT b FROM " + table + " WHERE d IN (10, 11)", "VALUES 5, 6");
-        assertQuery(select + " WHERE d_trunc = 10", "VALUES (10, 2, 10, 11, 5, 6)");
+        assertQuery(select + " WHERE partition.d_trunc = 10", "VALUES (10, 2, 10, 11, 5, 6)");
 
         assertQuery("SELECT b FROM " + table + " WHERE d IN (120, 121, 123)", "VALUES 7, 8, 9");
-        assertQuery(select + " WHERE d_trunc = 120", "VALUES (120, 3, 120, 123, 7, 9)");
+        assertQuery(select + " WHERE partition.d_trunc = 120", "VALUES (120, 3, 120, 123, 7, 9)");
 
         assertQuery("SELECT b FROM " + table + " WHERE d IN (-1, -5, -10)", "VALUES 10, 11, 12");
-        assertQuery(select + " WHERE d_trunc = -10", "VALUES (-10, 3, -10, -1, 10, 12)");
+        assertQuery(select + " WHERE partition.d_trunc = -10", "VALUES (-10, 3, -10, -1, 10, 12)");
 
         assertQuery("SELECT b FROM " + table + " WHERE d = -11", "VALUES 13");
-        assertQuery(select + " WHERE d_trunc = -20", "VALUES (-20, 1, -11, -11, 13, 13)");
+        assertQuery(select + " WHERE partition.d_trunc = -20", "VALUES (-20, 1, -11, -11, 13, 13)");
 
         assertQuery("SELECT b FROM " + table + " WHERE d IN (-123, -130)", "VALUES 14, 15");
-        assertQuery(select + " WHERE d_trunc = -130", "VALUES (-130, 2, -130, -123, 14, 15)");
+        assertQuery(select + " WHERE partition.d_trunc = -130", "VALUES (-130, 2, -130, -123, 14, 15)");
 
         // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
         assertQuery(
@@ -1639,7 +1619,7 @@ public abstract class BaseIcebergConnectorTest
     public void testTruncateDecimalTransform()
     {
         assertUpdate("CREATE TABLE test_truncate_decimal_transform (d DECIMAL(9, 2), b BIGINT) WITH (partitioning = ARRAY['truncate(d, 10)'])");
-        String select = "SELECT d_trunc, row_count, d.min AS d_min, d.max AS d_max, b.min AS b_min, b.max AS b_max FROM \"test_truncate_decimal_transform$partitions\"";
+        String select = "SELECT partition.d_trunc, record_count, data.d.min AS d_min, data.d.max AS d_max, data.b.min AS b_min, data.b.max AS b_max FROM \"test_truncate_decimal_transform$partitions\"";
 
         assertUpdate("INSERT INTO test_truncate_decimal_transform VALUES" +
                 "(12.34, 1)," +
@@ -1648,19 +1628,19 @@ public abstract class BaseIcebergConnectorTest
                 "(0.05, 4)," +
                 "(-0.05, 5)", 5);
 
-        assertQuery("SELECT d_trunc FROM \"test_truncate_decimal_transform$partitions\"", "VALUES 12.30, 12.20, 0.00, -0.10");
+        assertQuery("SELECT partition.d_trunc FROM \"test_truncate_decimal_transform$partitions\"", "VALUES 12.30, 12.20, 0.00, -0.10");
 
         assertQuery("SELECT b FROM test_truncate_decimal_transform WHERE d IN (12.34, 12.30)", "VALUES 1, 2");
-        assertQuery(select + " WHERE d_trunc = 12.30", "VALUES (12.30, 2, 12.30, 12.34, 1, 2)");
+        assertQuery(select + " WHERE partition.d_trunc = 12.30", "VALUES (12.30, 2, 12.30, 12.34, 1, 2)");
 
         assertQuery("SELECT b FROM test_truncate_decimal_transform WHERE d = 12.29", "VALUES 3");
-        assertQuery(select + " WHERE d_trunc = 12.20", "VALUES (12.20, 1, 12.29, 12.29, 3, 3)");
+        assertQuery(select + " WHERE partition.d_trunc = 12.20", "VALUES (12.20, 1, 12.29, 12.29, 3, 3)");
 
         assertQuery("SELECT b FROM test_truncate_decimal_transform WHERE d = 0.05", "VALUES 4");
-        assertQuery(select + " WHERE d_trunc = 0.00", "VALUES (0.00, 1, 0.05, 0.05, 4, 4)");
+        assertQuery(select + " WHERE partition.d_trunc = 0.00", "VALUES (0.00, 1, 0.05, 0.05, 4, 4)");
 
         assertQuery("SELECT b FROM test_truncate_decimal_transform WHERE d = -0.05", "VALUES 5");
-        assertQuery(select + " WHERE d_trunc = -0.10", "VALUES (-0.10, 1, -0.05, -0.05, 5, 5)");
+        assertQuery(select + " WHERE partition.d_trunc = -0.10", "VALUES (-0.10, 1, -0.05, -0.05, 5, 5)");
 
         // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
         assertQuery(
@@ -1681,7 +1661,7 @@ public abstract class BaseIcebergConnectorTest
     @Test
     public void testBucketTransform()
     {
-        String select = "SELECT d_bucket, row_count, d.min AS d_min, d.max AS d_max, b.min AS b_min, b.max AS b_max FROM \"test_bucket_transform$partitions\"";
+        String select = "SELECT partition.d_bucket, record_count, data.d.min AS d_min, data.d.max AS d_max, data.b.min AS b_min, data.b.max AS b_max FROM \"test_bucket_transform$partitions\"";
 
         assertUpdate("CREATE TABLE test_bucket_transform (d VARCHAR, b BIGINT) WITH (partitioning = ARRAY['bucket(d, 2)'])");
         assertUpdate(
@@ -1697,9 +1677,9 @@ public abstract class BaseIcebergConnectorTest
 
         assertQuery("SELECT COUNT(*) FROM \"test_bucket_transform$partitions\"", "SELECT 2");
 
-        assertQuery(select + " WHERE d_bucket = 0", "VALUES(0, 3, 'Grozny', 'mommy', 1, 7)");
+        assertQuery(select + " WHERE partition.d_bucket = 0", "VALUES(0, 3, 'Grozny', 'mommy', 1, 7)");
 
-        assertQuery(select + " WHERE d_bucket = 1", "VALUES(1, 4, 'Greece', 'moscow', 2, 6)");
+        assertQuery(select + " WHERE partition.d_bucket = 1", "VALUES(1, 4, 'Greece', 'moscow', 2, 6)");
 
         // Exercise IcebergMetadata.applyFilter with non-empty Constraint.predicate, via non-pushdownable predicates
         assertQuery(
@@ -1734,7 +1714,7 @@ public abstract class BaseIcebergConnectorTest
 
         assertQuery("SELECT COUNT(*) FROM \"test_void_transform$partitions\"", "SELECT 1");
         assertQuery(
-                "SELECT d_null, row_count, file_count, d.min, d.max, d.null_count, b.min, b.max, b.null_count FROM \"test_void_transform$partitions\"",
+                "SELECT partition.d_null, record_count, file_count, data.d.min, data.d.max, data.d.null_count, data.b.min, data.b.max, data.b.null_count FROM \"test_void_transform$partitions\"",
                 "VALUES (NULL, 7, 1, 'Warsaw', 'mommy', 2, 1, 7, 0)");
 
         assertQuery(
@@ -2095,6 +2075,53 @@ public abstract class BaseIcebergConnectorTest
         assertQuery("SELECT struct_t.f1  FROM " + tableName + " WHERE id = 11 AND map_t = MAP(ARRAY[11, 13], ARRAY[12, 14])", "VALUES 11");
 
         dropTable(tableName);
+    }
+
+    @Test(dataProviderClass = DataProviders.class, dataProvider = "trueFalse")
+    public void testPartitionsTableWithColumnNameConflict(boolean partitioned)
+    {
+        assertUpdate("DROP TABLE IF EXISTS test_partitions_with_conflict");
+        assertUpdate("CREATE TABLE test_partitions_with_conflict (" +
+                " p integer, " +
+                " row_count integer, " +
+                " record_count integer, " +
+                " file_count integer, " +
+                " total_size integer " +
+                ") " +
+                (partitioned ? "WITH(partitioning = ARRAY['p'])" : ""));
+
+        assertUpdate("INSERT INTO test_partitions_with_conflict VALUES (11, 12, 13, 14, 15)", 1);
+
+        // sanity check
+        assertThat(query("SELECT * FROM test_partitions_with_conflict"))
+                .matches("VALUES (11, 12, 13, 14, 15)");
+
+        // test $partitions
+        assertThat(query("SELECT * FROM \"test_partitions_with_conflict$partitions\""))
+                .matches("SELECT " +
+                        (partitioned ? "CAST(ROW(11) AS row(p integer)), " : "") +
+                        "BIGINT '1', " +
+                        "BIGINT '1', " +
+                        // total_size is not exactly deterministic, so grab whatever value there is
+                        "(SELECT total_size FROM \"test_partitions_with_conflict$partitions\"), " +
+                        "CAST(" +
+                        "  ROW (" +
+                        (partitioned ? "" : "  ROW(11, 11, 0), ") +
+                        "    ROW(12, 12, 0), " +
+                        "    ROW(13, 13, 0), " +
+                        "    ROW(14, 14, 0), " +
+                        "    ROW(15, 15, 0) " +
+                        "  ) " +
+                        "  AS row(" +
+                        (partitioned ? "" : "    p row(min integer, max integer, null_count bigint), ") +
+                        "    row_count row(min integer, max integer, null_count bigint), " +
+                        "    record_count row(min integer, max integer, null_count bigint), " +
+                        "    file_count row(min integer, max integer, null_count bigint), " +
+                        "    total_size row(min integer, max integer, null_count bigint) " +
+                        "  )" +
+                        ")");
+
+        assertUpdate("DROP TABLE test_partitions_with_conflict");
     }
 
     private void assertFilterPushdown(
@@ -2664,46 +2691,24 @@ public abstract class BaseIcebergConnectorTest
         String schema = getSession().getSchema().orElseThrow();
         assertThat(query("SELECT column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name = 'test_all_types$partitions' "))
                 .skippingTypesCheck()
-                .matches("VALUES " +
-                        // Generic columns (selected tested below)
-                        " 'row_count', " +
-                        " 'file_count', " +
-                        " 'total_size', " +
-                        // Table columns
-                        " 'a_boolean', " +
-                        " 'an_integer', " +
-                        " 'a_bigint', " +
-                        " 'a_real', " +
-                        " 'a_double', " +
-                        " 'a_short_decimal', " +
-                        " 'a_long_decimal', " +
-                        " 'a_varchar', " +
-                        " 'a_varbinary', " +
-                        " 'a_date', " +
-                        " 'a_time', " +
-                        " 'a_timestamp', " +
-                        " 'a_timestamptz', " +
-                        " 'a_uuid' " +
-                        // Note: non-primitive columns not being returned from $partitions (otherwise they would be tested below)
-                        "");
+                .matches("VALUES 'record_count', 'file_count', 'total_size', 'data'");
         assertThat(query("SELECT " +
-                "  row_count," +
+                "  record_count," +
                 "  file_count, " +
-                "  a_boolean, " +
-                "  an_integer, " +
-                "  a_bigint, " +
-                "  a_real, " +
-                "  a_double, " +
-                "  a_short_decimal, " +
-                "  a_long_decimal, " +
-                "  a_varchar, " +
-                "  a_varbinary, " +
-                "  a_date, " +
-                "  a_time, " +
-                "  a_timestamp, " +
-                "  a_timestamptz, " +
-                "  a_uuid " +
-                // Note: partitioning on non-primitive columns is not allowed in Iceberg
+                "  data.a_boolean, " +
+                "  data.an_integer, " +
+                "  data.a_bigint, " +
+                "  data.a_real, " +
+                "  data.a_double, " +
+                "  data.a_short_decimal, " +
+                "  data.a_long_decimal, " +
+                "  data.a_varchar, " +
+                "  data.a_varbinary, " +
+                "  data.a_date, " +
+                "  data.a_time, " +
+                "  data.a_timestamp, " +
+                "  data.a_timestamptz, " +
+                "  data.a_uuid " +
                 " FROM \"test_all_types$partitions\" "))
                 .matches(
                         format == ORC

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
@@ -18,7 +18,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
-import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.ICEBERG;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
@@ -74,18 +73,64 @@ public class TestIcebergPartitionEvolution
 
         assertThat(onTrino().executeQuery("SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'test_dropped_partition_field$partitions'"))
                 .containsOnly(
-                        row("a", "varchar"),
-                        row("b", "varchar"),
-                        // A/B is now partitioning column in the first partitioning spec, and non-partitioning in new one
-                        // TODO (https://github.com/trinodb/trino/issues/8729): $partitions table (as every other table) cannot have duplicate column names
-                        row(dropFirst ? "a" : "b", "row(min varchar, max varchar, null_count bigint)"),
-                        row("row_count", "bigint"),
+                        row("partition", "row(a varchar, b varchar)"),
+                        row("record_count", "bigint"),
                         row("file_count", "bigint"),
                         row("total_size", "bigint"),
-                        row("c", "row(min varchar, max varchar, null_count bigint)"));
-        assertQueryFailure(() -> onTrino().executeQuery("SELECT a, b, c.min, c.max, row_count FROM \"test_dropped_partition_field$partitions\""))
-                // TODO (https://github.com/trinodb/trino/issues/8729): cannot read from $partitions table because of duplicate column names
-                .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Multiple entries with same key: " + (dropFirst ? "a=a and a=a" : "b=b and b=b"));
+                        row("data", "row(" +
+                                // A/B is now partitioning column in the first partitioning spec, and non-partitioning in new one
+                                (dropFirst ? "a" : "b") + " row(min varchar, max varchar, null_count bigint), " +
+                                "c row(min varchar, max varchar, null_count bigint))"));
+        assertThat(onTrino().executeQuery("SELECT partition, record_count, file_count, data FROM \"test_dropped_partition_field$partitions\""))
+                .containsOnly(
+                        row(
+                                rowBuilder().addField("a", "one").addField("b", "small").build(),
+                                2L,
+                                1L,
+                                rowBuilder()
+                                        .addField(
+                                                dropFirst ? "a" : "b",
+                                                dropFirst ? singletonMetrics("one") : singletonMetrics("small"))
+                                        .addField("c", dataMetrics("rabbit", "snake", 0))
+                                        .build()),
+                        row(
+                                rowBuilder().addField("a", "one").addField("b", "big").build(),
+                                1L,
+                                1L,
+                                rowBuilder()
+                                        .addField(
+                                                dropFirst ? "a" : "b",
+                                                dropFirst ? singletonMetrics("one") : singletonMetrics("big"))
+                                        .addField("c", singletonMetrics("rabbit"))
+                                        .build()),
+                        row(
+                                rowBuilder().addField("a", "another").addField("b", "small").build(),
+                                1L,
+                                1L,
+                                rowBuilder()
+                                        .addField(
+                                                dropFirst ? "a" : "b",
+                                                dropFirst ? singletonMetrics("another") : singletonMetrics("small"))
+                                        .addField("c", singletonMetrics("snake"))
+                                        .build()),
+                        row(
+                                rowBuilder().addField("a", "something").addField("b", "completely").build(),
+                                1L,
+                                1L,
+                                rowBuilder()
+                                        .addField(
+                                                dropFirst ? "a" : "b",
+                                                dropFirst ? singletonMetrics("something") : singletonMetrics("completely"))
+                                        .addField("c", singletonMetrics("else"))
+                                        .build()),
+                        row(
+                                rowBuilder().addField("a", null).addField("b", null).build(),
+                                1L,
+                                1L,
+                                rowBuilder()
+                                        .addField(dropFirst ? "a" : "b", dataMetrics(null, null, 1))
+                                        .addField("c", singletonMetrics("nothing"))
+                                        .build()));
 
         onTrino().executeQuery("INSERT INTO test_dropped_partition_field VALUES ('yet', 'another', 'row')");
         assertThat(onTrino().executeQuery("SELECT * FROM test_dropped_partition_field"))
@@ -103,5 +148,24 @@ public class TestIcebergPartitionEvolution
     public Object[][] testDroppedPartitionFieldDataProvider()
     {
         return new Object[][] {{true}, {false}};
+    }
+
+    private static io.trino.jdbc.Row singletonMetrics(Object value)
+    {
+        return dataMetrics(value, value, 0);
+    }
+
+    private static io.trino.jdbc.Row dataMetrics(Object min, Object max, long nullCount)
+    {
+        return rowBuilder()
+                .addField("min", min)
+                .addField("max", max)
+                .addField("null_count", nullCount)
+                .build();
+    }
+
+    private static io.trino.jdbc.Row.Builder rowBuilder()
+    {
+        return io.trino.jdbc.Row.builder();
     }
 }


### PR DESCRIPTION
Nest partition columns in `partition` column of row type (absent if no
partition columns).
Nest data metrics columns in `data` column of row type (absent if there
are no primitive data columns).

Fixes https://github.com/trinodb/trino/issues/9519
Fixes https://github.com/trinodb/trino/issues/8729