### PR TITLE
Add return type in LISTAGG documentation

### DIFF
--- a/docs/src/main/sphinx/functions/aggregate.rst
+++ b/docs/src/main/sphinx/functions/aggregate.rst
@@ -144,7 +144,7 @@ General aggregate functions
 
     Returns the geometric mean of all input values.
 
-.. function:: listagg(x, separator)
+.. function:: listagg(x, separator) -> varchar
 
     Returns the concatenated input values, separated by the ``separator`` string.
 


### PR DESCRIPTION
```
trino> SELECT TYPEOF(listagg(value, ',') WITHIN GROUP (ORDER BY value)) listagg_type
    -> FROM (VALUES 'a', 'c', 'b') t(value);
 listagg_type
--------------
 varchar
(1 row)
```