### PR TITLE
Disallow querying iceberg tables in hive

### DIFF
--- a/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
+++ b/plugin/trino-hive-hadoop2/src/test/java/io/trino/plugin/hive/TestHiveAlluxioMetastore.java
@@ -167,6 +167,13 @@ public class TestHiveAlluxioMetastore
     }
 
     @Override
+    public void testDisallowQueryingOfIcebergTables()
+    {
+        // Alluxio metastore does not support create operations
+        throw new SkipException("not supported");
+    }
+
+    @Override
     public void testIllegalStorageFormatDuringTableScan()
     {
         // Alluxio metastore does not support create operations

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -267,6 +267,7 @@ import static io.trino.plugin.hive.util.HiveUtil.getRegularColumnHandles;
 import static io.trino.plugin.hive.util.HiveUtil.hiveColumnHandles;
 import static io.trino.plugin.hive.util.HiveUtil.isDeltaLakeTable;
 import static io.trino.plugin.hive.util.HiveUtil.isHiveSystemSchema;
+import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
 import static io.trino.plugin.hive.util.HiveUtil.toPartitionValues;
 import static io.trino.plugin.hive.util.HiveUtil.verifyPartitionTypeSupported;
 import static io.trino.plugin.hive.util.HiveWriteUtils.checkTableIsWritable;
@@ -435,6 +436,9 @@ public class HiveMetadata
 
         if (isDeltaLakeTable(table)) {
             throw new TrinoException(HIVE_UNSUPPORTED_FORMAT, format("Cannot query Delta Lake table '%s'", tableName));
+        }
+        if (isIcebergTable(table)) {
+            throw new TrinoException(HIVE_UNSUPPORTED_FORMAT, format("Cannot query Iceberg table '%s'", tableName));
         }
 
         // we must not allow system tables due to how permissions are checked in SystemTableAwareAccessControl

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionsSystemTableProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PartitionsSystemTableProvider.java
@@ -43,6 +43,7 @@ import static io.trino.plugin.hive.util.HiveBucketing.getHiveBucketHandle;
 import static io.trino.plugin.hive.util.HiveUtil.getPartitionKeyColumnHandles;
 import static io.trino.plugin.hive.util.HiveUtil.getRegularColumnHandles;
 import static io.trino.plugin.hive.util.HiveUtil.isDeltaLakeTable;
+import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
 import static io.trino.plugin.hive.util.SystemTables.createSystemTable;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
@@ -82,7 +83,7 @@ public class PartitionsSystemTableProvider
         Table sourceTable = metadata.getMetastore()
                 .getTable(new HiveIdentity(session), sourceTableName.getSchemaName(), sourceTableName.getTableName())
                 .orElse(null);
-        if (sourceTable == null || isDeltaLakeTable(sourceTable)) {
+        if (sourceTable == null || isDeltaLakeTable(sourceTable) || isIcebergTable(sourceTable)) {
             return Optional.empty();
         }
         verifyOnline(sourceTableName, Optional.empty(), getProtectMode(sourceTable), sourceTable.getParameters());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PropertiesSystemTableProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PropertiesSystemTableProvider.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.trino.plugin.hive.SystemTableHandler.PROPERTIES;
 import static io.trino.plugin.hive.util.HiveUtil.isDeltaLakeTable;
+import static io.trino.plugin.hive.util.HiveUtil.isIcebergTable;
 import static io.trino.plugin.hive.util.SystemTables.createSystemTable;
 
 public class PropertiesSystemTableProvider
@@ -61,7 +62,7 @@ public class PropertiesSystemTableProvider
                 .getTable(new HiveIdentity(session), sourceTableName.getSchemaName(), sourceTableName.getTableName())
                 .orElseThrow(() -> new TableNotFoundException(tableName));
 
-        if (isDeltaLakeTable(table)) {
+        if (isDeltaLakeTable(table) || isIcebergTable(table)) {
             return Optional.empty();
         }
         Map<String, String> sortedTableParameters = ImmutableSortedMap.copyOf(table.getParameters());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PropertiesSystemTableProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PropertiesSystemTableProvider.java
@@ -17,7 +17,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.metastore.Table;
-import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -33,11 +32,9 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.trino.plugin.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
 import static io.trino.plugin.hive.SystemTableHandler.PROPERTIES;
 import static io.trino.plugin.hive.util.HiveUtil.isDeltaLakeTable;
 import static io.trino.plugin.hive.util.SystemTables.createSystemTable;
-import static java.lang.String.format;
 
 public class PropertiesSystemTableProvider
         implements SystemTableProvider
@@ -65,7 +62,7 @@ public class PropertiesSystemTableProvider
                 .orElseThrow(() -> new TableNotFoundException(tableName));
 
         if (isDeltaLakeTable(table)) {
-            throw new TrinoException(HIVE_UNSUPPORTED_FORMAT, format("Cannot query Delta Lake table '%s'", sourceTableName));
+            return Optional.empty();
         }
         Map<String, String> sortedTableParameters = ImmutableSortedMap.copyOf(table.getParameters());
         List<ColumnMetadata> columns = sortedTableParameters.keySet().stream()

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/util/HiveUtil.java
@@ -180,6 +180,9 @@ public final class HiveUtil
     public static final String SPARK_TABLE_PROVIDER_KEY = "spark.sql.sources.provider";
     public static final String DELTA_LAKE_PROVIDER = "delta";
 
+    public static final String ICEBERG_TABLE_TYPE_NAME = "table_type";
+    public static final String ICEBERG_TABLE_TYPE_VALUE = "iceberg";
+
     private static final DateTimeFormatter HIVE_DATE_PARSER = ISODateTimeFormat.date().withZoneUTC();
     private static final DateTimeFormatter HIVE_TIMESTAMP_PARSER;
     private static final Field COMPRESSION_CODECS_FIELD;
@@ -191,8 +194,6 @@ public final class HiveUtil
     private static final String BIG_DECIMAL_POSTFIX = "BD";
 
     private static final Splitter COLUMN_NAMES_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
-    private static final String ICEBERG_TABLE_TYPE_NAME = "table_type";
-    private static final String ICEBERG_TABLE_TYPE_VALUE = "iceberg";
 
     static {
         DateTimeParser[] timestampWithoutTimeZoneParser = {

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHiveFileSystem.java
@@ -217,7 +217,7 @@ public abstract class AbstractTestHiveFileSystem
                 new NodeVersion("test_version"),
                 new NoneHiveRedirectionsProvider(),
                 ImmutableSet.of(
-                        new PartitionsSystemTableProvider(hivePartitionManager),
+                        new PartitionsSystemTableProvider(hivePartitionManager, TESTING_TYPE_MANAGER),
                         new PropertiesSystemTableProvider()),
                 new DefaultHiveMaterializedViewMetadataFactory(),
                 SqlStandardAccessControlMetadata::new,

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveInMemoryMetastore.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveInMemoryMetastore.java
@@ -61,4 +61,10 @@ public class TestHiveInMemoryMetastore
     {
         throw new SkipException("not supported");
     }
+
+    @Override
+    public void testDisallowQueryingOfIcebergTables()
+    {
+        throw new SkipException("not supported");
+    }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveViewsCompatibility.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergHiveViewsCompatibility.java
@@ -21,6 +21,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 import static io.trino.tempto.assertions.QueryAssert.Row.row;
+import static io.trino.tempto.assertions.QueryAssert.assertQueryFailure;
 import static io.trino.tempto.assertions.QueryAssert.assertThat;
 import static io.trino.tests.product.TestGroups.HMS_ONLY;
 import static io.trino.tests.product.TestGroups.ICEBERG;
@@ -53,8 +54,8 @@ public class TestIcebergHiveViewsCompatibility
             onTrino().executeQuery("CREATE VIEW hive.default.hive_view_qualified_hive AS SELECT * FROM hive.default.hive_table");
             onTrino().executeQuery("CREATE VIEW hive.default.hive_view_unqualified_hive AS SELECT * FROM hive_table");
             onTrino().executeQuery("CREATE VIEW hive.default.hive_view_qualified_iceberg AS SELECT * FROM iceberg.default.iceberg_table");
-            // this should probably fail but it does not now; testing current behavior as a documentation
-            onTrino().executeQuery("CREATE VIEW hive.default.hive_view_unqualified_iceberg AS SELECT * FROM iceberg_table");
+            assertQueryFailure(() -> onTrino().executeQuery("CREATE VIEW hive.default.hive_view_unqualified_iceberg AS SELECT * FROM iceberg_table"))
+                    .hasMessageMatching("Query failed \\(#\\w+\\):\\Q Cannot query Iceberg table 'default.iceberg_table'");
 
             onTrino().executeQuery("USE iceberg.default"); // for sake of unqualified table references
             onTrino().executeQuery("CREATE VIEW iceberg.default.iceberg_view_qualified_hive AS SELECT * FROM hive.default.hive_table");
@@ -75,7 +76,6 @@ public class TestIcebergHiveViewsCompatibility
                             .add(row("hive_view_qualified_hive"))
                             .add(row("hive_view_unqualified_hive"))
                             .add(row("hive_view_qualified_iceberg"))
-                            .add(row("hive_view_unqualified_iceberg"))
                             .add(row("iceberg_view_qualified_hive"))
                             .add(row("iceberg_view_qualified_iceberg"))
                             .add(row("iceberg_view_unqualified_iceberg"))
@@ -88,7 +88,6 @@ public class TestIcebergHiveViewsCompatibility
                             .add(row("hive_view_qualified_hive"))
                             .add(row("hive_view_unqualified_hive"))
                             .add(row("hive_view_qualified_iceberg"))
-                            .add(row("hive_view_unqualified_iceberg"))
                             .add(row("iceberg_view_qualified_hive"))
                             .add(row("iceberg_view_qualified_iceberg"))
                             .add(row("iceberg_view_unqualified_iceberg"))
@@ -98,10 +97,6 @@ public class TestIcebergHiveViewsCompatibility
             assertThat(onTrino().executeQuery("SELECT * FROM hive.default.hive_view_qualified_hive")).containsOnly(row(1));
             assertThat(onTrino().executeQuery("SELECT * FROM hive.default.hive_view_unqualified_hive")).containsOnly(row(1));
             assertThat(onTrino().executeQuery("SELECT * FROM hive.default.hive_view_qualified_iceberg")).containsOnly(row(2));
-            assertThatThrownBy(() -> onTrino().executeQuery("SELECT * FROM hive.default.hive_view_unqualified_iceberg"))
-                    // hive connector tries to read from iceberg table
-                    // TODO: make query fail with nicer message
-                    .hasMessageContaining("Unable to create input format org.apache.hadoop.mapred.FileInputFormat");
             assertThat(onTrino().executeQuery("SELECT * FROM hive.default.iceberg_view_qualified_hive")).containsOnly(row(1));
             assertThat(onTrino().executeQuery("SELECT * FROM hive.default.iceberg_view_qualified_iceberg")).containsOnly(row(2));
             assertThat(onTrino().executeQuery("SELECT * FROM hive.default.iceberg_view_unqualified_iceberg")).containsOnly(row(2));
@@ -110,10 +105,6 @@ public class TestIcebergHiveViewsCompatibility
             assertThat(onTrino().executeQuery("SELECT * FROM iceberg.default.hive_view_qualified_hive")).containsOnly(row(1));
             assertThat(onTrino().executeQuery("SELECT * FROM iceberg.default.hive_view_unqualified_hive")).containsOnly(row(1));
             assertThat(onTrino().executeQuery("SELECT * FROM iceberg.default.hive_view_qualified_iceberg")).containsOnly(row(2));
-            assertThatThrownBy(() -> onTrino().executeQuery("SELECT * FROM iceberg.default.hive_view_unqualified_iceberg"))
-                    // hive connector tries to read from iceberg table
-                    // TODO: make query fail with nicer message
-                    .hasMessageContaining("Unable to create input format org.apache.hadoop.mapred.FileInputFormat");
             assertThat(onTrino().executeQuery("SELECT * FROM iceberg.default.iceberg_view_qualified_hive")).containsOnly(row(1));
             assertThat(onTrino().executeQuery("SELECT * FROM iceberg.default.iceberg_view_qualified_iceberg")).containsOnly(row(2));
             assertThat(onTrino().executeQuery("SELECT * FROM iceberg.default.iceberg_view_unqualified_iceberg")).containsOnly(row(2));


### PR DESCRIPTION
Hive connector cannot read from Iceberg tables reason
why querying such tables shouldn't be permitted within
the hive connector.
In case of trying to query an Iceberg table from the
hive connector provide a meaningful message to the user
about not supporting such an operation.

In case that the hive users don't want to see at all
the Iceberg tables, the property `hive.hide-iceberg-tables`
can be set for the `hive` connector to `true`.

Fixes #8693