### PR TITLE
Correct log retention properties

### DIFF
--- a/docs/src/main/sphinx/admin/properties-logging.rst
+++ b/docs/src/main/sphinx/admin/properties-logging.rst
@@ -18,7 +18,7 @@ directory, configured by the launcher script as detailed in
 * **Type:** :ref:`prop-type-integer`
 * **Default value:** ``30``
 
-The maximum number of general application log files to use, before log
+The number of days to retain general application log files before log
 rotation replaces old content.
 
 ``log.max-size``


### PR DESCRIPTION
The `log.max-history` property is not a count of log files to keep, but rather a maximum age to retain old files.