### PR TITLE
 FileBasedSystemAccessControl: Make impersonation new_user optional 

### DIFF
--- a/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
@@ -101,6 +101,9 @@ public class TestFileBasedSystemAccessControl
                 .isInstanceOf(AccessDeniedException.class)
                 .hasMessageContaining("Access Denied: User invalid-other cannot impersonate user test");
 
+        accessControlManager.checkCanImpersonateUser(Identity.ofUser("canImpersonateAnyUser"), "any");
+        accessControlManager.checkCanImpersonateUser(Identity.ofUser("canImpersonateAnyUser"), "user");
+
         newAccessControlManager(transactionManager, "catalog_principal.json").checkCanImpersonateUser(Identity.ofUser("anything"), "anythingElse");
     }
 

--- a/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
+++ b/core/trino-main/src/test/java/io/trino/security/TestFileBasedSystemAccessControl.java
@@ -80,41 +80,28 @@ public class TestFileBasedSystemAccessControl
 
         accessControlManager.checkCanImpersonateUser(Identity.ofUser("alice"), "bob");
         accessControlManager.checkCanImpersonateUser(Identity.ofUser("alice"), "charlie");
-        try {
-            accessControlManager.checkCanImpersonateUser(Identity.ofUser("alice"), "admin");
-            throw new AssertionError("expected AccessDeniedException");
-        }
-        catch (AccessDeniedException expected) {
-        }
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("alice"), "admin"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Access Denied: User alice cannot impersonate user admin");
 
         accessControlManager.checkCanImpersonateUser(Identity.ofUser("admin"), "alice");
         accessControlManager.checkCanImpersonateUser(Identity.ofUser("admin"), "bob");
         accessControlManager.checkCanImpersonateUser(Identity.ofUser("admin"), "anything");
         accessControlManager.checkCanImpersonateUser(Identity.ofUser("admin-other"), "anything");
-        try {
-            accessControlManager.checkCanImpersonateUser(Identity.ofUser("admin-test"), "alice");
-            throw new AssertionError("expected AccessDeniedException");
-        }
-        catch (AccessDeniedException expected) {
-        }
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("admin-test"), "alice"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Access Denied: User admin-test cannot impersonate user alice");
 
-        try {
-            accessControlManager.checkCanImpersonateUser(Identity.ofUser("invalid"), "alice");
-            throw new AssertionError("expected AccessDeniedException");
-        }
-        catch (AccessDeniedException expected) {
-        }
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("invalid"), "alice"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Access Denied: User invalid cannot impersonate user alice");
 
         accessControlManager.checkCanImpersonateUser(Identity.ofUser("anything"), "test");
-        try {
-            accessControlManager.checkCanImpersonateUser(Identity.ofUser("invalid-other"), "test");
-            throw new AssertionError("expected AccessDeniedException");
-        }
-        catch (AccessDeniedException expected) {
-        }
+        assertThatThrownBy(() -> accessControlManager.checkCanImpersonateUser(Identity.ofUser("invalid-other"), "test"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("Access Denied: User invalid-other cannot impersonate user test");
 
-        accessControlManager = newAccessControlManager(transactionManager, "catalog_principal.json");
-        accessControlManager.checkCanImpersonateUser(Identity.ofUser("anything"), "anythingElse");
+        newAccessControlManager(transactionManager, "catalog_principal.json").checkCanImpersonateUser(Identity.ofUser("anything"), "anythingElse");
     }
 
     @Test

--- a/core/trino-main/src/test/resources/catalog_impersonation.json
+++ b/core/trino-main/src/test/resources/catalog_impersonation.json
@@ -21,6 +21,12 @@
         {
             "original_user": ".*",
             "new_user": "test"
+        },
+        {
+            "original_user": "canImpersonateAnyUser"
+        },
+        {
+            "allow": false
         }
     ]
 }

--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -364,18 +364,18 @@ use the following rules:
 Impersonation rules
 -------------------
 
-These rules control the ability of a user to impersonate another user.  In
+These rules control the ability of a user to impersonate another user. In
 some environments it is desirable for an administrator (or managed system) to
-run queries on behalf of other users.  In these cases, the administrator
+run queries on behalf of other users. In these cases, the administrator
 authenticates using their credentials, and then submits a query as a different
-user.  When the user context is changed, Trino will verify the administrator
+user. When the user context is changed, Trino will verify the administrator
 is authorized to run queries as the target user.
 
 When these rules are present, the authorization is based on the first matching rule,
 processed from top to bottom. If no rules match, the authorization is denied.
 If impersonation rules are not present but the legacy principal rules are specified,
 it is assumed impersonation access control is being handled by the principal rules,
-so impersonation is allowed.  If neither impersonation nor principal rules are
+so impersonation is allowed. If neither impersonation nor principal rules are
 defined, impersonation is not allowed.
 
 Each impersonation rule is composed of the following fields:
@@ -383,10 +383,10 @@ Each impersonation rule is composed of the following fields:
 * ``original_user`` (optional): regex to match against the user requesting the impersonation. Defaults to ``.*``.
 * ``original_role`` (optional): regex to match against role names of the requesting impersonation. Defaults to ``.*``.
 * ``new_user`` (required): regex to match against the user that will be impersonated.
-* ``allow`` (optional): boolean indicating if the authentication should be allowed.
+* ``allow`` (optional): boolean indicating if the authentication should be allowed. Defaults to ``true``.
 
 The following example allows the ``admin`` role, to impersonate any user, except
-for ``bob``.  It also allows any user to impersonate the ``test`` user:
+for ``bob``. It also allows any user to impersonate the ``test`` user:
 
 .. literalinclude:: user-impersonation.json
     :language: json

--- a/docs/src/main/sphinx/security/file-system-access-control.rst
+++ b/docs/src/main/sphinx/security/file-system-access-control.rst
@@ -382,7 +382,7 @@ Each impersonation rule is composed of the following fields:
 
 * ``original_user`` (optional): regex to match against the user requesting the impersonation. Defaults to ``.*``.
 * ``original_role`` (optional): regex to match against role names of the requesting impersonation. Defaults to ``.*``.
-* ``new_user`` (required): regex to match against the user that will be impersonated.
+* ``new_user`` (optional): regex to match against the user that will be impersonated. Defaults to ``.*``.
 * ``allow`` (optional): boolean indicating if the authentication should be allowed. Defaults to ``true``.
 
 The following example allows the ``admin`` role, to impersonate any user, except

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ImpersonationRule.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/security/ImpersonationRule.java
@@ -29,14 +29,14 @@ public class ImpersonationRule
 {
     private final Optional<Pattern> originalUserPattern;
     private final Optional<Pattern> originalRolePattern;
-    private final Pattern newUserPattern;
+    private final Optional<Pattern> newUserPattern;
     private final boolean allow;
 
     @JsonCreator
     public ImpersonationRule(
             @JsonProperty("original_user") @JsonAlias("originalUser") Optional<Pattern> originalUserPattern,
             @JsonProperty("original_role") Optional<Pattern> originalRolePattern,
-            @JsonProperty("new_user") @JsonAlias("newUser") Pattern newUserPattern,
+            @JsonProperty("new_user") @JsonAlias("newUser") Optional<Pattern> newUserPattern,
             @JsonProperty("allow") Boolean allow)
     {
         this.originalUserPattern = requireNonNull(originalUserPattern, "originalUserPattern is null");
@@ -49,7 +49,7 @@ public class ImpersonationRule
     {
         if (originalUserPattern.map(regex -> regex.matcher(originalUser).matches()).orElse(true) &&
                 originalRolePattern.map(regex -> originalRoles.stream().anyMatch(role -> regex.matcher(role).matches())).orElse(true) &&
-                newUserPattern.matcher(newUser).matches()) {
+                newUserPattern.map(regex -> regex.matcher(newUser).matches()).orElse(true)) {
             return Optional.of(allow);
         }
         return Optional.empty();


### PR DESCRIPTION
Hi Trino team!

When looking at the [File system access control](https://trino.io/docs/current/security/file-system-access-control.html#impersonation-rules) i noticed that the impersonation `new_user` attribute is mandatory.
I'm used to write a statement like this, this works for all my cases but not for the impersonation section. So i propose to make the `new_user` attribute optional. Also updated docs.
```
    {
      "allow": false
    }
```
