### PR TITLE
Update hive insert overwrite documentation

### DIFF
--- a/docs/src/main/sphinx/appendix/from-hive.rst
+++ b/docs/src/main/sphinx/appendix/from-hive.rst
@@ -147,5 +147,5 @@ query::
 The resulting behavior is equivalent to using `INSERT OVERWRITE
 <https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DML>`_ in Hive.
 
-Insert overwrite operation is not supported by Trino when the table is
-stored on S3, encrypted HDFS or an external location.
+Insert overwrite operation is not supported by Trino when the table is stored on
+encrypted HDFS, when the table is unpartitioned or table is transactional.

--- a/docs/src/main/sphinx/connector/hive.rst
+++ b/docs/src/main/sphinx/connector/hive.rst
@@ -668,6 +668,8 @@ features:
 * :ref:`sql-security-operations`, see also :ref:`hive-sql-standard-based-authorization`
 * :ref:`sql-transactions`
 
+Refer to :doc:`the migration guide </appendix/from-hive>` for practical advice on migrating from Hive to Trino.
+
 .. _hive-alter-table-execute:
 
 ALTER TABLE EXECUTE


### PR DESCRIPTION
fixes #10160

@aczajkowski I want to confirm this text with you before I mark this PR as ready for review. I think we added support for S3 `Insert Overwrite` from 363 onwards hence I have removed the S3 limitation from the docs. So could you please confirm if this change is correct or not?