### PR TITLE
Test for Hive compatibility across file formats

### DIFF
--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/HiveProductTest.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/HiveProductTest.java
@@ -75,4 +75,15 @@ public class HiveProductTest
         return getHiveVersionMajor() == 0
                 || (getHiveVersionMajor() == 1 && getHiveVersionMinor() < 2);
     }
+
+    protected boolean isHiveWithBrokenAvroTimestamps()
+    {
+        // In 3.1.0 timestamp semantics in hive changed in backward incompatible way,
+        // which was fixed for Parquet and Avro in 3.1.2 (https://issues.apache.org/jira/browse/HIVE-21002)
+        // we do have a work-around for Parquet, but still need this for Avro until
+        // https://github.com/trinodb/trino/issues/5144 is addressed
+        return getHiveVersionMajor() == 3 &&
+                getHiveVersionMinor() == 1 &&
+                (getHiveVersionPatch() == 0 || getHiveVersionPatch() == 1);
+    }
 }

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAllDatatypesFromHiveConnector.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestAllDatatypesFromHiveConnector.java
@@ -405,17 +405,6 @@ public class TestAllDatatypesFromHiveConnector
                         "kot binarny".getBytes(UTF_8)));
     }
 
-    private boolean isHiveWithBrokenAvroTimestamps()
-    {
-        // In 3.1.0 timestamp semantics in hive changed in backward incompatible way,
-        // which was fixed for Parquet and Avro in 3.1.2 (https://issues.apache.org/jira/browse/HIVE-21002)
-        // we do have a work-around for Parquet, but still need this for Avro until
-        // https://github.com/trinodb/trino/issues/5144 is addressed
-        return getHiveVersionMajor() == 3 &&
-                getHiveVersionMinor() == 1 &&
-                (getHiveVersionPatch() == 0 || getHiveVersionPatch() == 1);
-    }
-
     private static TableInstance<?> mutableTableInstanceOf(TableDefinition tableDefinition)
     {
         if (tableDefinition.getDatabase().isPresent()) {


### PR DESCRIPTION
Test whether the information written by Trino is correctly read by Hive across the following file formats:

ORC
PARQUET
RCBINARY
RCTEXT
SEQUENCEFILE
TEXTFILE
AVRO


This is the second attempt to merge these changes after https://github.com/trinodb/trino/pull/10309 (which has been reverted after finding the issue https://github.com/trinodb/trino/issues/10486)