### PR TITLE
Fix failure when selecting a constant and all fields from row

### DIFF
--- a/core/trino-main/src/test/java/io/trino/sql/query/TestSelectAll.java
+++ b/core/trino-main/src/test/java/io/trino/sql/query/TestSelectAll.java
@@ -86,6 +86,8 @@ public class TestSelectAll
         MaterializedResult materializedResult1 = assertions.execute("SELECT (SELECT (rand(), rand(), rand(), rand())).*");
         long distinctValuesCount1 = materializedResult1.getMaterializedRows().get(0).getFields().stream().distinct().count();
         assertTrue(distinctValuesCount1 >= 3, "rand() must be computed multiple times");
+
+        assertThat(assertions.query("SELECT 1, (2, 3).*")).matches("SELECT 1, 2, 3");
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/10298

In a query
`SELECT 1, ROW(2, 3).*`,
on the planning phase the expression `Row(2, 3).*` is unfolded
into subscript expressions: `ROW(2, 3)[1]` and `ROW(2, 3)[2]`.
Because the query also contains the literal `1`, the subscript
index in `ROW(2, 3)[1]` was rewritten into a symbol by the
`TranslationMap`. The resulting expression was `ROW(2, 3)[s]`,
which was incorrect, since the row subscript is required to be
a constant.

This change modifies the `TranslationMap`s rewrite method
so that the subscript index is not rewritten.