### PR TITLE
Reuse single row block writer

### DIFF
--- a/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
+++ b/core/trino-main/src/test/java/io/trino/block/AbstractTestBlock.java
@@ -25,6 +25,7 @@ import io.trino.spi.block.BlockEncodingSerde;
 import io.trino.spi.block.DictionaryBlock;
 import io.trino.spi.block.DictionaryId;
 import io.trino.spi.block.MapHashTables;
+import io.trino.spi.block.SingleRowBlockWriter;
 import io.trino.spi.block.TestingBlockEncodingSerde;
 import org.openjdk.jol.info.ClassLayout;
 import org.testng.annotations.Test;
@@ -127,6 +128,9 @@ public abstract class AbstractTestBlock
                 }
                 else if (type == SliceOutput.class) {
                     retainedSize += ((SliceOutput) field.get(block)).getRetainedSize();
+                }
+                else if (type == SingleRowBlockWriter.class) {
+                    retainedSize += SingleRowBlockWriter.INSTANCE_SIZE;
                 }
                 else if (type == int[].class) {
                     retainedSize += sizeOf((int[]) field.get(block));

--- a/core/trino-main/src/test/java/io/trino/block/BenchmarkRowBlockBuilder.java
+++ b/core/trino-main/src/test/java/io/trino/block/BenchmarkRowBlockBuilder.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.block;
+
+import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.block.SingleRowBlockWriter;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.profile.GCProfiler;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
+import static io.trino.jmh.Benchmarks.benchmark;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkRowBlockBuilder
+{
+    @Benchmark
+    public void benchmarkBeginBlockEntry(BenchmarkData data, Blackhole blackhole)
+    {
+        for (int i = 0; i < data.rows; i++) {
+            SingleRowBlockWriter singleRowBlockWriter = data.getBlockBuilder().beginBlockEntry();
+            for (int fieldIndex = 0; fieldIndex < data.getTypes().size(); fieldIndex++) {
+                singleRowBlockWriter.writeLong(data.getRandom().nextLong()).closeEntry();
+            }
+            blackhole.consume(singleRowBlockWriter);
+            data.getBlockBuilder().closeEntry();
+        }
+        blackhole.consume(data.getBlockBuilder());
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private RowBlockBuilder blockBuilder;
+        private List<Type> types;
+        @Param({"10", "100", "1000"})
+        private int rows = 10;
+
+        @Param({"2", "4", "8"})
+        private int typesLength = 2;
+
+        private Random random;
+
+        @Setup(Level.Iteration)
+        public void setup()
+        {
+            types = Collections.nCopies(typesLength, BIGINT);
+            RowType rowType = RowType.anonymous(types);
+            blockBuilder = (RowBlockBuilder) rowType.createBlockBuilder(null, rows);
+            random = new Random(1024L);
+        }
+
+        public int getRows()
+        {
+            return rows;
+        }
+
+        public Random getRandom()
+        {
+            return random;
+        }
+
+        public List<Type> getTypes()
+        {
+            return types;
+        }
+
+        public RowBlockBuilder getBlockBuilder()
+        {
+            return blockBuilder;
+        }
+    }
+
+    public static void main(String[] args)
+            throws Exception
+    {
+        benchmark(BenchmarkRowBlockBuilder.class)
+                .withOptions(
+                        options -> options
+                                .addProfiler(GCProfiler.class))
+                .run();
+    }
+}

--- a/core/trino-main/src/test/java/io/trino/block/TestSingleRowBlockWriter.java
+++ b/core/trino-main/src/test/java/io/trino/block/TestSingleRowBlockWriter.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.block;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.spi.block.RowBlockBuilder;
+import io.trino.spi.block.SingleRowBlockWriter;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.BooleanType.BOOLEAN;
+import static org.testng.Assert.assertEquals;
+
+public class TestSingleRowBlockWriter
+{
+    private RowBlockBuilder rowBlockBuilder;
+
+    @BeforeClass
+    public void setup()
+    {
+        List<Type> types = ImmutableList.of(BIGINT, BOOLEAN);
+        rowBlockBuilder = (RowBlockBuilder) RowType.anonymous(types).createBlockBuilder(null, 8);
+    }
+
+    @Test
+    public void testGetSizeInBytes()
+    {
+        SingleRowBlockWriter singleRowBlockWriter = rowBlockBuilder.beginBlockEntry();
+        // Test whether new singleRowBlockWriter has size equal to 0
+        assertEquals(0, singleRowBlockWriter.getSizeInBytes());
+
+        singleRowBlockWriter.writeLong(10).closeEntry();
+        assertEquals(9, singleRowBlockWriter.getSizeInBytes());
+
+        singleRowBlockWriter.writeByte(10).closeEntry();
+        assertEquals(11, singleRowBlockWriter.getSizeInBytes());
+        rowBlockBuilder.closeEntry();
+
+        // Test whether previous entry does not mix to the next entry (for size). Does reset works on size?
+        singleRowBlockWriter = rowBlockBuilder.beginBlockEntry();
+        assertEquals(0, singleRowBlockWriter.getSizeInBytes());
+
+        singleRowBlockWriter.writeLong(10).closeEntry();
+        assertEquals(9, singleRowBlockWriter.getSizeInBytes());
+
+        singleRowBlockWriter.writeByte(10).closeEntry();
+        assertEquals(11, singleRowBlockWriter.getSizeInBytes());
+        rowBlockBuilder.closeEntry();
+    }
+}

--- a/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/AbstractSingleRowBlock.java
@@ -21,13 +21,6 @@ import java.util.List;
 public abstract class AbstractSingleRowBlock
         implements Block
 {
-    protected final int rowIndex;
-
-    protected AbstractSingleRowBlock(int rowIndex)
-    {
-        this.rowIndex = rowIndex;
-    }
-
     @Override
     public final List<Block> getChildren()
     {
@@ -37,6 +30,8 @@ public abstract class AbstractSingleRowBlock
     abstract Block[] getRawFieldBlocks();
 
     protected abstract Block getRawFieldBlock(int fieldIndex);
+
+    protected abstract int getRowIndex();
 
     private void checkFieldIndex(int position)
     {
@@ -49,119 +44,119 @@ public abstract class AbstractSingleRowBlock
     public boolean isNull(int position)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).isNull(rowIndex);
+        return getRawFieldBlock(position).isNull(getRowIndex());
     }
 
     @Override
     public byte getByte(int position, int offset)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getByte(rowIndex, offset);
+        return getRawFieldBlock(position).getByte(getRowIndex(), offset);
     }
 
     @Override
     public short getShort(int position, int offset)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getShort(rowIndex, offset);
+        return getRawFieldBlock(position).getShort(getRowIndex(), offset);
     }
 
     @Override
     public int getInt(int position, int offset)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getInt(rowIndex, offset);
+        return getRawFieldBlock(position).getInt(getRowIndex(), offset);
     }
 
     @Override
     public long getLong(int position, int offset)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getLong(rowIndex, offset);
+        return getRawFieldBlock(position).getLong(getRowIndex(), offset);
     }
 
     @Override
     public Slice getSlice(int position, int offset, int length)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getSlice(rowIndex, offset, length);
+        return getRawFieldBlock(position).getSlice(getRowIndex(), offset, length);
     }
 
     @Override
     public int getSliceLength(int position)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getSliceLength(rowIndex);
+        return getRawFieldBlock(position).getSliceLength(getRowIndex());
     }
 
     @Override
     public int compareTo(int position, int offset, int length, Block otherBlock, int otherPosition, int otherOffset, int otherLength)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).compareTo(rowIndex, offset, length, otherBlock, otherPosition, otherOffset, otherLength);
+        return getRawFieldBlock(position).compareTo(getRowIndex(), offset, length, otherBlock, otherPosition, otherOffset, otherLength);
     }
 
     @Override
     public boolean bytesEqual(int position, int offset, Slice otherSlice, int otherOffset, int length)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).bytesEqual(rowIndex, offset, otherSlice, otherOffset, length);
+        return getRawFieldBlock(position).bytesEqual(getRowIndex(), offset, otherSlice, otherOffset, length);
     }
 
     @Override
     public int bytesCompare(int position, int offset, int length, Slice otherSlice, int otherOffset, int otherLength)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).bytesCompare(rowIndex, offset, length, otherSlice, otherOffset, otherLength);
+        return getRawFieldBlock(position).bytesCompare(getRowIndex(), offset, length, otherSlice, otherOffset, otherLength);
     }
 
     @Override
     public void writeBytesTo(int position, int offset, int length, BlockBuilder blockBuilder)
     {
         checkFieldIndex(position);
-        getRawFieldBlock(position).writeBytesTo(rowIndex, offset, length, blockBuilder);
+        getRawFieldBlock(position).writeBytesTo(getRowIndex(), offset, length, blockBuilder);
     }
 
     @Override
     public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).equals(rowIndex, offset, otherBlock, otherPosition, otherOffset, length);
+        return getRawFieldBlock(position).equals(getRowIndex(), offset, otherBlock, otherPosition, otherOffset, length);
     }
 
     @Override
     public long hash(int position, int offset, int length)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).hash(rowIndex, offset, length);
+        return getRawFieldBlock(position).hash(getRowIndex(), offset, length);
     }
 
     @Override
     public <T> T getObject(int position, Class<T> clazz)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getObject(rowIndex, clazz);
+        return getRawFieldBlock(position).getObject(getRowIndex(), clazz);
     }
 
     @Override
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         checkFieldIndex(position);
-        getRawFieldBlock(position).writePositionTo(rowIndex, blockBuilder);
+        getRawFieldBlock(position).writePositionTo(getRowIndex(), blockBuilder);
     }
 
     @Override
     public Block getSingleValueBlock(int position)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getSingleValueBlock(rowIndex);
+        return getRawFieldBlock(position).getSingleValueBlock(getRowIndex());
     }
 
     @Override
     public long getEstimatedDataSizeForStats(int position)
     {
         checkFieldIndex(position);
-        return getRawFieldBlock(position).getEstimatedDataSizeForStats(rowIndex);
+        return getRawFieldBlock(position).getEstimatedDataSizeForStats(getRowIndex());
     }
 
     @Override

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlock.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlock.java
@@ -27,10 +27,11 @@ public class SingleRowBlock
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleRowBlock.class).instanceSize();
 
     private final Block[] fieldBlocks;
+    private final int rowIndex;
 
     SingleRowBlock(int rowIndex, Block[] fieldBlocks)
     {
-        super(rowIndex);
+        this.rowIndex = rowIndex;
         this.fieldBlocks = fieldBlocks;
     }
 
@@ -62,7 +63,7 @@ public class SingleRowBlock
     {
         long sizeInBytes = 0;
         for (int i = 0; i < fieldBlocks.length; i++) {
-            sizeInBytes += getRawFieldBlock(i).getRegionSizeInBytes(rowIndex, 1);
+            sizeInBytes += getRawFieldBlock(i).getRegionSizeInBytes(getRowIndex(), 1);
         }
         return sizeInBytes;
     }
@@ -92,6 +93,7 @@ public class SingleRowBlock
         return SingleRowBlockEncoding.NAME;
     }
 
+    @Override
     public int getRowIndex()
     {
         return rowIndex;
@@ -122,6 +124,6 @@ public class SingleRowBlock
             // All blocks are already loaded
             return this;
         }
-        return new SingleRowBlock(rowIndex, loadedFieldBlocks);
+        return new SingleRowBlock(getRowIndex(), loadedFieldBlocks);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/block/SingleRowBlockWriter.java
@@ -24,24 +24,17 @@ public class SingleRowBlockWriter
         extends AbstractSingleRowBlock
         implements BlockBuilder
 {
-    private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleRowBlockWriter.class).instanceSize();
+    public static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleRowBlockWriter.class).instanceSize();
 
     private final BlockBuilder[] fieldBlockBuilders;
-    private final long initialBlockBuilderSize;
-    private int positionsWritten;
 
     private int currentFieldIndexToWrite;
+    private int rowIndex = -1;
     private boolean fieldBlockBuilderReturned;
 
-    SingleRowBlockWriter(int rowIndex, BlockBuilder[] fieldBlockBuilders)
+    SingleRowBlockWriter(BlockBuilder[] fieldBlockBuilders)
     {
-        super(rowIndex);
         this.fieldBlockBuilders = fieldBlockBuilders;
-        long initialBlockBuilderSize = 0;
-        for (BlockBuilder fieldBlockBuilder : fieldBlockBuilders) {
-            initialBlockBuilderSize += fieldBlockBuilder.getSizeInBytes();
-        }
-        this.initialBlockBuilderSize = initialBlockBuilderSize;
     }
 
     /**
@@ -75,13 +68,23 @@ public class SingleRowBlockWriter
     }
 
     @Override
+    protected int getRowIndex()
+    {
+        return rowIndex;
+    }
+
+    @Override
     public long getSizeInBytes()
     {
         long currentBlockBuilderSize = 0;
+         /*
+          * We need to use subtraction in order to compute size because getRegionSizeInBytes(0, 1)
+          * returns non-zero result even if field block builder has no position appended
+          */
         for (BlockBuilder fieldBlockBuilder : fieldBlockBuilders) {
-            currentBlockBuilderSize += fieldBlockBuilder.getSizeInBytes();
+            currentBlockBuilderSize += fieldBlockBuilder.getSizeInBytes() - fieldBlockBuilder.getRegionSizeInBytes(0, rowIndex);
         }
-        return currentBlockBuilderSize - initialBlockBuilderSize;
+        return currentBlockBuilderSize;
     }
 
     @Override
@@ -189,7 +192,6 @@ public class SingleRowBlockWriter
     private void entryAdded()
     {
         currentFieldIndexToWrite++;
-        positionsWritten++;
     }
 
     @Override
@@ -198,7 +200,7 @@ public class SingleRowBlockWriter
         if (fieldBlockBuilderReturned) {
             throw new IllegalStateException("field block builder has been returned");
         }
-        return positionsWritten;
+        return currentFieldIndexToWrite;
     }
 
     @Override
@@ -228,6 +230,24 @@ public class SingleRowBlockWriter
         else {
             return format("SingleRowBlockWriter{numFields=%d, fieldBlockBuilderReturned=true}", fieldBlockBuilders.length);
         }
+    }
+
+    void setRowIndex(int rowIndex)
+    {
+        if (this.rowIndex != -1) {
+            throw new IllegalStateException("SingleRowBlockWriter should be reset before usage");
+        }
+        this.rowIndex = rowIndex;
+    }
+
+    void reset()
+    {
+        if (this.rowIndex == -1) {
+            throw new IllegalStateException("SingleRowBlockWriter is already reset");
+        }
+        this.rowIndex = -1;
+        this.currentFieldIndexToWrite = 0;
+        this.fieldBlockBuilderReturned = false;
     }
 
     private void checkFieldIndexToWrite()


### PR DESCRIPTION
  * Add benchmark BenchmarkRowBlockBuilder to bench RowBlockBuilder.beginBlockEntry()
  * Reuse SingleRowBlockWriter instance instead of creating it every time

```
         Benchmark                                                                           (rows)  (typesLength)  Mode  Cnt       Score       Error   Units
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                       10              2  avgt    5       0.605 ±     0.066   us/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                       10              2  avgt    5       0.508 ±     0.067   us/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                        10              2  avgt    5    1912.558 ±    65.766  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                        10              2  avgt    5    1311.819 ±     0.979  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                   10              2  avgt    5    1273.917 ±    95.104    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                   10              2  avgt    5     734.502 ±    97.158    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space               10              2  avgt    5     612.496 ±    61.736  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space               10              2  avgt    5       5.711 ±     0.004  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm          10              2  avgt    5     408.120 ±    67.460    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm          10              2  avgt    5       3.198 ±     0.423    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                  10              2  avgt    5    1320.322 ±     0.742  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                  10              2  avgt    5    1320.375 ±     0.986  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm             10              2  avgt    5     879.617 ±    95.724    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm             10              2  avgt    5     739.293 ±    97.792    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space           10              2  avgt    5       0.381 ±     0.001  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space           10              2  avgt    5       0.381 ±     0.001  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm      10              2  avgt    5       0.254 ±     0.028    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm      10              2  avgt    5       0.213 ±     0.028    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                             10              2  avgt    5      40.000              counts
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                             10              2  avgt    5      40.000              counts
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                              10              2  avgt    5      67.000                  ms
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                              10              2  avgt    5      53.000                  ms
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                       10              4  avgt    5       1.137 ±     0.194   us/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                       10              4  avgt    5       0.965 ±     0.247   us/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                        10              4  avgt    5    1446.003 ±   745.039  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                        10              4  avgt    5    1557.988 ±     9.044  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                   10              4  avgt    5    1809.210 ±   963.746    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                   10              4  avgt    5    1655.344 ±   412.794    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space               10              4  avgt    5     327.684 ±   274.993  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space               10              4  avgt    5       9.588 ±     0.673  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm          10              4  avgt    5     410.905 ±   365.540    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm          10              4  avgt    5      10.185 ±     2.395    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                  10              4  avgt    5    1141.099 ±   474.297  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                  10              4  avgt    5    1571.807 ±     9.125  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm             10              4  avgt    5    1427.140 ±   594.993    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm             10              4  avgt    5    1670.026 ±   416.455    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space           10              4  avgt    5       0.753 ±     0.073  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space           10              4  avgt    5       0.761 ±     0.004  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm      10              4  avgt    5       0.942 ±     0.185    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm      10              4  avgt    5       0.809 ±     0.202    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                             10              4  avgt    5      45.000              counts
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                             10              4  avgt    5      65.000              counts
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                              10              4  avgt    5      63.000                  ms
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                              10              4  avgt    5      80.000                  ms
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                       10              8  avgt    5       2.262 ±     0.389   us/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                       10              8  avgt    5       1.747 ±     0.037   us/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                        10              8  avgt    5    1462.316 ±    28.010  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                        10              8  avgt    5    1301.432 ±     1.075  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                   10              8  avgt    5    3641.248 ±   555.241    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                   10              8  avgt    5    2503.436 ±    52.911    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space               10              8  avgt    5     172.422 ±    24.232  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space               10              8  avgt    5      17.592 ±     0.655  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm          10              8  avgt    5     429.066 ±    58.763    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm          10              8  avgt    5      33.841 ±     1.794    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                  10              8  avgt    5     881.525 ±     1.012  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                  10              8  avgt    5     881.129 ±     0.729  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm             10              8  avgt    5    2195.422 ±   376.088    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm             10              8  avgt    5    1694.941 ±    35.824    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space           10              8  avgt    5       1.523 ±     0.002  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space           10              8  avgt    5       1.523 ±     0.001  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm      10              8  avgt    5       3.793 ±     0.650    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm      10              8  avgt    5       2.930 ±     0.062    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                             10              8  avgt    5     110.000              counts
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                             10              8  avgt    5     115.000              counts
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                              10              8  avgt    5     114.000                  ms
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                              10              8  avgt    5     114.000                  ms
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                      100              2  avgt    5       5.616 ±     0.270   us/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                      100              2  avgt    5       5.019 ±     0.053   us/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                       100              2  avgt    5    2009.009 ±    29.691  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                       100              2  avgt    5    1361.696 ±     1.348  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                  100              2  avgt    5   12424.520 ±   406.403    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                  100              2  avgt    5    7530.159 ±    87.250    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space              100              2  avgt    5     656.633 ±    46.408  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space              100              2  avgt    5       6.165 ±     0.656  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm         100              2  avgt    5    4060.902 ±   315.492    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm         100              2  avgt    5      34.095 ±     3.841    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                 100              2  avgt    5    1372.809 ±     1.067  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                 100              2  avgt    5    1371.954 ±     1.360  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm            100              2  avgt    5    8490.338 ±   409.582    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm            100              2  avgt    5    7586.884 ±    87.913    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space          100              2  avgt    5       0.381 ±     0.001  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space          100              2  avgt    5       0.381 ±     0.001  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm     100              2  avgt    5       2.355 ±     0.114    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm     100              2  avgt    5       2.105 ±     0.024    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                            100              2  avgt    5      40.000              counts
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                            100              2  avgt    5      45.000              counts
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                             100              2  avgt    5      65.000                  ms
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                             100              2  avgt    5      59.000                  ms
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                      100              4  avgt    5      11.773 ±     1.474   us/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                      100              4  avgt    5       9.492 ±     0.442   us/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                       100              4  avgt    5    1388.038 ±    38.807  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                       100              4  avgt    5    1617.491 ±     1.035  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                  100              4  avgt    5   17995.007 ±  1749.722    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                  100              4  avgt    5   16916.095 ±   781.269    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space              100              4  avgt    5     320.579 ±    56.247  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space              100              4  avgt    5       9.966 ±     0.653  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm         100              4  avgt    5    4158.110 ±  1011.443    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm         100              4  avgt    5     104.242 ±    10.990    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                 100              4  avgt    5    1094.612 ±     1.369  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                 100              4  avgt    5    1634.544 ±     1.046  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm            100              4  avgt    5   14193.565 ±  1774.536    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm            100              4  avgt    5   17094.442 ±   789.529    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space          100              4  avgt    5       0.761 ±     0.001  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space          100              4  avgt    5       0.761 ±     0.001  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm     100              4  avgt    5       9.874 ±     1.234    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm     100              4  avgt    5       7.956 ±     0.367    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                            100              4  avgt    5      65.000              counts
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                            100              4  avgt    5      65.000              counts
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                             100              4  avgt    5      88.000                  ms
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                             100              4  avgt    5      83.000                  ms
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                      100              8  avgt    5      24.495 ±     1.330   us/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                      100              8  avgt    5      17.741 ±     0.576   us/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                       100              8  avgt    5    1436.307 ±    74.508  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                       100              8  avgt    5    1350.509 ±     3.310  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                  100              8  avgt    5   38649.974 ±     0.001    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                  100              8  avgt    5   26394.021 ±   833.587    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space              100              8  avgt    5     163.985 ±     8.507  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space              100              8  avgt    5      17.579 ±     0.646  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm         100              8  avgt    5    4412.724 ±     0.001    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm         100              8  avgt    5     343.561 ±    13.530    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                 100              8  avgt    5     877.247 ±    45.507  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                 100              8  avgt    5     920.445 ±     2.256  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm            100              8  avgt    5   23606.071 ±     0.027    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm            100              8  avgt    5   17988.955 ±   568.133    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space          100              8  avgt    5       1.451 ±     0.075  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space          100              8  avgt    5       1.522 ±     0.004  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm     100              8  avgt    5      39.051 ±     0.001    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm     100              8  avgt    5      29.746 ±     0.939    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                            100              8  avgt    5     115.000              counts
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                            100              8  avgt    5     110.000              counts
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                             100              8  avgt    5     123.000                  ms
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                             100              8  avgt    5     120.000                  ms
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                     1000              2  avgt    5      61.578 ±    10.756   us/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                     1000              2  avgt    5      53.094 ±     2.464   us/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                      1000              2  avgt    5    1791.829 ±   101.988  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                      1000              2  avgt    5    1771.344 ±    78.276  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                 1000              2  avgt    5  121437.903 ± 14186.309    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                 1000              2  avgt    5  103499.342 ±     0.930    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space             1000              2  avgt    5     581.872 ±   110.569  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space             1000              2  avgt    5       5.616 ±     0.248  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm        1000              2  avgt    5   39394.424 ±  3478.381    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm        1000              2  avgt    5     328.170 ±     0.003    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                1000              2  avgt    5    1215.598 ±    19.786  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                1000              2  avgt    5    1788.032 ±   100.316  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm           1000              2  avgt    5   82438.995 ± 15527.518    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm           1000              2  avgt    5  104471.803 ±  1731.930    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space         1000              2  avgt    5       0.381 ±     0.001  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space         1000              2  avgt    5       0.374 ±     0.017  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm    1000              2  avgt    5      25.822 ±     4.498    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm    1000              2  avgt    5      21.878 ±     0.001    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                           1000              2  avgt    5      40.000              counts
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                           1000              2  avgt    5      40.000              counts
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                            1000              2  avgt    5      61.000                  ms
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                            1000              2  avgt    5      63.000                  ms
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                     1000              4  avgt    5     115.850 ±    14.251   us/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                     1000              4  avgt    5      99.106 ±    37.785   us/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                      1000              4  avgt    5    1636.463 ±   817.986  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                      1000              4  avgt    5    1427.091 ±     1.567  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                 1000              4  avgt    5  208444.492 ± 97826.674    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                 1000              4  avgt    5  155757.808 ± 59425.176    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space             1000              4  avgt    5     319.815 ±   284.456  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space             1000              4  avgt    5       9.214 ±     0.662  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm        1000              4  avgt    5   40655.138 ± 33555.602    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm        1000              4  avgt    5    1006.981 ±   454.877    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                1000              4  avgt    5    1342.369 ±   502.321  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                1000              4  avgt    5    1411.688 ±   302.080  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm           1000              4  avgt    5  171155.645 ± 64834.980    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm           1000              4  avgt    5  153480.166 ± 32348.692    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space         1000              4  avgt    5       0.757 ±     0.042  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space         1000              4  avgt    5       0.685 ±     0.656  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm    1000              4  avgt    5      96.463 ±     7.566    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm    1000              4  avgt    5      75.421 ±    84.596    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                           1000              4  avgt    5      60.000              counts
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                           1000              4  avgt    5      65.000              counts
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                            1000              4  avgt    5      80.000                  ms
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                            1000              4  avgt    5      89.000                  ms
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                     1000              8  avgt    5     210.534 ±    18.223   us/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry                                     1000              8  avgt    5     185.474 ±     3.522   us/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                      1000              8  avgt    5    1363.622 ±    15.691  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate                      1000              8  avgt    5    1700.597 ±    31.361  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                 1000              8  avgt    5  316166.935 ± 23975.704    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.alloc.rate.norm                 1000              8  avgt    5  346495.485 ±     0.001    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space             1000              8  avgt    5     186.323 ±    12.352  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space             1000              8  avgt    5      16.308 ±     0.301  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm        1000              8  avgt    5   43193.966 ±  2815.784    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Eden_Space.norm        1000              8  avgt    5    3322.718 ±     0.001    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                1000              8  avgt    5     819.683 ±     0.831  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen                1000              8  avgt    5    1161.843 ±    21.426  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm           1000              8  avgt    5  190060.070 ± 16500.276    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Old_Gen.norm           1000              8  avgt    5  236724.815 ±     0.293    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space         1000              8  avgt    5       1.523 ±     0.002  MB/sec
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space         1000              8  avgt    5       1.377 ±     0.621  MB/sec
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm    1000              8  avgt    5     353.108 ±    30.655    B/op
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.churn.G1_Survivor_Space.norm    1000              8  avgt    5     280.585 ±   127.154    B/op
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                           1000              8  avgt    5     115.000              counts
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.count                           1000              8  avgt    5     115.000              counts
(before) BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                            1000              8  avgt    5     110.000                  ms
(after)  BenchmarkRowBlockBuilder.benchmarkBeginBlockEntry:·gc.time                            1000              8  avgt    5     138.000                  ms
```