### PR TITLE
Introduce a logout page for Oauth2 authentication

### DIFF
--- a/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiLogoutResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/ui/OAuth2WebUiLogoutResource.java
@@ -13,6 +13,7 @@
  */
 package io.trino.server.ui;
 
+import com.google.common.io.Resources;
 import io.trino.server.security.ResourceSecurity;
 
 import javax.ws.rs.GET;
@@ -23,10 +24,12 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import java.io.IOException;
+
 import static io.trino.server.security.ResourceSecurity.AccessType.WEB_UI;
-import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOCATION_URI;
 import static io.trino.server.ui.FormWebUiAuthenticationFilter.UI_LOGOUT;
 import static io.trino.server.ui.OAuthWebUiCookie.delete;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 @Path(UI_LOGOUT)
 public class OAuth2WebUiLogoutResource
@@ -34,8 +37,9 @@ public class OAuth2WebUiLogoutResource
     @ResourceSecurity(WEB_UI)
     @GET
     public Response logout(@Context HttpHeaders httpHeaders, @Context UriInfo uriInfo, @Context SecurityContext securityContext)
+            throws IOException
     {
-        return Response.seeOther(UI_LOCATION_URI)
+        return Response.ok(Resources.toString(Resources.getResource(getClass(), "/oauth2/logout.html"), UTF_8))
                 .cookie(delete())
                 .build();
     }

--- a/core/trino-main/src/main/resources/oauth2/logout.html
+++ b/core/trino-main/src/main/resources/oauth2/logout.html
@@ -1,0 +1,51 @@
+<!--
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
+    <meta name="description" content="Web Interface - Presto">
+    <title>Cluster Overview - Presto</title>
+
+    <link rel="icon" href="/ui/assets/favicon.ico">
+
+    <!-- Bootstrap core -->
+    <link href="/ui/vendor/bootstrap/css/bootstrap.css" rel="stylesheet">
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+    <!-- CSS loader -->
+    <link href="/ui/vendor/css-loaders/loader.css" rel="stylesheet">
+
+    <!-- Custom CSS -->
+    <link href="/ui/assets/trino.css" rel="stylesheet">
+</head>
+
+<body>
+
+<h2 class="text-center">OAuth2 logout succeeded</h2>
+
+<h4 class="text-center">This browser window can be closed</h4>
+
+<!-- Fonts -->
+<link href="https://fonts.googleapis.com/css?family=Roboto:400,500,700" rel="stylesheet">
+
+</body>
+</html>

--- a/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
+++ b/core/trino-main/src/test/java/io/trino/server/ui/TestWebUi.java
@@ -755,7 +755,7 @@ public class TestWebUi
         assertResponseCode(client, getLocation(baseUri, "/ui/api/unknown"), SC_NOT_FOUND);
 
         // logout
-        assertRedirect(client, getLogoutLocation(baseUri), getUiLocation(baseUri), false);
+        assertOk(client, getLogoutLocation(baseUri));
         assertThat(cookieManager.getCookieStore().getCookies()).isEmpty();
         assertRedirect(client, getUiLocation(baseUri), "http://example.com/authorize", false);
     }


### PR DESCRIPTION
After clicking "Log Out", cookies were deleted, but Web UI was redirecting back to `/ui` which was redirecting to `/authorize` and IdP was authorizing immediately.
User could not notice logging out from Trino actually happened, so I introduced a simple page informing about this.