### PR TITLE
expose physicalInputDataSize and inputDataSize in JDBC client

### DIFF
--- a/client/trino-client/src/main/java/io/trino/client/StageStats.java
+++ b/client/trino-client/src/main/java/io/trino/client/StageStats.java
@@ -40,6 +40,8 @@ public class StageStats
     private final long processedRows;
     private final long processedBytes;
     private final long physicalInputBytes;
+    private final long physicalInputDataSize;
+    private final long inputDataSize;
     private final List<StageStats> subStages;
 
     @JsonCreator
@@ -57,6 +59,8 @@ public class StageStats
             @JsonProperty("processedRows") long processedRows,
             @JsonProperty("processedBytes") long processedBytes,
             @JsonProperty("physicalInputBytes") long physicalInputBytes,
+            @JsonProperty("physicalInputDataSize") long physicalInputDataSize,
+            @JsonProperty("inputDataSize") long inputDataSize,
             @JsonProperty("subStages") List<StageStats> subStages)
     {
         this.stageId = stageId;
@@ -72,6 +76,8 @@ public class StageStats
         this.processedRows = processedRows;
         this.processedBytes = processedBytes;
         this.physicalInputBytes = physicalInputBytes;
+        this.physicalInputDataSize = physicalInputDataSize;
+        this.inputDataSize = inputDataSize;
         this.subStages = ImmutableList.copyOf(requireNonNull(subStages, "subStages is null"));
     }
 
@@ -154,6 +160,18 @@ public class StageStats
     }
 
     @JsonProperty
+    public long getPhysicalInputDataSize()
+    {
+        return physicalInputDataSize;
+    }
+
+    @JsonProperty
+    public long getInputDataSize()
+    {
+        return inputDataSize;
+    }
+
+    @JsonProperty
     public List<StageStats> getSubStages()
     {
         return subStages;
@@ -175,6 +193,8 @@ public class StageStats
                 .add("processedRows", processedRows)
                 .add("processedBytes", processedBytes)
                 .add("physicalInputBytes", physicalInputBytes)
+                .add("physicalInputDataSize", physicalInputDataSize)
+                .add("inputDataSize", inputDataSize)
                 .add("subStages", subStages)
                 .toString();
     }
@@ -199,6 +219,8 @@ public class StageStats
         private long processedRows;
         private long processedBytes;
         private long physicalInputBytes;
+        private long physicalInputDataSize;
+        private long inputDataSize;
         private List<StageStats> subStages;
 
         private Builder() {}
@@ -281,6 +303,18 @@ public class StageStats
             return this;
         }
 
+        public Builder setPhysicalInputDataSize(long physicalInputDataSize)
+        {
+            this.physicalInputDataSize = physicalInputDataSize;
+            return this;
+        }
+
+        public Builder setInputDataSize(long inputDataSize)
+        {
+            this.inputDataSize = inputDataSize;
+            return this;
+        }
+
         public Builder setSubStages(List<StageStats> subStages)
         {
             this.subStages = ImmutableList.copyOf(requireNonNull(subStages, "subStages is null"));
@@ -303,6 +337,8 @@ public class StageStats
                     processedRows,
                     processedBytes,
                     physicalInputBytes,
+                    physicalInputDataSize,
+                    inputDataSize,
                     subStages);
         }
     }

--- a/client/trino-client/src/main/java/io/trino/client/StatementStats.java
+++ b/client/trino-client/src/main/java/io/trino/client/StatementStats.java
@@ -45,6 +45,8 @@ public class StatementStats
     private final long physicalInputBytes;
     private final long peakMemoryBytes;
     private final long spilledBytes;
+    private final long physicalInputDataSize;
+    private final long inputDataSize;
     private final StageStats rootStage;
 
     @JsonCreator
@@ -66,6 +68,8 @@ public class StatementStats
             @JsonProperty("physicalInputBytes") long physicalInputBytes,
             @JsonProperty("peakMemoryBytes") long peakMemoryBytes,
             @JsonProperty("spilledBytes") long spilledBytes,
+            @JsonProperty("physicalInputDataSize") long physicalInputDataSize,
+            @JsonProperty("inputDataSize") long inputDataSize,
             @JsonProperty("rootStage") StageStats rootStage)
     {
         this.state = requireNonNull(state, "state is null");
@@ -85,6 +89,8 @@ public class StatementStats
         this.physicalInputBytes = physicalInputBytes;
         this.peakMemoryBytes = peakMemoryBytes;
         this.spilledBytes = spilledBytes;
+        this.physicalInputDataSize = physicalInputDataSize;
+        this.inputDataSize = inputDataSize;
         this.rootStage = rootStage;
     }
 
@@ -184,6 +190,18 @@ public class StatementStats
         return peakMemoryBytes;
     }
 
+    @JsonProperty
+    public long getPhysicalInputDataSize()
+    {
+        return physicalInputDataSize;
+    }
+
+    @JsonProperty
+    public long getInputDataSize()
+    {
+        return inputDataSize;
+    }
+
     @Nullable
     @JsonProperty
     public StageStats getRootStage()
@@ -227,6 +245,8 @@ public class StatementStats
                 .add("physicalInputBytes", physicalInputBytes)
                 .add("peakMemoryBytes", peakMemoryBytes)
                 .add("spilledBytes", spilledBytes)
+                .add("physicalInputDataSize", physicalInputDataSize)
+                .add("inputDataSize", inputDataSize)
                 .add("rootStage", rootStage)
                 .toString();
     }
@@ -255,6 +275,8 @@ public class StatementStats
         private long physicalInputBytes;
         private long peakMemoryBytes;
         private long spilledBytes;
+        private long physicalInputDataSize;
+        private long inputDataSize;
         private StageStats rootStage;
 
         private Builder() {}
@@ -361,6 +383,18 @@ public class StatementStats
             return this;
         }
 
+        public Builder setPhysicalInputDataSize(long physicalInputDataSize)
+        {
+            this.physicalInputDataSize = physicalInputDataSize;
+            return this;
+        }
+
+        public Builder setInputDataSize(long inputDataSize)
+        {
+            this.inputDataSize = inputDataSize;
+            return this;
+        }
+
         public Builder setRootStage(StageStats rootStage)
         {
             this.rootStage = rootStage;
@@ -387,6 +421,8 @@ public class StatementStats
                     physicalInputBytes,
                     peakMemoryBytes,
                     spilledBytes,
+                    physicalInputDataSize,
+                    inputDataSize,
                     rootStage);
         }
     }

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/QueryStats.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/QueryStats.java
@@ -39,6 +39,8 @@ public final class QueryStats
     private final long processedRows;
     private final long processedBytes;
     private final long peakMemoryBytes;
+    private final long physicalInputDataSize;
+    private final long inputDataSize;
     private final Optional<StageStats> rootStage;
 
     public QueryStats(
@@ -58,6 +60,8 @@ public final class QueryStats
             long processedRows,
             long processedBytes,
             long peakMemoryBytes,
+            long physicalInputDataSize,
+            long inputDataSize,
             Optional<StageStats> rootStage)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
@@ -76,6 +80,8 @@ public final class QueryStats
         this.processedRows = processedRows;
         this.processedBytes = processedBytes;
         this.peakMemoryBytes = peakMemoryBytes;
+        this.physicalInputDataSize = physicalInputDataSize;
+        this.inputDataSize = inputDataSize;
         this.rootStage = requireNonNull(rootStage, "rootStage is null");
     }
 
@@ -98,6 +104,8 @@ public final class QueryStats
                 stats.getProcessedRows(),
                 stats.getProcessedBytes(),
                 stats.getPeakMemoryBytes(),
+                stats.getPhysicalInputDataSize(),
+                stats.getInputDataSize(),
                 Optional.ofNullable(stats.getRootStage()).map(StageStats::create));
     }
 
@@ -179,6 +187,16 @@ public final class QueryStats
     public long getPeakMemoryBytes()
     {
         return peakMemoryBytes;
+    }
+
+    public long getPhysicalInputDataSize()
+    {
+        return physicalInputDataSize;
+    }
+
+    public long getInputDataSize()
+    {
+        return inputDataSize;
     }
 
     public Optional<StageStats> getRootStage()

--- a/client/trino-jdbc/src/main/java/io/trino/jdbc/StageStats.java
+++ b/client/trino-jdbc/src/main/java/io/trino/jdbc/StageStats.java
@@ -34,6 +34,8 @@ public final class StageStats
     private final long wallTimeMillis;
     private final long processedRows;
     private final long processedBytes;
+    private final long physicalInputDataSize;
+    private final long inputDataSize;
     private final List<StageStats> subStages;
 
     public StageStats(
@@ -49,6 +51,8 @@ public final class StageStats
             long wallTimeMillis,
             long processedRows,
             long processedBytes,
+            long physicalInputDataSize,
+            long inputDataSize,
             List<StageStats> subStages)
     {
         this.stageId = requireNonNull(stageId, "stageId is null");
@@ -63,6 +67,8 @@ public final class StageStats
         this.wallTimeMillis = wallTimeMillis;
         this.processedRows = processedRows;
         this.processedBytes = processedBytes;
+        this.physicalInputDataSize = physicalInputDataSize;
+        this.inputDataSize = inputDataSize;
         this.subStages = ImmutableList.copyOf(requireNonNull(subStages, "subStages is null"));
     }
 
@@ -81,6 +87,8 @@ public final class StageStats
                 stats.getWallTimeMillis(),
                 stats.getProcessedRows(),
                 stats.getProcessedBytes(),
+                stats.getPhysicalInputDataSize(),
+                stats.getInputDataSize(),
                 stats.getSubStages().stream()
                         .map(StageStats::create)
                         .collect(toList()));
@@ -144,6 +152,16 @@ public final class StageStats
     public long getProcessedBytes()
     {
         return processedBytes;
+    }
+
+    public long getPhysicalInputDataSize()
+    {
+        return physicalInputDataSize;
+    }
+
+    public long getInputDataSize()
+    {
+        return inputDataSize;
     }
 
     public List<StageStats> getSubStages()

--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestProgressMonitor.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestProgressMonitor.java
@@ -90,7 +90,7 @@ public class TestProgressMonitor
                 nextUriId == null ? null : server.url(format("/v1/statement/%s/%s", queryId, nextUriId)).uri(),
                 responseColumns,
                 data,
-                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
+                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
                 null,
                 ImmutableList.of(),
                 null,


### PR DESCRIPTION
This is an ongoing PR to fix the following issue: 

Fixes #4863

