### PR TITLE
calculate range comparision method handle only once per SortedRangeSet

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/Range.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/Range.java
@@ -46,13 +46,17 @@ public final class Range
 
     Range(Type type, boolean lowInclusive, Optional<Object> lowValue, boolean highInclusive, Optional<Object> highValue)
     {
+        this(type, lowInclusive, lowValue, highInclusive, highValue, getComparisonOperator(type));
+    }
+
+    Range(Type type, boolean lowInclusive, Optional<Object> lowValue, boolean highInclusive, Optional<Object> highValue, MethodHandle comparisonOperator)
+    {
         requireNonNull(type, "type is null");
         this.type = type;
-        // choice of placing unordered values first or last does not matter for this code
-        MethodHandle comparisonOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getComparisonUnorderedLastOperator(type, simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL));
 
         requireNonNull(lowValue, "lowValue is null");
         requireNonNull(highValue, "highValue is null");
+        requireNonNull(comparisonOperator, "comparisonOperator is null");
 
         if (lowValue.isEmpty() && lowInclusive) {
             throw new IllegalArgumentException("low bound must be exclusive for low unbounded range");
@@ -90,6 +94,12 @@ public final class Range
         if (isFloatingPointNaN(type, value)) {
             throw new IllegalArgumentException("cannot use NaN as range bound");
         }
+    }
+
+    protected static MethodHandle getComparisonOperator(Type type)
+    {
+        // choice of placing unordered values first or last does not matter for this code
+        return TUPLE_DOMAIN_TYPE_OPERATORS.getComparisonUnorderedLastOperator(type, simpleConvention(FAIL_ON_NULL, NEVER_NULL, NEVER_NULL));
     }
 
     public static Range all(Type type)

--- a/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/predicate/SortedRangeSet.java
@@ -84,7 +84,7 @@ public final class SortedRangeSet
         this.hashCodeOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getHashCodeOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION));
         // choice of placing unordered values first or last does not matter for this code
         this.comparisonOperator = TUPLE_DOMAIN_TYPE_OPERATORS.getComparisonUnorderedLastOperator(type, simpleConvention(FAIL_ON_NULL, BLOCK_POSITION, BLOCK_POSITION));
-        // Calculating the comparison operator once instead of per range to avoid lock contention in cases of large number of ranges
+        // Calculating the comparison operator once instead of per range to avoid hitting TypeOperators cache
         this.rangeComparisonOperator = Range.getComparisonOperator(type);
 
         requireNonNull(inclusive, "inclusive is null");


### PR DESCRIPTION
While using LargeDynamicFilters enabled which resulted in ±300K ranges SortedRangeSet we've got some lock contention in this backtrace when calling `SortedRangeSet.getOrderedRanges` from multiple threads :

`java.util.concurrent.ConcurrentHashMap.computeIfAbsent(java.base@11.0.12/ConcurrentHashMap.java:1723)
        - waiting to lock <0x00007f05c1c6fc60> (a java.util.concurrent.ConcurrentHashMap$Node)
        at io.trino.spi.type.TypeOperators.lambda$new$1(TypeOperators.java:72)
        at io.trino.spi.type.TypeOperators$$Lambda$4659/0x00007ede7d71fcb0.apply(Unknown Source)
        at io.trino.spi.type.TypeOperators.getOperatorAdaptor(TypeOperators.java:169)
        at io.trino.spi.type.TypeOperators.getOperatorAdaptor(TypeOperators.java:163)
        at io.trino.spi.type.TypeOperators.getComparisonUnorderedLastOperator(TypeOperators.java:125)
        at io.trino.spi.predicate.Range.<init>(Range.java:52)
        at io.trino.spi.predicate.SortedRangeSet$RangeView.toRange(SortedRangeSet.java:1132)
        at io.trino.spi.predicate.SortedRangeSet.getRange(SortedRangeSet.java:475)
        at io.trino.spi.predicate.SortedRangeSet.getOrderedRanges(SortedRangeSet.java:340)`
        
   when calling `getComparisonUnorderedLastOperator` once per `SortedRangeSet` the contention is reduced... 