### PR TITLE
Remove beta disclaimer from BigQuery documentation

### DIFF
--- a/docs/src/main/sphinx/connector/bigquery.rst
+++ b/docs/src/main/sphinx/connector/bigquery.rst
@@ -8,17 +8,6 @@ different systems like BigQuery and Hive. The connector uses the `BigQuery
 Storage API <https://cloud.google.com/bigquery/docs/reference/storage/>`_ to
 read the data from the tables.
 
-Beta disclaimer
----------------
-
-This connector is in Beta and is subject to change.
-
-Changes may include, but are not limited to:
-
-* Type conversion
-* Partitioning
-* Parameters
-
 BigQuery Storage API
 --------------------
 


### PR DESCRIPTION
We released BigQuery connector in version 331 (16 Mar 2020). Removing this disclaimer is no problem to me. 