### PR TITLE
Fix failure handling in ExchangeClientBuffer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DeduplicationExchangeClientBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DeduplicationExchangeClientBuffer.java
@@ -300,7 +300,13 @@ public class DeduplicationExchangeClientBuffer
     @Override
     public synchronized boolean isFinished()
     {
-        return closed || failure != null || (inputFinished && pageBuffer.isEmpty());
+        return failure == null && (closed || (inputFinished && pageBuffer.isEmpty()));
+    }
+
+    @Override
+    public synchronized boolean isFailed()
+    {
+        return failure != null;
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/ExchangeClient.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExchangeClient.java
@@ -244,7 +244,7 @@ public class ExchangeClient
 
     private synchronized void scheduleRequestIfNecessary()
     {
-        if (isFinished()) {
+        if ((buffer.isFinished() || buffer.isFailed()) && completedClients.size() == allClients.size()) {
             return;
         }
 
@@ -284,7 +284,7 @@ public class ExchangeClient
         }
 
         synchronized (this) {
-            if (closed.get() || buffer.isFinished()) {
+            if (closed.get() || buffer.isFinished() || buffer.isFailed()) {
                 return false;
             }
 

--- a/core/trino-main/src/main/java/io/trino/operator/ExchangeClientBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ExchangeClientBuffer.java
@@ -44,6 +44,8 @@ public interface ExchangeClientBuffer
 
     boolean isFinished();
 
+    boolean isFailed();
+
     long getRemainingCapacityInBytes();
 
     long getRetainedSizeInBytes();

--- a/core/trino-main/src/main/java/io/trino/operator/StreamingExchangeClientBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/StreamingExchangeClientBuffer.java
@@ -163,7 +163,13 @@ public class StreamingExchangeClientBuffer
     @Override
     public synchronized boolean isFinished()
     {
-        return failure != null || (noMoreTasks && activeTasks.isEmpty() && bufferedPages.isEmpty());
+        return failure == null && noMoreTasks && activeTasks.isEmpty() && bufferedPages.isEmpty();
+    }
+
+    @Override
+    public synchronized boolean isFailed()
+    {
+        return failure != null;
     }
 
     @Override

--- a/core/trino-main/src/test/java/io/trino/operator/TestDeduplicationExchangeClientBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestDeduplicationExchangeClientBuffer.java
@@ -296,7 +296,8 @@ public class TestDeduplicationExchangeClientBuffer
             assertEquals(buffer.getRetainedSizeInBytes(), page1.getRetainedSizeInBytes());
 
             buffer.addPages(task, ImmutableList.of(page2));
-            assertTrue(buffer.isFinished());
+            assertFalse(buffer.isFinished());
+            assertTrue(buffer.isFailed());
             assertNotBlocked(buffer.isBlocked());
             assertEquals(buffer.getRetainedSizeInBytes(), 0);
             assertEquals(buffer.getBufferedPageCount(), 0);
@@ -366,7 +367,8 @@ public class TestDeduplicationExchangeClientBuffer
             assertFalse(buffer.isFinished());
 
             buffer.noMoreTasks();
-            assertTrue(buffer.isFinished());
+            assertFalse(buffer.isFinished());
+            assertTrue(buffer.isFailed());
         }
 
         // single task producing no results, fail after noMoreTasks
@@ -381,7 +383,8 @@ public class TestDeduplicationExchangeClientBuffer
             assertFalse(buffer.isFinished());
 
             buffer.taskFailed(taskId, new RuntimeException());
-            assertTrue(buffer.isFinished());
+            assertFalse(buffer.isFinished());
+            assertTrue(buffer.isFailed());
         }
 
         // single task producing one page, fail after noMoreTasks
@@ -397,7 +400,8 @@ public class TestDeduplicationExchangeClientBuffer
             assertFalse(buffer.isFinished());
 
             buffer.taskFailed(taskId, new RuntimeException());
-            assertTrue(buffer.isFinished());
+            assertFalse(buffer.isFinished());
+            assertTrue(buffer.isFailed());
         }
 
         // single task producing one page, finish after noMoreTasks

--- a/core/trino-main/src/test/java/io/trino/operator/TestStreamingExchangeClientBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestStreamingExchangeClientBuffer.java
@@ -165,7 +165,8 @@ public class TestStreamingExchangeClientBuffer
             RuntimeException error = new RuntimeException();
             buffer.taskFailed(TASK_0, error);
 
-            assertTrue(buffer.isFinished());
+            assertFalse(buffer.isFinished());
+            assertTrue(buffer.isFailed());
             assertTrue(buffer.isBlocked().isDone());
             assertThatThrownBy(buffer::pollPage).isEqualTo(error);
         }

--- a/core/trino-main/src/test/java/io/trino/operator/TestingExchangeClientBuffer.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestingExchangeClientBuffer.java
@@ -147,6 +147,12 @@ public class TestingExchangeClientBuffer
         return finished;
     }
 
+    @Override
+    public boolean isFailed()
+    {
+        return false;
+    }
+
     public synchronized void setFinished(boolean finished)
     {
         this.finished = finished;


### PR DESCRIPTION
Do not mark the buffer as finished in case of a failure.

The failure of a source task is propagated when the pollPage is called.
Marking the buffer as finished would make the ExchangeClient think that the exchange
is completed succesfully and the error might not get propagated as the
pollPage might never get called.