### PR TITLE
Fix tpch q08 product test requirements

### DIFF
--- a/testing/trino-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q08.sql
+++ b/testing/trino-product-tests/src/main/resources/sql-tests/testcases/hive_tpch/q08.sql
@@ -1,4 +1,4 @@
--- database: presto; groups: tpch; tables: part,supplier,lineitem,orders,customer,nation
+-- database: presto; groups: tpch; tables: part,supplier,lineitem,orders,customer,nation,region
 SELECT
   o_year,
   sum(CASE


### PR DESCRIPTION
When trying to run this single test with: 
`testing/bin/ptl test run --environment=multinode -- -tests sql_tests.testcases.hive_tpch.q08`

It fails with:
`Query failed (#20211203_224334_00000_wzpi8): line 21:10: Table 'hive.default.region' does not exist`

This is just fixing the test requirements so it does not fail.

I think during a normal product test run, other tests create this immutable region table so it is not a problem unless you run a single test.