### PR TITLE
Handle setBytes future in table scan and filter operators

### DIFF
--- a/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/DriverContext.java
@@ -228,11 +228,6 @@ public class DriverContext
         return driverMemoryContext.getRevocableMemory();
     }
 
-    public void moreMemoryAvailable()
-    {
-        operatorContexts.forEach(OperatorContext::moreMemoryAvailable);
-    }
-
     public boolean isPerOperatorCpuTimerEnabled()
     {
         return pipelineContext.isPerOperatorCpuTimerEnabled();

--- a/core/trino-main/src/main/java/io/trino/operator/FilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/FilterAndProjectOperator.java
@@ -63,7 +63,7 @@ public class FilterAndProjectOperator
                         page,
                         avoidPageMaterialization))
                 .transformProcessor(processor -> mergePages(types, minOutputPageSize.toBytes(), minOutputPageRowCount, processor, localAggregatedMemoryContext))
-                .withProcessStateMonitor(state -> memoryTrackingContext.localSystemMemoryContext().setBytes(localAggregatedMemoryContext.getBytes()));
+                .blocking(() -> memoryTrackingContext.localSystemMemoryContext().setBytes(localAggregatedMemoryContext.getBytes()));
     }
 
     @Override

--- a/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/OperatorContext.java
@@ -412,11 +412,6 @@ public class OperatorContext
         return spillContext;
     }
 
-    public void moreMemoryAvailable()
-    {
-        memoryFuture.get().set(null);
-    }
-
     public synchronized boolean isMemoryRevokingRequested()
     {
         return memoryRevokingRequested;

--- a/core/trino-main/src/main/java/io/trino/operator/PipelineContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/PipelineContext.java
@@ -261,11 +261,6 @@ public class PipelineContext
         return pipelineMemoryContext.localSystemMemoryContext();
     }
 
-    public void moreMemoryAvailable()
-    {
-        drivers.forEach(DriverContext::moreMemoryAvailable);
-    }
-
     public boolean isPerOperatorCpuTimerEnabled()
     {
         return taskContext.isPerOperatorCpuTimerEnabled();

--- a/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
+++ b/core/trino-main/src/main/java/io/trino/operator/ScanFilterAndProjectOperator.java
@@ -283,7 +283,7 @@ public class ScanFilterAndProjectOperator
             return WorkProcessor
                     .create(new RecordCursorToPages(session, yieldSignal, cursorProcessor, types, pageSourceMemoryContext, outputMemoryContext))
                     .yielding(yieldSignal::isSet)
-                    .withProcessStateMonitor(state -> memoryContext.setBytes(localAggregatedMemoryContext.getBytes()));
+                    .blocking(() -> memoryContext.setBytes(localAggregatedMemoryContext.getBytes()));
         }
 
         WorkProcessor<Page> processPageSource()
@@ -299,7 +299,7 @@ public class ScanFilterAndProjectOperator
                             page,
                             avoidPageMaterialization))
                     .transformProcessor(processor -> mergePages(types, minOutputPageSize.toBytes(), minOutputPageRowCount, processor, localAggregatedMemoryContext))
-                    .withProcessStateMonitor(state -> memoryContext.setBytes(localAggregatedMemoryContext.getBytes()));
+                    .blocking(() -> memoryContext.setBytes(localAggregatedMemoryContext.getBytes()));
         }
     }
 

--- a/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
+++ b/core/trino-main/src/main/java/io/trino/operator/TaskContext.java
@@ -323,11 +323,6 @@ public class TaskContext
         return taskMemoryContext.localSystemMemoryContext();
     }
 
-    public void moreMemoryAvailable()
-    {
-        pipelineContexts.forEach(PipelineContext::moreMemoryAvailable);
-    }
-
     public boolean isPerOperatorCpuTimerEnabled()
     {
         return perOperatorCpuTimerEnabled;

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessor.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessor.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -64,6 +65,11 @@ public interface WorkProcessor<T>
     default WorkProcessor<T> yielding(BooleanSupplier yieldSignal)
     {
         return WorkProcessorUtils.yielding(this, yieldSignal);
+    }
+
+    default WorkProcessor<T> blocking(Supplier<ListenableFuture<Void>> futureSupplier)
+    {
+        return WorkProcessorUtils.blocking(this, futureSupplier);
     }
 
     default WorkProcessor<T> withProcessEntryMonitor(Runnable monitor)

--- a/core/trino-main/src/main/java/io/trino/operator/WorkProcessorUtils.java
+++ b/core/trino-main/src/main/java/io/trino/operator/WorkProcessorUtils.java
@@ -28,6 +28,7 @@ import java.util.PriorityQueue;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -180,6 +181,24 @@ public final class WorkProcessorUtils
 
             return getNextState(processor);
         }
+    }
+
+    static <T> WorkProcessor<T> blocking(WorkProcessor<T> processor, Supplier<ListenableFuture<Void>> futureSupplier)
+    {
+        requireNonNull(processor, "processor is null");
+        requireNonNull(futureSupplier, "futureSupplier is null");
+        return processor.transform(element -> {
+            if (element == null) {
+                return TransformationState.finished();
+            }
+
+            ListenableFuture<Void> future = futureSupplier.get();
+            if (!future.isDone()) {
+                return TransformationState.blocked(future);
+            }
+
+            return TransformationState.ofResult(element);
+        });
     }
 
     static <T> WorkProcessor<T> processEntryMonitor(WorkProcessor<T> processor, Runnable monitor)

--- a/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessor.java
+++ b/core/trino-main/src/test/java/io/trino/operator/TestWorkProcessor.java
@@ -234,6 +234,33 @@ public class TestWorkProcessor
     }
 
     @Test(timeOut = 10_000)
+    public void testBlock()
+    {
+        SettableFuture<Void> phase1 = SettableFuture.create();
+
+        List<ProcessState<Integer>> scenario = ImmutableList.of(
+                ProcessState.blocked(phase1),
+                ProcessState.ofResult(1),
+                ProcessState.ofResult(2),
+                ProcessState.finished());
+
+        SettableFuture<Void> phase2 = SettableFuture.create();
+        WorkProcessor<Integer> processor = processorFrom(scenario)
+                .blocking(() -> phase2);
+
+        assertBlocks(processor);
+        assertUnblocks(processor, phase1);
+
+        assertBlocks(processor);
+        assertUnblocks(processor, phase2);
+
+        assertResult(processor, 1);
+        assertResult(processor, 2);
+
+        assertFinishes(processor);
+    }
+
+    @Test(timeOut = 10_000)
     public void testProcessStateMonitor()
     {
         SettableFuture<Void> future = SettableFuture.create();


### PR DESCRIPTION
Previously setBytes future was ignored which could lead
to OOM if operators continued processing. This change
should improve memory handling in highly concurrent
scanarios.