### PR TITLE
Add Iceberg $properties system table

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -238,6 +238,8 @@ public class IcebergMetadata
                 return Optional.of(new ManifestsTable(systemTableName, table, getSnapshotId(table, name.getSnapshotId())));
             case FILES:
                 return Optional.of(new FilesTable(systemTableName, typeManager, table, getSnapshotId(table, name.getSnapshotId())));
+            case PROPERTIES:
+                return Optional.of(new PropertiesTable(systemTableName, table));
         }
         return Optional.empty();
     }

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PropertiesTable.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/PropertiesTable.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.trino.plugin.iceberg;
+
+import com.google.common.collect.ImmutableList;
+import io.trino.plugin.iceberg.util.PageListBuilder;
+import io.trino.spi.Page;
+import io.trino.spi.connector.ColumnMetadata;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.ConnectorSession;
+import io.trino.spi.connector.ConnectorTableMetadata;
+import io.trino.spi.connector.ConnectorTransactionHandle;
+import io.trino.spi.connector.FixedPageSource;
+import io.trino.spi.connector.SchemaTableName;
+import io.trino.spi.connector.SystemTable;
+import io.trino.spi.predicate.TupleDomain;
+import org.apache.iceberg.Table;
+
+import java.util.List;
+
+import static io.trino.spi.type.VarcharType.VARCHAR;
+import static java.util.Objects.requireNonNull;
+
+public class PropertiesTable
+        implements SystemTable
+{
+    private final ConnectorTableMetadata tableMetadata;
+    private final Table icebergTable;
+
+    public PropertiesTable(SchemaTableName tableName, Table icebergTable)
+    {
+        this.icebergTable = requireNonNull(icebergTable, "icebergTable is null");
+
+        this.tableMetadata = new ConnectorTableMetadata(requireNonNull(tableName, "tableName is null"),
+                ImmutableList.<ColumnMetadata>builder()
+                        .add(new ColumnMetadata("key", VARCHAR))
+                        .add(new ColumnMetadata("value", VARCHAR))
+                        .build());
+    }
+
+    @Override
+    public Distribution getDistribution()
+    {
+        return Distribution.SINGLE_COORDINATOR;
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata()
+    {
+        return tableMetadata;
+    }
+
+    @Override
+    public ConnectorPageSource pageSource(ConnectorTransactionHandle transactionHandle, ConnectorSession session, TupleDomain<Integer> constraint)
+    {
+        return new FixedPageSource(buildPages(tableMetadata, icebergTable));
+    }
+
+    private static List<Page> buildPages(ConnectorTableMetadata tableMetadata, Table icebergTable)
+    {
+        PageListBuilder pagesBuilder = PageListBuilder.forTable(tableMetadata);
+
+        icebergTable.properties().entrySet().forEach(prop -> {
+            pagesBuilder.beginRow();
+            pagesBuilder.appendVarchar(prop.getKey());
+            pagesBuilder.appendVarchar(prop.getValue());
+            pagesBuilder.endRow();
+        });
+
+        return pagesBuilder.build();
+    }
+}

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableType.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TableType.java
@@ -21,4 +21,5 @@ public enum TableType
     MANIFESTS,
     PARTITIONS,
     FILES,
+    PROPERTIES,
 }

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/BaseIcebergConnectorTest.java
@@ -2954,6 +2954,15 @@ public abstract class BaseIcebergConnectorTest
         }
     }
 
+    @Test
+    public void testGetIcebergTableProperties()
+    {
+        assertUpdate("CREATE TABLE test_iceberg_get_table_props (x BIGINT)");
+        assertThat(query("SELECT * FROM \"test_iceberg_get_table_props$properties\""))
+                .matches(format("VALUES (VARCHAR 'write.format.default', VARCHAR '%s')", format.name()));
+        dropTable("test_iceberg_get_table_props");
+    }
+
     protected abstract boolean supportsIcebergFileStatistics(String typeName);
 
     @Test(dataProvider = "testDataMappingSmokeTestDataProvider")

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMetastoreAccessOperations.java
@@ -48,6 +48,7 @@ import static io.trino.plugin.iceberg.TableType.FILES;
 import static io.trino.plugin.iceberg.TableType.HISTORY;
 import static io.trino.plugin.iceberg.TableType.MANIFESTS;
 import static io.trino.plugin.iceberg.TableType.PARTITIONS;
+import static io.trino.plugin.iceberg.TableType.PROPERTIES;
 import static io.trino.plugin.iceberg.TableType.SNAPSHOTS;
 import static io.trino.testing.TestingSession.testSessionBuilder;
 import static java.lang.String.format;
@@ -287,9 +288,15 @@ public class TestIcebergMetastoreAccessOperations
                         .addCopies(GET_TABLE, 1)
                         .build());
 
+        // select from $properties
+        assertMetastoreInvocations("SELECT * FROM \"test_select_snapshots$properties\"",
+                ImmutableMultiset.builder()
+                        .addCopies(GET_TABLE, 1)
+                        .build());
+
         // This test should get updated if a new system table is added.
         assertThat(TableType.values())
-                .containsExactly(DATA, HISTORY, SNAPSHOTS, MANIFESTS, PARTITIONS, FILES);
+                .containsExactly(DATA, HISTORY, SNAPSHOTS, MANIFESTS, PARTITIONS, FILES, PROPERTIES);
     }
 
     private void assertMetastoreInvocations(String query, Multiset<?> expectedInvocations)


### PR DESCRIPTION
Iceberg supports a collection of system tables for access metadata. Unlike when using Iceberg with Spark where you have full access to the Iceberg Java API, tooling dependent on Trino do not have a way of getting the tables properties of a given table. 

My team has found it useful to have this "Properties" table so that we can inspect the tables properties via Trino. More specifically we have [DBT](https://www.getdbt.com/) based modeling framework written in Python that utilizes Trino as its engine. It relies on specific metadata that we are currently storing in the table properties of our Iceberg tables. Iceberg's Python API is lacking in features and support, thus didn't want to depend on it yet. These few small changes to add this "Properties" table to Trino was ideal solution to our predicament.

It's also important to note that the original Iceberg Spec does not include such a table in Spark SQL, though I do not see a huge necessity for it given the Java API which can be imported into a Spark based application. 