### PR TITLE
Remove unnecessary toString() calls in logs

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/glue/GlueHiveMetastore.java
@@ -636,7 +636,7 @@ public class GlueHiveMetastore
         }
         catch (Exception e) {
             // don't fail if unable to delete path
-            log.warn(e, "Failed to delete path: %s", path.toString());
+            log.warn(e, "Failed to delete path: %s", path);
         }
     }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -1124,7 +1124,7 @@ public class ThriftHiveMetastore
         }
         catch (IOException | RuntimeException e) {
             // don't fail if unable to delete path
-            log.warn(e, "Failed to delete path: %s", path.toString());
+            log.warn(e, "Failed to delete path: %s", path);
         }
     }
 

--- a/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
@@ -130,7 +130,7 @@ public class HttpEventListener
                                 }
 
                                 if (!(result.getStatusCode() >= 200 && result.getStatusCode() < 300)) {
-                                    log.error("Received status code %d from ingest server URI %s; expecting status 200", result.getStatusCode(), request.getUri().toString());
+                                    log.error("Received status code %d from ingest server URI %s; expecting status 200", result.getStatusCode(), request.getUri());
                                 }
                             }
 

--- a/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/s3config/S3TableConfigClient.java
+++ b/plugin/trino-kinesis/src/main/java/io/trino/plugin/kinesis/s3config/S3TableConfigClient.java
@@ -167,7 +167,7 @@ public class S3TableConfigClient
             log.info("Completed getting S3 object listing.");
         }
         catch (AmazonClientException e) {
-            log.error("Skipping update as faced error fetching table descriptions from S3 %s", e.toString());
+            log.error("Skipping update as faced error fetching table descriptions from S3 %s", e);
         }
         return result;
     }

--- a/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/s3config/TestS3TableConfigClient.java
+++ b/plugin/trino-kinesis/src/test/java/io/trino/plugin/kinesis/s3config/TestS3TableConfigClient.java
@@ -53,7 +53,7 @@ public class TestS3TableConfigClient
         assertTrue(uri1.getRegion() == null);
 
         // show info:
-        log.info("Tested out URI1 : %s", uri1.toString());
+        log.info("Tested out URI1 : %s", uri1);
 
         AmazonS3URI uri2 = new AmazonS3URI("s3://some.big.bucket/long/complex/path");
         assertNotNull(uri2.getKey());
@@ -65,7 +65,7 @@ public class TestS3TableConfigClient
         assertTrue(uri2.getRegion() == null);
 
         // info:
-        log.info("Tested out URI2 : %s", uri2.toString());
+        log.info("Tested out URI2 : %s", uri2);
 
         AmazonS3URI uri3 = new AmazonS3URI("s3://trino.kinesis.config/unit-test/trino-kinesis");
         assertNotNull(uri3.getKey());


### PR DESCRIPTION
These are format strings, which already do a conversion to `String` behind the scenes. And since these are logs, they perform this conversion lazily (only when needed), so calling `toString` eagerly is wasteful.