### PR TITLE
Fix log messages which are not format strings

### DIFF
--- a/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcVendorCompatibility.java
+++ b/client/trino-jdbc/src/test/java/io/trino/jdbc/TestJdbcVendorCompatibility.java
@@ -372,7 +372,7 @@ public class TestJdbcVendorCompatibility
                 catch (RuntimeException | AssertionError e) {
                     String message = format("Failure when checking behavior against %s", driver);
                     // log immediately since further tests may take more time; "log and rethrown" is not harmful in tests
-                    log.error(e, message);
+                    log.error(e, "%s", message);
                     failures.add(new AssertionError(message, e));
                 }
             }

--- a/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SqlTaskManager.java
@@ -206,7 +206,7 @@ public class SqlTaskManager
         }
         currentMemoryPoolAssignmentVersion = assignments.getVersion();
         if (coordinatorId != null && !coordinatorId.equals(assignments.getCoordinatorId())) {
-            log.warn("Switching coordinator affinity from " + coordinatorId + " to " + assignments.getCoordinatorId());
+            log.warn("Switching coordinator affinity from %s to %s", coordinatorId, assignments.getCoordinatorId());
         }
         coordinatorId = assignments.getCoordinatorId();
 

--- a/core/trino-main/src/main/java/io/trino/execution/executor/TaskExecutor.java
+++ b/core/trino-main/src/main/java/io/trino/execution/executor/TaskExecutor.java
@@ -261,7 +261,7 @@ public class TaskExecutor
         checkArgument(maxDriversPerTask.isEmpty() || maxDriversPerTask.getAsInt() <= maximumNumberOfDriversPerTask,
                 "maxDriversPerTask cannot be greater than the configured value");
 
-        log.debug("Task scheduled " + taskId);
+        log.debug("Task scheduled %s", taskId);
 
         TaskHandle taskHandle = new TaskHandle(taskId, waitingSplits, utilizationSupplier, initialSplitConcurrency, splitConcurrencyAdjustFrequency, maxDriversPerTask);
 
@@ -302,7 +302,7 @@ public class TaskExecutor
         long threadUsageNanos = taskHandle.getScheduledNanos();
         completedTasksPerLevel.incrementAndGet(computeLevel(threadUsageNanos));
 
-        log.debug("Task finished or failed " + taskHandle.getTaskId());
+        log.debug("Task finished or failed %s", taskHandle.getTaskId());
     }
 
     public List<ListenableFuture<Void>> enqueueSplits(TaskHandle taskHandle, boolean intermediate, List<? extends SplitRunner> taskSplits)

--- a/core/trino-main/src/main/java/io/trino/memory/ClusterMemoryManager.java
+++ b/core/trino-main/src/main/java/io/trino/memory/ClusterMemoryManager.java
@@ -351,7 +351,7 @@ public class ClusterMemoryManager
             Joiner.on(",").withKeyValueSeparator("=").appendTo(nodeDescription, memoryPoolInfo.getQueryMemoryReservations());
             nodeDescription.append('\n');
         }
-        log.info(nodeDescription.toString());
+        log.info("%s", nodeDescription);
     }
 
     @VisibleForTesting

--- a/core/trino-main/src/main/java/io/trino/server/Server.java
+++ b/core/trino-main/src/main/java/io/trino/server/Server.java
@@ -152,7 +152,7 @@ public class Server
             addMessages(message, "Warnings", ImmutableList.copyOf(e.getWarnings()));
             message.append("\n");
             message.append("==========");
-            log.error(message.toString());
+            log.error("%s", message);
             System.exit(1);
         }
         catch (Throwable e) {

--- a/core/trino-main/src/main/java/io/trino/spiller/FileSingleStreamSpillerFactory.java
+++ b/core/trino-main/src/main/java/io/trino/spiller/FileSingleStreamSpillerFactory.java
@@ -147,11 +147,11 @@ public class FileSingleStreamSpillerFactory
         try (DirectoryStream<Path> stream = newDirectoryStream(path, SPILL_FILE_GLOB)) {
             stream.forEach(spillFile -> {
                 try {
-                    log.info("Deleting old spill file: " + spillFile);
+                    log.info("Deleting old spill file: %s", spillFile);
                     delete(spillFile);
                 }
                 catch (Exception e) {
-                    log.warn("Could not cleanup old spill file: " + spillFile);
+                    log.warn("Could not cleanup old spill file: %s", spillFile);
                 }
             });
         }

--- a/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloTableManager.java
+++ b/plugin/trino-accumulo/src/main/java/io/trino/plugin/accumulo/AccumuloTableManager.java
@@ -70,7 +70,7 @@ public class AccumuloTableManager
         }
         catch (NamespaceExistsException e) {
             // Suppress race condition between test for existence and creation
-            LOG.warn("NamespaceExistsException suppressed when creating " + schema);
+            LOG.warn("NamespaceExistsException suppressed when creating %s", schema);
         }
     }
 

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
@@ -544,7 +544,7 @@ public class CassandraSession
                 }
                 else {
                     long delay = Math.min(schedule.nextDelayMs(), timeLeft);
-                    log.warn(e.getCustomMessage(10, true, true));
+                    log.warn("%s", e.getCustomMessage(10, true, true));
                     log.warn("Reconnecting in %dms", delay);
                     try {
                         Thread.sleep(delay);

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -2154,7 +2154,7 @@ public class HiveMetadata
             // Until table is cleaned up there will duplicate rows present.
             metastore.dropDeclaredIntentionToWrite(handle.getWriteDeclarationId().get());
             String errorMessage = "Error while deleting data files in FINISH phase of OPTIMIZE for table " + table.getTableName() + "; remaining files need to be deleted manually:  " + remainingFilesToDelete;
-            log.error(e, errorMessage);
+            log.error(e, "%s", errorMessage);
             throw new TrinoException(HIVE_FILESYSTEM_ERROR, errorMessage, e);
         }
     }

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/SortingFileWriter.java
@@ -260,7 +260,7 @@ public class SortingFileWriter
             }
         }
         catch (IOException e) {
-            log.warn(e, "Failed to delete temporary file: " + file);
+            log.warn(e, "Failed to delete temporary file: %s", file);
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -636,7 +636,7 @@ public class GlueHiveMetastore
         }
         catch (Exception e) {
             // don't fail if unable to delete path
-            log.warn(e, "Failed to delete path: " + path.toString());
+            log.warn(e, "Failed to delete path: %s", path.toString());
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -1124,7 +1124,7 @@ public class ThriftHiveMetastore
         }
         catch (IOException | RuntimeException e) {
             // don't fail if unable to delete path
-            log.warn(e, "Failed to delete path: " + path.toString());
+            log.warn(e, "Failed to delete path: %s", path.toString());
         }
     }
 

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -675,7 +675,7 @@ public abstract class AbstractTestHive
                 deleteRecursively(temporaryStagingDirectory, ALLOW_INSECURE);
             }
             catch (Exception e) {
-                log.warn(e, "Error deleting " + temporaryStagingDirectory);
+                log.warn(e, "Error deleting %s", temporaryStagingDirectory);
             }
         }
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveLocal.java
@@ -62,7 +62,6 @@ import static io.trino.plugin.hive.HiveType.HIVE_STRING;
 import static io.trino.plugin.hive.util.HiveBucketing.BucketingVersion.BUCKETING_V1;
 import static io.trino.plugin.hive.util.HiveUtil.SPARK_TABLE_PROVIDER_KEY;
 import static io.trino.testing.TestingConnectorSession.SESSION;
-import static java.lang.String.format;
 import static java.nio.file.Files.copy;
 import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
@@ -267,7 +266,7 @@ public abstract class AbstractTestHiveLocal
             throws IOException
     {
         java.nio.file.Path tempDir = java.nio.file.Files.createTempDirectory(getClass().getSimpleName()).normalize();
-        log.info(format("Copying resource dir '%s' to %s", resourceName, tempDir));
+        log.info("Copying resource dir '%s' to %s", resourceName, tempDir);
         ClassPath.from(getClass().getClassLoader())
                 .getResources().stream()
                 .filter(resourceInfo -> resourceInfo.getResourceName().startsWith(resourceName))

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestDataWritableWriter.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/write/TestDataWritableWriter.java
@@ -84,7 +84,7 @@ public class TestDataWritableWriter
             }
             catch (RuntimeException e) {
                 String errorMessage = "Parquet record is malformed: " + e.getMessage();
-                log.error(e, errorMessage);
+                log.error(e, "%s", errorMessage);
                 throw new RuntimeException(errorMessage, e);
             }
             recordConsumer.endMessage();

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisShardCheckpointer.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/KinesisShardCheckpointer.java
@@ -105,7 +105,7 @@ public class KinesisShardCheckpointer
     // storing last read sequence no. in dynamodb table
     public void checkpoint(String lastReadSequenceNumber)
     {
-        log.info("Trying to checkpoint at " + lastReadSequenceNumber);
+        log.info("Trying to checkpoint at %s", lastReadSequenceNumber);
         try {
             ExtendedSequenceNumber esn = new ExtendedSequenceNumber(lastReadSequenceNumber);
             kinesisClientLease.setCheckpoint(esn);
@@ -141,7 +141,7 @@ public class KinesisShardCheckpointer
             log.info("Previous checkpoint not found. Starting from beginning of shard");
         }
         else {
-            log.info("Resuming from " + lastReadSeqNumber);
+            log.info("Resuming from %s", lastReadSeqNumber);
         }
         return lastReadSeqNumber;
     }

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/s3config/S3TableConfigClient.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/s3config/S3TableConfigClient.java
@@ -167,7 +167,7 @@ public class S3TableConfigClient
             log.info("Completed getting S3 object listing.");
         }
         catch (AmazonClientException e) {
-            log.error("Skipping update as faced error fetching table descriptions from S3 " + e.toString());
+            log.error("Skipping update as faced error fetching table descriptions from S3 %s", e.toString());
         }
         return result;
     }

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestRecordAccess.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/TestRecordAccess.java
@@ -199,14 +199,14 @@ public class TestRecordAccess
         assertEquals(types.size(), 5);
         assertEquals(types.get(0).toString(), "bigint");
         assertEquals(types.get(1).toString(), "varchar");
-        log.info("Types : " + types.toString());
+        log.info("Types : %s", types);
 
         List<MaterializedRow> rows = result.getMaterializedRows();
         assertEquals(rows.size(), uncompressedMessages + compressedMessages);
         for (MaterializedRow row : rows) {
             assertEquals(row.getFieldCount(), 5);
             assertTrue((long) row.getFields().get(0) >= 100);
-            log.info("ROW: " + row.toString());
+            log.info("ROW: %s", row);
         }
     }
 

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/s3config/TestS3TableConfigClient.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/s3config/TestS3TableConfigClient.java
@@ -53,7 +53,7 @@ public class TestS3TableConfigClient
         assertTrue(uri1.getRegion() == null);
 
         // show info:
-        log.info("Tested out URI1 : " + uri1.toString());
+        log.info("Tested out URI1 : %s", uri1.toString());
 
         AmazonS3URI uri2 = new AmazonS3URI("s3://some.big.bucket/long/complex/path");
         assertNotNull(uri2.getKey());
@@ -65,7 +65,7 @@ public class TestS3TableConfigClient
         assertTrue(uri2.getRegion() == null);
 
         // info:
-        log.info("Tested out URI2 : " + uri2.toString());
+        log.info("Tested out URI2 : %s", uri2.toString());
 
         AmazonS3URI uri3 = new AmazonS3URI("s3://trino.kinesis.config/unit-test/trino-kinesis");
         assertNotNull(uri3.getKey());

--- a/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticator.java
+++ b/plugin/trino-password-authenticators/src/main/java/io/trino/plugin/password/ldap/LdapAuthenticator.java
@@ -123,7 +123,7 @@ public class LdapAuthenticator
                     String groupSearch = replaceUser(groupAuthorizationSearchPattern.get(), user);
                     if (!client.isGroupMember(searchBase, groupSearch, userDistinguishedName, credential.getPassword())) {
                         String message = format("User [%s] not a member of an authorized group", user);
-                        log.debug(message);
+                        log.debug("%s", message);
                         throw new AccessDeniedException(message);
                     }
                 }
@@ -186,12 +186,12 @@ public class LdapAuthenticator
         Set<String> userDistinguishedNames = client.lookupUserDistinguishedNames(searchBase, searchFilter, bindDistinguishedName.orElseThrow(), bindPassword.orElseThrow());
         if (userDistinguishedNames.isEmpty()) {
             String message = format("User [%s] not a member of an authorized group", user);
-            log.debug(message);
+            log.debug("%s", message);
             throw new AccessDeniedException(message);
         }
         if (userDistinguishedNames.size() > 1) {
             String message = format("Multiple group membership results for user [%s]: %s", user, userDistinguishedNames);
-            log.debug(message);
+            log.debug("%s", message);
             throw new AccessDeniedException(message);
         }
         return getOnlyElement(userDistinguishedNames);

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/ShardRecoveryManager.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/storage/ShardRecoveryManager.java
@@ -284,7 +284,7 @@ public class ShardRecoveryManager
             Files.move(file.toPath(), quarantine.toPath(), ATOMIC_MOVE);
         }
         catch (IOException e) {
-            log.warn(e, "Quarantine of corrupt file failed: " + quarantine);
+            log.warn(e, "Quarantine of corrupt file failed: %s", quarantine);
             file.delete();
         }
     }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveTransactionalTable.java
@@ -1998,7 +1998,7 @@ public class TestHiveTransactionalTable
             verify(startedCompactions.size() < 2, "Expected at most 1 compaction");
 
             if (startedCompactions.isEmpty()) {
-                log.info("Compaction has not started yet. Existing compactions: " + getTableCompactions(compactMode, tableName, Optional.empty()));
+                log.info("Compaction has not started yet. Existing compactions: %s", getTableCompactions(compactMode, tableName, Optional.empty()));
                 continue;
             }
 


### PR DESCRIPTION
These all use variants of the `Logger` method which take a `String` and no format string arguments. Formerly this was treated as a simple message to be passed to logs verbatim, but this creates plenty of opportunities to mis-use it. A change in Airlift may change the semantics of these methods to treat the `String` as a format string with no arguments, and mark them as `@FormatMethod`s, so that Error Prone can catch improper uses (see airlift/airlift#954).

There are roughly four categories of instances flagged given the above:

* Logging using concatenation instead of the format string:
  - `logger.info("Foo " + bar + " bazzed");`
* Logging a pre-formatted String:
  - `logger.info(String.format("%s %d", foo, bar));`
* Preparing a message beforehand so that it can be used to log and as an exception message:
  - ```
    String message = String.format(...);
    logger.info(message);
    throw new Exception(message);
    ```
* Non-static-string:
  - `log.error(message.toString());`

Most of the above have pretty obvious fixes, except for the third kind, where it's hard to avoid duplication of the message string (which this commit doesn't try to do).