### PR TITLE
Migrate deprecated `rollback()` call

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RollbackToSnapshotProcedure.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/RollbackToSnapshotProcedure.java
@@ -74,7 +74,7 @@ public class RollbackToSnapshotProcedure
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             SchemaTableName schemaTableName = new SchemaTableName(schema, table);
             Table icebergTable = catalogFactory.create(clientSession.getIdentity()).loadTable(clientSession, schemaTableName);
-            icebergTable.rollback().toSnapshotId(snapshotId).commit();
+            icebergTable.manageSnapshots().setCurrentSnapshot(snapshotId).commit();
         }
     }
 }


### PR DESCRIPTION
Related tests to test the functionality for regressions:

- `io.trino.plugin.iceberg.TestIcebergOrcConnectorTest#testRollbackSnapshot`
- `io.trino.plugin.iceberg.TestIcebergParquetConnectorTest#testRollbackSnapshot`