### PR TITLE
Make testShowSchemasLikeWithEscape more resilient

### DIFF
--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
@@ -44,7 +44,6 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 public abstract class AbstractTestQueries
@@ -304,7 +303,9 @@ public abstract class AbstractTestQueries
             Set<Object> allSchemas = computeActual("SHOW SCHEMAS").getOnlyColumnAsSet();
             assertEquals(allSchemas, computeActual("SHOW SCHEMAS LIKE '%_%'").getOnlyColumnAsSet());
             Set<Object> result = computeActual("SHOW SCHEMAS LIKE '%$_%' ESCAPE '$'").getOnlyColumnAsSet();
-            assertNotEquals(allSchemas, result);
+            assertThat(result)
+                    .isSubsetOf(allSchemas)
+                    .isNotEqualTo(allSchemas);
             assertThat(result).contains("information_schema").allMatch(schemaName -> ((String) schemaName).contains("_"));
         });
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestQueries.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.Set;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.connector.informationschema.InformationSchemaTable.INFORMATION_SCHEMA;
 import static io.trino.operator.scalar.ApplyFunction.APPLY_FUNCTION;
@@ -303,6 +304,8 @@ public abstract class AbstractTestQueries
             Set<Object> allSchemas = computeActual("SHOW SCHEMAS").getOnlyColumnAsSet();
             assertEquals(allSchemas, computeActual("SHOW SCHEMAS LIKE '%_%'").getOnlyColumnAsSet());
             Set<Object> result = computeActual("SHOW SCHEMAS LIKE '%$_%' ESCAPE '$'").getOnlyColumnAsSet();
+            verify(allSchemas.stream().anyMatch(schema -> ((String) schema).contains("_")),
+                    "This test expects at least one schema without underscore in it's name. Satisfy this assumption or override the test.");
             assertThat(result)
                     .isSubsetOf(allSchemas)
                     .isNotEqualTo(allSchemas);


### PR DESCRIPTION
The two commits propose alternative solutions. The first commit looks like it reduces test coverage so I prefer the 2nd one.