### PR TITLE
Migrate deprecated QueryAssert.assertThat method calls

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestCreateDropView.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestCreateDropView.java
@@ -18,6 +18,7 @@ import io.trino.tempto.Requires;
 import io.trino.tempto.fulfillment.table.hive.tpch.ImmutableTpchTablesRequirements.ImmutableNationTable;
 import org.testng.annotations.Test;
 
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.context.ContextDsl.executeWith;
 import static io.trino.tempto.query.QueryExecutor.query;
@@ -72,8 +73,8 @@ public class TestCreateDropView
     public void createSimpleViewTwiceShouldFail()
     {
         executeWith(createViewAs("SELECT * FROM nation"), view -> {
-            assertThat(() -> query(format("CREATE VIEW %s AS SELECT * FROM nation", view.getName())))
-                    .failsWithMessage("View already exists");
+            assertQueryFailure(() -> query(format("CREATE VIEW %s AS SELECT * FROM nation", view.getName())))
+                    .hasMessageContaining("View already exists");
             assertThat(query(format("SELECT * FROM %s", view.getName())))
                     .hasRowsCount(25);
         });
@@ -87,8 +88,8 @@ public class TestCreateDropView
                     .hasRowsCount(25);
             assertThat(query(format("DROP VIEW %s", view.getName())))
                     .hasRowsCount(1);
-            assertThat(() -> query(format("SELECT * FROM %s", view.getName())))
-                    .failsWithMessage("does not exist");
+            assertQueryFailure(() -> query(format("SELECT * FROM %s", view.getName())))
+                    .hasMessageContaining("does not exist");
         });
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSqlCancel.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestSqlCancel.java
@@ -43,6 +43,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static io.airlift.http.client.Request.Builder.prepareDelete;
 import static io.airlift.http.client.ResponseHandlerUtils.propagate;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.CANCEL_QUERY;
@@ -89,8 +90,8 @@ public class TestSqlCancel
         String sql = format("CREATE TABLE %s AS SELECT * FROM tpch.sf1.lineitem", tableName);
 
         runAndCancelQuery(sql);
-        assertThat(() -> query("SELECT * from " + tableName))
-                .failsWithMessage(format("Table 'hive.default.%s' does not exist", tableName));
+        assertQueryFailure(() -> query("SELECT * from " + tableName))
+                .hasMessageContaining("Table 'hive.default.%s' does not exist", tableName);
     }
 
     @Test(groups = CANCEL_QUERY, timeOut = 60_000L)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestInsertIntoCassandraTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestInsertIntoCassandraTable.java
@@ -179,8 +179,8 @@ public class TestInsertIntoCassandraTable
         onCasssandra(format("CREATE TABLE %s.%s (key int, value frozen<tuple<int, text, float>>, PRIMARY KEY (key))",
                  KEY_SPACE, tableName));
 
-        assertThat(() -> query(format("INSERT INTO %s.%s.%s (key, value) VALUES (1, ROW(1, 'text-1', 1.11))", CONNECTOR_NAME, KEY_SPACE, tableName)))
-                .failsWithMessage("Unsupported column type: row(integer, varchar, real)");
+        assertQueryFailure(() -> query(format("INSERT INTO %s.%s.%s (key, value) VALUES (1, ROW(1, 'text-1', 1.11))", CONNECTOR_NAME, KEY_SPACE, tableName)))
+                .hasMessageContaining("Unsupported column type: row(integer, varchar, real)");
 
         onCasssandra(format("DROP TABLE IF EXISTS %s.%s", KEY_SPACE, tableName));
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestInvalidSelect.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/cassandra/TestInvalidSelect.java
@@ -19,7 +19,7 @@ import io.trino.tempto.RequirementsProvider;
 import io.trino.tempto.configuration.Configuration;
 import org.testng.annotations.Test;
 
-import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.CASSANDRA;
@@ -43,23 +43,23 @@ public class TestInvalidSelect
     public void testInvalidTable()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, KEY_SPACE, "bogus");
-        assertThat(() -> query(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage(format("Table '%s' does not exist", tableName));
+        assertQueryFailure(() -> query(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining(format("Table '%s' does not exist", tableName));
     }
 
     @Test(groups = {CASSANDRA, PROFILE_SPECIFIC_TESTS})
     public void testInvalidSchema()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, "does_not_exist", "bogus");
-        assertThat(() -> query(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage("Schema 'does_not_exist' does not exist");
+        assertQueryFailure(() -> query(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining("Schema 'does_not_exist' does not exist");
     }
 
     @Test(groups = {CASSANDRA, PROFILE_SPECIFIC_TESTS})
     public void testInvalidColumn()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, KEY_SPACE, CASSANDRA_NATION.getName());
-        assertThat(() -> query(format("SELECT bogus FROM %s", tableName)))
-                .failsWithMessage("Column 'bogus' cannot be resolved");
+        assertQueryFailure(() -> query(format("SELECT bogus FROM %s", tableName)))
+                .hasMessageContaining("Column 'bogus' cannot be resolved");
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveDeltaLakeTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveDeltaLakeTable.java
@@ -15,7 +15,7 @@ package io.trino.tests.product.hive;
 
 import org.testng.annotations.Test;
 
-import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 
@@ -31,7 +31,7 @@ public class TestHiveDeltaLakeTable
                 "CREATE TABLE test_delta_lake_table (ignored int) " +
                 "TBLPROPERTIES ('spark.sql.sources.provider'='DELTA')");
 
-        assertThat(() -> onTrino().executeQuery("SELECT * FROM test_delta_lake_table")).failsWithMessage("Cannot query Delta Lake table");
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM test_delta_lake_table")).hasMessageContaining("Cannot query Delta Lake table");
 
         onHive().executeQuery("DROP TABLE test_delta_lake_table");
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViewCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveViewCompatibility.java
@@ -22,6 +22,7 @@ import org.testng.annotations.Test;
 import java.util.function.Consumer;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.HIVE_VIEW_COMPATIBILITY;
@@ -69,8 +70,8 @@ public class TestHiveViewCompatibility
         onCompatibilityTestServer().executeQuery("DROP VIEW IF EXISTS hive_duplicate_view");
         onCompatibilityTestServer().executeQuery("CREATE VIEW hive_duplicate_view AS SELECT * FROM nation");
 
-        assertThat(() -> query("CREATE VIEW hive_duplicate_view AS SELECT * FROM nation"))
-                .failsWithMessage("View already exists");
+        assertQueryFailure(() -> query("CREATE VIEW hive_duplicate_view AS SELECT * FROM nation"))
+                .hasMessageContaining("View already exists");
     }
 
     protected static void assertViewQuery(QueryExecutor queryExecutor, String query, Consumer<QueryAssert> assertion)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSqlStandardAccessControlChecks.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSqlStandardAccessControlChecks.java
@@ -18,6 +18,7 @@ import io.trino.tempto.ProductTest;
 import io.trino.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
 
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.AUTHORIZATION;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
@@ -53,14 +54,14 @@ public class TestSqlStandardAccessControlChecks
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlSelect()
     {
-        assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining("Access Denied: Cannot select from table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO bob", tableName));
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
 
-        assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", viewName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
+                .hasMessageContaining("Access Denied: Cannot select from table default.%s", viewName);
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO bob", viewName));
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", viewName))).hasNoRows();
     }
@@ -68,8 +69,8 @@ public class TestSqlStandardAccessControlChecks
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlSelectFromPartitions()
     {
-        assertThat(() -> bobExecutor.executeQuery(format("SELECT * FROM \"%s$partitions\"", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s$partitions", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("SELECT * FROM \"%s$partitions\"", tableName)))
+                .hasMessageContaining("Access Denied: Cannot select from table default.%s$partitions", tableName);
 
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO bob", tableName));
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM \"%s$partitions\"", tableName))).hasNoRows();
@@ -78,8 +79,8 @@ public class TestSqlStandardAccessControlChecks
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlInsert()
     {
-        assertThat(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot insert into table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName)))
+                .hasMessageContaining("Access Denied: Cannot insert into table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("GRANT INSERT ON %s TO bob", tableName));
         assertThat(bobExecutor.executeQuery(format("INSERT INTO %s VALUES (3, 22)", tableName))).hasRowsCount(1);
@@ -89,16 +90,16 @@ public class TestSqlStandardAccessControlChecks
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlUpdate()
     {
-        assertThat(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot update columns [month, day] in table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))
+                .hasMessageContaining("Access Denied: Cannot update columns [month, day] in table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("GRANT INSERT ON %s TO bob", tableName));
-        assertThat(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot update columns [month, day] in table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))
+                .hasMessageContaining("Access Denied: Cannot update columns [month, day] in table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("GRANT UPDATE ON %s TO bob", tableName));
-        assertThat(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))
-                .failsWithMessage("Hive update is only supported for ACID transactional tables");
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))
+                .hasMessageContaining("Hive update is only supported for ACID transactional tables");
     }
 
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
@@ -106,8 +107,8 @@ public class TestSqlStandardAccessControlChecks
     {
         aliceExecutor.executeQuery(format("INSERT INTO %s VALUES (4, 13)", tableName));
         assertThat(aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasRowsCount(1);
-        assertThat(() -> bobExecutor.executeQuery(format("DELETE FROM %s WHERE day=4", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot delete from table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("DELETE FROM %s WHERE day=4", tableName)))
+                .hasMessageContaining("Access Denied: Cannot delete from table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("GRANT DELETE ON %s TO bob", tableName));
         bobExecutor.executeQuery(format("DELETE FROM %s", tableName));
@@ -120,8 +121,8 @@ public class TestSqlStandardAccessControlChecks
         String createTableAsSelect = "bob_create_table_as_select";
 
         bobExecutor.executeQuery("DROP TABLE IF EXISTS " + createTableAsSelect);
-        assertThat(() -> bobExecutor.executeQuery(format("CREATE TABLE %s AS SELECT * FROM %s", createTableAsSelect, tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("CREATE TABLE %s AS SELECT * FROM %s", createTableAsSelect, tableName)))
+                .hasMessageContaining("Access Denied: Cannot select from table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO bob", tableName));
         bobExecutor.executeQuery(format("CREATE TABLE %s AS SELECT * FROM %s", createTableAsSelect, tableName));
@@ -132,20 +133,20 @@ public class TestSqlStandardAccessControlChecks
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlDropTable()
     {
-        assertThat(() -> bobExecutor.executeQuery(format("DROP TABLE %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot drop table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("DROP TABLE %s", tableName)))
+                .hasMessageContaining("Access Denied: Cannot drop table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("DROP TABLE %s", tableName));
-        assertThat(() -> aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage("does not exist");
+        assertQueryFailure(() -> aliceExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining("does not exist");
     }
 
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlAlterTable()
     {
         assertThat(aliceExecutor.executeQuery(format("SHOW COLUMNS FROM %s", tableName))).hasRowsCount(2);
-        assertThat(() -> bobExecutor.executeQuery(format("ALTER TABLE %s ADD COLUMN year bigint", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot add a column to table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("ALTER TABLE %s ADD COLUMN year bigint", tableName)))
+                .hasMessageContaining("Access Denied: Cannot add a column to table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("ALTER TABLE %s ADD COLUMN year bigint", tableName));
         assertThat(aliceExecutor.executeQuery(format("SHOW COLUMNS FROM %s", tableName))).hasRowsCount(3);
@@ -162,8 +163,8 @@ public class TestSqlStandardAccessControlChecks
 
         // Bob needs SELECT on the table to create the view
         bobExecutor.executeQuery("DROP VIEW IF EXISTS " + viewName);
-        assertThat(() -> bobExecutor.executeQuery(createViewSql))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(createViewSql))
+                .hasMessageContaining("Access Denied: Cannot select from table default.%s", tableName);
 
         // Give Bob access to table, then create and execute view
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO bob", tableName));
@@ -171,13 +172,13 @@ public class TestSqlStandardAccessControlChecks
         assertThat(bobExecutor.executeQuery(format("SELECT * FROM %s", viewName))).hasNoRows();
 
         // Verify that Charlie does not have SELECT on the view, then grant access
-        assertThat(() -> charlieExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", viewName));
+        assertQueryFailure(() -> charlieExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
+                .hasMessageContaining("Access Denied: Cannot select from table default.%s", viewName);
         bobExecutor.executeQuery(format("GRANT SELECT ON %s TO charlie", viewName));
 
         // Charlie still cannot access view because Bob does not have SELECT WITH GRANT OPTION
-        assertThat(() -> charlieExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
-                .failsWithMessage(format("Access Denied: View owner does not have sufficient privileges: View owner 'bob' cannot create view that selects from default.%s", tableName));
+        assertQueryFailure(() -> charlieExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
+                .hasMessageContaining("Access Denied: View owner does not have sufficient privileges: View owner 'bob' cannot create view that selects from default.%s", tableName);
 
         // Give Bob SELECT WITH GRANT OPTION on the underlying table
         aliceExecutor.executeQuery(format("REVOKE SELECT ON %s FROM bob", tableName));
@@ -197,32 +198,32 @@ public class TestSqlStandardAccessControlChecks
 
         aliceExecutor.executeQuery("DROP VIEW IF EXISTS " + viewName);
         aliceExecutor.executeQuery(format("CREATE VIEW %s AS SELECT * FROM %s", viewName, tableName));
-        assertThat(() -> bobExecutor.executeQuery(format("DROP VIEW %s", viewName)))
-                .failsWithMessage(format("Access Denied: Cannot drop view default.%s", viewName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("DROP VIEW %s", viewName)))
+                .hasMessageContaining("Access Denied: Cannot drop view default.%s", viewName);
 
         aliceExecutor.executeQuery(format("DROP VIEW %s", viewName));
-        assertThat(() -> aliceExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
-                .failsWithMessage("does not exist");
+        assertQueryFailure(() -> aliceExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
+                .hasMessageContaining("does not exist");
     }
 
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlSelectWithCaseSensitiveUserName()
     {
-        assertThat(() -> caseSensitiveUserNameExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> caseSensitiveUserNameExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining("Access Denied: Cannot select from table default.%s", tableName);
 
         onHive().executeQuery("SET ROLE admin");
 
         // make sure that case matters
         onHive().executeQuery(format("GRANT SELECT ON TABLE %s TO USER casesensitiveusername", tableName));
-        assertThat(() -> caseSensitiveUserNameExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> caseSensitiveUserNameExecutor.executeQuery(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining("Access Denied: Cannot select from table default.%s", tableName);
 
         onHive().executeQuery(format("GRANT SELECT ON TABLE %s TO USER CaseSensitiveUserName", tableName));
         assertThat(caseSensitiveUserNameExecutor.executeQuery(format("SELECT * FROM %s", tableName))).hasNoRows();
 
-        assertThat(() -> caseSensitiveUserNameExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", viewName));
+        assertQueryFailure(() -> caseSensitiveUserNameExecutor.executeQuery(format("SELECT * FROM %s", viewName)))
+                .hasMessageContaining("Access Denied: Cannot select from table default.%s", viewName);
         onHive().executeQuery(format("GRANT SELECT ON TABLE %s TO USER CaseSensitiveUserName", viewName));
         assertThat(caseSensitiveUserNameExecutor.executeQuery(format("SELECT * FROM %s", viewName))).hasNoRows();
     }
@@ -230,8 +231,8 @@ public class TestSqlStandardAccessControlChecks
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlSetTableAuthorization()
     {
-        assertThat(() -> bobExecutor.executeQuery(format("ALTER TABLE %s SET AUTHORIZATION bob", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot set authorization for table default.%s to USER bob", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("ALTER TABLE %s SET AUTHORIZATION bob", tableName)))
+                .hasMessageContaining("Access Denied: Cannot set authorization for table default.%s to USER bob", tableName);
         aliceExecutor.executeQuery(format("ALTER TABLE %s SET AUTHORIZATION bob", tableName));
         bobExecutor.executeQuery(format("ALTER TABLE %s SET AUTHORIZATION alice", tableName));
     }
@@ -239,10 +240,10 @@ public class TestSqlStandardAccessControlChecks
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlSetViewAuthorization()
     {
-        assertThat(() -> bobExecutor.executeQuery(format("ALTER VIEW %s SET AUTHORIZATION bob", viewName)))
-                .failsWithMessage(format("Access Denied: Cannot set authorization for view default.%s to USER bob", viewName));
-        assertThat(() -> bobExecutor.executeQuery(format("DROP VIEW %s", viewName)))
-                .failsWithMessage(format("Access Denied: Cannot drop view default.%s", viewName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("ALTER VIEW %s SET AUTHORIZATION bob", viewName)))
+                .hasMessageContaining("Access Denied: Cannot set authorization for view default.%s to USER bob", viewName);
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("DROP VIEW %s", viewName)))
+                .hasMessageContaining("Access Denied: Cannot drop view default.%s", viewName);
 
         aliceExecutor.executeQuery(format("ALTER VIEW %s SET AUTHORIZATION bob", viewName));
         bobExecutor.executeQuery(format("DROP VIEW %s", viewName));
@@ -256,10 +257,10 @@ public class TestSqlStandardAccessControlChecks
 
         QueryExecutor hdfsExecutor = connectToPresto("hdfs@presto");
 
-        assertThat(() -> bobExecutor.executeQuery("ALTER VIEW test_hive_view SET AUTHORIZATION bob"))
-                .failsWithMessage("Access Denied: Cannot set authorization for view default.test_hive_view to USER bob");
-        assertThat(() -> bobExecutor.executeQuery("DROP VIEW test_hive_view"))
-                .failsWithMessage("Access Denied: Cannot drop view default.test_hive_view");
+        assertQueryFailure(() -> bobExecutor.executeQuery("ALTER VIEW test_hive_view SET AUTHORIZATION bob"))
+                .hasMessageContaining("Access Denied: Cannot set authorization for view default.test_hive_view to USER bob");
+        assertQueryFailure(() -> bobExecutor.executeQuery("DROP VIEW test_hive_view"))
+                .hasMessageContaining("Access Denied: Cannot drop view default.test_hive_view");
 
         hdfsExecutor.executeQuery("ALTER VIEW test_hive_view SET AUTHORIZATION bob");
         bobExecutor.executeQuery("DROP VIEW test_hive_view");
@@ -270,8 +271,8 @@ public class TestSqlStandardAccessControlChecks
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlShowColumns()
     {
-        assertThat(() -> bobExecutor.executeQuery(format("SHOW COLUMNS FROM %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot show columns of table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("SHOW COLUMNS FROM %s", tableName)))
+                .hasMessageContaining("Access Denied: Cannot show columns of table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO bob", tableName));
         assertThat(bobExecutor.executeQuery(format("SHOW COLUMNS FROM %s", tableName))).hasRowsCount(2);
@@ -280,8 +281,8 @@ public class TestSqlStandardAccessControlChecks
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlShowStatsFor()
     {
-        assertThat(() -> bobExecutor.executeQuery(format("SHOW STATS FOR %s", tableName)))
-                .failsWithMessage(format("Access Denied: Cannot select from table default.%s", tableName));
+        assertQueryFailure(() -> bobExecutor.executeQuery(format("SHOW STATS FOR %s", tableName)))
+                .hasMessageContaining("Access Denied: Cannot select from table default.%s", tableName);
 
         aliceExecutor.executeQuery(format("GRANT SELECT ON %s TO bob", tableName));
         assertThat(bobExecutor.executeQuery(format("SHOW STATS FOR %s", tableName))).hasRowsCount(3);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/BaseLdapJdbcTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/BaseLdapJdbcTest.java
@@ -87,7 +87,7 @@ public abstract class BaseLdapJdbcTest
     {
         assertThatThrownBy(() -> executeLdapQuery(NATION_SELECT_ALL_QUERY, user, password))
                 .isInstanceOf(SQLException.class)
-                .hasMessage(message);
+                .hasMessageContaining(message);
     }
 
     protected QueryResult executeLdapQuery(String query, String name, String password)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestLdapTrinoJdbc.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/jdbc/TestLdapTrinoJdbc.java
@@ -130,7 +130,7 @@ public class TestLdapTrinoJdbc
     {
         assertThatThrownBy(() -> DriverManager.getConnection("jdbc:trino://" + prestoServer(), ldapUserName, ldapUserPassword))
                 .isInstanceOf(SQLException.class)
-                .hasMessage("Authentication using username/password requires SSL to be enabled");
+                .hasMessageContaining("Authentication using username/password requires SSL to be enabled");
     }
 
     @Test(groups = {LDAP, TRINO_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)
@@ -139,7 +139,7 @@ public class TestLdapTrinoJdbc
         String url = format("jdbc:trino://%s?SSL=true&SSLTrustStorePath=%s&SSLTrustStorePassword=%s", prestoServer(), ldapTruststorePath, "wrong_password");
         assertThatThrownBy(() -> DriverManager.getConnection(url, ldapUserName, ldapUserPassword))
                 .isInstanceOf(SQLException.class)
-                .hasMessage("Error setting up SSL: keystore password was incorrect");
+                .hasMessageContaining("Error setting up SSL: keystore password was incorrect");
     }
 
     @Test(groups = {LDAP, TRINO_JDBC, PROFILE_SPECIFIC_TESTS}, timeOut = TIMEOUT)

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/sqlserver/TestInvalidSelect.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/sqlserver/TestInvalidSelect.java
@@ -19,7 +19,7 @@ import io.trino.tempto.RequirementsProvider;
 import io.trino.tempto.configuration.Configuration;
 import org.testng.annotations.Test;
 
-import static io.trino.tempto.assertions.QueryAssert.assertThat;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
@@ -43,23 +43,23 @@ public class TestInvalidSelect
     public void testNonExistentTable()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, KEY_SPACE, "bogus");
-        assertThat(() -> query(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage(format("Table '%s' does not exist", tableName));
+        assertQueryFailure(() -> query(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining("Table '%s' does not exist", tableName);
     }
 
     @Test(groups = {SQL_SERVER, PROFILE_SPECIFIC_TESTS})
     public void testNonExistentSchema()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, "does_not_exist", "bogus");
-        assertThat(() -> query(format("SELECT * FROM %s", tableName)))
-                .failsWithMessage("Schema 'does_not_exist' does not exist");
+        assertQueryFailure(() -> query(format("SELECT * FROM %s", tableName)))
+                .hasMessageContaining("Schema 'does_not_exist' does not exist");
     }
 
     @Test(groups = {SQL_SERVER, PROFILE_SPECIFIC_TESTS})
     public void testNonExistentColumn()
     {
         String tableName = format("%s.%s.%s", CONNECTOR_NAME, KEY_SPACE, NATION.getName());
-        assertThat(() -> query(format("SELECT bogus FROM %s", tableName)))
-                .failsWithMessage("Column 'bogus' cannot be resolved");
+        assertQueryFailure(() -> query(format("SELECT bogus FROM %s", tableName)))
+                .hasMessageContaining("Column 'bogus' cannot be resolved");
     }
 }


### PR DESCRIPTION
The method `io.trino.tempto.assertions.QueryAssert.assertThat(io.trino.tempto.query.QueryResult)`
has been marked as deprecated.
The usages of this method in the code base were replaced with
calls to `io.trino.tempto.assertions.QueryAssert.assertThat(io.trino.tempto.query.QueryResult)`