### PR TITLE
Update to Airbase 115 [minimalist]

### DIFF
--- a/core/trino-server-rpm/pom.xml
+++ b/core/trino-server-rpm/pom.xml
@@ -279,25 +279,27 @@
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>enforce-file-size</id>
+                        <id>default</id>
                         <phase>verify</phase>
                         <goals>
                             <goal>enforce</goal>
                         </goals>
-                        <configuration>
-                            <rules>
-                                <requireFilesSize>
-                                    <!-- Maven Central has a 1GB limit -->
-                                    <maxsize>1106000000</maxsize>
-                                    <files>
-                                        <file>${project.build.directory}/${project.build.finalName}.noarch.rpm</file>
-                                    </files>
-                                </requireFilesSize>
-                            </rules>
-                            <fail>true</fail>
-                        </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <!-- All Trino modules are imported into this module as "provided" dependencies what makes dependencies from all the modules to be cross checked for compatibility -->
+                    <!-- Override rules to disable dependency checks as dependencies of different connectors don't have to be compatible -->
+                    <rules combine.self="override">
+                        <requireFilesSize>
+                            <!-- Maven Central has a 1GB limit -->
+                            <maxsize>1106000000</maxsize>
+                            <files>
+                                <file>${project.build.directory}/${project.build.finalName}.noarch.rpm</file>
+                            </files>
+                        </requireFilesSize>
+                    </rules>
+                    <fail>true</fail>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/plugin/trino-elasticsearch/pom.xml
+++ b/plugin/trino-elasticsearch/pom.xml
@@ -283,6 +283,12 @@
             <artifactId>log4j-to-slf4j</artifactId>
             <version>2.15.0</version>
             <scope>runtime</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.osgi</groupId>
+                    <artifactId>org.osgi.core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Trino SPI -->

--- a/plugin/trino-google-sheets/pom.xml
+++ b/plugin/trino-google-sheets/pom.xml
@@ -57,6 +57,10 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava-jdk5</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/plugin/trino-redis/pom.xml
+++ b/plugin/trino-redis/pom.xml
@@ -103,6 +103,12 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>2.6.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-util</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- used by tests but also needed transitively -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>112</version>
+        <version>115</version>
     </parent>
 
     <groupId>io.trino</groupId>
@@ -49,7 +49,7 @@
         <dep.accumulo.version>1.7.4</dep.accumulo.version>
         <dep.accumulo-hadoop.version>2.7.7-1</dep.accumulo-hadoop.version>
         <dep.antlr.version>4.9.2</dep.antlr.version>
-        <dep.airlift.version>209</dep.airlift.version>
+        <dep.airlift.version>212</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.12.85</dep.aws-sdk.version>
         <dep.okhttp.version>3.14.9</dep.okhttp.version>
@@ -65,9 +65,6 @@
         <dep.docker-java.version>3.2.12</dep.docker-java.version>
         <dep.coral.version>1.0.121</dep.coral.version>
         <dep.confluent.version>5.5.2</dep.confluent.version>
-
-        <!-- TODO(https://github.com/airlift/airbase/pull/281): Required by testcontainers, remove when pulled from Airbase -->
-        <dep.slf4j.version>1.7.32</dep.slf4j.version>
 
         <dep.docker.images.version>53</dep.docker.images.version>
 
@@ -1025,6 +1022,12 @@
                 <groupId>com.google.cloud.bigdataoss</groupId>
                 <artifactId>gcsio</artifactId>
                 <version>${dep.gcs.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.google.code.gson</groupId>
+                        <artifactId>gson</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -1151,6 +1154,14 @@
                     <exclusion>
                         <groupId>org.glassfish.hk2.external</groupId>
                         <artifactId>jakarta.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>net.sf.jopt-simple</groupId>
+                        <artifactId>jopt-simple</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-cli</groupId>
+                        <artifactId>commons-cli</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1388,6 +1399,10 @@
                         <groupId>org.apache.httpcomponents</groupId>
                         <artifactId>httpclient</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>javax.servlet</groupId>
+                        <artifactId>servlet-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -1403,6 +1418,18 @@
                     <exclusion>
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-server</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-servlet</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-cli</groupId>
+                        <artifactId>commons-cli</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -1546,6 +1573,12 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${dep.testcontainers.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.osgi</groupId>
+                        <artifactId>org.osgi.core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -1560,6 +1593,12 @@
                 <groupId>org.xerial.snappy</groupId>
                 <artifactId>snappy-java</artifactId>
                 <version>1.1.8.4</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.osgi</groupId>
+                        <artifactId>org.osgi.core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <!-- Transitive dependency. Avoid different versions being used -->
@@ -1630,6 +1669,31 @@
                         <exclusionPatterns>
                             <exclusionPattern>org/joda/time/.*</exclusionPattern>
                         </exclusionPatterns>
+                        <exclusions>
+                            <!-- getOnlyElement is more readable than the stream analogue -->
+                            <exclusion>com/google/common/collect/Iterables.getOnlyElement:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
+                            <!-- getLast has lower complexity for array based lists than the stream analogue (O(1) vs O(log(N)) -->
+                            <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
+                            <!-- TODO: requires getting to common understanding which of those we want to enable -->
+                            <exclusion>com/google/common/collect/Iterables.transform:(Ljava/lang/Iterable;Lcom/google/common/base/Function;)Ljava/lang/Iterable;</exclusion>
+                            <exclusion>com/google/common/collect/Lists.transform:(Ljava/util/List;Lcom/google/common/base/Function;)Ljava/util/List;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.isEmpty:(Ljava/lang/Iterable;)Z</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.concat:(Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.all:(Ljava/lang/Iterable;Lcom/google/common/base/Predicate;)Z</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.any:(Ljava/lang/Iterable;Lcom/google/common/base/Predicate;)Z</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.skip:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.limit:(Ljava/lang/Iterable;I)Ljava/lang/Iterable;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.get:(Ljava/lang/Iterable;I)Ljava/lang/Object;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.getFirst:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.getLast:(Ljava/lang/Iterable;)Ljava/lang/Object;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.cycle:(Ljava/lang/Iterable;)Ljava/lang/Iterable;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.cycle:([Ljava/lang/Object;)Ljava/lang/Iterable;</exclusion>
+                            <exclusion>com/google/common/collect/Iterables.getOnlyElement:(Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Object;</exclusion>
+                        </exclusions>
                     </configuration>
                 </plugin>
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergSparkCompatibility.java
@@ -762,8 +762,8 @@ public class TestIcebergSparkCompatibility
             "with€euro",
             "with non-ascii ąęłóść Θ Φ Δ",
             "with👨‍🏭combining character",
-            " 👨‍🏭",
-            "👨‍🏭 ");
+            "👨‍🏭 ",
+            " 👨‍🏭");
 
     private static final String TRINO_INSERTED_PARTITION_VALUES =
             Streams.mapWithIndex(SPECIAL_CHARACTER_VALUES.stream(), ((value, index) -> format("(%d, '%s')", index, escapeTrinoString(value))))

--- a/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
+++ b/testing/trino-test-jdbc-compatibility-old-driver/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.14.0</version>
+            <version>3.18.1</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This PR does not include migration of some of the `Iterables` methods that are now banned by the lasted version of modernizer. The migration will be addressed separately.

Original PR: https://github.com/trinodb/trino/pull/10303