### PR TITLE
Remove redundant functional predicate from Constraint in Hive $partitions

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -141,7 +141,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -2442,12 +2441,6 @@ public class HiveMetadata
         }
         // it is too expensive to determine the exact number of deleted rows
         return OptionalLong.empty();
-    }
-
-    @VisibleForTesting
-    static Predicate<Map<ColumnHandle, NullableValue>> convertToPredicate(TupleDomain<ColumnHandle> tupleDomain)
-    {
-        return bindings -> tupleDomain.contains(TupleDomain.fromFixedValues(bindings));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionsSystemTableProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionsSystemTableProvider.java
@@ -14,7 +14,6 @@
 package io.trino.plugin.hive;
 
 import io.trino.plugin.hive.authentication.HiveIdentity;
-import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -22,7 +21,6 @@ import io.trino.spi.connector.Constraint;
 import io.trino.spi.connector.InMemoryRecordSet;
 import io.trino.spi.connector.SchemaTableName;
 import io.trino.spi.connector.SystemTable;
-import io.trino.spi.predicate.TupleDomain;
 import io.trino.spi.type.Type;
 
 import javax.inject.Inject;
@@ -35,7 +33,6 @@ import java.util.stream.IntStream;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Streams.stream;
-import static io.trino.plugin.hive.HiveMetadata.convertToPredicate;
 import static io.trino.plugin.hive.SystemTableHandler.PARTITIONS;
 import static io.trino.plugin.hive.util.SystemTables.createSystemTable;
 import static java.util.Objects.requireNonNull;
@@ -103,11 +100,7 @@ public class PartitionsSystemTableProvider
         return Optional.of(createSystemTable(
                 new ConnectorTableMetadata(tableName, partitionSystemTableColumns),
                 constraint -> {
-                    TupleDomain<ColumnHandle> targetTupleDomain = constraint.transformKeys(fieldIdToColumnHandle::get);
-                    Constraint targetConstraint = new Constraint(
-                            targetTupleDomain,
-                            Optional.of(convertToPredicate(targetTupleDomain)),
-                            targetTupleDomain.getDomains().map(Map::keySet));
+                    Constraint targetConstraint = new Constraint(constraint.transformKeys(fieldIdToColumnHandle::get));
                     Iterable<List<Object>> records = () ->
                             stream(partitionManager.getPartitions(metadata.getMetastore(), new HiveIdentity(session), sourceTableHandle, targetConstraint).getPartitions())
                                     .map(hivePartition ->

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -211,7 +211,6 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_PARTITION_VALUE;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_PARTITION_SCHEMA_MISMATCH;
 import static io.trino.plugin.hive.HiveMetadata.PRESTO_QUERY_ID_NAME;
 import static io.trino.plugin.hive.HiveMetadata.PRESTO_VERSION_NAME;
-import static io.trino.plugin.hive.HiveMetadata.convertToPredicate;
 import static io.trino.plugin.hive.HiveSessionProperties.getTemporaryStagingDirectoryPath;
 import static io.trino.plugin.hive.HiveSessionProperties.isTemporaryStagingDirectoryEnabled;
 import static io.trino.plugin.hive.HiveStorageFormat.AVRO;
@@ -5613,6 +5612,11 @@ public abstract class AbstractTestHive
         if (expectedTag == tag) {
             throw new TestingRollbackException();
         }
+    }
+
+    protected static Predicate<Map<ColumnHandle, NullableValue>> convertToPredicate(TupleDomain<ColumnHandle> tupleDomain)
+    {
+        return bindings -> tupleDomain.contains(TupleDomain.fromFixedValues(bindings));
     }
 
     private static class TestingRollbackException


### PR DESCRIPTION
Currently, for `Constraint` constructed by the engine (e.g. in
`PushPredicateIntoTableScan`), the `Constraint.predicate` is set only
when it is stricter than `Constraint.summary`. Conceptually this makes
sense: `TupleDomain` (the `summary`) is easier to decompose and absorb
by a connector. Passing same information in form of `Predicate` (the
`predicate`) would only lead to redundant computations.

In the future, if we want to make `predicate` always present, we will
need to give connectors a way to determine whether it brings more
information (i.e. is stricter than) the `summary`.

This commit changes an instance of `Constraint` used internally in Hive
connector. The invoked `PartitionManager`'s method uses both: `summary`
and `predicate`, so this commit removes redundant computations there.