### PR TITLE
Ignore REMOTE_TASK_FAILED errors in DeduplicationExchangeClientBuffer

### DIFF
--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
@@ -1013,7 +1013,7 @@ public class SqlQueryScheduler
         @Override
         public void onTaskFailed(TaskId taskId, Throwable failure)
         {
-            if (failure instanceof TrinoException && ((TrinoException) failure).getErrorCode() == REMOTE_TASK_FAILED.toErrorCode()) {
+            if (failure instanceof TrinoException && REMOTE_TASK_FAILED.toErrorCode().equals(((TrinoException) failure).getErrorCode())) {
                 // This error indicates that a downstream task was trying to fetch results from an upstream task that is marked as failed
                 // Instead of failing a downstream task let the coordinator handle and report the failure of an upstream task to ensure correct error reporting
                 log.info("Task failure discovered while fetching task results: %s", taskId);

--- a/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
+++ b/core/trino-main/src/main/java/io/trino/execution/scheduler/SqlQueryScheduler.java
@@ -1016,7 +1016,7 @@ public class SqlQueryScheduler
             if (failure instanceof TrinoException && REMOTE_TASK_FAILED.toErrorCode().equals(((TrinoException) failure).getErrorCode())) {
                 // This error indicates that a downstream task was trying to fetch results from an upstream task that is marked as failed
                 // Instead of failing a downstream task let the coordinator handle and report the failure of an upstream task to ensure correct error reporting
-                log.info("Task failure discovered while fetching task results: %s", taskId);
+                log.debug("Task failure discovered while fetching task results: %s", taskId);
                 return;
             }
             log.warn(failure, "Reported task failure: %s", taskId);

--- a/core/trino-main/src/main/java/io/trino/operator/StreamingExchangeClientBuffer.java
+++ b/core/trino-main/src/main/java/io/trino/operator/StreamingExchangeClientBuffer.java
@@ -141,7 +141,7 @@ public class StreamingExchangeClientBuffer
         }
         checkState(activeTasks.contains(taskId), "taskId not registered: %s", taskId);
 
-        if (t instanceof TrinoException && ((TrinoException) t).getErrorCode() == REMOTE_TASK_FAILED.toErrorCode()) {
+        if (t instanceof TrinoException && REMOTE_TASK_FAILED.toErrorCode().equals(((TrinoException) t).getErrorCode())) {
             // let coordinator handle this
             return;
         }

--- a/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestFailureRecovery.java
+++ b/testing/trino-testing/src/main/java/io/trino/testing/AbstractTestFailureRecovery.java
@@ -363,8 +363,7 @@ public abstract class AbstractTestFailureRecovery
                 .withCleanupQuery(cleanupQuery)
                 .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
                 .at(boundaryCoordinatorStage())
-                // TODO(https://github.com/trinodb/trino/issues/10395 original exception message is lost sometimes
-                .failsAlways(failure -> failure.hasMessageFindingMatch("\\Q" + FAILURE_INJECTION_MESSAGE + "\\E|Remote task failed.*"));
+                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
 
         assertThatQuery(query)
                 .withSession(session)
@@ -372,8 +371,7 @@ public abstract class AbstractTestFailureRecovery
                 .withCleanupQuery(cleanupQuery)
                 .experiencing(TASK_FAILURE, Optional.of(ErrorType.INTERNAL_ERROR))
                 .at(rootStage())
-                // TODO(https://github.com/trinodb/trino/issues/10395 original exception message is lost sometimes
-                .failsAlways(failure -> failure.hasMessageFindingMatch("\\Q" + FAILURE_INJECTION_MESSAGE + "\\E|Remote task failed.*"));
+                .failsAlways(failure -> failure.hasMessageContaining(FAILURE_INJECTION_MESSAGE));
 
         assertThatQuery(query)
                 .withSession(session)


### PR DESCRIPTION
REMOTE_TASK_FAILED errors are intended to be reported and handled as
part of a status update for a task to correctly report original error