### PR TITLE
Enable TRUNCATE TABLE for Hive Connector

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -1222,6 +1222,12 @@ public class HiveMetadata
     }
 
     @Override
+    public void truncateTable(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        executeDelete(session, tableHandle);
+    }
+
+    @Override
     public ConnectorTableHandle beginStatisticsCollection(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         HiveTableHandle handle = (HiveTableHandle) tableHandle;

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
@@ -221,6 +221,8 @@ public class TestHiveConnectorTest
 
             case SUPPORTS_DELETE:
                 return true;
+            case SUPPORTS_TRUNCATE:
+                return true;
 
             case SUPPORTS_MULTI_STATEMENT_WRITES:
                 return true;


### PR DESCRIPTION
This PR enables TRUNCATE TABLE for Hive Connector.

See also:
https://github.com/trinodb/trino/issues/8921
https://github.com/trinodb/trino/pull/8932
https://github.com/trinodb/trino/issues/5035