### PR TITLE
Enforce log4j2 isn't used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1657,6 +1657,12 @@
                                     <exclude>com.google.j2objc:j2objc-annotations</exclude>
                                 </excludes>
                             </requireUpperBoundDeps>
+                            <bannedDependencies>
+                                <excludes>
+                                    <!-- We don't use log4j2, additionally versions < 2.15.0 are vulnerable to the RCE Log4Shell (CVE-2021-44228) -->
+                                    <exclude>org.apache.logging.log4j:log4j-core</exclude>
+                                </excludes>
+                            </bannedDependencies>
                         </rules>
                     </configuration>
                     <dependencies>


### PR DESCRIPTION
We don't use log4j2 in Trino today.
Additionally versions older than 2.15.0 are vulnerable to a RCE
(CVE-2021-44228).

(Should this go into Airbase instead? The idea is to prevent a future dependency from adding the vulnerable versions.)