### PR TITLE
Support Coral-based view translation with table redirects

### DIFF
--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorContextInstance.java
@@ -18,6 +18,7 @@ import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.PageSorter;
 import io.trino.spi.VersionEmbedder;
 import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.type.TypeManager;
 
 import java.util.function.Supplier;
@@ -30,6 +31,7 @@ public class ConnectorContextInstance
     private final NodeManager nodeManager;
     private final VersionEmbedder versionEmbedder;
     private final TypeManager typeManager;
+    private final MetadataProvider metadataProvider;
     private final PageSorter pageSorter;
     private final PageIndexerFactory pageIndexerFactory;
     private final Supplier<ClassLoader> duplicatePluginClassLoaderFactory;
@@ -38,6 +40,7 @@ public class ConnectorContextInstance
             NodeManager nodeManager,
             VersionEmbedder versionEmbedder,
             TypeManager typeManager,
+            MetadataProvider metadataProvider,
             PageSorter pageSorter,
             PageIndexerFactory pageIndexerFactory,
             Supplier<ClassLoader> duplicatePluginClassLoaderFactory)
@@ -45,6 +48,7 @@ public class ConnectorContextInstance
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.versionEmbedder = requireNonNull(versionEmbedder, "versionEmbedder is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.metadataProvider = requireNonNull(metadataProvider, "metadataProvider is null");
         this.pageSorter = requireNonNull(pageSorter, "pageSorter is null");
         this.pageIndexerFactory = requireNonNull(pageIndexerFactory, "pageIndexerFactory is null");
         this.duplicatePluginClassLoaderFactory = requireNonNull(duplicatePluginClassLoaderFactory, "duplicatePluginClassLoaderFactory is null");
@@ -66,6 +70,12 @@ public class ConnectorContextInstance
     public TypeManager getTypeManager()
     {
         return typeManager;
+    }
+
+    @Override
+    public MetadataProvider getMetadataProvider()
+    {
+        return metadataProvider;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
+++ b/core/trino-main/src/main/java/io/trino/connector/ConnectorManager.java
@@ -367,6 +367,7 @@ public class ConnectorManager
                 new ConnectorAwareNodeManager(nodeManager, nodeInfo.getEnvironment(), catalogName, schedulerIncludeCoordinator),
                 versionEmbedder,
                 new InternalTypeManager(metadataManager, typeOperators),
+                new InternalMetadataProvider(metadataManager),
                 pageSorter,
                 pageIndexerFactory,
                 factory.getDuplicatePluginClassLoaderFactory());

--- a/core/trino-main/src/main/java/io/trino/connector/InternalMetadataProvider.java
+++ b/core/trino-main/src/main/java/io/trino/connector/InternalMetadataProvider.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.connector;
+
+import io.trino.FullConnectorSession;
+import io.trino.Session;
+import io.trino.metadata.MaterializedViewDefinition;
+import io.trino.metadata.MetadataManager;
+import io.trino.metadata.QualifiedObjectName;
+import io.trino.metadata.TableHandle;
+import io.trino.metadata.ViewColumn;
+import io.trino.metadata.ViewDefinition;
+import io.trino.spi.connector.CatalogSchemaTableName;
+import io.trino.spi.connector.ColumnSchema;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableSchema;
+import io.trino.spi.connector.MetadataProvider;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class InternalMetadataProvider
+        implements MetadataProvider
+{
+    private final MetadataManager metadataManager;
+
+    public InternalMetadataProvider(MetadataManager metadataManager)
+    {
+        this.metadataManager = requireNonNull(metadataManager, "metadataManager is null");
+    }
+
+    @Override
+    public Optional<ConnectorTableSchema> getRelationMetadata(ConnectorSession connectorSession, CatalogSchemaTableName tableName)
+    {
+        Session session = ((FullConnectorSession) connectorSession).getSession();
+        QualifiedObjectName qualifiedName = new QualifiedObjectName(tableName.getCatalogName(), tableName.getSchemaTableName().getSchemaName(), tableName.getSchemaTableName().getTableName());
+
+        Optional<MaterializedViewDefinition> materializedView = metadataManager.getMaterializedView(session, qualifiedName);
+        if (materializedView.isPresent()) {
+            return Optional.of(new ConnectorTableSchema(tableName.getSchemaTableName(), toColumnSchema(materializedView.get().getColumns())));
+        }
+
+        Optional<ViewDefinition> view = metadataManager.getView(session, qualifiedName);
+        if (view.isPresent()) {
+            return Optional.of(new ConnectorTableSchema(tableName.getSchemaTableName(), toColumnSchema(view.get().getColumns())));
+        }
+
+        Optional<TableHandle> tableHandle = metadataManager.getTableHandle(session, qualifiedName);
+        if (tableHandle.isPresent()) {
+            return Optional.of(metadataManager.getTableSchema(session, tableHandle.get()).getTableSchema());
+        }
+
+        return Optional.empty();
+    }
+
+    private List<ColumnSchema> toColumnSchema(List<ViewColumn> viewColumns)
+    {
+        return viewColumns.stream()
+                .map(viewColumn ->
+                        ColumnSchema.builder()
+                                .setName(viewColumn.getName())
+                                .setType(metadataManager.getType(viewColumn.getType()))
+                                .build())
+                .collect(toImmutableList());
+    }
+}

--- a/core/trino-main/src/main/java/io/trino/testing/TestingConnectorContext.java
+++ b/core/trino-main/src/main/java/io/trino/testing/TestingConnectorContext.java
@@ -25,6 +25,7 @@ import io.trino.spi.PageIndexerFactory;
 import io.trino.spi.PageSorter;
 import io.trino.spi.VersionEmbedder;
 import io.trino.spi.connector.ConnectorContext;
+import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.type.TypeManager;
 import io.trino.spi.type.TypeOperators;
 import io.trino.sql.gen.JoinCompiler;
@@ -33,6 +34,7 @@ import io.trino.type.InternalTypeManager;
 import io.trino.version.EmbedVersion;
 
 import static io.trino.metadata.MetadataManager.createTestMetadataManager;
+import static io.trino.spi.connector.MetadataProvider.NOOP_METADATA_PROVIDER;
 
 public final class TestingConnectorContext
         implements ConnectorContext
@@ -71,6 +73,12 @@ public final class TestingConnectorContext
     public TypeManager getTypeManager()
     {
         return typeManager;
+    }
+
+    @Override
+    public MetadataProvider getMetadataProvider()
+    {
+        return NOOP_METADATA_PROVIDER;
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorContext.java
@@ -36,6 +36,11 @@ public interface ConnectorContext
         throw new UnsupportedOperationException();
     }
 
+    default MetadataProvider getMetadataProvider()
+    {
+        throw new UnsupportedOperationException();
+    }
+
     default PageSorter getPageSorter()
     {
         throw new UnsupportedOperationException();

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/MetadataProvider.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/MetadataProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.connector;
+
+import java.util.Optional;
+
+public interface MetadataProvider
+{
+    MetadataProvider NOOP_METADATA_PROVIDER = (session, tableName) -> Optional.empty();
+
+    /**
+     * Return relation schema or empty if relation does not exist.
+     */
+    Optional<ConnectorTableSchema> getRelationMetadata(ConnectorSession session, CatalogSchemaTableName tableName);
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/CoralTableRedirectionResolver.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/CoralTableRedirectionResolver.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.hive;
+
+import io.trino.spi.connector.SchemaTableName;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import java.util.Optional;
+
+/**
+ * Handles table redirections during view translation.
+ */
+public interface CoralTableRedirectionResolver
+{
+    Optional<Table> redirect(SchemaTableName tableName);
+}

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -81,6 +81,7 @@ import io.trino.spi.connector.ConstraintApplicationResult;
 import io.trino.spi.connector.DiscretePredicates;
 import io.trino.spi.connector.LocalProperty;
 import io.trino.spi.connector.MaterializedViewFreshness;
+import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.connector.ProjectionApplicationResult;
 import io.trino.spi.connector.SchemaNotFoundException;
 import io.trino.spi.connector.SchemaTableName;
@@ -340,6 +341,7 @@ public class HiveMetadata
     private final HdfsEnvironment hdfsEnvironment;
     private final HivePartitionManager partitionManager;
     private final TypeManager typeManager;
+    private final MetadataProvider metadataProvider;
     private final LocationService locationService;
     private final JsonCodec<PartitionUpdate> partitionUpdateCodec;
     private final boolean writesToNonManagedTablesEnabled;
@@ -365,6 +367,7 @@ public class HiveMetadata
             boolean translateHiveViews,
             boolean hideDeltaLakeTables,
             TypeManager typeManager,
+            MetadataProvider metadataProvider,
             LocationService locationService,
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
             String trinoVersion,
@@ -381,6 +384,7 @@ public class HiveMetadata
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.partitionManager = requireNonNull(partitionManager, "partitionManager is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.metadataProvider = requireNonNull(metadataProvider, "metadataProvider is null");
         this.locationService = requireNonNull(locationService, "locationService is null");
         this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
         this.writesToNonManagedTablesEnabled = writesToNonManagedTablesEnabled;
@@ -2326,7 +2330,7 @@ public class HiveMetadata
                         throw new HiveViewNotSupportedException(viewName);
                     }
 
-                    ConnectorViewDefinition definition = createViewReader(metastore, session, view, typeManager)
+                    ConnectorViewDefinition definition = createViewReader(metastore, session, view, typeManager, this::redirectTable, metadataProvider)
                             .decodeViewData(view.getViewOriginalText().get(), view, catalogName);
                     // use owner from table metadata if it exists
                     if (view.getOwner().isPresent() && !definition.isRunAsInvoker()) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadataFactory.java
@@ -22,6 +22,7 @@ import io.trino.plugin.hive.metastore.MetastoreConfig;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.trino.plugin.hive.security.AccessControlMetadataFactory;
 import io.trino.plugin.hive.statistics.MetastoreHiveStatisticsProvider;
+import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.type.TypeManager;
 
 import javax.inject.Inject;
@@ -51,6 +52,7 @@ public class HiveMetadataFactory
     private final HdfsEnvironment hdfsEnvironment;
     private final HivePartitionManager partitionManager;
     private final TypeManager typeManager;
+    private final MetadataProvider metadataProvider;
     private final LocationService locationService;
     private final JsonCodec<PartitionUpdate> partitionUpdateCodec;
     private final BoundedExecutor renameExecution;
@@ -76,6 +78,7 @@ public class HiveMetadataFactory
             ExecutorService executorService,
             @ForHiveTransactionHeartbeats ScheduledExecutorService heartbeatService,
             TypeManager typeManager,
+            MetadataProvider metadataProvider,
             LocationService locationService,
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
             NodeVersion nodeVersion,
@@ -102,6 +105,7 @@ public class HiveMetadataFactory
                 hiveConfig.getHiveTransactionHeartbeatInterval(),
                 metastoreConfig.isHideDeltaLakeTables(),
                 typeManager,
+                metadataProvider,
                 locationService,
                 partitionUpdateCodec,
                 executorService,
@@ -131,6 +135,7 @@ public class HiveMetadataFactory
             Optional<Duration> hiveTransactionHeartbeatInterval,
             boolean hideDeltaLakeTables,
             TypeManager typeManager,
+            MetadataProvider metadataProvider,
             LocationService locationService,
             JsonCodec<PartitionUpdate> partitionUpdateCodec,
             ExecutorService executorService,
@@ -155,6 +160,7 @@ public class HiveMetadataFactory
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.partitionManager = requireNonNull(partitionManager, "partitionManager is null");
         this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.metadataProvider = requireNonNull(metadataProvider, "metadataProvider is null");
         this.locationService = requireNonNull(locationService, "locationService is null");
         this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
         this.trinoVersion = requireNonNull(trinoVersion, "trinoVersion is null");
@@ -205,6 +211,7 @@ public class HiveMetadataFactory
                 translateHiveViews,
                 hideDeltaLakeTables,
                 typeManager,
+                metadataProvider,
                 locationService,
                 partitionUpdateCodec,
                 trinoVersion,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/InternalHiveConnectorFactory.java
@@ -57,6 +57,7 @@ import io.trino.spi.connector.ConnectorNodePartitioningProvider;
 import io.trino.spi.connector.ConnectorPageSinkProvider;
 import io.trino.spi.connector.ConnectorPageSourceProvider;
 import io.trino.spi.connector.ConnectorSplitManager;
+import io.trino.spi.connector.MetadataProvider;
 import io.trino.spi.connector.TableProcedureMetadata;
 import io.trino.spi.eventlistener.EventListener;
 import io.trino.spi.procedure.Procedure;
@@ -108,6 +109,7 @@ public final class InternalHiveConnectorFactory
                         binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
                         binder.bind(NodeManager.class).toInstance(context.getNodeManager());
                         binder.bind(VersionEmbedder.class).toInstance(context.getVersionEmbedder());
+                        binder.bind(MetadataProvider.class).toInstance(context.getMetadataProvider());
                         binder.bind(PageIndexerFactory.class).toInstance(context.getPageIndexerFactory());
                         binder.bind(PageSorter.class).toInstance(context.getPageSorter());
                     },

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -60,7 +60,7 @@ public final class ViewReaderUtil
         ConnectorViewDefinition decodeViewData(String viewData, Table table, CatalogName catalogName);
     }
 
-    public static ViewReader createViewReader(SemiTransactionalHiveMetastore metastore, ConnectorSession session, Table table, TypeManager typemanager)
+    public static ViewReader createViewReader(SemiTransactionalHiveMetastore metastore, ConnectorSession session, Table table, TypeManager typeManager)
     {
         if (isPrestoView(table)) {
             return new PrestoViewReader();
@@ -69,7 +69,7 @@ public final class ViewReaderUtil
             return new LegacyHiveViewReader();
         }
 
-        return new HiveViewReader(new CoralSemiTransactionalHiveMSCAdapter(metastore, new HiveIdentity(session)), typemanager);
+        return new HiveViewReader(new CoralSemiTransactionalHiveMSCAdapter(metastore, new HiveIdentity(session)), typeManager);
     }
 
     public static final String PRESTO_VIEW_FLAG = "presto_view";

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ViewReaderUtil.java
@@ -21,13 +21,19 @@ import io.airlift.json.JsonCodecFactory;
 import io.airlift.json.ObjectMapperProvider;
 import io.trino.plugin.base.CatalogName;
 import io.trino.plugin.hive.authentication.HiveIdentity;
+import io.trino.plugin.hive.metastore.Column;
 import io.trino.plugin.hive.metastore.CoralSemiTransactionalHiveMSCAdapter;
 import io.trino.plugin.hive.metastore.SemiTransactionalHiveMetastore;
 import io.trino.plugin.hive.metastore.Table;
 import io.trino.spi.TrinoException;
+import io.trino.spi.connector.CatalogSchemaTableName;
 import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableSchema;
 import io.trino.spi.connector.ConnectorViewDefinition;
 import io.trino.spi.connector.ConnectorViewDefinition.ViewColumn;
+import io.trino.spi.connector.MetadataProvider;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.TableNotFoundException;
 import io.trino.spi.type.TypeManager;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.type.RelDataType;
@@ -37,6 +43,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -44,10 +51,15 @@ import static io.trino.plugin.hive.HiveErrorCode.HIVE_INVALID_VIEW_DATA;
 import static io.trino.plugin.hive.HiveErrorCode.HIVE_VIEW_TRANSLATION_ERROR;
 import static io.trino.plugin.hive.HiveMetadata.TABLE_COMMENT;
 import static io.trino.plugin.hive.HiveSessionProperties.isLegacyHiveViewTranslation;
+import static io.trino.plugin.hive.HiveStorageFormat.TEXTFILE;
+import static io.trino.plugin.hive.HiveType.toHiveType;
+import static io.trino.plugin.hive.metastore.StorageFormat.fromHiveStorageFormat;
+import static io.trino.plugin.hive.metastore.thrift.ThriftMetastoreUtil.toMetastoreApiTable;
 import static io.trino.plugin.hive.util.HiveUtil.checkCondition;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
+import static org.apache.hadoop.hive.metastore.TableType.EXTERNAL_TABLE;
 import static org.apache.hadoop.hive.metastore.TableType.VIRTUAL_VIEW;
 
 public final class ViewReaderUtil
@@ -60,7 +72,13 @@ public final class ViewReaderUtil
         ConnectorViewDefinition decodeViewData(String viewData, Table table, CatalogName catalogName);
     }
 
-    public static ViewReader createViewReader(SemiTransactionalHiveMetastore metastore, ConnectorSession session, Table table, TypeManager typeManager)
+    public static ViewReader createViewReader(
+            SemiTransactionalHiveMetastore metastore,
+            ConnectorSession session,
+            Table table,
+            TypeManager typeManager,
+            BiFunction<ConnectorSession, SchemaTableName, Optional<CatalogSchemaTableName>> tableRedirectionResolver,
+            MetadataProvider metadataProvider)
     {
         if (isPrestoView(table)) {
             return new PrestoViewReader();
@@ -69,7 +87,36 @@ public final class ViewReaderUtil
             return new LegacyHiveViewReader();
         }
 
-        return new HiveViewReader(new CoralSemiTransactionalHiveMSCAdapter(metastore, new HiveIdentity(session)), typeManager);
+        return new HiveViewReader(
+                new CoralSemiTransactionalHiveMSCAdapter(metastore, new HiveIdentity(session), coralTableRedirectionResolver(session, tableRedirectionResolver, metadataProvider)),
+                typeManager);
+    }
+
+    private static CoralTableRedirectionResolver coralTableRedirectionResolver(
+            ConnectorSession session,
+            BiFunction<ConnectorSession, SchemaTableName, Optional<CatalogSchemaTableName>> tableRedirectionResolver,
+            MetadataProvider metadataProvider)
+    {
+        return schemaTableName -> tableRedirectionResolver.apply(session, schemaTableName).map(target -> {
+            ConnectorTableSchema tableSchema = metadataProvider.getRelationMetadata(session, target)
+                    .orElseThrow(() -> new TableNotFoundException(
+                            target.getSchemaTableName(),
+                            format("%s is redirected to %s, but that relation cannot be found", schemaTableName, target)));
+            List<Column> columns = tableSchema.getColumns().stream()
+                    .filter(columnSchema -> !columnSchema.isHidden())
+                    .map(columnSchema -> new Column(columnSchema.getName(), toHiveType(columnSchema.getType()), Optional.empty() /* comment */))
+                    .collect(toImmutableList());
+            Table table = Table.builder()
+                    .setDatabaseName(schemaTableName.getSchemaName())
+                    .setTableName(schemaTableName.getTableName())
+                    .setTableType(EXTERNAL_TABLE.name())
+                    .setDataColumns(columns)
+                    // Required by 'Table', but not used by view translation.
+                    .withStorage(storage -> storage.setStorageFormat(fromHiveStorageFormat(TEXTFILE)))
+                    .setOwner(Optional.empty())
+                    .build();
+            return toMetastoreApiTable(table);
+        });
     }
 
     public static final String PRESTO_VIEW_FLAG = "presto_view";

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -268,6 +268,7 @@ import static io.trino.plugin.hive.util.HiveWriteUtils.getTableDefaultLocation;
 import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
 import static io.trino.spi.StandardErrorCode.TRANSACTION_CONFLICT;
 import static io.trino.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
+import static io.trino.spi.connector.MetadataProvider.NOOP_METADATA_PROVIDER;
 import static io.trino.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static io.trino.spi.connector.SortOrder.ASC_NULLS_FIRST;
 import static io.trino.spi.connector.SortOrder.DESC_NULLS_LAST;
@@ -819,6 +820,7 @@ public abstract class AbstractTestHive
                 Optional.empty(),
                 true,
                 TYPE_MANAGER,
+                NOOP_METADATA_PROVIDER,
                 locationService,
                 partitionUpdateCodec,
                 newFixedThreadPool(2),

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -106,6 +106,7 @@ import static io.trino.plugin.hive.HiveTestUtils.getHiveSessionProperties;
 import static io.trino.plugin.hive.HiveTestUtils.getTypes;
 import static io.trino.plugin.hive.metastore.PrincipalPrivileges.NO_PRIVILEGES;
 import static io.trino.plugin.hive.util.HiveWriteUtils.getRawFileSystem;
+import static io.trino.spi.connector.MetadataProvider.NOOP_METADATA_PROVIDER;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.testing.MaterializedResult.materializeSourceDataStream;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
@@ -209,6 +210,7 @@ public abstract class AbstractTestHiveFileSystem
                 newDirectExecutorService(),
                 heartbeatService,
                 TYPE_MANAGER,
+                NOOP_METADATA_PROVIDER,
                 locationService,
                 partitionUpdateCodec,
                 new NodeVersion("test_version"),

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-iceberg-redirections/hive.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/conf/environment/singlenode-hive-iceberg-redirections/hive.properties
@@ -8,3 +8,4 @@ hive.allow-comment-table=true
 hive.allow-drop-table=true
 hive.allow-rename-table=true
 hive.iceberg-catalog-name=iceberg
+hive.translate-hive-views=true

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/AbstractTestHiveViews.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/AbstractTestHiveViews.java
@@ -22,6 +22,7 @@ import io.trino.tempto.query.QueryExecutor;
 import io.trino.tempto.query.QueryResult;
 import io.trino.testng.services.Flaky;
 import io.trino.tests.product.utils.QueryExecutors;
+import org.intellij.lang.annotations.Language;
 import org.testng.SkipException;
 import org.testng.annotations.Test;
 
@@ -30,15 +31,23 @@ import java.sql.Date;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
 import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tempto.query.QueryExecutor.query;
+import static io.trino.tests.product.TestGroups.HIVE_ICEBERG_REDIRECTIONS;
 import static io.trino.tests.product.TestGroups.HIVE_VIEWS;
+import static io.trino.tests.product.TestGroups.PROFILE_SPECIFIC_TESTS;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 
@@ -530,6 +539,93 @@ public abstract class AbstractTestHiveViews
         }
     }
 
+    /**
+     * Test a Hive view that spans over Hive and Iceberg table when metastore does not contain an up to date information about table schema, requiring
+     * any potential view translation to follow redirections.
+     */
+    @Test(groups = {HIVE_ICEBERG_REDIRECTIONS, PROFILE_SPECIFIC_TESTS})
+    public void testViewReferencingHiveAndIcebergTables()
+    {
+        onTrino().executeQuery("DROP TABLE IF EXISTS iceberg.default.view_iceberg_table_actual_data");
+        onTrino().executeQuery("DROP TABLE IF EXISTS iceberg.default.view_iceberg_table");
+        onHive().executeQuery("DROP VIEW IF EXISTS hive_iceberg_view");
+
+        @Language("SQL")
+        String icebergTableData = "SELECT " +
+                "  true a_boolean, " +
+                "  1 an_integer, " +
+                "  BIGINT '1' a_bigint," +
+                "  REAL '1e0' a_real, " +
+                "  1e0 a_double, " +
+                "  DECIMAL '13.1' a_short_decimal, " +
+                "  DECIMAL '123456789123456.123456789' a_long_decimal, " +
+                "  VARCHAR 'abc' an_unbounded_varchar, " +
+                "  X'abcd' a_varbinary, " +
+                "  DATE '2005-09-10' a_date, " +
+                // TODO this results in: column [a_timestamp] of type timestamp(6) projected from query view at position 10 cannot be coerced to column [a_timestamp] of type timestamp(3) stored in view definition
+                //  This is because `HiveViewReader` unconditionally uses millisecond precision.
+                //  "  TIMESTAMP '2005-09-10 13:00:00.123456' a_timestamp, " +
+                // TODO Hive fails to define a view over `timestamp with time zone` column.
+                //  "  TIMESTAMP '2005-09-10 13:00:00.123456 Europe/Warsaw' a_timestamp_tz, " +
+                "  0 a_last_column ";
+        onTrino().executeQuery("CREATE TABLE iceberg.default.view_iceberg_table_actual_data AS " + icebergTableData);
+        onTrino().executeQuery("CREATE TABLE iceberg.default.view_iceberg_table AS TABLE iceberg.default.view_iceberg_table_actual_data");
+        onHive().executeQuery("CREATE VIEW hive_iceberg_view AS " +
+                "SELECT view_iceberg_table.*, r_regionkey, r_name " +
+                "FROM view_iceberg_table JOIN region ON an_integer = r_regionkey");
+
+        // For an Iceberg table, the table schema in the metastore is generally ignored when reading directly from the table.
+        // In order to test that it's not used for Hive view translation, we desynchronize the state between metastore and the
+        // actual Iceberg schema in the storage. We do this by recreating the table and registering it the second time, manually.
+        String tableDescription = onHive().executeQuery("SHOW CREATE TABLE default.view_iceberg_table_actual_data").rows().stream()
+                .map(row -> (String) getOnlyElement(row))
+                .collect(joining());
+        String location = extractMatch(tableDescription, "LOCATION\\s*'(?<location>[^']+)'", "location");
+        String metadataLocation = extractMatch(tableDescription, "'metadata_location'='(?<location>[^']+\\.metadata\\.json)'", "location");
+        onTrino().executeQuery("DROP TABLE iceberg.default.view_iceberg_table");
+        onHive().executeQuery("" +
+                "CREATE EXTERNAL TABLE default.view_iceberg_table (dummy_column int) " +
+                // See https://github.com/apache/iceberg/blob/7fcc71da65a47ca3c9f6eb6e862a238389b8bdc5/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L406-L414
+                // for reference on table setup.
+                "ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' " +
+                "STORED AS INPUTFORMAT 'org.apache.hadoop.mapred.FileInputFormat' " +
+                // The Iceberg connector and Iceberg library would set 'org.apache.hadoop.mapred.FileOutputFormat' output format, but that's rejected by H2.
+                "OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat' " +
+                "LOCATION '" + location + "' " +
+                "TBLPROPERTIES ('table_type'='iceberg', 'metadata_location'='" + metadataLocation + "') ");
+        // Verify the table is recreated correctly
+        assertThat(onTrino().executeQuery("TABLE iceberg.default.view_iceberg_table"))
+                .containsOnly(onTrino().executeQuery(icebergTableData).rows().stream()
+                        .map(QueryAssert.Row::new)
+                        .collect(toImmutableList()));
+
+        // Test querying the view
+        assertQueryFailure(() -> onHive().executeQuery("SELECT * FROM hive_iceberg_view"))
+                // Testing Hive is not set up for Iceberg support. TODO when this changes, switch to use `assertViewQuery`
+                .hasMessageContaining("SemanticException")
+                .hasMessageContaining("Invalid column reference 'an_integer' in definition of VIEW hive_iceberg_view");
+        assertThat(onTrino().executeQuery("SELECT * FROM hive_iceberg_view"))
+                .containsOnly(
+                        row(
+                                true,
+                                1,
+                                1L,
+                                1.0f,
+                                1d,
+                                new BigDecimal("13.1"),
+                                new BigDecimal("123456789123456.123456789"),
+                                "abc",
+                                new byte[] {(byte) 0xAB, (byte) 0xCD},
+                                Date.valueOf(LocalDate.of(2005, 9, 10)),
+                                0, // view_iceberg_table.a_last_column,
+                                1L,
+                                "AMERICA"));
+
+        onHive().executeQuery("DROP VIEW hive_iceberg_view");
+        onTrino().executeQuery("DROP TABLE iceberg.default.view_iceberg_table_actual_data");
+        onHive().executeQuery("DROP TABLE default.view_iceberg_table");
+    }
+
     protected static void assertViewQuery(String query, Consumer<QueryAssert> assertion)
     {
         // Ensure Hive and Presto view compatibility by comparing the results
@@ -559,5 +655,14 @@ public abstract class AbstractTestHiveViews
         // We need to setup sessions for both "trino" and "default" executors in tempto
         onTrino().executeQuery("RESET SESSION " + key);
         query("RESET SESSION " + key);
+    }
+
+    private static String extractMatch(String value, @Language("RegExp") String pattern, String groupName)
+    {
+        Matcher matcher = Pattern.compile(pattern).matcher(value);
+        verify(matcher.find(), "Did not find match in [%s] for [%s]", value, pattern);
+        String extract = matcher.group(groupName);
+        verify(!matcher.find(), "Match ambiguous in [%s] for [%s]", value, pattern);
+        return extract;
     }
 }


### PR DESCRIPTION
When Hive has Iceberg support enabled (`HiveIcebergStorageHandler`),
HiveServer2 can create a Hive view referencing Hive and Iceberg tables.
Before the change, such views can be handled easily using the legacy
view translation logic, but could not be handled with the Coral-based
view translation, unless the metastore has an up to date copy of the
Iceberg table's schema. This commit enables handling of such views, if
Hive→Iceberg redirects are enabled, by letting the Hive connector
inquire about the actual current schema of the Iceberg table.