### PR TITLE
Add a healthcheck to the Docker container image

### DIFF
--- a/core/docker/Dockerfile
+++ b/core/docker/Dockerfile
@@ -35,3 +35,5 @@ EXPOSE 8080
 USER trino:trino
 ENV LANG en_US.UTF-8
 CMD ["/usr/lib/trino/bin/run-trino"]
+HEALTHCHECK --interval=10s --timeout=5s --start-period=10s \
+  CMD /usr/lib/trino/bin/health-check

--- a/core/docker/bin/health-check
+++ b/core/docker/bin/health-check
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+function get_property() {
+    grep "^$1=" "$2" | cut -d'=' -f2
+}
+
+scheme=http
+port=8080
+
+config=/etc/trino/config.properties
+# prefer to use http even if https is enabled
+if [ "$(get_property 'http-server.http.enabled' "$config")" == "false" ]; then
+    scheme=https
+    port=$(get_property http-server.https.port "$config")
+else
+    port=$(get_property http-server.http.port "$config")
+fi
+
+endpoint="$scheme://localhost:$port/v1/info"
+
+# add --insecure to disable certificate verification in curl, in case a self-signed certificate is being used
+if ! info=$(curl --fail --silent --show-error --insecure "$endpoint"); then
+    echo >&2 "Server is not responding to requests"
+    exit 1
+fi
+
+if ! grep -q '"starting":\s*false' <<<"$info" >/dev/null; then
+    echo >&2 "Server is starting"
+    exit 1
+fi

--- a/core/docker/container-test.sh
+++ b/core/docker/container-test.sh
@@ -20,7 +20,7 @@ function test_trino_starts {
 
     set +e
     I=0
-    until RESULT=$(docker exec "${CONTAINER_ID}" trino --execute "SELECT 'success'" 2>/dev/null); do
+    until docker inspect "${CONTAINER_ID}" --format "{{json .State.Health.Status }}" | grep -q '"healthy"'; do
         if [[ $((I++)) -ge ${QUERY_RETRIES} ]]; then
             echo "🚨 Too many retries waiting for Trino to start"
             echo "Logs from ${CONTAINER_ID} follow..."
@@ -29,6 +29,9 @@ function test_trino_starts {
         fi
         sleep ${QUERY_PERIOD}
     done
+    if ! RESULT=$(docker exec "${CONTAINER_ID}" trino --execute "SELECT 'success'" 2>/dev/null); then
+        echo "🚨 Failed to execute a query after Trino container started"
+    fi
     set -e
 
     cleanup


### PR DESCRIPTION
By defining a healthcheck command in the container image, users can quickly see if the container is ready to accept requests in the output of `docker ps`:
```
% docker ps
CONTAINER ID   IMAGE                      COMMAND                  CREATED         STATUS                            PORTS      NAMES
8c630f90bbbc   trino:368-SNAPSHOT-amd64   "/usr/lib/trino/bin/…"   8 seconds ago   Up 7 seconds (health: starting)   8080/tcp   gifted_gauss
% docker ps
CONTAINER ID   IMAGE                      COMMAND                  CREATED              STATUS                        PORTS      NAMES
8c630f90bbbc   trino:368-SNAPSHOT-amd64   "/usr/lib/trino/bin/…"   About a minute ago   Up About a minute (healthy)   8080/tcp   gifted_gauss
```
Without this, the `STATUS` column only shows the uptime.

It also frees uses from having to figure out the exact condition and they can use a generic loop that would wait for the container to be ready, like so:
```bash
until docker inspect "${CONTAINER_ID}" --format "{{json .State.Health.Status }}" | grep -q '"healthy"'; do
  sleep 1
done
```

If the healthcheck fails 3 times, it'll start showing as unhealthy. To see more details about the failure, one would have to run `docker inspect $CONTAINER_ID --format "{{json .State.Health}}"`, or run it one more time as `docker exec -it $CONTAINER_ID /usr/lib/trino/bin/health-check`.

This healthcheck is enabled by default and can be disabled by adding `--no-healthcheck` to `docker run`.

The same healthcheck script could be used in readiness and liveness probes in https://github.com/trinodb/charts 