### PR TITLE
Load blocks before using them in projections

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/project/InputChannels.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/InputChannels.java
@@ -51,6 +51,11 @@ public class InputChannels
         return page.getColumns(inputChannels);
     }
 
+    public Page getLoadedInputChannels(Page page)
+    {
+        return page.getLoadedPage(inputChannels);
+    }
+
     @Override
     public String toString()
     {

--- a/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/project/PageProcessor.java
@@ -331,7 +331,7 @@ public class PageProcessor
                 else {
                     if (pageProjectWork == null) {
                         expressionProfiler.start();
-                        pageProjectWork = projection.project(session, yieldSignal, projection.getInputChannels().getInputChannels(page), positionsBatch);
+                        pageProjectWork = projection.project(session, yieldSignal, projection.getInputChannels().getLoadedInputChannels(page), positionsBatch);
                         expressionProfiler.stop(positionsBatch.size());
                     }
                     if (!pageProjectWork.process()) {


### PR DESCRIPTION
Avoids overheads of going via LazyBlock wrapper in
page projections