### PR TITLE
Disallow querying delta lake properties table

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -431,7 +431,7 @@ public class HiveMetadata
         }
 
         if (isDeltaLakeTable(table.get())) {
-            throw new TrinoException(HIVE_UNSUPPORTED_FORMAT, "Cannot query Delta Lake table");
+            throw new TrinoException(HIVE_UNSUPPORTED_FORMAT, format("Cannot query Delta Lake table '%s'", tableName));
         }
 
         // we must not allow system tables due to how permissions are checked in SystemTableAwareAccessControl

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/HiveMetadata.java
@@ -425,12 +425,15 @@ public class HiveMetadata
         if (isHiveSystemSchema(tableName.getSchemaName())) {
             return null;
         }
-        Optional<Table> table = metastore.getTable(new HiveIdentity(session), tableName.getSchemaName(), tableName.getTableName());
-        if (table.isEmpty()) {
+        Table table = metastore
+                .getTable(new HiveIdentity(session), tableName.getSchemaName(), tableName.getTableName())
+                .orElse(null);
+
+        if (table == null) {
             return null;
         }
 
-        if (isDeltaLakeTable(table.get())) {
+        if (isDeltaLakeTable(table)) {
             throw new TrinoException(HIVE_UNSUPPORTED_FORMAT, format("Cannot query Delta Lake table '%s'", tableName));
         }
 
@@ -439,15 +442,15 @@ public class HiveMetadata
             throw new TrinoException(HIVE_INVALID_METADATA, "Unexpected table present in Hive metastore: " + tableName);
         }
 
-        verifyOnline(tableName, Optional.empty(), getProtectMode(table.get()), table.get().getParameters());
+        verifyOnline(tableName, Optional.empty(), getProtectMode(table), table.getParameters());
 
         return new HiveTableHandle(
                 tableName.getSchemaName(),
                 tableName.getTableName(),
-                table.get().getParameters(),
-                getPartitionKeyColumnHandles(table.get(), typeManager),
-                getRegularColumnHandles(table.get(), typeManager, getTimestampPrecision(session)),
-                getHiveBucketHandle(session, table.get(), typeManager));
+                table.getParameters(),
+                getPartitionKeyColumnHandles(table, typeManager),
+                getRegularColumnHandles(table, typeManager, getTimestampPrecision(session)),
+                getHiveBucketHandle(session, table, typeManager));
     }
 
     @Override

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PropertiesSystemTableProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PropertiesSystemTableProvider.java
@@ -60,14 +60,14 @@ public class PropertiesSystemTableProvider
         }
 
         SchemaTableName sourceTableName = PROPERTIES.getSourceTableName(tableName);
-        Optional<Table> table = metadata.getMetastore().getTable(new HiveIdentity(session), sourceTableName.getSchemaName(), sourceTableName.getTableName());
-        if (table.isEmpty()) {
-            throw new TableNotFoundException(tableName);
-        }
-        if (isDeltaLakeTable(table.get())) {
+        Table table = metadata.getMetastore()
+                .getTable(new HiveIdentity(session), sourceTableName.getSchemaName(), sourceTableName.getTableName())
+                .orElseThrow(() -> new TableNotFoundException(tableName));
+
+        if (isDeltaLakeTable(table)) {
             throw new TrinoException(HIVE_UNSUPPORTED_FORMAT, format("Cannot query Delta Lake table '%s'", sourceTableName));
         }
-        Map<String, String> sortedTableParameters = ImmutableSortedMap.copyOf(table.get().getParameters());
+        Map<String, String> sortedTableParameters = ImmutableSortedMap.copyOf(table.getParameters());
         List<ColumnMetadata> columns = sortedTableParameters.keySet().stream()
                 .map(key -> new ColumnMetadata(key, VarcharType.VARCHAR))
                 .collect(toImmutableList());

--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PropertiesSystemTableProvider.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/PropertiesSystemTableProvider.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import io.trino.plugin.hive.authentication.HiveIdentity;
 import io.trino.plugin.hive.metastore.Table;
+import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorSession;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -32,8 +33,11 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.plugin.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
 import static io.trino.plugin.hive.SystemTableHandler.PROPERTIES;
+import static io.trino.plugin.hive.util.HiveUtil.isDeltaLakeTable;
 import static io.trino.plugin.hive.util.SystemTables.createSystemTable;
+import static java.lang.String.format;
 
 public class PropertiesSystemTableProvider
         implements SystemTableProvider
@@ -59,6 +63,9 @@ public class PropertiesSystemTableProvider
         Optional<Table> table = metadata.getMetastore().getTable(new HiveIdentity(session), sourceTableName.getSchemaName(), sourceTableName.getTableName());
         if (table.isEmpty()) {
             throw new TableNotFoundException(tableName);
+        }
+        if (isDeltaLakeTable(table.get())) {
+            throw new TrinoException(HIVE_UNSUPPORTED_FORMAT, format("Cannot query Delta Lake table '%s'", sourceTableName));
         }
         Map<String, String> sortedTableParameters = ImmutableSortedMap.copyOf(table.get().getParameters());
         List<ColumnMetadata> columns = sortedTableParameters.keySet().stream()

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -2894,7 +2894,7 @@ public abstract class AbstractTestHive
                 ConnectorMetadata metadata = transaction.getMetadata();
                 metadata.beginQuery(session);
                 assertThatThrownBy(() -> getTableHandle(metadata, tableName))
-                        .hasMessage("Cannot query Delta Lake table");
+                        .hasMessage(format("Cannot query Delta Lake table '%s'", tableName));
             }
 
             // Assert that table is hidden

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/AbstractTestHive.java
@@ -2876,6 +2876,7 @@ public abstract class AbstractTestHive
                 .setTableName(tableName.getTableName())
                 .setOwner(Optional.of(session.getUser()))
                 .setTableType(MANAGED_TABLE.name())
+                .setPartitionColumns(List.of(new Column("a_partition_column", HIVE_INT, Optional.empty())))
                 .setDataColumns(List.of(new Column("a_column", HIVE_STRING, Optional.empty())))
                 .setParameter(SPARK_TABLE_PROVIDER_KEY, DELTA_LAKE_PROVIDER);
         table.getStorageBuilder()
@@ -2894,6 +2895,24 @@ public abstract class AbstractTestHive
                 ConnectorMetadata metadata = transaction.getMetadata();
                 metadata.beginQuery(session);
                 assertThatThrownBy(() -> getTableHandle(metadata, tableName))
+                        .hasMessage(format("Cannot query Delta Lake table '%s'", tableName));
+            }
+
+            // Verify the hidden `$properties` Delta Lake table handle can't be obtained within the hive connector
+            SchemaTableName propertiesTableName = new SchemaTableName(tableName.getSchemaName(), format("%s$properties", tableName.getTableName()));
+            try (Transaction transaction = newTransaction()) {
+                ConnectorMetadata metadata = transaction.getMetadata();
+                metadata.beginQuery(session);
+                assertThatThrownBy(() -> metadata.getSystemTable(newSession(), propertiesTableName))
+                        .hasMessage(format("Cannot query Delta Lake table '%s'", tableName));
+            }
+
+            // Verify the hidden `$partitions` Delta Lake table handle can't be obtained within the hive connector
+            SchemaTableName partitionsTableName = new SchemaTableName(tableName.getSchemaName(), format("%s$partitions", tableName.getTableName()));
+            try (Transaction transaction = newTransaction()) {
+                ConnectorMetadata metadata = transaction.getMetadata();
+                metadata.beginQuery(session);
+                assertThatThrownBy(() -> metadata.getSystemTable(newSession(), partitionsTableName))
                         .hasMessage(format("Cannot query Delta Lake table '%s'", tableName));
             }
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveDeltaLakeTable.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveDeltaLakeTable.java
@@ -31,7 +31,8 @@ public class TestHiveDeltaLakeTable
                 "CREATE TABLE test_delta_lake_table (ignored int) " +
                 "TBLPROPERTIES ('spark.sql.sources.provider'='DELTA')");
 
-        assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM test_delta_lake_table")).hasMessageContaining("Cannot query Delta Lake table");
+        assertQueryFailure(() -> onTrino().executeQuery("SELECT * FROM test_delta_lake_table"))
+                .hasMessageContaining("Cannot query Delta Lake table 'default.test_delta_lake_table'");
 
         onHive().executeQuery("DROP TABLE test_delta_lake_table");
     }


### PR DESCRIPTION
Extracted relevant commits for disallowing the querying of the `$properties` table on the delta lake tables in hive from the PR https://github.com/trinodb/trino/pull/10441