### PR TITLE
Fix cleanup workflow not working for PRs from forks

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,11 +1,12 @@
 name: cleanup
 
 on:
-  # Triggered on every PR merge or close
-  pull_request:
+  # Triggered on every PR merge or close (but with the code and workflow as present in the base of the merge instead of the merge commmit)
+  pull_request_target:
     types:
       - closed
 
+# NOTE: Do not check out/execute code from the PR since a read-write token is present due to pull_request_target
 jobs:
   cancel:
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub provides a read-only token to workflows executed by pull_request
event for security. The pull_request even runs workflows with the code
and workflow as provided in the PR which can include malicious content.

The pull_request_target event runs in the context of the base of the PR
hence no code/workflow is used from the PR. It has access to a
read-write token which allows the cancel-workflow-action to cancel
workflow runs for forked PRs too.

Before this change the cleanup workflow was only cancelling ci runs for
closed PRs that were not created from a fork.

Thanks to @dain for bringing this to my attention. See logs of https://github.com/trinodb/trino/runs/4525565716?check_suite_focus=true for example failure.