### PR TITLE
Use proper path glob when uploading product test reports

### DIFF
--- a/.github/problem-matcher.json
+++ b/.github/problem-matcher.json
@@ -4,7 +4,7 @@
       "owner": "Maven - Error Prone and Checkstyle",
       "pattern": [
         {
-          "regexp": "^.*\\[(ERROR|WARN(?:ING)?)\\]\\s+(.*):\\[(\\d+),(\\d+)\\] (?:error: )?[\\[\\(](.*)[\\]\\)] (.*)$",
+          "regexp": "^.*\\[(ERROR)\\]\\s+(.*):\\[(\\d+),(\\d+)\\] (?:error: )?[\\[\\(](.*)[\\]\\)] (.*)$",
           "severity": 1,
           "file": 2,
           "line": 3,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,5 +625,5 @@ jobs:
         with:
           # Name prefix is checked in the `Annotate checks` workflow
           name: test report pt (${{ matrix.config }}, ${{ matrix.suite }}, ${{ matrix.jdk }})
-          path: testing/trino-product-tests/target/reports/testng-results.xml
+          path: testing/trino-product-tests/target/reports/**/testng-results.xml
           retention-days: ${{ env.TEST_REPORT_RETENTION_DAYS }}


### PR DESCRIPTION
This addresses warnings like this:
![image](https://user-images.githubusercontent.com/795177/145967518-d1d9c0b7-184e-47ef-aeff-d27ce23e2514.png)

This issue was introduced in #10137 