### PR TITLE
Report connector provided read time as connector metric

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -29,6 +29,7 @@ import io.trino.memory.context.AggregatedMemoryContext;
 import io.trino.memory.context.LocalMemoryContext;
 import io.trino.memory.context.MemoryTrackingContext;
 import io.trino.operator.OperationTimer.OperationTiming;
+import io.trino.plugin.base.metrics.DurationTiming;
 import io.trino.plugin.base.metrics.TDigestHistogram;
 import io.trino.spi.Page;
 import io.trino.spi.TrinoException;
@@ -74,6 +75,7 @@ public class OperatorContext
 
     private final CounterStat physicalInputDataSize = new CounterStat();
     private final CounterStat physicalInputPositions = new CounterStat();
+    private final AtomicLong physicalInputReadTimeNanos = new AtomicLong();
 
     private final CounterStat internalNetworkInputDataSize = new CounterStat();
     private final CounterStat internalNetworkPositions = new CounterStat();
@@ -182,7 +184,7 @@ public class OperatorContext
     {
         physicalInputDataSize.update(sizeInBytes);
         physicalInputPositions.update(positions);
-        addInputTiming.record(readNanos, 0);
+        physicalInputReadTimeNanos.getAndAdd(readNanos);
     }
 
     /**
@@ -532,6 +534,16 @@ public class OperatorContext
         return operatorMetrics.mergeWith(new Metrics(ImmutableMap.of("Input distribution", new TDigestHistogram(digest))));
     }
 
+    public static Metrics getConnectorMetrics(Metrics connectorMetrics, long physicalInputReadTimeNanos)
+    {
+        if (physicalInputReadTimeNanos == 0) {
+            return connectorMetrics;
+        }
+
+        return connectorMetrics.mergeWith(new Metrics(ImmutableMap.of(
+                "Physical input read time", new DurationTiming(new Duration(physicalInputReadTimeNanos, NANOSECONDS)))));
+    }
+
     public <C, R> R accept(QueryContextVisitor<C, R> visitor, C context)
     {
         return visitor.visitOperatorContext(this, context);
@@ -573,7 +585,7 @@ public class OperatorContext
 
                 dynamicFilterSplitsProcessed.get(),
                 getOperatorMetrics(metrics.get(), inputPositionsCount),
-                connectorMetrics.get(),
+                getConnectorMetrics(connectorMetrics.get(), physicalInputReadTimeNanos.get()),
 
                 DataSize.ofBytes(physicalWrittenDataSize.get()),
 

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorPipelineSourceOperator.java
@@ -50,6 +50,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.trino.operator.BlockedReason.WAITING_FOR_MEMORY;
+import static io.trino.operator.OperatorContext.getConnectorMetrics;
 import static io.trino.operator.OperatorContext.getOperatorMetrics;
 import static io.trino.operator.PageUtils.recordMaterializedBytes;
 import static io.trino.operator.WorkProcessor.ProcessState.Type.BLOCKED;
@@ -319,8 +320,7 @@ public class WorkProcessorPipelineSourceOperator
 
                         // WorkProcessorOperator doesn't have addInput call
                         0,
-                        // source operators report read time though
-                        new Duration(context.readTimeNanos.get(), NANOSECONDS),
+                        new Duration(0, NANOSECONDS),
                         ZERO_DURATION,
 
                         succinctBytes(context.physicalInputDataSize.get()),
@@ -344,7 +344,7 @@ public class WorkProcessorPipelineSourceOperator
 
                         context.dynamicFilterSplitsProcessed.get(),
                         getOperatorMetrics(context.metrics.get(), context.inputPositions.get()),
-                        context.connectorMetrics.get(),
+                        getConnectorMetrics(context.connectorMetrics.get(), context.readTimeNanos.get()),
 
                         DataSize.ofBytes(0),
 

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessorPipelineSourceOperator.java
@@ -26,6 +26,7 @@ import io.trino.metadata.Split;
 import io.trino.operator.WorkProcessor.Transformation;
 import io.trino.operator.WorkProcessor.TransformationState;
 import io.trino.operator.WorkProcessorAssertion.Transform;
+import io.trino.plugin.base.metrics.DurationTiming;
 import io.trino.plugin.base.metrics.LongCount;
 import io.trino.spi.Page;
 import io.trino.spi.connector.UpdatablePageSource;
@@ -217,7 +218,8 @@ public class TestWorkProcessorPipelineSourceOperator
                 .containsEntry("testSourceClosed", new LongCount(1));
         assertEquals(sourceOperatorStats.getConnectorMetrics().getMetrics(), ImmutableMap.of(
                 "testSourceConnectorMetric", new LongCount(2),
-                "testSourceConnectorClosed", new LongCount(1)));
+                "testSourceConnectorClosed", new LongCount(1),
+                "Physical input read time", new DurationTiming(new Duration(7, NANOSECONDS))));
 
         assertEquals(sourceOperatorStats.getDynamicFilterSplitsProcessed(), 42L);
 
@@ -230,7 +232,7 @@ public class TestWorkProcessorPipelineSourceOperator
         assertEquals(sourceOperatorStats.getInputDataSize(), DataSize.ofBytes(5));
         assertEquals(sourceOperatorStats.getInputPositions(), 6);
 
-        assertEquals(sourceOperatorStats.getAddInputWall(), new Duration(7, NANOSECONDS));
+        assertEquals(sourceOperatorStats.getAddInputWall(), new Duration(0, NANOSECONDS));
 
         // pipeline input stats should match source WorkProcessorOperator stats
         PipelineStats pipelineStats = pipelineOperator.getOperatorContext().getDriverContext().getPipelineContext().getPipelineStats();
@@ -253,7 +255,8 @@ public class TestWorkProcessorPipelineSourceOperator
                 .containsEntry("testSourceClosed", new LongCount(1));
         assertEquals(operatorSummaries.get(0).getConnectorMetrics().getMetrics(), ImmutableMap.of(
                 "testSourceConnectorMetric", new LongCount(2),
-                "testSourceConnectorClosed", new LongCount(1)));
+                "testSourceConnectorClosed", new LongCount(1),
+                "Physical input read time", new DurationTiming(new Duration(7, NANOSECONDS))));
         assertThat(operatorSummaries.get(1).getMetrics().getMetrics())
                 .hasSize(2)
                 .containsEntry("testOperatorMetric", new LongCount(1));

--- a/core/trino-spi/src/main/java/io/trino/spi/metrics/Timing.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/metrics/Timing.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.spi.metrics;
+
+import java.time.Duration;
+
+public interface Timing<T>
+        extends Metric<T>
+{
+    Duration getDuration();
+}

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/DurationTiming.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/metrics/DurationTiming.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.base.metrics;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.units.Duration;
+import io.trino.spi.metrics.Timing;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class DurationTiming
+        implements Timing<DurationTiming>
+{
+    // use Airlift duration for more human-friendly serialization format
+    // and to match duration serialization in other JSON objects
+    private final Duration duration;
+
+    @JsonCreator
+    public DurationTiming(Duration duration)
+    {
+        this.duration = requireNonNull(duration, "duration is null");
+    }
+
+    @JsonProperty("duration")
+    public Duration getAirliftDuration()
+    {
+        return duration;
+    }
+
+    @Override
+    public java.time.Duration getDuration()
+    {
+        return java.time.Duration.ofNanos(duration.roundTo(NANOSECONDS));
+    }
+
+    @Override
+    public DurationTiming mergeWith(DurationTiming other)
+    {
+        long durationNanos = duration.roundTo(NANOSECONDS);
+        long otherDurationNanos = other.getAirliftDuration().roundTo(NANOSECONDS);
+        return new DurationTiming(new Duration(durationNanos + otherDurationNanos, NANOSECONDS).convertToMostSuccinctTimeUnit());
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DurationTiming that = (DurationTiming) o;
+        return duration.equals(that.duration);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(duration);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper("")
+                .add("duration", duration)
+                .toString();
+    }
+}

--- a/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
+++ b/plugin/trino-hive/src/test/java/io/trino/plugin/hive/TestHiveConnectorTest.java
@@ -8279,6 +8279,14 @@ public class TestHiveConnectorTest
         assertUpdate("DROP TABLE " + tableName);
     }
 
+    @Test
+    public void testExplainAnalyzePhysicalReadWallTime()
+    {
+        assertExplainAnalyze(
+                "EXPLAIN ANALYZE VERBOSE SELECT * FROM nation a",
+                "'Physical input read time' = \\{duration=.*}");
+    }
+
     private static final Set<HiveStorageFormat> NAMED_COLUMN_ONLY_FORMATS = ImmutableSet.of(HiveStorageFormat.AVRO, HiveStorageFormat.JSON);
 
     @DataProvider

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -3022,12 +3022,12 @@ public abstract class BaseIcebergConnectorTest
         OperatorStats operatorStats = getOperatorStats(queryId);
         if (expectedSplitCount > 0) {
             assertThat(operatorStats.getTotalDrivers()).isEqualTo(expectedSplitCount);
-            assertThat(operatorStats.getAddInputCalls()).isGreaterThan(0);
+            assertThat(operatorStats.getPhysicalInputPositions()).isGreaterThan(0);
         }
         else {
             // expectedSplitCount == 0
             assertThat(operatorStats.getTotalDrivers()).isEqualTo(1);
-            assertThat(operatorStats.getAddInputCalls()).isEqualTo(0);
+            assertThat(operatorStats.getPhysicalInputPositions()).isEqualTo(0);
         }
     }
 


### PR DESCRIPTION
Previously connector provided read time was added
to OperatorContext#addInputTiming which caused table scan
wall time to be accounted for twice.