### PR TITLE
Don't delete Hive and Iceberg schema locations with nonempty subdirectories

### DIFF
--- a/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -389,7 +389,7 @@ public class SemiTransactionalHiveMetastore
             boolean deleteData = location.map(path -> {
                 HdfsContext context = new HdfsContext(session);
                 try (FileSystem fs = hdfsEnvironment.getFileSystem(context, path)) {
-                    return !fs.listFiles(path, false).hasNext();
+                    return !fs.listLocatedStatus(path).hasNext();
                 }
                 catch (IOException | RuntimeException e) {
                     log.warn(e, "Could not check schema directory '%s'", path);

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/TrinoHiveCatalog.java
@@ -231,7 +231,7 @@ class TrinoHiveCatalog
         boolean deleteData = location.map(path -> {
             HdfsContext context = new HdfsContext(session);
             try (FileSystem fs = hdfsEnvironment.getFileSystem(context, path)) {
-                return !fs.listFiles(path, false).hasNext();
+                return !fs.listLocatedStatus(path).hasNext();
             }
             catch (IOException e) {
                 log.warn(e, "Could not check schema directory '%s'", path);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCreateDropSchema.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCreateDropSchema.java
@@ -82,19 +82,37 @@ public class TestCreateDropSchema
     {
         String schemaName = "schema_with_nonempty_location_" + randomTableSuffix();
         String schemaDir = warehouseDirectory + "/schema-with-nonempty-location/";
+        // Use subdirectory to make sure file check is recursive
+        String subDir = schemaDir + "subdir/";
+        String externalFile = subDir + "external-file";
 
-        // Create file in schema directory before creating schema
-        String externalFile = schemaDir + "external-file";
-        hdfsClient.createDirectory(schemaDir);
+        // Create file below schema directory before creating schema
+        hdfsClient.createDirectory(subDir);
         hdfsClient.saveFile(externalFile, "");
 
         onTrino().executeQuery(format("CREATE SCHEMA %s WITH (location = '%s')", schemaName, schemaDir));
-        assertFileExistence(schemaDir, true, "schema directory exists after creating schema");
+        assertFileExistence(externalFile, true, "external file exists after creating schema");
         onTrino().executeQuery("DROP SCHEMA " + schemaName);
-        assertFileExistence(schemaDir, true, "schema directory exists after dropping schema");
         assertFileExistence(externalFile, true, "external file exists after dropping schema");
 
-        hdfsClient.delete(externalFile);
+        hdfsClient.delete(schemaDir);
+    }
+
+    @Test // make sure empty directories are noticed as well
+    public void testDropSchemaFilesWithEmptyExternalSubdir()
+    {
+        String schemaName = "schema_with_empty_subdirectory_" + randomTableSuffix();
+        String schemaDir = format("%s/%s.db/", warehouseDirectory, schemaName);
+        String externalSubdir = schemaDir + "external-subdir/";
+
+        hdfsClient.createDirectory(externalSubdir);
+
+        onTrino().executeQuery("CREATE SCHEMA " + schemaName);
+        assertFileExistence(externalSubdir, true, "external subdirectory exists after creating schema");
+        onTrino().executeQuery("DROP SCHEMA " + schemaName);
+        assertFileExistence(externalSubdir, true, "external subdirectory exists after dropping schema");
+
+        hdfsClient.delete(schemaDir);
     }
 
     // Tests create/drop schema transactions with default schema location

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCreateDropSchema.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestCreateDropSchema.java
@@ -54,19 +54,7 @@ public class TestCreateDropSchema
     }
 
     @Test
-    public void testDropSchemaWithLocationWithoutExternalFiles()
-    {
-        String schemaName = "schema_with_empty_location_" + randomTableSuffix();
-        String schemaDir = warehouseDirectory + "/schema-with-empty-location/";
-
-        onTrino().executeQuery(format("CREATE SCHEMA %s WITH (location = '%s')", schemaName, schemaDir));
-        assertFileExistence(schemaDir, true, "schema directory exists after creating schema");
-        onTrino().executeQuery("DROP SCHEMA " + schemaName);
-        assertFileExistence(schemaDir, false, "schema directory exists after dropping schema");
-    }
-
-    @Test
-    public void testDropSchemaFilesWithoutLocation()
+    public void testDropSchemaFiles()
     {
         String schemaName = "schema_without_location_" + randomTableSuffix();
         String schemaDir = format("%s/%s.db/", warehouseDirectory, schemaName);
@@ -78,7 +66,19 @@ public class TestCreateDropSchema
     }
 
     @Test
-    public void testDropSchemaFilesWithLocationWithExternalFile()
+    public void testDropSchemaFilesWithLocation()
+    {
+        String schemaName = "schema_with_empty_location_" + randomTableSuffix();
+        String schemaDir = warehouseDirectory + "/schema-with-empty-location/";
+
+        onTrino().executeQuery(format("CREATE SCHEMA %s WITH (location = '%s')", schemaName, schemaDir));
+        assertFileExistence(schemaDir, true, "schema directory exists after creating schema");
+        onTrino().executeQuery("DROP SCHEMA " + schemaName);
+        assertFileExistence(schemaDir, false, "schema directory exists after dropping schema");
+    }
+
+    @Test // specified location, external file in subdir
+    public void testDropWithExternalFilesInSubdirectory()
     {
         String schemaName = "schema_with_nonempty_location_" + randomTableSuffix();
         String schemaDir = warehouseDirectory + "/schema-with-nonempty-location/";
@@ -98,7 +98,7 @@ public class TestCreateDropSchema
         hdfsClient.delete(schemaDir);
     }
 
-    @Test // make sure empty directories are noticed as well
+    @Test // default location, empty external subdir
     public void testDropSchemaFilesWithEmptyExternalSubdir()
     {
         String schemaName = "schema_with_empty_subdirectory_" + randomTableSuffix();
@@ -115,8 +115,7 @@ public class TestCreateDropSchema
         hdfsClient.delete(schemaDir);
     }
 
-    // Tests create/drop schema transactions with default schema location
-    @Test
+    @Test // default location, transactions without external files
     public void testDropSchemaFilesTransactions()
     {
         String schemaName = "schema_directory_transactions_" + randomTableSuffix();
@@ -140,8 +139,8 @@ public class TestCreateDropSchema
         assertFileExistence(schemaDir, false, "schema directory exists after dropping schema");
     }
 
-    @Test
-    public void testDropSchemaFilesTransactionsWithExternalFile()
+    @Test // specified location, transaction with top-level external file
+    public void testDropTransactionsWithExternalFiles()
     {
         String schemaName = "schema_transactions_with_external_files_" + randomTableSuffix();
         String schemaDir = warehouseDirectory + "/schema-transactions-with-external-files/";

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestCreateDropSchema.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestCreateDropSchema.java
@@ -46,19 +46,7 @@ public class TestCreateDropSchema
     }
 
     @Test(groups = ICEBERG)
-    public void testDropSchemaWithLocationWithoutExternalFiles()
-    {
-        String schemaName = "schema_with_empty_location_" + randomTableSuffix();
-        String schemaDir = warehouseDirectory + "/schema-with-empty-location/";
-
-        onTrino().executeQuery(format("CREATE SCHEMA %s WITH (location = '%s')", schemaName, schemaDir));
-        assertFileExistence(schemaDir, true, "schema directory exists after creating schema");
-        onTrino().executeQuery("DROP SCHEMA " + schemaName);
-        assertFileExistence(schemaDir, false, "schema directory exists after dropping schema");
-    }
-
-    @Test(groups = ICEBERG)
-    public void testDropSchemaFilesWithoutLocation()
+    public void testDropSchemaFiles()
     {
         String schemaName = "schema_without_location_" + randomTableSuffix();
         String schemaDir = format("%s/%s.db/", warehouseDirectory, schemaName);
@@ -70,7 +58,19 @@ public class TestCreateDropSchema
     }
 
     @Test(groups = ICEBERG)
-    public void testDropSchemaFilesWithLocationWithExternalFile()
+    public void testDropSchemaFilesWithLocation()
+    {
+        String schemaName = "schema_with_empty_location_" + randomTableSuffix();
+        String schemaDir = warehouseDirectory + "/schema-with-empty-location/";
+
+        onTrino().executeQuery(format("CREATE SCHEMA %s WITH (location = '%s')", schemaName, schemaDir));
+        assertFileExistence(schemaDir, true, "schema directory exists after creating schema");
+        onTrino().executeQuery("DROP SCHEMA " + schemaName);
+        assertFileExistence(schemaDir, false, "schema directory exists after dropping schema");
+    }
+
+    @Test(groups = ICEBERG) // specified location, external file in subdir
+    public void testDropWithExternalFilesInSubdirectory()
     {
         String schemaName = "schema_with_nonempty_location_" + randomTableSuffix();
         String schemaDir = warehouseDirectory + "/schema-with-nonempty-location/";
@@ -107,8 +107,8 @@ public class TestCreateDropSchema
         hdfsClient.delete(schemaDir);
     }
 
-    @Test(groups = ICEBERG)
-    public void testDropSchemaWithExternalFileWithoutLocation()
+    @Test(groups = ICEBERG) // default location, external file at top level
+    public void testDropWithExternalFiles()
     {
         String schemaName = "schema_with_files_in_default_location_" + randomTableSuffix();
         String schemaDir = format("%s/%s.db/", warehouseDirectory, schemaName);

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestCreateDropSchema.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/iceberg/TestCreateDropSchema.java
@@ -74,19 +74,36 @@ public class TestCreateDropSchema
     {
         String schemaName = "schema_with_nonempty_location_" + randomTableSuffix();
         String schemaDir = warehouseDirectory + "/schema-with-nonempty-location/";
+        // Use subdirectory to make sure file check is recursive
+        String subDir = schemaDir + "subdir/";
+        String externalFile = subDir + "external-file";
 
-        // Create file in schema directory before creating schema
-        String externalFile = schemaDir + "external-file";
-        hdfsClient.createDirectory(schemaDir);
+        // Create file below schema directory before creating schema
+        hdfsClient.createDirectory(subDir);
         hdfsClient.saveFile(externalFile, "");
 
         onTrino().executeQuery(format("CREATE SCHEMA %s WITH (location = '%s')", schemaName, schemaDir));
-        assertFileExistence(schemaDir, true, "schema directory exists after creating schema");
+        assertFileExistence(externalFile, true, "external file exists after creating schema");
         onTrino().executeQuery("DROP SCHEMA " + schemaName);
-        assertFileExistence(schemaDir, true, "schema directory exists after dropping schema");
         assertFileExistence(externalFile, true, "external file exists after dropping schema");
 
-        hdfsClient.delete(externalFile);
+        hdfsClient.delete(schemaDir);
+    }
+
+    @Test(groups = ICEBERG) // make sure empty directories are noticed as well
+    public void testDropSchemaFilesWithEmptyExternalSubdir()
+    {
+        String schemaName = "schema_with_empty_subdirectory_" + randomTableSuffix();
+        String schemaDir = format("%s/%s.db/", warehouseDirectory, schemaName);
+        String externalSubdir = schemaDir + "external-subdir/";
+
+        hdfsClient.createDirectory(externalSubdir);
+
+        onTrino().executeQuery("CREATE SCHEMA " + schemaName);
+        assertFileExistence(externalSubdir, true, "external subdirectory exists after creating schema");
+        onTrino().executeQuery("DROP SCHEMA " + schemaName);
+        assertFileExistence(externalSubdir, true, "external subdirectory exists after dropping schema");
+
         hdfsClient.delete(schemaDir);
     }
 


### PR DESCRIPTION
This fixes an error in #10146 and #9767 that caused files in subdirectories to be ignored when determining whether to delete schema locations when dropping Hive and Iceberg schemas.

~~(Any empty subdirectories will still be deleted with the schema, though.)~~