### PR TITLE
Fix dependency ban to append to existing rules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1658,7 +1658,7 @@
                                 </excludes>
                             </requireUpperBoundDeps>
                             <bannedDependencies>
-                                <excludes>
+                                <excludes combine.children="append">
                                     <!-- We don't use log4j2, additionally versions < 2.15.0 are vulnerable to the RCE Log4Shell (CVE-2021-44228) -->
                                     <exclude>org.apache.logging.log4j:log4j-core</exclude>
                                 </excludes>


### PR DESCRIPTION
By default, `merge` is used to combine properties which doesn't work as expected for lists with children named the same: https://maven.apache.org/pom.html#default_configuration_inheritance