### PR TITLE
Remove `skip_on_cdh` test group

### DIFF
--- a/plugin/trino-hive-hadoop2/conf/hive-tests-config-cdh5.sh
+++ b/plugin/trino-hive-hadoop2/conf/hive-tests-config-cdh5.sh
@@ -1,2 +1,1 @@
 export HADOOP_BASE_IMAGE="ghcr.io/trinodb/testing/cdh5.15-hive"
-export DISTRO_SKIP_GROUP=skip_on_cdh

--- a/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/configs/ConfigCdh5.java
+++ b/testing/trino-product-tests-launcher/src/main/java/io/trino/tests/product/launcher/env/configs/ConfigCdh5.java
@@ -22,7 +22,6 @@ public class ConfigCdh5
 {
     /**
      * export HADOOP_BASE_IMAGE="ghcr.io/trinodb/testing/cdh5.15-hive"
-     * export DISTRO_SKIP_GROUP=skip_on_cdh,iceberg
      */
     @Override
     public String getHadoopBaseImage()
@@ -31,8 +30,19 @@ public class ConfigCdh5
     }
 
     @Override
-    public List<String> getExcludedGroups()
+    public List<String> getExcludedTests()
     {
-        return ImmutableList.of("skip_on_cdh");
+        return ImmutableList.copyOf(new String[] {
+                // CDH 5's Avro does not support date type
+                "io.trino.tests.product.hive.TestAllDatatypesFromHiveConnector.testSelectAllDatatypesAvro",
+
+                // CDH 5 metastore automatically gathers raw data size statistics on its own
+                "io.trino.tests.product.hive.TestHiveBasicTableStatistics.testCreateExternalUnpartitioned",
+                "io.trino.tests.product.hive.TestHiveBasicTableStatistics.testAnalyzePartitioned",
+
+                //  CDH 5 image has no lzo support
+                "io.trino.tests.product.hive.TestHiveCompression.testReadTextfileWithLzop",
+                "io.trino.tests.product.hive.TestHiveCompression.testReadSequencefileWithLzo"
+        });
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/TestGroups.java
@@ -57,7 +57,6 @@ public final class TestGroups
     public static final String LDAP_CLI = "ldap_cli";
     public static final String LDAP_AND_FILE_CLI = "ldap_and_file_cli";
     public static final String LDAP_MULTIPLE_BINDS = "ldap_multiple_binds";
-    public static final String SKIP_ON_CDH = "skip_on_cdh";
     public static final String HDP3_ONLY = "hdp3_only";
     public static final String TLS = "tls";
     public static final String ROLES = "roles";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAllDatatypesFromHiveConnector.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAllDatatypesFromHiveConnector.java
@@ -39,7 +39,6 @@ import static io.trino.tempto.fulfillment.table.TableHandle.tableHandle;
 import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable;
 import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.JDBC;
-import static io.trino.tests.product.TestGroups.SKIP_ON_CDH;
 import static io.trino.tests.product.TestGroups.SMOKE;
 import static io.trino.tests.product.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_AVRO;
 import static io.trino.tests.product.hive.AllSimpleTypesTableDefinitions.ALL_HIVE_SIMPLE_TYPES_ORC;
@@ -215,7 +214,7 @@ public class TestAllDatatypesFromHiveConnector
     }
 
     @Requires(AvroRequirements.class)
-    @Test(groups = {JDBC, SKIP_ON_CDH /* CDH 5's Avro does not support date type */})
+    @Test(groups = JDBC)
     public void testSelectAllDatatypesAvro()
     {
         String tableName = mutableTableInstanceOf(ALL_HIVE_SIMPLE_TYPES_AVRO).getNameInDatabase();

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBasicTableStatistics.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveBasicTableStatistics.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.OptionalLong;
 
 import static com.google.common.base.Verify.verify;
-import static io.trino.tests.product.TestGroups.SKIP_ON_CDH;
 import static io.trino.tests.product.hive.HiveProductTest.ERROR_COMMITTING_WRITE_TO_HIVE_ISSUE;
 import static io.trino.tests.product.hive.HiveProductTest.ERROR_COMMITTING_WRITE_TO_HIVE_MATCH;
 import static io.trino.tests.product.hive.util.TableLocationUtils.getTableLocation;
@@ -59,7 +58,7 @@ public class TestHiveBasicTableStatistics
         }
     }
 
-    @Test(groups = SKIP_ON_CDH /* CDH 5 metastore automatically gathers raw data size statistics on its own */)
+    @Test
     public void testCreateExternalUnpartitioned()
     {
         String tableName = "test_basic_statistics_external_unpartitioned_presto";
@@ -176,7 +175,7 @@ public class TestHiveBasicTableStatistics
         }
     }
 
-    @Test(groups = SKIP_ON_CDH /* CDH 5 metastore automatically gathers raw data size statistics on its own */)
+    @Test
     public void testAnalyzePartitioned()
     {
         String tableName = "test_basic_statistics_analyze_partitioned";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompression.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveCompression.java
@@ -26,7 +26,6 @@ import static io.trino.tempto.fulfillment.table.TableRequirements.immutableTable
 import static io.trino.tempto.fulfillment.table.hive.tpch.TpchTableDefinitions.ORDERS;
 import static io.trino.tempto.query.QueryExecutor.query;
 import static io.trino.tests.product.TestGroups.HIVE_COMPRESSION;
-import static io.trino.tests.product.TestGroups.SKIP_ON_CDH;
 import static io.trino.tests.product.utils.QueryExecutors.onHive;
 import static io.trino.tests.product.utils.QueryExecutors.onTrino;
 import static java.lang.String.format;
@@ -42,7 +41,7 @@ public class TestHiveCompression
         return immutableTable(ORDERS);
     }
 
-    @Test(groups = {HIVE_COMPRESSION, SKIP_ON_CDH /* no lzo support in CDH image */})
+    @Test(groups = HIVE_COMPRESSION)
     public void testReadTextfileWithLzop()
     {
         testReadCompressedTextfileTable(
@@ -51,7 +50,7 @@ public class TestHiveCompression
                 ".*\\.lzo"); // LZOP compression uses .lzo file extension by default
     }
 
-    @Test(groups = {HIVE_COMPRESSION, SKIP_ON_CDH /* no lzo support in CDH image */})
+    @Test(groups = HIVE_COMPRESSION)
     public void testReadSequencefileWithLzo()
     {
         testReadCompressedTextfileTable(


### PR DESCRIPTION
The main purpose of the test group 'skip_on_cdh' was
to exclude specific product tests from the test suites
executed on CDH 5.
The information about the excluded tests has been moved
now to `io.trino.tests.product.launcher.env.configs.ConfigCdh5.getExcludedTests`