### PR TITLE
Test and fix casts from exact numeric types to varchar

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/IntegerOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/IntegerOperators.java
@@ -17,6 +17,7 @@ import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
 import io.trino.spi.TrinoException;
+import io.trino.spi.function.LiteralParameter;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
@@ -24,6 +25,7 @@ import io.trino.spi.type.StandardTypes;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.CAST;
@@ -167,10 +169,16 @@ public final class IntegerOperators
     @ScalarOperator(CAST)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
-    public static Slice castToVarchar(@SqlType(StandardTypes.INTEGER) long value)
+    public static Slice castToVarchar(@LiteralParameter("x") long x, @SqlType(StandardTypes.INTEGER) long value)
     {
         // todo optimize me
-        return utf8Slice(String.valueOf(value));
+        String stringValue = String.valueOf(value);
+        // String is all-ASCII, so String.length() here returns actual code points count
+        if (stringValue.length() <= x) {
+            return utf8Slice(stringValue);
+        }
+
+        throw new TrinoException(INVALID_CAST_ARGUMENT, format("Value %s cannot be represented as varchar(%s)", value, x));
     }
 
     @ScalarOperator(SATURATED_FLOOR_CAST)

--- a/core/trino-main/src/main/java/io/trino/type/SmallintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/SmallintOperators.java
@@ -17,6 +17,7 @@ import com.google.common.primitives.Shorts;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
 import io.trino.spi.TrinoException;
+import io.trino.spi.function.LiteralParameter;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
@@ -24,6 +25,7 @@ import io.trino.spi.type.StandardTypes;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.CAST;
@@ -162,10 +164,16 @@ public final class SmallintOperators
     @ScalarOperator(CAST)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
-    public static Slice castToVarchar(@SqlType(StandardTypes.SMALLINT) long value)
+    public static Slice castToVarchar(@LiteralParameter("x") long x, @SqlType(StandardTypes.SMALLINT) long value)
     {
         // todo optimize me
-        return utf8Slice(String.valueOf(value));
+        String stringValue = String.valueOf(value);
+        // String is all-ASCII, so String.length() here returns actual code points count
+        if (stringValue.length() <= x) {
+            return utf8Slice(stringValue);
+        }
+
+        throw new TrinoException(INVALID_CAST_ARGUMENT, format("Value %s cannot be represented as varchar(%s)", value, x));
     }
 
     @ScalarOperator(SATURATED_FLOOR_CAST)

--- a/core/trino-main/src/main/java/io/trino/type/TinyintOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/TinyintOperators.java
@@ -16,6 +16,7 @@ package io.trino.type;
 import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
 import io.trino.spi.TrinoException;
+import io.trino.spi.function.LiteralParameter;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
@@ -23,6 +24,7 @@ import io.trino.spi.type.StandardTypes;
 
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.spi.StandardErrorCode.DIVISION_BY_ZERO;
+import static io.trino.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 import static io.trino.spi.StandardErrorCode.NUMERIC_VALUE_OUT_OF_RANGE;
 import static io.trino.spi.function.OperatorType.ADD;
 import static io.trino.spi.function.OperatorType.CAST;
@@ -155,9 +157,15 @@ public final class TinyintOperators
     @ScalarOperator(CAST)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
-    public static Slice castToVarchar(@SqlType(StandardTypes.TINYINT) long value)
+    public static Slice castToVarchar(@LiteralParameter("x") long x, @SqlType(StandardTypes.TINYINT) long value)
     {
         // todo optimize me
-        return utf8Slice(String.valueOf(value));
+        String stringValue = String.valueOf(value);
+        // String is all-ASCII, so String.length() here returns actual code points count
+        if (stringValue.length() <= x) {
+            return utf8Slice(stringValue);
+        }
+
+        throw new TrinoException(INVALID_CAST_ARGUMENT, format("Value %s cannot be represented as varchar(%s)", value, x));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -672,9 +672,12 @@ public class TestExpressionInterpreter
         assertEvaluatedEquals("CAST(TINYINT '123' AS varchar(3))", "'123'");
         assertEvaluatedEquals("CAST(TINYINT '123' AS varchar(50))", "'123'");
 
-        // incorrect behavior: the result value does not fit in the type
-        assertEvaluatedEquals("CAST(TINYINT '123' AS varchar(2))", "'123'");
-        assertEvaluatedEquals("CAST(TINYINT '-123' AS varchar(2))", "'-123'");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(TINYINT '123' AS varchar(2))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 123 cannot be represented as varchar(2)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(TINYINT '-123' AS varchar(2))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value -123 cannot be represented as varchar(2)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -658,9 +658,12 @@ public class TestExpressionInterpreter
         assertEvaluatedEquals("CAST(SMALLINT '1234' AS varchar(4))", "'1234'");
         assertEvaluatedEquals("CAST(SMALLINT '1234' AS varchar(50))", "'1234'");
 
-        // incorrect behavior: the result value does not fit in the type
-        assertEvaluatedEquals("CAST(SMALLINT '1234' AS varchar(3))", "'1234'");
-        assertEvaluatedEquals("CAST(SMALLINT '-1234' AS varchar(3))", "'-1234'");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(SMALLINT '1234' AS varchar(3))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 1234 cannot be represented as varchar(3)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(SMALLINT '-1234' AS varchar(3))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value -1234 cannot be represented as varchar(3)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -644,9 +644,12 @@ public class TestExpressionInterpreter
         assertEvaluatedEquals("CAST(1234 AS varchar(4))", "'1234'");
         assertEvaluatedEquals("CAST(1234 AS varchar(50))", "'1234'");
 
-        // incorrect behavior: the result value does not fit in the type
-        assertEvaluatedEquals("CAST(1234 AS varchar(3))", "'1234'");
-        assertEvaluatedEquals("CAST(-1234 AS varchar(3))", "'-1234'");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(1234 AS varchar(3))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 1234 cannot be represented as varchar(3)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(-1234 AS varchar(3))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value -1234 cannot be represented as varchar(3)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -687,23 +687,39 @@ public class TestExpressionInterpreter
         assertEvaluatedEquals("CAST(DECIMAL '12.4' AS varchar(4))", "'12.4'");
         assertEvaluatedEquals("CAST(DECIMAL '12.4' AS varchar(50))", "'12.4'");
 
-        // short decimal: incorrect behavior: the result value does not fit in the type
-        assertEvaluatedEquals("CAST(DECIMAL '12.4' AS varchar(3))", "'12.4'");
-        assertEvaluatedEquals("CAST(DECIMAL '-12.4' AS varchar(3))", "'-12.4'");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(DECIMAL '12.4' AS varchar(3))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 12.4 cannot be represented as varchar(3)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(DECIMAL '-12.4' AS varchar(3))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value -12.4 cannot be represented as varchar(3)");
+
         // the trailing 0 does not fit in the type
-        assertEvaluatedEquals("CAST(DECIMAL '12.40' AS varchar(4))", "'12.40'");
-        assertEvaluatedEquals("CAST(DECIMAL '-12.40' AS varchar(5))", "'-12.40'");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(DECIMAL '12.40' AS varchar(4))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 12.40 cannot be represented as varchar(4)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(DECIMAL '-12.40' AS varchar(5))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value -12.40 cannot be represented as varchar(5)");
 
         // long decimal
         assertEvaluatedEquals("CAST(DECIMAL '100000000000000000.1' AS varchar(20))", "'100000000000000000.1'");
         assertEvaluatedEquals("CAST(DECIMAL '100000000000000000.1' AS varchar(50))", "'100000000000000000.1'");
 
-        // long decimal: incorrect behavior: the result value does not fit in the type
-        assertEvaluatedEquals("CAST(DECIMAL '100000000000000000.1' AS varchar(3))", "'100000000000000000.1'");
-        assertEvaluatedEquals("CAST(DECIMAL '-100000000000000000.1' AS varchar(3))", "'-100000000000000000.1'");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(DECIMAL '100000000000000000.1' AS varchar(3))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 100000000000000000.1 cannot be represented as varchar(3)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(DECIMAL '-100000000000000000.1' AS varchar(3))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value -100000000000000000.1 cannot be represented as varchar(3)");
+
         // the trailing 0 does not fit in the type
-        assertEvaluatedEquals("CAST(DECIMAL '100000000000000000.10' AS varchar(20))", "'100000000000000000.10'");
-        assertEvaluatedEquals("CAST(DECIMAL '-100000000000000000.10' AS varchar(21))", "'-100000000000000000.10'");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(DECIMAL '100000000000000000.10' AS varchar(20))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 100000000000000000.10 cannot be represented as varchar(20)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(DECIMAL '-100000000000000000.10' AS varchar(21))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value -100000000000000000.10 cannot be represented as varchar(21)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -639,6 +639,65 @@ public class TestExpressionInterpreter
     }
 
     @Test
+    public void testCastIntegerToBoundedVarchar()
+    {
+        assertEvaluatedEquals("CAST(1234 AS varchar(4))", "'1234'");
+        assertEvaluatedEquals("CAST(1234 AS varchar(50))", "'1234'");
+
+        // incorrect behavior: the result value does not fit in the type
+        assertEvaluatedEquals("CAST(1234 AS varchar(3))", "'1234'");
+        assertEvaluatedEquals("CAST(-1234 AS varchar(3))", "'-1234'");
+    }
+
+    @Test
+    public void testCastSmallintToBoundedVarchar()
+    {
+        assertEvaluatedEquals("CAST(SMALLINT '1234' AS varchar(4))", "'1234'");
+        assertEvaluatedEquals("CAST(SMALLINT '1234' AS varchar(50))", "'1234'");
+
+        // incorrect behavior: the result value does not fit in the type
+        assertEvaluatedEquals("CAST(SMALLINT '1234' AS varchar(3))", "'1234'");
+        assertEvaluatedEquals("CAST(SMALLINT '-1234' AS varchar(3))", "'-1234'");
+    }
+
+    @Test
+    public void testCastTinyintToBoundedVarchar()
+    {
+        assertEvaluatedEquals("CAST(TINYINT '123' AS varchar(3))", "'123'");
+        assertEvaluatedEquals("CAST(TINYINT '123' AS varchar(50))", "'123'");
+
+        // incorrect behavior: the result value does not fit in the type
+        assertEvaluatedEquals("CAST(TINYINT '123' AS varchar(2))", "'123'");
+        assertEvaluatedEquals("CAST(TINYINT '-123' AS varchar(2))", "'-123'");
+    }
+
+    @Test
+    public void testCastDecimalToBoundedVarchar()
+    {
+        // short decimal
+        assertEvaluatedEquals("CAST(DECIMAL '12.4' AS varchar(4))", "'12.4'");
+        assertEvaluatedEquals("CAST(DECIMAL '12.4' AS varchar(50))", "'12.4'");
+
+        // short decimal: incorrect behavior: the result value does not fit in the type
+        assertEvaluatedEquals("CAST(DECIMAL '12.4' AS varchar(3))", "'12.4'");
+        assertEvaluatedEquals("CAST(DECIMAL '-12.4' AS varchar(3))", "'-12.4'");
+        // the trailing 0 does not fit in the type
+        assertEvaluatedEquals("CAST(DECIMAL '12.40' AS varchar(4))", "'12.40'");
+        assertEvaluatedEquals("CAST(DECIMAL '-12.40' AS varchar(5))", "'-12.40'");
+
+        // long decimal
+        assertEvaluatedEquals("CAST(DECIMAL '100000000000000000.1' AS varchar(20))", "'100000000000000000.1'");
+        assertEvaluatedEquals("CAST(DECIMAL '100000000000000000.1' AS varchar(50))", "'100000000000000000.1'");
+
+        // long decimal: incorrect behavior: the result value does not fit in the type
+        assertEvaluatedEquals("CAST(DECIMAL '100000000000000000.1' AS varchar(3))", "'100000000000000000.1'");
+        assertEvaluatedEquals("CAST(DECIMAL '-100000000000000000.1' AS varchar(3))", "'-100000000000000000.1'");
+        // the trailing 0 does not fit in the type
+        assertEvaluatedEquals("CAST(DECIMAL '100000000000000000.10' AS varchar(20))", "'100000000000000000.10'");
+        assertEvaluatedEquals("CAST(DECIMAL '-100000000000000000.10' AS varchar(21))", "'-100000000000000000.10'");
+    }
+
+    @Test
     public void testCastToBoolean()
     {
         // integer

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -148,16 +148,10 @@ public class TestSimplifyExpressions
         assertSimplifies("CAST(1234 AS varchar(4))", "'1234'");
         assertSimplifies("CAST(-1234 AS varchar(50))", "CAST('-1234' AS varchar(50))");
 
-        // the varchar type length is not enough to contain the number's representation:
-        // the cast operator returns a value that is too long for the expected type ('1234' for varchar(3))
-        // the value is then wrapped in another cast by the LiteralEncoder (CAST('1234' AS varchar(3))),
-        // so eventually we get a truncated string '123'
-        assertSimplifies("CAST(1234 AS varchar(3))", "CAST('1234' AS varchar(3))");
-        assertSimplifies("CAST(-1234 AS varchar(3))", "CAST('-1234' AS varchar(3))");
-
-        // the cast operator returns a value that is too long for the expected type ('1234' for varchar(3))
-        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
-        assertSimplifies("CAST(1234 AS varchar(3)) = '1234'", "true");
+        // cast from integer to varchar fails, so the expression is not modified
+        assertSimplifies("CAST(1234 AS varchar(3))", "CAST(1234 AS varchar(3))");
+        assertSimplifies("CAST(-1234 AS varchar(3))", "CAST(-1234 AS varchar(3))");
+        assertSimplifies("CAST(1234 AS varchar(3)) = '1234'", "CAST(1234 AS varchar(3)) = '1234'");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -187,16 +187,10 @@ public class TestSimplifyExpressions
         assertSimplifies("CAST(DECIMAL '12.4' AS varchar(4))", "'12.4'");
         assertSimplifies("CAST(DECIMAL '-12.4' AS varchar(50))", "CAST('-12.4' AS varchar(50))");
 
-        // the varchar type length is not enough to contain the number's representation:
-        // the cast operator returns a value that is too long for the expected type ('12.4' for varchar(3))
-        // the value is then wrapped in another cast by the LiteralEncoder (CAST('12.4' AS varchar(3))),
-        // so eventually we get a truncated string '12.'
-        assertSimplifies("CAST(DECIMAL '12.4' AS varchar(3))", "CAST('12.4' AS varchar(3))");
-        assertSimplifies("CAST(DECIMAL '-12.4' AS varchar(3))", "CAST('-12.4' AS varchar(3))");
-
-        // the cast operator returns a value that is too long for the expected type ('12.4' for varchar(3))
-        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
-        assertSimplifies("CAST(DECIMAL '12.4' AS varchar(3)) = '12.4'", "true");
+        // cast from short decimal to varchar fails, so the expression is not modified
+        assertSimplifies("CAST(DECIMAL '12.4' AS varchar(3))", "CAST(DECIMAL '12.4' AS varchar(3))");
+        assertSimplifies("CAST(DECIMAL '-12.4' AS varchar(3))", "CAST(DECIMAL '-12.4' AS varchar(3))");
+        assertSimplifies("CAST(DECIMAL '12.4' AS varchar(3)) = '12.4'", "CAST(DECIMAL '12.4' AS varchar(3)) = '12.4'");
     }
 
     @Test
@@ -206,16 +200,10 @@ public class TestSimplifyExpressions
         assertSimplifies("CAST(DECIMAL '100000000000000000.1' AS varchar(20))", "'100000000000000000.1'");
         assertSimplifies("CAST(DECIMAL '-100000000000000000.1' AS varchar(50))", "CAST('-100000000000000000.1' AS varchar(50))");
 
-        // the varchar type length is not enough to contain the number's representation:
-        // the cast operator returns a value that is too long for the expected type ('100000000000000000.1' for varchar(3))
-        // the value is then wrapped in another cast by the LiteralEncoder (CAST('100000000000000000.1' AS varchar(3))),
-        // so eventually we get a truncated string '100'
-        assertSimplifies("CAST(DECIMAL '100000000000000000.1' AS varchar(3))", "CAST('100000000000000000.1' AS varchar(3))");
-        assertSimplifies("CAST(DECIMAL '-100000000000000000.1' AS varchar(3))", "CAST('-100000000000000000.1' AS varchar(3))");
-
-        // the cast operator returns a value that is too long for the expected type ('100000000000000000.1' for varchar(3))
-        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
-        assertSimplifies("CAST(DECIMAL '100000000000000000.1' AS varchar(3)) = '100000000000000000.1'", "true");
+        // cast from long decimal to varchar fails, so the expression is not modified
+        assertSimplifies("CAST(DECIMAL '100000000000000000.1' AS varchar(3))", "CAST(DECIMAL '100000000000000000.1' AS varchar(3))");
+        assertSimplifies("CAST(DECIMAL '-100000000000000000.1' AS varchar(3))", "CAST(DECIMAL '-100000000000000000.1' AS varchar(3))");
+        assertSimplifies("CAST(DECIMAL '100000000000000000.1' AS varchar(3)) = '100000000000000000.1'", "CAST(DECIMAL '100000000000000000.1' AS varchar(3)) = '100000000000000000.1'");
     }
 
     private static void assertSimplifies(String expression, String expected)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -141,6 +141,101 @@ public class TestSimplifyExpressions
         assertSimplifies("CAST(12300000000 AS varchar(3)) = '12300000000'", "CAST(12300000000 AS varchar(3)) = '12300000000'");
     }
 
+    @Test
+    public void testCastIntegerToBoundedVarchar()
+    {
+        // the varchar type length is enough to contain the number's representation
+        assertSimplifies("CAST(1234 AS varchar(4))", "'1234'");
+        assertSimplifies("CAST(-1234 AS varchar(50))", "CAST('-1234' AS varchar(50))");
+
+        // the varchar type length is not enough to contain the number's representation:
+        // the cast operator returns a value that is too long for the expected type ('1234' for varchar(3))
+        // the value is then wrapped in another cast by the LiteralEncoder (CAST('1234' AS varchar(3))),
+        // so eventually we get a truncated string '123'
+        assertSimplifies("CAST(1234 AS varchar(3))", "CAST('1234' AS varchar(3))");
+        assertSimplifies("CAST(-1234 AS varchar(3))", "CAST('-1234' AS varchar(3))");
+
+        // the cast operator returns a value that is too long for the expected type ('1234' for varchar(3))
+        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
+        assertSimplifies("CAST(1234 AS varchar(3)) = '1234'", "true");
+    }
+
+    @Test
+    public void testCastSmallintToBoundedVarchar()
+    {
+        // the varchar type length is enough to contain the number's representation
+        assertSimplifies("CAST(SMALLINT '1234' AS varchar(4))", "'1234'");
+        assertSimplifies("CAST(SMALLINT '-1234' AS varchar(50))", "CAST('-1234' AS varchar(50))");
+
+        // the varchar type length is not enough to contain the number's representation:
+        // the cast operator returns a value that is too long for the expected type ('1234' for varchar(3))
+        // the value is then wrapped in another cast by the LiteralEncoder (CAST('1234' AS varchar(3))),
+        // so eventually we get a truncated string '123'
+        assertSimplifies("CAST(SMALLINT '1234' AS varchar(3))", "CAST('1234' AS varchar(3))");
+        assertSimplifies("CAST(SMALLINT '-1234' AS varchar(3))", "CAST('-1234' AS varchar(3))");
+
+        // the cast operator returns a value that is too long for the expected type ('1234' for varchar(3))
+        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
+        assertSimplifies("CAST(SMALLINT '1234' AS varchar(3)) = '1234'", "true");
+    }
+
+    @Test
+    public void testCastTinyintToBoundedVarchar()
+    {
+        // the varchar type length is enough to contain the number's representation
+        assertSimplifies("CAST(TINYINT '123' AS varchar(3))", "'123'");
+        assertSimplifies("CAST(TINYINT '-123' AS varchar(50))", "CAST('-123' AS varchar(50))");
+
+        // the varchar type length is not enough to contain the number's representation:
+        // the cast operator returns a value that is too long for the expected type ('123' for varchar(2))
+        // the value is then wrapped in another cast by the LiteralEncoder (CAST('123' AS varchar(2))),
+        // so eventually we get a truncated string '12'
+        assertSimplifies("CAST(TINYINT '123' AS varchar(2))", "CAST('123' AS varchar(2))");
+        assertSimplifies("CAST(TINYINT '-123' AS varchar(2))", "CAST('-123' AS varchar(2))");
+
+        // the cast operator returns a value that is too long for the expected type ('123' for varchar(2))
+        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
+        assertSimplifies("CAST(TINYINT '123' AS varchar(2)) = '123'", "true");
+    }
+
+    @Test
+    public void testCastShortDecimalToBoundedVarchar()
+    {
+        // the varchar type length is enough to contain the number's representation
+        assertSimplifies("CAST(DECIMAL '12.4' AS varchar(4))", "'12.4'");
+        assertSimplifies("CAST(DECIMAL '-12.4' AS varchar(50))", "CAST('-12.4' AS varchar(50))");
+
+        // the varchar type length is not enough to contain the number's representation:
+        // the cast operator returns a value that is too long for the expected type ('12.4' for varchar(3))
+        // the value is then wrapped in another cast by the LiteralEncoder (CAST('12.4' AS varchar(3))),
+        // so eventually we get a truncated string '12.'
+        assertSimplifies("CAST(DECIMAL '12.4' AS varchar(3))", "CAST('12.4' AS varchar(3))");
+        assertSimplifies("CAST(DECIMAL '-12.4' AS varchar(3))", "CAST('-12.4' AS varchar(3))");
+
+        // the cast operator returns a value that is too long for the expected type ('12.4' for varchar(3))
+        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
+        assertSimplifies("CAST(DECIMAL '12.4' AS varchar(3)) = '12.4'", "true");
+    }
+
+    @Test
+    public void testCastLongDecimalToBoundedVarchar()
+    {
+        // the varchar type length is enough to contain the number's representation
+        assertSimplifies("CAST(DECIMAL '100000000000000000.1' AS varchar(20))", "'100000000000000000.1'");
+        assertSimplifies("CAST(DECIMAL '-100000000000000000.1' AS varchar(50))", "CAST('-100000000000000000.1' AS varchar(50))");
+
+        // the varchar type length is not enough to contain the number's representation:
+        // the cast operator returns a value that is too long for the expected type ('100000000000000000.1' for varchar(3))
+        // the value is then wrapped in another cast by the LiteralEncoder (CAST('100000000000000000.1' AS varchar(3))),
+        // so eventually we get a truncated string '100'
+        assertSimplifies("CAST(DECIMAL '100000000000000000.1' AS varchar(3))", "CAST('100000000000000000.1' AS varchar(3))");
+        assertSimplifies("CAST(DECIMAL '-100000000000000000.1' AS varchar(3))", "CAST('-100000000000000000.1' AS varchar(3))");
+
+        // the cast operator returns a value that is too long for the expected type ('100000000000000000.1' for varchar(3))
+        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
+        assertSimplifies("CAST(DECIMAL '100000000000000000.1' AS varchar(3)) = '100000000000000000.1'", "true");
+    }
+
     private static void assertSimplifies(String expression, String expected)
     {
         ParsingOptions parsingOptions = new ParsingOptions();

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -161,16 +161,10 @@ public class TestSimplifyExpressions
         assertSimplifies("CAST(SMALLINT '1234' AS varchar(4))", "'1234'");
         assertSimplifies("CAST(SMALLINT '-1234' AS varchar(50))", "CAST('-1234' AS varchar(50))");
 
-        // the varchar type length is not enough to contain the number's representation:
-        // the cast operator returns a value that is too long for the expected type ('1234' for varchar(3))
-        // the value is then wrapped in another cast by the LiteralEncoder (CAST('1234' AS varchar(3))),
-        // so eventually we get a truncated string '123'
-        assertSimplifies("CAST(SMALLINT '1234' AS varchar(3))", "CAST('1234' AS varchar(3))");
-        assertSimplifies("CAST(SMALLINT '-1234' AS varchar(3))", "CAST('-1234' AS varchar(3))");
-
-        // the cast operator returns a value that is too long for the expected type ('1234' for varchar(3))
-        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
-        assertSimplifies("CAST(SMALLINT '1234' AS varchar(3)) = '1234'", "true");
+        // cast from smallint to varchar fails, so the expression is not modified
+        assertSimplifies("CAST(SMALLINT '1234' AS varchar(3))", "CAST(SMALLINT '1234' AS varchar(3))");
+        assertSimplifies("CAST(SMALLINT '-1234' AS varchar(3))", "CAST(SMALLINT '-1234' AS varchar(3))");
+        assertSimplifies("CAST(SMALLINT '1234' AS varchar(3)) = '1234'", "CAST(SMALLINT '1234' AS varchar(3)) = '1234'");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -174,16 +174,10 @@ public class TestSimplifyExpressions
         assertSimplifies("CAST(TINYINT '123' AS varchar(3))", "'123'");
         assertSimplifies("CAST(TINYINT '-123' AS varchar(50))", "CAST('-123' AS varchar(50))");
 
-        // the varchar type length is not enough to contain the number's representation:
-        // the cast operator returns a value that is too long for the expected type ('123' for varchar(2))
-        // the value is then wrapped in another cast by the LiteralEncoder (CAST('123' AS varchar(2))),
-        // so eventually we get a truncated string '12'
-        assertSimplifies("CAST(TINYINT '123' AS varchar(2))", "CAST('123' AS varchar(2))");
-        assertSimplifies("CAST(TINYINT '-123' AS varchar(2))", "CAST('-123' AS varchar(2))");
-
-        // the cast operator returns a value that is too long for the expected type ('123' for varchar(2))
-        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
-        assertSimplifies("CAST(TINYINT '123' AS varchar(2)) = '123'", "true");
+        // cast from smallint to varchar fails, so the expression is not modified
+        assertSimplifies("CAST(TINYINT '123' AS varchar(2))", "CAST(TINYINT '123' AS varchar(2))");
+        assertSimplifies("CAST(TINYINT '-123' AS varchar(2))", "CAST(TINYINT '-123' AS varchar(2))");
+        assertSimplifies("CAST(TINYINT '123' AS varchar(2)) = '123'", "CAST(TINYINT '123' AS varchar(2)) = '123'");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
@@ -24,6 +24,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 
 public class TestDecimalCasts
         extends AbstractTestFunctions
@@ -468,5 +469,13 @@ public class TestDecimalCasts
         assertFunction("CAST(DECIMAL '-1234567890.1234567890' AS VARCHAR)", VARCHAR, "-1234567890.1234567890");
         assertFunction("CAST(DECIMAL '1234567890.12345678900000000000' AS VARCHAR)", VARCHAR, "1234567890.12345678900000000000");
         assertFunction("CAST(DECIMAL '-1234567890.12345678900000000000' AS VARCHAR)", VARCHAR, "-1234567890.12345678900000000000");
+
+        assertFunction("cast(DECIMAL '12.4' as varchar(4))", createVarcharType(4), "12.4");
+        assertFunction("cast(DECIMAL '12.4' as varchar(50))", createVarcharType(50), "12.4");
+        assertFunctionThrowsIncorrectly("cast(DECIMAL '12.4' as varchar(3))", IllegalArgumentException.class, "Character count exceeds length limit 3.*");
+
+        assertFunction("cast(DECIMAL '100000000000000000.1' as varchar(20))", createVarcharType(20), "100000000000000000.1");
+        assertFunction("cast(DECIMAL '100000000000000000.1' as varchar(50))", createVarcharType(50), "100000000000000000.1");
+        assertFunctionThrowsIncorrectly("cast(DECIMAL '100000000000000000.1' as varchar(19))", IllegalArgumentException.class, "Character count exceeds length limit 19.*");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDecimalCasts.java
@@ -472,10 +472,10 @@ public class TestDecimalCasts
 
         assertFunction("cast(DECIMAL '12.4' as varchar(4))", createVarcharType(4), "12.4");
         assertFunction("cast(DECIMAL '12.4' as varchar(50))", createVarcharType(50), "12.4");
-        assertFunctionThrowsIncorrectly("cast(DECIMAL '12.4' as varchar(3))", IllegalArgumentException.class, "Character count exceeds length limit 3.*");
+        assertInvalidCast("cast(DECIMAL '12.4' as varchar(3))", "Value 12.4 cannot be represented as varchar(3)");
 
         assertFunction("cast(DECIMAL '100000000000000000.1' as varchar(20))", createVarcharType(20), "100000000000000000.1");
         assertFunction("cast(DECIMAL '100000000000000000.1' as varchar(50))", createVarcharType(50), "100000000000000000.1");
-        assertFunctionThrowsIncorrectly("cast(DECIMAL '100000000000000000.1' as varchar(19))", IllegalArgumentException.class, "Character count exceeds length limit 19.*");
+        assertInvalidCast("cast(DECIMAL '100000000000000000.1' as varchar(19))", "Value 100000000000000000.1 cannot be represented as varchar(19)");
     }
 }

--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
@@ -27,6 +27,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.String.format;
 
 public class TestIntegerOperators
@@ -210,6 +211,9 @@ public class TestIntegerOperators
     {
         assertFunction("cast(INTEGER '37' as varchar)", VARCHAR, "37");
         assertFunction("cast(INTEGER '17' as varchar)", VARCHAR, "17");
+        assertFunction("cast(INTEGER '123' as varchar(3))", createVarcharType(3), "123");
+        assertFunction("cast(INTEGER '123' as varchar(50))", createVarcharType(50), "123");
+        assertFunctionThrowsIncorrectly("cast(INTEGER '123' as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
@@ -213,7 +213,7 @@ public class TestIntegerOperators
         assertFunction("cast(INTEGER '17' as varchar)", VARCHAR, "17");
         assertFunction("cast(INTEGER '123' as varchar(3))", createVarcharType(3), "123");
         assertFunction("cast(INTEGER '123' as varchar(50))", createVarcharType(50), "123");
-        assertFunctionThrowsIncorrectly("cast(INTEGER '123' as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
+        assertInvalidCast("cast(INTEGER '123' as varchar(2))", "Value 123 cannot be represented as varchar(2)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestIntegerOperators.java
@@ -35,204 +35,204 @@ public class TestIntegerOperators
     @Test
     public void testLiteral()
     {
-        assertFunction("INTEGER'37'", INTEGER, 37);
-        assertFunction("INTEGER'17'", INTEGER, 17);
-        assertInvalidCast("INTEGER'" + ((long) Integer.MAX_VALUE + 1L) + "'");
+        assertFunction("INTEGER '37'", INTEGER, 37);
+        assertFunction("INTEGER '17'", INTEGER, 17);
+        assertInvalidCast("INTEGER '" + ((long) Integer.MAX_VALUE + 1L) + "'");
     }
 
     @Test
     public void testUnaryPlus()
     {
-        assertFunction("+INTEGER'37'", INTEGER, 37);
-        assertFunction("+INTEGER'17'", INTEGER, 17);
+        assertFunction("+INTEGER '37'", INTEGER, 37);
+        assertFunction("+INTEGER '17'", INTEGER, 17);
     }
 
     @Test
     public void testUnaryMinus()
     {
-        assertFunction("INTEGER'-37'", INTEGER, -37);
-        assertFunction("INTEGER'-17'", INTEGER, -17);
-        assertInvalidFunction("INTEGER'-" + Integer.MIN_VALUE + "'", INVALID_CAST_ARGUMENT);
+        assertFunction("INTEGER '-37'", INTEGER, -37);
+        assertFunction("INTEGER '-17'", INTEGER, -17);
+        assertInvalidFunction("INTEGER '-" + Integer.MIN_VALUE + "'", INVALID_CAST_ARGUMENT);
     }
 
     @Test
     public void testAdd()
     {
-        assertFunction("INTEGER'37' + INTEGER'37'", INTEGER, 37 + 37);
-        assertFunction("INTEGER'37' + INTEGER'17'", INTEGER, 37 + 17);
-        assertFunction("INTEGER'17' + INTEGER'37'", INTEGER, 17 + 37);
-        assertFunction("INTEGER'17' + INTEGER'17'", INTEGER, 17 + 17);
-        assertNumericOverflow(format("INTEGER'%s' + INTEGER'1'", Integer.MAX_VALUE), "integer addition overflow: 2147483647 + 1");
+        assertFunction("INTEGER '37' + INTEGER '37'", INTEGER, 37 + 37);
+        assertFunction("INTEGER '37' + INTEGER '17'", INTEGER, 37 + 17);
+        assertFunction("INTEGER '17' + INTEGER '37'", INTEGER, 17 + 37);
+        assertFunction("INTEGER '17' + INTEGER '17'", INTEGER, 17 + 17);
+        assertNumericOverflow(format("INTEGER '%s' + INTEGER '1'", Integer.MAX_VALUE), "integer addition overflow: 2147483647 + 1");
     }
 
     @Test
     public void testSubtract()
     {
-        assertFunction("INTEGER'37' - INTEGER'37'", INTEGER, 0);
-        assertFunction("INTEGER'37' - INTEGER'17'", INTEGER, 37 - 17);
-        assertFunction("INTEGER'17' - INTEGER'37'", INTEGER, 17 - 37);
-        assertFunction("INTEGER'17' - INTEGER'17'", INTEGER, 0);
-        assertNumericOverflow(format("INTEGER'%s' - INTEGER'1'", Integer.MIN_VALUE), "integer subtraction overflow: -2147483648 - 1");
+        assertFunction("INTEGER '37' - INTEGER '37'", INTEGER, 0);
+        assertFunction("INTEGER '37' - INTEGER '17'", INTEGER, 37 - 17);
+        assertFunction("INTEGER '17' - INTEGER '37'", INTEGER, 17 - 37);
+        assertFunction("INTEGER '17' - INTEGER '17'", INTEGER, 0);
+        assertNumericOverflow(format("INTEGER '%s' - INTEGER '1'", Integer.MIN_VALUE), "integer subtraction overflow: -2147483648 - 1");
     }
 
     @Test
     public void testMultiply()
     {
-        assertFunction("INTEGER'37' * INTEGER'37'", INTEGER, 37 * 37);
-        assertFunction("INTEGER'37' * INTEGER'17'", INTEGER, 37 * 17);
-        assertFunction("INTEGER'17' * INTEGER'37'", INTEGER, 17 * 37);
-        assertFunction("INTEGER'17' * INTEGER'17'", INTEGER, 17 * 17);
-        assertNumericOverflow(format("INTEGER'%s' * INTEGER'2'", Integer.MAX_VALUE), "integer multiplication overflow: 2147483647 * 2");
+        assertFunction("INTEGER '37' * INTEGER '37'", INTEGER, 37 * 37);
+        assertFunction("INTEGER '37' * INTEGER '17'", INTEGER, 37 * 17);
+        assertFunction("INTEGER '17' * INTEGER '37'", INTEGER, 17 * 37);
+        assertFunction("INTEGER '17' * INTEGER '17'", INTEGER, 17 * 17);
+        assertNumericOverflow(format("INTEGER '%s' * INTEGER '2'", Integer.MAX_VALUE), "integer multiplication overflow: 2147483647 * 2");
     }
 
     @Test
     public void testDivide()
     {
-        assertFunction("INTEGER'37' / INTEGER'37'", INTEGER, 1);
-        assertFunction("INTEGER'37' / INTEGER'17'", INTEGER, 37 / 17);
-        assertFunction("INTEGER'17' / INTEGER'37'", INTEGER, 17 / 37);
-        assertFunction("INTEGER'17' / INTEGER'17'", INTEGER, 1);
-        assertInvalidFunction("INTEGER'17' / INTEGER'0'", DIVISION_BY_ZERO);
+        assertFunction("INTEGER '37' / INTEGER '37'", INTEGER, 1);
+        assertFunction("INTEGER '37' / INTEGER '17'", INTEGER, 37 / 17);
+        assertFunction("INTEGER '17' / INTEGER '37'", INTEGER, 17 / 37);
+        assertFunction("INTEGER '17' / INTEGER '17'", INTEGER, 1);
+        assertInvalidFunction("INTEGER '17' / INTEGER '0'", DIVISION_BY_ZERO);
     }
 
     @Test
     public void testModulus()
     {
-        assertFunction("INTEGER'37' % INTEGER'37'", INTEGER, 0);
-        assertFunction("INTEGER'37' % INTEGER'17'", INTEGER, 37 % 17);
-        assertFunction("INTEGER'17' % INTEGER'37'", INTEGER, 17 % 37);
-        assertFunction("INTEGER'17' % INTEGER'17'", INTEGER, 0);
-        assertInvalidFunction("INTEGER'17' % INTEGER'0'", DIVISION_BY_ZERO);
+        assertFunction("INTEGER '37' % INTEGER '37'", INTEGER, 0);
+        assertFunction("INTEGER '37' % INTEGER '17'", INTEGER, 37 % 17);
+        assertFunction("INTEGER '17' % INTEGER '37'", INTEGER, 17 % 37);
+        assertFunction("INTEGER '17' % INTEGER '17'", INTEGER, 0);
+        assertInvalidFunction("INTEGER '17' % INTEGER '0'", DIVISION_BY_ZERO);
     }
 
     @Test
     public void testNegation()
     {
-        assertFunction("-(INTEGER'37')", INTEGER, -37);
-        assertFunction("-(INTEGER'17')", INTEGER, -17);
-        assertFunction("-(INTEGER'" + Integer.MAX_VALUE + "')", INTEGER, Integer.MIN_VALUE + 1);
-        assertNumericOverflow(format("-(INTEGER'%s')", Integer.MIN_VALUE), "integer negation overflow: -2147483648");
+        assertFunction("-(INTEGER '37')", INTEGER, -37);
+        assertFunction("-(INTEGER '17')", INTEGER, -17);
+        assertFunction("-(INTEGER '" + Integer.MAX_VALUE + "')", INTEGER, Integer.MIN_VALUE + 1);
+        assertNumericOverflow(format("-(INTEGER '%s')", Integer.MIN_VALUE), "integer negation overflow: -2147483648");
     }
 
     @Test
     public void testEqual()
     {
-        assertFunction("INTEGER'37' = INTEGER'37'", BOOLEAN, true);
-        assertFunction("INTEGER'37' = INTEGER'17'", BOOLEAN, false);
-        assertFunction("INTEGER'17' = INTEGER'37'", BOOLEAN, false);
-        assertFunction("INTEGER'17' = INTEGER'17'", BOOLEAN, true);
+        assertFunction("INTEGER '37' = INTEGER '37'", BOOLEAN, true);
+        assertFunction("INTEGER '37' = INTEGER '17'", BOOLEAN, false);
+        assertFunction("INTEGER '17' = INTEGER '37'", BOOLEAN, false);
+        assertFunction("INTEGER '17' = INTEGER '17'", BOOLEAN, true);
     }
 
     @Test
     public void testNotEqual()
     {
-        assertFunction("INTEGER'37' <> INTEGER'37'", BOOLEAN, false);
-        assertFunction("INTEGER'37' <> INTEGER'17'", BOOLEAN, true);
-        assertFunction("INTEGER'17' <> INTEGER'37'", BOOLEAN, true);
-        assertFunction("INTEGER'17' <> INTEGER'17'", BOOLEAN, false);
+        assertFunction("INTEGER '37' <> INTEGER '37'", BOOLEAN, false);
+        assertFunction("INTEGER '37' <> INTEGER '17'", BOOLEAN, true);
+        assertFunction("INTEGER '17' <> INTEGER '37'", BOOLEAN, true);
+        assertFunction("INTEGER '17' <> INTEGER '17'", BOOLEAN, false);
     }
 
     @Test
     public void testLessThan()
     {
-        assertFunction("INTEGER'37' < INTEGER'37'", BOOLEAN, false);
-        assertFunction("INTEGER'37' < INTEGER'17'", BOOLEAN, false);
-        assertFunction("INTEGER'17' < INTEGER'37'", BOOLEAN, true);
-        assertFunction("INTEGER'17' < INTEGER'17'", BOOLEAN, false);
+        assertFunction("INTEGER '37' < INTEGER '37'", BOOLEAN, false);
+        assertFunction("INTEGER '37' < INTEGER '17'", BOOLEAN, false);
+        assertFunction("INTEGER '17' < INTEGER '37'", BOOLEAN, true);
+        assertFunction("INTEGER '17' < INTEGER '17'", BOOLEAN, false);
     }
 
     @Test
     public void testLessThanOrEqual()
     {
-        assertFunction("INTEGER'37' <= INTEGER'37'", BOOLEAN, true);
-        assertFunction("INTEGER'37' <= INTEGER'17'", BOOLEAN, false);
-        assertFunction("INTEGER'17' <= INTEGER'37'", BOOLEAN, true);
-        assertFunction("INTEGER'17' <= INTEGER'17'", BOOLEAN, true);
+        assertFunction("INTEGER '37' <= INTEGER '37'", BOOLEAN, true);
+        assertFunction("INTEGER '37' <= INTEGER '17'", BOOLEAN, false);
+        assertFunction("INTEGER '17' <= INTEGER '37'", BOOLEAN, true);
+        assertFunction("INTEGER '17' <= INTEGER '17'", BOOLEAN, true);
     }
 
     @Test
     public void testGreaterThan()
     {
-        assertFunction("INTEGER'37' > INTEGER'37'", BOOLEAN, false);
-        assertFunction("INTEGER'37' > INTEGER'17'", BOOLEAN, true);
-        assertFunction("INTEGER'17' > INTEGER'37'", BOOLEAN, false);
-        assertFunction("INTEGER'17' > INTEGER'17'", BOOLEAN, false);
+        assertFunction("INTEGER '37' > INTEGER '37'", BOOLEAN, false);
+        assertFunction("INTEGER '37' > INTEGER '17'", BOOLEAN, true);
+        assertFunction("INTEGER '17' > INTEGER '37'", BOOLEAN, false);
+        assertFunction("INTEGER '17' > INTEGER '17'", BOOLEAN, false);
     }
 
     @Test
     public void testGreaterThanOrEqual()
     {
-        assertFunction("INTEGER'37' >= INTEGER'37'", BOOLEAN, true);
-        assertFunction("INTEGER'37' >= INTEGER'17'", BOOLEAN, true);
-        assertFunction("INTEGER'17' >= INTEGER'37'", BOOLEAN, false);
-        assertFunction("INTEGER'17' >= INTEGER'17'", BOOLEAN, true);
+        assertFunction("INTEGER '37' >= INTEGER '37'", BOOLEAN, true);
+        assertFunction("INTEGER '37' >= INTEGER '17'", BOOLEAN, true);
+        assertFunction("INTEGER '17' >= INTEGER '37'", BOOLEAN, false);
+        assertFunction("INTEGER '17' >= INTEGER '17'", BOOLEAN, true);
     }
 
     @Test
     public void testBetween()
     {
-        assertFunction("INTEGER'37' BETWEEN INTEGER'37' AND INTEGER'37'", BOOLEAN, true);
-        assertFunction("INTEGER'37' BETWEEN INTEGER'37' AND INTEGER'17'", BOOLEAN, false);
+        assertFunction("INTEGER '37' BETWEEN INTEGER '37' AND INTEGER '37'", BOOLEAN, true);
+        assertFunction("INTEGER '37' BETWEEN INTEGER '37' AND INTEGER '17'", BOOLEAN, false);
 
-        assertFunction("INTEGER'37' BETWEEN INTEGER'17' AND INTEGER'37'", BOOLEAN, true);
-        assertFunction("INTEGER'37' BETWEEN INTEGER'17' AND INTEGER'17'", BOOLEAN, false);
+        assertFunction("INTEGER '37' BETWEEN INTEGER '17' AND INTEGER '37'", BOOLEAN, true);
+        assertFunction("INTEGER '37' BETWEEN INTEGER '17' AND INTEGER '17'", BOOLEAN, false);
 
-        assertFunction("INTEGER'17' BETWEEN INTEGER'37' AND INTEGER'37'", BOOLEAN, false);
-        assertFunction("INTEGER'17' BETWEEN INTEGER'37' AND INTEGER'17'", BOOLEAN, false);
+        assertFunction("INTEGER '17' BETWEEN INTEGER '37' AND INTEGER '37'", BOOLEAN, false);
+        assertFunction("INTEGER '17' BETWEEN INTEGER '37' AND INTEGER '17'", BOOLEAN, false);
 
-        assertFunction("INTEGER'17' BETWEEN INTEGER'17' AND INTEGER'37'", BOOLEAN, true);
-        assertFunction("INTEGER'17' BETWEEN INTEGER'17' AND INTEGER'17'", BOOLEAN, true);
+        assertFunction("INTEGER '17' BETWEEN INTEGER '17' AND INTEGER '37'", BOOLEAN, true);
+        assertFunction("INTEGER '17' BETWEEN INTEGER '17' AND INTEGER '17'", BOOLEAN, true);
     }
 
     @Test
     public void testCastToBigint()
     {
-        assertFunction("cast(INTEGER'37' as bigint)", BIGINT, 37L);
-        assertFunction("cast(INTEGER'17' as bigint)", BIGINT, 17L);
+        assertFunction("cast(INTEGER '37' as bigint)", BIGINT, 37L);
+        assertFunction("cast(INTEGER '17' as bigint)", BIGINT, 17L);
     }
 
     @Test
     public void testCastToSmallint()
     {
-        assertFunction("cast(INTEGER'37' as smallint)", SMALLINT, (short) 37);
-        assertFunction("cast(INTEGER'17' as smallint)", SMALLINT, (short) 17);
+        assertFunction("cast(INTEGER '37' as smallint)", SMALLINT, (short) 37);
+        assertFunction("cast(INTEGER '17' as smallint)", SMALLINT, (short) 17);
     }
 
     @Test
     public void testCastToTinyint()
     {
-        assertFunction("cast(INTEGER'37' as tinyint)", TINYINT, (byte) 37);
-        assertFunction("cast(INTEGER'17' as tinyint)", TINYINT, (byte) 17);
+        assertFunction("cast(INTEGER '37' as tinyint)", TINYINT, (byte) 37);
+        assertFunction("cast(INTEGER '17' as tinyint)", TINYINT, (byte) 17);
     }
 
     @Test
     public void testCastToVarchar()
     {
-        assertFunction("cast(INTEGER'37' as varchar)", VARCHAR, "37");
-        assertFunction("cast(INTEGER'17' as varchar)", VARCHAR, "17");
+        assertFunction("cast(INTEGER '37' as varchar)", VARCHAR, "37");
+        assertFunction("cast(INTEGER '17' as varchar)", VARCHAR, "17");
     }
 
     @Test
     public void testCastToDouble()
     {
-        assertFunction("cast(INTEGER'37' as double)", DOUBLE, 37.0);
-        assertFunction("cast(INTEGER'17' as double)", DOUBLE, 17.0);
+        assertFunction("cast(INTEGER '37' as double)", DOUBLE, 37.0);
+        assertFunction("cast(INTEGER '17' as double)", DOUBLE, 17.0);
     }
 
     @Test
     public void testCastToFloat()
     {
-        assertFunction("cast(INTEGER'37' as real)", REAL, 37.0f);
-        assertFunction("cast(INTEGER'-2147483648' as real)", REAL, -2147483648.0f);
-        assertFunction("cast(INTEGER'0' as real)", REAL, 0.0f);
+        assertFunction("cast(INTEGER '37' as real)", REAL, 37.0f);
+        assertFunction("cast(INTEGER '-2147483648' as real)", REAL, -2147483648.0f);
+        assertFunction("cast(INTEGER '0' as real)", REAL, 0.0f);
     }
 
     @Test
     public void testCastToBoolean()
     {
-        assertFunction("cast(INTEGER'37' as boolean)", BOOLEAN, true);
-        assertFunction("cast(INTEGER'17' as boolean)", BOOLEAN, true);
-        assertFunction("cast(INTEGER'0' as boolean)", BOOLEAN, false);
+        assertFunction("cast(INTEGER '37' as boolean)", BOOLEAN, true);
+        assertFunction("cast(INTEGER '17' as boolean)", BOOLEAN, true);
+        assertFunction("cast(INTEGER '0' as boolean)", BOOLEAN, false);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
@@ -35,204 +35,204 @@ public class TestSmallintOperators
     @Test
     public void testLiteral()
     {
-        assertFunction("SMALLINT'37'", SMALLINT, (short) 37);
-        assertFunction("SMALLINT'17'", SMALLINT, (short) 17);
-        assertInvalidCast("SMALLINT'" + ((long) Short.MAX_VALUE + 1L) + "'");
+        assertFunction("SMALLINT '37'", SMALLINT, (short) 37);
+        assertFunction("SMALLINT '17'", SMALLINT, (short) 17);
+        assertInvalidCast("SMALLINT '" + ((long) Short.MAX_VALUE + 1L) + "'");
     }
 
     @Test
     public void testUnaryPlus()
     {
-        assertFunction("+SMALLINT'37'", SMALLINT, (short) 37);
-        assertFunction("+SMALLINT'17'", SMALLINT, (short) 17);
+        assertFunction("+SMALLINT '37'", SMALLINT, (short) 37);
+        assertFunction("+SMALLINT '17'", SMALLINT, (short) 17);
     }
 
     @Test
     public void testUnaryMinus()
     {
-        assertFunction("SMALLINT'-37'", SMALLINT, (short) -37);
-        assertFunction("SMALLINT'-17'", SMALLINT, (short) -17);
-        assertInvalidFunction("SMALLINT'-" + Short.MIN_VALUE + "'", INVALID_CAST_ARGUMENT);
+        assertFunction("SMALLINT '-37'", SMALLINT, (short) -37);
+        assertFunction("SMALLINT '-17'", SMALLINT, (short) -17);
+        assertInvalidFunction("SMALLINT '-" + Short.MIN_VALUE + "'", INVALID_CAST_ARGUMENT);
     }
 
     @Test
     public void testAdd()
     {
-        assertFunction("SMALLINT'37' + SMALLINT'37'", SMALLINT, (short) (37 + 37));
-        assertFunction("SMALLINT'37' + SMALLINT'17'", SMALLINT, (short) (37 + 17));
-        assertFunction("SMALLINT'17' + SMALLINT'37'", SMALLINT, (short) (17 + 37));
-        assertFunction("SMALLINT'17' + SMALLINT'17'", SMALLINT, (short) (17 + 17));
-        assertNumericOverflow(format("SMALLINT'%s' + SMALLINT'1'", Short.MAX_VALUE), "smallint addition overflow: 32767 + 1");
+        assertFunction("SMALLINT '37' + SMALLINT '37'", SMALLINT, (short) (37 + 37));
+        assertFunction("SMALLINT '37' + SMALLINT '17'", SMALLINT, (short) (37 + 17));
+        assertFunction("SMALLINT '17' + SMALLINT '37'", SMALLINT, (short) (17 + 37));
+        assertFunction("SMALLINT '17' + SMALLINT '17'", SMALLINT, (short) (17 + 17));
+        assertNumericOverflow(format("SMALLINT '%s' + SMALLINT '1'", Short.MAX_VALUE), "smallint addition overflow: 32767 + 1");
     }
 
     @Test
     public void testSubtract()
     {
-        assertFunction("SMALLINT'37' - SMALLINT'37'", SMALLINT, (short) 0);
-        assertFunction("SMALLINT'37' - SMALLINT'17'", SMALLINT, (short) (37 - 17));
-        assertFunction("SMALLINT'17' - SMALLINT'37'", SMALLINT, (short) (17 - 37));
-        assertFunction("SMALLINT'17' - SMALLINT'17'", SMALLINT, (short) 0);
-        assertNumericOverflow(format("SMALLINT'%s' - SMALLINT'1'", Short.MIN_VALUE), "smallint subtraction overflow: -32768 - 1");
+        assertFunction("SMALLINT '37' - SMALLINT '37'", SMALLINT, (short) 0);
+        assertFunction("SMALLINT '37' - SMALLINT '17'", SMALLINT, (short) (37 - 17));
+        assertFunction("SMALLINT '17' - SMALLINT '37'", SMALLINT, (short) (17 - 37));
+        assertFunction("SMALLINT '17' - SMALLINT '17'", SMALLINT, (short) 0);
+        assertNumericOverflow(format("SMALLINT '%s' - SMALLINT '1'", Short.MIN_VALUE), "smallint subtraction overflow: -32768 - 1");
     }
 
     @Test
     public void testMultiply()
     {
-        assertFunction("SMALLINT'37' * SMALLINT'37'", SMALLINT, (short) (37 * 37));
-        assertFunction("SMALLINT'37' * SMALLINT'17'", SMALLINT, (short) (37 * 17));
-        assertFunction("SMALLINT'17' * SMALLINT'37'", SMALLINT, (short) (17 * 37));
-        assertFunction("SMALLINT'17' * SMALLINT'17'", SMALLINT, (short) (17 * 17));
-        assertNumericOverflow(format("SMALLINT'%s' * SMALLINT'2'", Short.MAX_VALUE), "smallint multiplication overflow: 32767 * 2");
+        assertFunction("SMALLINT '37' * SMALLINT '37'", SMALLINT, (short) (37 * 37));
+        assertFunction("SMALLINT '37' * SMALLINT '17'", SMALLINT, (short) (37 * 17));
+        assertFunction("SMALLINT '17' * SMALLINT '37'", SMALLINT, (short) (17 * 37));
+        assertFunction("SMALLINT '17' * SMALLINT '17'", SMALLINT, (short) (17 * 17));
+        assertNumericOverflow(format("SMALLINT '%s' * SMALLINT '2'", Short.MAX_VALUE), "smallint multiplication overflow: 32767 * 2");
     }
 
     @Test
     public void testDivide()
     {
-        assertFunction("SMALLINT'37' / SMALLINT'37'", SMALLINT, (short) 1);
-        assertFunction("SMALLINT'37' / SMALLINT'17'", SMALLINT, (short) (37 / 17));
-        assertFunction("SMALLINT'17' / SMALLINT'37'", SMALLINT, (short) (17 / 37));
-        assertFunction("SMALLINT'17' / SMALLINT'17'", SMALLINT, (short) 1);
-        assertInvalidFunction("SMALLINT'17' / SMALLINT'0'", DIVISION_BY_ZERO);
+        assertFunction("SMALLINT '37' / SMALLINT '37'", SMALLINT, (short) 1);
+        assertFunction("SMALLINT '37' / SMALLINT '17'", SMALLINT, (short) (37 / 17));
+        assertFunction("SMALLINT '17' / SMALLINT '37'", SMALLINT, (short) (17 / 37));
+        assertFunction("SMALLINT '17' / SMALLINT '17'", SMALLINT, (short) 1);
+        assertInvalidFunction("SMALLINT '17' / SMALLINT '0'", DIVISION_BY_ZERO);
     }
 
     @Test
     public void testModulus()
     {
-        assertFunction("SMALLINT'37' % SMALLINT'37'", SMALLINT, (short) 0);
-        assertFunction("SMALLINT'37' % SMALLINT'17'", SMALLINT, (short) (37 % 17));
-        assertFunction("SMALLINT'17' % SMALLINT'37'", SMALLINT, (short) (17 % 37));
-        assertFunction("SMALLINT'17' % SMALLINT'17'", SMALLINT, (short) 0);
-        assertInvalidFunction("SMALLINT'17' % SMALLINT'0'", DIVISION_BY_ZERO);
+        assertFunction("SMALLINT '37' % SMALLINT '37'", SMALLINT, (short) 0);
+        assertFunction("SMALLINT '37' % SMALLINT '17'", SMALLINT, (short) (37 % 17));
+        assertFunction("SMALLINT '17' % SMALLINT '37'", SMALLINT, (short) (17 % 37));
+        assertFunction("SMALLINT '17' % SMALLINT '17'", SMALLINT, (short) 0);
+        assertInvalidFunction("SMALLINT '17' % SMALLINT '0'", DIVISION_BY_ZERO);
     }
 
     @Test
     public void testNegation()
     {
-        assertFunction("-(SMALLINT'37')", SMALLINT, (short) -37);
-        assertFunction("-(SMALLINT'17')", SMALLINT, (short) -17);
-        assertFunction("-(SMALLINT'" + Short.MAX_VALUE + "')", SMALLINT, (short) (Short.MIN_VALUE + 1));
-        assertNumericOverflow(format("-(SMALLINT'%s')", Short.MIN_VALUE), "smallint negation overflow: -32768");
+        assertFunction("-(SMALLINT '37')", SMALLINT, (short) -37);
+        assertFunction("-(SMALLINT '17')", SMALLINT, (short) -17);
+        assertFunction("-(SMALLINT '" + Short.MAX_VALUE + "')", SMALLINT, (short) (Short.MIN_VALUE + 1));
+        assertNumericOverflow(format("-(SMALLINT '%s')", Short.MIN_VALUE), "smallint negation overflow: -32768");
     }
 
     @Test
     public void testEqual()
     {
-        assertFunction("SMALLINT'37' = SMALLINT'37'", BOOLEAN, true);
-        assertFunction("SMALLINT'37' = SMALLINT'17'", BOOLEAN, false);
-        assertFunction("SMALLINT'17' = SMALLINT'37'", BOOLEAN, false);
-        assertFunction("SMALLINT'17' = SMALLINT'17'", BOOLEAN, true);
+        assertFunction("SMALLINT '37' = SMALLINT '37'", BOOLEAN, true);
+        assertFunction("SMALLINT '37' = SMALLINT '17'", BOOLEAN, false);
+        assertFunction("SMALLINT '17' = SMALLINT '37'", BOOLEAN, false);
+        assertFunction("SMALLINT '17' = SMALLINT '17'", BOOLEAN, true);
     }
 
     @Test
     public void testNotEqual()
     {
-        assertFunction("SMALLINT'37' <> SMALLINT'37'", BOOLEAN, false);
-        assertFunction("SMALLINT'37' <> SMALLINT'17'", BOOLEAN, true);
-        assertFunction("SMALLINT'17' <> SMALLINT'37'", BOOLEAN, true);
-        assertFunction("SMALLINT'17' <> SMALLINT'17'", BOOLEAN, false);
+        assertFunction("SMALLINT '37' <> SMALLINT '37'", BOOLEAN, false);
+        assertFunction("SMALLINT '37' <> SMALLINT '17'", BOOLEAN, true);
+        assertFunction("SMALLINT '17' <> SMALLINT '37'", BOOLEAN, true);
+        assertFunction("SMALLINT '17' <> SMALLINT '17'", BOOLEAN, false);
     }
 
     @Test
     public void testLessThan()
     {
-        assertFunction("SMALLINT'37' < SMALLINT'37'", BOOLEAN, false);
-        assertFunction("SMALLINT'37' < SMALLINT'17'", BOOLEAN, false);
-        assertFunction("SMALLINT'17' < SMALLINT'37'", BOOLEAN, true);
-        assertFunction("SMALLINT'17' < SMALLINT'17'", BOOLEAN, false);
+        assertFunction("SMALLINT '37' < SMALLINT '37'", BOOLEAN, false);
+        assertFunction("SMALLINT '37' < SMALLINT '17'", BOOLEAN, false);
+        assertFunction("SMALLINT '17' < SMALLINT '37'", BOOLEAN, true);
+        assertFunction("SMALLINT '17' < SMALLINT '17'", BOOLEAN, false);
     }
 
     @Test
     public void testLessThanOrEqual()
     {
-        assertFunction("SMALLINT'37' <= SMALLINT'37'", BOOLEAN, true);
-        assertFunction("SMALLINT'37' <= SMALLINT'17'", BOOLEAN, false);
-        assertFunction("SMALLINT'17' <= SMALLINT'37'", BOOLEAN, true);
-        assertFunction("SMALLINT'17' <= SMALLINT'17'", BOOLEAN, true);
+        assertFunction("SMALLINT '37' <= SMALLINT '37'", BOOLEAN, true);
+        assertFunction("SMALLINT '37' <= SMALLINT '17'", BOOLEAN, false);
+        assertFunction("SMALLINT '17' <= SMALLINT '37'", BOOLEAN, true);
+        assertFunction("SMALLINT '17' <= SMALLINT '17'", BOOLEAN, true);
     }
 
     @Test
     public void testGreaterThan()
     {
-        assertFunction("SMALLINT'37' > SMALLINT'37'", BOOLEAN, false);
-        assertFunction("SMALLINT'37' > SMALLINT'17'", BOOLEAN, true);
-        assertFunction("SMALLINT'17' > SMALLINT'37'", BOOLEAN, false);
-        assertFunction("SMALLINT'17' > SMALLINT'17'", BOOLEAN, false);
+        assertFunction("SMALLINT '37' > SMALLINT '37'", BOOLEAN, false);
+        assertFunction("SMALLINT '37' > SMALLINT '17'", BOOLEAN, true);
+        assertFunction("SMALLINT '17' > SMALLINT '37'", BOOLEAN, false);
+        assertFunction("SMALLINT '17' > SMALLINT '17'", BOOLEAN, false);
     }
 
     @Test
     public void testGreaterThanOrEqual()
     {
-        assertFunction("SMALLINT'37' >= SMALLINT'37'", BOOLEAN, true);
-        assertFunction("SMALLINT'37' >= SMALLINT'17'", BOOLEAN, true);
-        assertFunction("SMALLINT'17' >= SMALLINT'37'", BOOLEAN, false);
-        assertFunction("SMALLINT'17' >= SMALLINT'17'", BOOLEAN, true);
+        assertFunction("SMALLINT '37' >= SMALLINT '37'", BOOLEAN, true);
+        assertFunction("SMALLINT '37' >= SMALLINT '17'", BOOLEAN, true);
+        assertFunction("SMALLINT '17' >= SMALLINT '37'", BOOLEAN, false);
+        assertFunction("SMALLINT '17' >= SMALLINT '17'", BOOLEAN, true);
     }
 
     @Test
     public void testBetween()
     {
-        assertFunction("SMALLINT'37' BETWEEN SMALLINT'37' AND SMALLINT'37'", BOOLEAN, true);
-        assertFunction("SMALLINT'37' BETWEEN SMALLINT'37' AND SMALLINT'17'", BOOLEAN, false);
+        assertFunction("SMALLINT '37' BETWEEN SMALLINT '37' AND SMALLINT '37'", BOOLEAN, true);
+        assertFunction("SMALLINT '37' BETWEEN SMALLINT '37' AND SMALLINT '17'", BOOLEAN, false);
 
-        assertFunction("SMALLINT'37' BETWEEN SMALLINT'17' AND SMALLINT'37'", BOOLEAN, true);
-        assertFunction("SMALLINT'37' BETWEEN SMALLINT'17' AND SMALLINT'17'", BOOLEAN, false);
+        assertFunction("SMALLINT '37' BETWEEN SMALLINT '17' AND SMALLINT '37'", BOOLEAN, true);
+        assertFunction("SMALLINT '37' BETWEEN SMALLINT '17' AND SMALLINT '17'", BOOLEAN, false);
 
-        assertFunction("SMALLINT'17' BETWEEN SMALLINT'37' AND SMALLINT'37'", BOOLEAN, false);
-        assertFunction("SMALLINT'17' BETWEEN SMALLINT'37' AND SMALLINT'17'", BOOLEAN, false);
+        assertFunction("SMALLINT '17' BETWEEN SMALLINT '37' AND SMALLINT '37'", BOOLEAN, false);
+        assertFunction("SMALLINT '17' BETWEEN SMALLINT '37' AND SMALLINT '17'", BOOLEAN, false);
 
-        assertFunction("SMALLINT'17' BETWEEN SMALLINT'17' AND SMALLINT'37'", BOOLEAN, true);
-        assertFunction("SMALLINT'17' BETWEEN SMALLINT'17' AND SMALLINT'17'", BOOLEAN, true);
+        assertFunction("SMALLINT '17' BETWEEN SMALLINT '17' AND SMALLINT '37'", BOOLEAN, true);
+        assertFunction("SMALLINT '17' BETWEEN SMALLINT '17' AND SMALLINT '17'", BOOLEAN, true);
     }
 
     @Test
     public void testCastToBigint()
     {
-        assertFunction("cast(SMALLINT'37' as bigint)", BIGINT, 37L);
-        assertFunction("cast(SMALLINT'17' as bigint)", BIGINT, 17L);
+        assertFunction("cast(SMALLINT '37' as bigint)", BIGINT, 37L);
+        assertFunction("cast(SMALLINT '17' as bigint)", BIGINT, 17L);
     }
 
     @Test
     public void testCastToInteger()
     {
-        assertFunction("cast(SMALLINT'37' as integer)", INTEGER, 37);
-        assertFunction("cast(SMALLINT'17' as integer)", INTEGER, 17);
+        assertFunction("cast(SMALLINT '37' as integer)", INTEGER, 37);
+        assertFunction("cast(SMALLINT '17' as integer)", INTEGER, 17);
     }
 
     @Test
     public void testCastToTinyint()
     {
-        assertFunction("cast(SMALLINT'37' as tinyint)", TINYINT, (byte) 37);
-        assertFunction("cast(SMALLINT'17' as tinyint)", TINYINT, (byte) 17);
+        assertFunction("cast(SMALLINT '37' as tinyint)", TINYINT, (byte) 37);
+        assertFunction("cast(SMALLINT '17' as tinyint)", TINYINT, (byte) 17);
     }
 
     @Test
     public void testCastToVarchar()
     {
-        assertFunction("cast(SMALLINT'37' as varchar)", VARCHAR, "37");
-        assertFunction("cast(SMALLINT'17' as varchar)", VARCHAR, "17");
+        assertFunction("cast(SMALLINT '37' as varchar)", VARCHAR, "37");
+        assertFunction("cast(SMALLINT '17' as varchar)", VARCHAR, "17");
     }
 
     @Test
     public void testCastToDouble()
     {
-        assertFunction("cast(SMALLINT'37' as double)", DOUBLE, 37.0);
-        assertFunction("cast(SMALLINT'17' as double)", DOUBLE, 17.0);
+        assertFunction("cast(SMALLINT '37' as double)", DOUBLE, 37.0);
+        assertFunction("cast(SMALLINT '17' as double)", DOUBLE, 17.0);
     }
 
     @Test
     public void testCastToFloat()
     {
-        assertFunction("cast(SMALLINT'37' as real)", REAL, 37.0f);
-        assertFunction("cast(SMALLINT'-32768' as real)", REAL, -32768.0f);
-        assertFunction("cast(SMALLINT'0' as real)", REAL, 0.0f);
+        assertFunction("cast(SMALLINT '37' as real)", REAL, 37.0f);
+        assertFunction("cast(SMALLINT '-32768' as real)", REAL, -32768.0f);
+        assertFunction("cast(SMALLINT '0' as real)", REAL, 0.0f);
     }
 
     @Test
     public void testCastToBoolean()
     {
-        assertFunction("cast(SMALLINT'37' as boolean)", BOOLEAN, true);
-        assertFunction("cast(SMALLINT'17' as boolean)", BOOLEAN, true);
-        assertFunction("cast(SMALLINT'0' as boolean)", BOOLEAN, false);
+        assertFunction("cast(SMALLINT '37' as boolean)", BOOLEAN, true);
+        assertFunction("cast(SMALLINT '17' as boolean)", BOOLEAN, true);
+        assertFunction("cast(SMALLINT '0' as boolean)", BOOLEAN, false);
     }
 
     @Test
@@ -246,10 +246,10 @@ public class TestSmallintOperators
     public void testIsDistinctFrom()
     {
         assertFunction("CAST(NULL AS SMALLINT) IS DISTINCT FROM CAST(NULL AS SMALLINT)", BOOLEAN, false);
-        assertFunction("SMALLINT'37' IS DISTINCT FROM SMALLINT'37'", BOOLEAN, false);
-        assertFunction("SMALLINT'37' IS DISTINCT FROM SMALLINT'38'", BOOLEAN, true);
-        assertFunction("NULL IS DISTINCT FROM SMALLINT'37'", BOOLEAN, true);
-        assertFunction("SMALLINT'37' IS DISTINCT FROM NULL", BOOLEAN, true);
+        assertFunction("SMALLINT '37' IS DISTINCT FROM SMALLINT '37'", BOOLEAN, false);
+        assertFunction("SMALLINT '37' IS DISTINCT FROM SMALLINT '38'", BOOLEAN, true);
+        assertFunction("NULL IS DISTINCT FROM SMALLINT '37'", BOOLEAN, true);
+        assertFunction("SMALLINT '37' IS DISTINCT FROM NULL", BOOLEAN, true);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
@@ -213,7 +213,7 @@ public class TestSmallintOperators
         assertFunction("cast(SMALLINT '17' as varchar)", VARCHAR, "17");
         assertFunction("cast(SMALLINT '123' as varchar(3))", createVarcharType(3), "123");
         assertFunction("cast(SMALLINT '123' as varchar(50))", createVarcharType(50), "123");
-        assertFunctionThrowsIncorrectly("cast(SMALLINT '123' as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
+        assertInvalidCast("cast(SMALLINT '123' as varchar(2))", "Value 123 cannot be represented as varchar(2)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestSmallintOperators.java
@@ -27,6 +27,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.String.format;
 
 public class TestSmallintOperators
@@ -210,6 +211,9 @@ public class TestSmallintOperators
     {
         assertFunction("cast(SMALLINT '37' as varchar)", VARCHAR, "37");
         assertFunction("cast(SMALLINT '17' as varchar)", VARCHAR, "17");
+        assertFunction("cast(SMALLINT '123' as varchar(3))", createVarcharType(3), "123");
+        assertFunction("cast(SMALLINT '123' as varchar(50))", createVarcharType(50), "123");
+        assertFunctionThrowsIncorrectly("cast(SMALLINT '123' as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
@@ -27,6 +27,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.String.format;
 
 public class TestTinyintOperators
@@ -210,6 +211,9 @@ public class TestTinyintOperators
     {
         assertFunction("cast(TINYINT '37' as varchar)", VARCHAR, "37");
         assertFunction("cast(TINYINT '17' as varchar)", VARCHAR, "17");
+        assertFunction("cast(TINYINT '123' as varchar(3))", createVarcharType(3), "123");
+        assertFunction("cast(TINYINT '123' as varchar(50))", createVarcharType(50), "123");
+        assertFunctionThrowsIncorrectly("cast(TINYINT '123' as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
@@ -213,7 +213,7 @@ public class TestTinyintOperators
         assertFunction("cast(TINYINT '17' as varchar)", VARCHAR, "17");
         assertFunction("cast(TINYINT '123' as varchar(3))", createVarcharType(3), "123");
         assertFunction("cast(TINYINT '123' as varchar(50))", createVarcharType(50), "123");
-        assertFunctionThrowsIncorrectly("cast(TINYINT '123' as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
+        assertInvalidCast("cast(TINYINT '123' as varchar(2))", "Value 123 cannot be represented as varchar(2)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestTinyintOperators.java
@@ -35,204 +35,204 @@ public class TestTinyintOperators
     @Test
     public void testLiteral()
     {
-        assertFunction("TINYINT'37'", TINYINT, (byte) 37);
-        assertFunction("TINYINT'17'", TINYINT, (byte) 17);
-        assertInvalidCast("TINYINT'" + ((long) Byte.MAX_VALUE + 1L) + "'");
+        assertFunction("TINYINT '37'", TINYINT, (byte) 37);
+        assertFunction("TINYINT '17'", TINYINT, (byte) 17);
+        assertInvalidCast("TINYINT '" + ((long) Byte.MAX_VALUE + 1L) + "'");
     }
 
     @Test
     public void testUnaryPlus()
     {
-        assertFunction("+TINYINT'37'", TINYINT, (byte) 37);
-        assertFunction("+TINYINT'17'", TINYINT, (byte) 17);
+        assertFunction("+TINYINT '37'", TINYINT, (byte) 37);
+        assertFunction("+TINYINT '17'", TINYINT, (byte) 17);
     }
 
     @Test
     public void testUnaryMinus()
     {
-        assertFunction("TINYINT'-37'", TINYINT, (byte) -37);
-        assertFunction("TINYINT'-17'", TINYINT, (byte) -17);
-        assertInvalidFunction("TINYINT'-" + Byte.MIN_VALUE + "'", INVALID_CAST_ARGUMENT);
+        assertFunction("TINYINT '-37'", TINYINT, (byte) -37);
+        assertFunction("TINYINT '-17'", TINYINT, (byte) -17);
+        assertInvalidFunction("TINYINT '-" + Byte.MIN_VALUE + "'", INVALID_CAST_ARGUMENT);
     }
 
     @Test
     public void testAdd()
     {
-        assertFunction("TINYINT'37' + TINYINT'37'", TINYINT, (byte) (37 + 37));
-        assertFunction("TINYINT'37' + TINYINT'17'", TINYINT, (byte) (37 + 17));
-        assertFunction("TINYINT'17' + TINYINT'37'", TINYINT, (byte) (17 + 37));
-        assertFunction("TINYINT'17' + TINYINT'17'", TINYINT, (byte) (17 + 17));
-        assertNumericOverflow(format("TINYINT'%s' + TINYINT'1'", Byte.MAX_VALUE), "tinyint addition overflow: 127 + 1");
+        assertFunction("TINYINT '37' + TINYINT '37'", TINYINT, (byte) (37 + 37));
+        assertFunction("TINYINT '37' + TINYINT '17'", TINYINT, (byte) (37 + 17));
+        assertFunction("TINYINT '17' + TINYINT '37'", TINYINT, (byte) (17 + 37));
+        assertFunction("TINYINT '17' + TINYINT '17'", TINYINT, (byte) (17 + 17));
+        assertNumericOverflow(format("TINYINT '%s' + TINYINT '1'", Byte.MAX_VALUE), "tinyint addition overflow: 127 + 1");
     }
 
     @Test
     public void testSubtract()
     {
-        assertFunction("TINYINT'37' - TINYINT'37'", TINYINT, (byte) 0);
-        assertFunction("TINYINT'37' - TINYINT'17'", TINYINT, (byte) (37 - 17));
-        assertFunction("TINYINT'17' - TINYINT'37'", TINYINT, (byte) (17 - 37));
-        assertFunction("TINYINT'17' - TINYINT'17'", TINYINT, (byte) 0);
-        assertNumericOverflow(format("TINYINT'%s' - TINYINT'1'", Byte.MIN_VALUE), "tinyint subtraction overflow: -128 - 1");
+        assertFunction("TINYINT '37' - TINYINT '37'", TINYINT, (byte) 0);
+        assertFunction("TINYINT '37' - TINYINT '17'", TINYINT, (byte) (37 - 17));
+        assertFunction("TINYINT '17' - TINYINT '37'", TINYINT, (byte) (17 - 37));
+        assertFunction("TINYINT '17' - TINYINT '17'", TINYINT, (byte) 0);
+        assertNumericOverflow(format("TINYINT '%s' - TINYINT '1'", Byte.MIN_VALUE), "tinyint subtraction overflow: -128 - 1");
     }
 
     @Test
     public void testMultiply()
     {
-        assertFunction("TINYINT'11' * TINYINT'11'", TINYINT, (byte) (11 * 11));
-        assertFunction("TINYINT'11' * TINYINT'9'", TINYINT, (byte) (11 * 9));
-        assertFunction("TINYINT'9' * TINYINT'11'", TINYINT, (byte) (9 * 11));
-        assertFunction("TINYINT'9' * TINYINT'9'", TINYINT, (byte) (9 * 9));
-        assertNumericOverflow(format("TINYINT'%s' * TINYINT'2'", Byte.MAX_VALUE), "tinyint multiplication overflow: 127 * 2");
+        assertFunction("TINYINT '11' * TINYINT '11'", TINYINT, (byte) (11 * 11));
+        assertFunction("TINYINT '11' * TINYINT '9'", TINYINT, (byte) (11 * 9));
+        assertFunction("TINYINT '9' * TINYINT '11'", TINYINT, (byte) (9 * 11));
+        assertFunction("TINYINT '9' * TINYINT '9'", TINYINT, (byte) (9 * 9));
+        assertNumericOverflow(format("TINYINT '%s' * TINYINT '2'", Byte.MAX_VALUE), "tinyint multiplication overflow: 127 * 2");
     }
 
     @Test
     public void testDivide()
     {
-        assertFunction("TINYINT'37' / TINYINT'37'", TINYINT, (byte) 1);
-        assertFunction("TINYINT'37' / TINYINT'17'", TINYINT, (byte) (37 / 17));
-        assertFunction("TINYINT'17' / TINYINT'37'", TINYINT, (byte) (17 / 37));
-        assertFunction("TINYINT'17' / TINYINT'17'", TINYINT, (byte) 1);
-        assertInvalidFunction("TINYINT'17' / TINYINT'0'", DIVISION_BY_ZERO);
+        assertFunction("TINYINT '37' / TINYINT '37'", TINYINT, (byte) 1);
+        assertFunction("TINYINT '37' / TINYINT '17'", TINYINT, (byte) (37 / 17));
+        assertFunction("TINYINT '17' / TINYINT '37'", TINYINT, (byte) (17 / 37));
+        assertFunction("TINYINT '17' / TINYINT '17'", TINYINT, (byte) 1);
+        assertInvalidFunction("TINYINT '17' / TINYINT '0'", DIVISION_BY_ZERO);
     }
 
     @Test
     public void testModulus()
     {
-        assertFunction("TINYINT'37' % TINYINT'37'", TINYINT, (byte) 0);
-        assertFunction("TINYINT'37' % TINYINT'17'", TINYINT, (byte) (37 % 17));
-        assertFunction("TINYINT'17' % TINYINT'37'", TINYINT, (byte) (17 % 37));
-        assertFunction("TINYINT'17' % TINYINT'17'", TINYINT, (byte) 0);
-        assertInvalidFunction("TINYINT'17' % TINYINT'0'", DIVISION_BY_ZERO);
+        assertFunction("TINYINT '37' % TINYINT '37'", TINYINT, (byte) 0);
+        assertFunction("TINYINT '37' % TINYINT '17'", TINYINT, (byte) (37 % 17));
+        assertFunction("TINYINT '17' % TINYINT '37'", TINYINT, (byte) (17 % 37));
+        assertFunction("TINYINT '17' % TINYINT '17'", TINYINT, (byte) 0);
+        assertInvalidFunction("TINYINT '17' % TINYINT '0'", DIVISION_BY_ZERO);
     }
 
     @Test
     public void testNegation()
     {
-        assertFunction("-(TINYINT'37')", TINYINT, (byte) -37);
-        assertFunction("-(TINYINT'17')", TINYINT, (byte) -17);
-        assertFunction("-(TINYINT'" + Byte.MAX_VALUE + "')", TINYINT, (byte) (Byte.MIN_VALUE + 1));
-        assertNumericOverflow(format("-(TINYINT'%s')", Byte.MIN_VALUE), "tinyint negation overflow: -128");
+        assertFunction("-(TINYINT '37')", TINYINT, (byte) -37);
+        assertFunction("-(TINYINT '17')", TINYINT, (byte) -17);
+        assertFunction("-(TINYINT '" + Byte.MAX_VALUE + "')", TINYINT, (byte) (Byte.MIN_VALUE + 1));
+        assertNumericOverflow(format("-(TINYINT '%s')", Byte.MIN_VALUE), "tinyint negation overflow: -128");
     }
 
     @Test
     public void testEqual()
     {
-        assertFunction("TINYINT'37' = TINYINT'37'", BOOLEAN, true);
-        assertFunction("TINYINT'37' = TINYINT'17'", BOOLEAN, false);
-        assertFunction("TINYINT'17' = TINYINT'37'", BOOLEAN, false);
-        assertFunction("TINYINT'17' = TINYINT'17'", BOOLEAN, true);
+        assertFunction("TINYINT '37' = TINYINT '37'", BOOLEAN, true);
+        assertFunction("TINYINT '37' = TINYINT '17'", BOOLEAN, false);
+        assertFunction("TINYINT '17' = TINYINT '37'", BOOLEAN, false);
+        assertFunction("TINYINT '17' = TINYINT '17'", BOOLEAN, true);
     }
 
     @Test
     public void testNotEqual()
     {
-        assertFunction("TINYINT'37' <> TINYINT'37'", BOOLEAN, false);
-        assertFunction("TINYINT'37' <> TINYINT'17'", BOOLEAN, true);
-        assertFunction("TINYINT'17' <> TINYINT'37'", BOOLEAN, true);
-        assertFunction("TINYINT'17' <> TINYINT'17'", BOOLEAN, false);
+        assertFunction("TINYINT '37' <> TINYINT '37'", BOOLEAN, false);
+        assertFunction("TINYINT '37' <> TINYINT '17'", BOOLEAN, true);
+        assertFunction("TINYINT '17' <> TINYINT '37'", BOOLEAN, true);
+        assertFunction("TINYINT '17' <> TINYINT '17'", BOOLEAN, false);
     }
 
     @Test
     public void testLessThan()
     {
-        assertFunction("TINYINT'37' < TINYINT'37'", BOOLEAN, false);
-        assertFunction("TINYINT'37' < TINYINT'17'", BOOLEAN, false);
-        assertFunction("TINYINT'17' < TINYINT'37'", BOOLEAN, true);
-        assertFunction("TINYINT'17' < TINYINT'17'", BOOLEAN, false);
+        assertFunction("TINYINT '37' < TINYINT '37'", BOOLEAN, false);
+        assertFunction("TINYINT '37' < TINYINT '17'", BOOLEAN, false);
+        assertFunction("TINYINT '17' < TINYINT '37'", BOOLEAN, true);
+        assertFunction("TINYINT '17' < TINYINT '17'", BOOLEAN, false);
     }
 
     @Test
     public void testLessThanOrEqual()
     {
-        assertFunction("TINYINT'37' <= TINYINT'37'", BOOLEAN, true);
-        assertFunction("TINYINT'37' <= TINYINT'17'", BOOLEAN, false);
-        assertFunction("TINYINT'17' <= TINYINT'37'", BOOLEAN, true);
-        assertFunction("TINYINT'17' <= TINYINT'17'", BOOLEAN, true);
+        assertFunction("TINYINT '37' <= TINYINT '37'", BOOLEAN, true);
+        assertFunction("TINYINT '37' <= TINYINT '17'", BOOLEAN, false);
+        assertFunction("TINYINT '17' <= TINYINT '37'", BOOLEAN, true);
+        assertFunction("TINYINT '17' <= TINYINT '17'", BOOLEAN, true);
     }
 
     @Test
     public void testGreaterThan()
     {
-        assertFunction("TINYINT'37' > TINYINT'37'", BOOLEAN, false);
-        assertFunction("TINYINT'37' > TINYINT'17'", BOOLEAN, true);
-        assertFunction("TINYINT'17' > TINYINT'37'", BOOLEAN, false);
-        assertFunction("TINYINT'17' > TINYINT'17'", BOOLEAN, false);
+        assertFunction("TINYINT '37' > TINYINT '37'", BOOLEAN, false);
+        assertFunction("TINYINT '37' > TINYINT '17'", BOOLEAN, true);
+        assertFunction("TINYINT '17' > TINYINT '37'", BOOLEAN, false);
+        assertFunction("TINYINT '17' > TINYINT '17'", BOOLEAN, false);
     }
 
     @Test
     public void testGreaterThanOrEqual()
     {
-        assertFunction("TINYINT'37' >= TINYINT'37'", BOOLEAN, true);
-        assertFunction("TINYINT'37' >= TINYINT'17'", BOOLEAN, true);
-        assertFunction("TINYINT'17' >= TINYINT'37'", BOOLEAN, false);
-        assertFunction("TINYINT'17' >= TINYINT'17'", BOOLEAN, true);
+        assertFunction("TINYINT '37' >= TINYINT '37'", BOOLEAN, true);
+        assertFunction("TINYINT '37' >= TINYINT '17'", BOOLEAN, true);
+        assertFunction("TINYINT '17' >= TINYINT '37'", BOOLEAN, false);
+        assertFunction("TINYINT '17' >= TINYINT '17'", BOOLEAN, true);
     }
 
     @Test
     public void testBetween()
     {
-        assertFunction("TINYINT'37' BETWEEN TINYINT'37' AND TINYINT'37'", BOOLEAN, true);
-        assertFunction("TINYINT'37' BETWEEN TINYINT'37' AND TINYINT'17'", BOOLEAN, false);
+        assertFunction("TINYINT '37' BETWEEN TINYINT '37' AND TINYINT '37'", BOOLEAN, true);
+        assertFunction("TINYINT '37' BETWEEN TINYINT '37' AND TINYINT '17'", BOOLEAN, false);
 
-        assertFunction("TINYINT'37' BETWEEN TINYINT'17' AND TINYINT'37'", BOOLEAN, true);
-        assertFunction("TINYINT'37' BETWEEN TINYINT'17' AND TINYINT'17'", BOOLEAN, false);
+        assertFunction("TINYINT '37' BETWEEN TINYINT '17' AND TINYINT '37'", BOOLEAN, true);
+        assertFunction("TINYINT '37' BETWEEN TINYINT '17' AND TINYINT '17'", BOOLEAN, false);
 
-        assertFunction("TINYINT'17' BETWEEN TINYINT'37' AND TINYINT'37'", BOOLEAN, false);
-        assertFunction("TINYINT'17' BETWEEN TINYINT'37' AND TINYINT'17'", BOOLEAN, false);
+        assertFunction("TINYINT '17' BETWEEN TINYINT '37' AND TINYINT '37'", BOOLEAN, false);
+        assertFunction("TINYINT '17' BETWEEN TINYINT '37' AND TINYINT '17'", BOOLEAN, false);
 
-        assertFunction("TINYINT'17' BETWEEN TINYINT'17' AND TINYINT'37'", BOOLEAN, true);
-        assertFunction("TINYINT'17' BETWEEN TINYINT'17' AND TINYINT'17'", BOOLEAN, true);
+        assertFunction("TINYINT '17' BETWEEN TINYINT '17' AND TINYINT '37'", BOOLEAN, true);
+        assertFunction("TINYINT '17' BETWEEN TINYINT '17' AND TINYINT '17'", BOOLEAN, true);
     }
 
     @Test
     public void testCastToBigint()
     {
-        assertFunction("cast(TINYINT'37' as bigint)", BIGINT, 37L);
-        assertFunction("cast(TINYINT'17' as bigint)", BIGINT, 17L);
+        assertFunction("cast(TINYINT '37' as bigint)", BIGINT, 37L);
+        assertFunction("cast(TINYINT '17' as bigint)", BIGINT, 17L);
     }
 
     @Test
     public void testCastToInteger()
     {
-        assertFunction("cast(TINYINT'37' as integer)", INTEGER, 37);
-        assertFunction("cast(TINYINT'17' as integer)", INTEGER, 17);
+        assertFunction("cast(TINYINT '37' as integer)", INTEGER, 37);
+        assertFunction("cast(TINYINT '17' as integer)", INTEGER, 17);
     }
 
     @Test
     public void testCastToSmallint()
     {
-        assertFunction("cast(TINYINT'37' as smallint)", SMALLINT, (short) 37);
-        assertFunction("cast(TINYINT'17' as smallint)", SMALLINT, (short) 17);
+        assertFunction("cast(TINYINT '37' as smallint)", SMALLINT, (short) 37);
+        assertFunction("cast(TINYINT '17' as smallint)", SMALLINT, (short) 17);
     }
 
     @Test
     public void testCastToVarchar()
     {
-        assertFunction("cast(TINYINT'37' as varchar)", VARCHAR, "37");
-        assertFunction("cast(TINYINT'17' as varchar)", VARCHAR, "17");
+        assertFunction("cast(TINYINT '37' as varchar)", VARCHAR, "37");
+        assertFunction("cast(TINYINT '17' as varchar)", VARCHAR, "17");
     }
 
     @Test
     public void testCastToDouble()
     {
-        assertFunction("cast(TINYINT'37' as double)", DOUBLE, 37.0);
-        assertFunction("cast(TINYINT'17' as double)", DOUBLE, 17.0);
+        assertFunction("cast(TINYINT '37' as double)", DOUBLE, 37.0);
+        assertFunction("cast(TINYINT '17' as double)", DOUBLE, 17.0);
     }
 
     @Test
     public void testCastToFloat()
     {
-        assertFunction("cast(TINYINT'37' as real)", REAL, 37.0f);
-        assertFunction("cast(TINYINT'-128' as real)", REAL, -128.0f);
-        assertFunction("cast(TINYINT'0' as real)", REAL, 0.0f);
+        assertFunction("cast(TINYINT '37' as real)", REAL, 37.0f);
+        assertFunction("cast(TINYINT '-128' as real)", REAL, -128.0f);
+        assertFunction("cast(TINYINT '0' as real)", REAL, 0.0f);
     }
 
     @Test
     public void testCastToBoolean()
     {
-        assertFunction("cast(TINYINT'37' as boolean)", BOOLEAN, true);
-        assertFunction("cast(TINYINT'17' as boolean)", BOOLEAN, true);
-        assertFunction("cast(TINYINT'0' as boolean)", BOOLEAN, false);
+        assertFunction("cast(TINYINT '37' as boolean)", BOOLEAN, true);
+        assertFunction("cast(TINYINT '17' as boolean)", BOOLEAN, true);
+        assertFunction("cast(TINYINT '0' as boolean)", BOOLEAN, false);
     }
 
     @Test
@@ -246,10 +246,10 @@ public class TestTinyintOperators
     public void testIsDistinctFrom()
     {
         assertFunction("CAST(NULL AS TINYINT) IS DISTINCT FROM CAST(NULL AS TINYINT)", BOOLEAN, false);
-        assertFunction("TINYINT'37' IS DISTINCT FROM TINYINT'37'", BOOLEAN, false);
-        assertFunction("TINYINT'37' IS DISTINCT FROM TINYINT'38'", BOOLEAN, true);
-        assertFunction("NULL IS DISTINCT FROM TINYINT'37'", BOOLEAN, true);
-        assertFunction("TINYINT'37' IS DISTINCT FROM NULL", BOOLEAN, true);
+        assertFunction("TINYINT '37' IS DISTINCT FROM TINYINT '37'", BOOLEAN, false);
+        assertFunction("TINYINT '37' IS DISTINCT FROM TINYINT '38'", BOOLEAN, true);
+        assertFunction("NULL IS DISTINCT FROM TINYINT '37'", BOOLEAN, true);
+        assertFunction("TINYINT '37' IS DISTINCT FROM NULL", BOOLEAN, true);
     }
 
     @Test


### PR DESCRIPTION
Applies to: integer, smallint, tinyint, decimal.
Bigint was handlen in another PR

For https://github.com/trinodb/trino/issues/552