### PR TITLE
Report implicated rules when iterative timeout exhausted

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ExpressionRewriteRuleSet.java
@@ -62,6 +62,7 @@ import static io.trino.sql.planner.plan.Patterns.project;
 import static io.trino.sql.planner.plan.Patterns.values;
 import static io.trino.sql.tree.SortItem.Ordering.ASCENDING;
 import static io.trino.sql.tree.SortItem.Ordering.DESCENDING;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class ExpressionRewriteRuleSet
@@ -144,6 +145,12 @@ public class ExpressionRewriteRuleSet
             }
             return Result.ofPlanNode(new ProjectNode(projectNode.getId(), projectNode.getSource(), assignments));
         }
+
+        @Override
+        public String toString()
+        {
+            return format("%s(%s)", getClass().getSimpleName(), rewriter);
+        }
     }
 
     private static final class AggregationExpressionRewrite
@@ -214,6 +221,12 @@ public class ExpressionRewriteRuleSet
             }
             return Result.empty();
         }
+
+        @Override
+        public String toString()
+        {
+            return format("%s(%s)", getClass().getSimpleName(), rewriter);
+        }
     }
 
     private static final class FilterExpressionRewrite
@@ -240,6 +253,12 @@ public class ExpressionRewriteRuleSet
                 return Result.empty();
             }
             return Result.ofPlanNode(new FilterNode(filterNode.getId(), filterNode.getSource(), rewritten));
+        }
+
+        @Override
+        public String toString()
+        {
+            return format("%s(%s)", getClass().getSimpleName(), rewriter);
         }
     }
 
@@ -282,6 +301,12 @@ public class ExpressionRewriteRuleSet
                         joinNode.getReorderJoinStatsAndCost()));
             }
             return Result.empty();
+        }
+
+        @Override
+        public String toString()
+        {
+            return format("%s(%s)", getClass().getSimpleName(), rewriter);
         }
     }
 
@@ -330,6 +355,12 @@ public class ExpressionRewriteRuleSet
                 return Result.ofPlanNode(new ValuesNode(valuesNode.getId(), valuesNode.getOutputSymbols(), rows.build()));
             }
             return Result.empty();
+        }
+
+        @Override
+        public String toString()
+        {
+            return format("%s(%s)", getClass().getSimpleName(), rewriter);
         }
     }
 
@@ -471,6 +502,12 @@ public class ExpressionRewriteRuleSet
             }
 
             return Optional.empty();
+        }
+
+        @Override
+        public String toString()
+        {
+            return format("%s(%s)", getClass().getSimpleName(), rewriter);
         }
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/TestIterativeOptimizer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/TestIterativeOptimizer.java
@@ -78,7 +78,7 @@ public class TestIterativeOptimizer
 
         assertTrinoExceptionThrownBy(() -> queryRunner.inTransaction(transactionSession -> queryRunner.createPlan(transactionSession, "SELECT nationkey FROM nation", ImmutableList.of(optimizer), WarningCollector.NOOP)))
                 .hasErrorCode(OPTIMIZER_TIMEOUT)
-                .hasMessage("The optimizer exhausted the time limit of 1 ms");
+                .hasMessageMatching("The optimizer exhausted the time limit of 1 ms: (no rules invoked|(?s)Top rules:.*(RemoveRedundantIdentityProjections|AddIdentityOverTableScan).*)");
     }
 
     private static class AddIdentityOverTableScan

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/TestIterativeOptimizer.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/TestIterativeOptimizer.java
@@ -66,7 +66,7 @@ public class TestIterativeOptimizer
         }
     }
 
-    @Test(timeOut = 1000)
+    @Test(timeOut = 10_000)
     public void optimizerTimeoutsOnNonConvergingPlan()
     {
         PlanOptimizer optimizer = new IterativeOptimizer(


### PR DESCRIPTION
This produces a failure like

```
io.trino.spi.TrinoException: The optimizer exhausted the time limit of 5000 ms: Top rules: {
		io.trino.sql.planner.iterative.rule.RemoveRedundantTableScanPredicate@5b6cc344: 3103 ms, 13812 invocations, 13812 applications,
		io.trino.sql.planner.iterative.rule.ExpressionRewriteRuleSet$FilterExpressionRewrite@25b4754a: 1084 ms, 13812 invocations, 13811 applications,
		io.trino.sql.planner.iterative.rule.ExpressionRewriteRuleSet$FilterExpressionRewrite@1a336906: 307 ms, 13812 invocations, 0 applications,
		io.trino.sql.planner.iterative.rule.ExpressionRewriteRuleSet$FilterExpressionRewrite@4db46344: 43 ms, 13812 invocations, 0 applications,
		io.trino.sql.planner.iterative.rule.ExpressionRewriteRuleSet$FilterExpressionRewrite@39afe59f: 41 ms, 13812 invocations, 0 applications }
	at io.trino.sql.planner.iterative.IterativeOptimizer$Context.checkTimeoutNotExhausted(IterativeOptimizer.java:359)
```