### PR TITLE
Re-enable SET AUTHORIZATION ROLE on VIEW SECURITY DEFINER

### DIFF
--- a/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
+++ b/core/trino-main/src/main/java/io/trino/FeaturesConfig.java
@@ -1131,8 +1131,8 @@ public class FeaturesConfig
     }
 
     @Config("legacy.allow-set-view-authorization")
-    @ConfigDescription("For security reasons ALTER VIEW SET AUTHORIZATION is disabled for SECURITY DEFINER; " +
-            "setting this option to true will re-enable this functionality")
+    @ConfigDescription("For security reasons ALTER VIEW SET AUTHORIZATION is restricted for SECURITY DEFINER; " +
+            "setting this option to true will remove these restrictions")
     public FeaturesConfig setAllowSetViewAuthorization(boolean allowSetViewAuthorization)
     {
         this.allowSetViewAuthorization = allowSetViewAuthorization;

--- a/core/trino-main/src/main/java/io/trino/execution/SetViewAuthorizationTask.java
+++ b/core/trino-main/src/main/java/io/trino/execution/SetViewAuthorizationTask.java
@@ -16,30 +16,48 @@ package io.trino.execution;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.trino.FeaturesConfig;
 import io.trino.Session;
+import io.trino.connector.CatalogName;
 import io.trino.execution.warnings.WarningCollector;
+import io.trino.metadata.Catalog.SecurityManagement;
 import io.trino.metadata.Metadata;
 import io.trino.metadata.QualifiedObjectName;
 import io.trino.metadata.ViewDefinition;
 import io.trino.security.AccessControl;
-import io.trino.spi.TrinoException;
+import io.trino.security.SecurityContext;
+import io.trino.spi.security.AccessDeniedException;
+import io.trino.spi.security.Identity;
+import io.trino.spi.security.RoleGrant;
+import io.trino.spi.security.SelectedRole;
 import io.trino.spi.security.TrinoPrincipal;
+import io.trino.sql.analyzer.AnalyzerFactory;
+import io.trino.sql.parser.SqlParser;
+import io.trino.sql.tree.CreateView;
 import io.trino.sql.tree.Expression;
+import io.trino.sql.tree.QualifiedName;
+import io.trino.sql.tree.Query;
 import io.trino.sql.tree.SetViewAuthorization;
+import io.trino.transaction.TransactionManager;
 
 import javax.inject.Inject;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
+import static com.google.common.base.Verify.verify;
 import static com.google.common.util.concurrent.Futures.immediateVoidFuture;
 import static io.trino.metadata.MetadataUtil.checkRoleExists;
 import static io.trino.metadata.MetadataUtil.createPrincipal;
 import static io.trino.metadata.MetadataUtil.createQualifiedObjectName;
 import static io.trino.metadata.MetadataUtil.getRequiredCatalogHandle;
-import static io.trino.spi.StandardErrorCode.NOT_SUPPORTED;
+import static io.trino.metadata.MetadataUtil.processRoleCommandCatalog;
 import static io.trino.spi.StandardErrorCode.TABLE_NOT_FOUND;
+import static io.trino.spi.security.AccessDeniedException.denySetViewAuthorization;
+import static io.trino.spi.security.PrincipalType.USER;
+import static io.trino.sql.ParameterUtils.parameterExtractor;
+import static io.trino.sql.ParsingUtil.createParsingOptions;
 import static io.trino.sql.analyzer.SemanticExceptions.semanticException;
-import static java.lang.String.format;
+import static io.trino.sql.tree.CreateView.Security.DEFINER;
 import static java.util.Objects.requireNonNull;
 
 public class SetViewAuthorizationTask
@@ -47,13 +65,25 @@ public class SetViewAuthorizationTask
 {
     private final Metadata metadata;
     private final AccessControl accessControl;
+    private final SqlParser sqlParser;
+    private final TransactionManager transactionManager;
+    private final AnalyzerFactory analyzerFactory;
     private final boolean isAllowSetViewAuthorization;
 
     @Inject
-    public SetViewAuthorizationTask(Metadata metadata, AccessControl accessControl, FeaturesConfig featuresConfig)
+    public SetViewAuthorizationTask(
+            Metadata metadata,
+            AccessControl accessControl,
+            SqlParser sqlParser,
+            TransactionManager transactionManager,
+            AnalyzerFactory analyzerFactory,
+            FeaturesConfig featuresConfig)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.accessControl = requireNonNull(accessControl, "accessControl is null");
+        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.analyzerFactory = requireNonNull(analyzerFactory, "analyzerFactory is null");
         this.isAllowSetViewAuthorization = requireNonNull(featuresConfig, "featuresConfig is null").isAllowSetViewAuthorization();
     }
 
@@ -80,16 +110,115 @@ public class SetViewAuthorizationTask
         checkRoleExists(session, statement, metadata, principal, Optional.of(viewName.getCatalogName()).filter(catalog -> metadata.isCatalogManagedSecurity(session, catalog)));
 
         if (!view.isRunAsInvoker() && !isAllowSetViewAuthorization) {
-            throw new TrinoException(
-                    NOT_SUPPORTED,
-                    format(
-                            "Cannot set authorization for view %s to %s: this feature is disabled",
-                            viewName.getCatalogName() + '.' + viewName.getSchemaName() + '.' + viewName.getObjectName(), principal));
+            // With SECURITY DEFINER the privileges to access data depend on the owner,
+            // so we can't allow changing the owner if it allows the user to gain more privileges.
+            switch (principal.getType()) {
+                case USER:
+                    checkCanSetAuthorizationToUser(viewName, principal);
+                    break;
+
+                case ROLE:
+                    checkCanSetAuthorizationToRole(session, metadata, accessControl, statement, viewName, principal);
+                    break;
+            }
+
+            checkCanAccessViewEntities(session, stateMachine, parameters, viewName, view, principal);
+            checkTargetPrincipalCanCreateView(session, transactionManager, accessControl, viewName, principal);
         }
+
         accessControl.checkCanSetViewAuthorization(session.toSecurityContext(), viewName, principal);
 
         metadata.setViewAuthorization(session, viewName.asCatalogSchemaTableName(), principal);
 
         return immediateVoidFuture();
+    }
+
+    private void checkCanSetAuthorizationToUser(QualifiedObjectName viewName, TrinoPrincipal principal)
+    {
+        // TODO: implement a separate permission to transfer ownership to another user
+        denySetViewAuthorization(viewName.toString(), principal);
+    }
+
+    private void checkCanSetAuthorizationToRole(Session session, Metadata metadata, AccessControl accessControl, SetViewAuthorization statement, QualifiedObjectName viewName, TrinoPrincipal principal)
+    {
+        // The logic for ROLEs is that the user should be able to transfer ownership to any role they can assume,
+        // as this does not give them any additional privileges they can't already obtain:
+        Optional<String> catalog = processRoleCommandCatalog(metadata, session, statement, Optional.of(viewName.getCatalogName()));
+        if (catalog.isPresent()) {
+            try {
+                accessControl.checkCanSetCatalogRole(SecurityContext.of(session), principal.getName(), catalog.get());
+            }
+            catch (AccessDeniedException e) {
+                wrapAccessDeniedException(viewName, principal, e);
+            }
+        }
+        else {
+            Set<RoleGrant> roleGrants = metadata.listApplicableRoles(session, new TrinoPrincipal(USER, session.getUser()), Optional.empty());
+            if (roleGrants.stream().map(RoleGrant::getRoleName).noneMatch(principal.getName()::equals)) {
+                denySetViewAuthorization(viewName.toString(), principal, "Not a member of role " + principal.getName());
+            }
+        }
+    }
+
+    private void checkCanAccessViewEntities(Session session, QueryStateMachine stateMachine, List<Expression> parameters, QualifiedObjectName viewName, ViewDefinition view, TrinoPrincipal targetPrincipal)
+    {
+        CreateView statement = new CreateView(
+                QualifiedName.of(viewName.getCatalogName(), viewName.getSchemaName(), viewName.getObjectName()),
+                (Query) sqlParser.createStatement(view.getOriginalSql(), createParsingOptions(session)),
+                false,
+                view.getComment(),
+                Optional.of(DEFINER));
+        try {
+            analyzerFactory.createAnalyzer(session, parameters, parameterExtractor(statement, parameters), stateMachine.getWarningCollector())
+                    .analyze(statement);
+        }
+        catch (AccessDeniedException e) {
+            wrapAccessDeniedException(viewName, targetPrincipal, e);
+        }
+    }
+
+    private void checkTargetPrincipalCanCreateView(Session session, TransactionManager transactionManager, AccessControl accessControl, QualifiedObjectName viewName, TrinoPrincipal targetPrincipal)
+    {
+        SecurityContext targetPrincipalContext = new SecurityContext(session.getRequiredTransactionId(), getPrincipalIdentity(session, transactionManager, viewName, targetPrincipal), session.getQueryId());
+        try {
+            accessControl.checkCanCreateView(targetPrincipalContext, viewName);
+        }
+        catch (AccessDeniedException e) {
+            wrapAccessDeniedException(viewName, targetPrincipal, e);
+        }
+    }
+
+    private Identity getPrincipalIdentity(Session session, TransactionManager transactionManager, QualifiedObjectName viewName, TrinoPrincipal principal)
+    {
+        switch (principal.getType()) {
+            case USER:
+                return Identity.ofUser(principal.getName());
+            case ROLE:
+                // The operation will change the owner to current view's owner + role, but we check for the current
+                // user + role, because the logic is that we should allow it if the current user would be able to do it
+                // by creating the view having assumed the role.
+                Identity.Builder identityBuilder = Identity.forUser(session.getUser());
+                SecurityManagement securityManagement = transactionManager
+                        .getCatalogMetadata(session.getRequiredTransactionId(), new CatalogName(viewName.getCatalogName()))
+                        .getSecurityManagement();
+                switch (securityManagement) {
+                    case CONNECTOR:
+                        identityBuilder = identityBuilder.withConnectorRole(viewName.getCatalogName(), new SelectedRole(SelectedRole.Type.ROLE, Optional.of(principal.getName())));
+                        break;
+                    case SYSTEM:
+                        identityBuilder = identityBuilder.withEnabledRoles(Set.of(principal.getName()));
+                        break;
+                }
+                return identityBuilder.build();
+        }
+        throw new IllegalArgumentException("Unknown principal type: " + principal.getType());
+    }
+
+    private static void wrapAccessDeniedException(QualifiedObjectName objectName, TrinoPrincipal principal, AccessDeniedException e)
+    {
+        String prefix = AccessDeniedException.PREFIX;
+        verify(e.getMessage().startsWith(prefix));
+        String msg = e.getMessage().substring(prefix.length());
+        denySetViewAuthorization(objectName.toString(), principal, msg);
     }
 }

--- a/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
+++ b/core/trino-spi/src/main/java/io/trino/spi/security/AccessDeniedException.java
@@ -385,7 +385,12 @@ public class AccessDeniedException
 
     public static void denySetViewAuthorization(String viewName, TrinoPrincipal principal)
     {
-        throw new AccessDeniedException(format("Cannot set authorization for view %s to %s", viewName, principal));
+        denySetViewAuthorization(viewName, principal, null);
+    }
+
+    public static void denySetViewAuthorization(String viewName, TrinoPrincipal principal, String extraInfo)
+    {
+        throw new AccessDeniedException(format("Cannot set authorization for view %s to %s%s", viewName, principal, formatExtraInfo(extraInfo)));
     }
 
     public static void denyDropView(String viewName)

--- a/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop-kerberos/config.properties
+++ b/testing/trino-product-tests-launcher/src/main/resources/docker/presto-product-tests/common/hadoop-kerberos/config.properties
@@ -23,4 +23,3 @@ internal-communication.https.required=true
 internal-communication.shared-secret=internal-shared-secret
 internal-communication.https.keystore.path=/docker/presto-product-tests/conf/presto/etc/docker.cluster.jks
 internal-communication.https.keystore.key=123456
-legacy.allow-set-view-authorization=true

--- a/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSqlStandardAccessControlChecks.java
+++ b/testing/trino-product-tests/src/main/java/io/trino/tests/product/hive/TestSqlStandardAccessControlChecks.java
@@ -48,7 +48,8 @@ public class TestSqlStandardAccessControlChecks
         aliceExecutor.executeQuery(format("CREATE TABLE %s(month bigint, day bigint) WITH (partitioned_by = ARRAY['day'])", tableName));
 
         aliceExecutor.executeQuery(format("DROP VIEW IF EXISTS %s", viewName));
-        aliceExecutor.executeQuery(format("CREATE VIEW %s AS SELECT month, day FROM %s", viewName, tableName));
+        // TODO: switch back to SECURITY DEFINER when SET AUTHORIZATION USER is allowed again
+        aliceExecutor.executeQuery(format("CREATE VIEW %s SECURITY INVOKER AS SELECT month, day FROM %s", viewName, tableName));
     }
 
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
@@ -249,7 +250,7 @@ public class TestSqlStandardAccessControlChecks
         bobExecutor.executeQuery(format("DROP VIEW %s", viewName));
     }
 
-    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS}, enabled = false) // TODO: disabled until SET AUTHORIZATION to USER is re-enabled for views with SECURITY DEFINER
     public void testAccessControlSetHiveViewAuthorization()
     {
         onHive().executeQuery("CREATE TABLE test_hive_table (col1 int)");


### PR DESCRIPTION
This PR re-enables `SET AUTHORIZATION ROLE` on views with `SECURITY DEFINER` with new access control rules that are meant to prevent any potential mis-use.

The new rules are:

* `SECURITY INVOKER`: unchanged; the view owner can change ownership to any user or role
* `SECURITY DEFINER`: as above, plus additional checks that depend on whether the target principal is USER or ROLE:
  * `USER`: disallowed (ideally there should be a separate privilege for this)
  * `ROLE`: the change is allowed if both of the following checks pass:
    1. The current user would be able to create the view from scratch (has privileges to create views in the catalog, is able to `SELECT` all tables and `EXECUTE` all functions accessed by the view)
    1. The target principal has privileges to create views in the catalog

Basically the idea is that it should be allowed if it would also be possible to just `DROP` and `CREATE` the view from scratch with the new owner - but only with the view is executed with the definer's privileges, because ownership does not affect what the view can access when it's executed with privileges of the invoker.