### PR TITLE
Update maven to 3.8.4

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.8.3/apache-maven-3.8.3-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.8.4/apache-maven-3.8.4-bin.zip


### PR DESCRIPTION
Overview About the Changes:
- Regression fixes from Maven 3.8.3
- Upgrade to Jansi 2.4.0 which supports macOS on ARM natively