### PR TITLE
Speed up builds of freshly checked out branches

### DIFF
--- a/core/trino-main/pom.xml
+++ b/core/trino-main/pom.xml
@@ -462,6 +462,20 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.gaul</groupId>
+                    <artifactId>modernizer-maven-plugin</artifactId>
+                    <configuration>
+                        <ignoreClassNamePatterns>
+                            <!-- we require certain org.testng.Assert methods be called via our Assert class, so that class needs to be allowed to call them -->
+                            <ignoreClassNamePattern>io/trino/testing/assertions/Assert</ignoreClassNamePattern>
+                        </ignoreClassNamePatterns>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -479,17 +493,6 @@
                         <version>${dep.plugin.surefire.version}</version>
                     </dependency>
                 </dependencies>
-            </plugin>
-
-            <plugin>
-                <groupId>org.gaul</groupId>
-                <artifactId>modernizer-maven-plugin</artifactId>
-                <configuration>
-                    <ignoreClassNamePatterns>
-                        <!-- we require certain org.testng.Assert methods be called via our Assert class, so that class needs to be allowed to call them -->
-                        <ignoreClassNamePattern>io/trino/testing/assertions/Assert</ignoreClassNamePattern>
-                    </ignoreClassNamePatterns>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/core/trino-server-rpm/pom.xml
+++ b/core/trino-server-rpm/pom.xml
@@ -79,6 +79,33 @@
                         </mapping>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>default</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <!-- All Trino modules are imported into this module as "provided" dependencies what makes dependencies from all the modules to be cross checked for compatibility -->
+                        <!-- Override rules to disable dependency checks as dependencies of different connectors don't have to be compatible -->
+                        <rules combine.self="override">
+                            <requireFilesSize>
+                                <!-- Maven Central has a 1GB limit -->
+                                <maxsize>1106000000</maxsize>
+                                <files>
+                                    <file>${project.build.directory}/${project.build.finalName}.noarch.rpm</file>
+                                </files>
+                            </requireFilesSize>
+                        </rules>
+                        <fail>true</fail>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -272,33 +299,6 @@
                             </rules>
                         </package>
                     </packages>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <!-- All Trino modules are imported into this module as "provided" dependencies what makes dependencies from all the modules to be cross checked for compatibility -->
-                    <!-- Override rules to disable dependency checks as dependencies of different connectors don't have to be compatible -->
-                    <rules combine.self="override">
-                        <requireFilesSize>
-                            <!-- Maven Central has a 1GB limit -->
-                            <maxsize>1106000000</maxsize>
-                            <files>
-                                <file>${project.build.directory}/${project.build.finalName}.noarch.rpm</file>
-                            </files>
-                        </requireFilesSize>
-                    </rules>
-                    <fail>true</fail>
                 </configuration>
             </plugin>
         </plugins>

--- a/core/trino-server/pom.xml
+++ b/core/trino-server/pom.xml
@@ -27,30 +27,32 @@
     </properties>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <rules combine.self="override">
-                        <requireFilesSize>
-                            <!-- Maven Central has a 1GB limit -->
-                            <maxsize>1073741824</maxsize>
-                            <files>
-                                <file>${project.build.directory}/${project.artifactId}-${project.version}.tar.gz</file>
-                            </files>
-                        </requireFilesSize>
-                    </rules>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <configuration>
+                        <rules combine.self="override">
+                            <requireFilesSize>
+                                <!-- Maven Central has a 1GB limit -->
+                                <maxsize>1073741824</maxsize>
+                                <files>
+                                    <file>${project.build.directory}/${project.artifactId}-${project.version}.tar.gz</file>
+                                </files>
+                            </requireFilesSize>
+                        </rules>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>enforce</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/plugin/trino-accumulo/pom.xml
+++ b/plugin/trino-accumulo/pom.xml
@@ -320,33 +320,35 @@
     </dependencies>
 
     <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-iterators</id>
-                        <!-- the resource is not needed for compilation -->
-                        <phase>process-test-classes</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <skip>false</skip>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>io.trino</groupId>
-                                    <artifactId>trino-accumulo-iterators</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>jar</type>
-                                </artifactItem>
-                            </artifactItems>
-                            <stripVersion>true</stripVersion>
-                            <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>copy-iterators</id>
+                            <!-- the resource is not needed for compilation -->
+                            <phase>process-test-classes</phase>
+                            <goals>
+                                <goal>copy</goal>
+                            </goals>
+                            <configuration>
+                                <skip>false</skip>
+                                <artifactItems>
+                                    <artifactItem>
+                                        <groupId>io.trino</groupId>
+                                        <artifactId>trino-accumulo-iterators</artifactId>
+                                        <version>${project.version}</version>
+                                        <type>jar</type>
+                                    </artifactItem>
+                                </artifactItems>
+                                <stripVersion>true</stripVersion>
+                                <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/plugin/trino-cassandra/pom.xml
+++ b/plugin/trino-cassandra/pom.xml
@@ -203,33 +203,35 @@
     </dependencies>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.basepom.maven</groupId>
-                <artifactId>duplicate-finder-maven-plugin</artifactId>
-                <configuration>
-                    <ignoredDependencies>
-                        <dependency>
-                            <groupId>org.cassandraunit</groupId>
-                            <artifactId>cassandra-unit</artifactId>
-                        </dependency>
-                    </ignoredDependencies>
-                </configuration>
-            </plugin>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.basepom.maven</groupId>
+                    <artifactId>duplicate-finder-maven-plugin</artifactId>
+                    <configuration>
+                        <ignoredDependencies>
+                            <dependency>
+                                <groupId>org.cassandraunit</groupId>
+                                <artifactId>cassandra-unit</artifactId>
+                            </dependency>
+                        </ignoredDependencies>
+                    </configuration>
+                </plugin>
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <rules>
-                        <requireUpperBoundDeps>
-                            <excludes combine.children="append">
-                                <exclude>org.yaml:snakeyaml</exclude>
-                            </excludes>
-                        </requireUpperBoundDeps>
-                    </rules>
-                </configuration>
-            </plugin>
-        </plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <configuration>
+                        <rules>
+                            <requireUpperBoundDeps>
+                                <excludes combine.children="append">
+                                    <exclude>org.yaml:snakeyaml</exclude>
+                                </excludes>
+                            </requireUpperBoundDeps>
+                        </rules>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/plugin/trino-password-authenticators/pom.xml
+++ b/plugin/trino-password-authenticators/pom.xml
@@ -120,17 +120,19 @@
     </dependencies>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.gaul</groupId>
-                <artifactId>modernizer-maven-plugin</artifactId>
-                <configuration>
-                    <ignoreClassNamePatterns>
-                        <!-- To allow usage of java.util.Hashtable -->
-                        <ignoreClassNamePattern>io/trino/plugin/password/jndi/JndiUtils</ignoreClassNamePattern>
-                    </ignoreClassNamePatterns>
-                </configuration>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.gaul</groupId>
+                    <artifactId>modernizer-maven-plugin</artifactId>
+                    <configuration>
+                        <ignoreClassNamePatterns>
+                            <!-- To allow usage of java.util.Hashtable -->
+                            <ignoreClassNamePattern>io/trino/plugin/password/jndi/JndiUtils</ignoreClassNamePattern>
+                        </ignoreClassNamePatterns>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/plugin/trino-phoenix/pom.xml
+++ b/plugin/trino-phoenix/pom.xml
@@ -313,27 +313,29 @@
     </dependencies>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.basepom.maven</groupId>
-                <artifactId>duplicate-finder-maven-plugin</artifactId>
-                <configuration>
-                    <ignoredResourcePatterns>
-                        <ignoredResourcePattern>mrapp-generated-classpath</ignoredResourcePattern>
-                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
-                        <!-- org.apache.commons:commons-math3 french localization file duplicate-->
-                        <ignoredResourcePattern>assets/org/apache/commons/math3/exception/util/LocalizedFormats_fr.properties</ignoredResourcePattern>
-                        <!-- io.airlift:joni and phoenix-client's org.jruby.joni:joni resource duplicates-->
-                        <ignoredResourcePattern>tables/.*\.bin</ignoredResourcePattern>
-                    </ignoredResourcePatterns>
-                    <ignoredDependencies>
-                        <dependency>
-                            <groupId>com.clearspring.analytics</groupId>
-                            <artifactId>stream</artifactId>
-                        </dependency>
-                    </ignoredDependencies>
-                </configuration>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.basepom.maven</groupId>
+                    <artifactId>duplicate-finder-maven-plugin</artifactId>
+                    <configuration>
+                        <ignoredResourcePatterns>
+                            <ignoredResourcePattern>mrapp-generated-classpath</ignoredResourcePattern>
+                            <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                            <!-- org.apache.commons:commons-math3 french localization file duplicate-->
+                            <ignoredResourcePattern>assets/org/apache/commons/math3/exception/util/LocalizedFormats_fr.properties</ignoredResourcePattern>
+                            <!-- io.airlift:joni and phoenix-client's org.jruby.joni:joni resource duplicates-->
+                            <ignoredResourcePattern>tables/.*\.bin</ignoredResourcePattern>
+                        </ignoredResourcePatterns>
+                        <ignoredDependencies>
+                            <dependency>
+                                <groupId>com.clearspring.analytics</groupId>
+                                <artifactId>stream</artifactId>
+                            </dependency>
+                        </ignoredDependencies>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/plugin/trino-phoenix5/pom.xml
+++ b/plugin/trino-phoenix5/pom.xml
@@ -332,32 +332,34 @@
     </dependencies>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.basepom.maven</groupId>
-                <artifactId>duplicate-finder-maven-plugin</artifactId>
-                <configuration>
-                    <ignoredResourcePatterns>
-                        <ignoredResourcePattern>mrapp-generated-classpath</ignoredResourcePattern>
-                        <ignoredResourcePattern>about.html</ignoredResourcePattern>
-                        <!-- org.apache.commons:commons-math3 french localization file duplicate-->
-                        <ignoredResourcePattern>assets/org/apache/commons/math3/exception/util/LocalizedFormats_fr.properties</ignoredResourcePattern>
-                        <!-- io.airlift:joni and phoenix-client's org.jruby.joni:joni resource duplicates-->
-                        <ignoredResourcePattern>tables/.*\.bin</ignoredResourcePattern>
-                        <ignoredResourcePattern>jetty-dir.css</ignoredResourcePattern>
-                    </ignoredResourcePatterns>
-                    <ignoredDependencies>
-                        <dependency>
-                            <groupId>com.clearspring.analytics</groupId>
-                            <artifactId>stream</artifactId>
-                        </dependency>
-                        <dependency>
-                            <groupId>javax.xml.bind</groupId>
-                            <artifactId>jaxb-api</artifactId>
-                        </dependency>
-                    </ignoredDependencies>
-                </configuration>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.basepom.maven</groupId>
+                    <artifactId>duplicate-finder-maven-plugin</artifactId>
+                    <configuration>
+                        <ignoredResourcePatterns>
+                            <ignoredResourcePattern>mrapp-generated-classpath</ignoredResourcePattern>
+                            <ignoredResourcePattern>about.html</ignoredResourcePattern>
+                            <!-- org.apache.commons:commons-math3 french localization file duplicate-->
+                            <ignoredResourcePattern>assets/org/apache/commons/math3/exception/util/LocalizedFormats_fr.properties</ignoredResourcePattern>
+                            <!-- io.airlift:joni and phoenix-client's org.jruby.joni:joni resource duplicates-->
+                            <ignoredResourcePattern>tables/.*\.bin</ignoredResourcePattern>
+                            <ignoredResourcePattern>jetty-dir.css</ignoredResourcePattern>
+                        </ignoredResourcePatterns>
+                        <ignoredDependencies>
+                            <dependency>
+                                <groupId>com.clearspring.analytics</groupId>
+                                <artifactId>stream</artifactId>
+                            </dependency>
+                            <dependency>
+                                <groupId>javax.xml.bind</groupId>
+                                <artifactId>jaxb-api</artifactId>
+                            </dependency>
+                        </ignoredDependencies>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/plugin/trino-pinot/pom.xml
+++ b/plugin/trino-pinot/pom.xml
@@ -526,21 +526,23 @@
     </dependencies>
 
     <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <configuration>
-                    <rules>
-                        <requireUpperBoundDeps>
-                            <excludes combine.children="append">
-                                <exclude>org.apache.thrift:libthrift</exclude>
-                                <exclude>io.netty:netty</exclude>
-                            </excludes>
-                        </requireUpperBoundDeps>
-                    </rules>
-                </configuration>
-            </plugin>
-        </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <configuration>
+                        <rules>
+                            <requireUpperBoundDeps>
+                                <excludes combine.children="append">
+                                    <exclude>org.apache.thrift:libthrift</exclude>
+                                    <exclude>io.netty:netty</exclude>
+                                </excludes>
+                            </requireUpperBoundDeps>
+                        </rules>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1858,5 +1858,15 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>quick</id>
+            <properties>
+                <skipTests>true</skipTests>
+                <maven.site.skip>true</maven.site.skip>
+                <maven.source.skip>true</maven.source.skip>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <air.check.skip-all>true</air.check.skip-all>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Add a `quick` profile, which allows to quickly build the project without any checks or tests, assuming it has just been checked out from a clean branch (master) which has been tested by the CI workflow and is known to be correct. The new profile is supposed to make it easier, instead of having to remember all the correct properties (compare the commands in the next section).

I'm not disabling any modules (like docs) on purpose, they still have to be disabled explicitly. Note that building the tarball with Provisio takes up ~25% of wall-time, and the GC and JIT take ~50%. 

### Timings

I ran all the commands on my macbook with the profiler enabled:
```
export MAVEN_OPTS="-agentpath:$HOME/Downloads/async-profiler-2.5.1-macos/build/libasyncProfiler.dylib=start,event=cpu,file=mvn-profile.html"
```

#### Base

Running on master (only skip tests and checks):

```
./mvnw clean install --strict-checksums -V -DskipTests -Dair.check.skip-all -pl '!:trino-server-rpm,!docs' 
```

yields `Total time:  04:41 min`.

When also skipping test compilation, building source JARs, and others:

```
./mvnw clean install --strict-checksums -V -DskipTests -Dmaven.test.skip=true -Dmaven.source.skip=true -Dmaven.site.skip=true -Dmaven.javadoc.skip=true -Dair.check.skip-all -pl '!:trino-server-rpm,!docs'
```

yields `Total time:  03:48 min`.

Running the same command using Maven Daemon, the 3rd run after starting the daemon yields `Total time:  01:28 min (Wall Clock)`.

#### With the profile

Running:
```
./mvnw clean install --strict-checksums -V -Dquick -pl '!:trino-server-rpm,!docs'
```
yields `Total time:  03:08 min`, 40 seconds quicker.

Running this 3rd time after starting the daemon:
```
mvnd clean install --strict-checksums -V -Dquick -pl '!:trino-server-rpm,!docs'
```

yields `Total time:  01:19 min (Wall Clock)`, 10 seconds quicker.


All the work here is based solely on https://peter.palaga.org/presentations/211021-baselone-maven-my-life-is-short/