### PR TITLE
Ensure files are not overwritten

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/RcFileFileWriterFactory.java
@@ -133,7 +133,7 @@ public class RcFileFileWriterFactory
 
         try {
             FileSystem fileSystem = hdfsEnvironment.getFileSystem(session.getIdentity(), path, configuration);
-            OutputStream outputStream = fileSystem.create(path);
+            OutputStream outputStream = fileSystem.create(path, false);
 
             Optional<Supplier<RcFileDataSource>> validationInputFactory = Optional.empty();
             if (isRcfileOptimizedWriterValidate(session)) {

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/orc/OrcFileWriterFactory.java
@@ -227,7 +227,7 @@ public class OrcFileWriterFactory
     public static OrcDataSink createOrcDataSink(FileSystem fileSystem, Path path)
             throws IOException
     {
-        return new OutputStreamOrcDataSink(fileSystem.create(path));
+        return new OutputStreamOrcDataSink(fileSystem.create(path, false));
     }
 
     private static CompressionKind getCompression(Properties schema, JobConf configuration)

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/parquet/ParquetFileWriterFactory.java
@@ -117,7 +117,7 @@ public class ParquetFileWriterFactory
             ParquetSchemaConverter schemaConverter = new ParquetSchemaConverter(fileColumnTypes, fileColumnNames);
 
             return Optional.of(new ParquetFileWriter(
-                    fileSystem.create(path),
+                    fileSystem.create(path, false),
                     rollbackAction,
                     fileColumnTypes,
                     schemaConverter.getMessageType(),


### PR DESCRIPTION
Add a sanity check.
Note it does not always work as flag is ignored by some filesystems (see TrinoS3FileSystem).