### PR TITLE
Support kafka timestamp pushdown for open ranges

### DIFF
--- a/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
+++ b/plugin/trino-kafka/src/main/java/io/trino/plugin/kafka/KafkaFilterManager.java
@@ -59,7 +59,7 @@ import static java.util.Objects.requireNonNull;
 
 public class KafkaFilterManager
 {
-    private static final long INVALID_KAFKA_RANGE_INDEX = -1;
+    private static final long INVALID_KAFKA_RANGE_INDEX = 0L;
     private static final String TOPIC_CONFIG_TIMESTAMP_KEY = "message.timestamp.type";
     private static final String TOPIC_CONFIG_TIMESTAMP_VALUE_LOG_APPEND_TIME = "LogAppendTime";
 
@@ -225,7 +225,7 @@ public class KafkaFilterManager
                 else {
                     io.trino.spi.predicate.Range span = ranges.getSpan();
                     low = getLowIncludedValue(span).orElse(low);
-                    high = getHighIncludedValue(span).orElse(high);
+                    high = getHighIncludedValue(span).orElse(Long.MAX_VALUE - 1);
                 }
             }
         }

--- a/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaFilterManager.java
+++ b/plugin/trino-kafka/src/test/java/io/trino/plugin/kafka/TestKafkaFilterManager.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import static io.trino.spi.predicate.Domain.multipleValues;
 import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.TimestampType.TIMESTAMP_MILLIS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -68,5 +69,19 @@ public class TestKafkaFilterManager
         assertTrue(KafkaFilterManager.filterRangeByDomain(testDomain).isPresent());
         assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getBegin(), 2L);
         assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getEnd(), 5L);
+
+        testDomain = Domain.create(SortedRangeSet.copyOf(TIMESTAMP_MILLIS,
+                ImmutableList.of(Range.greaterThan(TIMESTAMP_MILLIS, 1642054805000000L))), false);
+        assertEquals(testDomain.getValues().getRanges().getSpan().toString(), "(2022-01-13 06:20:05.000, <max>)");
+        assertTrue(KafkaFilterManager.filterRangeByDomain(testDomain).isPresent());
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getBegin(), 1642054805001000L);
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getEnd(), Long.MAX_VALUE);
+
+        testDomain = Domain.create(SortedRangeSet.copyOf(TIMESTAMP_MILLIS,
+                ImmutableList.of(Range.lessThan(TIMESTAMP_MILLIS, 1642054805000000L))), false);
+        assertEquals(testDomain.getValues().getRanges().getSpan().toString(), "(<min>, 2022-01-13 06:20:05.000)");
+        assertTrue(KafkaFilterManager.filterRangeByDomain(testDomain).isPresent());
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getBegin(), 0L);
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getEnd(), 1642054804999001L);
     }
 }


### PR DESCRIPTION
Fixes #10494. The result proceeds as below:
```
trino:tpch> select _timestamp FROM test where _timestamp > timestamp '2022-01-13 06:18:05' and _timestamp < current_timestamp LIMIT 10;
       _timestamp
-------------------------
 2022-01-13 06:18:05.721
 2022-01-13 06:18:10.616
 2022-01-13 06:18:14.888
 2022-01-13 06:18:19.000
 2022-01-13 06:18:23.671
 2022-01-13 06:20:38.190
 2022-01-13 06:20:42.264
 2022-01-13 06:20:46.936
 2022-01-13 06:20:51.194
 2022-01-13 06:20:56.374
(10 rows)

trino:tpch> select _timestamp FROM test where _timestamp > timestamp '2022-01-13 06:20:05' LIMIT 10;
       _timestamp
-------------------------
 2022-01-13 06:20:38.190
 2022-01-13 06:20:42.264
 2022-01-13 06:20:46.936
 2022-01-13 06:20:51.194
 2022-01-13 06:20:56.374
(5 rows)

rino:tpch> select _timestamp FROM test where _timestamp < timestamp '2022-01-13 06:20:05' LIMIT 10;
       _timestamp
-------------------------
 2022-01-13 06:18:05.721
 2022-01-13 06:18:10.616
 2022-01-13 06:18:14.888
 2022-01-13 06:18:19.000
 2022-01-13 06:18:23.671
(5 rows)
```