### PR TITLE
Allow access to Postgres partitioned tables

### DIFF
--- a/docs/src/main/sphinx/connector/postgresql.rst
+++ b/docs/src/main/sphinx/connector/postgresql.rst
@@ -12,7 +12,7 @@ Requirements
 
 To connect to PostgreSQL, you need:
 
-* PostgreSQL 9.6 or higher.
+* PostgreSQL 10.x or higher.
 * Network access from the Trino coordinator and workers to PostgreSQL.
   Port 5432 is the default port.
 

--- a/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
+++ b/plugin/trino-postgresql/src/main/java/io/trino/plugin/postgresql/PostgreSqlClient.java
@@ -277,7 +277,7 @@ public class PostgreSqlClient
         this.varcharMapType = (MapType) typeManager.getType(mapType(VARCHAR.getTypeSignature(), VARCHAR.getTypeSignature()));
 
         ImmutableList.Builder<String> tableTypes = ImmutableList.builder();
-        tableTypes.add("TABLE", "VIEW", "MATERIALIZED VIEW", "FOREIGN TABLE");
+        tableTypes.add("TABLE", "PARTITIONED TABLE", "VIEW", "MATERIALIZED VIEW", "FOREIGN TABLE");
         if (postgreSqlConfig.isIncludeSystemTables()) {
             tableTypes.add("SYSTEM TABLE", "SYSTEM VIEW");
         }

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -205,6 +205,41 @@ public class TestPostgreSqlConnectorTest
     }
 
     @Test
+    public void testPartitionedTables()
+            throws Exception
+    {
+        try (TestTable testTable = new TestTable(
+                postgreSqlServer::execute,
+                "test_part_tbl",
+                "(id int NOT NULL, payload varchar, logdate date NOT NULL) PARTITION BY RANGE (logdate)")) {
+            String values202111 = "(1, 'A', '2021-11-01'), (2, 'B', '2021-11-25')";
+            String values202112 = "(3, 'C', '2021-12-01')";
+            execute(format("CREATE TABLE %s_2021_11 PARTITION OF %s FOR VALUES FROM ('2021-11-01') TO ('2021-12-01')", testTable.getName(), testTable.getName()));
+            execute(format("CREATE TABLE %s_2021_12 PARTITION OF %s FOR VALUES FROM ('2021-12-01') TO ('2022-01-01')", testTable.getName(), testTable.getName()));
+            execute(format("INSERT INTO %s VALUES %s ,%s", testTable.getName(), values202111, values202112));
+            assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet())
+                    .contains(testTable.getName(), testTable.getName() + "_2021_11", testTable.getName() + "_2021_12");
+            assertQuery(format("SELECT * FROM %s", testTable.getName()), format("VALUES %s, %s", values202111, values202112));
+            assertQuery(format("SELECT * FROM %s_2021_12", testTable.getName()), "VALUES " + values202112);
+        }
+
+        try (TestTable testTable = new TestTable(
+                postgreSqlServer::execute,
+                "test_part_tbl",
+                "(id int NOT NULL, type varchar, logdate varchar) PARTITION BY LIST (type)")) {
+            String valuesA = "(1, 'A', '2021-11-11'), (4, 'A', '2021-12-25')";
+            String valuesB = "(3, 'B', '2021-12-12'), (2, 'B', '2021-12-28')";
+            execute(format("CREATE TABLE %s_a PARTITION OF %s FOR VALUES IN ('A')", testTable.getName(), testTable.getName()));
+            execute(format("CREATE TABLE %s_b PARTITION OF %s FOR VALUES IN ('B')", testTable.getName(), testTable.getName()));
+            assertUpdate(format("INSERT INTO %s VALUES %s ,%s", testTable.getName(), valuesA, valuesB), 4);
+            assertThat(computeActual("SHOW TABLES").getOnlyColumnAsSet())
+                    .contains(testTable.getName(), testTable.getName() + "_a", testTable.getName() + "_b");
+            assertQuery(format("SELECT * FROM %s", testTable.getName()), format("VALUES %s, %s", valuesA, valuesB));
+            assertQuery(format("SELECT * FROM %s_a", testTable.getName()), "VALUES " + valuesA);
+        }
+    }
+
+    @Test
     public void testTableWithNoSupportedColumns()
             throws Exception
     {


### PR DESCRIPTION
Fixes https://github.com/trinodb/trino/issues/10400

Postgres Jdbc `42.2.14+` added a new `PARTITIONED TABLE` type that must be included in `PgDatabaseMetaData.getTables` function arguments to retrieve partitioned tables