### PR TITLE
Load lazy blocks before using them in page filter

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/InputChannels.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/InputChannels.java
@@ -51,6 +51,11 @@ public class InputChannels
         return page.getColumns(inputChannels);
     }
 
+    public Page getLoadedInputChannels(Page page)
+    {
+        return page.getLoadedPage(inputChannels);
+    }
+
     @Override
     public String toString()
     {

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -118,7 +118,7 @@ public class PageProcessor
         }
 
         if (filter.isPresent()) {
-            SelectedPositions selectedPositions = filter.get().filter(session, filter.get().getInputChannels().getInputChannels(page));
+            SelectedPositions selectedPositions = filter.get().filter(session, filter.get().getInputChannels().getLoadedInputChannels(page));
             if (selectedPositions.isEmpty()) {
                 return WorkProcessor.of();
             }


### PR DESCRIPTION
Helps to avoid calls to LazyData#getTopLevelBlock in
generated page filter methods