### PR TITLE
Don't fail the annotate workflow if there are no artifacts

### DIFF
--- a/.github/workflows/annotate.yml
+++ b/.github/workflows/annotate.yml
@@ -39,6 +39,8 @@ jobs:
           pwd
           ls
           for archive in *.zip; do
+            # $archive is literally *.zip if there are no zip files matching the glob expression
+            [ -f "$archive" ] || continue
             name=$(basename "$archive" .zip)
             mkdir "$name"
             (cd "$name" && unzip ../"$archive")


### PR DESCRIPTION
The new workflow added in #10137 fails if there are no artifacts, which happens for workflows of forks that are not yet rebased, or if they did not run all jobs. This workflow should never fail in such cases.

This is caused by a shell quirk where the `for` loop runs even if the glob did not match any files. It can be turned off in bash using `shopt -s nullglob` or an explicit check can be added, which would work in other shells too.