### PR TITLE
Only read required fields during aggregation pushdown

### DIFF
--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -466,7 +466,7 @@ public interface Metadata
             List<AggregateFunction> aggregations,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<String> requiredColumns);
+            Set<ColumnHandle> requiredColumns);
 
     Optional<JoinApplicationResult<TableHandle>> applyJoin(
             Session session,

--- a/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/Metadata.java
@@ -465,7 +465,8 @@ public interface Metadata
             TableHandle table,
             List<AggregateFunction> aggregations,
             Map<String, ColumnHandle> assignments,
-            List<List<ColumnHandle>> groupingSets);
+            List<List<ColumnHandle>> groupingSets,
+            Set<String> requiredColumns);
 
     Optional<JoinApplicationResult<TableHandle>> applyJoin(
             Session session,

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1682,7 +1682,7 @@ public final class MetadataManager
             List<AggregateFunction> aggregations,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<String> requiredColumns)
+            Set<ColumnHandle> requiredColumns)
     {
         // Global aggregation is represented by [[]]
         checkArgument(!groupingSets.isEmpty(), "No grouping sets provided");

--- a/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
+++ b/core/trino-main/src/main/java/io/trino/metadata/MetadataManager.java
@@ -1681,7 +1681,8 @@ public final class MetadataManager
             TableHandle table,
             List<AggregateFunction> aggregations,
             Map<String, ColumnHandle> assignments,
-            List<List<ColumnHandle>> groupingSets)
+            List<List<ColumnHandle>> groupingSets,
+            Set<String> requiredColumns)
     {
         // Global aggregation is represented by [[]]
         checkArgument(!groupingSets.isEmpty(), "No grouping sets provided");
@@ -1694,7 +1695,7 @@ public final class MetadataManager
         }
 
         ConnectorSession connectorSession = session.toConnectorSession(catalogName);
-        return metadata.applyAggregation(connectorSession, table.getConnectorHandle(), aggregations, assignments, groupingSets)
+        return metadata.applyAggregation(connectorSession, table.getConnectorHandle(), aggregations, assignments, groupingSets, requiredColumns)
                 .map(result -> {
                     verifyProjection(table, result.getProjections(), result.getAssignments(), aggregations.size());
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -589,6 +589,7 @@ public class PlanOptimizers
                 .add(new PushDistinctLimitIntoTableScan(plannerContext))
                 .add(new PushTopNIntoTableScan(metadata))
                 .build();
+
         IterativeOptimizer pushIntoTableScanOptimizer = new IterativeOptimizer(
                 metadata,
                 ruleStats,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/PlanOptimizers.java
@@ -589,7 +589,6 @@ public class PlanOptimizers
                 .add(new PushDistinctLimitIntoTableScan(plannerContext))
                 .add(new PushTopNIntoTableScan(metadata))
                 .build();
-
         IterativeOptimizer pushIntoTableScanOptimizer = new IterativeOptimizer(
                 metadata,
                 ruleStats,

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementFilteredAggregations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/ImplementFilteredAggregations.java
@@ -154,6 +154,7 @@ public class ImplementFilteredAggregations
                         ImmutableList.of(),
                         aggregationNode.getStep(),
                         aggregationNode.getHashSymbol(),
-                        aggregationNode.getGroupIdSymbol()));
+                        aggregationNode.getGroupIdSymbol(),
+                        Optional.of(aggregationNode.getOutputSymbols())));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneAggregationColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneAggregationColumns.java
@@ -48,7 +48,9 @@ public class PruneAggregationColumns
         // The special `groupid` symbol will never be referenced but if we prune it then other optimizer rules break
         // for example: PushPartialAggregationThroughExchange
         boolean pruneOutputSymbols = aggregationNode.getGroupingSetCount() <= 1 &&
-                (referencedOutputs.size() != aggregationNode.getOutputSymbols().size());
+                (referencedOutputs.size() != aggregationNode.getOutputSymbols().size()) &&
+                // Prevent output pruning if we would prune all the output symbols, see TestSubqueries
+                prunedAggregations.size() + referencedOutputs.size() != 0;
 
         if (!pruneAggregations && !pruneOutputSymbols) {
             return Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneAggregationColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneAggregationColumns.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static io.trino.sql.planner.plan.Patterns.aggregation;
 
@@ -44,13 +43,12 @@ public class PruneAggregationColumns
                 aggregationNode.getAggregations(),
                 referencedOutputs::contains);
 
-
         boolean pruneAggregations = prunedAggregations.size() != aggregationNode.getAggregations().size();
         // TODO: prune output symbols for aggregation nodes with multiple grouping sets
         // The special `groupid` symbol will never be referenced but if we prune it then other optimizer rules break
         // for example: PushPartialAggregationThroughExchange
-        boolean canPruneOutputSymbols = aggregationNode.getGroupingSetCount() <= 1;
-        boolean pruneOutputSymbols = canPruneOutputSymbols && (referencedOutputs.size() != aggregationNode.getOutputSymbols().size());
+        boolean pruneOutputSymbols = aggregationNode.getGroupingSetCount() <= 1 &&
+                (referencedOutputs.size() != aggregationNode.getOutputSymbols().size());
 
         if (!pruneAggregations && !pruneOutputSymbols) {
             return Optional.empty();
@@ -67,6 +65,6 @@ public class PruneAggregationColumns
                         aggregationNode.getStep(),
                         aggregationNode.getHashSymbol(),
                         aggregationNode.getGroupIdSymbol(),
-                        pruneOutputSymbols ? Optional.of(new ArrayList<>(referencedOutputs)): Optional.empty()));
+                        pruneOutputSymbols ? Optional.of(new ArrayList<>(referencedOutputs)) : Optional.empty()));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneAggregationColumns.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PruneAggregationColumns.java
@@ -18,9 +18,11 @@ import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.plan.AggregationNode;
 import io.trino.sql.planner.plan.PlanNode;
 
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static io.trino.sql.planner.plan.Patterns.aggregation;
 
@@ -42,7 +44,7 @@ public class PruneAggregationColumns
                 aggregationNode.getAggregations(),
                 referencedOutputs::contains);
 
-        if (prunedAggregations.size() == aggregationNode.getAggregations().size()) {
+        if (prunedAggregations.size() == aggregationNode.getAggregations().size() && referencedOutputs.size() == aggregationNode.getOutputSymbols().size()) {
             return Optional.empty();
         }
 
@@ -56,6 +58,7 @@ public class PruneAggregationColumns
                         aggregationNode.getPreGroupedSymbols(),
                         aggregationNode.getStep(),
                         aggregationNode.getHashSymbol(),
-                        aggregationNode.getGroupIdSymbol()));
+                        aggregationNode.getGroupIdSymbol(),
+                        Optional.of(new ArrayList<>(referencedOutputs))));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
@@ -155,7 +155,7 @@ public class PushAggregationIntoTableScan
                 .collect(toImmutableList());
 
         Set<Symbol> requiredSymbols = new HashSet<>(aggregationNode.getOutputSymbols());
-        Set<ColumnHandle> outputGroupByColumns = groupingKeys.stream().filter(requiredSymbols::contains).map(groupingKey ->
+        Set<ColumnHandle> outputGroupingColumns = groupingKeys.stream().filter(requiredSymbols::contains).map(groupingKey ->
                 assignments.get(groupingKey.getName())
         ).collect(Collectors.toSet());
         Optional<AggregationApplicationResult<TableHandle>> aggregationPushdownResult = plannerContext.getMetadata().applyAggregation(
@@ -164,7 +164,7 @@ public class PushAggregationIntoTableScan
                 aggregateFunctions,
                 assignments,
                 ImmutableList.of(groupByColumns),
-                outputGroupByColumns);
+                outputGroupingColumns);
 
         if (aggregationPushdownResult.isEmpty()) {
             return Optional.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationIntoTableScan.java
@@ -44,7 +44,6 @@ import io.trino.sql.planner.plan.TableScanNode;
 import io.trino.sql.tree.Expression;
 import io.trino.sql.tree.SymbolReference;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -155,7 +156,7 @@ public class PushAggregationThroughOuterJoin
                     join.getLeft(),
                     rewrittenAggregation,
                     join.getCriteria(),
-                    join.getLeft().getOutputSymbols(),
+                    join.getLeft().getOutputSymbols().stream().filter(aggregation.getOutputSymbols()::contains).collect(Collectors.toList()),
                     ImmutableList.copyOf(rewrittenAggregation.getAggregations().keySet()),
                     // there are no duplicate rows possible since outer rows were guaranteed to be distinct
                     false,
@@ -175,7 +176,7 @@ public class PushAggregationThroughOuterJoin
                     join.getRight(),
                     join.getCriteria(),
                     ImmutableList.copyOf(rewrittenAggregation.getAggregations().keySet()),
-                    join.getRight().getOutputSymbols(),
+                    join.getRight().getOutputSymbols().stream().filter(aggregation.getOutputSymbols()::contains).collect(Collectors.toList()),
                     // there are no duplicate rows possible since outer rows were guaranteed to be distinct
                     false,
                     join.getFilter(),

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDistinctLimitIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDistinctLimitIntoTableScan.java
@@ -14,6 +14,7 @@
 package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;
@@ -74,7 +75,8 @@ public class PushDistinctLimitIntoTableScan
                 node,
                 captures.get(TABLE_SCAN),
                 ImmutableMap.of(),
-                node.getDistinctSymbols());
+                node.getDistinctSymbols(),
+                ImmutableSet.of());
 
         if (result.isEmpty()) {
             return Result.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDistinctLimitIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDistinctLimitIntoTableScan.java
@@ -75,8 +75,7 @@ public class PushDistinctLimitIntoTableScan
                 node,
                 captures.get(TABLE_SCAN),
                 ImmutableMap.of(),
-                node.getDistinctSymbols(),
-                ImmutableSet.of());
+                node.getDistinctSymbols());
 
         if (result.isEmpty()) {
             return Result.empty();

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDistinctLimitIntoTableScan.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushDistinctLimitIntoTableScan.java
@@ -14,7 +14,6 @@
 package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import io.trino.Session;
 import io.trino.matching.Capture;
 import io.trino.matching.Captures;

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -248,7 +248,8 @@ public class PushPartialAggregationThroughExchange
                 ImmutableList.of(),
                 PARTIAL,
                 node.getHashSymbol(),
-                node.getGroupIdSymbol());
+                node.getGroupIdSymbol(),
+                Optional.of(AggregationNode.buildOutputSymbols(node.getGroupingKeys(), node.getHashSymbol(), intermediateAggregation, Optional.of(node.getOutputSymbols()))));
 
         return new AggregationNode(
                 node.getId(),
@@ -260,6 +261,7 @@ public class PushPartialAggregationThroughExchange
                 ImmutableList.of(),
                 FINAL,
                 node.getHashSymbol(),
-                node.getGroupIdSymbol());
+                node.getGroupIdSymbol(),
+                Optional.of(AggregationNode.buildOutputSymbols(node.getGroupingKeys(), node.getHashSymbol(), finalAggregation, Optional.of(node.getOutputSymbols()))));
     }
 }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
@@ -137,7 +137,10 @@ public class SingleDistinctAggregationToGroupBy
                                 SINGLE,
                                 Optional.empty(),
                                 Optional.empty(),
-                                Optional.of(aggregation.getOutputSymbols())),
+                                Optional.of(ImmutableList.<Symbol>builder()
+                                        .addAll(aggregation.getGroupingKeys())
+                                        .addAll(symbols)
+                                        .build())),
                         // remove DISTINCT flag from function calls
                         aggregation.getAggregations()
                                 .entrySet().stream()

--- a/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/iterative/rule/SingleDistinctAggregationToGroupBy.java
@@ -136,7 +136,8 @@ public class SingleDistinctAggregationToGroupBy
                                 ImmutableList.of(),
                                 SINGLE,
                                 Optional.empty(),
-                                Optional.empty()),
+                                Optional.empty(),
+                                Optional.of(aggregation.getOutputSymbols())),
                         // remove DISTINCT flag from function calls
                         aggregation.getAggregations()
                                 .entrySet().stream()
@@ -147,7 +148,8 @@ public class SingleDistinctAggregationToGroupBy
                         emptyList(),
                         aggregation.getStep(),
                         aggregation.getHashSymbol(),
-                        aggregation.getGroupIdSymbol()));
+                        aggregation.getGroupIdSymbol(),
+                        Optional.of(aggregation.getOutputSymbols())));
     }
 
     private static Aggregation removeDistinct(Aggregation aggregation)

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/PropertyDerivations.java
@@ -366,10 +366,10 @@ public final class PropertyDerivations
         {
             ActualProperties properties = Iterables.getOnlyElement(inputProperties);
 
-            ActualProperties translated = properties.translate(symbol -> node.getGroupingKeys().contains(symbol) ? Optional.of(symbol) : Optional.empty());
+            ActualProperties translated = properties.translate(symbol -> node.getGroupingKeys().contains(symbol) && node.getOutputSymbols().contains(symbol) ? Optional.of(symbol) : Optional.empty());
 
             return ActualProperties.builderFrom(translated)
-                    .local(LocalProperties.grouped(node.getGroupingKeys()))
+                    .local(LocalProperties.grouped(node.getGroupingKeys().stream().filter(node.getOutputSymbols()::contains).collect(Collectors.toSet())))
                     .build();
         }
 

--- a/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -402,7 +402,7 @@ public final class StreamPropertyDerivations
             StreamProperties properties = Iterables.getOnlyElement(inputProperties);
 
             // Only grouped symbols projected symbols are passed through
-            return properties.translate(symbol -> node.getGroupingKeys().contains(symbol) ? Optional.of(symbol) : Optional.empty());
+            return properties.translate(symbol -> node.getGroupingKeys().contains(symbol) && node.getOutputSymbols().contains(symbol) ? Optional.of(symbol) : Optional.empty());
         }
 
         @Override

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/AggregationNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/AggregationNode.java
@@ -106,8 +106,8 @@ public class AggregationNode
         checkArgument(preGroupedSymbols.isEmpty() || groupingSets.getGroupingKeys().containsAll(preGroupedSymbols), "Pre-grouped symbols must be a subset of the grouping keys");
         this.preGroupedSymbols = ImmutableList.copyOf(preGroupedSymbols);
 
-        if(outputs.isPresent()){
-            List<Symbol> copiedOutputs =  ImmutableList.copyOf(outputs.get());
+        if (outputs.isPresent()) {
+            List<Symbol> copiedOutputs = ImmutableList.copyOf(outputs.get());
             copiedOutputs.forEach(symbol -> {
                 boolean isValidOutput = groupingSets.getGroupingKeys().contains(symbol) ||
                         (hashSymbol.isPresent() && hashSymbol.get().equals(symbol)) ||
@@ -116,7 +116,8 @@ public class AggregationNode
                 verify(isValidOutput, "Symbol %s is not a valid output symbol", symbol);
             });
             this.outputs = copiedOutputs;
-        }else{
+        }
+        else {
             this.outputs = buildOutputSymbols(groupingSets.getGroupingKeys(), hashSymbol, aggregations, Optional.empty());
         }
     }

--- a/core/trino-main/src/main/java/io/trino/sql/planner/plan/AggregationNode.java
+++ b/core/trino-main/src/main/java/io/trino/sql/planner/plan/AggregationNode.java
@@ -124,12 +124,13 @@ public class AggregationNode
     public static List<Symbol> buildOutputSymbols(List<Symbol> groupingKeys, Optional<Symbol> hashSymbol, Map<Symbol, AggregationNode.Aggregation> aggregations, Optional<List<Symbol>> referencedSymbols)
     {
         ImmutableList.Builder<Symbol> outputsBuilder = ImmutableList.builder();
-        outputsBuilder.addAll(groupingKeys);
         hashSymbol.ifPresent(outputsBuilder::add);
         outputsBuilder.addAll(aggregations.keySet());
-        return outputsBuilder.build().stream().filter(symbol ->
+
+        outputsBuilder.addAll(groupingKeys.stream().filter(symbol ->
                 referencedSymbols.map(referenced -> referenced.contains(symbol)).orElse(true)
-        ).collect(Collectors.toList());
+        ).collect(Collectors.toList()));
+        return outputsBuilder.build();
     }
 
     public List<Symbol> getGroupingKeys()

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -256,9 +256,10 @@ public class MockConnector
                 ConnectorTableHandle handle,
                 List<AggregateFunction> aggregates,
                 Map<String, ColumnHandle> assignments,
-                List<List<ColumnHandle>> groupingSets)
+                List<List<ColumnHandle>> groupingSets,
+                Set<String> requiredColumns)
         {
-            return applyAggregation.apply(session, handle, aggregates, assignments, groupingSets);
+            return applyAggregation.apply(session, handle, aggregates, assignments, groupingSets, requiredColumns);
         }
 
         @Override

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnector.java
@@ -257,7 +257,7 @@ public class MockConnector
                 List<AggregateFunction> aggregates,
                 Map<String, ColumnHandle> assignments,
                 List<List<ColumnHandle>> groupingSets,
-                Set<String> requiredColumns)
+                Set<ColumnHandle> requiredColumns)
         {
             return applyAggregation.apply(session, handle, aggregates, assignments, groupingSets, requiredColumns);
         }

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -214,7 +214,8 @@ public class MockConnectorFactory
                 ConnectorTableHandle handle,
                 List<AggregateFunction> aggregates,
                 Map<String, ColumnHandle> assignments,
-                List<List<ColumnHandle>> groupingSets);
+                List<List<ColumnHandle>> groupingSets,
+                Set<String> requiredColumns);
     }
 
     @FunctionalInterface
@@ -271,7 +272,7 @@ public class MockConnectorFactory
         private BiFunction<ConnectorSession, SchemaTableName, ConnectorTableHandle> getTableHandle = defaultGetTableHandle();
         private Function<SchemaTableName, List<ColumnMetadata>> getColumns = defaultGetColumns();
         private ApplyProjection applyProjection = (session, handle, projections, assignments) -> Optional.empty();
-        private ApplyAggregation applyAggregation = (session, handle, aggregates, assignments, groupingSets) -> Optional.empty();
+        private ApplyAggregation applyAggregation = (session, handle, aggregates, assignments, groupingSets, requiredColumns) -> Optional.empty();
         private ApplyJoin applyJoin = (session, joinType, left, right, joinConditions, leftAssignments, rightAssignments) -> Optional.empty();
         private BiFunction<ConnectorSession, SchemaTableName, Optional<ConnectorNewTableLayout>> getInsertLayout = defaultGetInsertLayout();
         private BiFunction<ConnectorSession, ConnectorTableMetadata, Optional<ConnectorNewTableLayout>> getNewTableLayout = defaultGetNewTableLayout();

--- a/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
+++ b/core/trino-main/src/test/java/io/trino/connector/MockConnectorFactory.java
@@ -215,7 +215,7 @@ public class MockConnectorFactory
                 List<AggregateFunction> aggregates,
                 Map<String, ColumnHandle> assignments,
                 List<List<ColumnHandle>> groupingSets,
-                Set<String> requiredColumns);
+                Set<ColumnHandle> requiredColumns);
     }
 
     @FunctionalInterface

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -578,7 +578,8 @@ public abstract class AbstractMockMetadata
             TableHandle table,
             List<AggregateFunction> aggregations,
             Map<String, ColumnHandle> assignments,
-            List<List<ColumnHandle>> groupingSets)
+            List<List<ColumnHandle>> groupingSets,
+            Set<String> requiredColumns)
     {
         return Optional.empty();
     }

--- a/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
+++ b/core/trino-main/src/test/java/io/trino/metadata/AbstractMockMetadata.java
@@ -579,7 +579,7 @@ public abstract class AbstractMockMetadata
             List<AggregateFunction> aggregations,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<String> requiredColumns)
+            Set<ColumnHandle> requiredColumns)
     {
         return Optional.empty();
     }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/assertions/PlanMatchPattern.java
@@ -297,7 +297,7 @@ public final class PlanMatchPattern
             Step step,
             PlanMatchPattern source)
     {
-        return aggregation(groupingSets, aggregations, preGroupedSymbols, ImmutableList.of(), groupId, step, source);
+        return aggregation(groupingSets, aggregations, preGroupedSymbols, ImmutableList.of(), groupId, step, Optional.empty(), source);
     }
 
     public static PlanMatchPattern aggregation(
@@ -309,7 +309,20 @@ public final class PlanMatchPattern
             Step step,
             PlanMatchPattern source)
     {
-        PlanMatchPattern result = node(AggregationNode.class, source).with(new AggregationMatcher(groupingSets, preGroupedSymbols, masks, groupId, step));
+        return aggregation(groupingSets, aggregations, preGroupedSymbols, masks, groupId, step, Optional.empty(), source);
+    }
+
+    public static PlanMatchPattern aggregation(
+            GroupingSetDescriptor groupingSets,
+            Map<Optional<String>, ExpectedValueProvider<FunctionCall>> aggregations,
+            List<String> preGroupedSymbols,
+            List<String> masks,
+            Optional<Symbol> groupId,
+            Step step,
+            Optional<List<String>> outputSymbols,
+            PlanMatchPattern source)
+    {
+        PlanMatchPattern result = node(AggregationNode.class, source).with(new AggregationMatcher(groupingSets, preGroupedSymbols, masks, groupId, step, outputSymbols));
         aggregations.entrySet().forEach(
                 aggregation -> result.withAlias(aggregation.getKey(), new AggregationFunctionMatcher(aggregation.getValue())));
         return result;

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneAggregationColumns.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPruneAggregationColumns.java
@@ -15,6 +15,7 @@ package io.trino.sql.planner.iterative.rule;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import io.trino.sql.planner.Symbol;
 import io.trino.sql.planner.iterative.rule.test.BaseRuleTest;
 import io.trino.sql.planner.iterative.rule.test.PlanBuilder;
@@ -22,6 +23,7 @@ import io.trino.sql.planner.plan.Assignments;
 import io.trino.sql.planner.plan.ProjectNode;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -30,8 +32,8 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.aggregation;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.expression;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static io.trino.sql.planner.assertions.PlanMatchPattern.project;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
-import static io.trino.sql.planner.assertions.PlanMatchPattern.strictProject;
 import static io.trino.sql.planner.assertions.PlanMatchPattern.values;
 import static io.trino.sql.planner.plan.AggregationNode.Step.SINGLE;
 
@@ -39,42 +41,88 @@ public class TestPruneAggregationColumns
         extends BaseRuleTest
 {
     @Test
-    public void testNotAllInputsReferenced()
+    public void testNotAllAggregationsReferenced()
     {
         tester().assertThat(new PruneAggregationColumns())
-                .on(p -> buildProjectedAggregation(p, symbol -> symbol.getName().equals("b")))
+                .on(p -> buildProjectedAggregation(p, ImmutableList.of(p.symbol("a"), p.symbol("b")), symbol -> ImmutableSet.of("key", "b").contains(symbol.getName())))
                 .matches(
-                        strictProject(
+                        project(
                                 ImmutableMap.of("b", expression("b")),
                                 aggregation(
                                         singleGroupingSet("key"),
                                         ImmutableMap.of(
                                                 Optional.of("b"),
                                                 functionCall("count", false, ImmutableList.of())),
+                                        ImmutableList.of(),
+                                        ImmutableList.of(),
                                         Optional.empty(),
                                         SINGLE,
+                                        Optional.of(ImmutableList.of("key", "b")),
                                         values("key"))));
     }
 
     @Test
-    public void testAllOutputsReferenced()
+    public void testNotAllGroupingKeysReferenced()
     {
         tester().assertThat(new PruneAggregationColumns())
-                .on(p -> buildProjectedAggregation(p, alwaysTrue()))
+                .on(p -> buildProjectedAggregation(p, ImmutableList.of(p.symbol("a")), symbol -> ImmutableSet.of("a").contains(symbol.getName())))
+                .matches(
+                        project(
+                                ImmutableMap.of("a", expression("a")),
+                                aggregation(
+                                        singleGroupingSet("key"),
+                                        ImmutableMap.of(
+                                                Optional.of("a"),
+                                                functionCall("count", false, ImmutableList.of())),
+                                        ImmutableList.of(),
+                                        ImmutableList.of(),
+                                        Optional.empty(),
+                                        SINGLE,
+                                        Optional.of(ImmutableList.of("a")),
+                                        values("key"))));
+    }
+
+    @Test
+    public void testNotAllAggregationsAndGroupingKeysReferenced()
+    {
+        tester().assertThat(new PruneAggregationColumns())
+                .on(p -> buildProjectedAggregation(p, ImmutableList.of(p.symbol("a"), p.symbol("b")), symbol -> ImmutableSet.of("a").contains(symbol.getName())))
+                .matches(
+                        project(
+                                ImmutableMap.of("a", expression("a")),
+                                aggregation(
+                                        singleGroupingSet("key"),
+                                        ImmutableMap.of(
+                                                Optional.of("a"),
+                                                functionCall("count", false, ImmutableList.of())),
+                                        ImmutableList.of(),
+                                        ImmutableList.of(),
+                                        Optional.empty(),
+                                        SINGLE,
+                                        Optional.of(ImmutableList.of("a")),
+                                        values("key"))));
+    }
+
+    @Test
+    public void testRuleDoesNotFire()
+    {
+        tester().assertThat(new PruneAggregationColumns())
+                .on(p -> buildProjectedAggregation(p, ImmutableList.of(p.symbol("a"), p.symbol("b")), alwaysTrue()))
                 .doesNotFire();
     }
 
-    private ProjectNode buildProjectedAggregation(PlanBuilder planBuilder, Predicate<Symbol> projectionFilter)
+    private ProjectNode buildProjectedAggregation(PlanBuilder planBuilder, List<Symbol> aggregationSymbols, Predicate<Symbol> projectionFilter)
     {
-        Symbol a = planBuilder.symbol("a");
-        Symbol b = planBuilder.symbol("b");
         Symbol key = planBuilder.symbol("key");
+        ImmutableList<Symbol> allSymbols = ImmutableList.<Symbol>builder().add(key).addAll(aggregationSymbols).build();
+
         return planBuilder.project(
-                Assignments.identity(ImmutableList.of(a, b).stream().filter(projectionFilter).collect(toImmutableSet())),
-                planBuilder.aggregation(aggregationBuilder -> aggregationBuilder
-                        .source(planBuilder.values(key))
-                        .singleGroupingSet(key)
-                        .addAggregation(a, PlanBuilder.expression("count()"), ImmutableList.of())
-                        .addAggregation(b, PlanBuilder.expression("count()"), ImmutableList.of())));
+                Assignments.identity(allSymbols.stream().filter(projectionFilter).collect(toImmutableSet())),
+                planBuilder.aggregation(aggregationBuilder -> {
+                    PlanBuilder.AggregationBuilder builder = aggregationBuilder
+                            .source(planBuilder.values(key))
+                            .singleGroupingSet(key);
+                    aggregationSymbols.forEach(symbol -> builder.addAggregation(symbol, PlanBuilder.expression("count()"), ImmutableList.of()));
+                }));
     }
 }

--- a/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDistinctLimitIntoTableScan.java
+++ b/core/trino-main/src/test/java/io/trino/sql/planner/iterative/rule/TestPushDistinctLimitIntoTableScan.java
@@ -73,9 +73,9 @@ public class TestPushDistinctLimitIntoTableScan
                 TEST_CATALOG.getCatalogName(),
                 MockConnectorFactory.builder()
                         .withApplyAggregation(
-                                (session, handle, aggregates, assignments, groupingSets) -> {
+                                (session, handle, aggregates, assignments, groupingSets, requiredColumns) -> {
                                     if (testApplyAggregation != null) {
-                                        return testApplyAggregation.apply(session, handle, aggregates, assignments, groupingSets);
+                                        return testApplyAggregation.apply(session, handle, aggregates, assignments, groupingSets, requiredColumns);
                                     }
                                     return Optional.empty();
                                 })
@@ -115,7 +115,7 @@ public class TestPushDistinctLimitIntoTableScan
     public void testNoEffect()
     {
         AtomicInteger applyCallCounter = new AtomicInteger();
-        testApplyAggregation = (session, handle, aggregates, assignments, groupingSets) -> {
+        testApplyAggregation = (session, handle, aggregates, assignments, groupingSets, requiredColumns) -> {
             applyCallCounter.incrementAndGet();
             return Optional.empty();
         };
@@ -142,7 +142,7 @@ public class TestPushDistinctLimitIntoTableScan
         AtomicReference<Map<String, ColumnHandle>> applyAssignments = new AtomicReference<>();
         AtomicReference<List<List<ColumnHandle>>> applyGroupingSets = new AtomicReference<>();
 
-        testApplyAggregation = (session, handle, aggregates, assignments, groupingSets) -> {
+        testApplyAggregation = (session, handle, aggregates, assignments, groupingSets, requiredColumns) -> {
             applyCallCounter.incrementAndGet();
             applyAggregates.set(List.copyOf(aggregates));
             applyAssignments.set(Map.copyOf(assignments));

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1254,7 +1254,7 @@ public interface ConnectorMetadata
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<String> requiredColumns)
+            Set<ColumnHandle> requiredColumns)
     {
         return Optional.empty();
     }

--- a/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/connector/ConnectorMetadata.java
@@ -1187,7 +1187,7 @@ public interface ConnectorMetadata
      * <p>
      * If the method returns a result, the list of assignments in the result will be merged with existing assignments. The projections
      * returned by the method must have the same order as the given input list of aggregates.
-     * </p>
+     * </p
      * As an example, given the following plan:
      *
      * <pre>
@@ -1253,7 +1253,8 @@ public interface ConnectorMetadata
             ConnectorTableHandle handle,
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
-            List<List<ColumnHandle>> groupingSets)
+            List<List<ColumnHandle>> groupingSets,
+            Set<String> requiredColumns)
     {
         return Optional.empty();
     }

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -938,10 +938,11 @@ public class ClassLoaderSafeConnectorMetadata
             ConnectorTableHandle table,
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
-            List<List<ColumnHandle>> groupingSets)
+            List<List<ColumnHandle>> groupingSets,
+            Set<String> requiredColumns)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.applyAggregation(session, table, aggregates, assignments, groupingSets);
+            return delegate.applyAggregation(session, table, aggregates, assignments, groupingSets, requiredColumns);
         }
     }
 

--- a/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/lib/trino-plugin-toolkit/src/main/java/io/trino/plugin/base/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -939,7 +939,7 @@ public class ClassLoaderSafeConnectorMetadata
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<String> requiredColumns)
+            Set<ColumnHandle> requiredColumns)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.applyAggregation(session, table, aggregates, assignments, groupingSets, requiredColumns);

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -246,7 +246,7 @@ public class DefaultJdbcMetadata
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<ColumnHandle> requiredColumns)
+            Set<ColumnHandle> outputGroupingColumns)
     {
         if (!isAggregationPushdownEnabled(session)) {
             return Optional.empty();
@@ -288,7 +288,7 @@ public class DefaultJdbcMetadata
                                 groupKey,
                                 tableColumns))
                         .orElse(groupKey -> {}))
-                .filter(column -> requiredColumns.isEmpty() || requiredColumns.contains(column))
+                .filter(outputGroupingColumns::contains)
                 .forEach(newColumns::add);
 
         for (AggregateFunction aggregate : aggregates) {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -246,7 +246,7 @@ public class DefaultJdbcMetadata
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<String> requiredColumns)
+            Set<ColumnHandle> requiredColumns)
     {
         if (!isAggregationPushdownEnabled(session)) {
             return Optional.empty();
@@ -288,7 +288,7 @@ public class DefaultJdbcMetadata
                                 groupKey,
                                 tableColumns))
                         .orElse(groupKey -> {}))
-                .filter(column -> requiredColumns.isEmpty() || requiredColumns.contains(column.getColumnName()))
+                .filter(column -> requiredColumns.isEmpty() || requiredColumns.contains(column))
                 .forEach(newColumns::add);
 
         for (AggregateFunction aggregate : aggregates) {

--- a/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/main/java/io/trino/plugin/jdbc/DefaultJdbcMetadata.java
@@ -245,7 +245,8 @@ public class DefaultJdbcMetadata
             ConnectorTableHandle table,
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
-            List<List<ColumnHandle>> groupingSets)
+            List<List<ColumnHandle>> groupingSets,
+            Set<String> requiredColumns)
     {
         if (!isAggregationPushdownEnabled(session)) {
             return Optional.empty();
@@ -287,6 +288,7 @@ public class DefaultJdbcMetadata
                                 groupKey,
                                 tableColumns))
                         .orElse(groupKey -> {}))
+                .filter(column -> requiredColumns.isEmpty() || requiredColumns.contains(column.getColumnName()))
                 .forEach(newColumns::add);
 
         for (AggregateFunction aggregate : aggregates) {

--- a/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
+++ b/plugin/trino-base-jdbc/src/test/java/io/trino/plugin/jdbc/TestDefaultJdbcMetadata.java
@@ -248,7 +248,8 @@ public class TestDefaultJdbcMetadata
                 handle,
                 ImmutableList.of(new AggregateFunction("count", BIGINT, List.of(), List.of(), false, Optional.empty())),
                 ImmutableMap.of(),
-                ImmutableList.of(ImmutableList.of(groupByColumn)));
+                ImmutableList.of(ImmutableList.of(groupByColumn)),
+                ImmutableSet.of());
 
         ConnectorTableHandle baseTableHandle = metadata.getTableHandle(session, new SchemaTableName("example", "numbers"));
         Optional<AggregationApplicationResult<ConnectorTableHandle>> aggregationResult = applyAggregation.apply(baseTableHandle);
@@ -370,7 +371,8 @@ public class TestDefaultJdbcMetadata
                 tableHandle,
                 ImmutableList.of(new AggregateFunction("count", BIGINT, List.of(), List.of(), false, Optional.empty())),
                 ImmutableMap.of(),
-                groupByColumns);
+                groupByColumns,
+                ImmutableSet.of());
         assertThat(aggResult).isPresent();
         return (JdbcTableHandle) aggResult.get().getHandle();
     }

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
@@ -246,7 +246,7 @@ public class PhoenixMetadata
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<ColumnHandle> requiredColumns)
+            Set<ColumnHandle> outputGroupingColumns)
     {
         // TODO support aggregation pushdown
         return Optional.empty();

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
@@ -246,7 +246,7 @@ public class PhoenixMetadata
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<String> requiredColumns)
+            Set<ColumnHandle> requiredColumns)
     {
         // TODO support aggregation pushdown
         return Optional.empty();

--- a/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
+++ b/plugin/trino-phoenix/src/main/java/io/trino/plugin/phoenix/PhoenixMetadata.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -244,7 +245,8 @@ public class PhoenixMetadata
             ConnectorTableHandle table,
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
-            List<List<ColumnHandle>> groupingSets)
+            List<List<ColumnHandle>> groupingSets,
+            Set<String> requiredColumns)
     {
         // TODO support aggregation pushdown
         return Optional.empty();

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -49,6 +49,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -265,7 +266,8 @@ public class PhoenixMetadata
             ConnectorTableHandle table,
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
-            List<List<ColumnHandle>> groupingSets)
+            List<List<ColumnHandle>> groupingSets,
+            Set<String> requiredColumns)
     {
         // TODO support aggregation pushdown
         return Optional.empty();

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -267,7 +267,7 @@ public class PhoenixMetadata
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<String> requiredColumns)
+            Set<ColumnHandle> requiredColumns)
     {
         // TODO support aggregation pushdown
         return Optional.empty();

--- a/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
+++ b/plugin/trino-phoenix5/src/main/java/io/trino/plugin/phoenix5/PhoenixMetadata.java
@@ -267,7 +267,7 @@ public class PhoenixMetadata
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<ColumnHandle> requiredColumns)
+            Set<ColumnHandle> outputGroupingColumns)
     {
         // TODO support aggregation pushdown
         return Optional.empty();

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
@@ -334,7 +334,7 @@ public class PinotMetadata
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
             List<List<ColumnHandle>> groupingSets,
-            Set<String> requiredColumns)
+            Set<ColumnHandle> requiredColumns)
     {
         if (!isAggregationPushdownEnabled(session)) {
             return Optional.empty();

--- a/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
+++ b/plugin/trino-pinot/src/main/java/io/trino/plugin/pinot/PinotMetadata.java
@@ -63,6 +63,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -332,7 +333,8 @@ public class PinotMetadata
             ConnectorTableHandle handle,
             List<AggregateFunction> aggregates,
             Map<String, ColumnHandle> assignments,
-            List<List<ColumnHandle>> groupingSets)
+            List<List<ColumnHandle>> groupingSets,
+            Set<String> requiredColumns)
     {
         if (!isAggregationPushdownEnabled(session)) {
             return Optional.empty();

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -582,10 +582,9 @@ public class TestPostgreSqlConnectorTest
     }
 
     @Test
-    public void testPruneUnnecessaryGroupingKeysInPushdown() {
-        assertThat(query("select min(nationkey) from nation group by regionkey")).matches(
-                PlanMatchPattern.output(PlanMatchPattern.node(TableScanNode.class))
-        );
+    public void testPruneUnnecessaryGroupingKeysInPushdown()
+    {
+        assertThat(query("select min(nationkey) from nation group by regionkey")).matches(PlanMatchPattern.output(PlanMatchPattern.node(TableScanNode.class)));
     }
 
     private String getLongInClause(int start, int length)

--- a/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
+++ b/plugin/trino-postgresql/src/test/java/io/trino/plugin/postgresql/TestPostgreSqlConnectorTest.java
@@ -24,6 +24,7 @@ import io.trino.plugin.jdbc.RemoteDatabaseEvent;
 import io.trino.spi.connector.ColumnHandle;
 import io.trino.spi.predicate.Range;
 import io.trino.spi.predicate.TupleDomain;
+import io.trino.sql.planner.assertions.PlanMatchPattern;
 import io.trino.sql.planner.plan.FilterNode;
 import io.trino.sql.planner.plan.JoinNode;
 import io.trino.sql.planner.plan.TableScanNode;
@@ -578,6 +579,13 @@ public class TestPostgreSqlConnectorTest
                     .matches("VALUES 1")
                     .isFullyPushedDown();
         }
+    }
+
+    @Test
+    public void testPruneUnnecessaryGroupingKeysInPushdown() {
+        assertThat(query("select min(nationkey) from nation group by regionkey")).matches(
+                PlanMatchPattern.output(PlanMatchPattern.node(TableScanNode.class))
+        );
     }
 
     private String getLongInClause(int start, int length)


### PR DESCRIPTION
Resolves https://github.com/trinodb/trino/issues/9021

DRAFT PR, still writing tests (right now `PushAggregationIntoTableScan` has no tests) and cleaning up code but wanted to get some feedback on the approach

Approach:
Previously `AggregationNode` always output symbols for all the aggregated fields and the grouping fields. However, in queries like `select min(nationkey) from nation group by regionkey` the only output symbol is the aggregated field. Thus, I added an overloaded constructor to allow explicitly setting the output symbols for `AggregationNode`.

There was already a `PruneAggregationColumns` rule that pruned unneeded aggregations when there was a `project->aggregation` pattern, I modified this rule to also prune unneeded output symbols from the aggregation node. 

Once the unneeded output symbols were pruned from the `AggregationNode`, implementing the change suggested in this PR was possible to do:
https://github.com/trinodb/trino/pull/9698/files