### PR TITLE
Remove outdated note from OAuth2 docs

### DIFF
--- a/docs/src/main/sphinx/security/oauth2.rst
+++ b/docs/src/main/sphinx/security/oauth2.rst
@@ -13,11 +13,6 @@ steps:
 #. the user's browser is redirected back to the Trino coordinator with an authorization code
 #. the Trino coordinator exchanges the authorization code for a token
 
-.. note::
-
-    OAuth 2.0 authentication currently supports JWT access tokens only, and
-    therefore does not support opaque access tokens.
-
 To enable OAuth 2.0 authentication for Trino, configuration changes are made on
 the Trino coordinator. No changes are required to the worker configuration;
 only the communication from the clients to the coordinator is authenticated.


### PR DESCRIPTION
Opaque tokens are supported since 361:
https://github.com/trinodb/trino/pull/8641