### PR TITLE
Http Event Listener retry for codes not in [200, 300) and expections, rertry delay calculation fix, better logging

### DIFF
--- a/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
@@ -82,7 +82,7 @@ public class HttpEventListener
     public void queryCreated(QueryCreatedEvent queryCreatedEvent)
     {
         if (config.getLogCreated()) {
-            sendLog(queryCreatedEvent);
+            sendLog(queryCreatedEvent, queryCreatedEvent.getMetadata().getQueryId());
         }
     }
 
@@ -90,7 +90,7 @@ public class HttpEventListener
     public void queryCompleted(QueryCompletedEvent queryCompletedEvent)
     {
         if (config.getLogCompleted()) {
-            sendLog(queryCompletedEvent);
+            sendLog(queryCompletedEvent, queryCompletedEvent.getMetadata().getQueryId());
         }
     }
 
@@ -98,11 +98,11 @@ public class HttpEventListener
     public void splitCompleted(SplitCompletedEvent splitCompletedEvent)
     {
         if (config.getLogSplit()) {
-            sendLog(splitCompletedEvent);
+            sendLog(splitCompletedEvent, splitCompletedEvent.getQueryId());
         }
     }
 
-    private <T> void sendLog(T event)
+    private <T> void sendLog(T event, String queryId)
     {
         Request request = preparePost()
                 .addHeaders(Multimaps.forMap(config.getHttpHeaders()))
@@ -111,10 +111,10 @@ public class HttpEventListener
                 .setBodyGenerator(out -> objectWriter.writeValue(out, event))
                 .build();
 
-        attemptToSend(request, 0, Duration.valueOf("0s"));
+        attemptToSend(request, 0, Duration.valueOf("0s"), queryId);
     }
 
-    private void attemptToSend(Request request, int attempt, Duration delay)
+    private void attemptToSend(Request request, int attempt, Duration delay, String queryId)
     {
         this.executor.schedule(
                 () -> Futures.addCallback(client.executeAsync(request, createStatusResponseHandler()),
@@ -125,19 +125,45 @@ public class HttpEventListener
                                 verify(result != null);
 
                                 if (result.getStatusCode() >= 500 && attempt < config.getRetryCount()) {
-                                    attemptToSend(request, attempt + 1, nextDelay(delay));
+                                    Duration nextDelay = nextDelay(delay);
+                                    int nextAttepmt = attempt + 1;
+
+                                    log.warn("QueryId = \"%s\", attempt = %d/%d, URL = %s | Ingest server responded with code %d, will retry after approximately %d seconds",
+                                            queryId, attempt + 1, config.getRetryCount() + 1, request.getUri().toString(),
+                                            result.getStatusCode(), nextDelay.roundTo(TimeUnit.SECONDS));
+
+                                    attemptToSend(request, nextAttepmt, nextDelay, queryId);
                                     return;
                                 }
 
                                 if (!(result.getStatusCode() >= 200 && result.getStatusCode() < 300)) {
-                                    log.error("Received status code %d from ingest server URI %s; expecting status 200", result.getStatusCode(), request.getUri());
+                                    log.warn("QueryId = \"%s\", attempt = %d/%d, URL = %s | Received status code %d from ingest server; expecting status 200",
+                                            queryId, attempt + 1, config.getRetryCount(), request.getUri().toString(),
+                                            result.getStatusCode(), request.getUri().toString());
+                                    return;
                                 }
+
+                                log.debug("QueryId = \"%s\", attempt = %d/%d, URL = %s | Query event delivered successfully",
+                                        queryId, attempt + 1, config.getRetryCount() + 1, request.getUri().toString());
                             }
 
                             @Override
                             public void onFailure(Throwable t)
                             {
-                                log.error("Error sending HTTP request to ingest server with URL %s: %s", request.getUri(), t);
+                                if (attempt < config.getRetryCount()) {
+                                    Duration nextDelay = nextDelay(delay);
+                                    int nextAttempt = attempt + 1;
+
+                                    log.warn(t, "QueryId = \"%s\", attempt = %d/%d, URL = %s | Sending event caused an exception, will retry after %d seconds",
+                                            queryId, attempt + 1, config.getRetryCount() + 1, request.getUri().toString(),
+                                            nextDelay.roundTo(TimeUnit.SECONDS));
+
+                                    attemptToSend(request, nextAttempt, nextDelay, queryId);
+                                    return;
+                                }
+
+                                log.error(t, "QueryId = \"%s\", attempt = %d/%d, URL = %s | Error sending HTTP request",
+                                        queryId, attempt + 1, config.getRetryCount() + 1, request.getUri().toString());
                             }
                         }, executor),
                 (long) delay.getValue(), delay.getUnit());

--- a/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
@@ -124,22 +124,15 @@ public class HttpEventListener
                             {
                                 verify(result != null);
 
-                                if (result.getStatusCode() >= 500 && attempt < config.getRetryCount()) {
+                                if (!(result.getStatusCode() >= 200 && result.getStatusCode() < 300) && attempt < config.getRetryCount()) {
                                     Duration nextDelay = nextDelay(delay);
-                                    int nextAttepmt = attempt + 1;
+                                    int nextAttempt = attempt + 1;
 
                                     log.warn("QueryId = \"%s\", attempt = %d/%d, URL = %s | Ingest server responded with code %d, will retry after approximately %d seconds",
                                             queryId, attempt + 1, config.getRetryCount() + 1, request.getUri().toString(),
                                             result.getStatusCode(), nextDelay.roundTo(TimeUnit.SECONDS));
 
-                                    attemptToSend(request, nextAttepmt, nextDelay, queryId);
-                                    return;
-                                }
-
-                                if (!(result.getStatusCode() >= 200 && result.getStatusCode() < 300)) {
-                                    log.warn("QueryId = \"%s\", attempt = %d/%d, URL = %s | Received status code %d from ingest server; expecting status 200",
-                                            queryId, attempt + 1, config.getRetryCount(), request.getUri().toString(),
-                                            result.getStatusCode(), request.getUri().toString());
+                                    attemptToSend(request, nextAttempt, nextDelay, queryId);
                                     return;
                                 }
 

--- a/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
+++ b/plugin/trino-http-event-listener/src/main/java/io/trino/plugin/httpquery/HttpEventListener.java
@@ -164,6 +164,10 @@ public class HttpEventListener
 
     private Duration nextDelay(Duration delay)
     {
+        if (delay.compareTo(Duration.valueOf("0s")) == 0) {
+            return config.getRetryDelay();
+        }
+
         Duration newDuration = Duration.succinctDuration(delay.getValue(TimeUnit.SECONDS) * this.config.getBackoffBase(), TimeUnit.SECONDS);
         if (newDuration.compareTo(config.getMaxDelay()) > 0) {
             return config.getMaxDelay();

--- a/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpQueryListener.java
+++ b/plugin/trino-http-event-listener/src/test/java/io/trino/plugin/httpquery/TestHttpQueryListener.java
@@ -227,7 +227,7 @@ public class TestHttpQueryListener
         querylogListener.queryCompleted(null);
         querylogListener.splitCompleted(null);
 
-        assertNull(server.takeRequest(1, TimeUnit.SECONDS));
+        assertNull(server.takeRequest(5, TimeUnit.SECONDS));
     }
 
     @Test
@@ -246,13 +246,13 @@ public class TestHttpQueryListener
         server.enqueue(new MockResponse().setResponseCode(200));
 
         querylogListener.queryCreated(queryCreatedEvent);
-        checkRequest(server.takeRequest(1, TimeUnit.SECONDS), queryCreatedEvent);
+        checkRequest(server.takeRequest(5, TimeUnit.SECONDS), queryCreatedEvent);
 
         querylogListener.queryCompleted(queryCompleteEvent);
-        checkRequest(server.takeRequest(1, TimeUnit.SECONDS), queryCompleteEvent);
+        checkRequest(server.takeRequest(5, TimeUnit.SECONDS), queryCompleteEvent);
 
         querylogListener.splitCompleted(splitCompleteEvent);
-        checkRequest(server.takeRequest(1, TimeUnit.SECONDS), splitCompleteEvent);
+        checkRequest(server.takeRequest(5, TimeUnit.SECONDS), splitCompleteEvent);
     }
 
     @Test
@@ -268,7 +268,7 @@ public class TestHttpQueryListener
 
         querylogListener.queryCompleted(queryCompleteEvent);
 
-        assertEquals(server.takeRequest(1, TimeUnit.SECONDS).getHeader("Content-Type"), "application/json; charset=utf-8");
+        assertEquals(server.takeRequest(5, TimeUnit.SECONDS).getHeader("Content-Type"), "application/json; charset=utf-8");
     }
 
     public void testHttpHeadersShouldBePresent()
@@ -284,7 +284,7 @@ public class TestHttpQueryListener
 
         querylogListener.queryCompleted(queryCompleteEvent);
 
-        checkRequest(server.takeRequest(1, TimeUnit.SECONDS), new HashMap<>() {{
+        checkRequest(server.takeRequest(5, TimeUnit.SECONDS), new HashMap<>() {{
                 put("Authorization", "Trust Me!");
                 put("Cache-Control", "no-cache");
             }}, queryCompleteEvent);
@@ -305,7 +305,7 @@ public class TestHttpQueryListener
             }});
         querylogListener.queryCompleted(queryCompleteEvent);
 
-        RecordedRequest recordedRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        RecordedRequest recordedRequest = server.takeRequest(5, TimeUnit.SECONDS);
 
         assertNotNull(recordedRequest, "Handshake probably failed");
         assertEquals(recordedRequest.getTlsVersion().javaName(), "TLSv1.3");
@@ -328,7 +328,7 @@ public class TestHttpQueryListener
             }});
         querylogListener.queryCompleted(queryCompleteEvent);
 
-        RecordedRequest recordedRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        RecordedRequest recordedRequest = server.takeRequest(5, TimeUnit.SECONDS);
 
         assertNull(recordedRequest, "Handshake should have failed");
     }
@@ -347,7 +347,7 @@ public class TestHttpQueryListener
             }});
         querylogListener.queryCompleted(queryCompleteEvent);
 
-        RecordedRequest recordedRequest = server.takeRequest(1, TimeUnit.SECONDS);
+        RecordedRequest recordedRequest = server.takeRequest(5, TimeUnit.SECONDS);
 
         assertNull(recordedRequest, "Handshake should have failed");
     }
@@ -367,8 +367,8 @@ public class TestHttpQueryListener
 
         querylogListener.queryCompleted(queryCompleteEvent);
 
-        assertNotNull(server.takeRequest(1, TimeUnit.SECONDS)); // First request that responds with 500
-        checkRequest(server.takeRequest(1, TimeUnit.SECONDS), queryCompleteEvent); // The retry that responds with 200
+        assertNotNull(server.takeRequest(5, TimeUnit.SECONDS)); // First request that responds with 500
+        checkRequest(server.takeRequest(5, TimeUnit.SECONDS), queryCompleteEvent); // The retry that responds with 200
     }
 
     @Test
@@ -386,8 +386,8 @@ public class TestHttpQueryListener
 
         querylogListener.queryCompleted(queryCompleteEvent);
 
-        assertNotNull(server.takeRequest(1, TimeUnit.SECONDS)); // First request, send back 400
-        checkRequest(server.takeRequest(1, TimeUnit.SECONDS), queryCompleteEvent); // The retry that responds with 200
+        assertNotNull(server.takeRequest(5, TimeUnit.SECONDS)); // First request, send back 400
+        checkRequest(server.takeRequest(5, TimeUnit.SECONDS), queryCompleteEvent); // The retry that responds with 200
     }
 
     @Test


### PR DESCRIPTION
I have been running into problems while using the event listener. Problems are usually one of:

1. Broken Pipe Exceptions, which are irregular and usually occur less than 2 times per hour. These aren't critical but cause dropped events. (Cause of these I suspect might be bad timing between trino and the receiving server in regards to timeouts) here is an [exception](https://gist.github.com/mosiac1/657c2a2555791637a24d3089e7aad7f5);

2. Regular timeouts. There are cases where most of the plugin's attempts to send events will end with a timeout (from the http-client, not from the receiving server). The cause of these issues I haven't been able to track down yet. What I know is that it's probably not the fault of the ingest server because when the plugin keeps timing-out other requests to that server went through correctly (event from the same machine as trino). This usually happens when there are high loads on trino.

The changes this PR implements are simple and self-explanatory from the title. 

These should fix problem 1. and help with tracking down problem 2. 

Any ideas regarding problem 2 are greatly appreciated!