### PR TITLE
Increase test timeout

### DIFF
--- a/testing/trino-tests/src/test/java/io/trino/execution/TestQueryTracker.java
+++ b/testing/trino-tests/src/test/java/io/trino/execution/TestQueryTracker.java
@@ -54,7 +54,7 @@ public class TestQueryTracker
         Session defaultSession = testSessionBuilder()
                 .setCatalog("mock")
                 .setSchema("default")
-                .setSystemProperty(QUERY_MAX_PLANNING_TIME, "1s")
+                .setSystemProperty(QUERY_MAX_PLANNING_TIME, "2s")
                 .build();
 
         DistributedQueryRunner queryRunner = DistributedQueryRunner
@@ -77,12 +77,12 @@ public class TestQueryTracker
         return queryRunner;
     }
 
-    @Test(timeOut = 5_000)
+    @Test(timeOut = 10_000)
     public void testInterruptApplyFilter()
             throws InterruptedException
     {
         assertThatThrownBy(() -> getQueryRunner().execute("SELECT * FROM t1 WHERE col = 'abc'"))
-                .hasMessageContaining("Query exceeded the maximum planning time limit of 1.00s");
+                .hasMessageContaining("Query exceeded the maximum planning time limit of 2.00s");
 
         interrupted.await();
     }


### PR DESCRIPTION
A mix of local experiments and wishful thinking led me to believe that multiplying everything by 2 should reduce flakiness.
This does not solve https://github.com/trinodb/trino/issues/8432, it is merely an attempt to reduce/profile the problem.