### PR TITLE
Remove reference to deprecated default query executor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dep.drift.version>1.14</dep.drift.version>
         <dep.scribejava.version>6.9.0</dep.scribejava.version>
         <dep.selenium.version>3.141.59</dep.selenium.version>
-        <dep.tempto.version>186</dep.tempto.version>
+        <dep.tempto.version>187</dep.tempto.version>
         <dep.gcs.version>2.0.0</dep.gcs.version>
         <dep.errorprone.version>2.10.0</dep.errorprone.version>
         <dep.testcontainers.version>1.16.2</dep.testcontainers.version>

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestAlterTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestAlterTable.java
@@ -23,9 +23,9 @@ import org.testng.annotations.Test;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.ALTER_TABLE;
 import static io.trino.tests.product.TestGroups.SMOKE;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 @Requires(ImmutableNationTable.class)
@@ -39,71 +39,71 @@ public class TestAlterTable
     @AfterTestWithContext
     public void dropTestTables()
     {
-        query(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
-        query(format("DROP TABLE IF EXISTS %s", RENAMED_TABLE_NAME));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", RENAMED_TABLE_NAME));
     }
 
     @Test(groups = {ALTER_TABLE, SMOKE})
     public void renameTable()
     {
-        query(format("CREATE TABLE %s AS SELECT * FROM nation", TABLE_NAME));
+        onTrino().executeQuery(format("CREATE TABLE %s AS SELECT * FROM nation", TABLE_NAME));
 
-        assertThat(query(format("ALTER TABLE %s RENAME TO %s", TABLE_NAME, RENAMED_TABLE_NAME)))
+        assertThat(onTrino().executeQuery(format("ALTER TABLE %s RENAME TO %s", TABLE_NAME, RENAMED_TABLE_NAME)))
                 .hasRowsCount(1);
 
-        assertThat(query(format("SELECT * FROM %s", RENAMED_TABLE_NAME)))
+        assertThat(onTrino().executeQuery(format("SELECT * FROM %s", RENAMED_TABLE_NAME)))
                 .hasRowsCount(25);
 
         // rename back to original name
-        assertThat(query(format("ALTER TABLE %s RENAME TO %s", RENAMED_TABLE_NAME, TABLE_NAME)))
+        assertThat(onTrino().executeQuery(format("ALTER TABLE %s RENAME TO %s", RENAMED_TABLE_NAME, TABLE_NAME)))
                 .hasRowsCount(1);
     }
 
     @Test(groups = {ALTER_TABLE, SMOKE})
     public void renameColumn()
     {
-        query(format("CREATE TABLE %s AS SELECT * FROM nation", TABLE_NAME));
+        onTrino().executeQuery(format("CREATE TABLE %s AS SELECT * FROM nation", TABLE_NAME));
 
-        assertThat(query(format("ALTER TABLE %s RENAME COLUMN n_nationkey TO nationkey", TABLE_NAME)))
+        assertThat(onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN n_nationkey TO nationkey", TABLE_NAME)))
                 .hasRowsCount(1);
-        assertThat(query(format("SELECT count(nationkey) FROM %s", TABLE_NAME)))
+        assertThat(onTrino().executeQuery(format("SELECT count(nationkey) FROM %s", TABLE_NAME)))
                 .containsExactlyInOrder(row(25));
-        assertQueryFailure(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO nATIoNkEy", TABLE_NAME)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN nationkey TO nATIoNkEy", TABLE_NAME)))
                 .hasMessageContaining("Column 'nationkey' already exists");
-        assertQueryFailure(() -> query(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_regionkeY", TABLE_NAME)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_regionkeY", TABLE_NAME)))
                 .hasMessageContaining("Column 'n_regionkey' already exists");
 
-        query(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_nationkey", TABLE_NAME));
+        onTrino().executeQuery(format("ALTER TABLE %s RENAME COLUMN nationkey TO n_nationkey", TABLE_NAME));
     }
 
     @Test(groups = {ALTER_TABLE, SMOKE})
     public void addColumn()
     {
-        query(format("CREATE TABLE %s AS SELECT * FROM nation", TABLE_NAME));
+        onTrino().executeQuery(format("CREATE TABLE %s AS SELECT * FROM nation", TABLE_NAME));
 
-        assertThat(query(format("SELECT count(1) FROM %s", TABLE_NAME)))
+        assertThat(onTrino().executeQuery(format("SELECT count(1) FROM %s", TABLE_NAME)))
                 .containsExactlyInOrder(row(25));
-        assertThat(query(format("ALTER TABLE %s ADD COLUMN some_new_column BIGINT", TABLE_NAME)))
+        assertThat(onTrino().executeQuery(format("ALTER TABLE %s ADD COLUMN some_new_column BIGINT", TABLE_NAME)))
                 .hasRowsCount(1);
-        assertQueryFailure(() -> query(format("ALTER TABLE %s ADD COLUMN n_nationkey BIGINT", TABLE_NAME)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("ALTER TABLE %s ADD COLUMN n_nationkey BIGINT", TABLE_NAME)))
                 .hasMessageContaining("Column 'n_nationkey' already exists");
-        assertQueryFailure(() -> query(format("ALTER TABLE %s ADD COLUMN n_naTioNkEy BIGINT", TABLE_NAME)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("ALTER TABLE %s ADD COLUMN n_naTioNkEy BIGINT", TABLE_NAME)))
                 .hasMessageContaining("Column 'n_naTioNkEy' already exists");
     }
 
     @Test(groups = {ALTER_TABLE, SMOKE})
     public void dropColumn()
     {
-        query(format("CREATE TABLE %s AS SELECT n_nationkey, n_regionkey, n_name FROM nation", TABLE_NAME));
+        onTrino().executeQuery(format("CREATE TABLE %s AS SELECT n_nationkey, n_regionkey, n_name FROM nation", TABLE_NAME));
 
-        assertThat(query(format("SELECT count(n_nationkey) FROM %s", TABLE_NAME)))
+        assertThat(onTrino().executeQuery(format("SELECT count(n_nationkey) FROM %s", TABLE_NAME)))
                 .containsExactlyInOrder(row(25));
-        assertThat(query(format("ALTER TABLE %s DROP COLUMN n_name", TABLE_NAME)))
+        assertThat(onTrino().executeQuery(format("ALTER TABLE %s DROP COLUMN n_name", TABLE_NAME)))
                 .hasRowsCount(1);
-        assertThat(query(format("ALTER TABLE %s DROP COLUMN n_nationkey", TABLE_NAME)))
+        assertThat(onTrino().executeQuery(format("ALTER TABLE %s DROP COLUMN n_nationkey", TABLE_NAME)))
                 .hasRowsCount(1);
-        assertQueryFailure(() -> query(format("ALTER TABLE %s DROP COLUMN n_regionkey", TABLE_NAME)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("ALTER TABLE %s DROP COLUMN n_regionkey", TABLE_NAME)))
                 .hasMessageContaining("Cannot drop the only column in a table");
-        query(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", TABLE_NAME));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestCreateDropView.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestCreateDropView.java
@@ -21,10 +21,10 @@ import org.testng.annotations.Test;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.context.ContextDsl.executeWith;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tempto.sql.SqlContexts.createViewAs;
 import static io.trino.tests.product.TestGroups.CREATE_DROP_VIEW;
 import static io.trino.tests.product.TestGroups.SMOKE;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 @Requires(ImmutableNationTable.class)
@@ -34,8 +34,8 @@ public class TestCreateDropView
     @Test(groups = CREATE_DROP_VIEW)
     public void createSimpleView()
     {
-        executeWith(createViewAs("SELECT * FROM nation"), view -> {
-            assertThat(query(format("SELECT * FROM %s", view.getName())))
+        executeWith(createViewAs("SELECT * FROM nation", onTrino()), view -> {
+            assertThat(onTrino().executeQuery(format("SELECT * FROM %s", view.getName())))
                     .hasRowsCount(25);
         });
     }
@@ -43,8 +43,8 @@ public class TestCreateDropView
     @Test(groups = CREATE_DROP_VIEW)
     public void querySimpleViewQualified()
     {
-        executeWith(createViewAs("SELECT * FROM nation"), view -> {
-            assertThat(query(format("SELECT %s.n_regionkey FROM %s", view.getName(), view.getName())))
+        executeWith(createViewAs("SELECT * FROM nation", onTrino()), view -> {
+            assertThat(onTrino().executeQuery(format("SELECT %s.n_regionkey FROM %s", view.getName(), view.getName())))
                     .hasRowsCount(25);
         });
     }
@@ -52,8 +52,8 @@ public class TestCreateDropView
     @Test(groups = CREATE_DROP_VIEW)
     public void createViewWithAggregate()
     {
-        executeWith(createViewAs("SELECT n_regionkey, count(*) countries FROM nation GROUP BY n_regionkey ORDER BY n_regionkey"), view -> {
-            assertThat(query(format("SELECT * FROM %s", view.getName())))
+        executeWith(createViewAs("SELECT n_regionkey, count(*) countries FROM nation GROUP BY n_regionkey ORDER BY n_regionkey", onTrino()), view -> {
+            assertThat(onTrino().executeQuery(format("SELECT * FROM %s", view.getName())))
                     .hasRowsCount(5);
         });
     }
@@ -61,10 +61,10 @@ public class TestCreateDropView
     @Test(groups = {CREATE_DROP_VIEW, SMOKE})
     public void createOrReplaceSimpleView()
     {
-        executeWith(createViewAs("SELECT * FROM nation"), view -> {
-            assertThat(query(format("CREATE OR REPLACE VIEW %s AS SELECT * FROM nation", view.getName())))
+        executeWith(createViewAs("SELECT * FROM nation", onTrino()), view -> {
+            assertThat(onTrino().executeQuery(format("CREATE OR REPLACE VIEW %s AS SELECT * FROM nation", view.getName())))
                     .hasRowsCount(1);
-            assertThat(query(format("SELECT * FROM %s", view.getName())))
+            assertThat(onTrino().executeQuery(format("SELECT * FROM %s", view.getName())))
                     .hasRowsCount(25);
         });
     }
@@ -72,10 +72,10 @@ public class TestCreateDropView
     @Test(groups = CREATE_DROP_VIEW)
     public void createSimpleViewTwiceShouldFail()
     {
-        executeWith(createViewAs("SELECT * FROM nation"), view -> {
-            assertQueryFailure(() -> query(format("CREATE VIEW %s AS SELECT * FROM nation", view.getName())))
+        executeWith(createViewAs("SELECT * FROM nation", onTrino()), view -> {
+            assertQueryFailure(() -> onTrino().executeQuery(format("CREATE VIEW %s AS SELECT * FROM nation", view.getName())))
                     .hasMessageContaining("View already exists");
-            assertThat(query(format("SELECT * FROM %s", view.getName())))
+            assertThat(onTrino().executeQuery(format("SELECT * FROM %s", view.getName())))
                     .hasRowsCount(25);
         });
     }
@@ -83,12 +83,12 @@ public class TestCreateDropView
     @Test(groups = {CREATE_DROP_VIEW, SMOKE})
     public void dropViewTest()
     {
-        executeWith(createViewAs("SELECT * FROM nation"), view -> {
-            assertThat(query(format("SELECT * FROM %s", view.getName())))
+        executeWith(createViewAs("SELECT * FROM nation", onTrino()), view -> {
+            assertThat(onTrino().executeQuery(format("SELECT * FROM %s", view.getName())))
                     .hasRowsCount(25);
-            assertThat(query(format("DROP VIEW %s", view.getName())))
+            assertThat(onTrino().executeQuery(format("DROP VIEW %s", view.getName())))
                     .hasRowsCount(1);
-            assertQueryFailure(() -> query(format("SELECT * FROM %s", view.getName())))
+            assertQueryFailure(() -> onTrino().executeQuery(format("SELECT * FROM %s", view.getName())))
                     .hasMessageContaining("does not exist");
         });
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestCreateTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestCreateTable.java
@@ -19,8 +19,8 @@ import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequiremen
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.CREATE_TABLE;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 @Requires(ImmutableNationTable.class)
@@ -31,17 +31,17 @@ public class TestCreateTable
     public void shouldCreateTableAsSelect()
     {
         String tableName = "create_table_as_select";
-        query(format("DROP TABLE IF EXISTS %s", tableName));
-        query(format("CREATE TABLE %s(nationkey, name) AS SELECT n_nationkey, n_name FROM nation", tableName));
-        assertThat(query(format("SELECT * FROM %s", tableName))).hasRowsCount(25);
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
+        onTrino().executeQuery(format("CREATE TABLE %s(nationkey, name) AS SELECT n_nationkey, n_name FROM nation", tableName));
+        assertThat(onTrino().executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(25);
     }
 
     @Test(groups = CREATE_TABLE)
     public void shouldCreateTableAsEmptySelect()
     {
         String tableName = "create_table_as_empty_select";
-        query(format("DROP TABLE IF EXISTS %s", tableName));
-        query(format("CREATE TABLE %s(nationkey, name) AS SELECT n_nationkey, n_name FROM nation WHERE 0 is NULL", tableName));
-        assertThat(query(format("SELECT nationkey, name FROM %s", tableName))).hasRowsCount(0);
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
+        onTrino().executeQuery(format("CREATE TABLE %s(nationkey, name) AS SELECT n_nationkey, n_name FROM nation WHERE 0 is NULL", tableName));
+        assertThat(onTrino().executeQuery(format("SELECT nationkey, name FROM %s", tableName))).hasRowsCount(0);
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestJmxConnector.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestJmxConnector.java
@@ -17,9 +17,9 @@ import io.trino.tempto.ProductTest;
 import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.JDBC;
 import static io.trino.tests.product.TestGroups.JMX_CONNECTOR;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.sql.JDBCType.BIGINT;
 import static java.sql.JDBCType.VARCHAR;
 
@@ -30,7 +30,7 @@ public class TestJmxConnector
     public void selectFromJavaRuntimeJmxMBean()
     {
         String sql = "SELECT node, vmname, vmversion FROM jmx.current.\"java.lang:type=runtime\"";
-        assertThat(query(sql))
+        assertThat(onTrino().executeQuery(sql))
                 .hasColumns(VARCHAR, VARCHAR, VARCHAR)
                 .hasAnyRows();
     }
@@ -38,7 +38,7 @@ public class TestJmxConnector
     @Test(groups = JMX_CONNECTOR)
     public void selectFromJavaOperatingSystemJmxMBean()
     {
-        assertThat(query("SELECT openfiledescriptorcount, maxfiledescriptorcount " +
+        assertThat(onTrino().executeQuery("SELECT openfiledescriptorcount, maxfiledescriptorcount " +
                 "FROM jmx.current.\"java.lang:type=operatingsystem\""))
                 .hasColumns(BIGINT, BIGINT)
                 .hasAnyRows();

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSimpleQuery.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSimpleQuery.java
@@ -27,9 +27,9 @@ import org.testng.annotations.Test;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.context.ThreadLocalTestContextHolder.testContextIfSet;
 import static io.trino.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.SIMPLE;
 import static io.trino.tests.product.TestGroups.SMOKE;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestSimpleQuery
@@ -61,14 +61,14 @@ public class TestSimpleQuery
     @Requires(SimpleTestRequirements.class)
     public void selectAllFromNation()
     {
-        QueryAssert.assertThat(query("select * from nation")).hasRowsCount(25);
+        QueryAssert.assertThat(onTrino().executeQuery("select * from nation")).hasRowsCount(25);
     }
 
     @Test(groups = {SIMPLE, SMOKE})
     @Requires(SimpleTestRequirements.class)
     public void selectCountFromNation()
     {
-        QueryAssert.assertThat(query("select count(*) from nation"))
+        QueryAssert.assertThat(onTrino().executeQuery("select count(*) from nation"))
                 .hasRowsCount(1)
                 .contains(row(25));
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSqlCancel.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSqlCancel.java
@@ -45,8 +45,8 @@ import static io.airlift.http.client.Request.Builder.prepareDelete;
 import static io.airlift.http.client.ResponseHandlerUtils.propagate;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.CANCEL_QUERY;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 import static java.lang.System.nanoTime;
 import static java.util.Objects.requireNonNull;
@@ -90,7 +90,7 @@ public class TestSqlCancel
         String sql = format("CREATE TABLE %s AS SELECT * FROM tpch.sf1.lineitem", tableName);
 
         runAndCancelQuery(sql);
-        assertQueryFailure(() -> query("SELECT * from " + tableName))
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT * from " + tableName))
                 .hasMessageContaining("Table 'hive.default.%s' does not exist", tableName);
     }
 
@@ -99,11 +99,11 @@ public class TestSqlCancel
             throws Exception
     {
         String tableName = "cancel_insertinto_" + nanoTime();
-        query(format("CREATE TABLE %s (orderkey BIGINT, partkey BIGINT, shipinstruct VARCHAR(25)) ", tableName));
+        onTrino().executeQuery(format("CREATE TABLE %s (orderkey BIGINT, partkey BIGINT, shipinstruct VARCHAR(25)) ", tableName));
         String sql = format("INSERT INTO %s SELECT orderkey, partkey, shipinstruct FROM tpch.sf1.lineitem", tableName);
         runAndCancelQuery(sql);
-        assertThat(query("SELECT * from " + tableName)).hasNoRows();
-        query("DROP TABLE " + tableName);
+        assertThat(onTrino().executeQuery("SELECT * from " + tableName)).hasNoRows();
+        onTrino().executeQuery("DROP TABLE " + tableName);
     }
 
     @Test(groups = CANCEL_QUERY, timeOut = 60_000L)
@@ -116,7 +116,7 @@ public class TestSqlCancel
     private void runAndCancelQuery(String sql)
             throws Exception
     {
-        Future<?> queryExecution = executor.submit(() -> query(sql));
+        Future<?> queryExecution = executor.submit(() -> onTrino().executeQuery(sql));
 
         cancelQuery(sql);
 
@@ -140,7 +140,7 @@ public class TestSqlCancel
         Stopwatch stopwatch = Stopwatch.createStarted();
         while (stopwatch.elapsed(SECONDS) < 30) {
             String findQuerySql = "SELECT query_id from system.runtime.queries WHERE query = '%s' and state = 'RUNNING' LIMIT 2";
-            QueryResult queryResult = query(format(findQuerySql, sql));
+            QueryResult queryResult = onTrino().executeQuery(format(findQuerySql, sql));
             checkState(queryResult.getRowsCount() < 2, "Query is executed multiple times");
             if (queryResult.getRowsCount() == 1) {
                 String queryId = (String) queryResult.row(0).get(0);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSystemConnector.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSystemConnector.java
@@ -19,9 +19,9 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.JDBC;
 import static io.trino.tests.product.TestGroups.SYSTEM_CONNECTOR;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.sql.JDBCType.ARRAY;
 import static java.sql.JDBCType.BIGINT;
 import static java.sql.JDBCType.TIMESTAMP_WITH_TIMEZONE;
@@ -34,7 +34,7 @@ public class TestSystemConnector
     public void selectRuntimeNodes()
     {
         String sql = "SELECT node_id, http_uri, node_version, state FROM system.runtime.nodes";
-        assertThat(query(sql))
+        assertThat(onTrino().executeQuery(sql))
                 .hasColumns(VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                 .hasAnyRows();
     }
@@ -42,7 +42,7 @@ public class TestSystemConnector
     @Test(groups = {SYSTEM_CONNECTOR, JDBC})
     public void testRuleStats()
     {
-        assertThat(query("SELECT rule_name, invocations, matches, failures FROM system.runtime.optimizer_rule_stats"))
+        assertThat(onTrino().executeQuery("SELECT rule_name, invocations, matches, failures FROM system.runtime.optimizer_rule_stats"))
                 .hasColumns(VARCHAR, BIGINT, BIGINT, BIGINT)
                 .hasAnyRows();
     }
@@ -66,7 +66,7 @@ public class TestSystemConnector
                 "  error_type," +
                 "  error_code " +
                 "FROM system.runtime.queries";
-        assertThat(query(sql))
+        assertThat(onTrino().executeQuery(sql))
                 .hasColumns(VARCHAR, VARCHAR, VARCHAR, VARCHAR, ARRAY,
                         BIGINT, BIGINT, BIGINT, TIMESTAMP_WITH_TIMEZONE, TIMESTAMP_WITH_TIMEZONE,
                         TIMESTAMP_WITH_TIMEZONE, TIMESTAMP_WITH_TIMEZONE, VARCHAR, VARCHAR)
@@ -102,7 +102,7 @@ public class TestSystemConnector
                 "  last_heartbeat," +
                 "  \"end\" " +
                 "FROM SYSTEM.runtime.tasks";
-        assertThat(query(sql))
+        assertThat(onTrino().executeQuery(sql))
                 .hasColumns(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR,
                         BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT,
                         BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT, BIGINT,
@@ -114,7 +114,7 @@ public class TestSystemConnector
     public void selectMetadataCatalogs()
     {
         String sql = "select catalog_name, connector_id, connector_name from system.metadata.catalogs";
-        assertThat(query(sql))
+        assertThat(onTrino().executeQuery(sql))
                 .hasColumns(VARCHAR, VARCHAR, VARCHAR)
                 .contains(
                         ImmutableList.of(

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/blackhole/TestBlackHoleConnector.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/blackhole/TestBlackHoleConnector.java
@@ -20,8 +20,8 @@ import java.util.UUID;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.BLACKHOLE_CONNECTOR;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 public class TestBlackHoleConnector
@@ -32,16 +32,16 @@ public class TestBlackHoleConnector
         String nullTable = "\"blackhole\".default.nation_" + UUID.randomUUID().toString().replace("-", "");
         String table = "tpch.tiny.nation";
 
-        assertThat(query(format("SELECT count(*) from %s", table))).containsExactlyInOrder(row(25));
-        QueryResult result = query(format("CREATE TABLE %s AS SELECT * FROM %s", nullTable, table));
+        assertThat(onTrino().executeQuery(format("SELECT count(*) from %s", table))).containsExactlyInOrder(row(25));
+        QueryResult result = onTrino().executeQuery(format("CREATE TABLE %s AS SELECT * FROM %s", nullTable, table));
         try {
             assertThat(result).updatedRowsCountIsEqualTo(25);
-            assertThat(query(format("INSERT INTO %s SELECT * FROM %s", nullTable, table)))
+            assertThat(onTrino().executeQuery(format("INSERT INTO %s SELECT * FROM %s", nullTable, table)))
                     .updatedRowsCountIsEqualTo(25);
-            assertThat(query(format("SELECT * FROM %s", nullTable))).hasNoRows();
+            assertThat(onTrino().executeQuery(format("SELECT * FROM %s", nullTable))).hasNoRows();
         }
         finally {
-            query(format("DROP TABLE %s", nullTable));
+            onTrino().executeQuery(format("DROP TABLE %s", nullTable));
         }
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestInsertIntoCassandraTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestInsertIntoCassandraTable.java
@@ -34,13 +34,13 @@ import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.MutableTableRequirement.State.CREATED;
 import static io.trino.tempto.fulfillment.table.MutableTablesState.mutableTablesState;
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.CASSANDRA;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.cassandra.DataTypesTableDefinition.CASSANDRA_ALL_TYPES;
 import static io.trino.tests.product.cassandra.TestConstants.CONNECTOR_NAME;
 import static io.trino.tests.product.cassandra.TestConstants.KEY_SPACE;
 import static io.trino.tests.product.utils.QueryAssertions.assertContainsEventually;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
@@ -66,16 +66,16 @@ public class TestInsertIntoCassandraTable
         TableName table = mutableTablesState().get(CASSANDRA_INSERT_TABLE).getTableName();
         String tableNameInDatabase = format("%s.%s", CONNECTOR_NAME, table.getNameInDatabase());
 
-        assertContainsEventually(() -> query(format("SHOW TABLES FROM %s.%s", CONNECTOR_NAME, KEY_SPACE)),
-                query(format("SELECT '%s'", table.getSchemalessNameInDatabase())),
+        assertContainsEventually(() -> onTrino().executeQuery(format("SHOW TABLES FROM %s.%s", CONNECTOR_NAME, KEY_SPACE)),
+                onTrino().executeQuery(format("SELECT '%s'", table.getSchemalessNameInDatabase())),
                 new Duration(1, MINUTES));
 
-        QueryResult queryResult = query("SELECT * FROM " + tableNameInDatabase);
+        QueryResult queryResult = onTrino().executeQuery("SELECT * FROM " + tableNameInDatabase);
         assertThat(queryResult).hasNoRows();
 
         // TODO Following types are not supported now. We need to change null into the value after fixing it
         // blob, frozen<set<type>>, inet, list<type>, map<type,type>, set<type>, decimal, varint
-        query("INSERT INTO " + tableNameInDatabase +
+        onTrino().executeQuery("INSERT INTO " + tableNameInDatabase +
                 "(a, b, bl, bo, d, do, dt, f, fr, i, ti, si, integer, l, m, s, t, ts, tu, u, v, vari) VALUES (" +
                 "'ascii value', " +
                 "BIGINT '99999', " +
@@ -100,7 +100,7 @@ public class TestInsertIntoCassandraTable
                 "'varchar value'," +
                 "null)");
 
-        assertThat(query("SELECT * FROM " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableNameInDatabase)).containsOnly(
                 row(
                         "ascii value",
                         99999,
@@ -126,19 +126,19 @@ public class TestInsertIntoCassandraTable
                         null));
 
         // insert null for all datatypes
-        query("INSERT INTO " + tableNameInDatabase +
+        onTrino().executeQuery("INSERT INTO " + tableNameInDatabase +
                 "(a, b, bl, bo, d, do, dt, f, fr, i, ti, si, integer, l, m, s, t, ts, tu, u, v, vari) VALUES (" +
                 "'key 1', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null) ");
-        assertThat(query(format("SELECT * FROM %s WHERE a = 'key 1'", tableNameInDatabase))).containsOnly(
+        assertThat(onTrino().executeQuery(format("SELECT * FROM %s WHERE a = 'key 1'", tableNameInDatabase))).containsOnly(
                 row("key 1", null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null));
 
         // insert into only a subset of columns
-        query(format("INSERT INTO %s (a, bo, integer, t) VALUES ('key 2', false, 999, 'text 2')", tableNameInDatabase));
-        assertThat(query(format("SELECT * FROM %s WHERE a = 'key 2'", tableNameInDatabase))).containsOnly(
+        onTrino().executeQuery(format("INSERT INTO %s (a, bo, integer, t) VALUES ('key 2', false, 999, 'text 2')", tableNameInDatabase));
+        assertThat(onTrino().executeQuery(format("SELECT * FROM %s WHERE a = 'key 2'", tableNameInDatabase))).containsOnly(
                 row("key 2", null, null, false, null, null, null, null, null, null, 999, null, null, null, null, "text 2", null, null, null, null, null, null));
 
         // negative test: failed to insert null to primary key
-        assertQueryFailure(() -> query(format("INSERT INTO %s (a) VALUES (null) ", tableNameInDatabase)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("INSERT INTO %s (a) VALUES (null) ", tableNameInDatabase)))
                 .hasMessageContaining("Invalid null value in condition for column a");
     }
 
@@ -156,14 +156,14 @@ public class TestInsertIntoCassandraTable
                 CASSANDRA_MATERIALIZED_VIEW,
                 table.getNameInDatabase()));
 
-        assertContainsEventually(() -> query(format("SHOW TABLES FROM %s.%s", CONNECTOR_NAME, KEY_SPACE)),
-                query(format("SELECT lower('%s')", CASSANDRA_MATERIALIZED_VIEW)),
+        assertContainsEventually(() -> onTrino().executeQuery(format("SHOW TABLES FROM %s.%s", CONNECTOR_NAME, KEY_SPACE)),
+                onTrino().executeQuery(format("SELECT lower('%s')", CASSANDRA_MATERIALIZED_VIEW)),
                 new Duration(1, MINUTES));
 
-        assertQueryFailure(() -> query(format("INSERT INTO %s.%s.%s (a) VALUES (null) ", CONNECTOR_NAME, KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("INSERT INTO %s.%s.%s (a) VALUES (null) ", CONNECTOR_NAME, KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW)))
                 .hasMessageContaining("Inserting into materialized views not yet supported");
 
-        assertQueryFailure(() -> query(format("DROP TABLE %s.%s.%s", CONNECTOR_NAME, KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("DROP TABLE %s.%s.%s", CONNECTOR_NAME, KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW)))
                 .hasMessageContaining("Dropping materialized views not yet supported");
 
         onCasssandra(format("DROP MATERIALIZED VIEW IF EXISTS %s.%s", KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW));
@@ -179,7 +179,7 @@ public class TestInsertIntoCassandraTable
         onCasssandra(format("CREATE TABLE %s.%s (key int, value frozen<tuple<int, text, float>>, PRIMARY KEY (key))",
                  KEY_SPACE, tableName));
 
-        assertQueryFailure(() -> query(format("INSERT INTO %s.%s.%s (key, value) VALUES (1, ROW(1, 'text-1', 1.11))", CONNECTOR_NAME, KEY_SPACE, tableName)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("INSERT INTO %s.%s.%s (key, value) VALUES (1, ROW(1, 'text-1', 1.11))", CONNECTOR_NAME, KEY_SPACE, tableName)))
                 .hasMessageContaining("Unsupported column type: row(integer, varchar, real)");
 
         onCasssandra(format("DROP TABLE IF EXISTS %s.%s", KEY_SPACE, tableName));

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestInvalidSelect.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestInvalidSelect.java
@@ -21,12 +21,12 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.CASSANDRA;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.cassandra.CassandraTpchTableDefinitions.CASSANDRA_NATION;
 import static io.trino.tests.product.cassandra.TestConstants.CONNECTOR_NAME;
 import static io.trino.tests.product.cassandra.TestConstants.KEY_SPACE;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 public class TestInvalidSelect
@@ -43,7 +43,7 @@ public class TestInvalidSelect
     public void testInvalidTable()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, KEY_SPACE, "bogus");
-        assertQueryFailure(() -> query(format("SELECT * FROM %s", tableName)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("SELECT * FROM %s", tableName)))
                 .hasMessageContaining("Table '%s' does not exist", tableName);
     }
 
@@ -51,7 +51,7 @@ public class TestInvalidSelect
     public void testInvalidSchema()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, "does_not_exist", "bogus");
-        assertQueryFailure(() -> query(format("SELECT * FROM %s", tableName)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("SELECT * FROM %s", tableName)))
                 .hasMessageContaining("Schema 'does_not_exist' does not exist");
     }
 
@@ -59,7 +59,7 @@ public class TestInvalidSelect
     public void testInvalidColumn()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, KEY_SPACE, CASSANDRA_NATION.getName());
-        assertQueryFailure(() -> query(format("SELECT bogus FROM %s", tableName)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("SELECT bogus FROM %s", tableName)))
                 .hasMessageContaining("Column 'bogus' cannot be resolved");
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestSelect.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestSelect.java
@@ -36,7 +36,6 @@ import static io.trino.tempto.Requirements.compose;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.CASSANDRA;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.TpchTableResults.PRESTO_NATION_RESULT;
@@ -181,7 +180,7 @@ public class TestSelect
     public void testAllDataTypes()
     {
         // NOTE: DECIMAL is treated like DOUBLE
-        QueryResult query = query(format(
+        QueryResult query = onTrino().executeQuery(format(
                 "SELECT a, b, bl, bo, d, do, dt, f, fr, i, integer, l, m, s, si, t, ti, ts, tu, u, v, vari FROM %s.%s.%s",
                 CONNECTOR_NAME, KEY_SPACE, CASSANDRA_ALL_TYPES.getName()));
 
@@ -286,16 +285,16 @@ public class TestSelect
                 KEY_SPACE,
                 CASSANDRA_ALL_TYPES.getName()));
 
-        assertContainsEventually(() -> query(format("SHOW TABLES FROM %s.%s", CONNECTOR_NAME, KEY_SPACE)),
-                query(format("SELECT '%s'", materializedViewName)),
+        assertContainsEventually(() -> onTrino().executeQuery(format("SHOW TABLES FROM %s.%s", CONNECTOR_NAME, KEY_SPACE)),
+                onTrino().executeQuery(format("SELECT '%s'", materializedViewName)),
                 new Duration(1, MINUTES));
 
         // Materialized view may not return all results during the creation
-        assertContainsEventually(() -> query(format("SELECT status_replicated FROM %s.system.built_views WHERE view_name = '%s'", CONNECTOR_NAME, materializedViewName)),
-                query("SELECT true"),
+        assertContainsEventually(() -> onTrino().executeQuery(format("SELECT status_replicated FROM %s.system.built_views WHERE view_name = '%s'", CONNECTOR_NAME, materializedViewName)),
+                onTrino().executeQuery("SELECT true"),
                 new Duration(1, MINUTES));
 
-        QueryResult query = query(format(
+        QueryResult query = onTrino().executeQuery(format(
                 "SELECT a, b, bl, bo, d, do, dt, f, fr, i, integer, l, m, s, si, t, ti, ts, tu, u, v, vari FROM %s.%s.%s WHERE a = '\0'",
                 CONNECTOR_NAME, KEY_SPACE, materializedViewName));
 
@@ -345,13 +344,13 @@ public class TestSelect
                 KEY_SPACE,
                 CASSANDRA_SUPPLIER.getName()));
 
-        assertContainsEventually(() -> query(format("SHOW TABLES FROM %s.%s", CONNECTOR_NAME, KEY_SPACE)),
-                query(format("SELECT '%s'", mvName)),
+        assertContainsEventually(() -> onTrino().executeQuery(format("SHOW TABLES FROM %s.%s", CONNECTOR_NAME, KEY_SPACE)),
+                onTrino().executeQuery(format("SELECT '%s'", mvName)),
                 new Duration(1, MINUTES));
 
         // Materialized view may not return all results during the creation
-        assertContainsEventually(() -> query(format("SELECT status_replicated FROM %s.system.built_views WHERE view_name = '%s'", CONNECTOR_NAME, mvName)),
-                query("SELECT true"),
+        assertContainsEventually(() -> onTrino().executeQuery(format("SELECT status_replicated FROM %s.system.built_views WHERE view_name = '%s'", CONNECTOR_NAME, mvName)),
+                onTrino().executeQuery("SELECT true"),
                 new Duration(1, MINUTES));
 
         QueryResult aggregateQueryResult = onTrino()

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/TestFunctions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/TestFunctions.java
@@ -18,8 +18,8 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.JSON_FUNCTIONS;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 
 public class TestFunctions
         extends ProductTest
@@ -27,12 +27,12 @@ public class TestFunctions
     @Test(groups = JSON_FUNCTIONS)
     public void testScalarFunction()
     {
-        assertThat(query("SELECT upper('value')")).containsExactlyInOrder(row("VALUE"));
+        assertThat(onTrino().executeQuery("SELECT upper('value')")).containsExactlyInOrder(row("VALUE"));
     }
 
     @Test(groups = JSON_FUNCTIONS)
     public void testAggregate()
     {
-        assertThat(query("SELECT min(x) FROM (VALUES 1,2,3,4) t(x)")).containsExactlyInOrder(row(1));
+        assertThat(onTrino().executeQuery("SELECT min(x) FROM (VALUES 1,2,3,4) t(x)")).containsExactlyInOrder(row(1));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/operators/TestComparison.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/operators/TestComparison.java
@@ -19,9 +19,9 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.COMPARISON;
 import static io.trino.tests.product.TestGroups.QUERY_ENGINE;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 public class TestComparison
@@ -45,42 +45,42 @@ public class TestComparison
     @Test(groups = {COMPARISON, QUERY_ENGINE}, dataProvider = "operands")
     public void testLessThanOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
-        assertThat(query(format("select cast(%s as %s) < cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
+        assertThat(onTrino().executeQuery(format("select cast(%s as %s) < cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
                 .containsExactlyInOrder(row(true));
     }
 
     @Test(groups = {COMPARISON, QUERY_ENGINE}, dataProvider = "operands")
     public void testGreaterThanOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
-        assertThat(query(format("select cast(%s as %s) > cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
+        assertThat(onTrino().executeQuery(format("select cast(%s as %s) > cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
                 .containsExactlyInOrder(row(false));
     }
 
     @Test(groups = {COMPARISON, QUERY_ENGINE}, dataProvider = "operands")
     public void testLessThanOrEqualOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
-        assertThat(query(format("select cast(%s as %s) <= cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
+        assertThat(onTrino().executeQuery(format("select cast(%s as %s) <= cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
                 .containsExactlyInOrder(row(true));
     }
 
     @Test(groups = {COMPARISON, QUERY_ENGINE}, dataProvider = "operands")
     public void testGreaterThanOrEqualOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
-        assertThat(query(format("select cast(%s as %s) >= cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
+        assertThat(onTrino().executeQuery(format("select cast(%s as %s) >= cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
                 .containsExactlyInOrder(row(false));
     }
 
     @Test(groups = {COMPARISON, QUERY_ENGINE}, dataProvider = "operands")
     public void testEqualOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
-        assertThat(query(format("select cast(%s as %s) = cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
+        assertThat(onTrino().executeQuery(format("select cast(%s as %s) = cast(%s as %s)", leftOperand, typeName, rightOperand, typeName)))
                 .containsExactlyInOrder(row(false));
     }
 
     @Test(groups = {COMPARISON, QUERY_ENGINE}, dataProvider = "operands")
     public void testBetweenOperatorExists(String leftOperand, String rightOperand, String typeName)
     {
-        assertThat(query(format("select cast(%s as %s) BETWEEN cast(%s as %s) AND cast(%s as %s)", leftOperand, typeName, leftOperand, typeName, rightOperand, typeName)))
+        assertThat(onTrino().executeQuery(format("select cast(%s as %s) BETWEEN cast(%s as %s) AND cast(%s as %s)", leftOperand, typeName, leftOperand, typeName, rightOperand, typeName)))
                 .containsExactlyInOrder(row(true));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/operators/TestLogical.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/functions/operators/TestLogical.java
@@ -18,9 +18,9 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.LOGICAL;
 import static io.trino.tests.product.TestGroups.QUERY_ENGINE;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 
 public class TestLogical
         extends ProductTest
@@ -28,11 +28,11 @@ public class TestLogical
     @Test(groups = {LOGICAL, QUERY_ENGINE})
     public void testLogicalOperatorsExists()
     {
-        assertThat(query("select true AND true")).containsExactlyInOrder(row(true));
-        assertThat(query("select true OR false")).containsExactlyInOrder(row(true));
-        assertThat(query("select 1 in (1, 2, 3)")).containsExactlyInOrder(row(true));
-        assertThat(query("select 'ala ma kota' like 'ala%'")).containsExactlyInOrder(row(true));
-        assertThat(query("select NOT true")).containsExactlyInOrder(row(false));
-        assertThat(query("select null is null")).containsExactlyInOrder(row(true));
+        assertThat(onTrino().executeQuery("select true AND true")).containsExactlyInOrder(row(true));
+        assertThat(onTrino().executeQuery("select true OR false")).containsExactlyInOrder(row(true));
+        assertThat(onTrino().executeQuery("select 1 in (1, 2, 3)")).containsExactlyInOrder(row(true));
+        assertThat(onTrino().executeQuery("select 'ala ma kota' like 'ala%'")).containsExactlyInOrder(row(true));
+        assertThat(onTrino().executeQuery("select NOT true")).containsExactlyInOrder(row(false));
+        assertThat(onTrino().executeQuery("select null is null")).containsExactlyInOrder(row(true));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/AbstractTestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/AbstractTestHiveViews.java
@@ -40,7 +40,6 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.HIVE_ICEBERG_REDIRECTIONS;
 import static io.trino.tests.product.TestGroups.HIVE_VIEWS;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
@@ -174,7 +173,7 @@ public abstract class AbstractTestHiveViews
         onHive().executeQuery("DROP VIEW IF EXISTS view_with_unsupported_coercion");
         onHive().executeQuery("CREATE VIEW view_with_unsupported_coercion AS SELECT length(n_comment) FROM nation");
 
-        assertQueryFailure(() -> query("SELECT COUNT(*) FROM view_with_unsupported_coercion"))
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT COUNT(*) FROM view_with_unsupported_coercion"))
                 .hasMessageContaining("View 'hive.default.view_with_unsupported_coercion' is stale or in invalid state: a column of type bigint projected from query view at position 0 has no name");
     }
 
@@ -230,7 +229,7 @@ public abstract class AbstractTestHiveViews
         onHive().executeQuery("DROP VIEW IF EXISTS view_with_repeat_function");
         onHive().executeQuery("CREATE VIEW view_with_repeat_function AS SELECT REPEAT(n_comment,2) FROM nation");
 
-        assertQueryFailure(() -> query("SELECT COUNT(*) FROM view_with_repeat_function"))
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT COUNT(*) FROM view_with_repeat_function"))
                 .hasMessageContaining("View 'hive.default.view_with_repeat_function' is stale or in invalid state: a column of type array(varchar(152)) projected from query view at position 0 has no name");
     }
 
@@ -240,7 +239,7 @@ public abstract class AbstractTestHiveViews
         onHive().executeQuery("DROP VIEW IF EXISTS hive_duplicate_view");
         onHive().executeQuery("CREATE VIEW hive_duplicate_view AS SELECT * FROM nation");
 
-        assertQueryFailure(() -> query("CREATE VIEW hive_duplicate_view AS SELECT * FROM nation"))
+        assertQueryFailure(() -> onTrino().executeQuery("CREATE VIEW hive_duplicate_view AS SELECT * FROM nation"))
                 .hasMessageContaining("View already exists");
     }
 
@@ -260,12 +259,12 @@ public abstract class AbstractTestHiveViews
                 "FROM\n" +
                 "  \"default\".\"nation\"";
 
-        QueryResult actualResult = query(format(showCreateViewSql, "hive"));
+        QueryResult actualResult = onTrino().executeQuery(format(showCreateViewSql, "hive"));
         assertThat(actualResult).hasRowsCount(1);
         assertEquals((String) actualResult.row(0).get(0), format(expectedResult, "hive"));
 
         // Verify the translated view sql for a catalog other than "hive", which is configured to the same metastore
-        actualResult = query(format(showCreateViewSql, "hive_with_external_writes"));
+        actualResult = onTrino().executeQuery(format(showCreateViewSql, "hive_with_external_writes"));
         assertThat(actualResult).hasRowsCount(1);
         assertEquals((String) actualResult.row(0).get(0), format(expectedResult, "hive_with_external_writes"));
     }
@@ -338,16 +337,16 @@ public abstract class AbstractTestHiveViews
 
         boolean hiveWithTableNamesByType = getHiveVersionMajor() >= 3 ||
                 (getHiveVersionMajor() == 2 && getHiveVersionMinor() >= 3);
-        assertThat(query("SELECT * FROM information_schema.tables WHERE table_schema = 'test_schema'")).containsOnly(
+        assertThat(onTrino().executeQuery("SELECT * FROM information_schema.tables WHERE table_schema = 'test_schema'")).containsOnly(
                 row("hive", "test_schema", "trino_table", "BASE TABLE"),
                 row("hive", "test_schema", "hive_table", "BASE TABLE"),
                 row("hive", "test_schema", "hive_test_view", hiveWithTableNamesByType ? "VIEW" : "BASE TABLE"),
                 row("hive", "test_schema", "trino_test_view", "VIEW"));
 
-        assertThat(query("SELECT view_definition FROM information_schema.views WHERE table_schema = 'test_schema' and table_name = 'hive_test_view'")).containsOnly(
+        assertThat(onTrino().executeQuery("SELECT view_definition FROM information_schema.views WHERE table_schema = 'test_schema' and table_name = 'hive_test_view'")).containsOnly(
                 row("SELECT \"n_nationkey\", \"n_name\", \"n_regionkey\", \"n_comment\"\nFROM \"default\".\"nation\""));
 
-        assertThat(query("DESCRIBE test_schema.hive_test_view"))
+        assertThat(onTrino().executeQuery("DESCRIBE test_schema.hive_test_view"))
                 .contains(row("n_nationkey", "bigint", "", ""));
     }
 
@@ -365,7 +364,7 @@ public abstract class AbstractTestHiveViews
                 "SELECT * FROM hive_view_parametrized",
                 queryAssert -> queryAssert.containsOnly(row(new BigDecimal("1.2345"), 42, "bar")));
 
-        assertThat(query("SELECT data_type FROM information_schema.columns WHERE table_name = 'hive_view_parametrized'")).containsOnly(
+        assertThat(onTrino().executeQuery("SELECT data_type FROM information_schema.columns WHERE table_name = 'hive_view_parametrized'")).containsOnly(
                 row("decimal(20,4)"),
                 row("bigint"),
                 row("varchar"));
@@ -413,19 +412,19 @@ public abstract class AbstractTestHiveViews
         unsetSessionProperty("hive.timestamp_precision");
         unsetSessionProperty("hive_timestamp_nanos.timestamp_precision");
 
-        assertThat(query("SELECT CAST(ts AS varchar) FROM timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123"));
+        assertThat(onTrino().executeQuery("SELECT CAST(ts AS varchar) FROM timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123"));
         assertThatThrownBy(
                 // TODO(https://github.com/trinodb/trino/issues/6295) it is not possible to query Hive view with timestamps if hive.timestamp-precision=NANOSECONDS
-                () -> assertThat(query("SELECT CAST(ts AS varchar) FROM hive_timestamp_nanos.default.timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123456789"))
+                () -> assertThat(onTrino().executeQuery("SELECT CAST(ts AS varchar) FROM hive_timestamp_nanos.default.timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123456789"))
         ).hasMessageContaining("timestamp(9) projected from query view at position 0 cannot be coerced to column [ts] of type timestamp(3) stored in view definition");
 
         setSessionProperty("hive.timestamp_precision", "'MILLISECONDS'");
         setSessionProperty("hive_timestamp_nanos.timestamp_precision", "'MILLISECONDS'");
 
-        assertThat(query("SELECT CAST(ts AS varchar) FROM timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123"));
+        assertThat(onTrino().executeQuery("SELECT CAST(ts AS varchar) FROM timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123"));
         assertThatThrownBy(
                 // TODO(https://github.com/trinodb/trino/issues/6295) it is not possible to query Hive view with timestamps if hive.timestamp-precision=NANOSECONDS
-                () -> assertThat(query("SELECT CAST(ts AS varchar) FROM hive_timestamp_nanos.default.timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123"))
+                () -> assertThat(onTrino().executeQuery("SELECT CAST(ts AS varchar) FROM hive_timestamp_nanos.default.timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123"))
         ).hasMessageContaining("timestamp(9) projected from query view at position 0 cannot be coerced to column [ts] of type timestamp(3) stored in view definition");
 
         setSessionProperty("hive.timestamp_precision", "'NANOSECONDS'");
@@ -433,10 +432,10 @@ public abstract class AbstractTestHiveViews
 
         // TODO(https://github.com/trinodb/trino/issues/6295) timestamp_precision has no effect on Hive views
         // should be: assertThat(query("SELECT CAST(ts AS varchar) FROM timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123456789"))
-        assertThat(query("SELECT CAST(ts AS varchar) FROM timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123"));
+        assertThat(onTrino().executeQuery("SELECT CAST(ts AS varchar) FROM timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123"));
         assertThatThrownBy(
                 // TODO(https://github.com/trinodb/trino/issues/6295) it is not possible to query Hive view with timestamps if hive.timestamp-precision=NANOSECONDS
-                () -> assertThat(query("SELECT CAST(ts AS varchar) FROM hive_timestamp_nanos.default.timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123456789"))
+                () -> assertThat(onTrino().executeQuery("SELECT CAST(ts AS varchar) FROM hive_timestamp_nanos.default.timestamp_hive_view")).containsOnly(row("1990-01-02 12:13:14.123456789"))
         ).hasMessageContaining("timestamp(9) projected from query view at position 0 cannot be coerced to column [ts] of type timestamp(3) stored in view definition");
     }
 
@@ -447,7 +446,7 @@ public abstract class AbstractTestHiveViews
         onHive().executeQuery("CREATE VIEW current_user_hive_view as SELECT current_user() AS cu FROM nation LIMIT 1");
 
         String testQuery = "SELECT cu FROM current_user_hive_view";
-        assertThat(query(testQuery)).containsOnly(row("hive"));
+        assertThat(onTrino().executeQuery(testQuery)).containsOnly(row("hive"));
         assertThat(connectToTrino("alice@presto").executeQuery(testQuery)).containsOnly(row("alice"));
     }
 
@@ -487,7 +486,7 @@ public abstract class AbstractTestHiveViews
                 + "UNION ALL\n"
                 + "SELECT r_regionkey FROM union_helper\n");
 
-        assertThat(query("SELECT r_regionkey FROM union_all_view"))
+        assertThat(onTrino().executeQuery("SELECT r_regionkey FROM union_all_view"))
                 // Copy the keys 5 times because there are 5 nations per region
                 .containsOnly(
                         // base rows
@@ -647,14 +646,14 @@ public abstract class AbstractTestHiveViews
     {
         // We need to setup sessions for both "trino" and "default" executors in tempto
         onTrino().executeQuery(format("SET SESSION %s = %s", key, value));
-        query(format("SET SESSION %s = %s", key, value));
+        onTrino().executeQuery(format("SET SESSION %s = %s", key, value));
     }
 
     protected void unsetSessionProperty(String key)
     {
         // We need to setup sessions for both "trino" and "default" executors in tempto
         onTrino().executeQuery("RESET SESSION " + key);
-        query("RESET SESSION " + key);
+        onTrino().executeQuery("RESET SESSION " + key);
     }
 
     private static String extractMatch(String value, @Language("RegExp") String pattern, String groupName)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAllDatatypesFromHiveConnector.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAllDatatypesFromHiveConnector.java
@@ -37,7 +37,6 @@ import static io.trino.tempto.context.ThreadLocalTestContextHolder.testContext;
 import static io.trino.tempto.fulfillment.table.MutableTableRequirement.State.CREATED;
 import static io.trino.tempto.fulfillment.table.TableHandle.tableHandle;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.JDBC;
 import static io.trino.tests.product.TestGroups.SMOKE;
 import static io.trino.tests.product.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_AVRO;
@@ -47,6 +46,7 @@ import static io.trino.tests.product.hive.AllSimpleTypesTableDefinitions.ALL_HIV
 import static io.trino.tests.product.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_TEXTFILE;
 import static io.trino.tests.product.hive.AllSimpleTypesTableDefinitions.populateDataToHiveTable;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.sql.JDBCType.BIGINT;
@@ -129,7 +129,7 @@ public class TestAllDatatypesFromHiveConnector
         String tableName = ALL_HIVE_SIMPLE_TYPES_TEXTFILE.getName();
 
         assertProperAllDatatypesSchema(tableName);
-        QueryResult queryResult = query(format("SELECT * FROM %s", tableName));
+        QueryResult queryResult = onTrino().executeQuery(format("SELECT * FROM %s", tableName));
 
         assertColumnTypes(queryResult);
         assertThat(queryResult).containsOnly(
@@ -161,7 +161,7 @@ public class TestAllDatatypesFromHiveConnector
 
         assertProperAllDatatypesSchema(tableName);
 
-        QueryResult queryResult = query(format("SELECT * FROM %s", tableName));
+        QueryResult queryResult = onTrino().executeQuery(format("SELECT * FROM %s", tableName));
         assertColumnTypes(queryResult);
         assertThat(queryResult).containsOnly(
                 row(
@@ -192,7 +192,7 @@ public class TestAllDatatypesFromHiveConnector
 
         assertProperAllDatatypesSchema(tableName);
 
-        QueryResult queryResult = query(format("SELECT * FROM %s", tableName));
+        QueryResult queryResult = onTrino().executeQuery(format("SELECT * FROM %s", tableName));
         assertColumnTypes(queryResult);
         assertThat(queryResult).containsOnly(
                 row(
@@ -236,7 +236,7 @@ public class TestAllDatatypesFromHiveConnector
                         ")",
                 tableName));
 
-        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
+        assertThat(onTrino().executeQuery("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
                 row("c_int", "integer"),
                 row("c_bigint", "bigint"),
                 row("c_float", "real"),
@@ -251,7 +251,7 @@ public class TestAllDatatypesFromHiveConnector
                 row("c_boolean", "boolean"),
                 row("c_binary", "varbinary"));
 
-        QueryResult queryResult = query("SELECT * FROM " + tableName);
+        QueryResult queryResult = onTrino().executeQuery("SELECT * FROM " + tableName);
         assertThat(queryResult).hasColumns(
                 INTEGER,
                 BIGINT,
@@ -289,7 +289,7 @@ public class TestAllDatatypesFromHiveConnector
 
     private void assertProperAllDatatypesSchema(String tableName)
     {
-        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
+        assertThat(onTrino().executeQuery("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
                 row("c_tinyint", "tinyint"),
                 row("c_smallint", "smallint"),
                 row("c_int", "integer"),
@@ -369,7 +369,7 @@ public class TestAllDatatypesFromHiveConnector
                 "'kot binarny'" +
                 ")", tableName));
 
-        assertThat(query(format("SHOW COLUMNS FROM %s", tableName)).project(1, 2)).containsExactlyInOrder(
+        assertThat(onTrino().executeQuery(format("SHOW COLUMNS FROM %s", tableName)).project(1, 2)).containsExactlyInOrder(
                 row("c_tinyint", "tinyint"),
                 row("c_smallint", "smallint"),
                 row("c_int", "integer"),
@@ -385,7 +385,7 @@ public class TestAllDatatypesFromHiveConnector
                 row("c_boolean", "boolean"),
                 row("c_binary", "varbinary"));
 
-        QueryResult queryResult = query(format("SELECT * FROM %s", tableName));
+        QueryResult queryResult = onTrino().executeQuery(format("SELECT * FROM %s", tableName));
         assertColumnTypesParquet(queryResult);
         assertThat(queryResult).containsOnly(
                 row(

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaStrictness.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAvroSchemaStrictness.java
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.query.QueryExecutor.param;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.AVRO;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
@@ -83,7 +82,7 @@ public class TestAvroSchemaStrictness
                 param(VARCHAR, schemaPath),
                 param(VARCHAR, tablePath));
 
-        assertThat(query("SELECT valid, invalid FROM " + tableName))
+        assertThat(onTrino().executeQuery("SELECT valid, invalid FROM " + tableName))
                 .containsOnly(row("valid", "invalid"), row(null, null));
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestComments.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestComments.java
@@ -21,8 +21,8 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.COMMENT;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,8 +36,8 @@ public class TestComments
     @AfterTestWithContext
     public void dropTestTable()
     {
-        query("DROP TABLE IF EXISTS " + COMMENT_TABLE_NAME);
-        query("DROP TABLE IF EXISTS " + COMMENT_COLUMN_NAME);
+        onTrino().executeQuery("DROP TABLE IF EXISTS " + COMMENT_TABLE_NAME);
+        onTrino().executeQuery("DROP TABLE IF EXISTS " + COMMENT_COLUMN_NAME);
     }
 
     @Test(groups = COMMENT)
@@ -52,21 +52,21 @@ public class TestComments
                         "   format = 'RCBINARY'\n" +
                         ")",
                 COMMENT_TABLE_NAME);
-        query(createTableSql);
+        onTrino().executeQuery(createTableSql);
 
-        QueryResult actualResult = query("SHOW CREATE TABLE " + COMMENT_TABLE_NAME);
+        QueryResult actualResult = onTrino().executeQuery("SHOW CREATE TABLE " + COMMENT_TABLE_NAME);
         assertThat((String) actualResult.row(0).get(0)).matches(tableWithCommentPattern(COMMENT_TABLE_NAME, Optional.of("old comment")));
 
-        query(format("COMMENT ON TABLE %s IS 'new comment'", COMMENT_TABLE_NAME));
-        actualResult = query("SHOW CREATE TABLE " + COMMENT_TABLE_NAME);
+        onTrino().executeQuery(format("COMMENT ON TABLE %s IS 'new comment'", COMMENT_TABLE_NAME));
+        actualResult = onTrino().executeQuery("SHOW CREATE TABLE " + COMMENT_TABLE_NAME);
         assertThat((String) actualResult.row(0).get(0)).matches(tableWithCommentPattern(COMMENT_TABLE_NAME, Optional.of("new comment")));
 
-        query(format("COMMENT ON TABLE %s IS ''", COMMENT_TABLE_NAME));
-        actualResult = query("SHOW CREATE TABLE " + COMMENT_TABLE_NAME);
+        onTrino().executeQuery(format("COMMENT ON TABLE %s IS ''", COMMENT_TABLE_NAME));
+        actualResult = onTrino().executeQuery("SHOW CREATE TABLE " + COMMENT_TABLE_NAME);
         assertThat((String) actualResult.row(0).get(0)).matches(tableWithCommentPattern(COMMENT_TABLE_NAME, Optional.of("")));
 
-        query(format("COMMENT ON TABLE %s IS NULL", COMMENT_TABLE_NAME));
-        actualResult = query("SHOW CREATE TABLE " + COMMENT_TABLE_NAME);
+        onTrino().executeQuery(format("COMMENT ON TABLE %s IS NULL", COMMENT_TABLE_NAME));
+        actualResult = onTrino().executeQuery("SHOW CREATE TABLE " + COMMENT_TABLE_NAME);
         assertThat((String) actualResult.row(0).get(0)).matches(tableWithCommentPattern(COMMENT_TABLE_NAME, Optional.empty()));
     }
 
@@ -90,7 +90,7 @@ public class TestComments
                         "   format = 'RCBINARY'\n" +
                         ")",
                 COMMENT_COLUMN_NAME);
-        query(createTableSql);
+        onTrino().executeQuery(createTableSql);
 
         String createTableSqlPattern = format("\\Q" +
                         "CREATE TABLE hive.default.%s (\n" +
@@ -99,7 +99,7 @@ public class TestComments
                         "   c3 bigint\n" +
                         ")\\E(?s:.*)",
                 COMMENT_COLUMN_NAME);
-        QueryResult actualResult = query("SHOW CREATE TABLE " + COMMENT_COLUMN_NAME);
+        QueryResult actualResult = onTrino().executeQuery("SHOW CREATE TABLE " + COMMENT_COLUMN_NAME);
         assertThat((String) actualResult.row(0).get(0)).matches(createTableSqlPattern);
 
         createTableSqlPattern = format("\\Q" +
@@ -110,8 +110,8 @@ public class TestComments
                         ")\\E(?s:.*)",
                 COMMENT_COLUMN_NAME);
 
-        query(format("COMMENT ON COLUMN %s.c1 IS 'new comment'", COMMENT_COLUMN_NAME));
-        actualResult = query("SHOW CREATE TABLE " + COMMENT_COLUMN_NAME);
+        onTrino().executeQuery(format("COMMENT ON COLUMN %s.c1 IS 'new comment'", COMMENT_COLUMN_NAME));
+        actualResult = onTrino().executeQuery("SHOW CREATE TABLE " + COMMENT_COLUMN_NAME);
         assertThat((String) actualResult.row(0).get(0)).matches(createTableSqlPattern);
 
         createTableSqlPattern = format("\\Q" +
@@ -122,8 +122,8 @@ public class TestComments
                         ")\\E(?s:.*)",
                 COMMENT_COLUMN_NAME);
 
-        query(format("COMMENT ON COLUMN %s.c1 IS ''", COMMENT_COLUMN_NAME));
-        actualResult = query("SHOW CREATE TABLE " + COMMENT_COLUMN_NAME);
+        onTrino().executeQuery(format("COMMENT ON COLUMN %s.c1 IS ''", COMMENT_COLUMN_NAME));
+        actualResult = onTrino().executeQuery("SHOW CREATE TABLE " + COMMENT_COLUMN_NAME);
         assertThat((String) actualResult.row(0).get(0)).matches(createTableSqlPattern);
 
         createTableSqlPattern = format("\\Q" +
@@ -134,8 +134,8 @@ public class TestComments
                         ")\\E(?s:.*)",
                 COMMENT_COLUMN_NAME);
 
-        query(format("COMMENT ON COLUMN %s.c1 IS NULL", COMMENT_COLUMN_NAME));
-        actualResult = query("SHOW CREATE TABLE " + COMMENT_COLUMN_NAME);
+        onTrino().executeQuery(format("COMMENT ON COLUMN %s.c1 IS NULL", COMMENT_COLUMN_NAME));
+        actualResult = onTrino().executeQuery("SHOW CREATE TABLE " + COMMENT_COLUMN_NAME);
         assertThat((String) actualResult.row(0).get(0)).matches(createTableSqlPattern);
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCsvFileHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCsvFileHiveTable.java
@@ -18,7 +18,6 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -38,7 +37,7 @@ public class TestCsvFileHiveTable
                         ") " +
                         "AS SELECT CAST(1 AS VARCHAR)  AS col_name1, CAST(2 AS VARCHAR) AS col_name2;");
         onTrino().executeQuery("INSERT INTO test_create_csv_skip_header VALUES ('3', '4')");
-        assertThat(query("SELECT * FROM test_create_csv_skip_header")).containsOnly(row("1", "2"), row("3", "4"));
+        assertThat(onTrino().executeQuery("SELECT * FROM test_create_csv_skip_header")).containsOnly(row("1", "2"), row("3", "4"));
         assertThat(onHive().executeQuery("SELECT * FROM test_create_csv_skip_header")).containsOnly(row("1", "2"), row("3", "4"));
         onHive().executeQuery("DROP TABLE test_create_csv_skip_header");
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestExternalHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestExternalHiveTable.java
@@ -29,7 +29,6 @@ import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.MutableTablesState.mutableTablesState;
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
 import static io.trino.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_BIGINT_REGIONKEY;
 import static io.trino.tests.product.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_REGIONKEY_NUMBER_OF_LINES_PER_SPLIT;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
@@ -63,7 +62,7 @@ public class TestExternalHiveTable
         insertNationPartition(nation, 1);
 
         onHive().executeQuery("ANALYZE TABLE " + EXTERNAL_TABLE_NAME + " PARTITION (p_regionkey) COMPUTE STATISTICS");
-        assertThat(query("SHOW STATS FOR " + EXTERNAL_TABLE_NAME)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + EXTERNAL_TABLE_NAME)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_comment", null, null, null, null, null, null),
@@ -71,7 +70,7 @@ public class TestExternalHiveTable
                 row(null, null, null, null, 5.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + EXTERNAL_TABLE_NAME + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
-        assertThat(query("SHOW STATS FOR " + EXTERNAL_TABLE_NAME)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + EXTERNAL_TABLE_NAME)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 38.0, 5.0, 0.0, null, null, null),
                 row("p_comment", 499.0, 5.0, 0.0, null, null, null),
@@ -88,7 +87,7 @@ public class TestExternalHiveTable
         insertNationPartition(nation, 1);
 
         // Running ANALYZE on an external table is allowed as long as the user has the privileges.
-        assertThat(query("ANALYZE hive.default." + EXTERNAL_TABLE_NAME)).containsExactlyInOrder(row(5));
+        assertThat(onTrino().executeQuery("ANALYZE hive.default." + EXTERNAL_TABLE_NAME)).containsExactlyInOrder(row(5));
     }
 
     @Test
@@ -141,13 +140,13 @@ public class TestExternalHiveTable
         String schema = "schema_without_location";
         String schemaLocation = "/tmp/" + schema;
         hdfsClient.createDirectory(schemaLocation);
-        query(format("CREATE SCHEMA %s.%s WITH (location='%s')", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema, schemaLocation));
+        onTrino().executeQuery(format("CREATE SCHEMA %s.%s WITH (location='%s')", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema, schemaLocation));
 
         hdfsClient.delete(schemaLocation);
 
         String table = "test_create_external";
         String tableLocation = "/tmp/" + table;
-        query(format("CREATE TABLE %s.%s.%s WITH (external_location = '%s') AS SELECT * FROM tpch.tiny.nation", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema, table, tableLocation));
+        onTrino().executeQuery(format("CREATE TABLE %s.%s.%s WITH (external_location = '%s') AS SELECT * FROM tpch.tiny.nation", HIVE_CATALOG_WITH_EXTERNAL_WRITES, schema, table, tableLocation));
     }
 
     private void insertNationPartition(TableInstance<?> nation, int partition)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBucketedTables.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBucketedTables.java
@@ -44,7 +44,6 @@ import static io.trino.tempto.fulfillment.table.MutableTablesState.mutableTables
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.trino.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
 import static io.trino.tempto.query.QueryExecutor.param;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.BIG_QUERY;
 import static io.trino.tests.product.TpchTableResults.PRESTO_NATION_RESULT;
 import static io.trino.tests.product.hive.BucketingType.BUCKETED_DEFAULT;
@@ -113,7 +112,7 @@ public class TestHiveBucketedTables
         String tableName = mutableTableInstanceOf(BUCKETED_NATION).getNameInDatabase();
         populateHiveTable(tableName, NATION.getName());
 
-        assertThat(query("SELECT * FROM " + tableName)).matches(PRESTO_NATION_RESULT);
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableName)).matches(PRESTO_NATION_RESULT);
     }
 
     @Test(groups = BIG_QUERY)
@@ -126,11 +125,11 @@ public class TestHiveBucketedTables
 
         onHive().executeQuery(format("ALTER TABLE %s NOT CLUSTERED", tableName));
 
-        assertThat(query(format("SELECT count(DISTINCT n_nationkey), count(*) FROM %s", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(DISTINCT n_nationkey), count(*) FROM %s", tableName)))
                 .hasRowsCount(1)
                 .contains(row(25, 50));
 
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
                 .containsExactlyInOrder(row(2));
     }
 
@@ -143,11 +142,11 @@ public class TestHiveBucketedTables
             populateHivePartitionedTable(tableName, NATION.getName(), "part_key = 'insert'");
         }
 
-        assertThat(query(format("SELECT count(DISTINCT n_nationkey), count(*) FROM %s", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(DISTINCT n_nationkey), count(*) FROM %s", tableName)))
                 .hasRowsCount(1)
                 .contains(row(25, 75));
 
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
                 .containsExactlyInOrder(row(3));
     }
 
@@ -159,13 +158,13 @@ public class TestHiveBucketedTables
         populateHiveTable(tableName, NATION.getName());
         populateHiveTable(tableName, NATION.getName());
 
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
                 .containsExactlyInOrder(row(2));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
                 .containsExactlyInOrder(row(10));
-        assertThat(query(format("SELECT n_regionkey, count(*) FROM %s GROUP BY n_regionkey", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT n_regionkey, count(*) FROM %s GROUP BY n_regionkey", tableName)))
                 .containsOnly(row(0, 10), row(1, 10), row(2, 10), row(3, 10), row(4, 10));
-        assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
                 .containsExactlyInOrder(row(500));
     }
 
@@ -177,13 +176,13 @@ public class TestHiveBucketedTables
         populateHiveTable(tableName, NATION.getName());
         populateHiveTable(tableName, NATION.getName());
 
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
                 .containsExactlyInOrder(row(2));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
                 .containsExactlyInOrder(row(10));
-        assertThat(query(format("SELECT n_regionkey, count(*) FROM %s GROUP BY n_regionkey", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT n_regionkey, count(*) FROM %s GROUP BY n_regionkey", tableName)))
                 .containsOnly(row(0, 10), row(1, 10), row(2, 10), row(3, 10), row(4, 10));
-        assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
                 .containsExactlyInOrder(row(500));
     }
 
@@ -197,18 +196,18 @@ public class TestHiveBucketedTables
         populateHivePartitionedTable(tableName, NATION.getName(), "part_key = 'insert_1'");
         populateHivePartitionedTable(tableName, NATION.getName(), "part_key = 'insert_2'");
 
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_nationkey = 1", tableName)))
                 .containsExactlyInOrder(row(4));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_regionkey = 1", tableName)))
                 .containsExactlyInOrder(row(20));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey = 1 AND part_key = 'insert_1'", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_regionkey = 1 AND part_key = 'insert_1'", tableName)))
                 .hasRowsCount(1)
                 .containsExactlyInOrder(row(10));
-        assertThat(query(format("SELECT n_regionkey, count(*) FROM %s WHERE part_key = 'insert_2' GROUP BY n_regionkey", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT n_regionkey, count(*) FROM %s WHERE part_key = 'insert_2' GROUP BY n_regionkey", tableName)))
                 .containsOnly(row(0, 10), row(1, 10), row(2, 10), row(3, 10), row(4, 10));
-        assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey", tableName, tableName)))
                 .containsExactlyInOrder(row(2000));
-        assertThat(query(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey WHERE n.part_key = 'insert_1'", tableName, tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s n JOIN %s n1 ON n.n_regionkey = n1.n_regionkey WHERE n.part_key = 'insert_1'", tableName, tableName)))
                 .containsExactlyInOrder(row(1000));
     }
 
@@ -217,7 +216,7 @@ public class TestHiveBucketedTables
     public void testSelectFromEmptyBucketedTableEmptyTablesAllowed()
     {
         String tableName = mutableTableInstanceOf(BUCKETED_NATION).getNameInDatabase();
-        assertThat(query(format("SELECT count(*) FROM %s", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s", tableName)))
                 .containsExactlyInOrder(row(0));
     }
 
@@ -228,9 +227,9 @@ public class TestHiveBucketedTables
         String tableName = mutableTableInstanceOf(BUCKETED_NATION).getNameInDatabase();
         populateRowToHiveTable(tableName, ImmutableList.of("2", "'name'", "2", "'comment'"), Optional.empty());
         // insert one row into nation
-        assertThat(query(format("SELECT count(*) from %s", tableName)))
+        assertThat(onTrino().executeQuery(format("SELECT count(*) from %s", tableName)))
                 .containsExactlyInOrder(row(1));
-        assertThat(query(format("select n_nationkey from %s where n_regionkey = 2", tableName)))
+        assertThat(onTrino().executeQuery(format("select n_nationkey from %s where n_regionkey = 2", tableName)))
                 .containsExactlyInOrder(row(2));
     }
 
@@ -242,12 +241,12 @@ public class TestHiveBucketedTables
 
         String ctasQuery = "CREATE TABLE %s WITH (bucket_count = 4, bucketed_by = ARRAY['n_regionkey'], partitioned_by = ARRAY['part_key']) " +
                 "AS SELECT n_nationkey, n_name, n_regionkey, n_comment, n_name as part_key FROM %s";
-        query(format(ctasQuery, tableName, NATION.getName()));
+        onTrino().executeQuery(format(ctasQuery, tableName, NATION.getName()));
 
-        assertThat(query(format("SELECT count(*) FROM %s", tableName))).containsExactlyInOrder(row(25));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(5));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0 AND part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s", tableName))).containsExactlyInOrder(row(25));
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(5));
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_regionkey=0 AND part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
     }
 
     @Test
@@ -256,12 +255,12 @@ public class TestHiveBucketedTables
     {
         String tableName = mutableTablesState().get(BUCKETED_PARTITIONED_NATION).getNameInDatabase();
 
-        query(format("INSERT INTO %s SELECT n_nationkey, n_name, n_regionkey, n_comment, n_name FROM %s", tableName, NATION.getName()));
+        onTrino().executeQuery(format("INSERT INTO %s SELECT n_nationkey, n_name, n_regionkey, n_comment, n_name FROM %s", tableName, NATION.getName()));
 
-        assertThat(query(format("SELECT count(*) FROM %s", tableName))).containsExactlyInOrder(row(25));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(5));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0 AND part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s", tableName))).containsExactlyInOrder(row(25));
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(5));
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_regionkey=0 AND part_key='ALGERIA'", tableName))).containsExactlyInOrder(row(1));
     }
 
     @Test
@@ -270,12 +269,12 @@ public class TestHiveBucketedTables
     {
         String tableName = mutableTablesState().get(BUCKETED_NATION).getNameInDatabase();
 
-        query(format("INSERT INTO %s SELECT * FROM %s", tableName, NATION.getName()));
+        onTrino().executeQuery(format("INSERT INTO %s SELECT * FROM %s", tableName, NATION.getName()));
         // make sure that insert will not overwrite existing data
-        query(format("INSERT INTO %s SELECT * FROM %s", tableName, NATION.getName()));
+        onTrino().executeQuery(format("INSERT INTO %s SELECT * FROM %s", tableName, NATION.getName()));
 
-        assertThat(query(format("SELECT count(*) FROM %s", tableName))).containsExactlyInOrder(row(50));
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(10));
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s", tableName))).containsExactlyInOrder(row(50));
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(10));
     }
 
     @Test
@@ -285,10 +284,10 @@ public class TestHiveBucketedTables
         String tableName = mutableTablesState().get(BUCKETED_NATION_PREPARED).getNameInDatabase();
 
         // nations has 25 rows and NDV=5 for n_regionkey, setting bucket_count=10 will surely create empty buckets
-        query(format("CREATE TABLE %s WITH (bucket_count = 10, bucketed_by = ARRAY['n_regionkey']) AS SELECT * FROM %s", tableName, NATION.getName()));
+        onTrino().executeQuery(format("CREATE TABLE %s WITH (bucket_count = 10, bucketed_by = ARRAY['n_regionkey']) AS SELECT * FROM %s", tableName, NATION.getName()));
 
-        assertThat(query(format("SELECT * FROM %s", tableName))).matches(PRESTO_NATION_RESULT);
-        assertThat(query(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(5));
+        assertThat(onTrino().executeQuery(format("SELECT * FROM %s", tableName))).matches(PRESTO_NATION_RESULT);
+        assertThat(onTrino().executeQuery(format("SELECT count(*) FROM %s WHERE n_regionkey=0", tableName))).containsExactlyInOrder(row(5));
     }
 
     @Test

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercion.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCoercion.java
@@ -52,11 +52,11 @@ import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.context.ThreadLocalTestContextHolder.testContext;
 import static io.trino.tempto.fulfillment.table.MutableTableRequirement.State.CREATED;
 import static io.trino.tempto.fulfillment.table.TableHandle.tableHandle;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.HIVE_COERCION;
 import static io.trino.tests.product.TestGroups.JDBC;
 import static io.trino.tests.product.hive.TestHiveCoercion.ColumnContext.columnContext;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 import static java.sql.JDBCType.ARRAY;
 import static java.sql.JDBCType.BIGINT;
@@ -260,12 +260,12 @@ public class TestHiveCoercion
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN int_to_bigint int_to_bigint bigint", tableName));
         onHive().executeQuery(format("ALTER TABLE %s CHANGE COLUMN float_to_double float_to_double double", tableName));
 
-        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
+        assertThat(onTrino().executeQuery("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
                 row("int_to_bigint", "bigint"),
                 row("float_to_double", "double"),
                 row("id", "bigint"));
 
-        QueryResult queryResult = query("SELECT * FROM " + tableName);
+        QueryResult queryResult = onTrino().executeQuery("SELECT * FROM " + tableName);
         assertThat(queryResult).hasColumns(BIGINT, DOUBLE, BIGINT);
 
         assertThat(queryResult).containsOnly(
@@ -326,7 +326,7 @@ public class TestHiveCoercion
 
     protected void insertTableRows(String tableName, String floatToDoubleType)
     {
-        query(format(
+        onTrino().executeQuery(format(
                 "INSERT INTO %1$s VALUES " +
                         "(" +
                         "  CAST(ROW ('as is', -1, 100, 2323, 12345) AS ROW(keep VARCHAR, ti2si TINYINT, si2int SMALLINT, int2bi INTEGER, bi2vc BIGINT)), " +
@@ -617,7 +617,7 @@ public class TestHiveCoercion
     {
         String floatType = tableName.toLowerCase(ENGLISH).contains("parquet") ? "double" : "real";
 
-        assertThat(query("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
+        assertThat(onTrino().executeQuery("SHOW COLUMNS FROM " + tableName).project(1, 2)).containsExactlyInOrder(
                 row("row_to_row", "row(keep varchar, ti2si smallint, si2int integer, int2bi bigint, bi2vc varchar)"),
                 row("list_to_list", "array(row(ti2int integer, si2bi bigint, bi2vc varchar))"),
                 row("map_to_map", "map(integer, row(ti2bi bigint, int2bi bigint, float2double double, add tinyint))"),

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompression.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompression.java
@@ -24,7 +24,6 @@ import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.trino.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.ORDERS;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.HIVE_COMPRESSION;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
@@ -74,7 +73,7 @@ public class TestHiveCompression
                 tableName));
         onHive().executeQuery(format("INSERT INTO %s VALUES(1, 'test data')", tableName));
 
-        assertThat(query("SELECT * FROM " + tableName)).containsExactlyInOrder(row(1, "test data"));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableName)).containsExactlyInOrder(row(1, "test data"));
 
         onHive().executeQuery("DROP TABLE " + tableName);
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveIgnoreAbsentPartitions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveIgnoreAbsentPartitions.java
@@ -27,9 +27,9 @@ import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.MutableTableRequirement.State.LOADED;
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_BIGINT_REGIONKEY;
 import static io.trino.tests.product.hive.util.TableLocationUtils.getTablePath;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -58,18 +58,18 @@ public class TestHiveIgnoreAbsentPartitions
         String tablePath = getTablePath(tableNameInDatabase, 1);
         String partitionPath = format("%s/p_regionkey=9999", tablePath);
 
-        assertThat(query("SELECT count(*) FROM " + tableNameInDatabase)).containsOnly(row(15));
+        assertThat(onTrino().executeQuery("SELECT count(*) FROM " + tableNameInDatabase)).containsOnly(row(15));
 
         assertFalse(hdfsClient.exist(partitionPath), format("Expected partition %s to not exist", tableNameInDatabase));
-        query(format("CALL hive.system.create_empty_partition('default', '%s', array['p_regionkey'], array['9999'])", tableNameInDatabase));
+        onTrino().executeQuery(format("CALL hive.system.create_empty_partition('default', '%s', array['p_regionkey'], array['9999'])", tableNameInDatabase));
 
-        query("SET SESSION hive.ignore_absent_partitions = false");
+        onTrino().executeQuery("SET SESSION hive.ignore_absent_partitions = false");
         hdfsClient.delete(partitionPath);
         assertFalse(hdfsClient.exist(partitionPath), format("Expected partition %s to not exist", partitionPath));
-        assertQueryFailure(() -> query("SELECT count(*) FROM " + tableNameInDatabase)).hasMessageContaining("Partition location does not exist");
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT count(*) FROM " + tableNameInDatabase)).hasMessageContaining("Partition location does not exist");
 
-        query("SET SESSION hive.ignore_absent_partitions = true");
-        assertThat(query("SELECT count(*) FROM " + tableNameInDatabase)).containsOnly(row(15));
+        onTrino().executeQuery("SET SESSION hive.ignore_absent_partitions = true");
+        assertThat(onTrino().executeQuery("SELECT count(*) FROM " + tableNameInDatabase)).containsOnly(row(15));
     }
 
     @Test
@@ -78,21 +78,21 @@ public class TestHiveIgnoreAbsentPartitions
     {
         String tableName = "unpartitioned_absent_table_data";
 
-        query("DROP TABLE IF EXISTS " + tableName);
+        onTrino().executeQuery("DROP TABLE IF EXISTS " + tableName);
 
-        assertThat(query(format("CREATE TABLE %s AS SELECT * FROM (VALUES 1,2,3) t(dummy_col)", tableName))).containsOnly(row(3));
-        assertThat(query("SELECT count(*) FROM " + tableName)).containsOnly(row(3));
+        assertThat(onTrino().executeQuery(format("CREATE TABLE %s AS SELECT * FROM (VALUES 1,2,3) t(dummy_col)", tableName))).containsOnly(row(3));
+        assertThat(onTrino().executeQuery("SELECT count(*) FROM " + tableName)).containsOnly(row(3));
 
         String tablePath = getTablePath(tableName, 0);
         assertTrue(hdfsClient.exist(tablePath));
         hdfsClient.delete(tablePath);
 
-        query("SET SESSION hive.ignore_absent_partitions = false");
-        assertQueryFailure(() -> query("SELECT count(*) FROM " + tableName)).hasMessageContaining("Partition location does not exist");
+        onTrino().executeQuery("SET SESSION hive.ignore_absent_partitions = false");
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT count(*) FROM " + tableName)).hasMessageContaining("Partition location does not exist");
 
-        query("SET SESSION hive.ignore_absent_partitions = true");
-        assertQueryFailure(() -> query("SELECT count(*) FROM " + tableName)).hasMessageContaining("Partition location does not exist");
+        onTrino().executeQuery("SET SESSION hive.ignore_absent_partitions = true");
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT count(*) FROM " + tableName)).hasMessageContaining("Partition location does not exist");
 
-        query("DROP TABLE " + tableName);
+        onTrino().executeQuery("DROP TABLE " + tableName);
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePropertiesTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHivePropertiesTable.java
@@ -22,7 +22,6 @@ import java.util.List;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.HIVE_VIEWS;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
@@ -39,7 +38,7 @@ public class TestHivePropertiesTable
         onTrino().executeQuery("CREATE TABLE test_trino_view_properties_base (col INT)");
         onTrino().executeQuery("CREATE VIEW test_trino_view_properties AS SELECT * FROM test_trino_view_properties_base");
 
-        assertThat(query("SHOW COLUMNS FROM \"test_trino_view_properties$properties\""))
+        assertThat(onTrino().executeQuery("SHOW COLUMNS FROM \"test_trino_view_properties$properties\""))
                 .containsExactlyInOrder(
                         row("comment", "varchar", "", ""),
                         row("presto_query_id", "varchar", "", ""),
@@ -48,7 +47,7 @@ public class TestHivePropertiesTable
                         row("transient_lastddltime", "varchar", "", ""),
                         row("trino_created_by", "varchar", "", ""));
 
-        assertThat(query("SELECT * FROM \"test_trino_view_properties$properties\""))
+        assertThat(onTrino().executeQuery("SELECT * FROM \"test_trino_view_properties$properties\""))
                 .hasRowsCount(1)
                 .containsExactlyInOrder(new Row(getTablePropertiesOnHive("test_trino_view_properties")));
 
@@ -66,10 +65,10 @@ public class TestHivePropertiesTable
         onHive().executeQuery("CREATE VIEW test_hive_view_properties AS SELECT * FROM test_hive_view_properties_base");
 
         // Use "contains" method because the table properties for Hive views aren't identical among testing environments
-        assertThat(query("SHOW COLUMNS FROM \"test_hive_view_properties$properties\""))
+        assertThat(onTrino().executeQuery("SHOW COLUMNS FROM \"test_hive_view_properties$properties\""))
                 .contains(row("transient_lastddltime", "varchar", "", ""));
 
-        assertThat(query("SELECT * FROM \"test_hive_view_properties$properties\""))
+        assertThat(onTrino().executeQuery("SELECT * FROM \"test_hive_view_properties$properties\""))
                 .hasRowsCount(1)
                 .containsExactlyInOrder(new Row(getTablePropertiesOnHive("test_hive_view_properties")));
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRequireQueryPartitionsFilter.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRequireQueryPartitionsFilter.java
@@ -28,8 +28,8 @@ import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.MutableTableRequirement.State.LOADED;
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_BIGINT_REGIONKEY;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 public class TestHiveRequireQueryPartitionsFilter
@@ -50,10 +50,10 @@ public class TestHiveRequireQueryPartitionsFilter
     {
         String tableName = tablesState.get("test_table").getNameInDatabase();
 
-        query("SET SESSION hive.query_partition_filter_required = true");
-        assertQueryFailure(() -> query("SELECT COUNT(*) FROM " + tableName))
+        onTrino().executeQuery("SET SESSION hive.query_partition_filter_required = true");
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT COUNT(*) FROM " + tableName))
                 .hasMessageMatching(format("Query failed \\(#\\w+\\): Filter required on default\\.%s for at least one partition column: p_regionkey", tableName));
-        assertThat(query(format("SELECT COUNT(*) FROM %s WHERE p_regionkey = 1", tableName))).containsOnly(row(5));
+        assertThat(onTrino().executeQuery(format("SELECT COUNT(*) FROM %s WHERE p_regionkey = 1", tableName))).containsOnly(row(5));
     }
 
     @Test(dataProvider = "queryPartitionFilterRequiredSchemasDataProvider")
@@ -61,12 +61,12 @@ public class TestHiveRequireQueryPartitionsFilter
     {
         String tableName = tablesState.get("test_table").getNameInDatabase();
 
-        query("SET SESSION hive.query_partition_filter_required = true");
-        query(format("SET SESSION hive.query_partition_filter_required_schemas = %s", queryPartitionFilterRequiredSchemas));
+        onTrino().executeQuery("SET SESSION hive.query_partition_filter_required = true");
+        onTrino().executeQuery(format("SET SESSION hive.query_partition_filter_required_schemas = %s", queryPartitionFilterRequiredSchemas));
 
-        assertQueryFailure(() -> query("SELECT COUNT(*) FROM " + tableName))
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT COUNT(*) FROM " + tableName))
                 .hasMessageMatching(format("Query failed \\(#\\w+\\): Filter required on default\\.%s for at least one partition column: p_regionkey", tableName));
-        assertThat(query(format("SELECT COUNT(*) FROM %s WHERE p_regionkey = 1", tableName))).containsOnly(row(5));
+        assertThat(onTrino().executeQuery(format("SELECT COUNT(*) FROM %s WHERE p_regionkey = 1", tableName))).containsOnly(row(5));
     }
 
     @DataProvider

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveStorageFormats.java
@@ -61,7 +61,6 @@ import static io.trino.plugin.hive.HiveTimestampPrecision.MILLISECONDS;
 import static io.trino.plugin.hive.HiveTimestampPrecision.NANOSECONDS;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.defaultQueryExecutor;
 import static io.trino.tempto.query.QueryExecutor.param;
 import static io.trino.tests.product.TestGroups.HMS_ONLY;
 import static io.trino.tests.product.TestGroups.STORAGE_FORMATS;
@@ -951,7 +950,7 @@ public class TestHiveStorageFormats
 
     private void setAdminRole()
     {
-        setAdminRole(defaultQueryExecutor().getConnection());
+        setAdminRole(onTrino().getConnection());
     }
 
     private void setAdminRole(Connection connection)
@@ -997,7 +996,7 @@ public class TestHiveStorageFormats
 
     private static void setSessionProperties(StorageFormat storageFormat)
     {
-        setSessionProperties(defaultQueryExecutor().getConnection(), storageFormat);
+        setSessionProperties(onTrino().getConnection(), storageFormat);
     }
 
     private static void setSessionProperties(Connection connection, StorageFormat storageFormat)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTableStatistics.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTableStatistics.java
@@ -36,11 +36,11 @@ import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.MutableTablesState.mutableTablesState;
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
 import static io.trino.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_TEXTFILE;
 import static io.trino.tests.product.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_BIGINT_REGIONKEY;
 import static io.trino.tests.product.hive.HiveTableDefinitions.NATION_PARTITIONED_BY_VARCHAR_REGIONKEY;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 public class TestHiveTableStatistics
@@ -193,7 +193,7 @@ public class TestHiveTableStatistics
         // table not analyzed
 
         if (isHiveVersionBefore12()) {
-            assertThat(query(showStatsWholeTable)).containsOnly(
+            assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                     row("n_nationkey", null, null, null, null, null, null),
                     row("n_name", null, null, null, null, null, null),
                     row("n_regionkey", null, null, null, null, null, null),
@@ -201,7 +201,7 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, null, null, null));
         }
         else {
-            assertThat(query(showStatsWholeTable)).containsOnly(
+            assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                     row("n_nationkey", 0.0, 0.0, 1.0, null, null, null),
                     row("n_name", 0.0, 0.0, 1.0, null, null, null),
                     row("n_regionkey", 0.0, 0.0, 1.0, null, null, null),
@@ -213,7 +213,7 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("n_nationkey", null, null, null, null, null, null),
                 row("n_name", null, null, null, null, null, null),
                 row("n_regionkey", null, null, null, null, null, null),
@@ -224,7 +224,7 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("n_nationkey", null, anyOf(19., 25.), 0.0, null, "0", "24"),
                 row("n_name", 177.0, anyOf(24., 25.), 0.0, null, null, null),
                 row("n_regionkey", null, 5.0, 0.0, null, "0", "4"),
@@ -244,14 +244,14 @@ public class TestHiveTableStatistics
 
         // table not analyzed
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, null, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
@@ -262,21 +262,21 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"1\") COMPUTE STATISTICS");
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
@@ -287,21 +287,21 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS");
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
@@ -312,21 +312,21 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"1\") COMPUTE STATISTICS FOR COLUMNS");
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 114.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
                 row("p_comment", 1497.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 38.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
                 row("p_comment", 499.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
@@ -337,21 +337,21 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 109.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
                 row("p_comment", 1197.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 38.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
                 row("p_comment", 499.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, anyOf(4., 5.), 0.0, null, "8", "21"),
                 row("p_name", 31.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
@@ -371,14 +371,14 @@ public class TestHiveTableStatistics
 
         // table not analyzed
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, null, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
@@ -389,21 +389,21 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"AMERICA\") COMPUTE STATISTICS");
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
@@ -414,21 +414,21 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS");
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", 20.0, 1.0, 0.0, null, null, null),
@@ -439,21 +439,21 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey = \"AMERICA\") COMPUTE STATISTICS FOR COLUMNS");
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 114.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
                 row("p_comment", 1497.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 38.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
                 row("p_comment", 499.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", 20.0, 1.0, 0.0, null, null, null),
@@ -464,21 +464,21 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " PARTITION (p_regionkey) COMPUTE STATISTICS FOR COLUMNS");
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 109.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
                 row("p_comment", 1197.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 38.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
                 row("p_comment", 499.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, anyOf(4., 5.), 0.0, null, "8", "21"),
                 row("p_name", 31.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", 20.0, 1.0, 0.0, null, null, null),
@@ -495,7 +495,7 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
-        assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", null, null, null, null, null, null),
                 row("c_smallint", null, null, null, null, null, null),
                 row("c_int", null, null, null, null, null, null),
@@ -523,7 +523,7 @@ public class TestHiveTableStatistics
         }
 
         // SHOW STATS FORMAT: column_name, data_size, distinct_values_count, nulls_fraction, row_count
-        assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", null, 2.0, 0.0, null, "121", "127"),
                 row("c_smallint", null, 2.0, 0.0, null, "32761", "32767"),
                 row("c_int", null, 2.0, 0.0, null, "2147483641", "2147483647"),
@@ -554,7 +554,7 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
-        assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", 0.0, 0.0, 1.0, null, null, null),
                 row("c_smallint", 0.0, 0.0, 1.0, null, null, null),
                 row("c_int", 0.0, 0.0, 1.0, null, null, null),
@@ -581,7 +581,7 @@ public class TestHiveTableStatistics
             onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
         }
 
-        assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", 0.0, 0.0, 1.0, null, null, null),
                 row("c_smallint", 0.0, 0.0, 1.0, null, null, null),
                 row("c_int", 0.0, 0.0, 1.0, null, null, null),
@@ -609,7 +609,7 @@ public class TestHiveTableStatistics
 
         onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS");
 
-        assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", null, null, null, null, null, null),
                 row("c_smallint", null, null, null, null, null, null),
                 row("c_int", null, null, null, null, null, null),
@@ -636,7 +636,7 @@ public class TestHiveTableStatistics
             onHive().executeQuery("ANALYZE TABLE " + tableNameInDatabase + " COMPUTE STATISTICS FOR COLUMNS");
         }
 
-        assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", 0.0, 0.0, 1.0, null, null, null),
                 row("c_smallint", 0.0, 0.0, 1.0, null, null, null),
                 row("c_int", 0.0, 0.0, 1.0, null, null, null),
@@ -668,20 +668,20 @@ public class TestHiveTableStatistics
         onHive().executeQuery("CREATE TABLE " + tableName + " (c_string STRING, c_int INT) SKEWED BY (c_string) ON ('c1')");
         onHive().executeQuery("INSERT INTO TABLE " + tableName + " VALUES ('c1', 1), ('c1', 2)");
 
-        assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableName)).containsOnly(
                 row("c_string", null, null, null, null, null, null),
                 row("c_int", null, null, null, null, null, null),
                 row(null, null, null, null, 2.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableName + " COMPUTE STATISTICS");
 
-        assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableName)).containsOnly(
                 row("c_string", null, null, null, null, null, null),
                 row("c_int", null, null, null, null, null, null),
                 row(null, null, null, null, 2.0, null, null));
 
         onHive().executeQuery("ANALYZE TABLE " + tableName + " COMPUTE STATISTICS FOR COLUMNS");
-        assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableName)).containsOnly(
                 row("c_string", 4.0, 1.0, 0.0, null, null, null),
                 row("c_int", null, 2.0, 0.0, null, "1", "2"),
                 row(null, null, null, null, 2.0, null, null));
@@ -696,13 +696,13 @@ public class TestHiveTableStatistics
         onHive().executeQuery("CREATE TABLE " + tableName + " (c_string STRING, c_int INT) SKEWED BY (c_string) ON ('c1')");
         onHive().executeQuery("INSERT INTO TABLE " + tableName + " VALUES ('c1', 1), ('c1', 2)");
 
-        assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableName)).containsOnly(
                 row("c_string", null, null, null, null, null, null),
                 row("c_int", null, null, null, null, null, null),
                 row(null, null, null, null, 2.0, null, null));
 
-        assertThat(query("ANALYZE " + tableName)).containsExactlyInOrder(row(2));
-        assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
+        assertThat(onTrino().executeQuery("ANALYZE " + tableName)).containsExactlyInOrder(row(2));
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableName)).containsOnly(
                 row("c_string", 4.0, 1.0, 0.0, null, null, null),
                 row("c_int", null, 2.0, 0.0, null, "1", "2"),
                 row(null, null, null, null, 2.0, null, null));
@@ -718,7 +718,7 @@ public class TestHiveTableStatistics
 
         // table not analyzed
         if (isHiveVersionBefore12()) {
-            assertThat(query(showStatsWholeTable)).containsOnly(
+            assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                     row("n_nationkey", null, null, null, null, null, null),
                     row("n_name", null, null, null, null, null, null),
                     row("n_regionkey", null, null, null, null, null, null),
@@ -726,7 +726,7 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, null, null, null));
         }
         else {
-            assertThat(query(showStatsWholeTable)).containsOnly(
+            assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                     row("n_nationkey", 0.0, 0.0, 1.0, null, null, null),
                     row("n_name", 0.0, 0.0, 1.0, null, null, null),
                     row("n_regionkey", 0.0, 0.0, 1.0, null, null, null),
@@ -734,9 +734,9 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, 0.0, null, null));
         }
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(25));
+        assertThat(onTrino().executeQuery("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(25));
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("n_nationkey", null, 25.0, 0.0, null, "0", "24"),
                 row("n_name", 177.0, 25.0, 0.0, null, null, null),
                 row("n_regionkey", null, 5.0, 0.0, null, "0", "4"),
@@ -756,14 +756,14 @@ public class TestHiveTableStatistics
 
         // table not analyzed
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, null, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
@@ -772,23 +772,23 @@ public class TestHiveTableStatistics
 
         // analyze for single partition
 
-        assertThat(query("ANALYZE " + tableNameInDatabase + " WITH (partitions = ARRAY[ARRAY['1']])")).containsExactlyInOrder(row(5));
+        assertThat(onTrino().executeQuery("ANALYZE " + tableNameInDatabase + " WITH (partitions = ARRAY[ARRAY['1']])")).containsExactlyInOrder(row(5));
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 114.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
                 row("p_comment", 1497.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 38.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
                 row("p_comment", 499.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
@@ -797,23 +797,23 @@ public class TestHiveTableStatistics
 
         // analyze for all partitions
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(15));
+        assertThat(onTrino().executeQuery("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(15));
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 109.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", null, 3.0, 0.0, null, "1", "3"),
                 row("p_comment", 1197.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 38.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", null, 1.0, 0.0, null, "1", "1"),
                 row("p_comment", 499.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "8", "21"),
                 row("p_name", 31.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", null, 1.0, 0.0, null, "2", "2"),
@@ -833,14 +833,14 @@ public class TestHiveTableStatistics
 
         // table not analyzed
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
                 row("p_comment", null, null, null, null, null, null),
                 row(null, null, null, null, null, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
@@ -849,23 +849,23 @@ public class TestHiveTableStatistics
 
         // analyze for single partition
 
-        assertThat(query("ANALYZE " + tableNameInDatabase + " WITH (partitions = ARRAY[ARRAY['AMERICA']])")).containsExactlyInOrder(row(5));
+        assertThat(onTrino().executeQuery("ANALYZE " + tableNameInDatabase + " WITH (partitions = ARRAY[ARRAY['AMERICA']])")).containsExactlyInOrder(row(5));
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 114.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
                 row("p_comment", 1497.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 38.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
                 row("p_comment", 499.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, null, null, null, null, null),
                 row("p_name", null, null, null, null, null, null),
                 row("p_regionkey", null, null, null, null, null, null),
@@ -874,23 +874,23 @@ public class TestHiveTableStatistics
 
         // column analysis for all partitions
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(15));
+        assertThat(onTrino().executeQuery("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(15));
 
-        assertThat(query(showStatsWholeTable)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 109.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", 85.0, 3.0, 0.0, null, null, null),
                 row("p_comment", 1197.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 15.0, null, null));
 
-        assertThat(query(showStatsPartitionOne)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "1", "24"),
                 row("p_name", 38.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", 35.0, 1.0, 0.0, null, null, null),
                 row("p_comment", 499.0, 5.0, 0.0, null, null, null),
                 row(null, null, null, null, 5.0, null, null));
 
-        assertThat(query(showStatsPartitionTwo)).containsOnly(
+        assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                 row("p_nationkey", null, 5.0, 0.0, null, "8", "21"),
                 row("p_name", 31.0, 5.0, 0.0, null, null, null),
                 row("p_regionkey", 20.0, 1.0, 0.0, null, null, null),
@@ -906,7 +906,7 @@ public class TestHiveTableStatistics
         String tableNameInDatabase = mutableTablesState().get(ALL_TYPES_TABLE_NAME).getNameInDatabase();
 
         if (isHiveVersionBefore12()) {
-            assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+            assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                     row("c_tinyint", null, null, null, null, null, null),
                     row("c_smallint", null, null, null, null, null, null),
                     row("c_int", null, null, null, null, null, null),
@@ -925,7 +925,7 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, null, null, null));
         }
         else {
-            assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+            assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                     row("c_tinyint", 0.0, 0.0, 1.0, null, null, null),
                     row("c_smallint", 0.0, 0.0, 1.0, null, null, null),
                     row("c_int", 0.0, 0.0, 1.0, null, null, null),
@@ -944,10 +944,10 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, 0.0, null, null));
         }
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(2));
+        assertThat(onTrino().executeQuery("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(2));
 
         // SHOW STATS FORMAT: column_name, data_size, distinct_values_count, nulls_fraction, row_count
-        assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", null, 2.0, 0.0, null, "121", "127"),
                 row("c_smallint", null, 2.0, 0.0, null, "32761", "32767"),
                 row("c_int", null, 2.0, 0.0, null, "2147483641", "2147483647"),
@@ -975,7 +975,7 @@ public class TestHiveTableStatistics
         String tableNameInDatabase = mutableTablesState().get(EMPTY_ALL_TYPES_TABLE_NAME).getNameInDatabase();
 
         if (isHiveVersionBefore12()) {
-            assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+            assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                     row("c_tinyint", null, null, null, null, null, null),
                     row("c_smallint", null, null, null, null, null, null),
                     row("c_int", null, null, null, null, null, null),
@@ -994,7 +994,7 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, null, null, null));
         }
         else {
-            assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+            assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                     row("c_tinyint", 0.0, 0.0, 1.0, null, null, null),
                     row("c_smallint", 0.0, 0.0, 1.0, null, null, null),
                     row("c_int", 0.0, 0.0, 1.0, null, null, null),
@@ -1013,9 +1013,9 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, 0.0, null, null));
         }
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(0));
+        assertThat(onTrino().executeQuery("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(0));
 
-        assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", 0.0, 0.0, 1.0, null, null, null),
                 row("c_smallint", 0.0, 0.0, 1.0, null, null, null),
                 row("c_int", 0.0, 0.0, 1.0, null, null, null),
@@ -1043,7 +1043,7 @@ public class TestHiveTableStatistics
         // insert from Hive to prevent Trino collecting statistics on insert
         onHive().executeQuery("INSERT INTO TABLE " + tableNameInDatabase + " VALUES(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null)");
 
-        assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", null, null, null, null, null, null),
                 row("c_smallint", null, null, null, null, null, null),
                 row("c_int", null, null, null, null, null, null),
@@ -1061,9 +1061,9 @@ public class TestHiveTableStatistics
                 row("c_binary", null, null, null, null, null, null),
                 row(null, null, null, null, 1.0, null, null));
 
-        assertThat(query("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(1));
+        assertThat(onTrino().executeQuery("ANALYZE " + tableNameInDatabase)).containsExactlyInOrder(row(1));
 
-        assertThat(query("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableNameInDatabase)).containsOnly(
                 row("c_tinyint", 0.0, 0.0, 1.0, null, null, null),
                 row("c_smallint", 0.0, 0.0, 1.0, null, null, null),
                 row("c_int", 0.0, 0.0, 1.0, null, null, null),
@@ -1110,13 +1110,13 @@ public class TestHiveTableStatistics
         assertComputeTableStatisticsOnInsert(allTypesAllNullTable, getAllTypesAllNullTableStatistics());
 
         String tableName = "test_update_table_statistics";
-        query(format("DROP TABLE IF EXISTS %s", tableName));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
         try {
-            query(format("CREATE TABLE %s AS SELECT * FROM %s WITH NO DATA", tableName, allTypesTable));
-            query(format("INSERT INTO %s SELECT * FROM %s", tableName, allTypesTable));
-            query(format("INSERT INTO %s SELECT * FROM %s", tableName, allTypesAllNullTable));
-            query(format("INSERT INTO %s SELECT * FROM %s", tableName, allTypesAllNullTable));
-            assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(
+            onTrino().executeQuery(format("CREATE TABLE %s AS SELECT * FROM %s WITH NO DATA", tableName, allTypesTable));
+            onTrino().executeQuery(format("INSERT INTO %s SELECT * FROM %s", tableName, allTypesTable));
+            onTrino().executeQuery(format("INSERT INTO %s SELECT * FROM %s", tableName, allTypesAllNullTable));
+            onTrino().executeQuery(format("INSERT INTO %s SELECT * FROM %s", tableName, allTypesAllNullTable));
+            assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableName)).containsOnly(
                     row("c_tinyint", null, 2.0, 0.5, null, "121", "127"),
                     row("c_smallint", null, 2.0, 0.5, null, "32761", "32767"),
                     row("c_int", null, 2.0, 0.5, null, "2147483641", "2147483647"),
@@ -1136,7 +1136,7 @@ public class TestHiveTableStatistics
                     row("c_binary", 23.0, null, 0.5, null, null, null),
                     row(null, null, null, null, 4.0, null, null));
 
-            query(format("INSERT INTO %s VALUES( " +
+            onTrino().executeQuery(format("INSERT INTO %s VALUES( " +
                     "TINYINT '120', " +
                     "SMALLINT '32760', " +
                     "INTEGER '2147483640', " +
@@ -1153,7 +1153,7 @@ public class TestHiveTableStatistics
                     "false, " +
                     "CAST('cGllcyBiaW5hcm54' as VARBINARY))", tableName));
 
-            assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(ImmutableList.of(
+            assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableName)).containsOnly(ImmutableList.of(
                     row("c_tinyint", null, 2.0, 0.4, null, "120", "127"),
                     row("c_smallint", null, 2.0, 0.4, null, "32760", "32767"),
                     row("c_int", null, 2.0, 0.4, null, "2147483640", "2147483647"),
@@ -1174,7 +1174,7 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, 5.0, null, null)));
         }
         finally {
-            query(format("DROP TABLE IF EXISTS %s", tableName));
+            onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
         }
     }
 
@@ -1183,9 +1183,9 @@ public class TestHiveTableStatistics
     public void testComputePartitionStatisticsOnCreateTable()
     {
         String tableName = "test_compute_partition_statistics_on_create_table";
-        query(format("DROP TABLE IF EXISTS %s", tableName));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
         try {
-            query(format("CREATE TABLE %s WITH ( " +
+            onTrino().executeQuery(format("CREATE TABLE %s WITH ( " +
                     " partitioned_by = ARRAY['p_bigint', 'p_varchar']" +
                     ") AS " +
                     "SELECT * FROM ( " +
@@ -1231,7 +1231,7 @@ public class TestHiveTableStatistics
                     "" +
                     ") AS t (c_tinyint, c_smallint, c_int, c_bigint, c_float, c_double, c_decimal, c_decimal_w_params, c_timestamp, c_date, c_string, c_varchar, c_char, c_boolean, c_binary, p_bigint, p_varchar)", tableName));
 
-            assertThat(query(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 1 AND p_varchar = 'partition1')", tableName))).containsOnly(ImmutableList.of(
+            assertThat(onTrino().executeQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 1 AND p_varchar = 'partition1')", tableName))).containsOnly(ImmutableList.of(
                     row("c_tinyint", null, 1.0, 0.5, null, "120", "120"),
                     row("c_smallint", null, 1.0, 0.5, null, "32760", "32760"),
                     row("c_int", null, 1.0, 0.5, null, "2147483640", "2147483640"),
@@ -1253,7 +1253,7 @@ public class TestHiveTableStatistics
                     row("p_varchar", 20.0, 1.0, 0.0, null, null, null),
                     row(null, null, null, null, 2.0, null, null)));
 
-            assertThat(query(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 2 AND p_varchar = 'partition2')", tableName))).containsOnly(ImmutableList.of(
+            assertThat(onTrino().executeQuery(format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 2 AND p_varchar = 'partition2')", tableName))).containsOnly(ImmutableList.of(
                     row("c_tinyint", null, 1.0, 0.5, null, "99", "99"),
                     row("c_smallint", null, 1.0, 0.5, null, "333", "333"),
                     row("c_int", null, 1.0, 0.5, null, "444", "444"),
@@ -1276,7 +1276,7 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, 2.0, null, null)));
         }
         finally {
-            query(format("DROP TABLE IF EXISTS %s", tableName));
+            onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
         }
     }
 
@@ -1286,9 +1286,9 @@ public class TestHiveTableStatistics
     {
         String tableName = "test_compute_partition_statistics_on_insert";
 
-        query(format("DROP TABLE IF EXISTS %s", tableName));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
         try {
-            query(format("CREATE TABLE %s(" +
+            onTrino().executeQuery(format("CREATE TABLE %s(" +
                     "c_tinyint            TINYINT, " +
                     "c_smallint           SMALLINT, " +
                     "c_int                INT, " +
@@ -1310,18 +1310,18 @@ public class TestHiveTableStatistics
                     " partitioned_by = ARRAY['p_bigint', 'p_varchar']" +
                     ")", tableName));
 
-            query(format("INSERT INTO %s VALUES " +
+            onTrino().executeQuery(format("INSERT INTO %s VALUES " +
                     "(TINYINT '120', SMALLINT '32760', INTEGER '2147483640', BIGINT '9223372036854775800', REAL '123.340', DOUBLE '234.560', CAST(343.0 AS DECIMAL(10, 0)), CAST(345.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:15:30', DATE '2015-05-08', 'p1 varchar', CAST('p1 varchar10' AS VARCHAR(10)), CAST('p1 char10' AS CHAR(10)), false, CAST('p1 binary' as VARBINARY), BIGINT '1', 'partition1')," +
                     "(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '1', 'partition1')", tableName));
 
-            query(format("INSERT INTO %s VALUES " +
+            onTrino().executeQuery(format("INSERT INTO %s VALUES " +
                     "(TINYINT '99', SMALLINT '333', INTEGER '444', BIGINT '555', REAL '666.340', DOUBLE '777.560', CAST(888.0 AS DECIMAL(10, 0)), CAST(999.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:45:30', DATE '2015-05-09', 'p2 varchar', CAST('p2 varchar10' AS VARCHAR(10)), CAST('p2 char10' AS CHAR(10)), true, CAST('p2 binary' as VARBINARY), BIGINT '2', 'partition2')," +
                     "(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '2', 'partition2')", tableName));
 
             String showStatsPartitionOne = format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 1 AND p_varchar = 'partition1')", tableName);
             String showStatsPartitionTwo = format("SHOW STATS FOR (SELECT * FROM %s WHERE p_bigint = 2 AND p_varchar = 'partition2')", tableName);
 
-            assertThat(query(showStatsPartitionOne)).containsOnly(ImmutableList.of(
+            assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(ImmutableList.of(
                     row("c_tinyint", null, 1.0, 0.5, null, "120", "120"),
                     row("c_smallint", null, 1.0, 0.5, null, "32760", "32760"),
                     row("c_int", null, 1.0, 0.5, null, "2147483640", "2147483640"),
@@ -1343,7 +1343,7 @@ public class TestHiveTableStatistics
                     row("p_varchar", 20.0, 1.0, 0.0, null, null, null),
                     row(null, null, null, null, 2.0, null, null)));
 
-            assertThat(query(showStatsPartitionTwo)).containsOnly(ImmutableList.of(
+            assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(ImmutableList.of(
                     row("c_tinyint", null, 1.0, 0.5, null, "99", "99"),
                     row("c_smallint", null, 1.0, 0.5, null, "333", "333"),
                     row("c_int", null, 1.0, 0.5, null, "444", "444"),
@@ -1365,10 +1365,10 @@ public class TestHiveTableStatistics
                     row("p_varchar", 20.0, 1.0, 0.0, null, null, null),
                     row(null, null, null, null, 2.0, null, null)));
 
-            query(format("INSERT INTO %s VALUES( TINYINT '119', SMALLINT '32759', INTEGER '2147483639', BIGINT '9223372036854775799', REAL '122.340', DOUBLE '233.560', CAST(342.0 AS DECIMAL(10, 0)), CAST(344.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:15:29', DATE '2015-05-07', 'p1 varchar', CAST('p1 varchar10' AS VARCHAR(10)), CAST('p1 char10' AS CHAR(10)), true, CAST('p1 binary' as VARBINARY), BIGINT '1', 'partition1')", tableName));
-            query(format("INSERT INTO %s VALUES( null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '1', 'partition1')", tableName));
+            onTrino().executeQuery(format("INSERT INTO %s VALUES( TINYINT '119', SMALLINT '32759', INTEGER '2147483639', BIGINT '9223372036854775799', REAL '122.340', DOUBLE '233.560', CAST(342.0 AS DECIMAL(10, 0)), CAST(344.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:15:29', DATE '2015-05-07', 'p1 varchar', CAST('p1 varchar10' AS VARCHAR(10)), CAST('p1 char10' AS CHAR(10)), true, CAST('p1 binary' as VARBINARY), BIGINT '1', 'partition1')", tableName));
+            onTrino().executeQuery(format("INSERT INTO %s VALUES( null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '1', 'partition1')", tableName));
 
-            assertThat(query(showStatsPartitionOne)).containsOnly(ImmutableList.of(
+            assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(ImmutableList.of(
                     row("c_tinyint", null, 1.0, 0.5, null, "119", "120"),
                     row("c_smallint", null, 1.0, 0.5, null, "32759", "32760"),
                     row("c_int", null, 1.0, 0.5, null, "2147483639", "2147483640"),
@@ -1390,10 +1390,10 @@ public class TestHiveTableStatistics
                     row("p_varchar", 40.0, 1.0, 0.0, null, null, null),
                     row(null, null, null, null, 4.0, null, null)));
 
-            query(format("INSERT INTO %s VALUES( TINYINT '100', SMALLINT '334', INTEGER '445', BIGINT '556', REAL '667.340', DOUBLE '778.560', CAST(889.0 AS DECIMAL(10, 0)), CAST(1000.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:45:31', DATE '2015-05-10', VARCHAR 'p2 varchar', CAST('p2 varchar10' AS VARCHAR(10)), CAST('p2 char10' AS CHAR(10)), true, CAST('p2 binary' as VARBINARY), BIGINT '2', 'partition2')", tableName));
-            query(format("INSERT INTO %s VALUES( null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '2', 'partition2')", tableName));
+            onTrino().executeQuery(format("INSERT INTO %s VALUES( TINYINT '100', SMALLINT '334', INTEGER '445', BIGINT '556', REAL '667.340', DOUBLE '778.560', CAST(889.0 AS DECIMAL(10, 0)), CAST(1000.670 AS DECIMAL(10, 5)), TIMESTAMP '2015-05-10 12:45:31', DATE '2015-05-10', VARCHAR 'p2 varchar', CAST('p2 varchar10' AS VARCHAR(10)), CAST('p2 char10' AS CHAR(10)), true, CAST('p2 binary' as VARBINARY), BIGINT '2', 'partition2')", tableName));
+            onTrino().executeQuery(format("INSERT INTO %s VALUES( null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, BIGINT '2', 'partition2')", tableName));
 
-            assertThat(query(showStatsPartitionTwo)).containsOnly(ImmutableList.of(
+            assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(ImmutableList.of(
                     row("c_tinyint", null, 1.0, 0.5, null, "99", "100"),
                     row("c_smallint", null, 1.0, 0.5, null, "333", "334"),
                     row("c_int", null, 1.0, 0.5, null, "444", "445"),
@@ -1416,7 +1416,7 @@ public class TestHiveTableStatistics
                     row(null, null, null, null, 4.0, null, null)));
         }
         finally {
-            query(format("DROP TABLE IF EXISTS %s", tableName));
+            onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", tableName));
         }
     }
 
@@ -1424,12 +1424,12 @@ public class TestHiveTableStatistics
     public void testComputeFloatingPointStatistics(String dataType)
     {
         String tableName = "test_compute_floating_point_statistics";
-        query("DROP TABLE IF EXISTS " + tableName);
+        onTrino().executeQuery("DROP TABLE IF EXISTS " + tableName);
         try {
-            query(format("CREATE TABLE %1$s(c_basic %2$s, c_minmax %2$s, c_inf %2$s, c_ninf %2$s, c_nan %2$s, c_nzero %2$s)", tableName, dataType));
-            query("ANALYZE " + tableName); // TODO remove after https://github.com/trinodb/trino/issues/2469
+            onTrino().executeQuery(format("CREATE TABLE %1$s(c_basic %2$s, c_minmax %2$s, c_inf %2$s, c_ninf %2$s, c_nan %2$s, c_nzero %2$s)", tableName, dataType));
+            onTrino().executeQuery("ANALYZE " + tableName); // TODO remove after https://github.com/trinodb/trino/issues/2469
 
-            query(format(
+            onTrino().executeQuery(format(
                     "INSERT INTO %1$s(c_basic, c_minmax, c_inf, c_ninf, c_nan, c_nzero) VALUES " +
                             "  (%2$s '42.3', %2$s '576234.567',  %2$s 'Infinity', %2$s '-Infinity', %2$s 'NaN', %2$s '-0')," +
                             "  (%2$s '42.3', %2$s '-1234567.89', %2$s '-15', %2$s '45', %2$s '12345', %2$s '-47'), " +
@@ -1448,13 +1448,13 @@ public class TestHiveTableStatistics
                     row("c_nzero", null, 2., 0.33333333333, null, "-47.0", "0.0"),
                     row(null, null, null, null, 3., null, null));
 
-            assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(expectedStatistics);
+            assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableName)).containsOnly(expectedStatistics);
 
-            query("ANALYZE " + tableName);
-            assertThat(query("SHOW STATS FOR " + tableName)).containsOnly(expectedStatistics);
+            onTrino().executeQuery("ANALYZE " + tableName);
+            assertThat(onTrino().executeQuery("SHOW STATS FOR " + tableName)).containsOnly(expectedStatistics);
         }
         finally {
-            query("DROP TABLE IF EXISTS " + tableName);
+            onTrino().executeQuery("DROP TABLE IF EXISTS " + tableName);
         }
     }
 
@@ -1484,39 +1484,39 @@ public class TestHiveTableStatistics
             String showStatsWholeTable = format("SHOW STATS FOR %s", tableName);
 
             // drop all stats; which could have been created on insert
-            query(format("CALL system.drop_stats('default', '%s')", tableName));
+            onTrino().executeQuery(format("CALL system.drop_stats('default', '%s')", tableName));
 
             // sanity check that there are no statistics
-            assertThat(query(showStatsPartitionOne)).containsOnly(
+            assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                     row("p", null, null, null, null, null, null),
                     row("a", null, null, null, null, null, null),
                     row(null, null, null, null, null, null, null));
-            assertThat(query(showStatsPartitionTwo)).containsOnly(
+            assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                     row("p", null, null, null, null, null, null),
                     row("a", null, null, null, null, null, null),
                     row(null, null, null, null, null, null, null));
-            assertThat(query(showStatsWholeTable)).containsOnly(
+            assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                     row("p", null, null, null, null, null, null),
                     row("a", null, null, null, null, null, null),
                     row(null, null, null, null, null, null, null));
 
             // analyze first partition with Trino and second with Hive
-            query(format("ANALYZE %s WITH (partitions = ARRAY[ARRAY['1']])", tableName));
+            onTrino().executeQuery(format("ANALYZE %s WITH (partitions = ARRAY[ARRAY['1']])", tableName));
             onHive().executeQuery(format("ANALYZE TABLE %s PARTITION (p = \"2\") COMPUTE STATISTICS", tableName));
             onHive().executeQuery(format("ANALYZE TABLE %s PARTITION (p = \"2\") COMPUTE STATISTICS FOR COLUMNS", tableName));
 
             // we can get stats for individual partitions
-            assertThat(query(showStatsPartitionOne)).containsOnly(
+            assertThat(onTrino().executeQuery(showStatsPartitionOne)).containsOnly(
                     row("p", null, 1.0, 0.0, null, "1", "1"),
                     row("a", null, 4.0, 0.0, null, "1", "4"),
                     row(null, null, null, null, 4.0, null, null));
-            assertThat(query(showStatsPartitionTwo)).containsOnly(
+            assertThat(onTrino().executeQuery(showStatsPartitionTwo)).containsOnly(
                     row("p", null, 1.0, 0.0, null, "2", "2"),
                     row("a", null, 3.0, 0.0, null, "10", "12"),
                     row(null, null, null, null, 3.0, null, null));
 
             // as well as for whole table
-            assertThat(query(showStatsWholeTable)).containsOnly(
+            assertThat(onTrino().executeQuery(showStatsWholeTable)).containsOnly(
                     row("p", null, 2.0, 0.0, null, "1", "2"),
                     row("a", null, 4.0, 0.0, null, "1", "12"),
                     row(null, null, null, null, 7.0, null, null));
@@ -1529,28 +1529,28 @@ public class TestHiveTableStatistics
     private static void assertComputeTableStatisticsOnCreateTable(String sourceTableName, List<Row> expectedStatistics)
     {
         String copiedTableName = "assert_compute_table_statistics_on_create_table_" + sourceTableName;
-        query(format("DROP TABLE IF EXISTS %s", copiedTableName));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", copiedTableName));
         try {
-            query(format("CREATE TABLE %s AS SELECT * FROM %s", copiedTableName, sourceTableName));
-            assertThat(query("SHOW STATS FOR " + copiedTableName)).containsOnly(expectedStatistics);
+            onTrino().executeQuery(format("CREATE TABLE %s AS SELECT * FROM %s", copiedTableName, sourceTableName));
+            assertThat(onTrino().executeQuery("SHOW STATS FOR " + copiedTableName)).containsOnly(expectedStatistics);
         }
         finally {
-            query(format("DROP TABLE IF EXISTS %s", copiedTableName));
+            onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", copiedTableName));
         }
     }
 
     private void assertComputeTableStatisticsOnInsert(String sourceTableName, List<Row> expectedStatistics)
     {
         String copiedTableName = "assert_compute_table_statistics_on_insert_" + sourceTableName;
-        query(format("DROP TABLE IF EXISTS %s", copiedTableName));
+        onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", copiedTableName));
         try {
-            query(format("CREATE TABLE %s AS SELECT * FROM %s WITH NO DATA", copiedTableName, sourceTableName));
-            assertThat(query("SHOW STATS FOR " + copiedTableName)).containsOnly(getAllTypesEmptyTableStatistics());
-            query(format("INSERT INTO %s SELECT * FROM %s", copiedTableName, sourceTableName));
-            assertThat(query("SHOW STATS FOR " + copiedTableName)).containsOnly(expectedStatistics);
+            onTrino().executeQuery(format("CREATE TABLE %s AS SELECT * FROM %s WITH NO DATA", copiedTableName, sourceTableName));
+            assertThat(onTrino().executeQuery("SHOW STATS FOR " + copiedTableName)).containsOnly(getAllTypesEmptyTableStatistics());
+            onTrino().executeQuery(format("INSERT INTO %s SELECT * FROM %s", copiedTableName, sourceTableName));
+            assertThat(onTrino().executeQuery("SHOW STATS FOR " + copiedTableName)).containsOnly(expectedStatistics);
         }
         finally {
-            query(format("DROP TABLE IF EXISTS %s", copiedTableName));
+            onTrino().executeQuery(format("DROP TABLE IF EXISTS %s", copiedTableName));
         }
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTableInsert.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTableInsert.java
@@ -19,9 +19,9 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.HIVE_TRANSACTIONAL;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.util.Locale.ENGLISH;
 import static java.util.stream.Collectors.joining;
 
@@ -42,8 +42,8 @@ public class TestHiveTransactionalTableInsert
                 hiveTableProperties(type));
 
         try {
-            query("INSERT INTO " + tableName + " (a) VALUES (42)");
-            assertThat(query("SELECT * FROM " + tableName))
+            onTrino().executeQuery("INSERT INTO " + tableName + " (a) VALUES (42)");
+            assertThat(onTrino().executeQuery("SELECT * FROM " + tableName))
                     .containsOnly(row(42));
         }
         finally {

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViewCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViewCompatibility.java
@@ -24,7 +24,6 @@ import java.util.function.Consumer;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.HIVE_VIEW_COMPATIBILITY;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.utils.QueryExecutors.onCompatibilityTestServer;
@@ -70,7 +69,7 @@ public class TestHiveViewCompatibility
         onCompatibilityTestServer().executeQuery("DROP VIEW IF EXISTS hive_duplicate_view");
         onCompatibilityTestServer().executeQuery("CREATE VIEW hive_duplicate_view AS SELECT * FROM nation");
 
-        assertQueryFailure(() -> query("CREATE VIEW hive_duplicate_view AS SELECT * FROM nation"))
+        assertQueryFailure(() -> onTrino().executeQuery("CREATE VIEW hive_duplicate_view AS SELECT * FROM nation"))
                 .hasMessageContaining("View already exists");
     }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestInsertIntoHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestInsertIntoHiveTable.java
@@ -33,8 +33,8 @@ import static io.trino.tempto.fulfillment.table.MutableTableRequirement.State.CR
 import static io.trino.tempto.fulfillment.table.MutableTablesState.mutableTablesState;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_TEXTFILE;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class TestInsertIntoHiveTable
@@ -77,8 +77,8 @@ public class TestInsertIntoHiveTable
     public void testInsertIntoValuesToHiveTableAllHiveSimpleTypes()
     {
         String tableNameInDatabase = mutableTablesState().get(TABLE_NAME).getNameInDatabase();
-        assertThat(query("SELECT * FROM " + tableNameInDatabase)).hasNoRows();
-        query("INSERT INTO " + tableNameInDatabase + " VALUES(" +
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableNameInDatabase)).hasNoRows();
+        onTrino().executeQuery("INSERT INTO " + tableNameInDatabase + " VALUES(" +
                 "TINYINT '127', " +
                 "SMALLINT '32767', " +
                 "2147483647, " +
@@ -96,7 +96,7 @@ public class TestInsertIntoHiveTable
                 "from_base64('a290IGJpbmFybnk=')" +
                 ")");
 
-        assertThat(query("SELECT * FROM " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableNameInDatabase)).containsOnly(
                 row(
                         127,
                         32767,
@@ -119,9 +119,9 @@ public class TestInsertIntoHiveTable
     public void testInsertIntoSelectToHiveTableAllHiveSimpleTypes()
     {
         String tableNameInDatabase = mutableTablesState().get(TABLE_NAME).getNameInDatabase();
-        assertThat(query("SELECT * FROM " + tableNameInDatabase)).hasNoRows();
-        assertThat(query("INSERT INTO " + tableNameInDatabase + " SELECT * from textfile_all_types")).containsExactlyInOrder(row(1));
-        assertThat(query("SELECT * FROM " + tableNameInDatabase)).containsOnly(
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableNameInDatabase)).hasNoRows();
+        assertThat(onTrino().executeQuery("INSERT INTO " + tableNameInDatabase + " SELECT * from textfile_all_types")).containsExactlyInOrder(row(1));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableNameInDatabase)).containsOnly(
                 row(
                         127,
                         32767,
@@ -144,7 +144,7 @@ public class TestInsertIntoHiveTable
     public void testInsertIntoPartitionedWithSerdeProperty()
     {
         String tableNameInDatabase = mutableTablesState().get(PARTITIONED_TABLE_WITH_SERDE).getNameInDatabase();
-        assertThat(query("INSERT INTO " + tableNameInDatabase + " SELECT 1, 'Trino', '2018-01-01'")).containsExactlyInOrder(row(1));
-        assertThat(query("SELECT * FROM " + tableNameInDatabase)).containsExactlyInOrder(row(1, "Trino", "2018-01-01"));
+        assertThat(onTrino().executeQuery("INSERT INTO " + tableNameInDatabase + " SELECT 1, 'Trino', '2018-01-01'")).containsExactlyInOrder(row(1));
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableNameInDatabase)).containsExactlyInOrder(row(1, "Trino", "2018-01-01"));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSyncPartitionMetadata.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSyncPartitionMetadata.java
@@ -28,12 +28,13 @@ import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.hive.InlineDataSource.createResourceDataSource;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.HIVE_PARTITIONING;
 import static io.trino.tests.product.TestGroups.SMOKE;
 import static io.trino.tests.product.TestGroups.TRINO_JDBC;
 import static io.trino.tests.product.hive.HiveProductTest.ERROR_COMMITTING_WRITE_TO_HIVE_ISSUE;
 import static io.trino.tests.product.hive.HiveProductTest.ERROR_COMMITTING_WRITE_TO_HIVE_MATCH;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class TestSyncPartitionMetadata
@@ -56,10 +57,10 @@ public class TestSyncPartitionMetadata
         String tableName = "test_sync_partition_metadata_add_partition";
         prepare(hdfsClient, hdfsDataSourceWriter, tableName);
 
-        query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'ADD')");
+        onTrino().executeQuery("CALL system.sync_partition_metadata('default', '" + tableName + "', 'ADD')");
         assertPartitions(tableName, row("a", "1"), row("b", "2"), row("f", "9"));
-        assertQueryFailure(() -> query("SELECT payload, col_x, col_y FROM " + tableName + " ORDER BY 1, 2, 3 ASC"))
-                .hasMessageContaining("Partition location does not exist: hdfs://hadoop-master:9000%s/%s/col_x=b/col_y=2", warehouseDirectory, tableName);
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT payload, col_x, col_y FROM " + tableName + " ORDER BY 1, 2, 3 ASC"))
+                .hasMessageContaining(format("Partition location does not exist: hdfs://hadoop-master:9000%s/%s/col_x=b/col_y=2", warehouseDirectory, tableName));
         cleanup(tableName);
     }
 
@@ -70,7 +71,7 @@ public class TestSyncPartitionMetadata
         String tableName = "test_sync_partition_metadata_drop_partition";
         prepare(hdfsClient, hdfsDataSourceWriter, tableName);
 
-        query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'DROP')");
+        onTrino().executeQuery("CALL system.sync_partition_metadata('default', '" + tableName + "', 'DROP')");
         assertPartitions(tableName, row("a", "1"));
         assertData(tableName, row(1, "a", "1"));
 
@@ -84,7 +85,7 @@ public class TestSyncPartitionMetadata
         String tableName = "test_sync_partition_metadata_add_drop_partition";
         prepare(hdfsClient, hdfsDataSourceWriter, tableName);
 
-        query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'FULL')");
+        onTrino().executeQuery("CALL system.sync_partition_metadata('default', '" + tableName + "', 'FULL')");
         assertPartitions(tableName, row("a", "1"), row("f", "9"));
         assertData(tableName, row(1, "a", "1"), row(42, "f", "9"));
 
@@ -98,7 +99,7 @@ public class TestSyncPartitionMetadata
         String tableName = "test_repair_invalid_mode";
         prepare(hdfsClient, hdfsDataSourceWriter, tableName);
 
-        assertQueryFailure(() -> query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'INVALID')"))
+        assertQueryFailure(() -> onTrino().executeQuery("CALL system.sync_partition_metadata('default', '" + tableName + "', 'INVALID')"))
                 .hasMessageMatching("Query failed (.*): Invalid partition metadata sync mode: INVALID");
 
         cleanup(tableName);
@@ -116,7 +117,7 @@ public class TestSyncPartitionMetadata
         hdfsClient.createDirectory(tableLocation + "/COL_X=UPPER/COL_Y=12");
         hdfsDataSourceWriter.ensureDataOnHdfs(tableLocation + "/COL_X=UPPER/COL_Y=12", dataSource);
 
-        query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'FULL', false)");
+        onTrino().executeQuery("CALL system.sync_partition_metadata('default', '" + tableName + "', 'FULL', false)");
         assertPartitions(tableName, row("UPPER", "12"), row("a", "1"), row("f", "9"), row("g", "10"), row("h", "11"));
         assertData(tableName, row(1, "a", "1"), row(42, "UPPER", "12"), row(42, "f", "9"), row(42, "g", "10"), row(42, "h", "11"));
     }
@@ -131,8 +132,8 @@ public class TestSyncPartitionMetadata
         // this conflicts with a partition that already exits in the metastore
         hdfsDataSourceWriter.ensureDataOnHdfs(tableLocation(tableName) + "/COL_X=a/cOl_y=1", dataSource);
 
-        assertThatThrownBy(() -> query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'ADD', false)"))
-                .hasMessageContaining("One or more partitions already exist for table 'default.%s'", tableName);
+        assertThatThrownBy(() -> onTrino().executeQuery("CALL system.sync_partition_metadata('default', '" + tableName + "', 'ADD', false)"))
+                .hasMessageContaining(format("One or more partitions already exist for table 'default.%s'", tableName));
         assertPartitions(tableName, row("a", "1"), row("b", "2"));
     }
 
@@ -143,10 +144,10 @@ public class TestSyncPartitionMetadata
 
     private void prepare(HdfsClient hdfsClient, HdfsDataSourceWriter hdfsDataSourceWriter, String tableName)
     {
-        query("DROP TABLE IF EXISTS " + tableName);
+        onTrino().executeQuery("DROP TABLE IF EXISTS " + tableName);
 
-        query("CREATE TABLE " + tableName + " (payload bigint, col_x varchar, col_y varchar) WITH (format = 'ORC', partitioned_by = ARRAY[ 'col_x', 'col_y' ])");
-        query("INSERT INTO " + tableName + " VALUES (1, 'a', '1'), (2, 'b', '2')");
+        onTrino().executeQuery("CREATE TABLE " + tableName + " (payload bigint, col_x varchar, col_y varchar) WITH (format = 'ORC', partitioned_by = ARRAY[ 'col_x', 'col_y' ])");
+        onTrino().executeQuery("INSERT INTO " + tableName + " VALUES (1, 'a', '1'), (2, 'b', '2')");
 
         String tableLocation = tableLocation(tableName);
         // remove partition col_x=b/col_y=2
@@ -170,18 +171,18 @@ public class TestSyncPartitionMetadata
 
     private static void cleanup(String tableName)
     {
-        query("DROP TABLE " + tableName);
+        onTrino().executeQuery("DROP TABLE " + tableName);
     }
 
     private static void assertPartitions(String tableName, QueryAssert.Row... rows)
     {
-        QueryResult partitionListResult = query("SELECT * FROM \"" + tableName + "$partitions\" ORDER BY 1, 2");
+        QueryResult partitionListResult = onTrino().executeQuery("SELECT * FROM \"" + tableName + "$partitions\" ORDER BY 1, 2");
         assertThat(partitionListResult).containsExactlyInOrder(rows);
     }
 
     private static void assertData(String tableName, QueryAssert.Row... rows)
     {
-        QueryResult dataResult = query("SELECT payload, col_x, col_y FROM " + tableName + " ORDER BY 1, 2, 3 ASC");
+        QueryResult dataResult = onTrino().executeQuery("SELECT payload, col_x, col_y FROM " + tableName + " ORDER BY 1, 2, 3 ASC");
         assertThat(dataResult).containsExactlyInOrder(rows);
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestTablePartitioningSelect.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestTablePartitioningSelect.java
@@ -35,7 +35,7 @@ import static io.trino.tempto.fulfillment.table.MutableTableRequirement.State.LO
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
 import static io.trino.tempto.fulfillment.table.hive.InlineDataSource.createResourceDataSource;
 import static io.trino.tempto.fulfillment.table.hive.InlineDataSource.createStringDataSource;
-import static io.trino.tempto.query.QueryExecutor.query;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 
 public class TestTablePartitioningSelect
         extends ProductTest
@@ -95,12 +95,12 @@ public class TestTablePartitioningSelect
         String tableNameInDatabase = tablesState.get(TABLE_NAME).getNameInDatabase();
 
         String selectFromOnePartitionsSql = "SELECT * FROM " + tableNameInDatabase + " WHERE part_col = 2";
-        QueryResult onePartitionQueryResult = query(selectFromOnePartitionsSql);
+        QueryResult onePartitionQueryResult = onTrino().executeQuery(selectFromOnePartitionsSql);
         assertThat(onePartitionQueryResult).containsOnly(row(42, 2));
 
         try {
             // This query should fail or return null values for invalid partition data
-            assertThat(query("SELECT * FROM " + tableNameInDatabase)).containsOnly(row(42, 2), row(null, 1));
+            assertThat(onTrino().executeQuery("SELECT * FROM " + tableNameInDatabase)).containsOnly(row(42, 2), row(null, 1));
         }
         catch (QueryExecutionException expectedDueToInvalidPartitionData) {
         }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestTextFileHiveTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestTextFileHiveTable.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
@@ -71,7 +70,7 @@ public class TestTextFileHiveTable
                         "   skip_header_line_count = 1 " +
                         ")",
                 warehouseDirectory));
-        assertThat(query("SELECT * FROM test_create_textfile_skip_header")).containsOnly(row("value"), row("footer"));
+        assertThat(onTrino().executeQuery("SELECT * FROM test_create_textfile_skip_header")).containsOnly(row("value"), row("footer"));
         onHive().executeQuery("DROP TABLE test_create_textfile_skip_header");
 
         onHive().executeQuery("DROP TABLE IF EXISTS test_create_textfile_skip_footer");
@@ -84,7 +83,7 @@ public class TestTextFileHiveTable
                         "   skip_footer_line_count = 1 " +
                         ")",
                 warehouseDirectory));
-        assertThat(query("SELECT * FROM test_create_textfile_skip_footer")).containsOnly(row("header"), row("value"));
+        assertThat(onTrino().executeQuery("SELECT * FROM test_create_textfile_skip_footer")).containsOnly(row("header"), row("value"));
         onHive().executeQuery("DROP TABLE test_create_textfile_skip_footer");
 
         onHive().executeQuery("DROP TABLE IF EXISTS test_create_textfile_skip_header_footer");
@@ -98,7 +97,7 @@ public class TestTextFileHiveTable
                         "   skip_footer_line_count = 1 " +
                         ")",
                 warehouseDirectory));
-        assertThat(query("SELECT * FROM test_create_textfile_skip_header_footer")).containsExactlyInOrder(row("value"));
+        assertThat(onTrino().executeQuery("SELECT * FROM test_create_textfile_skip_header_footer")).containsExactlyInOrder(row("value"));
         onHive().executeQuery("DROP TABLE test_create_textfile_skip_header_footer");
     }
 
@@ -112,7 +111,7 @@ public class TestTextFileHiveTable
                 "STORED AS TEXTFILE " +
                 "TBLPROPERTIES ('skip.header.line.count'='1')");
         onTrino().executeQuery("INSERT INTO test_textfile_skip_header VALUES (1)");
-        assertThat(query("SELECT * FROM test_textfile_skip_header")).containsOnly(row(1));
+        assertThat(onTrino().executeQuery("SELECT * FROM test_textfile_skip_header")).containsOnly(row(1));
         onHive().executeQuery("DROP TABLE test_textfile_skip_header");
 
         onHive().executeQuery("DROP TABLE IF EXISTS test_textfile_skip_footer");
@@ -148,7 +147,7 @@ public class TestTextFileHiveTable
                         ") " +
                         "AS SELECT 1  AS col_header1, 2 as col_header2;");
         onTrino().executeQuery("INSERT INTO test_create_textfile_skip_header VALUES (3, 4)");
-        assertThat(query("SELECT * FROM test_create_textfile_skip_header")).containsOnly(row(1, 2), row(3, 4));
+        assertThat(onTrino().executeQuery("SELECT * FROM test_create_textfile_skip_header")).containsOnly(row(1, 2), row(3, 4));
         assertThat(onHive().executeQuery("SELECT * FROM test_create_textfile_skip_header")).containsOnly(row(1, 2), row(3, 4));
         onHive().executeQuery("DROP TABLE test_create_textfile_skip_header");
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/util/CachingTestUtils.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/util/CachingTestUtils.java
@@ -16,7 +16,7 @@ package io.trino.tests.product.hive.util;
 import io.trino.tempto.query.QueryResult;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static io.trino.tempto.query.QueryExecutor.query;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 
 public final class CachingTestUtils
 {
@@ -24,7 +24,7 @@ public final class CachingTestUtils
 
     public static CacheStats getCacheStats()
     {
-        QueryResult queryResult = query("SELECT " +
+        QueryResult queryResult = onTrino().executeQuery("SELECT " +
                 "  sum(Cached_rrc_requests) as cachedreads, " +
                 "  sum(Remote_rrc_requests + Direct_rrc_requests) as remotereads, " +
                 "  sum(Nonlocal_rrc_requests) as nonlocalreads " +
@@ -39,7 +39,7 @@ public final class CachingTestUtils
         long nonLocalReads = (Long) getOnlyElement(queryResult.rows())
                 .get(queryResult.tryFindColumnIndex("nonlocalreads").get() - 1);
 
-        long asyncDownloadedMb = (Long) getOnlyElement(query("SELECT sum(Count) FROM " +
+        long asyncDownloadedMb = (Long) getOnlyElement(onTrino().executeQuery("SELECT sum(Count) FROM " +
                 "jmx.current.\"metrics:name=rubix.bookkeeper.count.async_downloaded_mb\"").rows())
                 .get(0);
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestJdbc.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestJdbc.java
@@ -38,13 +38,12 @@ import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
 import static io.trino.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.NATION;
 import static io.trino.tempto.internal.convention.SqlResultDescriptor.sqlResultDescriptorForResource;
-import static io.trino.tempto.query.QueryExecutor.defaultQueryExecutor;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.JDBC;
 import static io.trino.tests.product.TpchTableResults.PRESTO_NATION_RESULT;
 import static io.trino.tests.product.utils.JdbcDriverUtils.getSessionProperty;
 import static io.trino.tests.product.utils.JdbcDriverUtils.resetSessionProperty;
 import static io.trino.tests.product.utils.JdbcDriverUtils.setSessionProperty;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.util.Locale.CHINESE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -80,14 +79,14 @@ public class TestJdbc
             throws SQLException
     {
         String tableNameInDatabase = mutableTablesState().get(TABLE_NAME).getNameInDatabase();
-        assertThat(query("SELECT * FROM " + tableNameInDatabase)).hasNoRows();
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableNameInDatabase)).hasNoRows();
 
         try (Statement statement = connection().createStatement()) {
             assertThat(statement.executeUpdate("insert into " + tableNameInDatabase + " select * from nation"))
                     .isEqualTo(25);
         }
 
-        assertThat(query("SELECT * FROM " + tableNameInDatabase)).matches(PRESTO_NATION_RESULT);
+        assertThat(onTrino().executeQuery("SELECT * FROM " + tableNameInDatabase)).matches(PRESTO_NATION_RESULT);
     }
 
     @Test(groups = JDBC)
@@ -216,6 +215,6 @@ public class TestJdbc
 
     private Connection connection()
     {
-        return defaultQueryExecutor().getConnection();
+        return onTrino().getConnection();
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestPreparedStatements.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestPreparedStatements.java
@@ -35,11 +35,10 @@ import static io.trino.tempto.fulfillment.table.MutableTableRequirement.State.CR
 import static io.trino.tempto.fulfillment.table.MutableTablesState.mutableTablesState;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.trino.tempto.fulfillment.table.TableRequirements.mutableTable;
-import static io.trino.tempto.query.QueryExecutor.defaultQueryExecutor;
 import static io.trino.tempto.query.QueryExecutor.param;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.JDBC;
 import static io.trino.tests.product.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_TEXTFILE;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.sql.JDBCType.BIGINT;
@@ -93,11 +92,11 @@ public class TestPreparedStatements
         String selectSql = "SELECT c_int FROM " + TABLE_NAME + " WHERE c_int = ?";
         final int testValue = 2147483647;
 
-        assertThat(query(selectSql, param(INTEGER, testValue))).containsOnly(row(testValue));
+        assertThat(onTrino().executeQuery(selectSql, param(INTEGER, testValue))).containsOnly(row(testValue));
 
-        assertThat(query(selectSql, param(INTEGER, null))).hasNoRows();
+        assertThat(onTrino().executeQuery(selectSql, param(INTEGER, null))).hasNoRows();
 
-        assertThat(query(selectSql, param(INTEGER, 2))).hasNoRows();
+        assertThat(onTrino().executeQuery(selectSql, param(INTEGER, 2))).hasNoRows();
     }
 
     @Test(groups = JDBC)
@@ -129,7 +128,7 @@ public class TestPreparedStatements
         String insertSqlWithTable = format(INSERT_SQL, tableNameInDatabase);
         String selectSqlWithTable = format(SELECT_STAR_SQL, tableNameInDatabase);
 
-        defaultQueryExecutor().executeQuery(
+        onTrino().executeQuery(
                 insertSqlWithTable,
                 param(TINYINT, null),
                 param(SMALLINT, null),
@@ -147,7 +146,7 @@ public class TestPreparedStatements
                 param(BOOLEAN, null),
                 param(VARBINARY, new byte[] {0, 1, 2, 3, 0, 42, -7}));
 
-        QueryResult result = defaultQueryExecutor().executeQuery(selectSqlWithTable);
+        QueryResult result = onTrino().executeQuery(selectSqlWithTable);
         assertColumnTypes(result);
         assertThat(result).containsOnly(
                 row(null, null, null, null, null, null, null, null, null, null, null, null, null, null,
@@ -162,7 +161,7 @@ public class TestPreparedStatements
         String insertSqlWithTable = format(INSERT_SQL, tableNameInDatabase);
         String selectSqlWithTable = format(SELECT_STAR_SQL, tableNameInDatabase);
 
-        query(
+        onTrino().executeQuery(
                 insertSqlWithTable,
                 param(TINYINT, 127),
                 param(SMALLINT, 32767),
@@ -180,7 +179,7 @@ public class TestPreparedStatements
                 param(BOOLEAN, Boolean.TRUE),
                 param(VARBINARY, new byte[] {0, 1, 2, 3, 0, 42, -7}));
 
-        query(
+        onTrino().executeQuery(
                 insertSqlWithTable,
                 param(TINYINT, 1),
                 param(SMALLINT, 2),
@@ -198,7 +197,7 @@ public class TestPreparedStatements
                 param(BOOLEAN, Boolean.FALSE),
                 param(VARBINARY, new byte[] {0, 1, 2, 3, 0, 42, -7}));
 
-        query(
+        onTrino().executeQuery(
                 insertSqlWithTable,
                 param(TINYINT, null),
                 param(SMALLINT, null),
@@ -216,7 +215,7 @@ public class TestPreparedStatements
                 param(BOOLEAN, null),
                 param(VARBINARY, null));
 
-        QueryResult result = query(selectSqlWithTable);
+        QueryResult result = onTrino().executeQuery(selectSqlWithTable);
         assertColumnTypes(result);
         assertThat(result).containsOnly(
                 row(
@@ -317,7 +316,7 @@ public class TestPreparedStatements
                     "null, " +
                     "null");
 
-            QueryResult result = query(selectSqlWithTable);
+            QueryResult result = onTrino().executeQuery(selectSqlWithTable);
             assertColumnTypes(result);
             assertThat(result).containsOnly(
                     row(
@@ -385,7 +384,7 @@ public class TestPreparedStatements
                     "null, " +
                     "X'00010203002AF9'");
 
-            QueryResult result = query(selectSqlWithTable);
+            QueryResult result = onTrino().executeQuery(selectSqlWithTable);
             assertColumnTypes(result);
             assertThat(result).containsOnly(
                     row(null, null, null, null, null, null, null, null, null, null, null, null, null, null,
@@ -415,6 +414,6 @@ public class TestPreparedStatements
 
     private Connection connection()
     {
-        return defaultQueryExecutor().getConnection();
+        return onTrino().getConnection();
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaAvroReadsSmokeTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaAvroReadsSmokeTest.java
@@ -52,10 +52,10 @@ import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.context.ThreadLocalTestContextHolder.testContext;
 import static io.trino.tempto.fulfillment.table.TableHandle.tableHandle;
 import static io.trino.tempto.fulfillment.table.kafka.KafkaMessageContentsBuilder.contentsBuilder;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.KAFKA;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.utils.QueryAssertions.assertEventually;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static io.trino.tests.product.utils.SchemaRegistryClientUtils.getSchemaRegistryClient;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -92,7 +92,7 @@ public class TestKafkaAvroReadsSmokeTest
         assertEventually(
                 new Duration(30, SECONDS),
                 () -> {
-                    QueryResult queryResult = query(format("select * from %s.%s", kafkaCatalog.getCatalogName(), KAFKA_SCHEMA + "." + topicName));
+                    QueryResult queryResult = onTrino().executeQuery(format("select * from %s.%s", kafkaCatalog.getCatalogName(), KAFKA_SCHEMA + "." + topicName));
                     assertThat(queryResult).containsOnly(row(
                             "foobar",
                             127,
@@ -110,7 +110,7 @@ public class TestKafkaAvroReadsSmokeTest
         assertEventually(
                 new Duration(30, SECONDS),
                 () -> {
-                    QueryResult queryResult = query(format("select * from %s.%s", kafkaCatalog.getCatalogName(), KAFKA_SCHEMA + "." + topicName));
+                    QueryResult queryResult = onTrino().executeQuery(format("select * from %s.%s", kafkaCatalog.getCatalogName(), KAFKA_SCHEMA + "." + topicName));
                     assertThat(queryResult).containsOnly(row(
                             null,
                             null,
@@ -131,7 +131,7 @@ public class TestKafkaAvroReadsSmokeTest
         assertEventually(
                 new Duration(30, SECONDS),
                 () -> {
-                    QueryResult queryResult = query(format(
+                    QueryResult queryResult = onTrino().executeQuery(format(
                             "SELECT a[1], a[2], m['key1'] FROM (SELECT %s as a, %s as m FROM %s.%s) t",
                             kafkaCatalog.isColumnMappingSupported() ? "c_array" : "a_array",
                             kafkaCatalog.isColumnMappingSupported() ? "c_map" : "a_map",
@@ -219,7 +219,7 @@ public class TestKafkaAvroReadsSmokeTest
         assertEventually(
                 new Duration(30, SECONDS),
                 () -> {
-                    QueryResult queryResult = query(format("select reference.a_varchar, reference.a_double from kafka_schema_registry.%s.%s", KAFKA_SCHEMA, AVRO_SCHEMA_WITH_REFERENCES_TOPIC_NAME));
+                    QueryResult queryResult = onTrino().executeQuery(format("select reference.a_varchar, reference.a_double from kafka_schema_registry.%s.%s", KAFKA_SCHEMA, AVRO_SCHEMA_WITH_REFERENCES_TOPIC_NAME));
                     assertThat(queryResult).containsOnly(row(
                             "foobar",
                             234.567));

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaAvroWritesSmokeTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaAvroWritesSmokeTest.java
@@ -19,9 +19,9 @@ import org.testng.annotations.Test;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.KAFKA;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 public class TestKafkaAvroWritesSmokeTest
@@ -36,7 +36,7 @@ public class TestKafkaAvroWritesSmokeTest
     @Test(groups = {KAFKA, PROFILE_SPECIFIC_TESTS})
     public void testInsertPrimitiveDataType()
     {
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "INSERT INTO %s.%s VALUES " +
                         "('jasio', 9223372036854775807, 1234567890.123456789, true), " +
                         "('stasio', -9223372036854775808, -1234567890.123456789, false), " +
@@ -47,7 +47,7 @@ public class TestKafkaAvroWritesSmokeTest
                 ALL_DATATYPES_AVRO_TABLE_NAME)))
                 .updatedRowsCountIsEqualTo(5);
 
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "SELECT * FROM %s.%s",
                 KAFKA_CATALOG,
                 ALL_DATATYPES_AVRO_TABLE_NAME)))
@@ -62,7 +62,7 @@ public class TestKafkaAvroWritesSmokeTest
     @Test(groups = {KAFKA, PROFILE_SPECIFIC_TESTS})
     public void testInsertStructuralDataType()
     {
-        assertQueryFailure(() -> query(format(
+        assertQueryFailure(() -> onTrino().executeQuery(format(
                 "INSERT INTO %s.%s VALUES " +
                         "(ARRAY[100, 102], map_from_entries(ARRAY[('key1', 'value1')]))",
                 KAFKA_CATALOG,

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaReadsSmokeTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaReadsSmokeTest.java
@@ -36,9 +36,9 @@ import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.trino.tempto.fulfillment.table.kafka.KafkaMessageContentsBuilder.contentsBuilder;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.KAFKA;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.Double.doubleToRawLongBits;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.String.format;
@@ -81,7 +81,7 @@ public class TestKafkaReadsSmokeTest
     @Requires(SimpleKeyAndValueTable.class)
     public void testSelectSimpleKeyAndValue()
     {
-        QueryResult queryResult = query(format(
+        QueryResult queryResult = onTrino().executeQuery(format(
                 "select varchar_key, bigint_key, varchar_value, bigint_value from %s.%s.%s",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
@@ -133,7 +133,7 @@ public class TestKafkaReadsSmokeTest
     @Requires(AllDataTypesRawTable.class)
     public void testSelectAllRawTable()
     {
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "select column_name,data_type from %s.information_schema.columns where table_schema='%s' and table_name='%s'",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
@@ -157,7 +157,7 @@ public class TestKafkaReadsSmokeTest
                 row("c_int_boolean", "boolean"),
                 row("c_long_boolean", "boolean"));
 
-        assertThat(query(format("select * from %s.%s.%s", KAFKA_CATALOG, SCHEMA_NAME, ALL_DATATYPES_RAW_TABLE_NAME))).containsOnly(row(
+        assertThat(onTrino().executeQuery(format("select * from %s.%s.%s", KAFKA_CATALOG, SCHEMA_NAME, ALL_DATATYPES_RAW_TABLE_NAME))).containsOnly(row(
                 "jasio",
                 0x01,
                 0x0203,
@@ -204,7 +204,7 @@ public class TestKafkaReadsSmokeTest
     @Requires(AllDataTypesCsvTable.class)
     public void testSelectAllCsvTable()
     {
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "select column_name,data_type from %s.information_schema.columns where table_schema='%s' and table_name='%s'",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
@@ -218,7 +218,7 @@ public class TestKafkaReadsSmokeTest
                 row("c_double", "double"),
                 row("c_boolean", "boolean"));
 
-        assertThat(query(format("select * from %s.%s.%s", KAFKA_CATALOG, SCHEMA_NAME, ALL_DATATYPES_CSV_TABLE_NAME))).containsOnly(
+        assertThat(onTrino().executeQuery(format("select * from %s.%s.%s", KAFKA_CATALOG, SCHEMA_NAME, ALL_DATATYPES_CSV_TABLE_NAME))).containsOnly(
                 row("jasio", 9223372036854775807L, 2147483647, 32767, 127, 1234567890.123456789, true),
                 row("stasio", -9223372036854775808L, -2147483648, -32768, -128, -1234567890.123456789, false),
                 row(null, null, null, null, null, null, null),
@@ -276,7 +276,7 @@ public class TestKafkaReadsSmokeTest
     @Requires(AllDataTypesJsonTable.class)
     public void testSelectAllJsonTable()
     {
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "select column_name,data_type from %s.information_schema.columns where table_schema='%s' and table_name='%s'",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
@@ -310,7 +310,7 @@ public class TestKafkaReadsSmokeTest
                 row("c_timetz_iso8601", "time(3) with time zone"),
                 row("c_timetz_custom", "time(3) with time zone"));
 
-        assertThat(query(format("select * from %s.%s.%s", KAFKA_CATALOG, SCHEMA_NAME, ALL_DATATYPES_JSON_TABLE_NAME))).containsOnly(row(
+        assertThat(onTrino().executeQuery(format("select * from %s.%s.%s", KAFKA_CATALOG, SCHEMA_NAME, ALL_DATATYPES_JSON_TABLE_NAME))).containsOnly(row(
                 "ala ma kota",
                 9223372036854775807L,
                 2147483647,

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaWritesSmokeTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/kafka/TestKafkaWritesSmokeTest.java
@@ -25,9 +25,9 @@ import java.time.LocalTime;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.KAFKA;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 public class TestKafkaWritesSmokeTest
@@ -41,7 +41,7 @@ public class TestKafkaWritesSmokeTest
     @Test(groups = {KAFKA, PROFILE_SPECIFIC_TESTS})
     public void testInsertSimpleKeyAndValue()
     {
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "INSERT INTO %s.%s.%s VALUES " +
                         "('jasio', 1, 'ania', 2), " +
                         "('piotr', 3, 'kasia', 4)",
@@ -50,7 +50,7 @@ public class TestKafkaWritesSmokeTest
                 SIMPLE_KEY_AND_VALUE_TABLE_NAME)))
                 .updatedRowsCountIsEqualTo(2);
 
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "SELECT * FROM %s.%s.%s",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
@@ -69,7 +69,7 @@ public class TestKafkaWritesSmokeTest
         //  BIGINT with dataFormat = BYTE takes up 8 bytes during write (as opposed to 1 byte
         //  during read) and hence a buffer overflow is possible before we are able to reach
         //  the end of row.
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "INSERT INTO %s.%s.%s VALUES " +
                         "('jasio', 9223372036854775807, 2147483647, 32767, 127, 1234567890.123456789, true), " +
                         "('piotr', -9223372036854775808, -2147483648, -32768, -128, -1234567890.123456789, false), " +
@@ -80,7 +80,7 @@ public class TestKafkaWritesSmokeTest
                 ALL_DATATYPES_RAW_TABLE_NAME)))
                 .updatedRowsCountIsEqualTo(4);
 
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "SELECT * FROM %s.%s.%s",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
@@ -97,7 +97,7 @@ public class TestKafkaWritesSmokeTest
     @Test(groups = {KAFKA, PROFILE_SPECIFIC_TESTS})
     public void testInsertCsvTable()
     {
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "INSERT INTO %s.%s.%s VALUES " +
                         "('jasio', 9223372036854775807, 2147483647, 32767, 127, 1234567890.123456789, true), " +
                         "('stasio', -9223372036854775808, -2147483648, -32768, -128, -1234567890.123456789, false), " +
@@ -109,7 +109,7 @@ public class TestKafkaWritesSmokeTest
                 ALL_DATATYPES_CSV_TABLE_NAME)))
                 .updatedRowsCountIsEqualTo(5);
 
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "SELECT * FROM %s.%s.%s",
                 KAFKA_CATALOG,
                 SCHEMA_NAME,
@@ -127,7 +127,7 @@ public class TestKafkaWritesSmokeTest
     @Test(groups = {KAFKA, PROFILE_SPECIFIC_TESTS})
     public void testInsertJsonTable()
     {
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "INSERT INTO %s.%s.%s VALUES (" +
                         "'ala ma kota'," +
                         "9223372036854775807," +
@@ -159,7 +159,7 @@ public class TestKafkaWritesSmokeTest
                 ALL_DATATYPES_JSON_TABLE_NAME)))
                 .updatedRowsCountIsEqualTo(1);
 
-        assertThat(query(format(
+        assertThat(onTrino().executeQuery(format(
                 "SELECT c_varchar, " +
                         "c_bigint, " +
                         "c_integer, " +

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/mysql/TestCreateTableAsSelect.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/mysql/TestCreateTableAsSelect.java
@@ -21,10 +21,10 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.MYSQL;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.utils.QueryExecutors.onMySql;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 public class TestCreateTableAsSelect
@@ -42,7 +42,7 @@ public class TestCreateTableAsSelect
     @Test(groups = {MYSQL, PROFILE_SPECIFIC_TESTS})
     public void testCreateTableAsSelect()
     {
-        QueryResult queryResult = query(format("CREATE TABLE mysql.%s AS SELECT * FROM tpch.tiny.nation", TABLE_NAME));
+        QueryResult queryResult = onTrino().executeQuery(format("CREATE TABLE mysql.%s AS SELECT * FROM tpch.tiny.nation", TABLE_NAME));
         assertThat(queryResult).containsOnly(row(25));
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/phoenix/TestPhoenix.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/phoenix/TestPhoenix.java
@@ -19,7 +19,6 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.PHOENIX;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
@@ -37,7 +36,7 @@ public class TestPhoenix
                     .containsOnly(row(25));
         }
         finally {
-            query("DROP TABLE nation");
+            onTrino().executeQuery("DROP TABLE nation");
         }
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/sqlserver/TestInvalidSelect.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/sqlserver/TestInvalidSelect.java
@@ -21,12 +21,12 @@ import org.testng.annotations.Test;
 
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
-import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.TestGroups.SQL_SERVER;
 import static io.trino.tests.product.sqlserver.SqlServerTpchTableDefinitions.NATION;
 import static io.trino.tests.product.sqlserver.TestConstants.CONNECTOR_NAME;
 import static io.trino.tests.product.sqlserver.TestConstants.KEY_SPACE;
+import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
 
 public class TestInvalidSelect
@@ -43,7 +43,7 @@ public class TestInvalidSelect
     public void testNonExistentTable()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, KEY_SPACE, "bogus");
-        assertQueryFailure(() -> query(format("SELECT * FROM %s", tableName)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("SELECT * FROM %s", tableName)))
                 .hasMessageContaining("Table '%s' does not exist", tableName);
     }
 
@@ -51,7 +51,7 @@ public class TestInvalidSelect
     public void testNonExistentSchema()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, "does_not_exist", "bogus");
-        assertQueryFailure(() -> query(format("SELECT * FROM %s", tableName)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("SELECT * FROM %s", tableName)))
                 .hasMessageContaining("Schema 'does_not_exist' does not exist");
     }
 
@@ -59,7 +59,7 @@ public class TestInvalidSelect
     public void testNonExistentColumn()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, KEY_SPACE, NATION.getName());
-        assertQueryFailure(() -> query(format("SELECT bogus FROM %s", tableName)))
+        assertQueryFailure(() -> onTrino().executeQuery(format("SELECT bogus FROM %s", tableName)))
                 .hasMessageContaining("Column 'bogus' cannot be resolved");
     }
 }

--- a/testing/trino-product-tests/src/main/resources/tempto-configuration.yaml
+++ b/testing/trino-product-tests/src/main/resources/tempto-configuration.yaml
@@ -4,9 +4,6 @@ hdfs:
     uri: http://${databases.hive.host}:50070
 
 databases:
-  default:
-    alias: presto
-
   hive:
     host: hadoop-master
     jdbc_driver_class: org.apache.hive.jdbc.HiveDriver


### PR DESCRIPTION
`onTrino().executeQuery` vs static `QueryExecutor.query` is confusing,
since both are the same thing.

Replace reference to `QueryExecutor.query` with
`onTrino().executeQuery`