### PR TITLE
fix materialized views to allow duplicated source tables without breaking the metadata schema

### DIFF
--- a/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
+++ b/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/IcebergMetadata.java
@@ -970,6 +970,7 @@ public class IcebergMetadata
                 .map(handle -> (IcebergTableHandle) handle)
                 .filter(handle -> handle.getSnapshotId().isPresent())
                 .map(handle -> handle.getSchemaTableName() + "=" + handle.getSnapshotId().get())
+                .distinct()
                 .collect(joining(","));
 
         // Update the 'dependsOnTables' property that tracks tables on which the materialized view depends and the corresponding snapshot ids of the tables

--- a/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedViews.java
+++ b/plugin/trino-iceberg/src/test/java/io/trino/plugin/iceberg/TestIcebergMaterializedViews.java
@@ -141,6 +141,20 @@ public class TestIcebergMaterializedViews
     }
 
     @Test
+    public void testCreateWithDuplicateSourceTableSucceeds()
+    {
+        assertUpdate("" +
+                "CREATE MATERIALIZED VIEW materialized_view_with_duplicate_source AS " +
+                "SELECT _bigint, _date FROM base_table1 " +
+                "UNION ALL " +
+                "SELECT _bigint, _date FROM base_table1 ");
+
+        assertUpdate("REFRESH MATERIALIZED VIEW materialized_view_with_duplicate_source", 12);
+
+        assertQuery("SELECT count(*) FROM materialized_view_with_duplicate_source", "VALUES 12");
+    }
+
+    @Test
     public void testShowCreate()
     {
         assertUpdate("CREATE MATERIALIZED VIEW materialized_view_with_property " +


### PR DESCRIPTION
fix #10229, remove duplicates from materialized view source tables when saving metdata

Fixes https://github.com/trinodb/trino/issues/10229