### PR TITLE
Proactively enforce memory limits in distincting accumulators

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/HashAggregationOperator.java
@@ -562,7 +562,8 @@ public class HashAggregationOperator
             }
 
             for (AggregatorFactory aggregatorFactory : aggregatorFactories) {
-                aggregatorFactory.createAggregator().evaluate(output.getBlockBuilder(channel));
+                // No input will be added to the accumulators, it is ok not to specify the memory callback
+                aggregatorFactory.createAggregator(UpdateMemory.NOOP).evaluate(output.getBlockBuilder(channel));
                 channel++;
             }
         }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AccumulatorFactory.java
@@ -13,13 +13,15 @@
  */
 package io.trino.operator.aggregation;
 
+import io.trino.operator.UpdateMemory;
+
 public interface AccumulatorFactory
 {
-    Accumulator createAccumulator();
+    Accumulator createAccumulator(UpdateMemory updateMemory);
 
-    Accumulator createIntermediateAccumulator();
+    Accumulator createIntermediateAccumulator(UpdateMemory updateMemory);
 
-    GroupedAccumulator createGroupedAccumulator();
+    GroupedAccumulator createGroupedAccumulator(UpdateMemory updateMemory);
 
-    GroupedAccumulator createGroupedIntermediateAccumulator();
+    GroupedAccumulator createGroupedIntermediateAccumulator(UpdateMemory updateMemory);
 }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/AggregatorFactory.java
@@ -14,6 +14,7 @@
 package io.trino.operator.aggregation;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.type.Type;
 import io.trino.sql.planner.plan.AggregationNode.Step;
 
@@ -53,38 +54,38 @@ public class AggregatorFactory
         checkArgument(step.isInputRaw() || inputChannels.size() == 1, "expected 1 input channel for intermediate aggregation");
     }
 
-    public Aggregator createAggregator()
+    public Aggregator createAggregator(UpdateMemory updateMemory)
     {
         Accumulator accumulator;
         if (step.isInputRaw()) {
-            accumulator = accumulatorFactory.createAccumulator();
+            accumulator = accumulatorFactory.createAccumulator(updateMemory);
         }
         else {
-            accumulator = accumulatorFactory.createIntermediateAccumulator();
+            accumulator = accumulatorFactory.createIntermediateAccumulator(updateMemory);
         }
         return new Aggregator(accumulator, step, intermediateType, finalType, inputChannels, maskChannel);
     }
 
-    public GroupedAggregator createGroupedAggregator()
+    public GroupedAggregator createGroupedAggregator(UpdateMemory updateMemory)
     {
         GroupedAccumulator accumulator;
         if (step.isInputRaw()) {
-            accumulator = accumulatorFactory.createGroupedAccumulator();
+            accumulator = accumulatorFactory.createGroupedAccumulator(updateMemory);
         }
         else {
-            accumulator = accumulatorFactory.createGroupedIntermediateAccumulator();
+            accumulator = accumulatorFactory.createGroupedIntermediateAccumulator(updateMemory);
         }
         return new GroupedAggregator(accumulator, step, intermediateType, finalType, inputChannels, maskChannel);
     }
 
-    public GroupedAggregator createUnspillGroupedAggregator(Step step, int inputChannel)
+    public GroupedAggregator createUnspillGroupedAggregator(Step step, int inputChannel, UpdateMemory updateMemory)
     {
         GroupedAccumulator accumulator;
         if (step.isInputRaw()) {
-            accumulator = accumulatorFactory.createGroupedAccumulator();
+            accumulator = accumulatorFactory.createGroupedAccumulator(updateMemory);
         }
         else {
-            accumulator = accumulatorFactory.createGroupedIntermediateAccumulator();
+            accumulator = accumulatorFactory.createGroupedIntermediateAccumulator(updateMemory);
         }
         return new GroupedAggregator(accumulator, step, intermediateType, finalType, ImmutableList.of(inputChannel), maskChannel);
     }

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/CompiledAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/CompiledAccumulatorFactory.java
@@ -14,6 +14,7 @@
 package io.trino.operator.aggregation;
 
 import com.google.common.collect.ImmutableList;
+import io.trino.operator.UpdateMemory;
 
 import java.lang.reflect.Constructor;
 import java.util.List;
@@ -38,7 +39,7 @@ public class CompiledAccumulatorFactory
     }
 
     @Override
-    public Accumulator createAccumulator()
+    public Accumulator createAccumulator(UpdateMemory updateMemory)
     {
         try {
             return accumulatorConstructor.newInstance(lambdaProviders);
@@ -49,7 +50,7 @@ public class CompiledAccumulatorFactory
     }
 
     @Override
-    public Accumulator createIntermediateAccumulator()
+    public Accumulator createIntermediateAccumulator(UpdateMemory updateMemory)
     {
         try {
             return accumulatorConstructor.newInstance(lambdaProviders);
@@ -60,7 +61,7 @@ public class CompiledAccumulatorFactory
     }
 
     @Override
-    public GroupedAccumulator createGroupedAccumulator()
+    public GroupedAccumulator createGroupedAccumulator(UpdateMemory updateMemory)
     {
         try {
             return groupedAccumulatorConstructor.newInstance(lambdaProviders);
@@ -71,7 +72,7 @@ public class CompiledAccumulatorFactory
     }
 
     @Override
-    public GroupedAccumulator createGroupedIntermediateAccumulator()
+    public GroupedAccumulator createGroupedIntermediateAccumulator(UpdateMemory updateMemory)
     {
         try {
             return groupedAccumulatorConstructor.newInstance(lambdaProviders);

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/OrderedAccumulatorFactory.java
@@ -18,6 +18,7 @@ import com.google.common.primitives.Ints;
 import io.trino.operator.GroupByIdBlock;
 import io.trino.operator.PagesIndex;
 import io.trino.operator.PagesIndex.Factory;
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -64,29 +65,29 @@ public class OrderedAccumulatorFactory
     }
 
     @Override
-    public Accumulator createAccumulator()
+    public Accumulator createAccumulator(UpdateMemory updateMemory)
     {
-        Accumulator accumulator = delegate.createAccumulator();
+        Accumulator accumulator = delegate.createAccumulator(updateMemory);
         return new OrderedAccumulator(accumulator, sourceTypes, argumentChannels, orderByChannels, orderings, pagesIndexFactory);
     }
 
     @Override
-    public Accumulator createIntermediateAccumulator()
+    public Accumulator createIntermediateAccumulator(UpdateMemory updateMemory)
     {
-        return delegate.createIntermediateAccumulator();
+        return delegate.createIntermediateAccumulator(updateMemory);
     }
 
     @Override
-    public GroupedAccumulator createGroupedAccumulator()
+    public GroupedAccumulator createGroupedAccumulator(UpdateMemory updateMemory)
     {
-        GroupedAccumulator accumulator = delegate.createGroupedAccumulator();
+        GroupedAccumulator accumulator = delegate.createGroupedAccumulator(updateMemory);
         return new OrderingGroupedAccumulator(accumulator, sourceTypes, argumentChannels, orderByChannels, orderings, pagesIndexFactory);
     }
 
     @Override
-    public GroupedAccumulator createGroupedIntermediateAccumulator()
+    public GroupedAccumulator createGroupedIntermediateAccumulator(UpdateMemory updateMemory)
     {
-        return delegate.createGroupedIntermediateAccumulator();
+        return delegate.createGroupedIntermediateAccumulator(updateMemory);
     }
 
     private static class OrderedAccumulator

--- a/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
+++ b/core/trino-main/src/main/java/io/trino/operator/aggregation/builder/InMemoryHashAggregationBuilder.java
@@ -120,10 +120,10 @@ public class InMemoryHashAggregationBuilder
         for (int i = 0; i < aggregatorFactories.size(); i++) {
             AggregatorFactory accumulatorFactory = aggregatorFactories.get(i);
             if (unspillIntermediateChannelOffset.isPresent()) {
-                builder.add(accumulatorFactory.createUnspillGroupedAggregator(step, unspillIntermediateChannelOffset.get() + i));
+                builder.add(accumulatorFactory.createUnspillGroupedAggregator(step, unspillIntermediateChannelOffset.get() + i, updateMemory));
             }
             else {
-                builder.add(accumulatorFactory.createGroupedAggregator());
+                builder.add(accumulatorFactory.createGroupedAggregator(updateMemory));
             }
         }
         groupedAggregators = builder.build();
@@ -346,7 +346,7 @@ public class InMemoryHashAggregationBuilder
             types.add(BIGINT);
         }
         for (AggregatorFactory factory : factories) {
-            types.add(factory.createAggregator().getType());
+            types.add(factory.createAggregator(UpdateMemory.NOOP).getType());
         }
         return types.build();
     }

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/AggregationTestUtils.java
@@ -18,6 +18,7 @@ import com.google.common.primitives.Ints;
 import io.trino.block.BlockAssertions;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.GroupByIdBlock;
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -217,7 +218,7 @@ public final class AggregationTestUtils
 
     private static Object aggregation(TestingAggregationFunction function, int[] args, OptionalInt maskChannel, Page... pages)
     {
-        Aggregator aggregator = function.createAggregatorFactory(SINGLE, Ints.asList(args), maskChannel).createAggregator();
+        Aggregator aggregator = function.createAggregatorFactory(SINGLE, Ints.asList(args), maskChannel).createAggregator(UpdateMemory.NOOP);
         for (Page page : pages) {
             if (page.getPositionCount() > 0) {
                 aggregator.processPage(page);
@@ -250,16 +251,16 @@ public final class AggregationTestUtils
     private static Object partialAggregation(TestingAggregationFunction function, int[] args, Page... pages)
     {
         AggregatorFactory finalAggregatorFactory = function.createAggregatorFactory(FINAL, Ints.asList(0), OptionalInt.empty());
-        Aggregator finalAggregator = finalAggregatorFactory.createAggregator();
+        Aggregator finalAggregator = finalAggregatorFactory.createAggregator(UpdateMemory.NOOP);
 
         // Test handling of empty intermediate blocks
         AggregatorFactory partialAggregatorFactory = function.createAggregatorFactory(PARTIAL, Ints.asList(args), OptionalInt.empty());
-        Block emptyBlock = getIntermediateBlock(function.getIntermediateType(), partialAggregatorFactory.createAggregator());
+        Block emptyBlock = getIntermediateBlock(function.getIntermediateType(), partialAggregatorFactory.createAggregator(UpdateMemory.NOOP));
 
         finalAggregator.processPage(new Page(emptyBlock));
 
         for (Page page : pages) {
-            Aggregator partialAggregation = partialAggregatorFactory.createAggregator();
+            Aggregator partialAggregation = partialAggregatorFactory.createAggregator(UpdateMemory.NOOP);
             if (page.getPositionCount() > 0) {
                 partialAggregation.processPage(page);
             }
@@ -299,7 +300,7 @@ public final class AggregationTestUtils
 
     public static Object groupedAggregation(TestingAggregationFunction function, int[] args, Page... pages)
     {
-        GroupedAggregator groupedAggregator = function.createAggregatorFactory(SINGLE, Ints.asList(args), OptionalInt.empty()).createGroupedAggregator();
+        GroupedAggregator groupedAggregator = function.createAggregatorFactory(SINGLE, Ints.asList(args), OptionalInt.empty()).createGroupedAggregator(UpdateMemory.NOOP);
         for (Page page : pages) {
             groupedAggregator.processPage(createGroupByIdBlock(0, page.getPositionCount()), page);
         }
@@ -336,16 +337,16 @@ public final class AggregationTestUtils
     private static Object groupedPartialAggregation(TestingAggregationFunction function, int[] args, Page... pages)
     {
         AggregatorFactory finalFactory = function.createAggregatorFactory(FINAL, ImmutableList.of(0), OptionalInt.empty());
-        GroupedAggregator finalAggregator = finalFactory.createGroupedAggregator();
+        GroupedAggregator finalAggregator = finalFactory.createGroupedAggregator(UpdateMemory.NOOP);
 
         // Add an empty block to test the handling of empty intermediates
         AggregatorFactory partialFactory = function.createAggregatorFactory(PARTIAL, Ints.asList(args), OptionalInt.empty());
-        Block emptyBlock = getIntermediateBlock(function.getIntermediateType(), partialFactory.createGroupedAggregator());
+        Block emptyBlock = getIntermediateBlock(function.getIntermediateType(), partialFactory.createGroupedAggregator(UpdateMemory.NOOP));
 
         finalAggregator.processPage(createGroupByIdBlock(0, emptyBlock.getPositionCount()), new Page(emptyBlock));
 
         for (Page page : pages) {
-            GroupedAggregator partialAggregator = partialFactory.createGroupedAggregator();
+            GroupedAggregator partialAggregator = partialFactory.createGroupedAggregator(UpdateMemory.NOOP);
             partialAggregator.processPage(createGroupByIdBlock(0, page.getPositionCount()), page);
             Block partialBlock = getIntermediateBlock(function.getIntermediateType(), partialAggregator);
             finalAggregator.processPage(createGroupByIdBlock(0, partialBlock.getPositionCount()), new Page(partialBlock));

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkArrayAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkArrayAggregation.java
@@ -16,6 +16,7 @@ package io.trino.operator.aggregation;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slices;
 import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
 import io.trino.spi.block.BlockBuilder;
@@ -98,7 +99,7 @@ public class BenchmarkArrayAggregation
                     throw new UnsupportedOperationException();
             }
             TestingAggregationFunction function = new TestingFunctionResolution().getAggregateFunction(QualifiedName.of("array_agg"), fromTypes(elementType));
-            aggregator = function.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty()).createAggregator();
+            aggregator = function.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty()).createAggregator(UpdateMemory.NOOP);
 
             block = createChannel(ARRAY_SIZE, elementType);
             page = new Page(block);

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkGroupedTypedHistogram.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/BenchmarkGroupedTypedHistogram.java
@@ -16,6 +16,7 @@ package io.trino.operator.aggregation;
 import com.google.common.collect.ImmutableList;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.GroupByIdBlock;
+import io.trino.operator.UpdateMemory;
 import io.trino.operator.aggregation.histogram.Histogram;
 import io.trino.spi.Page;
 import io.trino.spi.block.Block;
@@ -113,7 +114,7 @@ public class BenchmarkGroupedTypedHistogram
 
             TestingAggregationFunction aggregationFunction = getInternalAggregationFunctionVarChar();
             groupedAggregator = aggregationFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty())
-                    .createGroupedAggregator();
+                    .createGroupedAggregator(UpdateMemory.NOOP);
         }
     }
 

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestArrayAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestArrayAggregation.java
@@ -15,6 +15,7 @@ package io.trino.operator.aggregation;
 
 import com.google.common.collect.ImmutableList;
 import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.UpdateMemory;
 import io.trino.operator.aggregation.groupby.AggregationTestInput;
 import io.trino.operator.aggregation.groupby.AggregationTestInputBuilder;
 import io.trino.operator.aggregation.groupby.AggregationTestOutput;
@@ -142,7 +143,7 @@ public class TestArrayAggregation
     {
         TestingAggregationFunction bigIntAgg = FUNCTION_RESOLUTION.getAggregateFunction(QualifiedName.of("array_agg"), fromTypes(BIGINT));
         GroupedAggregator groupedAggregator = bigIntAgg.createAggregatorFactory(SINGLE, ImmutableList.of(), OptionalInt.empty())
-                .createGroupedAggregator();
+                .createGroupedAggregator(UpdateMemory.NOOP);
         BlockBuilder blockBuilder = bigIntAgg.getFinalType().createBlockBuilder(null, 1000);
 
         groupedAggregator.evaluate(0, blockBuilder);
@@ -198,7 +199,7 @@ public class TestArrayAggregation
         int arraySize = 30;
         Random random = new Random();
         GroupedAggregator groupedAggregator = varcharAgg.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty())
-                .createGroupedAggregator();
+                .createGroupedAggregator(UpdateMemory.NOOP);
 
         for (int j = 0; j < numGroups; j++) {
             List<String> expectedValues = new ArrayList<>();

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDistinctAccumulatorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDistinctAccumulatorFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.operator.aggregation;
+
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+import io.trino.ExceededMemoryLimitException;
+import io.trino.metadata.TestingFunctionResolution;
+import io.trino.spi.Page;
+import io.trino.sql.tree.QualifiedName;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.OptionalInt;
+
+import static io.trino.ExceededMemoryLimitException.exceededLocalTotalMemoryLimit;
+import static io.trino.block.BlockAssertions.createBooleansBlock;
+import static io.trino.block.BlockAssertions.createLongsBlock;
+import static io.trino.operator.aggregation.AggregationTestUtils.createGroupByIdBlock;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
+
+public class TestDistinctAccumulatorFactory
+{
+    private static final TestingFunctionResolution testingFunctionResolution = new TestingFunctionResolution();
+    private static final TestingAggregationFunction function = testingFunctionResolution.getAggregateFunction(QualifiedName.of("sum"), fromTypes(BIGINT));
+    private static final AggregatorFactory distinctFactory = function.createDistinctAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.of(1));
+    private static final Long[] longBlock = new Long[20000];
+    private static final Boolean[] booleanBlock = new Boolean[20000];
+
+    @BeforeClass
+    public void setUp()
+    {
+        for (int i = 0; i < longBlock.length; i++) {
+            longBlock[i] = (long) i;
+        }
+        Arrays.fill(booleanBlock, true);
+    }
+
+    @Test(expectedExceptions = ExceededMemoryLimitException.class)
+    public void testUpdateMemory()
+    {
+        Page page = new Page(createLongsBlock(longBlock), createBooleansBlock(booleanBlock));
+        Aggregator aggregator = distinctFactory.createAggregator(() -> {
+            throw exceededLocalTotalMemoryLimit(DataSize.ofBytes(0), "Test succeeds");
+        });
+        aggregator.processPage(page);
+    }
+
+    @Test(expectedExceptions = ExceededMemoryLimitException.class)
+    public void testUpdateMemoryForGroupedDistinctAccumulator()
+    {
+        Page page = new Page(createLongsBlock(longBlock), createBooleansBlock(booleanBlock));
+        GroupedAggregator aggregator = distinctFactory.createGroupedAggregator(() -> {
+            throw exceededLocalTotalMemoryLimit(DataSize.ofBytes(0), "Test succeeds");
+        });
+        aggregator.processPage(createGroupByIdBlock(0, page.getPositionCount()), page);
+    }
+
+    @Test(expectedExceptions = ExceededMemoryLimitException.class)
+    public void testUpdateMemoryForUnspillingGroupedDistinctAccumulator()
+    {
+        Page page = new Page(createLongsBlock(longBlock), createBooleansBlock(booleanBlock));
+        GroupedAggregator aggregator = distinctFactory.createUnspillGroupedAggregator(SINGLE, 0, () -> {
+            throw exceededLocalTotalMemoryLimit(DataSize.ofBytes(0), "Test succeeds");
+        });
+        aggregator.processPage(createGroupByIdBlock(0, page.getPositionCount()), page);
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDoubleHistogramAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestDoubleHistogramAggregation.java
@@ -16,6 +16,7 @@ package io.trino.operator.aggregation;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
@@ -89,7 +90,6 @@ public class TestDoubleHistogramAggregation
         Block intermediate = getIntermediateBlock(intermediateType, partialStep);
 
         Aggregator finalStep = getAggregator(FINAL);
-
         finalStep.processPage(new Page(intermediate));
         finalStep.processPage(new Page(intermediate));
         Block actual = getFinalBlock(finalType, finalStep);
@@ -121,7 +121,7 @@ public class TestDoubleHistogramAggregation
 
     private Aggregator getAggregator(Step step)
     {
-        return function.createAggregatorFactory(step, step.isInputRaw() ? ImmutableList.of(0, 1, 2) : ImmutableList.of(0), OptionalInt.empty()).createAggregator();
+        return function.createAggregatorFactory(step, step.isInputRaw() ? ImmutableList.of(0, 1, 2) : ImmutableList.of(0), OptionalInt.empty()).createAggregator(UpdateMemory.NOOP);
     }
 
     private static Map<Double, Double> extractSingleValue(Block block)

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestHistogram.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestHistogram.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Ints;
 import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.UpdateMemory;
 import io.trino.operator.aggregation.groupby.AggregationTestInput;
 import io.trino.operator.aggregation.groupby.AggregationTestInputBuilder;
 import io.trino.operator.aggregation.groupby.AggregationTestOutput;
@@ -238,7 +239,7 @@ public class TestHistogram
     {
         TestingAggregationFunction function = getInternalDefaultVarCharAggregation();
         GroupedAggregator groupedAggregator = function.createAggregatorFactory(SINGLE, Ints.asList(new int[] {}), OptionalInt.empty())
-                .createGroupedAggregator();
+                .createGroupedAggregator(UpdateMemory.NOOP);
         BlockBuilder blockBuilder = function.getFinalType().createBlockBuilder(null, 1000);
 
         groupedAggregator.evaluate(0, blockBuilder);
@@ -294,7 +295,7 @@ public class TestHistogram
         int itemCount = 30;
         Random random = new Random();
         GroupedAggregator groupedAggregator = aggregationFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0), OptionalInt.empty())
-                .createGroupedAggregator();
+                .createGroupedAggregator(UpdateMemory.NOOP);
 
         for (int j = 0; j < numGroups; j++) {
             Map<String, Long> expectedValues = new HashMap<>();

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestMultimapAggAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestMultimapAggAggregation.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.primitives.Ints;
 import io.trino.RowPageBuilder;
 import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.UpdateMemory;
 import io.trino.operator.aggregation.groupby.AggregationTestInput;
 import io.trino.operator.aggregation.groupby.AggregationTestInputBuilder;
 import io.trino.operator.aggregation.groupby.AggregationTestOutput;
@@ -121,7 +122,7 @@ public class TestMultimapAggAggregation
     public void testMultiplePages()
     {
         TestingAggregationFunction aggFunction = getAggregationFunction(BIGINT, BIGINT);
-        GroupedAggregator groupedAggregator = aggFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1), OptionalInt.empty()).createGroupedAggregator();
+        GroupedAggregator groupedAggregator = aggFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1), OptionalInt.empty()).createGroupedAggregator(UpdateMemory.NOOP);
 
         testMultimapAggWithGroupBy(aggFunction, groupedAggregator, 0, BIGINT, ImmutableList.of(1L, 1L), BIGINT, ImmutableList.of(2L, 3L));
     }
@@ -130,7 +131,7 @@ public class TestMultimapAggAggregation
     public void testMultiplePagesAndGroups()
     {
         TestingAggregationFunction aggFunction = getAggregationFunction(BIGINT, BIGINT);
-        GroupedAggregator groupedAggregator = aggFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1), OptionalInt.empty()).createGroupedAggregator();
+        GroupedAggregator groupedAggregator = aggFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1), OptionalInt.empty()).createGroupedAggregator(UpdateMemory.NOOP);
 
         testMultimapAggWithGroupBy(aggFunction, groupedAggregator, 0, BIGINT, ImmutableList.of(1L, 1L), BIGINT, ImmutableList.of(2L, 3L));
         testMultimapAggWithGroupBy(aggFunction, groupedAggregator, 300, BIGINT, ImmutableList.of(7L, 7L), BIGINT, ImmutableList.of(8L, 9L));
@@ -140,7 +141,7 @@ public class TestMultimapAggAggregation
     public void testManyValues()
     {
         TestingAggregationFunction aggFunction = getAggregationFunction(BIGINT, BIGINT);
-        GroupedAggregator groupedAggregator = aggFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1), OptionalInt.empty()).createGroupedAggregator();
+        GroupedAggregator groupedAggregator = aggFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1), OptionalInt.empty()).createGroupedAggregator(UpdateMemory.NOOP);
 
         int numGroups = 30000;
         int numKeys = 10;
@@ -166,7 +167,7 @@ public class TestMultimapAggAggregation
     public void testEmptyStateOutputIsNull()
     {
         TestingAggregationFunction aggregationFunction = getAggregationFunction(BIGINT, BIGINT);
-        GroupedAggregator groupedAggregator = aggregationFunction.createAggregatorFactory(SINGLE, Ints.asList(), OptionalInt.empty()).createGroupedAggregator();
+        GroupedAggregator groupedAggregator = aggregationFunction.createAggregatorFactory(SINGLE, Ints.asList(), OptionalInt.empty()).createGroupedAggregator(UpdateMemory.NOOP);
         BlockBuilder blockBuilder = aggregationFunction.getFinalType().createBlockBuilder(null, 1);
         groupedAggregator.evaluate(0, blockBuilder);
         assertTrue(blockBuilder.isNull(0));

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/TestRealHistogramAggregation.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/TestRealHistogramAggregation.java
@@ -16,6 +16,7 @@ package io.trino.operator.aggregation;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.UpdateMemory;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
 import io.trino.spi.TrinoException;
@@ -98,7 +99,7 @@ public class TestRealHistogramAggregation
 
     private Aggregator createAggregator(Step step)
     {
-        return function.createAggregatorFactory(step, step.isInputRaw() ? ImmutableList.of(0, 1, 2) : ImmutableList.of(0), OptionalInt.empty()).createAggregator();
+        return function.createAggregatorFactory(step, step.isInputRaw() ? ImmutableList.of(0, 1, 2) : ImmutableList.of(0), OptionalInt.empty()).createAggregator(UpdateMemory.NOOP);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/operator/aggregation/groupby/AggregationTestInput.java
+++ b/core/trino-main/src/test/java/io/trino/operator/aggregation/groupby/AggregationTestInput.java
@@ -16,6 +16,7 @@ package io.trino.operator.aggregation.groupby;
 
 import com.google.common.primitives.Ints;
 import io.trino.operator.GroupByIdBlock;
+import io.trino.operator.UpdateMemory;
 import io.trino.operator.aggregation.AggregationTestUtils;
 import io.trino.operator.aggregation.GroupedAggregator;
 import io.trino.operator.aggregation.TestingAggregationFunction;
@@ -71,6 +72,6 @@ public class AggregationTestInput
     public GroupedAggregator createGroupedAggregator()
     {
         return function.createAggregatorFactory(SINGLE, Ints.asList(args), OptionalInt.empty())
-                .createGroupedAggregator();
+                .createGroupedAggregator(UpdateMemory.NOOP);
     }
 }

--- a/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
+++ b/plugin/trino-geospatial/src/test/java/io/trino/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
@@ -22,6 +22,7 @@ import com.google.common.primitives.Ints;
 import io.trino.block.BlockAssertions;
 import io.trino.geospatial.KdbTreeUtils;
 import io.trino.geospatial.Rectangle;
+import io.trino.operator.UpdateMemory;
 import io.trino.operator.aggregation.Aggregator;
 import io.trino.operator.aggregation.AggregatorFactory;
 import io.trino.operator.aggregation.GroupedAggregator;
@@ -81,12 +82,12 @@ public class TestSpatialPartitioningInternalAggregation
         AggregatorFactory aggregatorFactory = function.createAggregatorFactory(SINGLE, Ints.asList(0, 1), OptionalInt.empty());
         Page page = new Page(geometryBlock, partitionCountBlock);
 
-        Aggregator aggregator = aggregatorFactory.createAggregator();
+        Aggregator aggregator = aggregatorFactory.createAggregator(UpdateMemory.NOOP);
         aggregator.processPage(page);
         String aggregation = (String) BlockAssertions.getOnlyValue(function.getFinalType(), getFinalBlock(function.getFinalType(), aggregator));
         assertEquals(aggregation, expectedValue);
 
-        GroupedAggregator groupedAggregator = aggregatorFactory.createGroupedAggregator();
+        GroupedAggregator groupedAggregator = aggregatorFactory.createGroupedAggregator(UpdateMemory.NOOP);
         groupedAggregator.processPage(createGroupByIdBlock(0, page.getPositionCount()), page);
         String groupValue = (String) getGroupValue(function.getFinalType(), groupedAggregator, 0);
         assertEquals(groupValue, expectedValue);

--- a/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestEvaluateClassifierPredictions.java
+++ b/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestEvaluateClassifierPredictions.java
@@ -17,6 +17,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import io.trino.RowPageBuilder;
 import io.trino.metadata.TestingFunctionResolution;
+import io.trino.operator.UpdateMemory;
 import io.trino.operator.aggregation.Aggregator;
 import io.trino.operator.aggregation.TestingAggregationFunction;
 import io.trino.spi.Page;
@@ -45,7 +46,7 @@ public class TestEvaluateClassifierPredictions
         TestingAggregationFunction aggregation = functionResolution.getAggregateFunction(
                 QualifiedName.of("evaluate_classifier_predictions"),
                 fromTypes(BIGINT, BIGINT));
-        Aggregator aggregator = aggregation.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1), OptionalInt.empty()).createAggregator();
+        Aggregator aggregator = aggregation.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1), OptionalInt.empty()).createAggregator(UpdateMemory.NOOP);
         aggregator.processPage(getPage());
         BlockBuilder finalOut = VARCHAR.createBlockBuilder(null, 1);
         aggregator.evaluate(finalOut);

--- a/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestLearnAggregations.java
+++ b/plugin/trino-ml/src/test/java/io/trino/plugin/ml/TestLearnAggregations.java
@@ -24,6 +24,7 @@ import io.trino.metadata.InternalBlockEncodingSerde;
 import io.trino.metadata.MetadataManager;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.metadata.TypeRegistry;
+import io.trino.operator.UpdateMemory;
 import io.trino.operator.aggregation.Aggregator;
 import io.trino.operator.aggregation.TestingAggregationFunction;
 import io.trino.plugin.ml.type.ClassifierParametricType;
@@ -89,7 +90,7 @@ public class TestLearnAggregations
         TestingAggregationFunction aggregationFunction = FUNCTION_RESOLUTION.getAggregateFunction(
                 QualifiedName.of("learn_classifier"),
                 fromTypeSignatures(BIGINT.getTypeSignature(), mapType(BIGINT.getTypeSignature(), DOUBLE.getTypeSignature())));
-        assertLearnClassifier(aggregationFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1), OptionalInt.empty()).createAggregator());
+        assertLearnClassifier(aggregationFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1), OptionalInt.empty()).createAggregator(UpdateMemory.NOOP));
     }
 
     @Test
@@ -98,7 +99,7 @@ public class TestLearnAggregations
         TestingAggregationFunction aggregationFunction = FUNCTION_RESOLUTION.getAggregateFunction(
                 QualifiedName.of("learn_libsvm_classifier"),
                 fromTypeSignatures(BIGINT.getTypeSignature(), mapType(BIGINT.getTypeSignature(), DOUBLE.getTypeSignature()), VARCHAR.getTypeSignature()));
-        assertLearnClassifier(aggregationFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1, 2), OptionalInt.empty()).createAggregator());
+        assertLearnClassifier(aggregationFunction.createAggregatorFactory(SINGLE, ImmutableList.of(0, 1, 2), OptionalInt.empty()).createAggregator(UpdateMemory.NOOP));
     }
 
     private static void assertLearnClassifier(Aggregator aggregator)


### PR DESCRIPTION
Comparable change: prestodb/presto#15644

GroupByHash allows to specify a memory accounting callback to enforce memory limits before the
hash table expansion happens.

Unfortunately distincting accumulators weren't providing a callback, so the memory limits for
distincting accumulators were enforced post factum, triggering out of memory errors on memory
constrained environments.

This patch provides a callback, so the task memory limit can be enforced.

This patch doesn't implement yield semantics for accumulators, thus the distincting accumulators
will not wait for the memory to become available in the pool. Although it is not ideal, it is
an improvement over the previous version, as at least the task memory limits will be enforced
proactively.