### PR TITLE
Disable distributed sort when failure recovery is enabled

### DIFF
--- a/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
+++ b/core/trino-main/src/main/java/io/trino/SystemSessionProperties.java
@@ -1002,6 +1002,11 @@ public final class SystemSessionProperties
 
     public static boolean isDistributedSortEnabled(Session session)
     {
+        if (getRetryPolicy(session) != RetryPolicy.NONE) {
+            // distributed sort is not supported with failure recovery capabilities enabled
+            return false;
+        }
+
         return session.getSystemProperty(DISTRIBUTED_SORT, Boolean.class);
     }
 
@@ -1217,9 +1222,6 @@ public final class SystemSessionProperties
         if (retryPolicy != RetryPolicy.NONE) {
             if (isEnableDynamicFiltering(session)) {
                 throw new TrinoException(NOT_SUPPORTED, "Dynamic filtering is not supported with automatic retries enabled");
-            }
-            if (isDistributedSortEnabled(session)) {
-                throw new TrinoException(NOT_SUPPORTED, "Distributed sort is not supported with automatic retries enabled");
             }
         }
         return retryPolicy;

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestFailureRecovery.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestFailureRecovery.java
@@ -80,7 +80,6 @@ public abstract class AbstractTestFailureRecovery
                         .put("exchange.http-client.idle-timeout", REQUEST_TIMEOUT.toString())
                         // TODO: re-enable once failure recover supported for this functionality
                         .put("enable-dynamic-filtering", "false")
-                        .put("distributed-sort", "false")
                         .build(),
                 ImmutableMap.<String, String>builder()
                         .put("scheduler.http-client.idle-timeout", REQUEST_TIMEOUT.toString())


### PR DESCRIPTION
Currently distributed sort is not supported with failure recovery
capabilities enabled.

Ordering guarantees that distributed sort requires is more difficuilt
to provide with failure recovery capabilities enabled. The strong
ordering guarantees would limit buffering, spilling and out-of-order
read/write strategies for exchanges.

Currently the sort operation is only performed on the final result
dataset that usually tends to be small. Given the low value of the
distributed sort and the limitationis it imposes it was decided not
to support it for now and silently disable it when failure recovery
is enabled.