### PR TITLE
Add support for file based security in the iceberg connector

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityConfig.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityConfig.java
@@ -24,6 +24,7 @@ public class IcebergSecurityConfig
         ALLOW_ALL,
         READ_ONLY,
         SYSTEM,
+        FILE,
     }
 
     private IcebergSecurity securitySystem = IcebergSecurity.ALLOW_ALL;

--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityModule.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergSecurityModule.java
@@ -17,11 +17,13 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import io.airlift.configuration.AbstractConfigurationAwareModule;
 import io.trino.plugin.base.security.ConnectorAccessControlModule;
+import io.trino.plugin.base.security.FileBasedAccessControlModule;
 import io.trino.plugin.base.security.ReadOnlySecurityModule;
 import io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity;
 
 import static io.airlift.configuration.ConditionalModule.conditionalModule;
 import static io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity.ALLOW_ALL;
+import static io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity.FILE;
 import static io.trino.plugin.iceberg.IcebergSecurityConfig.IcebergSecurity.READ_ONLY;
 
 public class IcebergSecurityModule
@@ -33,6 +35,7 @@ public class IcebergSecurityModule
         install(new ConnectorAccessControlModule());
         bindSecurityModule(ALLOW_ALL, new AllowAllSecurityModule());
         bindSecurityModule(READ_ONLY, new ReadOnlySecurityModule());
+        bindSecurityModule(FILE, new FileBasedAccessControlModule());
         // SYSTEM: do not bind an ConnectorAccessControl so the engine will use system security with system roles
     }
 


### PR DESCRIPTION
We'd like to be able to use file based security for the iceberg connector catalogs rather than relying on "allow all" or the system level security configuration.