### PR TITLE
Upgrade benchto driver to version 0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -535,7 +535,7 @@
             <dependency>
                 <groupId>io.trino.benchto</groupId>
                 <artifactId>benchto-driver</artifactId>
-                <version>0.16</version>
+                <version>0.17</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This version fixes issue with reporting queryInfo.