### PR TITLE
Set keep_alive_timeout as 10 seconds in ClickHouse testing server

### DIFF
--- a/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
+++ b/plugin/trino-clickhouse/src/test/java/io/trino/plugin/clickhouse/TestingClickHouseServer.java
@@ -22,6 +22,7 @@ import java.sql.Statement;
 
 import static java.lang.String.format;
 import static org.testcontainers.containers.ClickHouseContainer.HTTP_PORT;
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
 
 public class TestingClickHouseServer
         implements Closeable
@@ -33,6 +34,7 @@ public class TestingClickHouseServer
     {
         // Use 2nd stable version
         dockerContainer = (ClickHouseContainer) new ClickHouseContainer(CLICKHOUSE_IMAGE)
+                .withCopyFileToContainer(forClasspathResource("custom.xml"), "/etc/clickhouse-server/config.d/custom.xml")
                 .withStartupAttempts(10);
 
         dockerContainer.start();

--- a/plugin/trino-clickhouse/src/test/resources/custom.xml
+++ b/plugin/trino-clickhouse/src/test/resources/custom.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<yandex>
+    <!-- To avoid "failed to response" error message during copy of TPCH tables -->
+    <keep_alive_timeout>10</keep_alive_timeout>
+</yandex>


### PR DESCRIPTION
Fixes #9300

300 stress tests succeeded.