### PR TITLE
Improve DictionaryBlock copy methods

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryBlock.java
@@ -484,7 +484,7 @@ public class DictionaryBlock
         checkArrayRange(positions, offset, length);
 
         int[] newIds = new int[length];
-        boolean isCompact = isCompact() && length >= dictionary.getPositionCount();
+        boolean isCompact = length >= dictionary.getPositionCount() && isCompact();
         boolean[] seen = null;
         if (isCompact) {
             seen = new boolean[dictionary.getPositionCount()];

--- a/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryId.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/DictionaryId.java
@@ -13,7 +13,6 @@
  */
 package io.trino.spi.block;
 
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -71,6 +70,9 @@ public class DictionaryId
     @Override
     public int hashCode()
     {
-        return Objects.hash(mostSignificantBits, leastSignificantBits, sequenceId);
+        int hashCode = 31 + Long.hashCode(mostSignificantBits);
+        hashCode = (hashCode * 31) + Long.hashCode(leastSignificantBits);
+        hashCode = (hashCode * 31) + Long.hashCode(sequenceId);
+        return hashCode;
     }
 }


### PR DESCRIPTION
Improves `DictionaryBlock#copyRegion` and `#copyPositions` methods to detect scenarios that can avoid unnecessary work by removing the outer `DictionaryBlock` layer.

Also includes a one liner commit to perform the cheaper check first inside of `DictionaryBlock#getPositions`.