### PR TITLE
Allow binding read expression in JDBC connectors

### DIFF
--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/BaseJdbcClient.java
@@ -412,10 +412,10 @@ public abstract class BaseJdbcClient
     }
 
     @Override
-    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns)
+    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns, Map<String, String> columnExpressions)
             throws SQLException
     {
-        PreparedQuery preparedQuery = prepareQuery(session, connection, table, Optional.empty(), columns, ImmutableMap.of(), Optional.of(split));
+        PreparedQuery preparedQuery = prepareQuery(session, connection, table, Optional.empty(), columns, columnExpressions, Optional.of(split));
         return new QueryBuilder(this).prepareStatement(session, connection, preparedQuery);
     }
 

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/CachingJdbcClient.java
@@ -221,10 +221,10 @@ public class CachingJdbcClient
     }
 
     @Override
-    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns)
+    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns, Map<String, String> columnExpressions)
             throws SQLException
     {
-        return delegate.buildSql(session, connection, split, table, columns);
+        return delegate.buildSql(session, connection, split, table, columns, columnExpressions);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ForwardingJdbcClient.java
@@ -151,10 +151,10 @@ public abstract class ForwardingJdbcClient
     }
 
     @Override
-    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle tableHandle, List<JdbcColumnHandle> columnHandles)
+    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle tableHandle, List<JdbcColumnHandle> columnHandles, Map<String, String> columnExpressions)
             throws SQLException
     {
-        return delegate().buildSql(session, connection, split, tableHandle, columnHandles);
+        return delegate().buildSql(session, connection, split, tableHandle, columnHandles, columnExpressions);
     }
 
     @Override

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/JdbcClient.java
@@ -93,7 +93,7 @@ public interface JdbcClient
             List<JdbcColumnHandle> columns,
             Map<String, String> columnExpressions);
 
-    PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns)
+    PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columns, Map<String, String> columnExpressions)
             throws SQLException;
 
     Optional<PreparedQuery> implementJoin(

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ReadFunction.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/ReadFunction.java
@@ -15,10 +15,16 @@ package io.trino.plugin.jdbc;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Optional;
 
 public interface ReadFunction
 {
     Class<?> getJavaType();
+
+    default Optional<String> getBindExpression(String columnName)
+    {
+        return Optional.empty();
+    }
 
     default boolean isNull(ResultSet resultSet, int columnIndex)
             throws SQLException

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/jmx/StatisticsAwareJdbcClient.java
@@ -171,10 +171,10 @@ public final class StatisticsAwareJdbcClient
     }
 
     @Override
-    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle tableHandle, List<JdbcColumnHandle> columnHandles)
+    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle tableHandle, List<JdbcColumnHandle> columnHandles, Map<String, String> columnExpressions)
             throws SQLException
     {
-        return stats.getBuildSql().wrap(() -> delegate().buildSql(session, connection, split, tableHandle, columnHandles));
+        return stats.getBuildSql().wrap(() -> delegate().buildSql(session, connection, split, tableHandle, columnHandles, columnExpressions));
     }
 
     @Override

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixClient.java
@@ -249,7 +249,7 @@ public class PhoenixClient
     }
 
     @Override
-    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
+    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles, Map<String, String> columnExpressions)
             throws SQLException
     {
         PreparedStatement query = prepareStatement(

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixClient.java
@@ -249,7 +249,7 @@ public class PhoenixClient
     }
 
     @Override
-    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles)
+    public PreparedStatement buildSql(ConnectorSession session, Connection connection, JdbcSplit split, JdbcTableHandle table, List<JdbcColumnHandle> columnHandles, Map<String, String> columnExpressions)
             throws SQLException
     {
         PreparedStatement query = prepareStatement(


### PR DESCRIPTION
Some databases need expressions to get the expected result via JDBC drivers.