### PR TITLE
Fix flaky testParquetDictionaryPredicatePushdown

### DIFF
--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
@@ -4709,7 +4709,7 @@ public class TestHiveConnectorTest
 
     private void testParquetDictionaryPredicatePushdown(Session session)
     {
-        String tableName = "test_parquet_dictionary_pushdown";
+        String tableName = "test_parquet_dictionary_pushdown_" + randomTableSuffix();
         assertUpdate(session, "DROP TABLE IF EXISTS " + tableName);
         assertUpdate(session, "CREATE TABLE " + tableName + " (n BIGINT) WITH (format = 'PARQUET')");
         assertUpdate(session, "INSERT INTO " + tableName + " VALUES 1, 1, 2, 2, 4, 4, 5, 5", 8);


### PR DESCRIPTION
testParquetDictionaryPredicatePushdown is flaky due to always use same test table name, when `testParquetDictionaryPredicatePushdownWithOptimizedWriter` and `testParquetDictionaryPredicatePushdown` run in the same time, there is a chance that CI throw error `Table 'hive.tpch.test_parquet_dictionary_pushdown' does not exist`.

CI hit flaky test, see https://github.com/trinodb/trino/runs/4384185712?check_suite_focus=true