### PR TITLE
Implement flushing for partial TopNOperator

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -1633,9 +1633,16 @@ public class LocalExecutionPlanner
                     (int) node.getCount(),
                     sortChannels,
                     sortOrders,
-                    plannerContext.getTypeOperators());
+                    plannerContext.getTypeOperators(),
+                    getMaxPartialTopNMemorySize(node.getStep()));
 
             return new PhysicalOperation(operator, source.getLayout(), context, source);
+        }
+
+        private Optional<DataSize> getMaxPartialTopNMemorySize(TopNNode.Step step)
+        {
+            DataSize maxPartialTopNMemorySize = SystemSessionProperties.getMaxPartialTopNMemory(session);
+            return step == TopNNode.Step.PARTIAL && maxPartialTopNMemorySize.compareTo(DataSize.ofBytes(0)) > 0 ? Optional.of(maxPartialTopNMemorySize) : Optional.empty();
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkTopNOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkTopNOperator.java
@@ -38,6 +38,7 @@ import org.testng.annotations.Test;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -97,7 +98,8 @@ public class BenchmarkTopNOperator
                     Integer.valueOf(topN),
                     ImmutableList.of(0, 2),
                     ImmutableList.of(DESC_NULLS_LAST, ASC_NULLS_FIRST),
-                    new TypeOperators());
+                    new TypeOperators(),
+                    Optional.of(DataSize.of(16, DataSize.Unit.MEGABYTE)));
         }
 
         @TearDown

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/Top100Benchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/Top100Benchmark.java
@@ -14,6 +14,7 @@
 package io.trino.benchmark;
 
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
 import io.trino.operator.OperatorFactory;
 import io.trino.operator.TopNOperator;
 import io.trino.spi.type.Type;
@@ -21,6 +22,7 @@ import io.trino.sql.planner.plan.PlanNodeId;
 import io.trino.testing.LocalQueryRunner;
 
 import java.util.List;
+import java.util.Optional;
 
 import static io.trino.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_LAST;
@@ -45,7 +47,8 @@ public class Top100Benchmark
                 100,
                 ImmutableList.of(0),
                 ImmutableList.of(ASC_NULLS_LAST),
-                localQueryRunner.getTypeOperators());
+                localQueryRunner.getTypeOperators(),
+                Optional.of(DataSize.of(16, DataSize.Unit.MEGABYTE)));
         return ImmutableList.of(tableScanOperator, topNOperator);
     }
 

--- a/testing/trino-tests/src/test/java/io/trino/tests/TestPartialFlushingOrderByWithLimitQueries.java
+++ b/testing/trino-tests/src/test/java/io/trino/tests/TestPartialFlushingOrderByWithLimitQueries.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.tests;
+
+import io.trino.Session;
+import io.trino.SystemSessionProperties;
+import io.trino.plugin.tpch.TpchPlugin;
+import io.trino.testing.AbstractTestQueryFramework;
+import io.trino.testing.DistributedQueryRunner;
+import io.trino.testing.QueryRunner;
+import org.testng.annotations.Test;
+
+import static io.trino.plugin.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static io.trino.testing.TestingSession.testSessionBuilder;
+
+public class TestPartialFlushingOrderByWithLimitQueries
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session defaultSession = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema(TINY_SCHEMA_NAME)
+                .setSystemProperty(SystemSessionProperties.TASK_CONCURRENCY, "2")
+                .setSystemProperty(SystemSessionProperties.MAX_PARTIAL_TOP_N_MEMORY, "1B")
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(defaultSession)
+                .setNodeCount(2)
+                .build();
+
+        try {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch");
+            return queryRunner;
+        }
+        catch (Exception e) {
+            queryRunner.close();
+            throw e;
+        }
+    }
+
+    @Test
+    public void testOrderByLimit()
+    {
+        assertQueryOrdered("SELECT custkey, orderstatus FROM orders ORDER BY orderkey DESC LIMIT 10");
+        assertQueryOrdered("SELECT custkey, orderstatus FROM orders ORDER BY orderkey + 1 DESC LIMIT 10");
+        assertQuery("SELECT custkey, totalprice FROM orders ORDER BY orderkey LIMIT 0");
+    }
+
+    @Test
+    public void testOrderByLimitAll()
+    {
+        assertQuery("SELECT custkey, totalprice FROM orders ORDER BY orderkey LIMIT ALL", "SELECT custkey, totalprice FROM orders ORDER BY orderkey");
+    }
+
+    @Test
+    public void testOrderByWithSimilarExpressions()
+    {
+        assertQuery(
+                "WITH t AS (SELECT 1 x, 2 y) SELECT x, y FROM t ORDER BY x, y",
+                "SELECT 1, 2");
+        assertQuery(
+                "WITH t AS (SELECT 1 x, 2 y) SELECT x, y FROM t ORDER BY x, y LIMIT 1",
+                "SELECT 1, 2");
+        assertQuery(
+                "WITH t AS (SELECT 1 x, 1 y) SELECT x, y FROM t ORDER BY x, y LIMIT 1",
+                "SELECT 1, 1");
+        assertQuery(
+                "WITH t AS (SELECT orderkey x, orderkey y FROM orders) SELECT x, y FROM t ORDER BY x, y LIMIT 1",
+                "SELECT 1, 1");
+        assertQuery(
+                "WITH t AS (SELECT orderkey x, orderkey y FROM orders) SELECT x, y FROM t ORDER BY x, y DESC LIMIT 1",
+                "SELECT 1, 1");
+        assertQuery(
+                "WITH t AS (SELECT orderkey x, totalprice y, orderkey z FROM orders) SELECT x, y, z FROM t ORDER BY x, y, z LIMIT 1",
+                "SELECT 1, 172799.49, 1");
+    }
+}


### PR DESCRIPTION
It will prevent accumulating too many rows in partial TopNOperator.
So, it mitigates memory pressures in a cluster and results in less exceeding memory limit errors.