### PR TITLE
Update jline to 3.21.0

### DIFF
--- a/client/trino-cli/pom.xml
+++ b/client/trino-cli/pom.xml
@@ -16,7 +16,7 @@
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <project.build.targetJdk>8</project.build.targetJdk>
         <main-class>io.trino.cli.Trino</main-class>
-        <dep.jline.version>3.17.1</dep.jline.version>
+        <dep.jline.version>3.21.0</dep.jline.version>
     </properties>
 
     <dependencies>

--- a/client/trino-cli/src/main/java/io/trino/cli/InputReader.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/InputReader.java
@@ -26,6 +26,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 
+import static io.trino.cli.TerminalUtils.isRealTerminal;
 import static org.jline.reader.LineReader.BLINK_MATCHING_PAREN;
 import static org.jline.reader.LineReader.HISTORY_FILE;
 import static org.jline.reader.LineReader.Option.HISTORY_TIMESTAMPED;
@@ -44,7 +45,7 @@ public class InputReader
         reader = LineReaderBuilder.builder()
                 .terminal(TerminalUtils.getTerminal())
                 .variable(HISTORY_FILE, historyFile)
-                .variable(SECONDARY_PROMPT_PATTERN, colored("%P -> "))
+                .variable(SECONDARY_PROMPT_PATTERN, isRealTerminal() ? colored("%P -> ") : "") // workaround for https://github.com/jline/jline3/issues/751
                 .variable(BLINK_MATCHING_PAREN, 0)
                 .parser(new InputParser())
                 .highlighter(new InputHighlighter())


### PR DESCRIPTION
Fixes an incompatibility with ARM64:
```
    com.sun.jna.LastErrorException: [14] Bad address
    	at com.sun.jna.Native.invokeVoid(Native Method)
    	at com.sun.jna.Function.invoke(Function.java:415)
    	at com.sun.jna.Function.invoke(Function.java:361)
    	at com.sun.jna.Library$Handler.invoke(Library.java:265)
    	at com.sun.proxy.$Proxy6.ioctl(Unknown Source)
    	at org.jline.terminal.impl.jna.osx.OsXNativePty.getSize(OsXNativePty.java:82)
```