### PR TITLE
Add Java 17 as not supported

### DIFF
--- a/docs/src/main/sphinx/installation/deployment.rst
+++ b/docs/src/main/sphinx/installation/deployment.rst
@@ -33,7 +33,7 @@ Java runtime environment
 
 Trino requires a 64-bit version of Java 11, with a minimum required version of 11.0.11.
 Earlier patch versions such as 11.0.2 do not work, nor will earlier major versions such as Java 8.
-Newer major versions such as Java 12 or 13 are not supported -- they may work, but are not tested.
+Newer major versions such as Java 12 or 13, including Java 17, are not supported -- they may work, but are not tested.
 
 We recommend using `Azul Zulu <https://www.azul.com/downloads/zulu-community/>`_
 as the JDK for Trino, as Trino is tested against that distribution.


### PR DESCRIPTION
Make it explicit that current Java 17 is not supported/tested. Hopefully soon we can change that but until then it is important to mention Java 17 since it is the latest LTS version of Java.  We had feedback from user that are confused about the "might work" as well btw.

fyi @kpayne