### PR TITLE
Allow to specify the STS endpoint for hive connector on S3

### DIFF
--- a/docs/src/main/sphinx/connector/hive-s3.rst
+++ b/docs/src/main/sphinx/connector/hive-s3.rst
@@ -108,6 +108,12 @@ Property Name                                Description
 ``hive.s3.proxy.preemptive-basic-auth``      Whether to attempt to authenticate preemptively against proxy
                                              when using base authorization, defaults to ``false``.
 
+``hive.s3.sts.endpoint``                     Optional override for the sts endpoint given that IAM role based
+                                             authentication via sts is used.
+
+``hive.s3.sts.region``                       Optional override for the sts region given that IAM role based
+                                             authentication via sts is used.
+
 ============================================ =================================================================
 
 .. _hive-s3-credentials:

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Config.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/HiveS3Config.java
@@ -79,6 +79,8 @@ public class HiveS3Config
     private String s3proxyUsername;
     private String s3proxyPassword;
     private boolean s3preemptiveBasicProxyAuth;
+    private String s3StsEndpoint;
+    private String s3StsRegion;
 
     public String getS3AwsAccessKey()
     {
@@ -588,6 +590,30 @@ public class HiveS3Config
     public HiveS3Config setS3PreemptiveBasicProxyAuth(boolean s3preemptiveBasicProxyAuth)
     {
         this.s3preemptiveBasicProxyAuth = s3preemptiveBasicProxyAuth;
+        return this;
+    }
+
+    public String getS3StsEndpoint()
+    {
+        return s3StsEndpoint;
+    }
+
+    @Config("hive.s3.sts.endpoint")
+    public HiveS3Config setS3StsEndpoint(String s3StsEndpoint)
+    {
+        this.s3StsEndpoint = s3StsEndpoint;
+        return this;
+    }
+
+    public String getS3StsRegion()
+    {
+        return s3StsRegion;
+    }
+
+    @Config("hive.s3.sts.region")
+    public HiveS3Config setS3StsRegion(String s3StsRegion)
+    {
+        this.s3StsRegion = s3StsRegion;
         return this;
     }
 }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3ConfigurationInitializer.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/s3/TrinoS3ConfigurationInitializer.java
@@ -61,6 +61,8 @@ import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STAGING_DIRECTORY;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STORAGE_CLASS;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STREAMING_UPLOAD_ENABLED;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STREAMING_UPLOAD_PART_SIZE;
+import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STS_ENDPOINT;
+import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_STS_REGION;
 import static io.trino.plugin.hive.s3.TrinoS3FileSystem.S3_USER_AGENT_PREFIX;
 import static java.util.stream.Collectors.joining;
 
@@ -106,6 +108,8 @@ public class TrinoS3ConfigurationInitializer
     private final String s3proxyUsername;
     private final String s3proxyPassword;
     private final boolean s3preemptiveBasicProxyAuth;
+    private final String s3StsEndpoint;
+    private final String s3StsRegion;
 
     @Inject
     public TrinoS3ConfigurationInitializer(HiveS3Config config)
@@ -149,6 +153,8 @@ public class TrinoS3ConfigurationInitializer
         this.s3proxyUsername = config.getS3ProxyUsername();
         this.s3proxyPassword = config.getS3ProxyPassword();
         this.s3preemptiveBasicProxyAuth = config.getS3PreemptiveBasicProxyAuth();
+        this.s3StsEndpoint = config.getS3StsEndpoint();
+        this.s3StsRegion = config.getS3StsRegion();
     }
 
     @Override
@@ -230,5 +236,11 @@ public class TrinoS3ConfigurationInitializer
             config.set(S3_PROXY_PASSWORD, s3proxyPassword);
         }
         config.setBoolean(S3_PREEMPTIVE_BASIC_PROXY_AUTH, s3preemptiveBasicProxyAuth);
+        if (s3StsEndpoint != null) {
+            config.set(S3_STS_ENDPOINT, s3StsEndpoint);
+        }
+        if (s3StsRegion != null) {
+            config.set(S3_STS_REGION, s3StsRegion);
+        }
     }
 }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestHiveS3Config.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/s3/TestHiveS3Config.java
@@ -76,7 +76,9 @@ public class TestHiveS3Config
                 .setS3NonProxyHosts(ImmutableList.of())
                 .setS3ProxyUsername(null)
                 .setS3ProxyPassword(null)
-                .setS3PreemptiveBasicProxyAuth(false));
+                .setS3PreemptiveBasicProxyAuth(false)
+                .setS3StsEndpoint(null)
+                .setS3StsRegion(null));
     }
 
     @Test
@@ -125,6 +127,8 @@ public class TestHiveS3Config
                 .put("hive.s3.proxy.username", "test")
                 .put("hive.s3.proxy.password", "test")
                 .put("hive.s3.proxy.preemptive-basic-auth", "true")
+                .put("hive.s3.sts.endpoint", "http://minio:9000")
+                .put("hive.s3.sts.region", "eu-central-1")
                 .buildOrThrow();
 
         HiveS3Config expected = new HiveS3Config()
@@ -166,7 +170,9 @@ public class TestHiveS3Config
                 .setS3NonProxyHosts(ImmutableList.of("test", "test2", "test3"))
                 .setS3ProxyUsername("test")
                 .setS3ProxyPassword("test")
-                .setS3PreemptiveBasicProxyAuth(true);
+                .setS3PreemptiveBasicProxyAuth(true)
+                .setS3StsEndpoint("http://minio:9000")
+                .setS3StsRegion("eu-central-1");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
## Description

Allow to specify the STS endpoint for hive connector on S3

> Is this change a fix, improvement, new feature, refactoring, or other?

Improvement.

> Is this a change to the core query engine, a connector, client library, or the SPI interfaces? (be specific)

Hive/Iceberg/Delta connectors

> How would you describe this change to a non-technical end user or system administrator?

Allow to specify the STS endpoint for hive connector on S3

## Documentation

(x) No documentation is needed.
( ) Sufficient documentation is included in this PR.
( ) Documentation PR is available with #prnumber.
( ) Documentation issue #issuenumber is filed, and can be handled later.

## Release notes

() No release notes entries required.
(x) Release notes entries required with the following suggested text:

```markdown
# Hive/Iceberg/Delta connectors
* Allow specifying STS endpoint to be used when connecting to S3. ({issue}`10169`)
```
