### PR TITLE
[DOC] Update the wrong license link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,4 +6,4 @@ In order to accept your pull request, we need you to [submit a CLA](https://gith
 
 ## License
 
-By contributing to Trino, you agree that your contributions will be licensed under the [Apache License Version 2.0 (APLv2)](https://www.apache.org/licenses/LICENSE-2.0).
+By contributing to Trino, you agree that your contributions will be licensed under the [Apache License Version 2.0 (APLv2)](../LICENSE).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,4 +6,4 @@ In order to accept your pull request, we need you to [submit a CLA](https://gith
 
 ## License
 
-By contributing to Trino, you agree that your contributions will be licensed under the [Apache License Version 2.0 (APLv2)](LICENSE).
+By contributing to Trino, you agree that your contributions will be licensed under the [Apache License Version 2.0 (APLv2)](https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
This PR intend that fix the document issue;

When we click the [CONTRIBUTING](https://github.com/trinodb/trino/blob/master/.github/CONTRIBUTING.md)'s Apache License Version 2.0 (APLv2) link.

**Before the PR:**
![image](https://user-images.githubusercontent.com/51110188/144998848-61f72b1a-1ee4-4e25-aa43-447245ff8e44.png)
**After the PR:**
The link can jump normal.