### PR TITLE
Enhance date function

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
+++ b/core/trino-main/src/main/java/io/trino/operator/scalar/DateTimeFunctions.java
@@ -265,6 +265,36 @@ public final class DateTimeFunctions
         return MILLISECONDS.toDays(millis);
     }
 
+    @Description("Generate a date based on the year, month and day passed in")
+    @ScalarFunction("date")
+    @SqlType(StandardTypes.DATE)
+    public static long toDate(@SqlType(StandardTypes.BIGINT) long year, @SqlType(StandardTypes.BIGINT) long month, @SqlType(StandardTypes.BIGINT) long day)
+    {
+        try {
+            return MILLISECONDS.toDays(UTC_CHRONOLOGY.getDateTimeMillis(toIntExact(year), toIntExact(month), toIntExact(day), 0));
+        }
+        catch (IllegalArgumentException e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, String.format("year:%s, month:%s and day:%s can not make a valid date", year, month, day));
+        }
+    }
+
+    @Description("Generate a date based on the year and days passed in")
+    @ScalarFunction("date")
+    @SqlType(StandardTypes.DATE)
+    public static long toDate(@SqlType(StandardTypes.BIGINT) long year, @SqlType(StandardTypes.BIGINT) long days)
+    {
+        if (days <= 0) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, "Days must be greater than zero");
+        }
+        try {
+            long millis = UTC_CHRONOLOGY.getDateTimeMillis(toIntExact(year), 1, 1, 0);
+            return MILLISECONDS.toDays(millis + (days - 1) * 24 * 3600 * 1000);
+        }
+        catch (Exception e) {
+            throw new TrinoException(INVALID_FUNCTION_ARGUMENT, String.format("year:%s and days:%s can not make a valid date", year, days));
+        }
+    }
+
     @Description("Add the specified amount of date to the given date")
     @LiteralParameters("x")
     @ScalarFunction("date_add")

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/TestDateTimeFunctions.java
@@ -304,6 +304,16 @@ public class TestDateTimeFunctions
         assertFunction("date('" + DATE_ISO8601_STRING + "')", DateType.DATE, toDate(DATE));
         assertFunction("date(" + WEIRD_TIMESTAMP_LITERAL + ")", DateType.DATE, toDate(DATE));
         assertFunction("date(" + TIMESTAMP_LITERAL + ")", DateType.DATE, toDate(DATE));
+
+        assertFunction("date(2021, 100)", DateType.DATE, toDate(LocalDate.of(2021, 4, 10)));
+        assertFunction("date(2021, 400)", DateType.DATE, toDate(LocalDate.of(2022, 2, 4)));
+        assertFunction("date(2021, 4, 10)", DateType.DATE, toDate(LocalDate.of(2021, 4, 10)));
+        assertFunction("date(1752, 9, 3)", DateType.DATE, toDate(LocalDate.of(1752, 9, 3)));
+        assertFunction("date(-10, 1, 1)", DateType.DATE, toDate(LocalDate.of(-10, 1, 1)));
+        assertInvalidFunction("date(2021, -1)", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("date(2021, 1, -1)", INVALID_FUNCTION_ARGUMENT);
+        assertInvalidFunction("date(2021, 13, 1)", INVALID_FUNCTION_ARGUMENT);
+
     }
 
     @Test

--- a/docs/src/main/sphinx/functions/datetime.rst
+++ b/docs/src/main/sphinx/functions/datetime.rst
@@ -72,6 +72,26 @@ Date and time functions
 
     This is an alias for ``CAST(x AS date)``.
 
+.. function:: date(year, days) -> date
+
+    Generate a date based on the year and days passed in.
+
+        SELECT date(2021, 10);
+        -- 2021-01-10
+
+        SELECT date(2021, 100);
+        -- 2021-04-10
+
+        SELECT date(2021, 400);
+        -- 2022-02-04
+
+.. function:: date(year, month, day) -> date
+
+    Generate a date based on the year, month and day passed in.
+
+        SELECT date(2021, 1, 10);
+        -- 2021-01-10
+
 .. function:: last_day_of_month(x) -> date
 
     Returns the last day of the month.


### PR DESCRIPTION
This pr add a date_make() function, its reason: 

Although there is currently from_ iso8601_date() function, but its use is not concise enough. 

Secondly, when days exceeds the range of 1-365, an error will be reported. This function enhances this.

Its effect is as follows: 

       SELECT date(2021, 1, 4);
        -- 2022-01-04

       SELECT date(2021, 10);
        -- 2021-01-10

        SELECT date(2021, 100);
        -- 2021-04-10

        SELECT date(2021, 400);
        -- 2022-02-04

There are similar implementations in MySQL: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_makedate