### PR TITLE
Increase docs-checks timeout to 45 minutes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
     needs: path-filters
     if: ${{ needs.path-filters.outputs.docs == 'true' && needs.path-filters.outputs.other == 'false' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2


### PR DESCRIPTION
A timeout happened in https://github.com/trinodb/trino/runs/4676176783
The timeout value of `maven-checks` in ci.yml is also 45 min. https://github.com/trinodb/trino/blob/master/.github/workflows/ci.yml#L45