### PR TITLE
TPC-DS/TPCH-H stable results

### DIFF
--- a/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q39.sql
+++ b/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q39.sql
@@ -35,12 +35,12 @@ SELECT
 , "inv1"."i_item_sk"
 , "inv1"."d_moy"
 , "inv1"."mean"
-, "inv1"."cov"
+, CAST("inv1"."cov" AS DECIMAL(30, 10)) -- decrease precision to avoid unstable results due to roundings
 , "inv2"."w_warehouse_sk"
 , "inv2"."i_item_sk"
 , "inv2"."d_moy"
 , "inv2"."mean"
-, "inv2"."cov"
+, CAST("inv2"."cov" AS DECIMAL(30, 10)) -- decrease precision to avoid unstable results due to roundings
 FROM
   inv inv1
 , inv inv2

--- a/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q44.sql
+++ b/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q44.sql
@@ -64,5 +64,7 @@ FROM
 WHERE ("asceding"."rnk" = "descending"."rnk")
    AND ("i1"."i_item_sk" = "asceding"."item_sk")
    AND ("i2"."i_item_sk" = "descending"."item_sk")
-ORDER BY "asceding"."rnk" ASC
+ORDER BY "asceding"."rnk" ASC,
+   -- additional columns to assure results stability for larger scale factors; this is a deviation from TPC-DS specification
+   "i1"."i_product_name" ASC, "i2"."i_product_name" ASC
 LIMIT 100

--- a/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q65.sql
+++ b/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q65.sql
@@ -43,5 +43,7 @@ WHERE ("sb"."ss_store_sk" = "sc"."ss_store_sk")
    AND ("sc"."revenue" <= (DECIMAL '0.1' * "sb"."ave"))
    AND ("s_store_sk" = "sc"."ss_store_sk")
    AND ("i_item_sk" = "sc"."ss_item_sk")
-ORDER BY "s_store_name" ASC, "i_item_desc" ASC
+ORDER BY "s_store_name" ASC, "i_item_desc" ASC,
+   -- additional columns to assure results stability for larger scale factors; this is a deviation from TPC-DS specification
+   "i_brand" ASC, "sc"."revenue" ASC
 LIMIT 100

--- a/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q71.sql
+++ b/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q71.sql
@@ -48,4 +48,6 @@ WHERE ("sold_item_sk" = "i_item_sk")
    AND (("t_meal_time" = 'breakfast')
       OR ("t_meal_time" = 'dinner'))
 GROUP BY "i_brand", "i_brand_id", "t_hour", "t_minute"
-ORDER BY "ext_price" DESC, "i_brand_id" ASC
+ORDER BY "ext_price" DESC, "i_brand_id" ASC,
+   -- additional columns to assure results stability for larger scale factors; this is a deviation from TPC-DS specification
+   "t_hour" ASC, "t_minute" ASC

--- a/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q73.sql
+++ b/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q73.sql
@@ -31,4 +31,6 @@ FROM
 , ${database}.${schema}.customer
 WHERE ("ss_customer_sk" = "c_customer_sk")
    AND ("cnt" BETWEEN 1 AND 5)
-ORDER BY "cnt" DESC, "c_last_name" ASC
+ORDER BY "cnt" DESC, "c_last_name" ASC,
+   -- additional column to assure results stability for larger scale factors; this is a deviation from TPC-DS specification
+   "ss_ticket_number" ASC

--- a/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q77.sql
+++ b/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q77.sql
@@ -88,7 +88,7 @@ SELECT
 FROM
   (
    SELECT
-     '${database}.${schema}.store channel' "channel"
+     'store channel' "channel"
    , "ss"."s_store_sk" "id"
    , "sales"
    , COALESCE("returns", 0) "returns"

--- a/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpch/q11.sql
+++ b/testing/trino-benchto-benchmarks/src/main/resources/sql/presto/tpch/q11.sql
@@ -25,5 +25,7 @@ HAVING
       AND n.name = 'GERMANY'
   )
 ORDER BY 
-  value DESC
+  value DESC, 
+  -- additional column to assure results stability for larger scale factors; this is a deviation from TPC-H specification
+  ps.partkey ASC
 ;


### PR DESCRIPTION
TPC-H and TPC-DS queries we use do not return stable results for larger scale factors. Main reason is there are multiple rows with the same values for columns used in ORDER BY clause. Therefore, I'm adding additional sorting column to assure stable results.

For query tpc-ds 39, source of instability is rounding when doing standard deviation / average calculations. PR limits precision of result by casting it to decimal type.

I'm also fixing a search/replace bug in tpc-ds query 77.

Fixing stability is required to use benchto results verification functionality.