### PR TITLE
Phoenix Connector: Handle parallel execution of scans explicitly in Trino

### DIFF
--- a/docs/src/main/sphinx/connector/phoenix.rst
+++ b/docs/src/main/sphinx/connector/phoenix.rst
@@ -56,6 +56,11 @@ Property Name                                      Required   Description
                                                               default the location is ``/hbase``
 ``phoenix.config.resources``                       No         Comma-separated list of configuration files (e.g. ``hbase-site.xml``) to use for
                                                               connection properties.  These files must exist on the machines running Trino.
+``phoenix.max-scans-per-split``                    No         Maximum number of HBase scans that will be performed in a single split. Default is 20.
+                                                              Lower values will lead to more splits in Trino.
+                                                              Can also be set via session propery ``max_scans_per_split``.
+                                                              For details see: `<https://phoenix.apache.org/update_statistics.html>`_.
+                                                              (This setting has no effect when guideposts are disabled in Phoenix.)
 ================================================== ========== ===================================================================================
 
 .. include:: jdbc-common-configurations.fragment

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -65,7 +65,6 @@ import org.apache.phoenix.iterate.LookAheadResultIterator;
 import org.apache.phoenix.iterate.MapReduceParallelScanGrouper;
 import org.apache.phoenix.iterate.PeekingResultIterator;
 import org.apache.phoenix.iterate.ResultIterator;
-import org.apache.phoenix.iterate.RoundRobinResultIterator;
 import org.apache.phoenix.iterate.SequenceResultIterator;
 import org.apache.phoenix.iterate.TableResultIterator;
 import org.apache.phoenix.jdbc.DelegatePreparedStatement;
@@ -775,7 +774,7 @@ public class PhoenixClient
                         MapReduceParallelScanGrouper.getInstance());
                 iterators.add(LookAheadResultIterator.wrap(tableResultIterator));
             }
-            ResultIterator iterator = queryPlan.useRoundRobinIterator() ? RoundRobinResultIterator.newIterator(iterators, queryPlan) : ConcatResultIterator.newIterator(iterators);
+            ResultIterator iterator = ConcatResultIterator.newIterator(iterators);
             if (context.getSequenceManager().getSequenceCount() > 0) {
                 iterator = new SequenceResultIterator(iterator, context.getSequenceManager());
             }

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClientModule.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClientModule.java
@@ -89,6 +89,7 @@ public class PhoenixClientModule
         bindSessionPropertiesProvider(binder, TypeHandlingJdbcSessionProperties.class);
         bindSessionPropertiesProvider(binder, JdbcMetadataSessionProperties.class);
         bindSessionPropertiesProvider(binder, JdbcWriteSessionProperties.class);
+        bindSessionPropertiesProvider(binder, PhoenixSessionProperties.class);
 
         configBinder(binder).bindConfig(JdbcMetadataConfig.class);
         configBinder(binder).bindConfig(JdbcWriteConfig.class);

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixConfig.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixConfig.java
@@ -16,16 +16,31 @@ package io.trino.plugin.phoenix;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.validation.FileExists;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.util.List;
 
 public class PhoenixConfig
 {
+    static final int MAX_ALLOWED_SCANS_PER_SPLIT = 1000;
+
     private String connectionUrl;
     private List<String> resourceConfigFiles = ImmutableList.of();
+
+    /*
+     * By default group at most 20 HBase scans into a single Split.
+     * There is at least one Split per HBase region, HBase's default region size is 20GB
+     * and Phoenix' default scan chunk size is 300MB.
+     * Any value between 10 and perhaps 30 is a good default. 20 is a good compromise allowing
+     * 3-4 parallel scans per region with all default settings.
+     * A large value here makes sense when the Guidepost-width in Phoenix has been reduced.
+     */
+    private int maxScansPerSplit = 20;
 
     @NotNull
     public String getConnectionUrl()
@@ -50,6 +65,21 @@ public class PhoenixConfig
     public PhoenixConfig setResourceConfigFiles(String files)
     {
         this.resourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files);
+        return this;
+    }
+
+    @Min(1)
+    @Max(MAX_ALLOWED_SCANS_PER_SPLIT)
+    public int getMaxScansPerSplit()
+    {
+        return maxScansPerSplit;
+    }
+
+    @Config("phoenix.max-scans-per-split")
+    @ConfigDescription("Maximum number of HBase scans that will be performed in a single split.")
+    public PhoenixConfig setMaxScansPerSplit(int scansPerSplit)
+    {
+        this.maxScansPerSplit = scansPerSplit;
         return this;
     }
 }

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSessionProperties.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSessionProperties.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.spi.TrinoException;
+import io.trino.spi.session.PropertyMetadata;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static io.trino.spi.session.PropertyMetadata.integerProperty;
+import static java.lang.String.format;
+
+public final class PhoenixSessionProperties
+        implements SessionPropertiesProvider
+{
+    public static final String MAX_SCANS_PER_SPLIT = "max_scans_per_split";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public PhoenixSessionProperties(PhoenixConfig phoenixConfig)
+    {
+        sessionProperties = ImmutableList.of(
+                integerProperty(
+                        MAX_SCANS_PER_SPLIT,
+                        "Maximum number of HBase scans per split",
+                        phoenixConfig.getMaxScansPerSplit(),
+                        PhoenixSessionProperties::validateScansPerSplit,
+                        false));
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    private static void validateScansPerSplit(int maxScansPerSplit)
+    {
+        if (maxScansPerSplit < 1) {
+            throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s must be greater than 0: %s", MAX_SCANS_PER_SPLIT, maxScansPerSplit));
+        }
+        if (maxScansPerSplit > PhoenixConfig.MAX_ALLOWED_SCANS_PER_SPLIT) {
+            throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s cannot exceed %s: %s", MAX_SCANS_PER_SPLIT, PhoenixConfig.MAX_ALLOWED_SCANS_PER_SPLIT, maxScansPerSplit));
+        }
+    }
+}

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixSplitManager.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.phoenix;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import io.airlift.log.Logger;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
@@ -87,7 +88,8 @@ public class PhoenixSplitManager
                     columns,
                     Optional.empty());
 
-            List<ConnectorSplit> splits = getSplits(inputQuery).stream()
+            int maxScansPerSplit = session.getProperty(PhoenixSessionProperties.MAX_SCANS_PER_SPLIT, Integer.class);
+            List<ConnectorSplit> splits = getSplits(inputQuery, maxScansPerSplit).stream()
                     .map(PhoenixInputSplit.class::cast)
                     .map(split -> new PhoenixSplit(
                             getSplitAddresses(split),
@@ -113,15 +115,15 @@ public class PhoenixSplitManager
         }
     }
 
-    private List<InputSplit> getSplits(PhoenixPreparedStatement inputQuery)
+    private List<InputSplit> getSplits(PhoenixPreparedStatement inputQuery, int maxScansPerSplit)
             throws IOException
     {
         QueryPlan queryPlan = phoenixClient.getQueryPlan(inputQuery);
-        return generateSplits(queryPlan, queryPlan.getSplits());
+        return generateSplits(queryPlan, queryPlan.getSplits(), maxScansPerSplit);
     }
 
     // mostly copied from PhoenixInputFormat, but without the region size calculations
-    private List<InputSplit> generateSplits(QueryPlan queryPlan, List<KeyRange> splits)
+    private List<InputSplit> generateSplits(QueryPlan queryPlan, List<KeyRange> splits, int maxScansPerSplit)
             throws IOException
     {
         requireNonNull(queryPlan, "queryPlan is null");
@@ -147,7 +149,14 @@ public class PhoenixSplitManager
                         log.debug("EXPECTED_UPPER_REGION_KEY[%d] : %s", i, Bytes.toStringBinary(scans.get(i).getAttribute(EXPECTED_UPPER_REGION_KEY)));
                     }
                 }
-                inputSplits.add(new PhoenixInputSplit(scans, regionSize, regionLocation));
+                /*
+                 * Handle parallel execution explicitly in Trino rather than internally in Phoenix.
+                 * Each split is handled by a single ConcatResultIterator
+                 * (See PhoenixClient.getResultSet(...))
+                 */
+                for (List<Scan> splitScans : Lists.partition(scans, maxScansPerSplit)) {
+                    inputSplits.add(new PhoenixInputSplit(splitScans, regionSize, regionLocation));
+                }
             }
             return inputSplits;
         }

--- a/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixConfig.java
+++ b/plugin/trino-phoenix/src/test/java/io/trino/plugin/phoenix/TestPhoenixConfig.java
@@ -32,7 +32,8 @@ public class TestPhoenixConfig
     {
         assertRecordedDefaults(recordDefaults(PhoenixConfig.class)
                 .setConnectionUrl(null)
-                .setResourceConfigFiles(""));
+                .setResourceConfigFiles("")
+                .setMaxScansPerSplit(20));
     }
 
     @Test
@@ -44,11 +45,13 @@ public class TestPhoenixConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("phoenix.connection-url", "jdbc:phoenix:localhost:2181:/hbase")
                 .put("phoenix.config.resources", configFile.toString())
+                .put("phoenix.max-scans-per-split", "1")
                 .build();
 
         PhoenixConfig expected = new PhoenixConfig()
                 .setConnectionUrl("jdbc:phoenix:localhost:2181:/hbase")
-                .setResourceConfigFiles(configFile.toString());
+                .setResourceConfigFiles(configFile.toString())
+                .setMaxScansPerSplit(1);
 
         assertFullMapping(properties, expected);
     }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -66,7 +66,6 @@ import org.apache.phoenix.iterate.LookAheadResultIterator;
 import org.apache.phoenix.iterate.MapReduceParallelScanGrouper;
 import org.apache.phoenix.iterate.PeekingResultIterator;
 import org.apache.phoenix.iterate.ResultIterator;
-import org.apache.phoenix.iterate.RoundRobinResultIterator;
 import org.apache.phoenix.iterate.SequenceResultIterator;
 import org.apache.phoenix.iterate.TableResultIterator;
 import org.apache.phoenix.jdbc.DelegatePreparedStatement;
@@ -767,7 +766,7 @@ public class PhoenixClient
                         MapReduceParallelScanGrouper.getInstance());
                 iterators.add(LookAheadResultIterator.wrap(tableResultIterator));
             }
-            ResultIterator iterator = queryPlan.useRoundRobinIterator() ? RoundRobinResultIterator.newIterator(iterators, queryPlan) : ConcatResultIterator.newIterator(iterators);
+            ResultIterator iterator = ConcatResultIterator.newIterator(iterators);
             if (context.getSequenceManager().getSequenceCount() > 0) {
                 iterator = new SequenceResultIterator(iterator, context.getSequenceManager());
             }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClientModule.java
@@ -89,6 +89,7 @@ public class PhoenixClientModule
         bindSessionPropertiesProvider(binder, TypeHandlingJdbcSessionProperties.class);
         bindSessionPropertiesProvider(binder, JdbcMetadataSessionProperties.class);
         bindSessionPropertiesProvider(binder, JdbcWriteSessionProperties.class);
+        bindSessionPropertiesProvider(binder, PhoenixSessionProperties.class);
 
         configBinder(binder).bindConfig(JdbcMetadataConfig.class);
         configBinder(binder).bindConfig(JdbcWriteConfig.class);

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConfig.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixConfig.java
@@ -16,16 +16,31 @@ package io.trino.plugin.phoenix5;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import io.airlift.configuration.Config;
+import io.airlift.configuration.ConfigDescription;
 import io.airlift.configuration.validation.FileExists;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.util.List;
 
 public class PhoenixConfig
 {
+    static final int MAX_ALLOWED_SCANS_PER_SPLIT = 1000;
+
     private String connectionUrl;
     private List<String> resourceConfigFiles = ImmutableList.of();
+
+    /*
+     * By default group at most 20 HBase scans into a single Split.
+     * There is at least one Split per HBase region, HBase's default region size is 20GB
+     * and Phoenix' default scan chunk size is 300MB.
+     * Any value between 10 and perhaps 30 is a good default. 20 is a good compromise allowing
+     * 3-4 parallel scans per region with all default settings.
+     * A large value here makes sense when the Guidepost-width in Phoenix has been reduced.
+     */
+    private int maxScansPerSplit = 20;
 
     @NotNull
     public String getConnectionUrl()
@@ -50,6 +65,21 @@ public class PhoenixConfig
     public PhoenixConfig setResourceConfigFiles(String files)
     {
         this.resourceConfigFiles = Splitter.on(',').trimResults().omitEmptyStrings().splitToList(files);
+        return this;
+    }
+
+    @Min(1)
+    @Max(MAX_ALLOWED_SCANS_PER_SPLIT)
+    public int getMaxScansPerSplit()
+    {
+        return maxScansPerSplit;
+    }
+
+    @Config("phoenix.max-scans-per-split")
+    @ConfigDescription("Maximum number of HBase scans that will be performed in a single split.")
+    public PhoenixConfig setMaxScansPerSplit(int scansPerSplit)
+    {
+        this.maxScansPerSplit = scansPerSplit;
         return this;
     }
 }

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSessionProperties.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSessionProperties.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.phoenix5;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.base.session.SessionPropertiesProvider;
+import io.trino.spi.TrinoException;
+import io.trino.spi.session.PropertyMetadata;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+import static io.trino.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static io.trino.spi.session.PropertyMetadata.integerProperty;
+import static java.lang.String.format;
+
+public final class PhoenixSessionProperties
+        implements SessionPropertiesProvider
+{
+    public static final String MAX_SCANS_PER_SPLIT = "max_scans_per_split";
+
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public PhoenixSessionProperties(PhoenixConfig phoenixConfig)
+    {
+        sessionProperties = ImmutableList.of(
+                integerProperty(
+                        MAX_SCANS_PER_SPLIT,
+                        "Maximum number of HBase scans per split",
+                        phoenixConfig.getMaxScansPerSplit(),
+                        PhoenixSessionProperties::validateScansPerSplit,
+                        false));
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    private static void validateScansPerSplit(int maxScansPerSplit)
+    {
+        if (maxScansPerSplit < 1) {
+            throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s must be greater than 0: %s", MAX_SCANS_PER_SPLIT, maxScansPerSplit));
+        }
+        if (maxScansPerSplit > PhoenixConfig.MAX_ALLOWED_SCANS_PER_SPLIT) {
+            throw new TrinoException(INVALID_SESSION_PROPERTY, format("%s cannot exceed %s: %s", MAX_SCANS_PER_SPLIT, PhoenixConfig.MAX_ALLOWED_SCANS_PER_SPLIT, maxScansPerSplit));
+        }
+    }
+}

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixSplitManager.java
@@ -14,6 +14,7 @@
 package io.trino.plugin.phoenix5;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import io.airlift.log.Logger;
 import io.trino.plugin.jdbc.JdbcColumnHandle;
 import io.trino.plugin.jdbc.JdbcTableHandle;
@@ -87,7 +88,8 @@ public class PhoenixSplitManager
                     columns,
                     Optional.empty());
 
-            List<ConnectorSplit> splits = getSplits(inputQuery).stream()
+            int maxScansPerSplit = session.getProperty(PhoenixSessionProperties.MAX_SCANS_PER_SPLIT, Integer.class);
+            List<ConnectorSplit> splits = getSplits(inputQuery, maxScansPerSplit).stream()
                     .map(PhoenixInputSplit.class::cast)
                     .map(split -> new PhoenixSplit(
                             getSplitAddresses(split),
@@ -113,15 +115,15 @@ public class PhoenixSplitManager
         }
     }
 
-    private List<InputSplit> getSplits(PhoenixPreparedStatement inputQuery)
+    private List<InputSplit> getSplits(PhoenixPreparedStatement inputQuery, int maxScansPerSplit)
             throws IOException
     {
         QueryPlan queryPlan = phoenixClient.getQueryPlan(inputQuery);
-        return generateSplits(queryPlan, queryPlan.getSplits());
+        return generateSplits(queryPlan, queryPlan.getSplits(), maxScansPerSplit);
     }
 
     // mostly copied from PhoenixInputFormat, but without the region size calculations
-    private List<InputSplit> generateSplits(QueryPlan queryPlan, List<KeyRange> splits)
+    private List<InputSplit> generateSplits(QueryPlan queryPlan, List<KeyRange> splits, int maxScansPerSplit)
             throws IOException
     {
         requireNonNull(queryPlan, "queryPlan is null");
@@ -147,7 +149,14 @@ public class PhoenixSplitManager
                         log.debug("EXPECTED_UPPER_REGION_KEY[%d] : %s", i, Bytes.toStringBinary(scans.get(i).getAttribute(EXPECTED_UPPER_REGION_KEY)));
                     }
                 }
-                inputSplits.add(new PhoenixInputSplit(scans, regionSize, regionLocation));
+                /*
+                 * Handle parallel execution explicitly in Trino rather than internally in Phoenix.
+                 * Each split is handled by a single ConcatResultIterator
+                 * (See PhoenixClient.getResultSet(...))
+                 */
+                for (List<Scan> splitScans : Lists.partition(scans, maxScansPerSplit)) {
+                    inputSplits.add(new PhoenixInputSplit(splitScans, regionSize, regionLocation));
+                }
             }
             return inputSplits;
         }

--- a/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConfig.java
+++ b/plugin/trino-phoenix5/src/test/java/io/trino/plugin/phoenix5/TestPhoenixConfig.java
@@ -32,7 +32,8 @@ public class TestPhoenixConfig
     {
         assertRecordedDefaults(recordDefaults(PhoenixConfig.class)
                 .setConnectionUrl(null)
-                .setResourceConfigFiles(""));
+                .setResourceConfigFiles("")
+                .setMaxScansPerSplit(20));
     }
 
     @Test
@@ -44,11 +45,13 @@ public class TestPhoenixConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("phoenix.connection-url", "jdbc:phoenix:localhost:2181:/hbase")
                 .put("phoenix.config.resources", configFile.toString())
+                .put("phoenix.max-scans-per-split", "1")
                 .build();
 
         PhoenixConfig expected = new PhoenixConfig()
                 .setConnectionUrl("jdbc:phoenix:localhost:2181:/hbase")
-                .setResourceConfigFiles(configFile.toString());
+                .setResourceConfigFiles(configFile.toString())
+                .setMaxScansPerSplit(1);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Fixes #10143

Remove Phoenix intra-split parallelism, which sometimes "uncontrollably" uses a lot of the heap, and generate more fine grained splits in Trino instead.

Why 20 scans per split? There is no right value. 20 is a good compromise. When Guideposts are enabled (default in "on" Phoenix with a width of 300mb), each split represents at most 6gb worth of scanned data.

This *is* configurable in Phoenix, but currently it does not make much sense in Phoenix to make the guideposts width larger, or reduce it below 100mb. So 20 is about right. Any number between 10 and 60 will do. (With 20gb and 300mb guideposts it does not make much sense to set this higher then 60).

When guideposts are disabled, there is one scan per region and this change does not affect anything.

I'd prefer this hardcoded to a reasonable value instead of added yet another config option.

