### PR TITLE
Enforce Constraint.predicate's columns always known

### DIFF
--- a/core/trino-main/src/test/java/io/trino/metadata/TestInformationSchemaMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestInformationSchemaMetadata.java
@@ -46,6 +46,7 @@ import org.testng.annotations.Test;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.connector.CatalogName.createInformationSchemaCatalogName;
@@ -130,7 +131,7 @@ public class TestInformationSchemaMetadata
     public void testInformationSchemaPredicatePushdownWithConstraintPredicate()
     {
         TransactionId transactionId = transactionManager.beginTransaction(false);
-        Constraint constraint = new Constraint(TupleDomain.all(), Optional.of(TestInformationSchemaMetadata::testConstraint), Optional.empty());
+        Constraint constraint = new Constraint(TupleDomain.all(), TestInformationSchemaMetadata::testConstraint, testConstraintColumns());
 
         ConnectorSession session = createNewSession(transactionId);
         ConnectorMetadata metadata = new InformationSchemaMetadata("test_catalog", this.metadata);
@@ -192,7 +193,7 @@ public class TestInformationSchemaMetadata
         TransactionId transactionId = transactionManager.beginTransaction(false);
 
         // predicate on non columns enumerating table should not cause tables to be enumerated
-        Constraint constraint = new Constraint(TupleDomain.all(), Optional.of(TestInformationSchemaMetadata::testConstraint), Optional.empty());
+        Constraint constraint = new Constraint(TupleDomain.all(), TestInformationSchemaMetadata::testConstraint, testConstraintColumns());
         ConnectorSession session = createNewSession(transactionId);
         ConnectorMetadata metadata = new InformationSchemaMetadata("test_catalog", this.metadata);
         InformationSchemaTableHandle tableHandle = (InformationSchemaTableHandle)
@@ -252,12 +253,18 @@ public class TestInformationSchemaMetadata
         assertEquals(filtered.getPrefixes(), ImmutableSet.of(new QualifiedTablePrefix("test_catalog", "test_schema", "")));
     }
 
+    /**
+     * @see #testConstraintColumns()
+     */
     private static boolean testConstraint(Map<ColumnHandle, NullableValue> bindings)
     {
         // test_schema has a table named "another_table" and we filter that out in this predicate
+
+        // Note: the columns inspected here must be in sync with testConstraintColumns()
         NullableValue catalog = bindings.get(new InformationSchemaColumnHandle("table_catalog"));
         NullableValue schema = bindings.get(new InformationSchemaColumnHandle("table_schema"));
         NullableValue table = bindings.get(new InformationSchemaColumnHandle("table_name"));
+
         boolean isValid = true;
         if (catalog != null) {
             isValid = ((Slice) catalog.getValue()).toStringUtf8().equals("test_catalog");
@@ -269,6 +276,17 @@ public class TestInformationSchemaMetadata
             isValid &= ((Slice) table.getValue()).toStringUtf8().equals("test_view");
         }
         return isValid;
+    }
+
+    /**
+     * Returns set of columns inspected by {@link #testConstraint(Map)}.
+     */
+    private static Set<ColumnHandle> testConstraintColumns()
+    {
+        return Set.of(
+                new InformationSchemaColumnHandle("table_catalog"),
+                new InformationSchemaColumnHandle("table_schema"),
+                new InformationSchemaColumnHandle("table_name"));
     }
 
     private static ConnectorSession createNewSession(TransactionId transactionId)

--- a/core/trino-main/src/test/java/io/trino/metadata/TestInformationSchemaMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestInformationSchemaMetadata.java
@@ -233,7 +233,7 @@ public class TestInformationSchemaMetadata
 
         // Empty schema name
         InformationSchemaTableHandle filtered = metadata.applyFilter(session, tableHandle, new Constraint(TupleDomain.withColumnDomains(
-                ImmutableMap.of(tableSchemaColumn, Domain.singleValue(VARCHAR, Slices.utf8Slice(""))))))
+                        ImmutableMap.of(tableSchemaColumn, Domain.singleValue(VARCHAR, Slices.utf8Slice(""))))))
                 .map(ConstraintApplicationResult::getHandle)
                 .map(InformationSchemaTableHandle.class::cast)
                 .orElseThrow(AssertionError::new);
@@ -243,7 +243,7 @@ public class TestInformationSchemaMetadata
 
         // Empty table name
         filtered = metadata.applyFilter(session, tableHandle, new Constraint(TupleDomain.withColumnDomains(
-                ImmutableMap.of(tableNameColumn, Domain.singleValue(VARCHAR, Slices.utf8Slice(""))))))
+                        ImmutableMap.of(tableNameColumn, Domain.singleValue(VARCHAR, Slices.utf8Slice(""))))))
                 .map(ConstraintApplicationResult::getHandle)
                 .map(InformationSchemaTableHandle.class::cast)
                 .orElseThrow(AssertionError::new);

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/Constraint.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/Constraint.java
@@ -31,12 +31,12 @@ public class Constraint
 
     public static Constraint alwaysTrue()
     {
-        return new Constraint(TupleDomain.all(), Optional.empty(), Optional.empty());
+        return new Constraint(TupleDomain.all());
     }
 
     public static Constraint alwaysFalse()
     {
-        return new Constraint(TupleDomain.none(), Optional.of(bindings -> false), Optional.empty());
+        return new Constraint(TupleDomain.none(), bindings -> false, Set.of());
     }
 
     public Constraint(TupleDomain<ColumnHandle> summary)
@@ -49,19 +49,17 @@ public class Constraint
         this(summary, Optional.of(predicate), Optional.of(predicateColumns));
     }
 
-    /**
-     * @deprecated Use {@link #Constraint(TupleDomain)} or {@link #Constraint(TupleDomain, Predicate, Set)} instead.
-     */
-    @Deprecated // TODO update all usages and make private
-    public Constraint(TupleDomain<ColumnHandle> summary, Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate, Optional<Set<ColumnHandle>> predicateColumns)
+    private Constraint(TupleDomain<ColumnHandle> summary, Optional<Predicate<Map<ColumnHandle, NullableValue>>> predicate, Optional<Set<ColumnHandle>> predicateColumns)
     {
         this.summary = requireNonNull(summary, "summary is null");
         this.predicate = requireNonNull(predicate, "predicate is null");
         this.predicateColumns = requireNonNull(predicateColumns, "predicateColumns is null");
 
-        // TODO (https://github.com/trinodb/trino/issues/9589) validate that predicate is present *iff* predicateColumns is present
         if (predicateColumns.isPresent() && predicate.isEmpty()) {
             throw new IllegalArgumentException("predicateColumns cannot be present when predicate is not present");
+        }
+        if (predicateColumns.isEmpty() && predicate.isPresent()) {
+            throw new IllegalArgumentException("predicate cannot be present without predicateColumns");
         }
     }
 
@@ -84,7 +82,7 @@ public class Constraint
     }
 
     /**
-     * Set of columns the {@link #predicate()} result depends on.
+     * Set of columns the {@link #predicate()} result depends on. It's present if and only if {@link #predicate()} is present.
      */
     public Optional<Set<ColumnHandle>> getPredicateColumns()
     {

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSplitSource.java
@@ -303,7 +303,7 @@ public class IcebergSplitSource
         verify(constraint.getSummary().isAll());
 
         if (constraint.predicate().isEmpty() ||
-                constraint.getPredicateColumns().map(predicateColumns -> intersection(predicateColumns, identityPartitionColumns).isEmpty()).orElse(false)) {
+                intersection(constraint.getPredicateColumns().orElseThrow(), identityPartitionColumns).isEmpty()) {
             return true;
         }
         return constraint.predicate().get().test(partitionValues.get());

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -2020,6 +2020,7 @@ public abstract class BaseIcebergConnectorTest
         assertUpdate(insertStart + " VALUES (1, 101), (2, 102), (3, 103), (4, 104)", 4);
         TableStatistics tableStatistics = getTableStatistics(tableName, new Constraint(TupleDomain.all()));
         IcebergColumnHandle col1Handle = getColumnHandleFromStatistics(tableStatistics, "col1");
+        IcebergColumnHandle col2Handle = getColumnHandleFromStatistics(tableStatistics, "col2");
 
         // Constraint.predicate is currently not supported, because it's never provided by the engine.
         // TODO add (restore) test coverage when this changes.
@@ -2028,17 +2029,17 @@ public abstract class BaseIcebergConnectorTest
         assertThatThrownBy(() ->
                 getTableStatistics(tableName, new Constraint(
                         TupleDomain.all(),
-                        Optional.of(new TestRelationalNumberPredicate("col1", 3, i1 -> i1 >= 0)),
-                        Optional.of(ImmutableSet.of(col1Handle)))))
+                        new TestRelationalNumberPredicate("col1", 3, i1 -> i1 >= 0),
+                        Set.of(col1Handle))))
                 .isInstanceOf(VerifyException.class)
                 .hasMessage("Unexpected Constraint predicate");
 
-        // predicate on an unspecified set of columns column
+        // predicate on a non-partition column
         assertThatThrownBy(() ->
                 getTableStatistics(tableName, new Constraint(
                         TupleDomain.all(),
-                        Optional.of(new TestRelationalNumberPredicate("col2", 102, i -> i >= 0)),
-                        Optional.empty())))
+                        new TestRelationalNumberPredicate("col2", 102, i -> i >= 0),
+                        Set.of(col2Handle))))
                 .isInstanceOf(VerifyException.class)
                 .hasMessage("Unexpected Constraint predicate");
 


### PR DESCRIPTION
`Constraint.getPredicateColumns` should be always present whenever
`Constraint.predicate` is present. The columns covered by the predicate
are important for the connector, and enforcing the mutual presence makes
constraint consumption simpler.

Fixes https://github.com/trinodb/trino/issues/9589