### PR TITLE
Prevent lock contention in TypeOperators

### DIFF
--- a/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/type/TypeOperators.java
@@ -69,7 +69,14 @@ public class TypeOperators
     public TypeOperators()
     {
         ConcurrentHashMap<Object, Object> cache = new ConcurrentHashMap<>();
-        this.cache = (operatorConvention, supplier) -> cache.computeIfAbsent(operatorConvention, key -> supplier.get());
+        this.cache = (operatorConvention, supplier) -> {
+            // preform explicit get before calling computeIfAbsent since computeIfAbsent cause lock contention
+            Object operator = cache.get(operatorConvention);
+            if (operator != null) {
+                return operator;
+            }
+            return cache.computeIfAbsent(operatorConvention, key -> supplier.get());
+        };
     }
 
     public TypeOperators(BiFunction<Object, Supplier<Object>, Object> cache)


### PR DESCRIPTION
computeIfAbsent can cause lock contention,
therefore it should be avoided in performance
critical sections.