### PR TITLE
Run git commit id Maven plugin only once

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1743,6 +1743,16 @@
                     <artifactId>provisio-maven-plugin</artifactId>
                     <version>1.0.18</version>
                 </plugin>
+
+                <plugin>
+                    <groupId>pl.project13.maven</groupId>
+                    <artifactId>git-commit-id-plugin</artifactId>
+                    <configuration>
+                        <runOnlyOnce>true</runOnlyOnce>
+                        <injectAllReactorProjects>true</injectAllReactorProjects>
+                        <offline>true</offline>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
I ran a profiler and it turns out that this plugin takes up 10% of the wall time when building the whole project.

I'm also setting `offline` to `true` which is the default in the 5.0 version of this plugin: https://github.com/git-commit-id/git-commit-id-maven-plugin/releases/tag/v5.0.0 - this avoids talking to any remotes during the build, which we should not need.

From [the docs](https://github.com/git-commit-id/git-commit-id-maven-plugin/blob/master/docs/using-the-plugin.md):
```
When set to `true`, the plugin will not try to contact any remote repositories.
Any operations will only use the local state of the repo. If set to `false`, it will
execute `git fetch` operations e.g. to determine the `ahead` and `behind` branch
information.
```