### PR TITLE
Avoid firing RemoveRedundantTableScanPredicate when there is no TableScan predicate

### DIFF
--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantTableScanPredicate.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/RemoveRedundantTableScanPredicate.java
@@ -57,7 +57,7 @@ public class RemoveRedundantTableScanPredicate
 
     private static final Pattern<FilterNode> PATTERN =
             filter().with(source().matching(
-                    tableScan().capturedAs(TABLE_SCAN)));
+                    tableScan().capturedAs(TABLE_SCAN).matching(node -> !node.getEnforcedConstraint().isAll())));
 
     private final PlannerContext plannerContext;
     private final TypeAnalyzer typeAnalyzer;

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTableScanPredicate.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestRemoveRedundantTableScanPredicate.java
@@ -219,6 +219,20 @@ public class TestRemoveRedundantTableScanPredicate
     }
 
     @Test
+    public void doesNotFireOnNoTableScanPredicate()
+    {
+        ColumnHandle columnHandle = new TpchColumnHandle("nationkey", BIGINT);
+        tester().assertThat(removeRedundantTableScanPredicate)
+                .on(p -> p.filter(expression("(nationkey > 3 OR nationkey > 0) AND (nationkey > 3 OR nationkey < 1)"),
+                        p.tableScan(
+                                nationTableHandle,
+                                ImmutableList.of(p.symbol("nationkey", BIGINT)),
+                                ImmutableMap.of(p.symbol("nationkey", BIGINT), columnHandle),
+                                TupleDomain.all())))
+                .doesNotFire();
+    }
+
+    @Test
     public void doesNotFireIfRuleNotChangePlan()
     {
         tester().assertThat(removeRedundantTableScanPredicate)


### PR DESCRIPTION
Partially mitigates https://github.com/trinodb/trino/issues/10532