### PR TITLE
Test and fix casts from approximate numeric types to varchar

### DIFF
--- a/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
+++ b/core/trino-main/src/main/java/io/trino/type/DoubleOperators.java
@@ -19,6 +19,7 @@ import com.google.common.primitives.SignedBytes;
 import io.airlift.slice.Slice;
 import io.trino.operator.scalar.MathFunctions;
 import io.trino.spi.TrinoException;
+import io.trino.spi.function.LiteralParameter;
 import io.trino.spi.function.LiteralParameters;
 import io.trino.spi.function.ScalarOperator;
 import io.trino.spi.function.SqlType;
@@ -172,9 +173,15 @@ public final class DoubleOperators
     @ScalarOperator(CAST)
     @LiteralParameters("x")
     @SqlType("varchar(x)")
-    public static Slice castToVarchar(@SqlType(StandardTypes.DOUBLE) double value)
+    public static Slice castToVarchar(@LiteralParameter("x") long x, @SqlType(StandardTypes.DOUBLE) double value)
     {
-        return utf8Slice(String.valueOf(value));
+        String stringValue = String.valueOf(value);
+        // String is all-ASCII, so String.length() here returns actual code points count
+        if (stringValue.length() <= x) {
+            return utf8Slice(stringValue);
+        }
+
+        throw new TrinoException(INVALID_CAST_ARGUMENT, format("Value %s cannot be represented as varchar(%s)", value, x));
     }
 
     @ScalarOperator(SATURATED_FLOOR_CAST)

--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -89,6 +89,7 @@ import static io.trino.spi.type.IntegerType.INTEGER;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
+import static io.trino.spi.type.VarcharType.UNBOUNDED_LENGTH;
 import static io.trino.type.DateTimes.formatTimestamp;
 import static io.trino.type.JsonType.JSON;
 import static io.trino.util.DateTimeUtils.printDate;
@@ -671,7 +672,7 @@ public final class JsonUtil
                 return Slices.utf8Slice(parser.getText());
             case VALUE_NUMBER_FLOAT:
                 // Avoidance of loss of precision does not seem to be possible here because of Jackson implementation.
-                return DoubleOperators.castToVarchar(parser.getDoubleValue());
+                return DoubleOperators.castToVarchar(UNBOUNDED_LENGTH, parser.getDoubleValue());
             case VALUE_NUMBER_INT:
                 // An alternative is calling getLongValue and then BigintOperators.castToVarchar.
                 // It doesn't work as well because it can result in overflow and underflow exceptions for large integral numbers.

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -723,6 +723,97 @@ public class TestExpressionInterpreter
     }
 
     @Test
+    public void testCastDoubleToBoundedVarchar()
+    {
+        // NaN
+        assertEvaluatedEquals("CAST(0e0 / 0e0 AS varchar(3))", "'NaN'");
+        assertEvaluatedEquals("CAST(0e0 / 0e0 AS varchar(50))", "'NaN'");
+
+        // Infinity
+        assertEvaluatedEquals("CAST(DOUBLE 'Infinity' AS varchar(8))", "'Infinity'");
+        assertEvaluatedEquals("CAST(DOUBLE 'Infinity' AS varchar(50))", "'Infinity'");
+
+        // incorrect behavior: the string representation is not compliant with the SQL standard
+        assertEvaluatedEquals("CAST(0e0 AS varchar(3))", "'0.0'");
+        assertEvaluatedEquals("CAST(DOUBLE '0' AS varchar(3))", "'0.0'");
+        assertEvaluatedEquals("CAST(DOUBLE '-0' AS varchar(4))", "'-0.0'");
+        assertEvaluatedEquals("CAST(DOUBLE '0' AS varchar(50))", "'0.0'");
+
+        assertEvaluatedEquals("CAST(12e0 AS varchar(4))", "'12.0'");
+        assertEvaluatedEquals("CAST(12e2 AS varchar(6))", "'1200.0'");
+        assertEvaluatedEquals("CAST(12e-2 AS varchar(4))", "'0.12'");
+
+        assertEvaluatedEquals("CAST(12e0 AS varchar(50))", "'12.0'");
+        assertEvaluatedEquals("CAST(12e2 AS varchar(50))", "'1200.0'");
+        assertEvaluatedEquals("CAST(12e-2 AS varchar(50))", "'0.12'");
+
+        assertEvaluatedEquals("CAST(-12e0 AS varchar(5))", "'-12.0'");
+        assertEvaluatedEquals("CAST(-12e2 AS varchar(7))", "'-1200.0'");
+        assertEvaluatedEquals("CAST(-12e-2 AS varchar(5))", "'-0.12'");
+
+        assertEvaluatedEquals("CAST(-12e0 AS varchar(50))", "'-12.0'");
+        assertEvaluatedEquals("CAST(-12e2 AS varchar(50))", "'-1200.0'");
+        assertEvaluatedEquals("CAST(-12e-2 AS varchar(50))", "'-0.12'");
+
+        // the string representation is compliant with the SQL standard
+        assertEvaluatedEquals("CAST(12345678.9e0 AS varchar(12))", "'1.23456789E7'");
+        assertEvaluatedEquals("CAST(0.00001e0 AS varchar(6))", "'1.0E-5'");
+
+        // incorrect behavior: the result value does not fit in the type (also, it is not compliant with the SQL standard)
+        assertEvaluatedEquals("CAST(12e0 AS varchar(1))", "'12.0'");
+        assertEvaluatedEquals("CAST(-12e2 AS varchar(1))", "'-1200.0'");
+        assertEvaluatedEquals("CAST(0e0 AS varchar(1))", "'0.0'");
+        assertEvaluatedEquals("CAST(0e0 / 0e0 AS varchar(1))", "'NaN'");
+        assertEvaluatedEquals("CAST(DOUBLE 'Infinity' AS varchar(1))", "'Infinity'");
+        assertEvaluatedEquals("CAST(1200000e0 AS varchar(5))", "'1200000.0'");
+    }
+
+    @Test
+    public void testCastRealToBoundedVarchar()
+    {
+        // NaN
+        assertEvaluatedEquals("CAST(REAL '0e0' / REAL '0e0' AS varchar(3))", "'NaN'");
+        assertEvaluatedEquals("CAST(REAL '0e0' / REAL '0e0' AS varchar(50))", "'NaN'");
+
+        // Infinity
+        assertEvaluatedEquals("CAST(REAL 'Infinity' AS varchar(8))", "'Infinity'");
+        assertEvaluatedEquals("CAST(REAL 'Infinity' AS varchar(50))", "'Infinity'");
+
+        // incorrect behavior: the string representation is not compliant with the SQL standard
+        assertEvaluatedEquals("CAST(REAL '0' AS varchar(3))", "'0.0'");
+        assertEvaluatedEquals("CAST(REAL '-0' AS varchar(4))", "'-0.0'");
+        assertEvaluatedEquals("CAST(REAL '0' AS varchar(50))", "'0.0'");
+
+        assertEvaluatedEquals("CAST(REAL '12' AS varchar(4))", "'12.0'");
+        assertEvaluatedEquals("CAST(REAL '12e2' AS varchar(6))", "'1200.0'");
+        assertEvaluatedEquals("CAST(REAL '12e-2' AS varchar(4))", "'0.12'");
+
+        assertEvaluatedEquals("CAST(REAL '12' AS varchar(50))", "'12.0'");
+        assertEvaluatedEquals("CAST(REAL '12e2' AS varchar(50))", "'1200.0'");
+        assertEvaluatedEquals("CAST(REAL '12e-2' AS varchar(50))", "'0.12'");
+
+        assertEvaluatedEquals("CAST(REAL '-12' AS varchar(5))", "'-12.0'");
+        assertEvaluatedEquals("CAST(REAL '-12e2' AS varchar(7))", "'-1200.0'");
+        assertEvaluatedEquals("CAST(REAL '-12e-2' AS varchar(5))", "'-0.12'");
+
+        assertEvaluatedEquals("CAST(REAL '-12' AS varchar(50))", "'-12.0'");
+        assertEvaluatedEquals("CAST(REAL '-12e2' AS varchar(50))", "'-1200.0'");
+        assertEvaluatedEquals("CAST(REAL '-12e-2' AS varchar(50))", "'-0.12'");
+
+        // the string representation is compliant with the SQL standard
+        assertEvaluatedEquals("CAST(REAL '12345678.9e0' AS varchar(12))", "'1.2345679E7'");
+        assertEvaluatedEquals("CAST(REAL '0.00001e0' AS varchar(6))", "'1.0E-5'");
+
+        // incorrect behavior: the result value does not fit in the type (also, it is not compliant with the SQL standard)
+        assertEvaluatedEquals("CAST(REAL '12' AS varchar(1))", "'12.0'");
+        assertEvaluatedEquals("CAST(REAL '-12e2' AS varchar(1))", "'-1200.0'");
+        assertEvaluatedEquals("CAST(REAL '0' AS varchar(1))", "'0.0'");
+        assertEvaluatedEquals("CAST(REAL '0e0' / REAL '0e0' AS varchar(1))", "'NaN'");
+        assertEvaluatedEquals("CAST(REAL 'Infinity' AS varchar(1))", "'Infinity'");
+        assertEvaluatedEquals("CAST(REAL '1200000' AS varchar(5))", "'1200000.0'");
+    }
+
+    @Test
     public void testCastToBoolean()
     {
         // integer

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -759,13 +759,25 @@ public class TestExpressionInterpreter
         assertEvaluatedEquals("CAST(12345678.9e0 AS varchar(12))", "'1.23456789E7'");
         assertEvaluatedEquals("CAST(0.00001e0 AS varchar(6))", "'1.0E-5'");
 
-        // incorrect behavior: the result value does not fit in the type (also, it is not compliant with the SQL standard)
-        assertEvaluatedEquals("CAST(12e0 AS varchar(1))", "'12.0'");
-        assertEvaluatedEquals("CAST(-12e2 AS varchar(1))", "'-1200.0'");
-        assertEvaluatedEquals("CAST(0e0 AS varchar(1))", "'0.0'");
-        assertEvaluatedEquals("CAST(0e0 / 0e0 AS varchar(1))", "'NaN'");
-        assertEvaluatedEquals("CAST(DOUBLE 'Infinity' AS varchar(1))", "'Infinity'");
-        assertEvaluatedEquals("CAST(1200000e0 AS varchar(5))", "'1200000.0'");
+        // the result value does not fit in the type (also, it is not compliant with the SQL standard)
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(12e0 AS varchar(1))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 12.0 cannot be represented as varchar(1)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(-12e2 AS varchar(1))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value -1200.0 cannot be represented as varchar(1)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(0e0 AS varchar(1))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 0.0 cannot be represented as varchar(1)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(0e0 / 0e0 AS varchar(1))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value NaN cannot be represented as varchar(1)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(DOUBLE 'Infinity' AS varchar(1))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value Infinity cannot be represented as varchar(1)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(1200000e0 AS varchar(5))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 1200000.0 cannot be represented as varchar(5)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
+++ b/core/trino-main/src/test/java/io/trino/sql/TestExpressionInterpreter.java
@@ -816,13 +816,25 @@ public class TestExpressionInterpreter
         assertEvaluatedEquals("CAST(REAL '12345678.9e0' AS varchar(12))", "'1.2345679E7'");
         assertEvaluatedEquals("CAST(REAL '0.00001e0' AS varchar(6))", "'1.0E-5'");
 
-        // incorrect behavior: the result value does not fit in the type (also, it is not compliant with the SQL standard)
-        assertEvaluatedEquals("CAST(REAL '12' AS varchar(1))", "'12.0'");
-        assertEvaluatedEquals("CAST(REAL '-12e2' AS varchar(1))", "'-1200.0'");
-        assertEvaluatedEquals("CAST(REAL '0' AS varchar(1))", "'0.0'");
-        assertEvaluatedEquals("CAST(REAL '0e0' / REAL '0e0' AS varchar(1))", "'NaN'");
-        assertEvaluatedEquals("CAST(REAL 'Infinity' AS varchar(1))", "'Infinity'");
-        assertEvaluatedEquals("CAST(REAL '1200000' AS varchar(5))", "'1200000.0'");
+        // the result value does not fit in the type (also, it is not compliant with the SQL standard)
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(REAL '12' AS varchar(1))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 12.0 cannot be represented as varchar(1)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(REAL '-12e2' AS varchar(1))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value -1200.0 cannot be represented as varchar(1)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(REAL '0' AS varchar(1))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 0.0 cannot be represented as varchar(1)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(REAL '0e0' / REAL '0e0' AS varchar(1))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value NaN cannot be represented as varchar(1)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(REAL 'Infinity' AS varchar(1))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value Infinity cannot be represented as varchar(1)");
+        assertTrinoExceptionThrownBy(() -> evaluate("CAST(REAL '1200000' AS varchar(5))"))
+                .hasErrorCode(INVALID_CAST_ARGUMENT)
+                .hasMessage("Value 1200000.0 cannot be represented as varchar(5)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -236,18 +236,12 @@ public class TestSimplifyExpressions
         assertSimplifies("CAST(REAL '12e2' AS varchar(6))", "'1200.0'");
         assertSimplifies("CAST(REAL '-12e2' AS varchar(50))", "CAST('-1200.0' AS varchar(50))");
 
-        // the varchar type length is not enough to contain the number's representation:
-        // the cast operator returns a value that is too long for the expected type ('1200.0' for varchar(3))
-        // the value is then wrapped in another cast by the LiteralEncoder (CAST('1200.0' AS varchar(3))),
-        // so eventually we get a truncated string '120'
-        assertSimplifies("CAST(REAL '12e2' AS varchar(3))", "CAST('1200.0' AS varchar(3))");
-        assertSimplifies("CAST(REAL '-12e2' AS varchar(3))", "CAST('-1200.0' AS varchar(3))");
-        assertSimplifies("CAST(REAL 'NaN' AS varchar(2))", "CAST('NaN' AS varchar(2))");
-        assertSimplifies("CAST(REAL 'Infinity' AS varchar(7))", "CAST('Infinity' AS varchar(7))");
-
-        // the cast operator returns a value that is too long for the expected type ('1200.0' for varchar(3))
-        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
-        assertSimplifies("CAST(REAL '12e2' AS varchar(3)) = '1200.0'", "true");
+        // cast from real to varchar fails, so the expression is not modified
+        assertSimplifies("CAST(REAL '12e2' AS varchar(3))", "CAST(REAL '12e2' AS varchar(3))");
+        assertSimplifies("CAST(REAL '-12e2' AS varchar(3))", "CAST(REAL '-12e2' AS varchar(3))");
+        assertSimplifies("CAST(REAL 'NaN' AS varchar(2))", "CAST(REAL 'NaN' AS varchar(2))");
+        assertSimplifies("CAST(REAL 'Infinity' AS varchar(7))", "CAST(REAL 'Infinity' AS varchar(7))");
+        assertSimplifies("CAST(REAL '12e2' AS varchar(3)) = '1200.0'", "CAST(REAL '12e2' AS varchar(3)) = '1200.0'");
     }
 
     private static void assertSimplifies(String expression, String expected)

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestSimplifyExpressions.java
@@ -217,18 +217,12 @@ public class TestSimplifyExpressions
         assertSimplifies("CAST(12e2 AS varchar(6))", "'1200.0'");
         assertSimplifies("CAST(-12e2 AS varchar(50))", "CAST('-1200.0' AS varchar(50))");
 
-        // the varchar type length is not enough to contain the number's representation:
-        // the cast operator returns a value that is too long for the expected type ('1200.0' for varchar(3))
-        // the value is then wrapped in another cast by the LiteralEncoder (CAST('1200.0' AS varchar(3))),
-        // so eventually we get a truncated string '120'
-        assertSimplifies("CAST(12e2 AS varchar(3))", "CAST('1200.0' AS varchar(3))");
-        assertSimplifies("CAST(-12e2 AS varchar(3))", "CAST('-1200.0' AS varchar(3))");
-        assertSimplifies("CAST(DOUBLE 'NaN' AS varchar(2))", "CAST('NaN' AS varchar(2))");
-        assertSimplifies("CAST(DOUBLE 'Infinity' AS varchar(7))", "CAST('Infinity' AS varchar(7))");
-
-        // the cast operator returns a value that is too long for the expected type ('1200.0' for varchar(3))
-        // the value is nested in a comparison expression, so it is not truncated by the LiteralEncoder
-        assertSimplifies("CAST(12e2 AS varchar(3)) = '1200.0'", "true");
+        // cast from double to varchar fails, so the expression is not modified
+        assertSimplifies("CAST(12e2 AS varchar(3))", "CAST(12e2 AS varchar(3))");
+        assertSimplifies("CAST(-12e2 AS varchar(3))", "CAST(-12e2 AS varchar(3))");
+        assertSimplifies("CAST(DOUBLE 'NaN' AS varchar(2))", "CAST(DOUBLE 'NaN' AS varchar(2))");
+        assertSimplifies("CAST(DOUBLE 'Infinity' AS varchar(7))", "CAST(DOUBLE 'Infinity' AS varchar(7))");
+        assertSimplifies("CAST(12e2 AS varchar(3)) = '1200.0'", "CAST(12e2 AS varchar(3)) = '1200.0'");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
@@ -28,6 +28,7 @@ import static io.trino.spi.type.BooleanType.BOOLEAN;
 import static io.trino.spi.type.DoubleType.DOUBLE;
 import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.doubleToRawLongBits;
 import static java.lang.Double.isNaN;
@@ -229,6 +230,17 @@ public class TestDoubleOperators
         assertFunction("cast(37.7E0 as varchar)", VARCHAR, "37.7");
         assertFunction("cast(17.1E0 as varchar)", VARCHAR, "17.1");
         assertFunction("cast(0E0/0E0 as varchar)", VARCHAR, "NaN");
+        assertFunction("cast(12e2 as varchar(6))", createVarcharType(6), "1200.0");
+        assertFunction("cast(12e2 as varchar(50))", createVarcharType(50), "1200.0");
+        assertFunction("cast(12345678.9e0 as varchar(50))", createVarcharType(50), "1.23456789E7");
+        assertFunction("cast(DOUBLE 'NaN' as varchar(3))", createVarcharType(3), "NaN");
+        assertFunction("cast(DOUBLE 'Infinity' as varchar(50))", createVarcharType(50), "Infinity");
+        assertFunctionThrowsIncorrectly("cast(12e2 as varchar(5))", IllegalArgumentException.class, "Character count exceeds length limit 5.*");
+        assertFunctionThrowsIncorrectly("cast(12e2 as varchar(4))", IllegalArgumentException.class, "Character count exceeds length limit 4.*");
+        assertFunctionThrowsIncorrectly("cast(0e0 as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
+        assertFunctionThrowsIncorrectly("cast(-0e0 as varchar(3))", IllegalArgumentException.class, "Character count exceeds length limit 3.*");
+        assertFunctionThrowsIncorrectly("cast(0e0 / 0e0 as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
+        assertFunctionThrowsIncorrectly("cast(DOUBLE 'Infinity' as varchar(7))", IllegalArgumentException.class, "Character count exceeds length limit 7.*");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestDoubleOperators.java
@@ -235,12 +235,12 @@ public class TestDoubleOperators
         assertFunction("cast(12345678.9e0 as varchar(50))", createVarcharType(50), "1.23456789E7");
         assertFunction("cast(DOUBLE 'NaN' as varchar(3))", createVarcharType(3), "NaN");
         assertFunction("cast(DOUBLE 'Infinity' as varchar(50))", createVarcharType(50), "Infinity");
-        assertFunctionThrowsIncorrectly("cast(12e2 as varchar(5))", IllegalArgumentException.class, "Character count exceeds length limit 5.*");
-        assertFunctionThrowsIncorrectly("cast(12e2 as varchar(4))", IllegalArgumentException.class, "Character count exceeds length limit 4.*");
-        assertFunctionThrowsIncorrectly("cast(0e0 as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
-        assertFunctionThrowsIncorrectly("cast(-0e0 as varchar(3))", IllegalArgumentException.class, "Character count exceeds length limit 3.*");
-        assertFunctionThrowsIncorrectly("cast(0e0 / 0e0 as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
-        assertFunctionThrowsIncorrectly("cast(DOUBLE 'Infinity' as varchar(7))", IllegalArgumentException.class, "Character count exceeds length limit 7.*");
+        assertInvalidCast("cast(12e2 as varchar(5))", "Value 1200.0 cannot be represented as varchar(5)");
+        assertInvalidCast("cast(12e2 as varchar(4))", "Value 1200.0 cannot be represented as varchar(4)");
+        assertInvalidCast("cast(0e0 as varchar(2))", "Value 0.0 cannot be represented as varchar(2)");
+        assertInvalidCast("cast(-0e0 as varchar(3))", "Value -0.0 cannot be represented as varchar(3)");
+        assertInvalidCast("cast(0e0 / 0e0 as varchar(2))", "Value NaN cannot be represented as varchar(2)");
+        assertInvalidCast("cast(DOUBLE 'Infinity' as varchar(7))", "Value Infinity cannot be represented as varchar(7)");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
@@ -43,243 +43,243 @@ public class TestRealOperators
     @Test
     public void testTypeConstructor()
     {
-        assertFunction("REAL'12.2'", REAL, 12.2f);
-        assertFunction("REAL'-17.76'", REAL, -17.76f);
-        assertFunction("REAL'NaN'", REAL, Float.NaN);
+        assertFunction("REAL '12.2'", REAL, 12.2f);
+        assertFunction("REAL '-17.76'", REAL, -17.76f);
+        assertFunction("REAL 'NaN'", REAL, Float.NaN);
         assertFunction("REAL '-NaN'", REAL, Float.NaN);
-        assertFunction("REAL'Infinity'", REAL, Float.POSITIVE_INFINITY);
-        assertFunction("REAL'-Infinity'", REAL, Float.NEGATIVE_INFINITY);
+        assertFunction("REAL 'Infinity'", REAL, Float.POSITIVE_INFINITY);
+        assertFunction("REAL '-Infinity'", REAL, Float.NEGATIVE_INFINITY);
     }
 
     @Test
     public void testAdd()
     {
-        assertFunction("REAL'12.34' + REAL'56.78'", REAL, 12.34f + 56.78f);
-        assertFunction("REAL'-17.34' + REAL'-22.891'", REAL, -17.34f + -22.891f);
-        assertFunction("REAL'-89.123' + REAL'754.0'", REAL, -89.123f + 754.0f);
-        assertFunction("REAL'-0.0' + REAL'0.0'", REAL, -0.0f + 0.0f);
-        assertFunction("REAL'NaN' + REAL'1.23'", REAL, Float.NaN);
-        assertFunction("REAL'1.23' + REAL'NaN'", REAL, Float.NaN);
-        assertFunction("REAL'NaN' + REAL'-NaN'", REAL, Float.NaN);
+        assertFunction("REAL '12.34' + REAL '56.78'", REAL, 12.34f + 56.78f);
+        assertFunction("REAL '-17.34' + REAL '-22.891'", REAL, -17.34f + -22.891f);
+        assertFunction("REAL '-89.123' + REAL '754.0'", REAL, -89.123f + 754.0f);
+        assertFunction("REAL '-0.0' + REAL '0.0'", REAL, -0.0f + 0.0f);
+        assertFunction("REAL 'NaN' + REAL '1.23'", REAL, Float.NaN);
+        assertFunction("REAL '1.23' + REAL 'NaN'", REAL, Float.NaN);
+        assertFunction("REAL 'NaN' + REAL '-NaN'", REAL, Float.NaN);
     }
 
     @Test
     public void testSubtract()
     {
-        assertFunction("REAL'12.34' - REAL'56.78'", REAL, 12.34f - 56.78f);
-        assertFunction("REAL'-17.34' - REAL'-22.891'", REAL, -17.34f - -22.891f);
-        assertFunction("REAL'-89.123' - REAL'754.0'", REAL, -89.123f - 754.0f);
-        assertFunction("REAL'-0.0' - REAL'0.0'", REAL, -0.0f - 0.0f);
-        assertFunction("REAL'NaN' - REAL'1.23'", REAL, Float.NaN);
-        assertFunction("REAL'1.23' - REAL'NaN'", REAL, Float.NaN);
-        assertFunction("REAL'NaN' - REAL'NaN'", REAL, Float.NaN);
+        assertFunction("REAL '12.34' - REAL '56.78'", REAL, 12.34f - 56.78f);
+        assertFunction("REAL '-17.34' - REAL '-22.891'", REAL, -17.34f - -22.891f);
+        assertFunction("REAL '-89.123' - REAL '754.0'", REAL, -89.123f - 754.0f);
+        assertFunction("REAL '-0.0' - REAL '0.0'", REAL, -0.0f - 0.0f);
+        assertFunction("REAL 'NaN' - REAL '1.23'", REAL, Float.NaN);
+        assertFunction("REAL '1.23' - REAL 'NaN'", REAL, Float.NaN);
+        assertFunction("REAL 'NaN' - REAL 'NaN'", REAL, Float.NaN);
     }
 
     @Test
     public void testMultiply()
     {
-        assertFunction("REAL'12.34' * REAL'56.78'", REAL, 12.34f * 56.78f);
-        assertFunction("REAL'-17.34' * REAL'-22.891'", REAL, -17.34f * -22.891f);
-        assertFunction("REAL'-89.123' * REAL'754.0'", REAL, -89.123f * 754.0f);
-        assertFunction("REAL'-0.0' * REAL'0.0'", REAL, -0.0f * 0.0f);
-        assertFunction("REAL'-17.71' * REAL'-1.0'", REAL, -17.71f * -1.0f);
-        assertFunction("REAL'NaN' * REAL'1.23'", REAL, Float.NaN);
-        assertFunction("REAL'1.23' * REAL'NaN'", REAL, Float.NaN);
-        assertFunction("REAL'NaN' * REAL'-NaN'", REAL, Float.NaN);
+        assertFunction("REAL '12.34' * REAL '56.78'", REAL, 12.34f * 56.78f);
+        assertFunction("REAL '-17.34' * REAL '-22.891'", REAL, -17.34f * -22.891f);
+        assertFunction("REAL '-89.123' * REAL '754.0'", REAL, -89.123f * 754.0f);
+        assertFunction("REAL '-0.0' * REAL '0.0'", REAL, -0.0f * 0.0f);
+        assertFunction("REAL '-17.71' * REAL '-1.0'", REAL, -17.71f * -1.0f);
+        assertFunction("REAL 'NaN' * REAL '1.23'", REAL, Float.NaN);
+        assertFunction("REAL '1.23' * REAL 'NaN'", REAL, Float.NaN);
+        assertFunction("REAL 'NaN' * REAL '-NaN'", REAL, Float.NaN);
     }
 
     @Test
     public void testDivide()
     {
-        assertFunction("REAL'12.34' / REAL'56.78'", REAL, 12.34f / 56.78f);
-        assertFunction("REAL'-17.34' / REAL'-22.891'", REAL, -17.34f / -22.891f);
-        assertFunction("REAL'-89.123' / REAL'754.0'", REAL, -89.123f / 754.0f);
-        assertFunction("REAL'-0.0' / REAL'0.0'", REAL, -0.0f / 0.0f);
-        assertFunction("REAL'-17.71' / REAL'-1.0'", REAL, -17.71f / -1.0f);
-        assertFunction("REAL'NaN' / REAL'1.23'", REAL, Float.NaN);
-        assertFunction("REAL'1.23' / REAL'NaN'", REAL, Float.NaN);
-        assertFunction("REAL'NaN' / REAL'-NaN'", REAL, Float.NaN);
+        assertFunction("REAL '12.34' / REAL '56.78'", REAL, 12.34f / 56.78f);
+        assertFunction("REAL '-17.34' / REAL '-22.891'", REAL, -17.34f / -22.891f);
+        assertFunction("REAL '-89.123' / REAL '754.0'", REAL, -89.123f / 754.0f);
+        assertFunction("REAL '-0.0' / REAL '0.0'", REAL, -0.0f / 0.0f);
+        assertFunction("REAL '-17.71' / REAL '-1.0'", REAL, -17.71f / -1.0f);
+        assertFunction("REAL 'NaN' / REAL '1.23'", REAL, Float.NaN);
+        assertFunction("REAL '1.23' / REAL 'NaN'", REAL, Float.NaN);
+        assertFunction("REAL 'NaN' / REAL '-NaN'", REAL, Float.NaN);
     }
 
     @Test
     public void testModulus()
     {
-        assertFunction("REAL'12.34' % REAL'56.78'", REAL, 12.34f % 56.78f);
-        assertFunction("REAL'-17.34' % REAL'-22.891'", REAL, -17.34f % -22.891f);
-        assertFunction("REAL'-89.123' % REAL'754.0'", REAL, -89.123f % 754.0f);
-        assertFunction("REAL'-0.0' % REAL'0.0'", REAL, -0.0f % 0.0f);
-        assertFunction("REAL'-17.71' % REAL'-1.0'", REAL, -17.71f % -1.0f);
-        assertFunction("REAL'NaN' % REAL'1.23'", REAL, Float.NaN);
-        assertFunction("REAL'1.23' % REAL'NaN'", REAL, Float.NaN);
-        assertFunction("REAL'NaN' % REAL'NaN'", REAL, Float.NaN);
+        assertFunction("REAL '12.34' % REAL '56.78'", REAL, 12.34f % 56.78f);
+        assertFunction("REAL '-17.34' % REAL '-22.891'", REAL, -17.34f % -22.891f);
+        assertFunction("REAL '-89.123' % REAL '754.0'", REAL, -89.123f % 754.0f);
+        assertFunction("REAL '-0.0' % REAL '0.0'", REAL, -0.0f % 0.0f);
+        assertFunction("REAL '-17.71' % REAL '-1.0'", REAL, -17.71f % -1.0f);
+        assertFunction("REAL 'NaN' % REAL '1.23'", REAL, Float.NaN);
+        assertFunction("REAL '1.23' % REAL 'NaN'", REAL, Float.NaN);
+        assertFunction("REAL 'NaN' % REAL 'NaN'", REAL, Float.NaN);
     }
 
     @Test
     public void testNegation()
     {
-        assertFunction("-REAL'12.34'", REAL, -12.34f);
-        assertFunction("-REAL'-17.34'", REAL, 17.34f);
-        assertFunction("-REAL'-0.0'", REAL, -(-0.0f));
-        assertFunction("-REAL'NaN'", REAL, Float.NaN);
-        assertFunction("-REAL'-NaN'", REAL, Float.NaN);
+        assertFunction("-REAL '12.34'", REAL, -12.34f);
+        assertFunction("-REAL '-17.34'", REAL, 17.34f);
+        assertFunction("-REAL '-0.0'", REAL, -(-0.0f));
+        assertFunction("-REAL 'NaN'", REAL, Float.NaN);
+        assertFunction("-REAL '-NaN'", REAL, Float.NaN);
     }
 
     @Test
     public void testEqual()
     {
-        assertFunction("REAL'12.34' = REAL'12.34'", BOOLEAN, true);
-        assertFunction("REAL'12.340' = REAL'12.34'", BOOLEAN, true);
-        assertFunction("REAL'-17.34' = REAL'-17.34'", BOOLEAN, true);
-        assertFunction("REAL'71.17' = REAL'23.45'", BOOLEAN, false);
-        assertFunction("REAL'-0.0' = REAL'0.0'", BOOLEAN, true);
-        assertFunction("REAL'NaN' = REAL'1.23'", BOOLEAN, false);
-        assertFunction("REAL'1.23' = REAL'NaN'", BOOLEAN, false);
-        assertFunction("REAL'NaN' = REAL'NaN'", BOOLEAN, false);
+        assertFunction("REAL '12.34' = REAL '12.34'", BOOLEAN, true);
+        assertFunction("REAL '12.340' = REAL '12.34'", BOOLEAN, true);
+        assertFunction("REAL '-17.34' = REAL '-17.34'", BOOLEAN, true);
+        assertFunction("REAL '71.17' = REAL '23.45'", BOOLEAN, false);
+        assertFunction("REAL '-0.0' = REAL '0.0'", BOOLEAN, true);
+        assertFunction("REAL 'NaN' = REAL '1.23'", BOOLEAN, false);
+        assertFunction("REAL '1.23' = REAL 'NaN'", BOOLEAN, false);
+        assertFunction("REAL 'NaN' = REAL 'NaN'", BOOLEAN, false);
     }
 
     @Test
     public void testNotEqual()
     {
-        assertFunction("REAL'12.34' <> REAL'12.34'", BOOLEAN, false);
-        assertFunction("REAL'12.34' <> REAL'12.340'", BOOLEAN, false);
-        assertFunction("REAL'-17.34' <> REAL'-17.34'", BOOLEAN, false);
-        assertFunction("REAL'71.17' <> REAL'23.45'", BOOLEAN, true);
-        assertFunction("REAL'-0.0' <> REAL'0.0'", BOOLEAN, false);
-        assertFunction("REAL'NaN' <> REAL'1.23'", BOOLEAN, true);
-        assertFunction("REAL'1.23' <> REAL'NaN'", BOOLEAN, true);
-        assertFunction("REAL'NaN' <> REAL'NaN'", BOOLEAN, true);
+        assertFunction("REAL '12.34' <> REAL '12.34'", BOOLEAN, false);
+        assertFunction("REAL '12.34' <> REAL '12.340'", BOOLEAN, false);
+        assertFunction("REAL '-17.34' <> REAL '-17.34'", BOOLEAN, false);
+        assertFunction("REAL '71.17' <> REAL '23.45'", BOOLEAN, true);
+        assertFunction("REAL '-0.0' <> REAL '0.0'", BOOLEAN, false);
+        assertFunction("REAL 'NaN' <> REAL '1.23'", BOOLEAN, true);
+        assertFunction("REAL '1.23' <> REAL 'NaN'", BOOLEAN, true);
+        assertFunction("REAL 'NaN' <> REAL 'NaN'", BOOLEAN, true);
     }
 
     @Test
     public void testLessThan()
     {
-        assertFunction("REAL'12.34' < REAL'754.123'", BOOLEAN, true);
-        assertFunction("REAL'-17.34' < REAL'-16.34'", BOOLEAN, true);
-        assertFunction("REAL'71.17' < REAL'23.45'", BOOLEAN, false);
-        assertFunction("REAL'-0.0' < REAL'0.0'", BOOLEAN, false);
-        assertFunction("REAL'NaN' < REAL'1.23'", BOOLEAN, false);
-        assertFunction("REAL'1.23' < REAL'NaN'", BOOLEAN, false);
-        assertFunction("REAL'NaN' < REAL'NaN'", BOOLEAN, false);
+        assertFunction("REAL '12.34' < REAL '754.123'", BOOLEAN, true);
+        assertFunction("REAL '-17.34' < REAL '-16.34'", BOOLEAN, true);
+        assertFunction("REAL '71.17' < REAL '23.45'", BOOLEAN, false);
+        assertFunction("REAL '-0.0' < REAL '0.0'", BOOLEAN, false);
+        assertFunction("REAL 'NaN' < REAL '1.23'", BOOLEAN, false);
+        assertFunction("REAL '1.23' < REAL 'NaN'", BOOLEAN, false);
+        assertFunction("REAL 'NaN' < REAL 'NaN'", BOOLEAN, false);
     }
 
     @Test
     public void testLessThanOrEqual()
     {
-        assertFunction("REAL'12.34' <= REAL'754.123'", BOOLEAN, true);
-        assertFunction("REAL'-17.34' <= REAL'-17.34'", BOOLEAN, true);
-        assertFunction("REAL'71.17' <= REAL'23.45'", BOOLEAN, false);
-        assertFunction("REAL'-0.0' <= REAL'0.0'", BOOLEAN, true);
-        assertFunction("REAL'NaN' <= REAL'1.23'", BOOLEAN, false);
-        assertFunction("REAL'1.23' <= REAL'NaN'", BOOLEAN, false);
-        assertFunction("REAL'NaN' <= REAL'NaN'", BOOLEAN, false);
+        assertFunction("REAL '12.34' <= REAL '754.123'", BOOLEAN, true);
+        assertFunction("REAL '-17.34' <= REAL '-17.34'", BOOLEAN, true);
+        assertFunction("REAL '71.17' <= REAL '23.45'", BOOLEAN, false);
+        assertFunction("REAL '-0.0' <= REAL '0.0'", BOOLEAN, true);
+        assertFunction("REAL 'NaN' <= REAL '1.23'", BOOLEAN, false);
+        assertFunction("REAL '1.23' <= REAL 'NaN'", BOOLEAN, false);
+        assertFunction("REAL 'NaN' <= REAL 'NaN'", BOOLEAN, false);
     }
 
     @Test
     public void testGreaterThan()
     {
-        assertFunction("REAL'12.34' > REAL'754.123'", BOOLEAN, false);
-        assertFunction("REAL'-17.34' > REAL'-17.34'", BOOLEAN, false);
-        assertFunction("REAL'71.17' > REAL'23.45'", BOOLEAN, true);
-        assertFunction("REAL'-0.0' > REAL'0.0'", BOOLEAN, false);
-        assertFunction("REAL'NaN' > REAL'1.23'", BOOLEAN, false);
-        assertFunction("REAL'1.23' > REAL'NaN'", BOOLEAN, false);
-        assertFunction("REAL'NaN' > REAL'NaN'", BOOLEAN, false);
+        assertFunction("REAL '12.34' > REAL '754.123'", BOOLEAN, false);
+        assertFunction("REAL '-17.34' > REAL '-17.34'", BOOLEAN, false);
+        assertFunction("REAL '71.17' > REAL '23.45'", BOOLEAN, true);
+        assertFunction("REAL '-0.0' > REAL '0.0'", BOOLEAN, false);
+        assertFunction("REAL 'NaN' > REAL '1.23'", BOOLEAN, false);
+        assertFunction("REAL '1.23' > REAL 'NaN'", BOOLEAN, false);
+        assertFunction("REAL 'NaN' > REAL 'NaN'", BOOLEAN, false);
     }
 
     @Test
     public void testGreaterThanOrEqual()
     {
-        assertFunction("REAL'12.34' >= REAL'754.123'", BOOLEAN, false);
-        assertFunction("REAL'-17.34' >= REAL'-17.34'", BOOLEAN, true);
-        assertFunction("REAL'71.17' >= REAL'23.45'", BOOLEAN, true);
-        assertFunction("REAL'-0.0' >= REAL'0.0'", BOOLEAN, true);
-        assertFunction("REAL'NaN' >= REAL'1.23'", BOOLEAN, false);
-        assertFunction("REAL'1.23' >= REAL'NaN'", BOOLEAN, false);
-        assertFunction("REAL'NaN' >= REAL'NaN'", BOOLEAN, false);
+        assertFunction("REAL '12.34' >= REAL '754.123'", BOOLEAN, false);
+        assertFunction("REAL '-17.34' >= REAL '-17.34'", BOOLEAN, true);
+        assertFunction("REAL '71.17' >= REAL '23.45'", BOOLEAN, true);
+        assertFunction("REAL '-0.0' >= REAL '0.0'", BOOLEAN, true);
+        assertFunction("REAL 'NaN' >= REAL '1.23'", BOOLEAN, false);
+        assertFunction("REAL '1.23' >= REAL 'NaN'", BOOLEAN, false);
+        assertFunction("REAL 'NaN' >= REAL 'NaN'", BOOLEAN, false);
     }
 
     @Test
     public void testBetween()
     {
-        assertFunction("REAL'12.34' BETWEEN REAL'9.12' AND REAL'25.89'", BOOLEAN, true);
-        assertFunction("REAL'-17.34' BETWEEN REAL'-17.34' AND REAL'-16.57'", BOOLEAN, true);
-        assertFunction("REAL'-17.34' BETWEEN REAL'-18.98' AND REAL'-17.34'", BOOLEAN, true);
-        assertFunction("REAL'0.0' BETWEEN REAL'-1.2' AND REAL'2.3'", BOOLEAN, true);
-        assertFunction("REAL'56.78' BETWEEN REAL'12.34' AND REAL'34.56'", BOOLEAN, false);
-        assertFunction("REAL'56.78' BETWEEN REAL'78.89' AND REAL'98.765'", BOOLEAN, false);
-        assertFunction("REAL'NaN' BETWEEN REAL'-1.2' AND REAL'2.3'", BOOLEAN, false);
-        assertFunction("REAL'56.78' BETWEEN REAL'-NaN' AND REAL'NaN'", BOOLEAN, false);
-        assertFunction("REAL'56.78' BETWEEN REAL'NaN' AND REAL'-NaN'", BOOLEAN, false);
-        assertFunction("REAL'56.78' BETWEEN REAL'56.78' AND REAL'NaN'", BOOLEAN, false);
-        assertFunction("REAL'NaN' BETWEEN REAL'NaN' AND REAL'NaN'", BOOLEAN, false);
+        assertFunction("REAL '12.34' BETWEEN REAL '9.12' AND REAL '25.89'", BOOLEAN, true);
+        assertFunction("REAL '-17.34' BETWEEN REAL '-17.34' AND REAL '-16.57'", BOOLEAN, true);
+        assertFunction("REAL '-17.34' BETWEEN REAL '-18.98' AND REAL '-17.34'", BOOLEAN, true);
+        assertFunction("REAL '0.0' BETWEEN REAL '-1.2' AND REAL '2.3'", BOOLEAN, true);
+        assertFunction("REAL '56.78' BETWEEN REAL '12.34' AND REAL '34.56'", BOOLEAN, false);
+        assertFunction("REAL '56.78' BETWEEN REAL '78.89' AND REAL '98.765'", BOOLEAN, false);
+        assertFunction("REAL 'NaN' BETWEEN REAL '-1.2' AND REAL '2.3'", BOOLEAN, false);
+        assertFunction("REAL '56.78' BETWEEN REAL '-NaN' AND REAL 'NaN'", BOOLEAN, false);
+        assertFunction("REAL '56.78' BETWEEN REAL 'NaN' AND REAL '-NaN'", BOOLEAN, false);
+        assertFunction("REAL '56.78' BETWEEN REAL '56.78' AND REAL 'NaN'", BOOLEAN, false);
+        assertFunction("REAL 'NaN' BETWEEN REAL 'NaN' AND REAL 'NaN'", BOOLEAN, false);
     }
 
     @Test
     public void testCastToVarchar()
     {
-        assertFunction("CAST(REAL'754.1985' as VARCHAR)", VARCHAR, "754.1985");
-        assertFunction("CAST(REAL'-754.2008' as VARCHAR)", VARCHAR, "-754.2008");
-        assertFunction("CAST(REAL'Infinity' as VARCHAR)", VARCHAR, "Infinity");
-        assertFunction("CAST(REAL'0.0' / REAL'0.0' as VARCHAR)", VARCHAR, "NaN");
+        assertFunction("CAST(REAL '754.1985' as VARCHAR)", VARCHAR, "754.1985");
+        assertFunction("CAST(REAL '-754.2008' as VARCHAR)", VARCHAR, "-754.2008");
+        assertFunction("CAST(REAL 'Infinity' as VARCHAR)", VARCHAR, "Infinity");
+        assertFunction("CAST(REAL '0.0' / REAL '0.0' as VARCHAR)", VARCHAR, "NaN");
     }
 
     @Test
     public void testCastToBigInt()
     {
-        assertFunction("CAST(REAL'754.1985' as BIGINT)", BIGINT, 754L);
-        assertFunction("CAST(REAL'-754.2008' as BIGINT)", BIGINT, -754L);
-        assertFunction("CAST(REAL'1.98' as BIGINT)", BIGINT, 2L);
-        assertFunction("CAST(REAL'-0.0' as BIGINT)", BIGINT, 0L);
+        assertFunction("CAST(REAL '754.1985' as BIGINT)", BIGINT, 754L);
+        assertFunction("CAST(REAL '-754.2008' as BIGINT)", BIGINT, -754L);
+        assertFunction("CAST(REAL '1.98' as BIGINT)", BIGINT, 2L);
+        assertFunction("CAST(REAL '-0.0' as BIGINT)", BIGINT, 0L);
         assertInvalidFunction("CAST(REAL 'NaN' as BIGINT)", INVALID_CAST_ARGUMENT);
     }
 
     @Test
     public void testCastToInteger()
     {
-        assertFunction("CAST(REAL'754.2008' AS INTEGER)", INTEGER, 754);
-        assertFunction("CAST(REAL'-754.1985' AS INTEGER)", INTEGER, -754);
-        assertFunction("CAST(REAL'9.99' AS INTEGER)", INTEGER, 10);
-        assertFunction("CAST(REAL'-0.0' AS INTEGER)", INTEGER, 0);
+        assertFunction("CAST(REAL '754.2008' AS INTEGER)", INTEGER, 754);
+        assertFunction("CAST(REAL '-754.1985' AS INTEGER)", INTEGER, -754);
+        assertFunction("CAST(REAL '9.99' AS INTEGER)", INTEGER, 10);
+        assertFunction("CAST(REAL '-0.0' AS INTEGER)", INTEGER, 0);
         assertInvalidFunction("CAST(REAL 'NaN' AS INTEGER)", INVALID_CAST_ARGUMENT);
     }
 
     @Test
     public void testCastToSmallint()
     {
-        assertFunction("CAST(REAL'754.2008' AS SMALLINT)", SMALLINT, (short) 754);
-        assertFunction("CAST(REAL'-754.1985' AS SMALLINT)", SMALLINT, (short) -754);
-        assertFunction("CAST(REAL'9.99' AS SMALLINT)", SMALLINT, (short) 10);
-        assertFunction("CAST(REAL'-0.0' AS SMALLINT)", SMALLINT, (short) 0);
+        assertFunction("CAST(REAL '754.2008' AS SMALLINT)", SMALLINT, (short) 754);
+        assertFunction("CAST(REAL '-754.1985' AS SMALLINT)", SMALLINT, (short) -754);
+        assertFunction("CAST(REAL '9.99' AS SMALLINT)", SMALLINT, (short) 10);
+        assertFunction("CAST(REAL '-0.0' AS SMALLINT)", SMALLINT, (short) 0);
         assertInvalidFunction("CAST(REAL 'NaN' AS SMALLINT)", INVALID_CAST_ARGUMENT);
     }
 
     @Test
     public void testCastToTinyint()
     {
-        assertFunction("CAST(REAL'127.45' AS TINYINT)", TINYINT, (byte) 127);
-        assertFunction("CAST(REAL'-128.234' AS TINYINT)", TINYINT, (byte) -128);
-        assertFunction("CAST(REAL'9.99' AS TINYINT)", TINYINT, (byte) 10);
-        assertFunction("CAST(REAL'-0.0' AS TINYINT)", TINYINT, (byte) 0);
+        assertFunction("CAST(REAL '127.45' AS TINYINT)", TINYINT, (byte) 127);
+        assertFunction("CAST(REAL '-128.234' AS TINYINT)", TINYINT, (byte) -128);
+        assertFunction("CAST(REAL '9.99' AS TINYINT)", TINYINT, (byte) 10);
+        assertFunction("CAST(REAL '-0.0' AS TINYINT)", TINYINT, (byte) 0);
         assertInvalidFunction("CAST(REAL 'NaN' AS TINYINT)", INVALID_CAST_ARGUMENT);
     }
 
     @Test
     public void testCastToDouble()
     {
-        assertFunction("CAST(REAL'754.1985' AS DOUBLE)", DOUBLE, (double) 754.1985f);
-        assertFunction("CAST(REAL'-754.2008' AS DOUBLE)", DOUBLE, (double) -754.2008f);
-        assertFunction("CAST(REAL'0.0' AS DOUBLE)", DOUBLE, (double) 0.0f);
-        assertFunction("CAST(REAL'-0.0' AS DOUBLE)", DOUBLE, (double) -0.0f);
-        assertFunction("CAST(CAST(REAL'754.1985' AS DOUBLE) AS REAL)", REAL, 754.1985f);
+        assertFunction("CAST(REAL '754.1985' AS DOUBLE)", DOUBLE, (double) 754.1985f);
+        assertFunction("CAST(REAL '-754.2008' AS DOUBLE)", DOUBLE, (double) -754.2008f);
+        assertFunction("CAST(REAL '0.0' AS DOUBLE)", DOUBLE, (double) 0.0f);
+        assertFunction("CAST(REAL '-0.0' AS DOUBLE)", DOUBLE, (double) -0.0f);
+        assertFunction("CAST(CAST(REAL '754.1985' AS DOUBLE) AS REAL)", REAL, 754.1985f);
         assertFunction("CAST(REAL 'NaN' AS DOUBLE)", DOUBLE, Double.NaN);
     }
 
     @Test
     public void testCastToBoolean()
     {
-        assertFunction("CAST(REAL'754.1985' AS BOOLEAN)", BOOLEAN, true);
-        assertFunction("CAST(REAL'0.0' AS BOOLEAN)", BOOLEAN, false);
-        assertFunction("CAST(REAL'-0.0' AS BOOLEAN)", BOOLEAN, false);
+        assertFunction("CAST(REAL '754.1985' AS BOOLEAN)", BOOLEAN, true);
+        assertFunction("CAST(REAL '0.0' AS BOOLEAN)", BOOLEAN, false);
+        assertFunction("CAST(REAL '-0.0' AS BOOLEAN)", BOOLEAN, false);
         assertFunction("CAST(REAL 'NaN' AS BOOLEAN)", BOOLEAN, true);
     }
 
@@ -287,13 +287,13 @@ public class TestRealOperators
     public void testIsDistinctFrom()
     {
         assertFunction("CAST(NULL AS REAL) IS DISTINCT FROM CAST(NULL AS REAL)", BOOLEAN, false);
-        assertFunction("REAL'37.7' IS DISTINCT FROM REAL'37.7'", BOOLEAN, false);
-        assertFunction("REAL'37.7' IS DISTINCT FROM REAL'37.8'", BOOLEAN, true);
-        assertFunction("NULL IS DISTINCT FROM REAL'37.7'", BOOLEAN, true);
-        assertFunction("REAL'37.7' IS DISTINCT FROM NULL", BOOLEAN, true);
+        assertFunction("REAL '37.7' IS DISTINCT FROM REAL '37.7'", BOOLEAN, false);
+        assertFunction("REAL '37.7' IS DISTINCT FROM REAL '37.8'", BOOLEAN, true);
+        assertFunction("NULL IS DISTINCT FROM REAL '37.7'", BOOLEAN, true);
+        assertFunction("REAL '37.7' IS DISTINCT FROM NULL", BOOLEAN, true);
         assertFunction("CAST(nan() AS REAL) IS DISTINCT FROM CAST(nan() AS REAL)", BOOLEAN, false);
-        assertFunction("REAL'NaN' IS DISTINCT FROM REAL'37.8'", BOOLEAN, true);
-        assertFunction("REAL'37.8' IS DISTINCT FROM REAL'NaN'", BOOLEAN, true);
+        assertFunction("REAL 'NaN' IS DISTINCT FROM REAL '37.8'", BOOLEAN, true);
+        assertFunction("REAL '37.8' IS DISTINCT FROM REAL 'NaN'", BOOLEAN, true);
     }
 
     @Test
@@ -303,7 +303,7 @@ public class TestRealOperators
         assertOperator(INDETERMINATE, "cast(-1.2 as real)", BOOLEAN, false);
         assertOperator(INDETERMINATE, "cast(1.2 as real)", BOOLEAN, false);
         assertOperator(INDETERMINATE, "cast(123 as real)", BOOLEAN, false);
-        assertOperator(INDETERMINATE, "REAL'NaN'", BOOLEAN, false);
+        assertOperator(INDETERMINATE, "REAL 'NaN'", BOOLEAN, false);
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
@@ -31,6 +31,7 @@ import static io.trino.spi.type.RealType.REAL;
 import static io.trino.spi.type.SmallintType.SMALLINT;
 import static io.trino.spi.type.TinyintType.TINYINT;
 import static io.trino.spi.type.VarcharType.VARCHAR;
+import static io.trino.spi.type.VarcharType.createVarcharType;
 import static java.lang.Float.floatToIntBits;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Float.isNaN;
@@ -221,6 +222,17 @@ public class TestRealOperators
         assertFunction("CAST(REAL '-754.2008' as VARCHAR)", VARCHAR, "-754.2008");
         assertFunction("CAST(REAL 'Infinity' as VARCHAR)", VARCHAR, "Infinity");
         assertFunction("CAST(REAL '0.0' / REAL '0.0' as VARCHAR)", VARCHAR, "NaN");
+        assertFunction("cast(REAL '12e2' as varchar(6))", createVarcharType(6), "1200.0");
+        assertFunction("cast(REAL '12e2' as varchar(50))", createVarcharType(50), "1200.0");
+        assertFunction("cast(REAL '12345678.9e0' as varchar(50))", createVarcharType(50), "1.2345679E7");
+        assertFunction("cast(REAL 'NaN' as varchar(3))", createVarcharType(3), "NaN");
+        assertFunction("cast(REAL 'Infinity' as varchar(50))", createVarcharType(50), "Infinity");
+        assertFunctionThrowsIncorrectly("cast(REAL '12e2' as varchar(5))", IllegalArgumentException.class, "Character count exceeds length limit 5.*");
+        assertFunctionThrowsIncorrectly("cast(REAL '12e2' as varchar(4))", IllegalArgumentException.class, "Character count exceeds length limit 4.*");
+        assertFunctionThrowsIncorrectly("cast(REAL '0e0' as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
+        assertFunctionThrowsIncorrectly("cast(REAL '-0e0' as varchar(3))", IllegalArgumentException.class, "Character count exceeds length limit 3.*");
+        assertFunctionThrowsIncorrectly("cast(REAL '0e0' / REAL '0e0' as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
+        assertFunctionThrowsIncorrectly("cast(REAL 'Infinity' as varchar(7))", IllegalArgumentException.class, "Character count exceeds length limit 7.*");
     }
 
     @Test

--- a/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
+++ b/core/trino-main/src/test/java/io/trino/type/TestRealOperators.java
@@ -227,12 +227,12 @@ public class TestRealOperators
         assertFunction("cast(REAL '12345678.9e0' as varchar(50))", createVarcharType(50), "1.2345679E7");
         assertFunction("cast(REAL 'NaN' as varchar(3))", createVarcharType(3), "NaN");
         assertFunction("cast(REAL 'Infinity' as varchar(50))", createVarcharType(50), "Infinity");
-        assertFunctionThrowsIncorrectly("cast(REAL '12e2' as varchar(5))", IllegalArgumentException.class, "Character count exceeds length limit 5.*");
-        assertFunctionThrowsIncorrectly("cast(REAL '12e2' as varchar(4))", IllegalArgumentException.class, "Character count exceeds length limit 4.*");
-        assertFunctionThrowsIncorrectly("cast(REAL '0e0' as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
-        assertFunctionThrowsIncorrectly("cast(REAL '-0e0' as varchar(3))", IllegalArgumentException.class, "Character count exceeds length limit 3.*");
-        assertFunctionThrowsIncorrectly("cast(REAL '0e0' / REAL '0e0' as varchar(2))", IllegalArgumentException.class, "Character count exceeds length limit 2.*");
-        assertFunctionThrowsIncorrectly("cast(REAL 'Infinity' as varchar(7))", IllegalArgumentException.class, "Character count exceeds length limit 7.*");
+        assertInvalidCast("cast(REAL '12e2' as varchar(5))", "Value 1200.0 cannot be represented as varchar(5)");
+        assertInvalidCast("cast(REAL '12e2' as varchar(4))", "Value 1200.0 cannot be represented as varchar(4)");
+        assertInvalidCast("cast(REAL '0e0' as varchar(2))", "Value 0.0 cannot be represented as varchar(2)");
+        assertInvalidCast("cast(REAL '-0e0' as varchar(3))", "Value -0.0 cannot be represented as varchar(3)");
+        assertInvalidCast("cast(REAL '0e0' / REAL '0e0' as varchar(2))", "Value NaN cannot be represented as varchar(2)");
+        assertInvalidCast("cast(REAL 'Infinity' as varchar(7))", "Value Infinity cannot be represented as varchar(7)");
     }
 
     @Test


### PR DESCRIPTION
This change applies to double and real types.
It includes correctness tests for casts to varchar, involving truncation and compliance of the output format with the SQL standard.
This change fixes the truncation issues.
Incorrect output format will be handled separately.