### PR TITLE
Improve performance of VariableWidthBlock#copyPositions

### DIFF
--- a/core/trino-main/src/test/java/io/trino/block/TestVariableWidthBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestVariableWidthBlock.java
@@ -61,6 +61,9 @@ public class TestVariableWidthBlock
         Slice[] expectedValues = alternatingNullValues(createExpectedValues(100));
         BlockBuilder blockBuilder = createBlockBuilderWithValues(expectedValues);
         assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 0, 2, 4, 6, 7, 9, 10, 16);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null));
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 1, 2, 3, 7, 8, 9, 10, 11, 50);
+        assertBlockFilteredPositions(expectedValues, blockBuilder.build(), () -> blockBuilder.newBlockBuilderLike(null), 7, 6, 6, 50, 11, 50);
     }
 
     @Test

--- a/core/trino-spi/src/test/java/io/trino/spi/block/BenchmarkVariableWidthBlock.java
+++ b/core/trino-spi/src/test/java/io/trino/spi/block/BenchmarkVariableWidthBlock.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.block;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.testng.annotations.Test;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static com.google.common.base.Preconditions.checkState;
+import static io.trino.jmh.Benchmarks.benchmark;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.openjdk.jmh.annotations.Mode.AverageTime;
+import static org.openjdk.jmh.annotations.Scope.Thread;
+
+@OutputTimeUnit(MICROSECONDS)
+@Fork(2)
+@Warmup(iterations = 5, time = 1000, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = MILLISECONDS)
+@BenchmarkMode(AverageTime)
+public class BenchmarkVariableWidthBlock
+{
+    private static final int SEED = 831;
+    private static final int POSITIONS = 8096;
+    private static final double NULLS_CHANCE = 0.2;
+
+    @Benchmark
+    public Block copyPositions(BenchmarkData data)
+    {
+        int[] positionIds = data.getPositionsIds();
+        return data.getVariableWidthBlock().copyPositions(positionIds, 0, positionIds.length);
+    }
+
+    @State(Thread)
+    public static class BenchmarkData
+    {
+        @Param({"200", "1000", "8000"})
+        private int selectedPositionsCount;
+
+        @Param({"false", "true"})
+        private boolean nullsAllowed;
+
+        @Param({
+                "GROUPED",
+                "SEQUENCE",
+                "RANDOM",
+        })
+        private SelectedPositions selectedPositions;
+
+        private int[] positionsIds;
+        private Block variableWidthBlock;
+
+        public BenchmarkData(int selectedPositionsCount, boolean nullsAllowed, SelectedPositions selectedPositions)
+        {
+            this.selectedPositionsCount = selectedPositionsCount;
+            this.nullsAllowed = nullsAllowed;
+            this.selectedPositions = selectedPositions;
+        }
+
+        public BenchmarkData()
+        {
+            this(1000, false, SelectedPositions.SEQUENCE);
+        }
+
+        @Setup
+        public void setup()
+        {
+            positionsIds = selectedPositions.generateIds(selectedPositionsCount);
+            Slice[] slices = generateValues();
+            variableWidthBlock = createBlockBuilderWithValues(slices).build();
+        }
+
+        private Slice[] generateValues()
+        {
+            Random random = new Random(SEED);
+            Slice[] generatedValues = new Slice[POSITIONS];
+            for (int position = 0; position < POSITIONS; position++) {
+                if (nullsAllowed && randomNullChance(random)) {
+                    generatedValues[position] = null;
+                }
+                else {
+                    int length = random.nextInt(380) + 20;
+                    byte[] buffer = new byte[length];
+                    random.nextBytes(buffer);
+                    generatedValues[position] = Slices.wrappedBuffer(buffer);
+                }
+            }
+            return generatedValues;
+        }
+
+        private static boolean randomNullChance(Random random)
+        {
+            double value = 0;
+            // chance has to be 0 to 1 exclusive.
+            while (value == 0) {
+                value = random.nextDouble();
+            }
+            return value < NULLS_CHANCE;
+        }
+
+        private static BlockBuilder createBlockBuilderWithValues(Slice[] generatedValues)
+        {
+            BlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, generatedValues.length, 32 * generatedValues.length);
+            for (Slice value : generatedValues) {
+                if (value == null) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    blockBuilder.writeBytes(value, 0, value.length()).closeEntry();
+                }
+            }
+            return blockBuilder;
+        }
+
+        public int[] getPositionsIds()
+        {
+            return positionsIds;
+        }
+
+        public Block getVariableWidthBlock()
+        {
+            return variableWidthBlock;
+        }
+    }
+
+    public enum SelectedPositions
+    {
+        SEQUENCE {
+            @Override
+            int[] generateIds(int positionsCount)
+            {
+                return IntStream.range(0, positionsCount).toArray();
+            }
+        },
+        RANDOM {
+            @Override
+            int[] generateIds(int positionsCount)
+            {
+                return new Random(SEED).ints(positionsCount, 0, POSITIONS).toArray();
+            }
+        },
+        GROUPED {
+            @Override
+            int[] generateIds(int positionsCount)
+            {
+                Random random = new Random(SEED);
+                int maxGroupSize = positionsCount / 10;
+                int[] ids = new int[positionsCount];
+                int index = 0;
+                int currentPosition = 0;
+                while (index < positionsCount) {
+                    checkState(
+                            currentPosition < POSITIONS,
+                            "Reduce maxGroupSize or positionsCount to fit the generated ids within POSITIONS");
+                    int groupSize = Math.min(
+                            random.nextInt(maxGroupSize),
+                            Math.min(positionsCount - index, POSITIONS - currentPosition));
+                    for (int i = 0; i < groupSize; i++) {
+                        ids[index] = currentPosition;
+                        index++;
+                        currentPosition++;
+                    }
+                    currentPosition++; // break group
+                }
+                return ids;
+            }
+        };
+
+        abstract int[] generateIds(int positionsCount);
+    }
+
+    @Test
+    public void testCopyPositions()
+    {
+        for (SelectedPositions selectedPositions : SelectedPositions.values()) {
+            for (boolean nullsAllowed : new boolean[] {false, true}) {
+                BenchmarkData data = new BenchmarkData(1024, nullsAllowed, selectedPositions);
+                data.setup();
+                copyPositions(data);
+            }
+        }
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        benchmark(BenchmarkVariableWidthBlock.class)
+                .withOptions(optionsBuilder -> optionsBuilder.jvmArgsAppend("-Xmx4g", "-Xms4g"))
+                .run();
+    }
+}


### PR DESCRIPTION
Instead of copying every position one at a time, copy
contiguous ranges of Slice to reduce the number of times
SliceOutput#writeBytes is called when there are sequences
in the positions being copied.

Reduce branches for populating null values

BenchmarkVariableWidthBlock.copyPositions
```
(nullsAllowed) (selectedPositions) (selectedPositionsCount) us/op Before us/op After
    FALSE          GROUPED             200                      7.108        4.222
    FALSE          GROUPED             1000                     48.71        22.427
    FALSE          GROUPED             8000                     476.058      186.539
    FALSE          SEQUENCE            200                      6.912        4.107
    FALSE          SEQUENCE            1000                     47.931       21.282
    FALSE          SEQUENCE            8000                     473.199      174.198
    FALSE          RANDOM              200                      8.175        7.505
    FALSE          RANDOM              1000                     53.125       51.679
    FALSE          RANDOM              8000                     519.651      478.773
    TRUE           GROUPED             200                      5.897        4.099
    TRUE           GROUPED             1000                     38.14        19.807
    TRUE           GROUPED             8000                     394.617      158.567
    TRUE           SEQUENCE            200                      6.06         3.508
    TRUE           SEQUENCE            1000                     39.77        17.536
    TRUE           SEQUENCE            8000                     413.274      149.79
    TRUE           RANDOM              200                      7.076        7.201
    TRUE           RANDOM              1000                     42.756       43.626
    TRUE           RANDOM              8000                     416.765      385.222
```