### PR TITLE
Replace deprecated Guava method createTempDir

### DIFF
--- a/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkOrcDecimalReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/BenchmarkOrcDecimalReader.java
@@ -35,12 +35,12 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.jmh.Benchmarks.benchmark;
@@ -51,6 +51,7 @@ import static io.trino.orc.OrcTester.READER_OPTIONS;
 import static io.trino.orc.OrcTester.writeOrcColumnHive;
 import static io.trino.orc.metadata.CompressionKind.NONE;
 import static io.trino.spi.type.DecimalType.createDecimalType;
+import static java.nio.file.Files.createTempDirectory;
 import static java.util.UUID.randomUUID;
 
 @SuppressWarnings("MethodMayBeStatic")
@@ -88,15 +89,15 @@ public class BenchmarkOrcDecimalReader
     @State(Scope.Thread)
     public static class BenchmarkData
     {
-        private File temporary;
+        private Path temporary;
         private File dataPath;
 
         @Setup
         public void setup()
                 throws Exception
         {
-            temporary = createTempDir();
-            dataPath = new File(temporary, randomUUID().toString());
+            temporary = createTempDirectory(null);
+            dataPath = temporary.resolve(randomUUID().toString()).toFile();
 
             writeOrcColumnHive(dataPath, ORC_12, NONE, DECIMAL_TYPE, createDecimalValues().iterator());
         }
@@ -105,7 +106,7 @@ public class BenchmarkOrcDecimalReader
         public void tearDown()
                 throws IOException
         {
-            deleteRecursively(temporary.toPath(), ALLOW_INSECURE);
+            deleteRecursively(temporary, ALLOW_INSECURE);
         }
 
         private OrcRecordReader createRecordReader()

--- a/lib/trino-orc/src/test/java/io/trino/orc/TempFile.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TempFile.java
@@ -16,21 +16,23 @@ package io.trino.orc;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.nio.file.Files.createTempDirectory;
 
 class TempFile
         implements Closeable
 {
-    private final File tempDir;
+    private final Path tempDir;
     private final File file;
 
     public TempFile()
+            throws IOException
     {
-        tempDir = createTempDir();
-        file = new File(tempDir, "data.orc");
+        tempDir = createTempDirectory(null);
+        file = tempDir.resolve("data.orc").toFile();
     }
 
     public File getFile()
@@ -43,6 +45,6 @@ class TempFile
             throws IOException
     {
         // hadoop creates crc files that must be deleted also, so just delete the whole directory
-        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+        deleteRecursively(tempDir, ALLOW_INSECURE);
     }
 }

--- a/lib/trino-orc/src/test/java/io/trino/orc/TestStructColumnReader.java
+++ b/lib/trino-orc/src/test/java/io/trino/orc/TestStructColumnReader.java
@@ -65,6 +65,7 @@ public class TestStructColumnReader
 
     @BeforeMethod
     public void setUp()
+            throws IOException
     {
         tempFile = new TempFile();
     }

--- a/lib/trino-rcfile/src/test/java/io/trino/rcfile/RcFileTester.java
+++ b/lib/trino-rcfile/src/test/java/io/trino/rcfile/RcFileTester.java
@@ -115,7 +115,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import static com.google.common.base.Functions.constant;
 import static com.google.common.collect.Iterables.transform;
 import static com.google.common.collect.Iterators.advance;
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
@@ -148,6 +147,7 @@ import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.type.DateTimes.MICROSECONDS_PER_MILLISECOND;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.Math.toIntExact;
+import static java.nio.file.Files.createTempDirectory;
 import static java.util.Collections.nCopies;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_COLUMNS;
@@ -1091,13 +1091,14 @@ public class RcFileTester
     private static class TempFile
             implements Closeable
     {
-        private final File tempDir;
+        private final java.nio.file.Path tempDir;
         private final File file;
 
         private TempFile()
+                throws IOException
         {
-            tempDir = createTempDir();
-            file = new File(tempDir, "data.rcfile");
+            tempDir = createTempDirectory(null);
+            file = tempDir.resolve("data.rcfile").toFile();
         }
 
         public File getFile()
@@ -1110,7 +1111,7 @@ public class RcFileTester
                 throws IOException
         {
             // hadoop creates crc files that must be deleted also, so just delete the whole directory
-            deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+            deleteRecursively(tempDir, ALLOW_INSECURE);
         }
     }
 

--- a/plugin/trino-atop/src/test/java/io/trino/plugin/atop/TestAtopHang.java
+++ b/plugin/trino-atop/src/test/java/io/trino/plugin/atop/TestAtopHang.java
@@ -25,11 +25,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.Resources.toByteArray;
 import static io.trino.plugin.atop.AtopErrorCode.ATOP_READ_TIMEOUT;
 import static io.trino.plugin.atop.LocalAtopQueryRunner.createQueryRunner;
 import static io.trino.testing.assertions.TrinoExceptionAssert.assertTrinoExceptionThrownBy;
+import static java.nio.file.Files.createTempDirectory;
 
 public class TestAtopHang
 {
@@ -39,8 +39,8 @@ public class TestAtopHang
     public void setUp()
             throws Exception
     {
-        File tempPath = createTempDir();
-        copyExecutable("hanging_atop.sh", tempPath);
+        Path tempPath = createTempDirectory(null);
+        copyExecutable("hanging_atop.sh", tempPath.toFile());
         queryRunner = createQueryRunner(ImmutableMap.of("atop.executable-path", tempPath + "/hanging_atop.sh", "atop.executable-read-timeout", "1s"), AtopProcessFactory.class);
     }
 

--- a/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
+++ b/plugin/trino-cassandra/src/test/java/io/trino/plugin/cassandra/CassandraServer.java
@@ -27,17 +27,17 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import static com.datastax.driver.core.ProtocolVersion.V3;
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.Files.write;
 import static com.google.common.io.Resources.getResource;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createDirectory;
+import static java.nio.file.Files.createTempDirectory;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
@@ -103,18 +103,17 @@ public class CassandraServer
     {
         String original = Resources.toString(getResource("cu-cassandra.yaml"), UTF_8);
 
-        File tempDirFile = createTempDir();
-        tempDirFile.deleteOnExit();
-        Path tmpDirPath = tempDirFile.toPath();
+        Path tmpDirPath = createTempDirectory(null);
         Path dataDir = tmpDirPath.resolve("data");
-        Files.createDirectory(dataDir);
+        createDirectory(dataDir);
 
         String modified = original.replaceAll("\\$\\{data_directory\\}", dataDir.toAbsolutePath().toString());
 
-        Path yamlLocation = tmpDirPath.resolve("cu-cassandra.yaml");
-        write(modified, yamlLocation.toFile(), UTF_8);
+        File yamlFile = tmpDirPath.resolve("cu-cassandra.yaml").toFile();
+        yamlFile.deleteOnExit();
+        write(modified, yamlFile, UTF_8);
 
-        return yamlLocation.toAbsolutePath().toString();
+        return yamlFile.getAbsolutePath();
     }
 
     public CassandraSession getSession()

--- a/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
+++ b/plugin/trino-elasticsearch/src/test/java/io/trino/plugin/elasticsearch/ElasticsearchServer.java
@@ -23,10 +23,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createTempDirectory;
 import static org.testcontainers.utility.MountableFile.forHostPath;
 
 public class ElasticsearchServer
@@ -48,7 +48,7 @@ public class ElasticsearchServer
         container.withNetwork(network);
         container.withNetworkAliases("elasticsearch-server");
 
-        configurationPath = createTempDir().toPath();
+        configurationPath = createTempDirectory(null);
         for (Map.Entry<String, String> entry : configurationFiles.entrySet()) {
             String name = entry.getKey();
             String contents = entry.getValue();

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
@@ -94,7 +94,6 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.Sets.intersection;
 import static com.google.common.io.Files.asCharSink;
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.FeaturesConfig.JoinDistributionType.BROADCAST;
@@ -154,6 +153,7 @@ import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createTempDirectory;
 import static java.util.Collections.nCopies;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -3789,14 +3789,14 @@ public class TestHiveConnectorTest
             List<String> tableProperties)
             throws Exception
     {
-        File tempDir = createTempDir();
-        File dataFile = new File(tempDir, "test.txt");
+        java.nio.file.Path tempDir = createTempDirectory(null);
+        File dataFile = tempDir.resolve("test.txt").toFile();
         Files.asCharSink(dataFile, UTF_8).write(fileContents);
 
         // Table properties
         StringJoiner propertiesSql = new StringJoiner(",\n   ");
         propertiesSql.add(
-                format("external_location = '%s'", new Path(tempDir.toURI().toASCIIString())));
+                format("external_location = '%s'", new Path(tempDir.toUri().toASCIIString())));
         propertiesSql.add("format = 'TEXTFILE'");
         tableProperties.forEach(propertiesSql::add);
 
@@ -3820,7 +3820,7 @@ public class TestHiveConnectorTest
         assertQuery(format("SELECT col1, col2 from %s", tableName), expectedResults);
         assertUpdate(format("DROP TABLE %s", tableName));
         assertFile(dataFile); // file should still exist after drop
-        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+        deleteRecursively(tempDir, ALLOW_INSECURE);
     }
 
     @Test
@@ -3873,16 +3873,16 @@ public class TestHiveConnectorTest
     public void testCreateExternalTableWithDataNotAllowed()
             throws IOException
     {
-        File tempDir = createTempDir();
+        java.nio.file.Path tempDir = createTempDirectory(null);
 
         @Language("SQL") String createTableSql = format("" +
                         "CREATE TABLE test_create_external_with_data_not_allowed " +
                         "WITH (external_location = '%s') AS " +
                         "SELECT * FROM tpch.tiny.nation",
-                tempDir.toURI().toASCIIString());
+                tempDir.toUri().toASCIIString());
 
         assertQueryFails(createTableSql, "Writes to non-managed Hive tables is disabled");
-        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+        deleteRecursively(tempDir, ALLOW_INSECURE);
     }
 
     private void testCreateTableWithHeaderAndFooter(String format)

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCreateExternalTableDisabled.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveCreateExternalTableDisabled.java
@@ -20,14 +20,14 @@ import io.trino.testing.QueryRunner;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
-import java.io.File;
+import java.nio.file.Path;
 
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.tpch.TpchTable.CUSTOMER;
 import static io.trino.tpch.TpchTable.ORDERS;
 import static java.lang.String.format;
+import static java.nio.file.Files.createTempDirectory;
 
 public class TestHiveCreateExternalTableDisabled
         extends AbstractTestQueryFramework
@@ -48,30 +48,30 @@ public class TestHiveCreateExternalTableDisabled
     public void testCreateExternalTableWithData()
             throws Exception
     {
-        File tempDir = createTempDir();
+        Path tempDir = createTempDirectory(null);
 
         @Language("SQL") String createTableSql = format("" +
                         "CREATE TABLE test_create_external " +
                         "WITH (external_location = '%s') AS " +
                         "SELECT * FROM tpch.tiny.nation",
-                tempDir.toURI().toASCIIString());
+                tempDir.toUri().toASCIIString());
         assertQueryFails(createTableSql, "Creating non-managed Hive tables is disabled");
 
-        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+        deleteRecursively(tempDir, ALLOW_INSECURE);
     }
 
     @Test
     public void testCreateExternalTable()
             throws Exception
     {
-        File tempDir = createTempDir();
+        Path tempDir = createTempDirectory(null);
 
         @Language("SQL") String createTableSql = format("" +
                         "CREATE TABLE test_create_external (n TINYINT) " +
                         "WITH (external_location = '%s')",
-                tempDir.toURI().toASCIIString());
+                tempDir.toUri().toASCIIString());
         assertQueryFails(createTableSql, "Cannot create non-managed Hive table");
 
-        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+        deleteRecursively(tempDir, ALLOW_INSECURE);
     }
 }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/AbstractTestBackupStore.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/AbstractTestBackupStore.java
@@ -17,6 +17,7 @@ import com.google.common.io.Files;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -28,7 +29,7 @@ import static org.testng.Assert.assertTrue;
 
 public abstract class AbstractTestBackupStore<T extends BackupStore>
 {
-    protected File temporary;
+    protected Path temporary;
     protected T store;
 
     @Test
@@ -36,7 +37,7 @@ public abstract class AbstractTestBackupStore<T extends BackupStore>
             throws Exception
     {
         // backup first file
-        File file1 = new File(temporary, "file1");
+        File file1 = temporary.resolve("file1").toFile();
         Files.write("hello world", file1, UTF_8);
         UUID uuid1 = randomUUID();
 
@@ -45,7 +46,7 @@ public abstract class AbstractTestBackupStore<T extends BackupStore>
         assertTrue(store.shardExists(uuid1));
 
         // backup second file
-        File file2 = new File(temporary, "file2");
+        File file2 = temporary.resolve("file2").toFile();
         Files.write("bye bye", file2, UTF_8);
         UUID uuid2 = randomUUID();
 
@@ -54,12 +55,12 @@ public abstract class AbstractTestBackupStore<T extends BackupStore>
         assertTrue(store.shardExists(uuid2));
 
         // verify first file
-        File restore1 = new File(temporary, "restore1");
+        File restore1 = temporary.resolve("restore1").toFile();
         store.restoreShard(uuid1, restore1);
         assertEquals(readAllBytes(file1.toPath()), readAllBytes(restore1.toPath()));
 
         // verify second file
-        File restore2 = new File(temporary, "restore2");
+        File restore2 = temporary.resolve("restore2").toFile();
         store.restoreShard(uuid2, restore2);
         assertEquals(readAllBytes(file2.toPath()), readAllBytes(restore2.toPath()));
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/TestBackupManager.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/TestBackupManager.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -32,12 +33,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.raptor.legacy.RaptorErrorCode.RAPTOR_BACKUP_CORRUPTION;
 import static io.trino.plugin.raptor.legacy.RaptorErrorCode.RAPTOR_BACKUP_ERROR;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.createTempDirectory;
 import static java.util.Objects.requireNonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -52,21 +53,22 @@ public class TestBackupManager
     private static final UUID FAILURE_UUID = randomUUID();
     private static final UUID CORRUPTION_UUID = randomUUID();
 
-    private File temporary;
+    private Path temporary;
     private BackupStore backupStore;
     private FileStorageService storageService;
     private BackupManager backupManager;
 
     @BeforeMethod
     public void setup()
+            throws IOException
     {
-        temporary = createTempDir();
+        temporary = createTempDirectory(null);
 
-        FileBackupStore fileStore = new FileBackupStore(new File(temporary, "backup"));
+        FileBackupStore fileStore = new FileBackupStore(temporary.resolve("backup").toFile());
         fileStore.start();
         backupStore = new TestingBackupStore(fileStore);
 
-        storageService = new FileStorageService(new File(temporary, "data"));
+        storageService = new FileStorageService(temporary.resolve("data").toFile());
         storageService.start();
 
         backupManager = new BackupManager(Optional.of(backupStore), storageService, 5);
@@ -76,7 +78,7 @@ public class TestBackupManager
     public void tearDown()
             throws Exception
     {
-        deleteRecursively(temporary.toPath(), ALLOW_INSECURE);
+        deleteRecursively(temporary, ALLOW_INSECURE);
         backupManager.shutdown();
     }
 
@@ -90,7 +92,7 @@ public class TestBackupManager
         List<CompletableFuture<?>> futures = new ArrayList<>();
         List<UUID> uuids = new ArrayList<>(5);
         for (int i = 0; i < 5; i++) {
-            File file = new File(temporary, "file" + i);
+            File file = temporary.resolve("file" + i).toFile();
             Files.write("hello world", file, UTF_8);
             uuids.add(randomUUID());
 
@@ -112,7 +114,7 @@ public class TestBackupManager
         assertEmptyStagingDirectory();
         assertBackupStats(0, 0, 0);
 
-        File file = new File(temporary, "failure");
+        File file = temporary.resolve("failure").toFile();
         Files.write("hello world", file, UTF_8);
 
         assertThatThrownBy(() -> backupManager.submit(FAILURE_UUID, file).get(10, SECONDS))
@@ -133,7 +135,7 @@ public class TestBackupManager
         assertEmptyStagingDirectory();
         assertBackupStats(0, 0, 0);
 
-        File file = new File(temporary, "corrupt");
+        File file = temporary.resolve("corrupt").toFile();
         Files.write("hello world", file, UTF_8);
 
         assertThatThrownBy(() -> backupManager.submit(CORRUPTION_UUID, file).get(10, SECONDS))

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/TestFileBackupStore.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/TestFileBackupStore.java
@@ -18,12 +18,13 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.UUID;
 
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static java.lang.String.format;
+import static java.nio.file.Files.createTempDirectory;
 import static org.testng.Assert.assertEquals;
 
 public class TestFileBackupStore
@@ -31,9 +32,10 @@ public class TestFileBackupStore
 {
     @BeforeClass
     public void setup()
+            throws IOException
     {
-        temporary = createTempDir();
-        store = new FileBackupStore(new File(temporary, "backup"));
+        temporary = createTempDirectory(null);
+        store = new FileBackupStore(temporary.resolve("backup").toFile());
         store.start();
     }
 
@@ -41,14 +43,14 @@ public class TestFileBackupStore
     public void tearDown()
             throws Exception
     {
-        deleteRecursively(temporary.toPath(), ALLOW_INSECURE);
+        deleteRecursively(temporary, ALLOW_INSECURE);
     }
 
     @Test
     public void testFilePaths()
     {
         UUID uuid = UUID.fromString("701e1a79-74f7-4f56-b438-b41e8e7d019d");
-        File expected = new File(temporary, format("backup/70/1e/%s.orc", uuid));
+        File expected = temporary.resolve("backup").resolve("70").resolve("1e").resolve(format("%s.orc", uuid)).toFile();
         assertEquals(store.getBackupFile(uuid), expected);
     }
 }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/TestHttpBackupStore.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/backup/TestHttpBackupStore.java
@@ -38,11 +38,11 @@ import java.net.URI;
 import java.util.Map;
 import java.util.function.Supplier;
 
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static com.google.inject.util.Modules.override;
 import static io.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static java.nio.file.Files.createTempDirectory;
 
 @Test(singleThreaded = true)
 public class TestHttpBackupStore
@@ -52,8 +52,9 @@ public class TestHttpBackupStore
 
     @BeforeMethod
     public void setup()
+            throws IOException
     {
-        temporary = createTempDir();
+        temporary = createTempDirectory(null);
 
         Map<String, String> properties = ImmutableMap.<String, String>builder()
                 .put("backup.http.uri", "http://localhost:8080")
@@ -83,7 +84,7 @@ public class TestHttpBackupStore
     public void teardown()
             throws IOException
     {
-        deleteRecursively(temporary.toPath(), ALLOW_INSECURE);
+        deleteRecursively(temporary, ALLOW_INSECURE);
         if (lifeCycleManager != null) {
             lifeCycleManager.stop();
         }

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorSplitManager.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/metadata/TestRaptorSplitManager.java
@@ -42,17 +42,16 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 import static com.google.common.base.Ticker.systemTicker;
 import static com.google.common.collect.Iterables.getOnlyElement;
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
@@ -66,6 +65,7 @@ import static io.trino.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITION
 import static io.trino.spi.type.VarcharType.createVarcharType;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static java.lang.String.format;
+import static java.nio.file.Files.createTempDirectory;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
@@ -80,7 +80,7 @@ public class TestRaptorSplitManager
             .build();
 
     private Handle dummyHandle;
-    private File temporary;
+    private Path temporary;
     private RaptorMetadata metadata;
     private RaptorSplitManager raptorSplitManager;
     private ConnectorTableHandle tableHandle;
@@ -94,7 +94,7 @@ public class TestRaptorSplitManager
         Jdbi dbi = createTestingJdbi();
         dummyHandle = dbi.open();
         createTablesWithRetry(dbi);
-        temporary = createTempDir();
+        temporary = createTempDirectory(null);
         AssignmentLimiter assignmentLimiter = new AssignmentLimiter(ImmutableSet::of, systemTicker(), new MetadataConfig());
         shardManager = new DatabaseShardManager(dbi, new DaoSupplier<>(dbi, ShardDao.class), ImmutableSet::of, assignmentLimiter, systemTicker(), new Duration(0, MINUTES));
         TestingNodeManager nodeManager = new TestingNodeManager();
@@ -134,7 +134,7 @@ public class TestRaptorSplitManager
             throws IOException
     {
         dummyHandle.close();
-        deleteRecursively(temporary.toPath(), ALLOW_INSECURE);
+        deleteRecursively(temporary, ALLOW_INSECURE);
     }
 
     @Test

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestRaptorStorageManager.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestRaptorStorageManager.java
@@ -55,6 +55,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
@@ -66,7 +67,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.hash.Hashing.md5;
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.Files.hash;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
@@ -96,6 +96,7 @@ import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.assertions.Assert.assertEquals;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
 import static java.lang.String.format;
+import static java.nio.file.Files.createTempDirectory;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
@@ -127,7 +128,7 @@ public class TestRaptorStorageManager
 
     private final NodeManager nodeManager = new TestingNodeManager();
     private Handle dummyHandle;
-    private File temporary;
+    private Path temporary;
     private StorageService storageService;
     private ShardRecoveryManager recoveryManager;
     private FileBackupStore fileBackupStore;
@@ -136,13 +137,14 @@ public class TestRaptorStorageManager
 
     @BeforeMethod
     public void setup()
+            throws IOException
     {
-        temporary = createTempDir();
-        File directory = new File(temporary, "data");
+        temporary = createTempDirectory(null);
+        File directory = temporary.resolve("data").toFile();
         storageService = new FileStorageService(directory);
         storageService.start();
 
-        File backupDirectory = new File(temporary, "backup");
+        File backupDirectory = temporary.resolve("backup").toFile();
         fileBackupStore = new FileBackupStore(backupDirectory);
         fileBackupStore.start();
         backupStore = Optional.of(fileBackupStore);
@@ -165,7 +167,7 @@ public class TestRaptorStorageManager
         if (dummyHandle != null) {
             dummyHandle.close();
         }
-        deleteRecursively(temporary.toPath(), ALLOW_INSECURE);
+        deleteRecursively(temporary, ALLOW_INSECURE);
     }
 
     @Test
@@ -365,7 +367,7 @@ public class TestRaptorStorageManager
     public void testWriterRollback()
     {
         // verify staging directory is empty
-        File staging = new File(new File(temporary, "data"), "staging");
+        File staging = temporary.resolve("data").resolve("staging").toFile();
         assertDirectory(staging);
         assertEquals(staging.list(), new String[] {});
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestShardEjector.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestShardEjector.java
@@ -35,7 +35,9 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -43,13 +45,13 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.trino.plugin.raptor.legacy.DatabaseTesting.createTestingJdbi;
 import static io.trino.plugin.raptor.legacy.metadata.SchemaDaoUtil.createTablesWithRetry;
 import static io.trino.plugin.raptor.legacy.metadata.TestDatabaseShardManager.createShardManager;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static java.nio.file.Files.createTempDirectory;
 import static java.util.UUID.randomUUID;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.stream.Collectors.toSet;
@@ -63,19 +65,20 @@ public class TestShardEjector
     private Jdbi dbi;
     private Handle dummyHandle;
     private ShardManager shardManager;
-    private File dataDir;
+    private Path dataDir;
     private StorageService storageService;
 
     @BeforeMethod
     public void setup()
+            throws IOException
     {
         dbi = createTestingJdbi();
         dummyHandle = dbi.open();
         createTablesWithRetry(dbi);
         shardManager = createShardManager(dbi);
 
-        dataDir = createTempDir();
-        storageService = new FileStorageService(dataDir);
+        dataDir = createTempDirectory(null);
+        storageService = new FileStorageService(dataDir.toFile());
         storageService.start();
     }
 
@@ -87,7 +90,7 @@ public class TestShardEjector
             dummyHandle.close();
         }
         if (dataDir != null) {
-            deleteRecursively(dataDir.toPath(), ALLOW_INSECURE);
+            deleteRecursively(dataDir, ALLOW_INSECURE);
         }
     }
 

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestShardWriter.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/TestShardWriter.java
@@ -32,9 +32,10 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.json.JsonCodec.jsonCodec;
@@ -53,6 +54,7 @@ import static io.trino.testing.StructuralTestUtil.arrayBlocksEqual;
 import static io.trino.testing.StructuralTestUtil.mapBlockOf;
 import static io.trino.testing.StructuralTestUtil.mapBlocksEqual;
 import static io.trino.type.InternalTypeManager.TESTING_TYPE_MANAGER;
+import static java.nio.file.Files.createTempDirectory;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -60,21 +62,22 @@ import static org.testng.Assert.assertTrue;
 
 public class TestShardWriter
 {
-    private File directory;
+    private Path directory;
 
     private static final JsonCodec<OrcFileMetadata> METADATA_CODEC = jsonCodec(OrcFileMetadata.class);
 
     @BeforeClass
     public void setup()
+            throws IOException
     {
-        directory = createTempDir();
+        directory = createTempDirectory(null);
     }
 
     @AfterClass(alwaysRun = true)
     public void tearDown()
             throws Exception
     {
-        deleteRecursively(directory.toPath(), ALLOW_INSECURE);
+        deleteRecursively(directory, ALLOW_INSECURE);
     }
 
     @Test
@@ -88,7 +91,7 @@ public class TestShardWriter
                 TypeSignatureParameter.typeParameter(createVarcharType(10).getTypeSignature()),
                 TypeSignatureParameter.typeParameter(BOOLEAN.getTypeSignature())));
         List<Type> columnTypes = ImmutableList.of(BIGINT, createVarcharType(10), VARBINARY, DOUBLE, BOOLEAN, arrayType, mapType, arrayOfArrayType);
-        File file = new File(directory, System.nanoTime() + ".orc");
+        File file = directory.resolve(System.nanoTime() + ".orc").toFile();
 
         byte[] bytes1 = octets(0x00, 0xFE, 0xFF);
         byte[] bytes3 = octets(0x01, 0x02, 0x19, 0x80);

--- a/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardCompactor.java
+++ b/plugin/trino-raptor-legacy/src/test/java/io/trino/plugin/raptor/legacy/storage/organization/TestShardCompactor.java
@@ -40,14 +40,13 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.UUID;
 
-import static com.google.common.io.Files.createTempDir;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
@@ -64,6 +63,7 @@ import static io.trino.testing.MaterializedResult.materializeSourceDataStream;
 import static io.trino.testing.QueryAssertions.assertEqualsIgnoreOrder;
 import static io.trino.testing.TestingConnectorSession.SESSION;
 import static io.trino.testing.assertions.Assert.assertEquals;
+import static java.nio.file.Files.createTempDirectory;
 import static java.util.Collections.nCopies;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
@@ -81,16 +81,17 @@ public class TestShardCompactor
 
     private RaptorStorageManager storageManager;
     private ShardCompactor compactor;
-    private File temporary;
+    private Path temporary;
     private Handle dummyHandle;
 
     @BeforeMethod
     public void setup()
+            throws IOException
     {
-        temporary = createTempDir();
+        temporary = createTempDirectory(null);
         Jdbi dbi = createTestingJdbi();
         dummyHandle = dbi.open();
-        storageManager = createRaptorStorageManager(dbi, temporary, MAX_SHARD_ROWS);
+        storageManager = createRaptorStorageManager(dbi, temporary.toFile(), MAX_SHARD_ROWS);
         compactor = new ShardCompactor(storageManager, READER_OPTIONS, new TypeOperators());
     }
 
@@ -101,7 +102,7 @@ public class TestShardCompactor
         if (dummyHandle != null) {
             dummyHandle.close();
         }
-        deleteRecursively(temporary.toPath(), ALLOW_INSECURE);
+        deleteRecursively(temporary, ALLOW_INSECURE);
     }
 
     @Test


### PR DESCRIPTION
Fixes #6908.

Replace `com.google.common.io.Files.createTempDir` with `java.nio.file.Files.createTempDirectory`. The return value of the replacement methods is `java.nio.Path` instead of `java.io.File`. I've made minimal changes to account for this difference. 