### PR TITLE
Fix iceberg connector bug not returning external location with `show create table`

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -106,6 +106,7 @@ import static io.trino.plugin.iceberg.IcebergErrorCode.ICEBERG_INVALID_METADATA;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isProjectionPushdownEnabled;
 import static io.trino.plugin.iceberg.IcebergSessionProperties.isStatisticsEnabled;
 import static io.trino.plugin.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
+import static io.trino.plugin.iceberg.IcebergTableProperties.LOCATION_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static io.trino.plugin.iceberg.IcebergTableProperties.getPartitioning;
 import static io.trino.plugin.iceberg.IcebergUtil.deserializePartitionValue;
@@ -600,6 +601,10 @@ public class IcebergMetadata
         properties.put(FILE_FORMAT_PROPERTY, getFileFormat(icebergTable));
         if (!icebergTable.spec().fields().isEmpty()) {
             properties.put(PARTITIONING_PROPERTY, toPartitionFields(icebergTable.spec()));
+        }
+
+        if (!icebergTable.location().isEmpty()) {
+            properties.put(LOCATION_PROPERTY, icebergTable.location());
         }
 
         return new ConnectorTableMetadata(table, columns, properties.build(), getTableComment(icebergTable));

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorSmokeTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergConnectorSmokeTest.java
@@ -19,7 +19,10 @@ import io.trino.testing.QueryRunner;
 import io.trino.testing.TestingConnectorBehavior;
 import org.testng.annotations.Test;
 
+import java.io.File;
+
 import static io.trino.plugin.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -69,6 +72,7 @@ public class TestIcebergConnectorSmokeTest
     @Override
     public void testShowCreateTable()
     {
+        File tempDir = getDistributedQueryRunner().getCoordinator().getBaseDataDir().toFile();
         assertThat((String) computeScalar("SHOW CREATE TABLE region"))
                 .isEqualTo("" +
                         "CREATE TABLE iceberg.tpch.region (\n" +
@@ -77,7 +81,8 @@ public class TestIcebergConnectorSmokeTest
                         "   comment varchar\n" +
                         ")\n" +
                         "WITH (\n" +
-                        "   format = 'ORC'\n" +
+                        "   format = 'ORC',\n" +
+                        format("   location = '%s/iceberg_data/tpch/region'\n", tempDir) +
                         ")");
     }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestHiveRedirectionToIceberg.java
@@ -269,6 +269,7 @@ public class TestHiveRedirectionToIceberg
                         ")\n" +
                         "WITH (\n" +
                         "   format = 'ORC',\n" +
+                        format("   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/%s',\n", tableName) +
                         "   partitioning = ARRAY['regionkey']\n" + // 'partitioning' comes from Iceberg
                         ")"));
 

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestIcebergPartitionEvolution.java
@@ -52,6 +52,7 @@ public class TestIcebergPartitionEvolution
                                 ")\n" +
                                 "WITH (\n" +
                                 "   format = 'ORC',\n" +
+                                "   location = 'hdfs://hadoop-master:9000/user/hive/warehouse/test_dropped_partition_field',\n" +
                                 "   partitioning = ARRAY[" + (dropFirst ? "'void(a)','b'" : "'a','void(b)'") + "]\n" +
                                 ")"));
 


### PR DESCRIPTION
Fixes: https://github.com/trinodb/trino/issues/9732

When doing a `show create table some_table` for an iceberg table, Trino does _not_ return the `location` property if one is defined.

```bash
trino > create table test_iceberg.schema1.some_table (c1 VARCHAR, c2 VARCHAR)
with (
    format = 'PARQUET',
    partitioning = ARRAY['c1'],
    location = 'gs://some/path'
);

...

trino> show create table test_iceberg.schema1.some_table;

CREATE TABLE test_iceberg.schema1.some_table (
   c1 varchar,
   c2 varchar
)
WITH (
   format = 'PARQUET',
   partitioning = ARRAY['c1']
)
```

### before the fix
<img width="750" alt="before" src="https://user-images.githubusercontent.com/8395995/148081084-352493f6-f2ed-4276-b837-2d3f0c918b32.png">

### after the fix
<img width="750" alt="after" src="https://user-images.githubusercontent.com/8395995/148081114-7a94df51-22ed-4596-a9b5-33e402e98e47.png">


