### PR TITLE
Prefer Stream equivalent of some of the Iterables utility methods

### DIFF
--- a/client/trino-cli/src/main/java/io/trino/cli/AlignedTablePrinter.java
+++ b/client/trino-cli/src/main/java/io/trino/cli/AlignedTablePrinter.java
@@ -23,6 +23,7 @@ import io.trino.client.Row;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -31,7 +32,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.repeat;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.partition;
-import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Streams.stream;
 import static com.google.common.io.BaseEncoding.base16;
 import static io.trino.client.ClientStandardTypes.BIGINT;
 import static io.trino.client.ClientStandardTypes.DECIMAL;
@@ -190,7 +191,7 @@ public class AlignedTablePrinter
         Iterable<List<String>> hexLines = partition(hexPairs, bytesPerLine);
 
         // lines: ["61 62 63", ...]
-        Iterable<String> lines = transform(hexLines, HEX_BYTE_JOINER::join);
+        Iterator<String> lines = stream(hexLines).map(HEX_BYTE_JOINER::join).iterator();
 
         // joined: "61 62 63\n..."
         return HEX_LINE_JOINER.join(lines);

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
@@ -101,7 +101,6 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Iterables.getFirst;
 import static com.google.common.collect.Iterables.getLast;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
@@ -889,7 +888,7 @@ public class SqlQueryScheduler
                 });
             }
 
-            Optional<PipelinedStageExecution> root = Optional.ofNullable(getFirst(stageExecutions, null));
+            Optional<PipelinedStageExecution> root = stageExecutions.stream().findFirst();
             root.ifPresent(stageExecution -> stageExecution.addStateChangeListener(state -> {
                 if (state == FINISHED) {
                     queryStateMachine.transitionToFinishing();

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataListing.java
@@ -37,7 +37,7 @@ import java.util.SortedSet;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.MoreCollectors.toOptional;
 import static io.trino.spi.StandardErrorCode.TABLE_REDIRECTION_ERROR;
 
 public final class MetadataListing
@@ -175,7 +175,7 @@ public final class MetadataListing
 
     public static Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(Session session, Metadata metadata, AccessControl accessControl, QualifiedTablePrefix prefix)
     {
-        List<TableColumnsMetadata> catalogColumns = getOnlyElement(metadata.listTableColumns(session, prefix).values(), List.of());
+        List<TableColumnsMetadata> catalogColumns = metadata.listTableColumns(session, prefix).values().stream().collect(toOptional()).orElse(List.of());
 
         Map<SchemaTableName, Optional<List<ColumnMetadata>>> tableColumns = catalogColumns.stream()
                 .collect(toImmutableMap(TableColumnsMetadata::getTable, TableColumnsMetadata::getColumns));

--- a/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
@@ -38,7 +38,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Iterables.getFirst;
 import static com.google.common.collect.Iterables.getLast;
 import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.Math.max;
@@ -245,7 +244,7 @@ public class DriverContext
 
     public CounterStat getInputDataSize()
     {
-        OperatorContext inputOperator = getFirst(operatorContexts, null);
+        OperatorContext inputOperator = operatorContexts.stream().findFirst().orElse(null);
         if (inputOperator != null) {
             return inputOperator.getInputDataSize();
         }
@@ -256,7 +255,7 @@ public class DriverContext
 
     public CounterStat getInputPositions()
     {
-        OperatorContext inputOperator = getFirst(operatorContexts, null);
+        OperatorContext inputOperator = operatorContexts.stream().findFirst().orElse(null);
         if (inputOperator != null) {
             return inputOperator.getInputPositions();
         }
@@ -333,7 +332,7 @@ public class DriverContext
         Duration elapsedTime = new Duration(nanosBetween(createNanos, executionEndTime == null ? System.nanoTime() : endNanos.get()), NANOSECONDS);
 
         List<OperatorStats> operators = getOperatorStats();
-        OperatorStats inputOperator = getFirst(operators, null);
+        OperatorStats inputOperator = operators.stream().findFirst().orElse(null);
 
         DataSize physicalInputDataSize;
         long physicalInputPositions;

--- a/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
+++ b/core/trino-main/src/main/java/io/trino/operator/MultiChannelGroupByHash.java
@@ -15,7 +15,6 @@ package io.trino.operator;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import io.trino.array.LongBigArray;
 import io.trino.spi.Page;
 import io.trino.spi.PageBuilder;
@@ -108,7 +107,7 @@ public class MultiChannelGroupByHash
         checkArgument(expectedSize > 0, "expectedSize must be greater than zero");
 
         this.inputHashChannel = requireNonNull(inputHashChannel, "inputHashChannel is null");
-        this.types = inputHashChannel.isPresent() ? ImmutableList.copyOf(Iterables.concat(hashTypes, ImmutableList.of(BIGINT))) : this.hashTypes;
+        this.types = inputHashChannel.isPresent() ? ImmutableList.<Type>builder().addAll(hashTypes).add(BIGINT).build() : this.hashTypes;
         this.channels = hashChannels.clone();
 
         this.hashGenerator = inputHashChannel.isPresent() ? new PrecomputedHashGenerator(inputHashChannel.get()) : new InterpretedHashGenerator(this.hashTypes, hashChannels, blockTypeOperators);

--- a/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
@@ -14,7 +14,6 @@
 package io.trino.operator;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.AtomicDouble;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -52,7 +51,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Sets.newConcurrentHashSet;
 import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.Math.max;
@@ -412,7 +411,7 @@ public class TaskContext
         // check for end state to avoid callback ordering problems
         updateStatsIfDone(taskStateMachine.getState());
 
-        List<PipelineStats> pipelineStats = ImmutableList.copyOf(transform(pipelineContexts, PipelineContext::getPipelineStats));
+        List<PipelineStats> pipelineStats = pipelineContexts.stream().map(PipelineContext::getPipelineStats).collect(toImmutableList());
 
         long lastExecutionEndTime = 0;
 

--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -17,7 +17,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.PeekingIterator;
 import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -297,8 +296,8 @@ public class WindowOperator
         List<SortOrder> ordering;
         if (preSortedChannelPrefix > 0) {
             // This already implies that set(preGroupedChannels) == set(partitionChannels) (enforced with checkArgument)
-            orderChannels = ImmutableList.copyOf(Iterables.skip(sortChannels, preSortedChannelPrefix));
-            ordering = ImmutableList.copyOf(Iterables.skip(sortOrder, preSortedChannelPrefix));
+            orderChannels = sortChannels.stream().skip(preSortedChannelPrefix).collect(toImmutableList());
+            ordering = sortOrder.stream().skip(preSortedChannelPrefix).collect(toImmutableList());
         }
         else {
             // Otherwise, we need to sort by the unGroupedPartitionChannels and all original sort channels

--- a/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WindowOperator.java
@@ -54,7 +54,6 @@ import static com.google.common.base.Preconditions.checkPositionIndex;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterators.peekingIterator;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.airlift.concurrent.MoreFutures.checkSuccess;
@@ -66,6 +65,7 @@ import static io.trino.sql.tree.WindowFrame.Type.RANGE;
 import static io.trino.util.MergeSortedPages.mergeSortedPages;
 import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Stream.concat;
 
 public class WindowOperator
         implements Operator
@@ -290,8 +290,8 @@ public class WindowOperator
                 .limit(preSortedChannelPrefix)
                 .collect(toImmutableList());
 
-        List<Integer> unGroupedOrderChannels = ImmutableList.copyOf(concat(unGroupedPartitionChannels, sortChannels));
-        List<SortOrder> unGroupedOrdering = ImmutableList.copyOf(concat(nCopies(unGroupedPartitionChannels.size(), ASC_NULLS_LAST), sortOrder));
+        List<Integer> unGroupedOrderChannels = concat(unGroupedPartitionChannels.stream(), sortChannels.stream()).collect(toImmutableList());
+        List<SortOrder> unGroupedOrdering = concat(nCopies(unGroupedPartitionChannels.size(), ASC_NULLS_LAST).stream(), sortOrder.stream()).collect(toImmutableList());
 
         List<Integer> orderChannels;
         List<SortOrder> ordering;

--- a/core/trino-main/src/main/java/io/trino/server/TaskResource.java
+++ b/core/trino-main/src/main/java/io/trino/server/TaskResource.java
@@ -13,7 +13,6 @@
  */
 package io.trino.server;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -65,7 +64,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.concurrent.MoreFutures.addTimeout;
 import static io.airlift.jaxrs.AsyncResponseHandler.bindAsyncResponse;
@@ -124,7 +123,7 @@ public class TaskResource
     {
         List<TaskInfo> allTaskInfo = taskManager.getAllTaskInfo();
         if (shouldSummarize(uriInfo)) {
-            allTaskInfo = ImmutableList.copyOf(transform(allTaskInfo, TaskInfo::summarize));
+            allTaskInfo = allTaskInfo.stream().map(TaskInfo::summarize).collect(toImmutableList());
         }
         return allTaskInfo;
     }

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/Analyzer.java
@@ -14,7 +14,6 @@
 package io.trino.sql.analyzer;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.metadata.Metadata;
@@ -30,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Streams.concat;
 import static io.trino.spi.StandardErrorCode.EXPRESSION_NOT_SCALAR;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.extractAggregateFunctions;
 import static io.trino.sql.analyzer.ExpressionTreeUtils.extractExpressions;
@@ -96,10 +97,7 @@ public class Analyzer
 
         List<GroupingOperation> groupingOperations = extractExpressions(ImmutableList.of(predicate), GroupingOperation.class);
 
-        List<Expression> found = ImmutableList.copyOf(Iterables.concat(
-                aggregates,
-                windowExpressions,
-                groupingOperations));
+        List<Expression> found = concat(aggregates.stream(), windowExpressions.stream(), groupingOperations.stream()).collect(toImmutableList());
 
         if (!found.isEmpty()) {
             throw semanticException(EXPRESSION_NOT_SCALAR, predicate, "%s cannot contain aggregations, window functions or grouping operations: %s", clause, found);

--- a/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/analyzer/StatementAnalyzer.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Streams;
 import io.trino.Session;
@@ -317,6 +316,7 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Stream.concat;
 
 class StatementAnalyzer
 {
@@ -3419,7 +3419,7 @@ class StatementAnalyzer
 
         private void analyzeGroupingOperations(QuerySpecification node, List<Expression> outputExpressions, List<Expression> orderByExpressions)
         {
-            List<GroupingOperation> groupingOperations = extractExpressions(Iterables.concat(outputExpressions, orderByExpressions), GroupingOperation.class);
+            List<GroupingOperation> groupingOperations = extractExpressions(concat(outputExpressions.stream(), orderByExpressions.stream()), GroupingOperation.class);
             boolean isGroupingOperationPresent = !groupingOperations.isEmpty();
 
             if (isGroupingOperationPresent && node.getGroupBy().isEmpty()) {
@@ -3442,7 +3442,7 @@ class StatementAnalyzer
         {
             checkState(orderByExpressions.isEmpty() || orderByScope.isPresent(), "non-empty orderByExpressions list without orderByScope provided");
 
-            List<FunctionCall> aggregates = extractAggregateFunctions(Iterables.concat(outputExpressions, orderByExpressions), metadata);
+            List<FunctionCall> aggregates = extractAggregateFunctions(concat(outputExpressions.stream(), orderByExpressions.stream()), metadata);
             analysis.setAggregates(node, aggregates);
 
             if (analysis.isAggregation(node)) {

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.primitives.Ints;
@@ -2144,8 +2143,8 @@ public class LocalExecutionPlanner
             };
 
             // Declare the input and output schemas for the index and acquire the actual Index
-            List<ColumnHandle> lookupSchema = Lists.transform(lookupSymbolSchema, forMap(node.getAssignments()));
-            List<ColumnHandle> outputSchema = Lists.transform(node.getOutputSymbols(), forMap(node.getAssignments()));
+            List<ColumnHandle> lookupSchema = lookupSymbolSchema.stream().map(forMap(node.getAssignments())).collect(toImmutableList());
+            List<ColumnHandle> outputSchema = node.getOutputSymbols().stream().map(forMap(node.getAssignments())).collect(toImmutableList());
             ConnectorIndex index = indexManager.getIndex(session, node.getIndexHandle(), lookupSchema, outputSchema);
 
             OperatorFactory operatorFactory = new IndexSourceOperator.IndexSourceOperatorFactory(context.getNextOperatorId(), node.getId(), index, probeKeyNormalizer);
@@ -2187,8 +2186,8 @@ public class LocalExecutionPlanner
         {
             List<IndexJoinNode.EquiJoinClause> clauses = node.getCriteria();
 
-            List<Symbol> probeSymbols = Lists.transform(clauses, IndexJoinNode.EquiJoinClause::getProbe);
-            List<Symbol> indexSymbols = Lists.transform(clauses, IndexJoinNode.EquiJoinClause::getIndex);
+            List<Symbol> probeSymbols = clauses.stream().map(IndexJoinNode.EquiJoinClause::getProbe).collect(toImmutableList());
+            List<Symbol> indexSymbols = clauses.stream().map(IndexJoinNode.EquiJoinClause::getIndex).collect(toImmutableList());
 
             // Plan probe side
             PhysicalOperation probeSource = node.getProbeSource().accept(this, context);
@@ -2345,8 +2344,8 @@ public class LocalExecutionPlanner
 
             List<JoinNode.EquiJoinClause> clauses = node.getCriteria();
 
-            List<Symbol> leftSymbols = Lists.transform(clauses, JoinNode.EquiJoinClause::getLeft);
-            List<Symbol> rightSymbols = Lists.transform(clauses, JoinNode.EquiJoinClause::getRight);
+            List<Symbol> leftSymbols = clauses.stream().map(JoinNode.EquiJoinClause::getLeft).collect(toImmutableList());
+            List<Symbol> rightSymbols = clauses.stream().map(JoinNode.EquiJoinClause::getRight).collect(toImmutableList());
 
             switch (node.getType()) {
                 case INNER:

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -268,7 +268,6 @@ import static com.google.common.collect.DiscreteDomain.integers;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Range.closedOpen;
 import static com.google.common.collect.Sets.difference;
@@ -351,6 +350,7 @@ import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.IntStream.range;
+import static java.util.stream.Stream.concat;
 
 public class LocalExecutionPlanner
 {
@@ -1896,7 +1896,7 @@ public class LocalExecutionPlanner
             Map<NodeRef<Expression>, Type> expressionTypes = typeAnalyzer.getTypes(
                     session,
                     context.getTypes(),
-                    concat(staticFilters.map(ImmutableList::of).orElse(ImmutableList.of()), assignments.getExpressions()));
+                    () -> concat(staticFilters.map(ImmutableList::of).orElse(ImmutableList.of()).stream(), assignments.getExpressions().stream()).iterator());
 
             Optional<RowExpression> translatedFilter = staticFilters.map(filter -> toRowExpression(filter, expressionTypes, sourceLayout));
             List<RowExpression> translatedProjections = projections.stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/LocalExecutionPlanner.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.primitives.Ints;
@@ -2131,7 +2130,7 @@ public class LocalExecutionPlanner
                 if (potentialProbeInputs.size() > 1) {
                     overlappingFieldSetsBuilder.add(potentialProbeInputs.stream().collect(toImmutableSet()));
                 }
-                remappedProbeKeyChannelsBuilder.add(Iterables.getFirst(potentialProbeInputs, null));
+                remappedProbeKeyChannelsBuilder.add(potentialProbeInputs.stream().findFirst().orElse(null));
             }
             List<Set<Integer>> overlappingFieldSets = overlappingFieldSetsBuilder.build();
             List<Integer> remappedProbeKeyChannels = remappedProbeKeyChannelsBuilder.build();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/QueryPlanner.java
@@ -143,6 +143,7 @@ import static io.trino.type.IntervalDayTimeType.INTERVAL_DAY_TIME;
 import static io.trino.type.IntervalYearMonthType.INTERVAL_YEAR_MONTH;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Stream.concat;
 
 class QueryPlanner
 {
@@ -199,7 +200,7 @@ class QueryPlanner
         List<Expression> outputs = selectExpressions.stream()
                 .map(SelectExpression::getExpression)
                 .collect(toImmutableList());
-        builder = builder.appendProjections(Iterables.concat(orderBy, outputs), symbolAllocator, idAllocator);
+        builder = builder.appendProjections(() -> concat(orderBy.stream(), outputs.stream()).iterator(), symbolAllocator, idAllocator);
 
         Optional<OrderingScheme> orderingScheme = orderingScheme(builder, query.getOrderBy(), analysis.getOrderByExpressions(query));
         builder = sort(builder, orderingScheme);
@@ -440,7 +441,7 @@ class QueryPlanner
 
         List<Expression> orderBy = analysis.getOrderByExpressions(node);
         builder = subqueryPlanner.handleSubqueries(builder, orderBy, analysis.getSubqueries(node));
-        builder = builder.appendProjections(Iterables.concat(orderBy, outputs), symbolAllocator, idAllocator);
+        builder = builder.appendProjections(() -> concat(orderBy.stream(), outputs.stream()).iterator(), symbolAllocator, idAllocator);
 
         builder = distinct(builder, node, outputs);
         Optional<OrderingScheme> orderingScheme = orderingScheme(builder, node.getOrderBy(), analysis.getOrderByExpressions(node));

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationMerge.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SetOperationMerge.java
@@ -14,7 +14,6 @@
 package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.Iterables;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.Lookup;
 import io.trino.sql.planner.iterative.Rule.Context;
@@ -25,13 +24,13 @@ import io.trino.sql.planner.plan.SetOperationNode;
 import io.trino.sql.planner.plan.UnionNode;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.Multimaps.asMap;
 
 class SetOperationMerge
 {
@@ -180,8 +179,8 @@ class SetOperationMerge
     private void addMergedMappings(SetOperationNode child, int childIndex, ImmutableListMultimap.Builder<Symbol, Symbol> newMappingsBuilder)
     {
         newSources.addAll(child.getSources());
-        for (Map.Entry<Symbol, Collection<Symbol>> mapping : node.getSymbolMapping().asMap().entrySet()) {
-            Symbol input = Iterables.get(mapping.getValue(), childIndex);
+        for (Map.Entry<Symbol, List<Symbol>> mapping : asMap(node.getSymbolMapping()).entrySet()) {
+            Symbol input = mapping.getValue().get(childIndex);
             newMappingsBuilder.putAll(mapping.getKey(), child.getSymbolMapping().get(input));
         }
     }
@@ -189,8 +188,8 @@ class SetOperationMerge
     private void addOriginalMappings(PlanNode child, int childIndex, ImmutableListMultimap.Builder<Symbol, Symbol> newMappingsBuilder)
     {
         newSources.add(child);
-        for (Map.Entry<Symbol, Collection<Symbol>> mapping : node.getSymbolMapping().asMap().entrySet()) {
-            newMappingsBuilder.put(mapping.getKey(), Iterables.get(mapping.getValue(), childIndex));
+        for (Map.Entry<Symbol, List<Symbol>> mapping : asMap(node.getSymbolMapping()).entrySet()) {
+            newMappingsBuilder.put(mapping.getKey(), mapping.getValue().get(childIndex));
         }
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/AddLocalExchanges.java
@@ -15,7 +15,6 @@ package io.trino.sql.planner.optimizations;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
 import io.trino.spi.connector.ConstantProperty;
@@ -735,7 +734,7 @@ public class AddLocalExchanges
             }
 
             // this build consumes the input completely, so we do not pass through parent preferences
-            List<Symbol> buildHashSymbols = Lists.transform(node.getCriteria(), JoinNode.EquiJoinClause::getRight);
+            List<Symbol> buildHashSymbols = node.getCriteria().stream().map(JoinNode.EquiJoinClause::getRight).collect(toImmutableList());
             StreamPreferredProperties buildPreference;
             if (getTaskConcurrency(session) > 1) {
                 buildPreference = exactlyPartitionedOn(buildHashSymbols);

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/IndexJoinOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/IndexJoinOptimizer.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.trino.Session;
 import io.trino.execution.warnings.WarningCollector;
@@ -62,6 +61,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.in;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.sql.ExpressionUtils.combineConjuncts;
@@ -117,8 +117,8 @@ public class IndexJoinOptimizer
             PlanNode rightRewritten = context.rewrite(node.getRight());
 
             if (!node.getCriteria().isEmpty()) { // Index join only possible with JOIN criteria
-                List<Symbol> leftJoinSymbols = Lists.transform(node.getCriteria(), JoinNode.EquiJoinClause::getLeft);
-                List<Symbol> rightJoinSymbols = Lists.transform(node.getCriteria(), JoinNode.EquiJoinClause::getRight);
+                List<Symbol> leftJoinSymbols = node.getCriteria().stream().map(JoinNode.EquiJoinClause::getLeft).collect(toImmutableList());
+                List<Symbol> rightJoinSymbols = node.getCriteria().stream().map(JoinNode.EquiJoinClause::getRight).collect(toImmutableList());
 
                 Optional<PlanNode> leftIndexCandidate = IndexSourceRewriter.rewriteWithIndex(
                         leftRewritten,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -16,7 +16,6 @@ package io.trino.sql.planner.optimizations;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import io.trino.Session;
 import io.trino.SystemSessionProperties;
 import io.trino.execution.warnings.WarningCollector;
@@ -188,7 +187,7 @@ public class MetadataQueryOptimizer
                 else if (source instanceof ProjectNode) {
                     // verify projections are deterministic
                     ProjectNode project = (ProjectNode) source;
-                    if (!Iterables.all(project.getAssignments().getExpressions(), expression -> isDeterministic(expression, plannerContext.getMetadata()))) {
+                    if (!project.getAssignments().getExpressions().stream().allMatch(expression -> isDeterministic(expression, plannerContext.getMetadata()))) {
                         return Optional.empty();
                     }
                     source = project.getSource();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/PatternRecognitionNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/PatternRecognitionNode.java
@@ -40,7 +40,6 @@ import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Iterables.concat;
 import static io.trino.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static io.trino.sql.tree.PatternRecognitionRelation.RowsPerMatch.ONE;
 import static io.trino.sql.tree.PatternRecognitionRelation.RowsPerMatch.WINDOW;
@@ -163,7 +162,10 @@ public class PatternRecognitionNode
 
     public Set<Symbol> getCreatedSymbols()
     {
-        return ImmutableSet.copyOf(concat(measures.keySet(), windowFunctions.keySet()));
+        return ImmutableSet.<Symbol>builder()
+                .addAll(measures.keySet())
+                .addAll(windowFunctions.keySet())
+                .build();
     }
 
     @JsonProperty

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/RowNumberNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/RowNumberNode.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Iterables.concat;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -83,7 +82,10 @@ public final class RowNumberNode
     @Override
     public List<Symbol> getOutputSymbols()
     {
-        return ImmutableList.copyOf(concat(source.getOutputSymbols(), ImmutableList.of(rowNumberSymbol)));
+        return ImmutableList.<Symbol>builder()
+                .addAll(source.getOutputSymbols())
+                .add(rowNumberSymbol)
+                .build();
     }
 
     @JsonProperty

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/SetOperationNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/SetOperationNode.java
@@ -20,7 +20,6 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
@@ -35,6 +34,7 @@ import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Multimaps.asMap;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -69,8 +69,8 @@ public abstract class SetOperationNode
 
         // Make sure each source positionally corresponds to their Symbol values in the Multimap
         for (int i = 0; i < sources.size(); i++) {
-            for (Collection<Symbol> expectedInputs : this.outputToInputs.asMap().values()) {
-                checkArgument(sources.get(i).getOutputSymbols().contains(Iterables.get(expectedInputs, i)), "Source does not provide required symbols");
+            for (List<Symbol> expectedInputs : asMap(this.outputToInputs).values()) {
+                checkArgument(sources.get(i).getOutputSymbols().contains(expectedInputs.get(i)), "Source does not provide required symbols");
             }
         }
     }
@@ -109,8 +109,8 @@ public abstract class SetOperationNode
     public Map<Symbol, SymbolReference> sourceSymbolMap(int sourceIndex)
     {
         ImmutableMap.Builder<Symbol, SymbolReference> builder = ImmutableMap.builder();
-        for (Map.Entry<Symbol, Collection<Symbol>> entry : outputToInputs.asMap().entrySet()) {
-            builder.put(entry.getKey(), Iterables.get(entry.getValue(), sourceIndex).toSymbolReference());
+        for (Map.Entry<Symbol, List<Symbol>> entry : asMap(outputToInputs).entrySet()) {
+            builder.put(entry.getKey(), entry.getValue().get(sourceIndex).toSymbolReference());
         }
 
         return builder.build();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/TopNRankingNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/TopNRankingNode.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Iterables.concat;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
@@ -89,7 +88,10 @@ public final class TopNRankingNode
     public List<Symbol> getOutputSymbols()
     {
         if (!partial) {
-            return ImmutableList.copyOf(concat(source.getOutputSymbols(), ImmutableList.of(rankingSymbol)));
+            return ImmutableList.<Symbol>builder()
+                    .addAll(source.getOutputSymbols())
+                    .add(rankingSymbol)
+                    .build();
         }
         return ImmutableList.copyOf(source.getOutputSymbols());
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/WindowNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/WindowNode.java
@@ -36,11 +36,11 @@ import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Iterables.concat;
 import static io.trino.sql.tree.FrameBound.Type.CURRENT_ROW;
 import static io.trino.sql.tree.FrameBound.Type.UNBOUNDED_PRECEDING;
 import static io.trino.sql.tree.WindowFrame.Type.RANGE;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Stream.concat;
 
 @Immutable
 public class WindowNode
@@ -91,7 +91,7 @@ public class WindowNode
     @Override
     public List<Symbol> getOutputSymbols()
     {
-        return ImmutableList.copyOf(concat(source.getOutputSymbols(), windowFunctions.keySet()));
+        return concat(source.getOutputSymbols().stream(), windowFunctions.keySet().stream()).collect(toImmutableList());
     }
 
     public Set<Symbol> getCreatedSymbols()

--- a/core/trino-main/src/test/java/io/trino/RowPagesBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/RowPagesBuilder.java
@@ -137,7 +137,10 @@ public class RowPagesBuilder
     public List<Type> getTypes()
     {
         if (hashEnabled) {
-            return ImmutableList.copyOf(Iterables.concat(types, ImmutableList.of(BigintType.BIGINT)));
+            return ImmutableList.<Type>builder()
+                    .addAll(types)
+                    .add(BigintType.BIGINT)
+                    .build();
         }
         return types;
     }

--- a/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
+++ b/core/trino-main/src/test/java/io/trino/execution/TestNodeScheduler.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.hash.Hashing;
@@ -417,7 +416,9 @@ public class TestNodeScheduler
     {
         setUpNodes();
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
-        InternalNode chosenNode = Iterables.get(nodeManager.getActiveConnectorNodes(CONNECTOR_ID), 0);
+        InternalNode chosenNode = nodeManager.getActiveConnectorNodes(CONNECTOR_ID).stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No active nodes found for connector: " + CONNECTOR_ID));
         TaskId taskId = new TaskId(new StageId("test", 1), 1, 0);
         RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(
                 taskId,
@@ -439,7 +440,9 @@ public class TestNodeScheduler
     {
         setUpNodes();
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
-        InternalNode chosenNode = Iterables.get(nodeManager.getActiveConnectorNodes(CONNECTOR_ID), 0);
+        InternalNode chosenNode = nodeManager.getActiveConnectorNodes(CONNECTOR_ID).stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("No active nodes found for connector: " + CONNECTOR_ID));
 
         TaskId taskId1 = new TaskId(new StageId("test", 1), 1, 0);
         RemoteTask remoteTask1 = remoteTaskFactory.createTableScanTask(taskId1,

--- a/core/trino-main/src/test/java/io/trino/metadata/TestDiscoveryNodeManager.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/TestDiscoveryNodeManager.java
@@ -16,7 +16,6 @@ package io.trino.metadata;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.discovery.client.ServiceDescriptor;
 import io.airlift.discovery.client.ServiceSelector;
@@ -48,6 +47,7 @@ import static io.airlift.testing.Assertions.assertEqualsIgnoreOrder;
 import static io.trino.metadata.NodeState.ACTIVE;
 import static io.trino.metadata.NodeState.INACTIVE;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Stream.concat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
@@ -197,14 +197,12 @@ public class TestDiscoveryNodeManager
         private synchronized void announceNodes(Set<InternalNode> activeNodes, Set<InternalNode> inactiveNodes)
         {
             ImmutableList.Builder<ServiceDescriptor> descriptors = ImmutableList.builder();
-            for (InternalNode node : Iterables.concat(activeNodes, inactiveNodes)) {
-                descriptors.add(serviceDescriptor("trino")
-                        .setNodeId(node.getNodeIdentifier())
-                        .addProperty("http", node.getInternalUri().toString())
-                        .addProperty("node_version", node.getNodeVersion().toString())
-                        .addProperty("coordinator", String.valueOf(node.isCoordinator()))
-                        .build());
-            }
+            concat(activeNodes.stream(), inactiveNodes.stream()).forEach(node -> descriptors.add(serviceDescriptor("trino")
+                    .setNodeId(node.getNodeIdentifier())
+                    .addProperty("http", node.getInternalUri().toString())
+                    .addProperty("node_version", node.getNodeVersion().toString())
+                    .addProperty("coordinator", String.valueOf(node.isCoordinator()))
+                    .build()));
 
             this.descriptors = descriptors.build();
         }

--- a/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
+++ b/core/trino-main/src/test/java/io/trino/operator/BenchmarkGroupByHash.java
@@ -14,7 +14,6 @@
 package io.trino.operator;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.slice.XxHash64;
@@ -230,7 +229,10 @@ public class BenchmarkGroupByHash
         List<Type> types = Collections.nCopies(channelCount, BIGINT);
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
         if (hashEnabled) {
-            types = ImmutableList.copyOf(Iterables.concat(types, ImmutableList.of(BIGINT)));
+            types = ImmutableList.<Type>builder()
+                    .addAll(types)
+                    .add(BIGINT)
+                    .build();
         }
 
         PageBuilder pageBuilder = new PageBuilder(types);
@@ -284,7 +286,10 @@ public class BenchmarkGroupByHash
         List<Type> types = Collections.nCopies(channelCount, VARCHAR);
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
         if (hashEnabled) {
-            types = ImmutableList.copyOf(Iterables.concat(types, ImmutableList.of(BIGINT)));
+            types = ImmutableList.<Type>builder()
+                    .addAll(types)
+                    .add(BIGINT)
+                    .build();
         }
 
         PageBuilder pageBuilder = new PageBuilder(types);

--- a/core/trino-main/src/test/java/io/trino/operator/TestHashSemiJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestHashSemiJoinOperator.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static com.google.common.collect.Iterables.concat;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.testing.Assertions.assertGreaterThan;
 import static io.airlift.testing.Assertions.assertGreaterThanOrEqual;
@@ -140,7 +139,7 @@ public class TestHashSemiJoinOperator
                 probeHashChannel);
 
         // expected
-        MaterializedResult expected = resultBuilder(driverContext.getSession(), concat(probeTypes, ImmutableList.of(BOOLEAN)))
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).add(BOOLEAN).build())
                 .row(30L, 0L, true)
                 .row(31L, 1L, false)
                 .row(32L, 2L, false)
@@ -205,7 +204,7 @@ public class TestHashSemiJoinOperator
                 probeHashChannel);
 
         // expected
-        MaterializedResult expected = resultBuilder(driverContext.getSession(), concat(probeTypes, ImmutableList.of(BOOLEAN)))
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).add(BOOLEAN).build())
                 .row("30", 0L, true)
                 .row("31", 1L, false)
                 .row("32", 2L, false)
@@ -300,7 +299,7 @@ public class TestHashSemiJoinOperator
                 probeHashChannel);
 
         // expected
-        MaterializedResult expected = resultBuilder(driverContext.getSession(), concat(probeTypes, ImmutableList.of(BOOLEAN)))
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).add(BOOLEAN).build())
                 .row(1L, true)
                 .row(2L, true)
                 .row(3L, true)
@@ -359,7 +358,7 @@ public class TestHashSemiJoinOperator
                 probeHashChannel);
 
         // expected
-        MaterializedResult expected = resultBuilder(driverContext.getSession(), concat(probeTypes, ImmutableList.of(BOOLEAN)))
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).add(BOOLEAN).build())
                 .row(0L, true)
                 .row(null, null)
                 .row(1L, true)
@@ -419,7 +418,7 @@ public class TestHashSemiJoinOperator
                 probeHashChannel);
 
         // expected
-        MaterializedResult expected = resultBuilder(driverContext.getSession(), concat(probeTypes, ImmutableList.of(BOOLEAN)))
+        MaterializedResult expected = resultBuilder(driverContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).add(BOOLEAN).build())
                 .row(0L, true)
                 .row(null, null)
                 .row(1L, true)

--- a/core/trino-main/src/test/java/io/trino/operator/TestTypeSignature.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestTypeSignature.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.google.common.collect.Lists.transform;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.DecimalType.createDecimalType;
 import static io.trino.spi.type.TypeSignature.arrayType;
@@ -41,7 +41,7 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.sql.analyzer.TypeSignatureTranslator.parseTypeSignature;
-import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -194,7 +194,7 @@ public class TestTypeSignature
 
     private static TypeSignature rowSignature(NamedTypeSignature... columns)
     {
-        return new TypeSignature("row", transform(asList(columns), TypeSignatureParameter::namedTypeParameter));
+        return new TypeSignature("row", stream(columns).map(TypeSignatureParameter::namedTypeParameter).collect(toImmutableList()));
     }
 
     private static NamedTypeSignature namedParameter(String name, TypeSignature value)

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestHashJoinOperator.java
@@ -15,7 +15,6 @@ package io.trino.operator.join;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.slice.Slices;
@@ -1684,6 +1683,9 @@ public class TestHashJoinOperator
 
     private static <T> List<T> concat(List<T> initialElements, List<T> moreElements)
     {
-        return ImmutableList.copyOf(Iterables.concat(initialElements, moreElements));
+        return ImmutableList.<T>builder()
+                .addAll(initialElements)
+                .addAll(moreElements)
+                .build();
     }
 }

--- a/core/trino-main/src/test/java/io/trino/operator/join/TestNestedLoopJoinOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/join/TestNestedLoopJoinOperator.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static com.google.common.collect.Iterables.concat;
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.trino.RowPagesBuilder.rowPagesBuilder;
 import static io.trino.SessionTestUtils.TEST_SESSION;
@@ -86,7 +85,7 @@ public class TestNestedLoopJoinOperator
         NestedLoopJoinOperatorFactory joinOperatorFactory = newJoinOperatorFactoryWithCompletedBuild(taskContext, buildPages, ImmutableList.of(0, 1, 2), ImmutableList.of(0, 1, 2));
 
         // expected
-        MaterializedResult expected = resultBuilder(taskContext.getSession(), concat(probePages.getTypes(), buildPages.getTypes()))
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.<Type>builder().addAll(probePages.getTypes()).addAll(buildPages.getTypes()).build())
                 .row("0", 1000L, 2000L, "20", 30L, 40L)
                 .row("0", 1000L, 2000L, "21", 31L, 41L)
                 .row("0", 1000L, 2000L, "22", 32L, 42L)
@@ -109,7 +108,7 @@ public class TestNestedLoopJoinOperator
                 .build();
 
         // expected
-        expected = resultBuilder(taskContext.getSession(), concat(probePages.getTypes(), buildPages.getTypes()))
+        expected = resultBuilder(taskContext.getSession(), ImmutableList.<Type>builder().addAll(probePages.getTypes()).addAll(buildPages.getTypes()).build())
                 .row("0", 1000L, 2000L, "20", 30L, 40L)
                 .row("1", 1001L, 2001L, "20", 30L, 40L)
                 .row("2", 1002L, 2002L, "20", 30L, 40L)
@@ -139,7 +138,7 @@ public class TestNestedLoopJoinOperator
         // expected
         List<Type> expectedProbeTypes = ImmutableList.of(probePages.getTypes().get(2), probePages.getTypes().get(0), probePages.getTypes().get(1));
         List<Type> expectedBuildTypes = ImmutableList.of(probePages.getTypes().get(1), probePages.getTypes().get(2), probePages.getTypes().get(0));
-        MaterializedResult expected = resultBuilder(taskContext.getSession(), concat(expectedProbeTypes, expectedBuildTypes))
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.<Type>builder().addAll(expectedProbeTypes).addAll(expectedBuildTypes).build())
                 .row(2000L, "0", 1000L, 30L, 40L, "20")
                 .row(2000L, "0", 1000L, 31L, 41L, "21")
                 .row(2000L, "0", 1000L, 32L, 42L, "22")
@@ -176,7 +175,7 @@ public class TestNestedLoopJoinOperator
         NestedLoopJoinOperatorFactory joinOperatorFactory = newJoinOperatorFactoryWithCompletedBuild(taskContext, buildPages, ImmutableList.of(0), ImmutableList.of(0));
 
         // expected
-        MaterializedResult expected = resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).addAll(buildPages.getTypes()).build())
                 .row("A", "a")
                 .row(null, "a")
                 .row(null, "a")
@@ -216,7 +215,7 @@ public class TestNestedLoopJoinOperator
         NestedLoopJoinOperatorFactory joinOperatorFactory = newJoinOperatorFactoryWithCompletedBuild(taskContext, buildPages, ImmutableList.of(0), ImmutableList.of(0));
 
         // expected
-        MaterializedResult expected = resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).addAll(buildPages.getTypes()).build())
                 .row("A", "a")
                 .row("A", null)
                 .row("A", null)
@@ -258,7 +257,7 @@ public class TestNestedLoopJoinOperator
         NestedLoopJoinOperatorFactory joinOperatorFactory = newJoinOperatorFactoryWithCompletedBuild(taskContext, buildPages, ImmutableList.of(0), ImmutableList.of(0));
 
         // expected
-        MaterializedResult expected = resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).addAll(buildPages.getTypes()).build())
                 .row("A", "a")
                 .row("A", null)
                 .row("A", "b")
@@ -310,7 +309,7 @@ public class TestNestedLoopJoinOperator
         NestedLoopJoinOperatorFactory joinOperatorFactory = newJoinOperatorFactoryWithCompletedBuild(taskContext, buildPages, ImmutableList.of(0), ImmutableList.of(0));
 
         // expected
-        MaterializedResult expected = resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).addAll(buildPages.getTypes()).build())
                 .row("A", "a")
                 .row("B", "a")
                 .row("A", null)
@@ -352,7 +351,7 @@ public class TestNestedLoopJoinOperator
         NestedLoopJoinOperatorFactory joinOperatorFactory = newJoinOperatorFactoryWithCompletedBuild(taskContext, buildPages, ImmutableList.of(0), ImmutableList.of(0));
 
         // expected
-        MaterializedResult expected = resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).addAll(buildPages.getTypes()).build())
                 .row("a", "A")
                 .row("a", "B")
                 .row(null, "A")
@@ -396,7 +395,7 @@ public class TestNestedLoopJoinOperator
         NestedLoopJoinOperatorFactory joinOperatorFactory = newJoinOperatorFactoryWithCompletedBuild(taskContext, buildPages, ImmutableList.of(0), ImmutableList.of(0));
 
         // expected
-        MaterializedResult expected = resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).addAll(buildPages.getTypes()).build())
                 .row("a", "A")
                 .row("a", "B")
                 .row("a", "C")
@@ -439,7 +438,7 @@ public class TestNestedLoopJoinOperator
         NestedLoopJoinOperatorFactory joinOperatorFactory = newJoinOperatorFactoryWithCompletedBuild(taskContext, buildPages, ImmutableList.of(0), ImmutableList.of(0));
 
         // expected
-        MaterializedResult expected = resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).addAll(buildPages.getTypes()).build())
                 .build();
 
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected);
@@ -466,7 +465,7 @@ public class TestNestedLoopJoinOperator
         NestedLoopJoinOperatorFactory joinOperatorFactory = newJoinOperatorFactoryWithCompletedBuild(taskContext, buildPages, ImmutableList.of(0), ImmutableList.of(0));
 
         // expected
-        MaterializedResult expected = resultBuilder(taskContext.getSession(), concat(probeTypes, buildPages.getTypes()))
+        MaterializedResult expected = resultBuilder(taskContext.getSession(), ImmutableList.<Type>builder().addAll(probeTypes).addAll(buildPages.getTypes()).build())
                 .build();
 
         assertOperatorEquals(joinOperatorFactory, taskContext.addPipelineContext(0, true, true, false).addDriverContext(), probeInput, expected);

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkEqualsConjunctsOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/BenchmarkEqualsConjunctsOperator.java
@@ -44,10 +44,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Iterables.cycle;
-import static com.google.common.collect.Iterables.limit;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.SessionTestUtils.TEST_SESSION;
 import static io.trino.jmh.Benchmarks.benchmark;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
@@ -133,7 +133,7 @@ public class BenchmarkEqualsConjunctsOperator
         @Setup
         public void setup()
         {
-            List<Type> types = ImmutableList.copyOf(limit(cycle(BIGINT), FIELDS_COUNT));
+            List<Type> types = Stream.generate(() -> BIGINT).limit(FIELDS_COUNT).collect(toImmutableList());
             ThreadLocalRandom random = ThreadLocalRandom.current();
             PageBuilder pageBuilder = new PageBuilder(types);
             while (!pageBuilder.isFull()) {

--- a/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
+++ b/core/trino-main/src/test/java/io/trino/operator/scalar/FunctionAssertions.java
@@ -97,6 +97,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static io.airlift.concurrent.Threads.daemonThreadsNamed;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -943,14 +944,16 @@ public final class FunctionAssertions
 
     private static RowType createTestRowType(int numberOfFields)
     {
-        Iterator<Type> types = Iterables.<Type>cycle(
-                BIGINT,
-                INTEGER,
-                VARCHAR,
-                DOUBLE,
-                BOOLEAN,
-                VARBINARY,
-                RowType.from(ImmutableList.of(RowType.field("nested_nested_column", VARCHAR)))).iterator();
+        Iterator<Type> types = Stream.generate(() -> ImmutableList.<Type>of(
+                        BIGINT,
+                        INTEGER,
+                        VARCHAR,
+                        DOUBLE,
+                        BOOLEAN,
+                        VARBINARY,
+                        RowType.from(ImmutableList.of(RowType.field("nested_nested_column", VARCHAR)))))
+                .flatMap(List::stream)
+                .iterator();
 
         List<RowType.Field> fields = new ArrayList<>();
         for (int fieldIdx = 0; fieldIdx < numberOfFields; fieldIdx++) {
@@ -962,14 +965,16 @@ public final class FunctionAssertions
 
     private static Block createTestRowData(RowType rowType)
     {
-        Iterator<Object> values = Iterables.cycle(
-                1234L,
-                34,
-                "hello",
-                12.34d,
-                true,
-                Slices.wrappedBuffer((byte) 0xab),
-                createRowBlock(ImmutableList.of(VARCHAR), Collections.singleton("innerFieldValue").toArray()).getObject(0, Block.class)).iterator();
+        Iterator<Object> values = Stream.generate(() -> ImmutableList.of(
+                        1234L,
+                        34,
+                        "hello",
+                        12.34d,
+                        true,
+                        Slices.wrappedBuffer((byte) 0xab),
+                        createRowBlock(ImmutableList.of(VARCHAR), Collections.singleton("innerFieldValue").toArray()).getObject(0, Block.class)))
+                .flatMap(List::stream)
+                .iterator();
 
         int numFields = rowType.getFields().size();
         Object[] rowValues = new Object[numFields];

--- a/core/trino-main/src/test/java/io/trino/sql/planner/TestEqualityInference.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/TestEqualityInference.java
@@ -17,7 +17,6 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.TestingFunctionResolution;
 import io.trino.operator.scalar.TryFunction;
@@ -178,18 +177,18 @@ public class TestEqualityInference
 
         // There should be equalities in the scope, that only use c1 and are all inferrable equalities
         assertFalse(equalityPartition.getScopeEqualities().isEmpty());
-        assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), matchesSymbolScope(matchesSymbols("c1"))));
-        assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), expression -> isInferenceCandidate(metadata, expression)));
+        assertTrue(equalityPartition.getScopeEqualities().stream().allMatch(matchesSymbolScope(matchesSymbols("c1"))));
+        assertTrue(equalityPartition.getScopeEqualities().stream().allMatch(expression -> isInferenceCandidate(metadata, expression)));
 
         // There should be equalities in the inverse scope, that never use c1 and are all inferrable equalities
         assertFalse(equalityPartition.getScopeComplementEqualities().isEmpty());
-        assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), matchesSymbolScope(not(matchesSymbols("c1")))));
-        assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), expression -> isInferenceCandidate(metadata, expression)));
+        assertTrue(equalityPartition.getScopeComplementEqualities().stream().allMatch(matchesSymbolScope(not(matchesSymbols("c1")))));
+        assertTrue(equalityPartition.getScopeComplementEqualities().stream().allMatch(expression -> isInferenceCandidate(metadata, expression)));
 
         // There should be equalities in the straddling scope, that should use both c1 and not c1 symbols
         assertFalse(equalityPartition.getScopeStraddlingEqualities().isEmpty());
-        assertTrue(Iterables.any(equalityPartition.getScopeStraddlingEqualities(), matchesStraddlingScope(matchesSymbols("c1"))));
-        assertTrue(Iterables.all(equalityPartition.getScopeStraddlingEqualities(), expression -> isInferenceCandidate(metadata, expression)));
+        assertTrue(equalityPartition.getScopeStraddlingEqualities().stream().anyMatch(matchesStraddlingScope(matchesSymbols("c1"))));
+        assertTrue(equalityPartition.getScopeStraddlingEqualities().stream().allMatch(expression -> isInferenceCandidate(metadata, expression)));
 
         // There should be a "full cover" of all of the equalities used
         // THUS, we should be able to plug the generated equalities back in and get an equivalent set of equalities back the next time around
@@ -225,18 +224,18 @@ public class TestEqualityInference
 
         // There should be equalities in the scope, that only use a* and b* symbols and are all inferrable equalities
         assertFalse(equalityPartition.getScopeEqualities().isEmpty());
-        assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), matchesSymbolScope(symbolBeginsWith("a", "b"))));
-        assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), expression -> isInferenceCandidate(metadata, expression)));
+        assertTrue(equalityPartition.getScopeEqualities().stream().allMatch(matchesSymbolScope(symbolBeginsWith("a", "b"))));
+        assertTrue(equalityPartition.getScopeEqualities().stream().allMatch(expression -> isInferenceCandidate(metadata, expression)));
 
         // There should be equalities in the inverse scope, that never use a* and b* symbols and are all inferrable equalities
         assertFalse(equalityPartition.getScopeComplementEqualities().isEmpty());
-        assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), matchesSymbolScope(not(symbolBeginsWith("a", "b")))));
-        assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), expression -> isInferenceCandidate(metadata, expression)));
+        assertTrue(equalityPartition.getScopeComplementEqualities().stream().allMatch(matchesSymbolScope(not(symbolBeginsWith("a", "b")))));
+        assertTrue(equalityPartition.getScopeComplementEqualities().stream().allMatch(expression -> isInferenceCandidate(metadata, expression)));
 
         // There should be equalities in the straddling scope, that should use both c1 and not c1 symbols
         assertFalse(equalityPartition.getScopeStraddlingEqualities().isEmpty());
-        assertTrue(Iterables.any(equalityPartition.getScopeStraddlingEqualities(), matchesStraddlingScope(symbolBeginsWith("a", "b"))));
-        assertTrue(Iterables.all(equalityPartition.getScopeStraddlingEqualities(), expression -> isInferenceCandidate(metadata, expression)));
+        assertTrue(equalityPartition.getScopeStraddlingEqualities().stream().anyMatch(matchesStraddlingScope(symbolBeginsWith("a", "b"))));
+        assertTrue(equalityPartition.getScopeStraddlingEqualities().stream().allMatch(expression -> isInferenceCandidate(metadata, expression)));
 
         // Again, there should be a "full cover" of all of the equalities used
         // THUS, we should be able to plug the generated equalities back in and get an equivalent set of equalities back the next time around
@@ -340,14 +339,14 @@ public class TestEqualityInference
 
     private static Predicate<Expression> matchesSymbolScope(Predicate<Symbol> symbolScope)
     {
-        return expression -> Iterables.all(SymbolsExtractor.extractUnique(expression), symbolScope);
+        return expression -> SymbolsExtractor.extractUnique(expression).stream().allMatch(symbolScope);
     }
 
     private static Predicate<Expression> matchesStraddlingScope(Predicate<Symbol> symbolScope)
     {
         return expression -> {
             Set<Symbol> symbols = SymbolsExtractor.extractUnique(expression);
-            return Iterables.any(symbols, symbolScope) && Iterables.any(symbols, not(symbolScope));
+            return symbols.stream().anyMatch(symbolScope) && symbols.stream().anyMatch(not(symbolScope));
         };
     }
 

--- a/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/SqlFormatter.java
@@ -141,7 +141,6 @@ import java.util.stream.Collectors;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.common.collect.Iterables.transform;
 import static io.trino.sql.ExpressionFormatter.formatExpression;
 import static io.trino.sql.ExpressionFormatter.formatGroupBy;
 import static io.trino.sql.ExpressionFormatter.formatOrderBy;
@@ -737,7 +736,7 @@ public final class SqlFormatter
             }
 
             builder.append("VALUES (");
-            Joiner.on(", ").appendTo(builder, transform(node.getValues(), ExpressionFormatter::formatExpression));
+            Joiner.on(", ").appendTo(builder, node.getValues().stream().map(ExpressionFormatter::formatExpression).iterator());
             builder.append(")");
 
             return null;

--- a/core/trino-parser/src/main/java/io/trino/sql/tree/QualifiedName.java
+++ b/core/trino-parser/src/main/java/io/trino/sql/tree/QualifiedName.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Iterables.isEmpty;
+import static com.google.common.collect.Streams.stream;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
@@ -48,7 +48,7 @@ public class QualifiedName
     public static QualifiedName of(Iterable<Identifier> originalParts)
     {
         requireNonNull(originalParts, "originalParts is null");
-        checkArgument(!isEmpty(originalParts), "originalParts is empty");
+        checkArgument(stream(originalParts).findAny().isPresent(), "originalParts is empty");
 
         return new QualifiedName(ImmutableList.copyOf(originalParts));
     }

--- a/lib/trino-matching/src/main/java/io/trino/matching/Pattern.java
+++ b/lib/trino-matching/src/main/java/io/trino/matching/Pattern.java
@@ -13,7 +13,6 @@
  */
 package io.trino.matching;
 
-import com.google.common.collect.Iterables;
 import io.trino.matching.pattern.CapturePattern;
 import io.trino.matching.pattern.FilterPattern;
 import io.trino.matching.pattern.TypeOfPattern;
@@ -24,7 +23,7 @@ import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import static com.google.common.base.Predicates.not;
+import static com.google.common.collect.Streams.stream;
 import static java.util.Objects.requireNonNull;
 
 public abstract class Pattern<T>
@@ -56,12 +55,12 @@ public abstract class Pattern<T>
     // or with(propName) map(isEmpty) equalTo(true)
     public static <F, C, T extends Iterable<S>, S> PropertyPattern<F, C, T> empty(Property<F, C, T> property)
     {
-        return PropertyPattern.upcast(property.matching(Iterables::isEmpty));
+        return PropertyPattern.upcast(property.matching(iterable -> stream(iterable).findAny().isEmpty()));
     }
 
     public static <F, C, T extends Iterable<S>, S> PropertyPattern<F, C, T> nonEmpty(Property<F, C, T> property)
     {
-        return PropertyPattern.upcast(property.matching(not(Iterables::isEmpty)));
+        return PropertyPattern.upcast(property.matching(iterable -> stream(iterable).findAny().isPresent()));
     }
 
     public Pattern<T> capturedAs(Capture<T> capture)

--- a/lib/trino-orc/src/test/java/io/trino/orc/AbstractTestOrcReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/AbstractTestOrcReader.java
@@ -38,10 +38,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import static com.google.common.collect.Iterables.concat;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.cycle;
 import static com.google.common.collect.Iterables.limit;
 import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Streams.concat;
 import static io.trino.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -154,14 +155,14 @@ public abstract class AbstractTestOrcReader
     public void testLongPatchedBase()
             throws Exception
     {
-        testRoundTripNumeric(limit(cycle(concat(intsBetween(0, 18), intsBetween(0, 18), ImmutableList.of(30_000, 20_000, 400_000, 30_000, 20_000))), 30_000));
+        testRoundTripNumeric(limit(cycle(concat(intsBetween(0, 18).stream(), intsBetween(0, 18).stream(), ImmutableList.of(30_000, 20_000, 400_000, 30_000, 20_000).stream()).collect(toImmutableList())), 30_000));
     }
 
     @Test
     public void testLongStrideDictionary()
             throws Exception
     {
-        testRoundTripNumeric(concat(ImmutableList.of(1), nCopies(9999, 123), ImmutableList.of(2), nCopies(9999, 123)));
+        testRoundTripNumeric(concat(ImmutableList.of(1).stream(), nCopies(9999, 123).stream(), ImmutableList.of(2).stream(), nCopies(9999, 123).stream()).collect(toImmutableList()));
     }
 
     private void testRoundTripNumeric(Iterable<? extends Number> values)
@@ -431,7 +432,7 @@ public abstract class AbstractTestOrcReader
     public void testStringStrideDictionary()
             throws Exception
     {
-        tester.testRoundTrip(VARCHAR, newArrayList(concat(ImmutableList.of("a"), nCopies(9999, "123"), ImmutableList.of("b"), nCopies(9999, "123"))));
+        tester.testRoundTrip(VARCHAR, concat(ImmutableList.of("a").stream(), nCopies(9999, "123").stream(), ImmutableList.of("b").stream(), nCopies(9999, "123").stream()).collect(toList()));
     }
 
     @Test

--- a/lib/trino-orc/src/test/java/io/trino/orc/AbstractTestOrcReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/AbstractTestOrcReader.java
@@ -32,17 +32,18 @@ import org.testng.annotations.Test;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Iterables.cycle;
-import static com.google.common.collect.Iterables.limit;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Streams.concat;
+import static com.google.common.collect.Streams.stream;
 import static io.trino.orc.OrcTester.HIVE_STORAGE_TIME_ZONE;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -98,7 +99,7 @@ public abstract class AbstractTestOrcReader
     public void testBooleanSequence()
             throws Exception
     {
-        tester.testRoundTrip(BOOLEAN, newArrayList(limit(cycle(ImmutableList.of(true, false, false)), 30_000)));
+        tester.testRoundTrip(BOOLEAN, newArrayList(() -> Stream.generate(() -> ImmutableList.of(true, false, false)).flatMap(Collection::stream).limit(30_000).iterator()));
     }
 
     @Test
@@ -129,7 +130,7 @@ public abstract class AbstractTestOrcReader
     public void testLongDirect()
             throws Exception
     {
-        testRoundTripNumeric(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000));
+        testRoundTripNumeric((Iterable<Integer>) () -> Stream.generate(() -> ImmutableList.of(1, 3, 5, 7, 11, 13, 17)).flatMap(Collection::stream).limit(30_000).iterator());
     }
 
     @Test
@@ -148,14 +149,14 @@ public abstract class AbstractTestOrcReader
     public void testLongShortRepeat()
             throws Exception
     {
-        testRoundTripNumeric(limit(repeatEach(4, cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17))), 30_000));
+        testRoundTripNumeric(() -> stream(repeatEach(4, () -> Stream.generate(() -> ImmutableList.<Number>of(1, 3, 5, 7, 11, 13, 17)).flatMap(List::stream).iterator())).limit(30_000).iterator());
     }
 
     @Test
     public void testLongPatchedBase()
             throws Exception
     {
-        testRoundTripNumeric(limit(cycle(concat(intsBetween(0, 18).stream(), intsBetween(0, 18).stream(), ImmutableList.of(30_000, 20_000, 400_000, 30_000, 20_000).stream()).collect(toImmutableList())), 30_000));
+        testRoundTripNumeric((Iterable<Integer>) () -> Stream.generate(() -> concat(intsBetween(0, 18).stream(), intsBetween(0, 18).stream(), ImmutableList.of(30_000, 20_000, 400_000, 30_000, 20_000).stream()).collect(toImmutableList())).flatMap(Collection::stream).limit(30_000).iterator());
     }
 
     @Test
@@ -311,7 +312,7 @@ public abstract class AbstractTestOrcReader
                 .put("2019-12-05 13:41:39.564", SqlTimestamp.fromMillis(3, 1575553299564L))
                 .build();
         map.forEach((expected, value) -> assertEquals(value.toString(), expected));
-        tester.testRoundTrip(TIMESTAMP_MILLIS, newArrayList(limit(cycle(map.values()), 30_000)));
+        tester.testRoundTrip(TIMESTAMP_MILLIS, newArrayList(() -> Stream.generate(() -> map.values()).flatMap(Collection::stream).limit(30_000).iterator()));
     }
 
     @Test
@@ -328,7 +329,7 @@ public abstract class AbstractTestOrcReader
                 .put("2019-12-05 13:41:39.564321", SqlTimestamp.newInstance(6, 1575553299564321L, 0))
                 .build();
         map.forEach((expected, value) -> assertEquals(value.toString(), expected));
-        tester.testRoundTrip(TIMESTAMP_MICROS, newArrayList(limit(cycle(map.values()), 30_000)));
+        tester.testRoundTrip(TIMESTAMP_MICROS, newArrayList(() -> Stream.generate(() -> map.values()).flatMap(Collection::stream).limit(30_000).iterator()));
     }
 
     @Test
@@ -345,7 +346,7 @@ public abstract class AbstractTestOrcReader
                 .put("2019-12-05 13:41:39.564321789", SqlTimestamp.newInstance(9, 1575553299564321L, 789_000))
                 .build();
         map.forEach((expected, value) -> assertEquals(value.toString(), expected));
-        tester.testRoundTrip(TIMESTAMP_NANOS, newArrayList(limit(cycle(map.values()), 30_000)));
+        tester.testRoundTrip(TIMESTAMP_NANOS, newArrayList(() -> Stream.generate(() -> map.values()).flatMap(Collection::stream).limit(30_000).iterator()));
     }
 
     @Test
@@ -362,7 +363,7 @@ public abstract class AbstractTestOrcReader
                 .put("2019-12-05 13:41:39.564 UTC", SqlTimestampWithTimeZone.newInstance(3, 1575553299564L, 0, UTC_KEY))
                 .build();
         map.forEach((expected, value) -> assertEquals(value.toString(), expected));
-        tester.testRoundTrip(TIMESTAMP_TZ_MILLIS, newArrayList(limit(cycle(map.values()), 30_000)));
+        tester.testRoundTrip(TIMESTAMP_TZ_MILLIS, newArrayList(() -> Stream.generate(() -> map.values()).flatMap(Collection::stream).limit(30_000).iterator()));
     }
 
     @Test
@@ -379,7 +380,7 @@ public abstract class AbstractTestOrcReader
                 .put("2019-12-05 13:41:39.564321 UTC", SqlTimestampWithTimeZone.newInstance(6, 1575553299564L, 321_000_000, UTC_KEY))
                 .build();
         map.forEach((expected, value) -> assertEquals(value.toString(), expected));
-        tester.testRoundTrip(TIMESTAMP_TZ_MICROS, newArrayList(limit(cycle(map.values()), 30_000)));
+        tester.testRoundTrip(TIMESTAMP_TZ_MICROS, newArrayList(() -> Stream.generate(() -> map.values()).flatMap(Collection::stream).limit(30_000).iterator()));
     }
 
     @Test
@@ -396,14 +397,14 @@ public abstract class AbstractTestOrcReader
                 .put("2019-12-05 13:41:39.564321789 UTC", SqlTimestampWithTimeZone.newInstance(9, 1575553299564L, 321_789_000, UTC_KEY))
                 .build();
         map.forEach((expected, value) -> assertEquals(value.toString(), expected));
-        tester.testRoundTrip(TIMESTAMP_TZ_NANOS, newArrayList(limit(cycle(map.values()), 30_000)));
+        tester.testRoundTrip(TIMESTAMP_TZ_NANOS, newArrayList(() -> Stream.generate(() -> map.values()).flatMap(Collection::stream).limit(30_000).iterator()));
     }
 
     @Test
     public void testStringUnicode()
             throws Exception
     {
-        tester.testRoundTrip(VARCHAR, newArrayList(limit(cycle(ImmutableList.of("apple", "apple pie", "apple\uD835\uDC03", "apple\uFFFD")), 30_000)));
+        tester.testRoundTrip(VARCHAR, newArrayList(() -> Stream.generate(() -> ImmutableList.of("apple", "apple pie", "apple\uD835\uDC03", "apple\uFFFD")).flatMap(Collection::stream).limit(30_000).iterator()));
     }
 
     @Test
@@ -423,7 +424,7 @@ public abstract class AbstractTestOrcReader
     {
         tester.testRoundTrip(
                 VARCHAR,
-                newArrayList(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000)).stream()
+                newArrayList(() -> Stream.generate(() -> ImmutableList.of(1, 3, 5, 7, 11, 13, 17)).flatMap(Collection::stream).limit(30_000).iterator()).stream()
                         .map(Object::toString)
                         .collect(toList()));
     }
@@ -439,7 +440,7 @@ public abstract class AbstractTestOrcReader
     public void testEmptyStringSequence()
             throws Exception
     {
-        tester.testRoundTrip(VARCHAR, newArrayList(limit(cycle(""), 30_000)));
+        tester.testRoundTrip(VARCHAR, newArrayList(() -> Stream.generate(() -> "").limit(30_000).iterator()));
     }
 
     @Test
@@ -459,7 +460,7 @@ public abstract class AbstractTestOrcReader
     {
         tester.testRoundTrip(
                 CHAR,
-                newArrayList(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000)).stream()
+                newArrayList(() -> Stream.generate(() -> ImmutableList.of(1, 3, 5, 7, 11, 13, 17)).flatMap(Collection::stream).limit(30_000).iterator()).stream()
                         .map(this::toCharValue)
                         .collect(toList()));
     }
@@ -468,7 +469,7 @@ public abstract class AbstractTestOrcReader
     public void testEmptyCharSequence()
             throws Exception
     {
-        tester.testRoundTrip(CHAR, newArrayList(limit(cycle("          "), 30_000)));
+        tester.testRoundTrip(CHAR, newArrayList(() -> Stream.generate(() -> "          ").limit(30_000).iterator()));
     }
 
     private String toCharValue(Object value)
@@ -494,7 +495,7 @@ public abstract class AbstractTestOrcReader
             throws Exception
     {
         tester.testRoundTrip(
-                VARBINARY, ImmutableList.copyOf(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000)).stream()
+                VARBINARY, ImmutableList.copyOf(() -> Stream.generate(() -> ImmutableList.of(1, 3, 5, 7, 11, 13, 17)).flatMap(Collection::stream).limit(30_000).iterator()).stream()
                         .map(Object::toString)
                         .map(string -> string.getBytes(UTF_8))
                         .map(SqlVarbinary::new)

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestReadBloomFilter.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestReadBloomFilter.java
@@ -26,9 +26,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static com.google.common.collect.Iterables.cycle;
-import static com.google.common.collect.Iterables.limit;
-import static com.google.common.collect.Lists.newArrayList;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.trino.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static io.trino.orc.OrcReader.MAX_BATCH_SIZE;
@@ -82,7 +79,7 @@ public class TestReadBloomFilter
     private static <T> void testType(Type type, List<T> uniqueValues, T inBloomFilter, T notInBloomFilter)
             throws Exception
     {
-        Stream<T> writeValues = newArrayList(limit(cycle(uniqueValues), 30_000)).stream();
+        Stream<T> writeValues = Stream.generate(() -> uniqueValues).flatMap(List::stream).limit(30_000);
 
         try (TempFile tempFile = new TempFile()) {
             writeOrcColumnHive(tempFile.getFile(), ORC_12, LZ4, type, writeValues.iterator());

--- a/lib/trino-rcfile/src/test/java/io/trino/rcfile/AbstractTestRcFileReader.java
+++ b/lib/trino-rcfile/src/test/java/io/trino/rcfile/AbstractTestRcFileReader.java
@@ -29,9 +29,8 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
-import static com.google.common.collect.Iterables.cycle;
-import static com.google.common.collect.Iterables.limit;
 import static io.trino.rcfile.RcFileTester.Format.BINARY;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -83,7 +82,7 @@ public abstract class AbstractTestRcFileReader
     public void testBooleanSequence()
             throws Exception
     {
-        tester.testRoundTrip(BOOLEAN, limit(cycle(ImmutableList.of(true, false, false)), 3_000));
+        tester.testRoundTrip(BOOLEAN, () -> Stream.generate(() -> ImmutableList.<Object>of(true, false, false)).flatMap(List::stream).limit(3_000).iterator());
     }
 
     @Test

--- a/lib/trino-rcfile/src/test/java/io/trino/rcfile/RcFileTester.java
+++ b/lib/trino-rcfile/src/test/java/io/trino/rcfile/RcFileTester.java
@@ -17,7 +17,6 @@ import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.airlift.slice.OutputStreamSliceOutput;
 import io.airlift.slice.Slice;
@@ -366,7 +365,7 @@ public class RcFileTester
             throws Exception
     {
         // json does not support null keys, so we just write the first value
-        Object nullKeyWrite = Iterables.getFirst(writeValues, null);
+        Object nullKeyWrite = stream(writeValues).findFirst().orElse(null);
 
         // values in simple map and mix in some null values
         testRoundTripType(

--- a/lib/trino-rcfile/src/test/java/io/trino/rcfile/RcFileTester.java
+++ b/lib/trino-rcfile/src/test/java/io/trino/rcfile/RcFileTester.java
@@ -113,8 +113,9 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.google.common.base.Functions.constant;
-import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterators.advance;
+import static com.google.common.collect.Streams.stream;
 import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -316,7 +317,7 @@ public class RcFileTester
         testRoundTripType(type, writeValues, skipFormatsSet);
 
         // all nulls
-        assertRoundTrip(type, transform(writeValues, constant(null)), skipFormatsSet);
+        assertRoundTrip(type, stream(writeValues).map(constant(null)).collect(toList()), skipFormatsSet);
 
         // values wrapped in struct
         if (structTestsEnabled) {
@@ -325,10 +326,10 @@ public class RcFileTester
 
         // values wrapped in a struct wrapped in a struct
         if (complexStructuralTestsEnabled) {
-            Iterable<Object> simpleStructs = transform(insertNullEvery(5, writeValues), RcFileTester::toHiveStruct);
+            Iterable<Object> simpleStructs = stream(insertNullEvery(5, writeValues)).map(RcFileTester::toHiveStruct).collect(toImmutableList());
             testRoundTripType(
                     RowType.from(ImmutableList.of(RowType.field("field", createRowType(type)))),
-                    transform(simpleStructs, Collections::singletonList),
+                    stream(simpleStructs).map(Collections::singletonList).collect(toImmutableList()),
                     skipFormatsSet);
         }
 
@@ -346,7 +347,7 @@ public class RcFileTester
         if (complexStructuralTestsEnabled) {
             testListRoundTrip(
                     createListType(type),
-                    transform(writeValues, RcFileTester::toHiveList),
+                    stream(writeValues).map(RcFileTester::toHiveList).collect(toImmutableList()),
                     skipFormatsSet);
         }
     }
@@ -357,7 +358,7 @@ public class RcFileTester
         // values in simple struct and mix in some null values
         testRoundTripType(
                 createRowType(type),
-                transform(insertNullEvery(5, writeValues), RcFileTester::toHiveStruct),
+                stream(insertNullEvery(5, writeValues)).map(RcFileTester::toHiveStruct).collect(toImmutableList()),
                 skipFormats);
     }
 
@@ -370,7 +371,7 @@ public class RcFileTester
         // values in simple map and mix in some null values
         testRoundTripType(
                 createMapType(type),
-                transform(insertNullEvery(5, writeValues), value -> toHiveMap(nullKeyWrite, value)),
+                stream(insertNullEvery(5, writeValues)).map(value -> toHiveMap(nullKeyWrite, value)).collect(toImmutableList()),
                 skipFormats);
     }
 
@@ -380,7 +381,7 @@ public class RcFileTester
         // values in simple list and mix in some null values
         testRoundTripType(
                 createListType(type),
-                transform(insertNullEvery(5, writeValues), RcFileTester::toHiveList),
+                stream(insertNullEvery(5, writeValues)).map(RcFileTester::toHiveList).collect(toImmutableList()),
                 skipFormats);
     }
 

--- a/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
+++ b/plugin/trino-cassandra/src/main/java/io/trino/plugin/cassandra/CassandraSession.java
@@ -70,7 +70,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Suppliers.memoize;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Iterables.transform;
 import static io.trino.plugin.cassandra.CassandraErrorCode.CASSANDRA_VERSION_ERROR;
 import static io.trino.plugin.cassandra.CassandraMetadata.PRESTO_COMMENT_METADATA;
 import static io.trino.plugin.cassandra.CassandraType.isFullySupported;
@@ -83,6 +82,7 @@ import static java.util.Comparator.comparing;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
 public class CassandraSession
@@ -199,7 +199,7 @@ public class CassandraSession
 
             // column ordering
             List<ExtraColumnMetadata> extras = extraColumnMetadataCodec.fromJson(columnOrderingString);
-            List<String> explicitColumnOrder = new ArrayList<>(ImmutableList.copyOf(transform(extras, ExtraColumnMetadata::getName)));
+            List<String> explicitColumnOrder = extras.stream().map(ExtraColumnMetadata::getName).collect(toCollection(ArrayList::new));
             hiddenColumns = extras.stream()
                     .filter(ExtraColumnMetadata::isHidden)
                     .map(ExtraColumnMetadata::getName)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/BackgroundHiveSplitLoader.java
@@ -191,7 +191,7 @@ public class BackgroundHiveSplitLoader
     public BackgroundHiveSplitLoader(
             Table table,
             AcidTransaction transaction,
-            Iterable<HivePartitionMetadata> partitions,
+            Iterator<HivePartitionMetadata> partitions,
             TupleDomain<? extends ColumnHandle> compactEffectivePredicate,
             DynamicFilter dynamicFilter,
             Duration dynamicFilteringWaitTimeout,

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ConcurrentLazyQueue.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/ConcurrentLazyQueue.java
@@ -17,14 +17,16 @@ import javax.annotation.concurrent.GuardedBy;
 
 import java.util.Iterator;
 
+import static java.util.Objects.requireNonNull;
+
 public class ConcurrentLazyQueue<E>
 {
     @GuardedBy("this")
     private final Iterator<E> iterator;
 
-    public ConcurrentLazyQueue(Iterable<E> iterable)
+    public ConcurrentLazyQueue(Iterator<E> iterator)
     {
-        this.iterator = iterable.iterator();
+        this.iterator = requireNonNull(iterator, "iterator is null");
     }
 
     public synchronized boolean isEmpty()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -21,7 +21,6 @@ import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.airlift.json.JsonCodec;
@@ -2530,7 +2529,7 @@ public class HiveMetadata
             // Do not create tuple domains for every partition at the same time!
             // There can be a huge number of partitions so use an iterable so
             // all domains do not need to be in memory at the same time.
-            Iterable<TupleDomain<ColumnHandle>> partitionDomains = Iterables.transform(partitions, (hivePartition) -> TupleDomain.fromFixedValues(hivePartition.getKeys()));
+            Iterable<TupleDomain<ColumnHandle>> partitionDomains = () -> partitions.stream().map(hivePartition -> TupleDomain.fromFixedValues(hivePartition.getKeys())).iterator();
             discretePredicates = Optional.of(new DiscretePredicates(partitionColumns, partitionDomains));
         }
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionUpdate.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionUpdate.java
@@ -21,6 +21,7 @@ import io.trino.spi.TrinoException;
 import org.apache.hadoop.fs.Path;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -163,7 +164,7 @@ public class PartitionUpdate
         return new HiveBasicStatistics(fileNames.size(), rowCount, inMemoryDataSizeInBytes, onDiskDataSizeInBytes);
     }
 
-    public static List<PartitionUpdate> mergePartitionUpdates(Iterable<PartitionUpdate> unMergedUpdates)
+    public static List<PartitionUpdate> mergePartitionUpdates(Iterator<PartitionUpdate> unMergedUpdates)
     {
         ImmutableList.Builder<PartitionUpdate> partitionUpdates = ImmutableList.builder();
         for (Collection<PartitionUpdate> partitionGroup : Multimaps.index(unMergedUpdates, PartitionUpdate::getName).asMap().values()) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -732,7 +732,7 @@ public class CachingHiveMetastore
     private Map<WithIdentity<HivePartitionName>, Optional<Partition>> loadPartitionsByNames(Iterable<? extends WithIdentity<HivePartitionName>> partitionNames)
     {
         requireNonNull(partitionNames, "partitionNames is null");
-        checkArgument(!Iterables.isEmpty(partitionNames), "partitionNames is empty");
+        checkArgument(stream(partitionNames).findAny().isPresent(), "partitionNames is empty");
 
         WithIdentity<HivePartitionName> firstPartition = Iterables.get(partitionNames, 0);
 

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/cache/CachingHiveMetastore.java
@@ -18,7 +18,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.SetMultimap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.jmx.CacheStatsMBean;
@@ -734,7 +733,9 @@ public class CachingHiveMetastore
         requireNonNull(partitionNames, "partitionNames is null");
         checkArgument(stream(partitionNames).findAny().isPresent(), "partitionNames is empty");
 
-        WithIdentity<HivePartitionName> firstPartition = Iterables.get(partitionNames, 0);
+        WithIdentity<HivePartitionName> firstPartition = stream(partitionNames)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("partitionNames is empty"));
 
         HiveTableName hiveTableName = firstPartition.getKey().getHiveTableName();
         HiveIdentity identity = updateIdentity(firstPartition.getIdentity());

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -173,9 +173,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Lists.reverse;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static com.google.common.collect.MoreCollectors.onlyElement;
@@ -309,6 +307,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.concat;
 import static org.apache.hadoop.hive.common.FileUtils.makePartName;
 import static org.apache.hadoop.hive.metastore.TableType.MANAGED_TABLE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -373,7 +372,7 @@ public abstract class AbstractTestHive
 
     private static final MaterializedResult CREATE_TABLE_PARTITIONED_DATA = new MaterializedResult(
             CREATE_TABLE_DATA.getMaterializedRows().stream()
-                    .map(row -> new MaterializedRow(row.getPrecision(), newArrayList(concat(row.getFields(), ImmutableList.of("2015-07-0" + row.getField(0))))))
+                    .map(row -> new MaterializedRow(row.getPrecision(), concat(row.getFields().stream(), ImmutableList.of("2015-07-0" + row.getField(0)).stream()).collect(toList())))
                     .collect(toList()),
             ImmutableList.<Type>builder()
                     .addAll(CREATE_TABLE_DATA.getTypes())

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestBackgroundHiveSplitLoader.java
@@ -516,7 +516,7 @@ public class TestBackgroundHiveSplitLoader
         BackgroundHiveSplitLoader backgroundHiveSplitLoader = new BackgroundHiveSplitLoader(
                 SIMPLE_TABLE,
                 NO_ACID_TRANSACTION,
-                () -> new Iterator<>()
+                new Iterator<>()
                 {
                     private boolean threw;
 
@@ -1070,7 +1070,7 @@ public class TestBackgroundHiveSplitLoader
         return new BackgroundHiveSplitLoader(
                 table,
                 NO_ACID_TRANSACTION,
-                hivePartitionMetadatas,
+                hivePartitionMetadatas.iterator(),
                 compactEffectivePredicate,
                 dynamicFilter,
                 dynamicFilteringProbeBlockingTimeout,
@@ -1103,7 +1103,7 @@ public class TestBackgroundHiveSplitLoader
         return new BackgroundHiveSplitLoader(
                 SIMPLE_TABLE,
                 NO_ACID_TRANSACTION,
-                hivePartitionMetadatas,
+                hivePartitionMetadatas.iterator(),
                 TupleDomain.none(),
                 DynamicFilter.EMPTY,
                 new Duration(0, SECONDS),
@@ -1149,10 +1149,10 @@ public class TestBackgroundHiveSplitLoader
                 Optional.empty());
     }
 
-    private static Iterable<HivePartitionMetadata> createPartitionMetadataWithOfflinePartitions()
+    private static Iterator<HivePartitionMetadata> createPartitionMetadataWithOfflinePartitions()
             throws RuntimeException
     {
-        return () -> new AbstractIterator<>()
+        return new AbstractIterator<>()
         {
             // This iterator is crafted to return a valid partition for the first calls to
             // hasNext() and next(), and then it should throw for the second call to hasNext()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/metastore/thrift/MockThriftMetastoreClient.java
@@ -16,7 +16,6 @@ package io.trino.plugin.hive.metastore.thrift;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
 import io.trino.plugin.hive.acid.AcidOperation;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -47,6 +46,7 @@ import java.util.Map;
 import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.apache.hadoop.hive.metastore.api.PrincipalType.ROLE;
 import static org.apache.hadoop.hive.metastore.api.PrincipalType.USER;
 
@@ -296,14 +296,14 @@ public class MockThriftMetastoreClient
         if (!dbName.equals(TEST_DATABASE) || !tableName.equals(TEST_TABLE) || !ImmutableSet.of(TEST_PARTITION1, TEST_PARTITION2).containsAll(names)) {
             throw new NoSuchObjectException();
         }
-        return Lists.transform(names, name -> {
+        return names.stream().map(name -> {
             try {
                 return new Partition(ImmutableList.copyOf(Warehouse.getPartValuesFromPartName(name)), TEST_DATABASE, TEST_TABLE, 0, 0, DEFAULT_STORAGE_DESCRIPTOR, ImmutableMap.of());
             }
             catch (MetaException e) {
                 throw new RuntimeException(e);
             }
-        });
+        }).collect(toImmutableList());
     }
 
     @Override

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/AbstractTestParquetReader.java
@@ -60,10 +60,11 @@ import java.util.stream.Stream;
 
 import static com.google.common.base.Functions.compose;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.cycle;
 import static com.google.common.collect.Iterables.limit;
-import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Streams.stream;
 import static io.trino.plugin.hive.parquet.ParquetTester.insertNullEvery;
 import static io.trino.spi.type.BigintType.BIGINT;
 import static io.trino.spi.type.BooleanType.BOOLEAN;
@@ -186,7 +187,7 @@ public abstract class AbstractTestParquetReader
     public void testArrayOfStructs()
             throws Exception
     {
-        Iterable<List<?>> structs = createNullableTestStructs(transform(intsBetween(0, 31_234), Object::toString), longsBetween(0, 31_234));
+        Iterable<List<?>> structs = createNullableTestStructs(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()), longsBetween(0, 31_234));
         Iterable<List<List<?>>> values = createTestArrays(structs);
         List<String> structFieldNames = asList("stringField", "longField");
         Type structType = RowType.from(asList(field("stringField", VARCHAR), field("longField", BIGINT)));
@@ -210,7 +211,7 @@ public abstract class AbstractTestParquetReader
                 "}");
         Iterable<Long> aValues = limit(cycle(asList(1L, null, 3L, 5L, null, null, null, 7L, 11L, null, 13L, 17L)), 30_000);
         Iterable<Boolean> bValues = limit(cycle(asList(null, true, false, null, null, true, false)), 30_000);
-        Iterable<String> cValues = transform(intsBetween(0, 31_234), Object::toString);
+        Iterable<String> cValues = intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList());
 
         Iterable<List<?>> structs = createTestStructs(aValues, bValues, cValues);
         Iterable<List<List<?>>> values = createTestArrays(structs);
@@ -227,7 +228,7 @@ public abstract class AbstractTestParquetReader
     {
         Iterable<Long> aValues = limit(cycle(asList(1L, null, 3L, 5L, null, null, null, 7L, 11L, null, 13L, 17L)), 30_000);
         Iterable<Boolean> bValues = limit(cycle(asList(null, true, false, null, null, true, false)), 30_000);
-        Iterable<String> cValues = transform(intsBetween(0, 31_234), Object::toString);
+        Iterable<String> cValues = intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList());
 
         Iterable<List<?>> structs = createTestStructs(aValues, bValues, cValues);
         Iterable<List<List<?>>> values = createTestArrays(structs);
@@ -241,7 +242,7 @@ public abstract class AbstractTestParquetReader
     public void testArrayOfArrayOfStructOfArray()
             throws Exception
     {
-        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()));
         Iterable<List<?>> structs = createNullableTestStructs(stringArrayField, limit(cycle(asList(1, null, 3, 5, null, 7, 11, null, 17)), 31_234));
         List<String> structFieldNames = asList("stringArrayField", "intField");
         Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(VARCHAR)), field("intField", INTEGER)));
@@ -260,7 +261,7 @@ public abstract class AbstractTestParquetReader
     public void testSingleLevelSchemaArrayOfArrayOfStructOfArray()
             throws Exception
     {
-        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()));
         Iterable<List<?>> structs = createTestStructs(stringArrayField, limit(cycle(asList(1, null, 3, 5, null, 7, 11, null, 17)), 31_234));
         List<String> structFieldNames = asList("stringArrayField", "intField");
         Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(VARCHAR)), field("intField", INTEGER)));
@@ -279,7 +280,7 @@ public abstract class AbstractTestParquetReader
     public void testArrayOfStructOfArray()
             throws Exception
     {
-        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()));
         Iterable<List<?>> structs = createNullableTestStructs(stringArrayField, limit(cycle(asList(1, 3, null, 5, 7, null, 11, 13, null, 17)), 31_234));
         List<String> structFieldNames = asList("stringArrayField", "intField");
         Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(VARCHAR)), field("intField", INTEGER)));
@@ -296,7 +297,7 @@ public abstract class AbstractTestParquetReader
     public void testSingleLevelSchemaArrayOfStructOfArray()
             throws Exception
     {
-        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()));
         Iterable<List<?>> structs = createTestStructs(stringArrayField, limit(cycle(asList(1, 3, null, 5, 7, null, 11, 13, null, 17)), 31_234));
         List<String> structFieldNames = asList("stringArrayField", "intField");
         Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(VARCHAR)), field("intField", INTEGER)));
@@ -313,7 +314,7 @@ public abstract class AbstractTestParquetReader
     public void testMap()
             throws Exception
     {
-        Iterable<Map<String, Long>> values = createTestMaps(transform(intsBetween(0, 100_000), Object::toString), longsBetween(0, 10_000));
+        Iterable<Map<String, Long>> values = createTestMaps(intsBetween(0, 100_000).stream().map(Object::toString).collect(toImmutableList()), longsBetween(0, 10_000));
         tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaLongObjectInspector), values, values, mapType(VARCHAR, BIGINT));
     }
 
@@ -339,7 +340,7 @@ public abstract class AbstractTestParquetReader
     public void testArrayOfMaps()
             throws Exception
     {
-        Iterable<Map<String, Long>> maps = createNullableTestMaps(transform(intsBetween(0, 10), Object::toString), longsBetween(0, 10));
+        Iterable<Map<String, Long>> maps = createNullableTestMaps(intsBetween(0, 10).stream().map(Object::toString).collect(toImmutableList()), longsBetween(0, 10));
         List<List<Map<String, Long>>> values = createTestArrays(maps);
         tester.testRoundTrip(getStandardListObjectInspector(getStandardMapObjectInspector(javaStringObjectInspector, javaLongObjectInspector)),
                 values, values, new ArrayType(mapType(VARCHAR, BIGINT)));
@@ -349,7 +350,7 @@ public abstract class AbstractTestParquetReader
     public void testSingleLevelSchemaArrayOfMaps()
             throws Exception
     {
-        Iterable<Map<String, Long>> maps = createTestMaps(transform(intsBetween(0, 10), Object::toString), longsBetween(0, 10));
+        Iterable<Map<String, Long>> maps = createTestMaps(intsBetween(0, 10).stream().map(Object::toString).collect(toImmutableList()), longsBetween(0, 10));
         List<List<Map<String, Long>>> values = createTestArrays(maps);
         ObjectInspector objectInspector = getStandardListObjectInspector(getStandardMapObjectInspector(javaStringObjectInspector, javaLongObjectInspector));
         tester.testSingleLevelArraySchemaRoundTrip(objectInspector, values, values, new ArrayType(mapType(VARCHAR, BIGINT)));
@@ -360,7 +361,7 @@ public abstract class AbstractTestParquetReader
             throws Exception
     {
         Iterable<Integer> keys = intsBetween(0, 10_000);
-        Iterable<List<?>> structs = createNullableTestStructs(transform(intsBetween(0, 10_000), Object::toString), longsBetween(0, 10_000));
+        Iterable<List<?>> structs = createNullableTestStructs(intsBetween(0, 10_000).stream().map(Object::toString).collect(toImmutableList()), longsBetween(0, 10_000));
         List<String> structFieldNames = asList("stringField", "longField");
         Type structType = RowType.from(asList(field("stringField", VARCHAR), field("longField", BIGINT)));
         Iterable<Map<Integer, List<?>>> maps = createNullableTestMaps(keys, structs);
@@ -377,7 +378,7 @@ public abstract class AbstractTestParquetReader
             throws Exception
     {
         Iterable<Integer> keys = intsBetween(0, 10_000);
-        Iterable<List<?>> structs = createNullableTestStructs(transform(intsBetween(0, 10_000), Object::toString), longsBetween(0, 10_000));
+        Iterable<List<?>> structs = createNullableTestStructs(intsBetween(0, 10_000).stream().map(Object::toString).collect(toImmutableList()), longsBetween(0, 10_000));
         List<String> structFieldNames = asList("stringField", "longField");
         Type structType = RowType.from(asList(field("stringField", VARCHAR), field("longField", BIGINT)));
         Iterable<Map<Integer, List<?>>> maps = createTestMaps(keys, structs);
@@ -393,7 +394,7 @@ public abstract class AbstractTestParquetReader
     public void testSingleLevelArrayOfStructOfSingleElement()
             throws Exception
     {
-        Iterable<List<?>> structs = createTestStructs(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List<?>> structs = createTestStructs(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()));
         Iterable<List<List<?>>> values = createTestArrays(structs);
         List<String> structFieldNames = singletonList("test");
         Type structType = RowType.from(singletonList(field("test", VARCHAR)));
@@ -409,7 +410,7 @@ public abstract class AbstractTestParquetReader
     public void testSingleLevelArrayOfStructOfStructOfSingleElement()
             throws Exception
     {
-        Iterable<List<?>> structs = createTestStructs(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List<?>> structs = createTestStructs(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()));
         Iterable<List<?>> structsOfStructs = createTestStructs(structs);
         Iterable<List<List<?>>> values = createTestArrays(structsOfStructs);
         List<String> structFieldNames = singletonList("test");
@@ -432,7 +433,7 @@ public abstract class AbstractTestParquetReader
             throws Exception
     {
         Iterable<List<Integer>> arrays = createNullableTestArrays(limit(cycle(asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 10_000));
-        Iterable<String> keys = transform(intsBetween(0, 10_000), Object::toString);
+        Iterable<String> keys = intsBetween(0, 10_000).stream().map(Object::toString).collect(toImmutableList());
         Iterable<Map<String, List<Integer>>> maps = createNullableTestMaps(keys, arrays);
         List<List<Map<String, List<Integer>>>> values = createTestArrays(maps);
         tester.testRoundTrip(getStandardListObjectInspector(
@@ -447,7 +448,7 @@ public abstract class AbstractTestParquetReader
             throws Exception
     {
         Iterable<List<Integer>> arrays = createNullableTestArrays(intsBetween(0, 10_000));
-        Iterable<String> keys = transform(intsBetween(0, 10_000), Object::toString);
+        Iterable<String> keys = intsBetween(0, 10_000).stream().map(Object::toString).collect(toImmutableList());
         Iterable<Map<String, List<Integer>>> maps = createTestMaps(keys, arrays);
         List<List<Map<String, List<Integer>>>> values = createTestArrays(maps);
         tester.testSingleLevelArraySchemaRoundTrip(getStandardListObjectInspector(
@@ -488,7 +489,7 @@ public abstract class AbstractTestParquetReader
             throws Exception
     {
         Iterable<Long> keys = longsBetween(0, 30_000);
-        Iterable<List<?>> structs = createNullableTestStructs(transform(intsBetween(0, 30_000), Object::toString), longsBetween(0, 30_000));
+        Iterable<List<?>> structs = createNullableTestStructs(intsBetween(0, 30_000).stream().map(Object::toString).collect(toImmutableList()), longsBetween(0, 30_000));
         List<String> structFieldNames = asList("stringField", "longField");
         Type structType = RowType.from(asList(field("stringField", VARCHAR), field("longField", BIGINT)));
         Iterable<Map<Long, List<?>>> values = createTestMaps(keys, structs);
@@ -512,7 +513,7 @@ public abstract class AbstractTestParquetReader
     public void testStruct()
             throws Exception
     {
-        List<List<?>> values = createTestStructs(transform(intsBetween(0, 31_234), Object::toString), longsBetween(0, 31_234));
+        List<List<?>> values = createTestStructs(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()), longsBetween(0, 31_234));
         List<String> structFieldNames = asList("stringField", "longField");
         Type structType = RowType.from(asList(field("stringField", VARCHAR), field("longField", BIGINT)));
         tester.testRoundTrip(getStandardStructObjectInspector(structFieldNames, asList(javaStringObjectInspector, javaLongObjectInspector)), values, values, structType);
@@ -680,7 +681,7 @@ public abstract class AbstractTestParquetReader
     public void testStructOfArrayAndPrimitive()
             throws Exception
     {
-        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()));
         List<List<?>> values = createTestStructs(stringArrayField, limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234));
         List<String> structFieldNames = asList("stringArrayField", "intField");
 
@@ -693,7 +694,7 @@ public abstract class AbstractTestParquetReader
     public void testStructOfSingleLevelArrayAndPrimitive()
             throws Exception
     {
-        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()));
         List<List<?>> values = createTestStructs(stringArrayField, limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234));
         List<String> structFieldNames = asList("stringArrayField", "intField");
 
@@ -706,7 +707,7 @@ public abstract class AbstractTestParquetReader
     public void testStructOfPrimitiveAndArray()
             throws Exception
     {
-        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()));
         Iterable<Integer> intField = limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234);
         List<List<?>> values = createTestStructs(intField, stringArrayField);
         List<String> structFieldNames = asList("intField", "stringArrayField");
@@ -720,7 +721,7 @@ public abstract class AbstractTestParquetReader
     public void testStructOfPrimitiveAndSingleLevelArray()
             throws Exception
     {
-        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString));
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList()));
         Iterable<Integer> intField = limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 31_234);
         List<List<?>> values = createTestStructs(intField, stringArrayField);
         List<String> structFieldNames = asList("intField", "stringArrayField");
@@ -735,7 +736,7 @@ public abstract class AbstractTestParquetReader
             throws Exception
     {
         Iterable<List<Integer>> intArrayField = createNullableTestArrays(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000));
-        Iterable<List<String>> stringArrayField = createNullableTestArrays(transform(intsBetween(0, 30_000), Object::toString));
+        Iterable<List<String>> stringArrayField = createNullableTestArrays(intsBetween(0, 30_000).stream().map(Object::toString).collect(toImmutableList()));
         List<List<?>> values = createTestStructs(stringArrayField, intArrayField);
         List<String> structFieldNames = asList("stringArrayField", "intArrayField");
 
@@ -749,7 +750,7 @@ public abstract class AbstractTestParquetReader
             throws Exception
     {
         Iterable<List<List<Integer>>> intArrayField = createNullableTestArrays(createNullableTestArrays(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000)));
-        Iterable<List<List<String>>> stringArrayField = createNullableTestArrays(createNullableTestArrays(transform(intsBetween(0, 31_234), Object::toString)));
+        Iterable<List<List<String>>> stringArrayField = createNullableTestArrays(createNullableTestArrays(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList())));
         List<List<?>> values = createTestStructs(stringArrayField, intArrayField);
         List<String> structFieldNames = asList("stringArrayField", "intArrayField");
         Type structType = RowType.from(asList(field("stringArrayField", new ArrayType(new ArrayType(VARCHAR))), field("intArrayField", new ArrayType(new ArrayType(INTEGER)))));
@@ -765,7 +766,7 @@ public abstract class AbstractTestParquetReader
             throws Exception
     {
         Iterable<List<List<Integer>>> intArrayField = createNullableTestArrays(createTestArrays(limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17)), 30_000)));
-        Iterable<List<List<String>>> stringArrayField = createNullableTestArrays(createTestArrays(transform(intsBetween(0, 31_234), Object::toString)));
+        Iterable<List<List<String>>> stringArrayField = createNullableTestArrays(createTestArrays(intsBetween(0, 31_234).stream().map(Object::toString).collect(toImmutableList())));
         List<List<?>> values = createTestStructs(stringArrayField, intArrayField);
         List<String> structFieldNames = asList("stringArrayField", "intArrayField");
 
@@ -1327,8 +1328,8 @@ public abstract class AbstractTestParquetReader
     public void testMapSchemas()
             throws Exception
     {
-        Iterable<Map<String, Integer>> values = createTestMaps(transform(intsBetween(0, 100_000), Object::toString), intsBetween(0, 10_000));
-        Iterable<Map<String, Integer>> nullableValues = createTestMaps(transform(intsBetween(0, 30_000), Object::toString), limit(cycle(asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
+        Iterable<Map<String, Integer>> values = createTestMaps(intsBetween(0, 100_000).stream().map(Object::toString).collect(toImmutableList()), intsBetween(0, 10_000));
+        Iterable<Map<String, Integer>> nullableValues = createTestMaps(intsBetween(0, 30_000).stream().map(Object::toString).collect(toImmutableList()), limit(cycle(asList(1, null, 3, 5, null, null, null, 7, 11, null, 13, 17)), 30_000));
         tester.testRoundTrip(getStandardMapObjectInspector(javaStringObjectInspector, javaIntObjectInspector), values, values, mapType(VARCHAR, INTEGER));
 
         // Map<String, Integer> (nullable map, non-null values)
@@ -1435,25 +1436,25 @@ public abstract class AbstractTestParquetReader
             throws Exception
     {
         tester.testRoundTrip(javaByteObjectInspector,
-                transform(writeValues, AbstractTestParquetReader::intToByte),
+                stream(writeValues).map(AbstractTestParquetReader::intToByte).collect(toImmutableList()),
                 AbstractTestParquetReader::byteToInt,
                 INTEGER);
 
         tester.testRoundTrip(javaShortObjectInspector,
-                transform(writeValues, AbstractTestParquetReader::intToShort),
+                stream(writeValues).map(AbstractTestParquetReader::intToShort).collect(toImmutableList()),
                 AbstractTestParquetReader::shortToInt,
                 INTEGER);
 
         tester.testRoundTrip(javaIntObjectInspector, writeValues, INTEGER);
-        tester.testRoundTrip(javaLongObjectInspector, transform(writeValues, AbstractTestParquetReader::intToLong), BIGINT);
+        tester.testRoundTrip(javaLongObjectInspector, stream(writeValues).map(AbstractTestParquetReader::intToLong).collect(toImmutableList()), BIGINT);
         tester.testRoundTrip(javaTimestampObjectInspector,
-                transform(writeValues, AbstractTestParquetReader::intToTimestamp),
-                transform(writeValues, AbstractTestParquetReader::intToSqlTimestamp),
+                stream(writeValues).map(AbstractTestParquetReader::intToTimestamp).collect(toImmutableList()),
+                stream(writeValues).map(AbstractTestParquetReader::intToSqlTimestamp).collect(toImmutableList()),
                 TIMESTAMP_MILLIS);
 
         tester.testRoundTrip(javaDateObjectInspector,
-                transform(writeValues, AbstractTestParquetReader::intToDate),
-                transform(writeValues, AbstractTestParquetReader::intToSqlDate),
+                stream(writeValues).map(AbstractTestParquetReader::intToDate).collect(toImmutableList()),
+                stream(writeValues).map(AbstractTestParquetReader::intToSqlDate).collect(toImmutableList()),
                 DATE);
     }
 
@@ -1510,14 +1511,14 @@ public abstract class AbstractTestParquetReader
     public void testStringDirectSequence()
             throws Exception
     {
-        tester.testRoundTrip(javaStringObjectInspector, transform(intsBetween(0, 30_000), Object::toString), createUnboundedVarcharType());
+        tester.testRoundTrip(javaStringObjectInspector, intsBetween(0, 30_000).stream().map(Object::toString).collect(toImmutableList()), createUnboundedVarcharType());
     }
 
     @Test
     public void testStringDictionarySequence()
             throws Exception
     {
-        tester.testRoundTrip(javaStringObjectInspector, limit(cycle(transform(ImmutableList.of(1, 3, 5, 7, 11, 13, 17), Object::toString)), 30_000), createUnboundedVarcharType());
+        tester.testRoundTrip(javaStringObjectInspector, limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17).stream().map(Object::toString).collect(toImmutableList())), 30_000), createUnboundedVarcharType());
     }
 
     @Test
@@ -1538,10 +1539,10 @@ public abstract class AbstractTestParquetReader
     public void testBinaryDirectSequence()
             throws Exception
     {
-        Iterable<byte[]> writeValues = transform(intsBetween(0, 30_000), compose(AbstractTestParquetReader::stringToByteArray, Object::toString));
+        List<byte[]> writeValues = intsBetween(0, 30_000).stream().map(compose(AbstractTestParquetReader::stringToByteArray, Object::toString)).collect(toImmutableList());
         tester.testRoundTrip(javaByteArrayObjectInspector,
                 writeValues,
-                transform(writeValues, AbstractTestParquetReader::byteArrayToVarbinary),
+                writeValues.stream().map(AbstractTestParquetReader::byteArrayToVarbinary).collect(toImmutableList()),
                 VARBINARY);
     }
 
@@ -1549,10 +1550,10 @@ public abstract class AbstractTestParquetReader
     public void testBinaryDictionarySequence()
             throws Exception
     {
-        Iterable<byte[]> writeValues = limit(cycle(transform(ImmutableList.of(1, 3, 5, 7, 11, 13, 17), compose(AbstractTestParquetReader::stringToByteArray, Object::toString))), 30_000);
+        Iterable<byte[]> writeValues = limit(cycle(ImmutableList.of(1, 3, 5, 7, 11, 13, 17).stream().map(compose(AbstractTestParquetReader::stringToByteArray, Object::toString)).collect(toImmutableList())), 30_000);
         tester.testRoundTrip(javaByteArrayObjectInspector,
                 writeValues,
-                transform(writeValues, AbstractTestParquetReader::byteArrayToVarbinary),
+                stream(writeValues).map(AbstractTestParquetReader::byteArrayToVarbinary).collect(toImmutableList()),
                 VARBINARY);
     }
 
@@ -1655,12 +1656,12 @@ public abstract class AbstractTestParquetReader
 
     private static Iterable<Float> floatSequence(double start, double step, int items)
     {
-        return transform(doubleSequence(start, step, items), input -> {
+        return stream(doubleSequence(start, step, items)).map(input -> {
             if (input == null) {
                 return null;
             }
             return input.floatValue();
-        });
+        }).collect(toImmutableList());
     }
 
     private static Iterable<Double> doubleSequence(double start, double step, int items)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -192,7 +192,7 @@ public class ParquetTester
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
     }
 
-    public void testRoundTrip(PrimitiveObjectInspector columnObjectInspector, Iterable<?> writeValues, Type parameterType)
+    public <T> void testRoundTrip(PrimitiveObjectInspector columnObjectInspector, Iterable<T> writeValues, Type parameterType)
             throws Exception
     {
         testRoundTrip(columnObjectInspector, writeValues, writeValues, parameterType);

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/ParquetTester.java
@@ -89,6 +89,7 @@ import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Functions.constant;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -118,7 +119,6 @@ import static io.trino.spi.type.VarbinaryType.VARBINARY;
 import static io.trino.spi.type.Varchars.truncateToLength;
 import static java.lang.Math.toIntExact;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Arrays.stream;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
@@ -361,7 +361,7 @@ public class ParquetTester
         for (CompressionCodecName compressionCodecName : writerCompressions) {
             for (ConnectorSession session : sessions) {
                 try (TempFile tempFile = new TempFile("test", "parquet")) {
-                    OptionalInt min = stream(writeValues).mapToInt(Iterables::size).min();
+                    OptionalInt min = Stream.of(writeValues).mapToInt(Iterables::size).min();
                     checkState(min.isPresent());
                     writeParquetColumnTrino(tempFile.getFile(), columnTypes, columnNames, getIterators(readValues), min.getAsInt(), compressionCodecName);
                     assertFileContents(
@@ -439,7 +439,7 @@ public class ParquetTester
                         expectedValues,
                         pageSource,
                         Optional.of(getParquetMaxReadBlockSize(session).toBytes()));
-                assertFalse(stream(expectedValues).allMatch(Iterator::hasNext));
+                assertFalse(Stream.of(expectedValues).allMatch(Iterator::hasNext));
             }
         }
     }
@@ -464,7 +464,7 @@ public class ParquetTester
             else {
                 assertPageSource(columnTypes, expectedValues, pageSource);
             }
-            assertFalse(stream(expectedValues).allMatch(Iterator::hasNext));
+            assertFalse(Stream.of(expectedValues).allMatch(Iterator::hasNext));
         }
     }
 
@@ -602,7 +602,7 @@ public class ParquetTester
                         () -> {});
         Object row = objectInspector.create();
         List<StructField> fields = ImmutableList.copyOf(objectInspector.getAllStructFieldRefs());
-        while (stream(valuesByField).allMatch(Iterator::hasNext)) {
+        while (Stream.of(valuesByField).allMatch(Iterator::hasNext)) {
             for (int field = 0; field < fields.size(); field++) {
                 Object value = valuesByField[field].next();
                 objectInspector.setStructFieldData(row, fields.get(field), value);
@@ -655,21 +655,21 @@ public class ParquetTester
 
     private static Iterator<?>[] getIterators(Iterable<?>[] values)
     {
-        return stream(values)
+        return Stream.of(values)
                 .map(Iterable::iterator)
                 .toArray(Iterator<?>[]::new);
     }
 
     private Iterable<?>[] transformToNulls(Iterable<?>[] values)
     {
-        return stream(values)
+        return Stream.of(values)
                 .map(v -> transform(v, constant(null)))
                 .toArray(Iterable<?>[]::new);
     }
 
     private static Iterable<?>[] reverse(Iterable<?>[] iterables)
     {
-        return stream(iterables)
+        return Stream.of(iterables)
                 .map(ImmutableList::copyOf)
                 .map(Lists::reverse)
                 .toArray(Iterable<?>[]::new);
@@ -677,7 +677,7 @@ public class ParquetTester
 
     private static Iterable<?>[] insertNullEvery(int n, Iterable<?>[] iterables)
     {
-        return stream(iterables)
+        return Stream.of(iterables)
                 .map(itr -> insertNullEvery(n, itr))
                 .toArray(Iterable<?>[]::new);
     }

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDecimalScaling.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/parquet/TestParquetDecimalScaling.java
@@ -52,7 +52,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Iterables.transform;
 import static io.trino.plugin.hive.parquet.TestParquetDecimalScaling.ParquetDecimalInsert.maximumValue;
 import static io.trino.plugin.hive.parquet.TestParquetDecimalScaling.ParquetDecimalInsert.minimumValue;
 import static io.trino.spi.type.Decimals.overflows;
@@ -63,6 +62,7 @@ import static java.lang.Integer.MAX_VALUE;
 import static java.lang.String.format;
 import static java.math.RoundingMode.UNNECESSARY;
 import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaIntObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaLongObjectInspector;
@@ -499,7 +499,7 @@ public class TestParquetDecimalScaling
     {
         Properties tableProperties = new Properties();
         tableProperties.setProperty("columns", Joiner.on(',').join(columnNames));
-        tableProperties.setProperty("columns.types", Joiner.on(',').join(transform(objectInspectors, ObjectInspector::getTypeName)));
+        tableProperties.setProperty("columns.types", objectInspectors.stream().map(ObjectInspector::getTypeName).collect(joining(",")));
         return tableProperties;
     }
 

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -19,7 +19,6 @@ import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import io.airlift.json.JsonCodec;
 import io.airlift.slice.Slice;
 import io.trino.plugin.base.classloader.ClassLoaderSafeSystemTable;
@@ -97,6 +96,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Streams.stream;
 import static io.trino.plugin.hive.HiveApplyProjectionUtil.extractSupportedProjectedColumns;
 import static io.trino.plugin.hive.HiveApplyProjectionUtil.replaceWithNewVariables;
 import static io.trino.plugin.hive.util.HiveUtil.isStructuralType;
@@ -283,7 +283,7 @@ public class IcebergMetadata
 
             Iterable<FileScanTask> files = () -> lazyFiles.get().iterator();
 
-            Iterable<TupleDomain<ColumnHandle>> discreteTupleDomain = Iterables.transform(files, fileScan -> {
+            Iterable<TupleDomain<ColumnHandle>> discreteTupleDomain = () -> stream(files).map(fileScan -> {
                 // Extract partition values in the data file
                 Map<Integer, Optional<String>> partitionColumnValueStrings = getPartitionKeys(fileScan);
                 Map<ColumnHandle, NullableValue> partitionValues = partitionSourceIds.stream()
@@ -301,7 +301,7 @@ public class IcebergMetadata
                                 }));
 
                 return TupleDomain.fromFixedValues(partitionValues);
-            });
+            }).iterator();
 
             discretePredicates = new DiscretePredicates(
                     columns.values().stream()

--- a/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxTableHandle.java
+++ b/plugin/trino-jmx/src/main/java/io/trino/plugin/jmx/JmxTableHandle.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public class JmxTableHandle
@@ -125,6 +125,6 @@ public class JmxTableHandle
     {
         return new ConnectorTableMetadata(
                 tableName,
-                ImmutableList.copyOf(transform(columnHandles, JmxColumnHandle::getColumnMetadata)));
+                columnHandles.stream().map(JmxColumnHandle::getColumnMetadata).collect(toImmutableList()));
     }
 }

--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
@@ -46,7 +46,7 @@ import java.util.function.Function;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.MoreCollectors.toOptional;
 import static io.trino.plugin.kafka.KafkaErrorCode.KAFKA_SPLIT_ERROR;
 import static io.trino.plugin.kafka.KafkaInternalFieldManager.OFFSET_TIMESTAMP_FIELD;
 import static io.trino.plugin.kafka.KafkaInternalFieldManager.PARTITION_ID_FIELD;
@@ -174,7 +174,7 @@ public class KafkaFilterManager
     {
         final long transferTimestamp = floorDiv(timestamp, MICROSECONDS_PER_MILLISECOND);
         Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsets = kafkaConsumer.offsetsForTimes(ImmutableMap.of(topicPartition, transferTimestamp));
-        return Optional.ofNullable(getOnlyElement(topicPartitionOffsets.values(), null)).map(OffsetAndTimestamp::offset);
+        return topicPartitionOffsets.values().stream().collect(toOptional()).map(OffsetAndTimestamp::offset);
     }
 
     private static Map<TopicPartition, Long> overridePartitionBeginOffsets(Map<TopicPartition, Long> partitionBeginOffsets,

--- a/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardManager.java
+++ b/plugin/trino-raptor-legacy/src/main/java/io/trino/plugin/raptor/legacy/metadata/DatabaseShardManager.java
@@ -20,7 +20,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.airlift.log.Logger;
@@ -59,6 +58,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
@@ -890,7 +890,7 @@ public class DatabaseShardManager
     {
         List<T> list = new ArrayList<>(collection);
         Collections.shuffle(list);
-        return Iterables.cycle(list).iterator();
+        return Stream.generate(() -> list).flatMap(List::stream).iterator();
     }
 
     private static ShardStats shardStats(Collection<ShardInfo> shards)

--- a/pom.xml
+++ b/pom.xml
@@ -1675,8 +1675,6 @@
                             <!-- getLast has lower complexity for array based lists than the stream analogue (O(1) vs O(log(N)) -->
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
-                            <!-- TODO: requires getting to common understanding which of those we want to enable -->
-                            <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
                         </exclusions>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1677,7 +1677,6 @@
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
                             <!-- TODO: requires getting to common understanding which of those we want to enable -->
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.getOnlyElement:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
                         </exclusions>
                     </configuration>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1680,8 +1680,6 @@
                             <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.all:(Ljava/lang/Iterable;Lcom/google/common/base/Predicate;)Z</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.any:(Ljava/lang/Iterable;Lcom/google/common/base/Predicate;)Z</exclusion>
                             <exclusion>com/google/common/collect/Iterables.skip:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.limit:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.get:(Ljava/lang/Iterable;I)Ljava/lang/Object;</exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1686,7 +1686,6 @@
                             <exclusion>com/google/common/collect/Iterables.skip:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.limit:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.get:(Ljava/lang/Iterable;I)Ljava/lang/Object;</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.getFirst:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.cycle:(Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.cycle:([Ljava/lang/Object;)Ljava/lang/Iterable;</exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1678,7 +1678,6 @@
                             <!-- TODO: requires getting to common understanding which of those we want to enable -->
                             <exclusion>com/google/common/collect/Iterables.skip:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.limit:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.get:(Ljava/lang/Iterable;I)Ljava/lang/Object;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.cycle:(Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.cycle:([Ljava/lang/Object;)Ljava/lang/Iterable;</exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1676,7 +1676,6 @@
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
                             <!-- TODO: requires getting to common understanding which of those we want to enable -->
-                            <exclusion>com/google/common/collect/Iterables.isEmpty:(Ljava/lang/Iterable;)Z</exclusion>
                             <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1676,11 +1676,7 @@
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
                             <!-- TODO: requires getting to common understanding which of those we want to enable -->
-                            <exclusion>com/google/common/collect/Iterables.skip:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.limit:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.cycle:(Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.cycle:([Ljava/lang/Object;)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.getOnlyElement:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
                         </exclusions>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1676,10 +1676,6 @@
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
                             <!-- TODO: requires getting to common understanding which of those we want to enable -->
-                            <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
-                            <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.skip:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.limit:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.get:(Ljava/lang/Iterable;I)Ljava/lang/Object;</exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1676,8 +1676,6 @@
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
                             <!-- TODO: requires getting to common understanding which of those we want to enable -->
-                            <exclusion>com/google/common/collect/Iterables.transform:(Ljava/lang/Iterable;Lcom/google/common/base/Function;)Ljava/lang/Iterable;</exclusion>
-                            <exclusion>com/google/common/collect/Lists.transform:(Ljava/util/List;Lcom/google/common/base/Function;)Ljava/util/List;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.isEmpty:(Ljava/lang/Iterable;)Z</exclusion>
                             <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
                             <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>

--- a/service/trino-verifier/src/main/java/io/trino/verifier/Validator.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/Validator.java
@@ -629,10 +629,10 @@ public class Validator
         Multiset<List<Object>> test = ImmutableSortedMultiset.copyOf(rowComparator(precision), testResults);
 
         try {
-            Iterable<ChangedRow> diff = ImmutableSortedMultiset.<ChangedRow>naturalOrder()
-                    .addAll(Iterables.transform(Multisets.difference(control, test), row -> new ChangedRow(Changed.REMOVED, row, precision)))
-                    .addAll(Iterables.transform(Multisets.difference(test, control), row -> new ChangedRow(Changed.ADDED, row, precision)))
-                    .build();
+            ImmutableSortedMultiset.Builder<ChangedRow> builder = ImmutableSortedMultiset.naturalOrder();
+            Multisets.difference(control, test).stream().map(row -> new ChangedRow(Changed.REMOVED, row, precision)).forEach(builder::add);
+            Multisets.difference(test, control).stream().map(row -> new ChangedRow(Changed.ADDED, row, precision)).forEach(builder::add);
+            Iterable<ChangedRow> diff = builder.build();
             diff = Iterables.limit(diff, 100);
 
             StringBuilder sb = new StringBuilder();

--- a/service/trino-verifier/src/main/java/io/trino/verifier/Validator.java
+++ b/service/trino-verifier/src/main/java/io/trino/verifier/Validator.java
@@ -19,7 +19,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMultiset;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multisets;
 import com.google.common.collect.Ordering;
@@ -56,6 +55,7 @@ import java.util.function.Function;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.verifier.QueryResult.State;
 import static java.lang.Double.isFinite;
@@ -632,8 +632,7 @@ public class Validator
             ImmutableSortedMultiset.Builder<ChangedRow> builder = ImmutableSortedMultiset.naturalOrder();
             Multisets.difference(control, test).stream().map(row -> new ChangedRow(Changed.REMOVED, row, precision)).forEach(builder::add);
             Multisets.difference(test, control).stream().map(row -> new ChangedRow(Changed.ADDED, row, precision)).forEach(builder::add);
-            Iterable<ChangedRow> diff = builder.build();
-            diff = Iterables.limit(diff, 100);
+            Iterable<ChangedRow> diff = builder.build().stream().limit(100).collect(toImmutableList());
 
             StringBuilder sb = new StringBuilder();
 

--- a/testing/trino-benchmark/src/main/java/io/trino/benchmark/AbstractOperatorBenchmark.java
+++ b/testing/trino-benchmark/src/main/java/io/trino/benchmark/AbstractOperatorBenchmark.java
@@ -15,7 +15,6 @@ package io.trino.benchmark;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import io.airlift.stats.CpuTimer;
 import io.airlift.stats.TestingGcMonitor;
 import io.airlift.units.DataSize;
@@ -257,7 +256,10 @@ public abstract class AbstractOperatorBenchmark
                 operatorId,
                 planNodeId,
                 () -> new PageProcessor(Optional.empty(), projections.build()),
-                ImmutableList.copyOf(Iterables.concat(types, ImmutableList.of(BIGINT))),
+                ImmutableList.<Type>builder()
+                        .addAll(types)
+                        .add(BIGINT)
+                        .build(),
                 getFilterAndProjectMinOutputPageSize(session),
                 getFilterAndProjectMinOutputPageRowCount(session));
     }

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/SuiteTestRun.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/suite/SuiteTestRun.java
@@ -18,7 +18,6 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import io.trino.tests.product.launcher.env.EnvironmentConfig;
 import io.trino.tests.product.launcher.env.EnvironmentProvider;
 
@@ -26,9 +25,11 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.tests.product.launcher.Configurations.nameForEnvironmentClass;
 import static java.lang.System.getenv;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Stream.concat;
 
 public class SuiteTestRun
 {
@@ -141,7 +142,7 @@ public class SuiteTestRun
 
     private static List<String> merge(List<String> first, List<String> second)
     {
-        return ImmutableList.copyOf(Iterables.concat(first, second));
+        return concat(first.stream(), second.stream()).collect(toImmutableList());
     }
 
     @Override

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/utils/QueryAssertions.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/utils/QueryAssertions.java
@@ -13,14 +13,14 @@
  */
 package io.trino.tests.product.utils;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Iterables;
 import io.airlift.units.Duration;
 import io.trino.tempto.query.QueryResult;
 
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
 import static org.testng.Assert.fail;
 
 public final class QueryAssertions
@@ -60,9 +60,9 @@ public final class QueryAssertions
                 fail(format("expected row missing: %s\nAll %s rows:\n    %s\nExpected subset %s rows:\n    %s\n",
                         row,
                         all.getRowsCount(),
-                        Joiner.on("\n    ").join(Iterables.limit(all.rows(), 100)),
+                        all.rows().stream().limit(100).map(Object::toString).collect(joining("\n    ")),
                         expectedSubset.getRowsCount(),
-                        Joiner.on("\n    ").join(Iterables.limit(expectedSubset.rows(), 100))));
+                        expectedSubset.rows().stream().limit(100).map(Object::toString).collect(Collectors.joining("\n    "))));
             }
         }
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/QueryAssertions.java
@@ -13,10 +13,8 @@
  */
 package io.trino.testing;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMultiset;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multisets;
 import io.airlift.log.Logger;
@@ -37,12 +35,14 @@ import java.util.OptionalLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static com.google.common.collect.Streams.stream;
 import static io.airlift.units.Duration.nanosSince;
 import static io.trino.testing.assertions.Assert.assertEventually;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -242,11 +242,11 @@ public final class QueryAssertions
                     limit,
                     unexpectedRows.size(),
                     actualSet.size(),
-                    Joiner.on("\n    ").join(Iterables.limit(unexpectedRows, limit)),
+                    unexpectedRows.stream().limit(limit).map(Object::toString).collect(joining("\n    ")),
                     limit,
                     missingRows.size(),
                     expectedSet.size(),
-                    Joiner.on("\n    ").join(Iterables.limit(missingRows, limit))));
+                    missingRows.stream().limit(limit).map(Object::toString).collect(joining("\n    "))));
         }
     }
 
@@ -262,9 +262,9 @@ public final class QueryAssertions
                 fail(format("expected row missing: %s\nAll %s rows:\n    %s\nExpected subset %s rows:\n    %s\n",
                         row,
                         all.getMaterializedRows().size(),
-                        Joiner.on("\n    ").join(Iterables.limit(all, 100)),
+                        stream(all).limit(100).map(Object::toString).collect(joining("\n    ")),
                         expectedSubset.getMaterializedRows().size(),
-                        Joiner.on("\n    ").join(Iterables.limit(expectedSubset, 100))));
+                        stream(expectedSubset).limit(100).map(Object::toString).collect(joining("\n    "))));
             }
         }
     }

--- a/testing/trino-testing/src/main/java/io/trino/testing/tpch/ConcatRecordSet.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/tpch/ConcatRecordSet.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkPositionIndex;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.Iterables.transform;
+import static com.google.common.collect.Streams.stream;
 import static java.util.Objects.requireNonNull;
 
 class ConcatRecordSet
@@ -53,8 +53,8 @@ class ConcatRecordSet
         // NOTE: the ConcatRecordCursor implementation relies on the fact that the
         // cursor creation in the Iterable is lazy so DO NOT materialize this into
         // an ImmutableList
-        Iterable<RecordCursor> recordCursors = transform(recordSets, RecordSet::cursor);
-        return new ConcatRecordCursor(recordCursors.iterator(), types);
+        Iterator<RecordCursor> recordCursorsIterator = stream(recordSets).map(RecordSet::cursor).iterator();
+        return new ConcatRecordCursor(recordCursorsIterator, types);
     }
 
     private static class ConcatRecordCursor


### PR DESCRIPTION
The new version of modernizr introduced by the latest version of Airbase prohibits usage of `Iterables` methods in favor of the Java Stream API. 

While the `Iterables` utilities are not technically deprecated, guava developers "gently encourage the migration": https://github.com/google/guava/commit/6b20d80ef7c21dcef3778d43ee54e7a7e9dec881#diff-08784dc2cc9548f6c056e199e0b9c188a59645275f25d58c4f080091be105a20R45